### PR TITLE
Double alias problem

### DIFF
--- a/lib/rubocop/cop/alias.rb
+++ b/lib/rubocop/cop/alias.rb
@@ -7,8 +7,11 @@ module Rubocop
 
       def inspect(file, source, tokens, sexp)
         each(:alias, sexp) do |s|
-          lineno = s[1][1][1][2].lineno
-
+          if s[1][1].count == 2
+            lineno = s[1][1][1][2].lineno
+          else
+            lineno = s[1][1][2].lineno
+          end
           add_offence(
             :convention,
             lineno,

--- a/spec/rubocop/cops/alias_spec.rb
+++ b/spec/rubocop/cops/alias_spec.rb
@@ -16,6 +16,19 @@ module Rubocop
           .to eq([Alias::ERROR_MESSAGE])
       end
 
+      it 'does not mess with double alias' do
+        culprit = <<-EOS
+    alias has_foo? foo?
+    alias has_bar? bar?
+    EOS
+        inspect_source(a,
+                       'file.rb',
+                       [culprit])
+        expect(a.offences.size).to eq(2)
+        expect(a.offences.map(&:message))
+          .to eq([Alias::ERROR_MESSAGE, Alias::ERROR_MESSAGE])
+      end
+
       it 'does not register an offence for alias_method' do
         inspect_source(a,
                        'file.rb',


### PR DESCRIPTION
Hi...

I've found a bug (#70)... it seems that rubocop (version 0.5.0) doesn't like so much a snippet of code like this one:

``` ruby
alias has_foo? foo?
alias has_bar? bar?
```

I've make a spec (maybe could be useful) and a fix (that is probably too much _naive_) but I hope this could be useful in some way...
