### PR TITLE
Fix a spec example refers rspec command arguments

### DIFF
--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -236,6 +236,8 @@ module Rubocop
       end
 
       it 'finds no violations when checking the rubocop source code' do
+        # Need to pass an empty array explicitly
+        # so that the CLI does not refer arguments of `rspec`
         cli.run([])
         expect($stdout.string.uncolored).to match(
           /files inspected, 0 offences detected\n/
@@ -291,6 +293,8 @@ module Rubocop
         end
         begin
           FileUtils::cd 'test' do
+            # Need to pass an empty array explicitly
+            # so that the CLI does not refer arguments of `rspec`
             expect(cli.run([])).to eq(0)
             expect($stdout.string.uncolored).to eq(
               ['', '1 files inspected, 0 offences detected',


### PR DESCRIPTION
It fails when executing command like `rspec --format documentation`
