### PR TITLE
The configuration property should be "Enabled", not "Enable".

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -47,7 +47,7 @@ module Rubocop
           cop.correlations = correlations
           config = $options[:config] || config_from_dotfile(File.dirname(file))
           cop_config = config[cop_klass.name.split('::').last] if config
-          cop_klass.enabled = cop_config.nil? || cop_config['Enable']
+          cop_klass.enabled = cop_config.nil? || cop_config['Enabled']
           cop.inspect(file, source, tokens, sexp)
           total_offences += cop.offences.count
           report << cop if cop.has_report?

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -72,10 +72,10 @@ module Rubocop
         File.open('example1.rb', 'w') { |f| f.puts 'x = 0 ' }
         File.open('rubocop.yml', 'w') do |f|
           f.puts('Encoding:',
-                 '  Enable: false',
+                 '  Enabled: false',
                  '',
                  'Indentation:',
-                 '  Enable: false')
+                 '  Enabled: false')
         end
         begin
           return_code = cli.run(['-c', 'rubocop.yml', 'example1.rb'])
@@ -97,10 +97,10 @@ module Rubocop
         File.open('example_src/example1.rb', 'w') { |f| f.puts 'x = 0 ' }
         File.open('example_src/.rubocop.yml', 'w') do |f|
           f.puts('Encoding:',
-                 '  Enable: false',
+                 '  Enabled: false',
                  '',
                  'Indentation:',
-                 '  Enable: false')
+                 '  Enabled: false')
         end
         begin
           return_code = cli.run(['example_src/example1.rb'])


### PR DESCRIPTION
Fixes a bug that prevented the "Enabled" settings in .rubocop.yml to have any effect.
