### PR TITLE
Support rubocop:disable and rubocop:enable comments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * New cop `RescueModifier` tracks uses of `rescue` in modifier form
 * New cop `PercentLiterals` tracks uses of `%q`, `%Q`, `%s` and `%x`
 * New cop `BraceAfterPercent` tracks uses of % literals with delimiters other than ()
+* Support for disabling cops locally in a file with rubocop:disable comments.
 
 ### Bugs fixed
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,30 @@ LineLength:
 It allows to enable/disable certain cops (checks) and to alter their
 behavior if they accept any parameters.
 
+One or more individual cops can be disabled locally in a section of a
+file by adding a comment such as
+
+```ruby
+# rubocop:disable LineLength, StringLiterals
+[...]
+# rubocop:enable LineLength, StringLiterals
+```
+
+You can also disable *all* cops with
+
+```ruby
+# rubocop:disable all
+[...]
+# rubocop:enable all
+```
+
+One or more cops can be disabled on a single line with an end-of-line
+comment.
+
+```ruby
+for x in (0..19) # rubocop:disable AvoidFor
+```
+
 ## Compatibility
 
 Unfortunately every major Ruby implementation has its own code

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -59,13 +59,16 @@ module Rubocop
         else
           tokens, sexp, correlations = CLI.rip_source(source)
           config = $options[:config] || config_from_dotfile(File.dirname(file))
+          disabled_lines = disabled_lines_in(source)
 
           cops.each do |cop_klass|
-            cop_config = config[cop_klass.name.split('::').last] if config
+            cop_name = cop_klass.name.split('::').last
+            cop_config = config[cop_name] if config
             if cop_config.nil? || cop_config['Enabled']
               cop_klass.config = cop_config
               cop = cop_klass.new
               cop.correlations = correlations
+              cop.disabled_lines = disabled_lines[cop_name]
               cop.inspect(file, source, tokens, sexp)
               total_offences += cop.offences.count
               report << cop if cop.has_report?
@@ -83,6 +86,39 @@ module Rubocop
       end
 
       return total_offences == 0 ? 0 : 1
+    end
+
+    def disabled_lines_in(source)
+      disabled_lines = Hash.new([])
+      disabled_section = {}
+      regexp = '# rubocop : (%s)\b ((?:\w+,? )+)'.gsub(' ', '\s*')
+      section_regexp = '^\s*' + sprintf(regexp, '(?:dis|en)able')
+      single_line_regexp = '\S.*' + sprintf(regexp, 'disable')
+
+      source.each_with_index do |line, ix|
+        each_mentioned_cop(/#{section_regexp}/, line) do |cop_name, kind|
+          disabled_section[cop_name] = (kind == 'disable')
+        end
+        disabled_section.keys.each do |cop_name|
+          disabled_lines[cop_name] += [ix + 1] if disabled_section[cop_name]
+        end
+
+        each_mentioned_cop(/#{single_line_regexp}/, line) do |cop_name, kind|
+          disabled_lines[cop_name] += [ix + 1] if kind == 'disable'
+        end
+      end
+      disabled_lines
+    end
+
+    def each_mentioned_cop(regexp, line)
+      match = line.match(regexp)
+      if match
+        kind, cops = match.captures
+        if cops.include?('all')
+          cops = Cop::Cop.all.map { |c| c.name.split('::').last }.join(',')
+        end
+        cops.split(/,\s*/).each { |cop_name| yield cop_name, kind }
+      end
     end
 
     def get_rid_of_invalid_byte_sequences(line)

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -32,7 +32,7 @@ module Rubocop
 
     class Cop
       attr_accessor :offences
-      attr_writer :correlations
+      attr_writer :correlations, :disabled_lines
 
       @all = []
       @config = {}
@@ -55,7 +55,9 @@ module Rubocop
       end
 
       def add_offence(severity, line_number, message)
-        @offences << Offence.new(severity, line_number, message)
+        unless @disabled_lines && @disabled_lines.include?(line_number)
+          @offences << Offence.new(severity, line_number, message)
+        end
       end
 
       private

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -315,6 +315,101 @@ module Rubocop
         expect(YAML.load_file('.rubocop.yml').keys.sort).to eq(cop_names.sort)
       end
 
+      it 'can have all cops disabled in a code section' do
+        File.open('example.rb', 'w') do |f|
+          f.puts '# encoding: utf-8'
+          f.puts '# rubocop:disable all'
+          f.puts '#' * 90
+          f.puts 'x(123456)'
+          f.puts 'y("123")'
+          f.puts 'def func'
+          f.puts '  # rubocop: enable LineLength, StringLiterals'
+          f.puts '  ' + '#' * 93
+          f.puts '  x(123456)'
+          f.puts '  y("123")'
+          f.puts 'end'
+        end
+        begin
+          expect(cli.run(['--emacs', 'example.rb'])).to eq(1)
+          # all cops were disabled, then 2 were enabled again, so we
+          # should get 2 offences reported.
+          expect($stdout.string.uncolored).to eq(
+            ['example.rb:8: C: Line is too long. [95/79]',
+             "example.rb:10: C: Prefer single-quoted strings when you don't " +
+             'need string interpolation or special symbols.',
+             '',
+             '1 files inspected, 2 offences detected',
+             ''].join("\n"))
+        ensure
+          File.delete 'example.rb'
+        end
+      end
+
+      it 'can have selected cops disabled in a code section' do
+        File.open('example.rb', 'w') do |f|
+          f.puts '# encoding: utf-8'
+          f.puts '# rubocop:disable LineLength,NumericLiterals,StringLiterals'
+          f.puts '#' * 90
+          f.puts 'x(123456)'
+          f.puts 'y("123")'
+          f.puts 'def func'
+          f.puts '  # rubocop: enable LineLength, StringLiterals'
+          f.puts '  ' + '#' * 93
+          f.puts '  x(123456)'
+          f.puts '  y("123")'
+          f.puts 'end'
+        end
+        begin
+          expect(cli.run(['--emacs', 'example.rb'])).to eq(1)
+          # 3 cops were disabled, then 2 were enabled again, so we
+          # should get 2 offences reported.
+          expect($stdout.string.uncolored).to eq(
+            ['example.rb:8: C: Line is too long. [95/79]',
+             "example.rb:10: C: Prefer single-quoted strings when you don't " +
+             'need string interpolation or special symbols.',
+             '',
+             '1 files inspected, 2 offences detected',
+             ''].join("\n"))
+        ensure
+          File.delete 'example.rb'
+        end
+      end
+
+      it 'can have all cops disabled on a single line' do
+        File.open('example.rb', 'w') do |f|
+          f.puts '# encoding: utf-8'
+          f.puts 'y("123", 123456) # rubocop:disable all'
+        end
+        begin
+          expect(cli.run(['--emacs', 'example.rb'])).to eq(0)
+          expect($stdout.string.uncolored).to eq(
+            ['',
+             '1 files inspected, 0 offences detected',
+             ''].join("\n"))
+        ensure
+          File.delete 'example.rb'
+        end
+      end
+
+      it 'can have selected cops disabled on a single line' do
+        File.open('example.rb', 'w') do |f|
+          f.puts '# encoding: utf-8'
+          f.puts '#' * 90 + ' # rubocop:disable LineLength'
+          f.puts '#' * 95
+          f.puts 'y("123") # rubocop:disable LineLength,StringLiterals'
+        end
+        begin
+          expect(cli.run(['--emacs', 'example.rb'])).to eq(1)
+          expect($stdout.string.uncolored).to eq(
+            ['example.rb:3: C: Line is too long. [95/79]',
+             '',
+             '1 files inspected, 1 offences detected',
+             ''].join("\n"))
+        ensure
+          File.delete 'example.rb'
+        end
+      end
+
       it 'finds a file with no .rb extension but has a shebang line' do
         FileUtils::mkdir 'test'
         File.open('test/example', 'w') do |f|


### PR DESCRIPTION
Fix for issue #34.
This one includes README and CHANGELOG updates, and support for disabling _all_ cops.
