### PR TITLE
add --silent parameter to silence summary output

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -26,6 +26,9 @@ module Rubocop
         opts.on('-c FILE', '--config FILE', 'Configuration file') do |f|
           $options[:config] = YAML.load_file(f)
         end
+        opts.on('-s', '--silent', 'Silence summary') do |s|
+          $options[:silent] = s
+        end
       end.parse!(args)
 
       cops = Cop::Cop.all
@@ -57,8 +60,10 @@ module Rubocop
         report.display unless report.empty?
       end
 
-      print "\n#{target_files(args).count} files inspected, "
-      puts "#{total_offences} offences detected"
+      unless $options[:silent]
+        print "\n#{target_files(args).count} files inspected, "
+        puts "#{total_offences} offences detected"
+      end
 
       return total_offences == 0 ? 0 : 1
     end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -15,7 +15,8 @@ module Rubocop
         message = ['Usage: rubocop [options] [file1, file2, ...]',
                    '    -v, --[no-]verbose               Run verbosely',
                    '    -e, --emacs                      Emacs style output',
-                   '    -c, --config FILE                Configuration file']
+                   '    -c, --config FILE                Configuration file',
+                   '    -s, --silent                     Silence summary']
         $stdout.string.should == (message * 2).join("\n") + "\n"
       end
 
@@ -61,6 +62,26 @@ module Rubocop
              'example2.rb:1: C: Tab detected.',
              '',
              '2 files inspected, 4 offences detected',
+             ''].join("\n")
+        ensure
+          File.delete 'example1.rb'
+          File.delete 'example2.rb'
+        end
+      end
+
+      it 'ommits summary when --silent passed' do
+        File.open('example1.rb', 'w') { |f| f.puts 'x = 0 ' }
+        File.open('example2.rb', 'w') { |f| f.puts "\tx = 0" }
+        begin
+          cli.run(['--emacs',
+                   '--silent',
+                   'example1.rb',
+                   'example2.rb']).should == 1
+          $stdout.string.should ==
+            ['example1.rb:1: C: Missing encoding comment.',
+             'example1.rb:1: C: Trailing whitespace detected.',
+             'example2.rb:1: C: Missing encoding comment.',
+             'example2.rb:1: C: Tab detected.',
              ''].join("\n")
         ensure
           File.delete 'example1.rb'


### PR DESCRIPTION
Adds a `--silent` flag, which makes the report omit summary data from output.

For my use-case I'm writing a git integration gem to provide git hooks that reject commits that have newly-authored or edited lines with rubocop errors, which will make gradual healing of large projects possible. Omitting the summary output makes the output significantly simpler to parse when run with the `--emacs` flag.

I considered adding `--[no-]summary` instead, but communicating the default behavior in the `--help` output, and supporting a default of true, proved to make things more complex. I'm open to suggestions on what to call the flag if `--silent` doesn't seem like a good fit.
