### PR TITLE
Bail out if we can't find a "when ... ;" due to lack of tokens.

### DIFF
--- a/lib/rubocop/cop/when_then.rb
+++ b/lib/rubocop/cop/when_then.rb
@@ -11,6 +11,9 @@ module Rubocop
           # when <value> <divider> <body>
           # where divider is either semicolon, then, or line break.
           last_pos_in_value = all_positions(s[1])[-1]
+
+          next unless last_pos_in_value # Give up if no positions found.
+
           start_index = tokens.index { |t| t.pos == last_pos_in_value }
           tokens[start_index..-1].each do |t|
             break if ['then', "\n"].include?(t.text)

--- a/spec/rubocop/cops/when_then_spec.rb
+++ b/spec/rubocop/cops/when_then_spec.rb
@@ -15,6 +15,13 @@ module Rubocop
           ['Never use "when x;". Use "when x then" instead.'])
       end
 
+      it 'misses semicolon but does not crash when there are no tokens' do
+        inspect_source(wt, 'file.rb', ['case a',
+                                       'when []; {}',
+                                       'end'])
+        expect(wt.offences.map(&:message)).to eq([])
+      end
+
       it 'accepts when x then' do
         inspect_source(wt, 'file.rb', ['case a',
                                        'when b then c',


### PR DESCRIPTION
This avoids a crash, but potentially misses a violation.
