### PR TITLE
New rule: Prefer %w over literal array syntax for an array of strings.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -229,3 +229,7 @@ HandleExceptions:
 # Use only ascii symbols in identifiers and comments.
 AsciiIdentifiersAndComments:
   Enabled: true
+
+# Prefer %w to the literal array syntax when you need an array of strings.
+AvoidLiteralStringArray:
+  Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * New cop `EnsureReturn` tracks usages of `return` in `ensure` blocks.
 * New cop `HandleExceptions` tracks suppressed exceptions
 * New cop `AsciiIdentifiersAndComments` tracks uses of non-ascii characters in identifiers and comments.
+* New cop `AvoidLiteralStringArray` tracks uses of literay array syntax for array of strings.
 
 ### Bugs fixed
 

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -53,6 +53,7 @@ require 'rubocop/cop/brace_after_percent'
 require 'rubocop/cop/ensure_return'
 require 'rubocop/cop/handle_exceptions'
 require 'rubocop/cop/ascii_identifiers_and_comments'
+require 'rubocop/cop/avoid_literal_string_array'
 
 require 'rubocop/report/report'
 require 'rubocop/report/plain_text'

--- a/lib/rubocop/cop/avoid_literal_string_array.rb
+++ b/lib/rubocop/cop/avoid_literal_string_array.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+module Rubocop
+  module Cop
+    class AvoidLiteralStringArray < Cop
+      ERROR_MESSAGE = 'Prefer %w() over literal array syntax for an array of' +
+        ' strings.'
+      LITERAL_ARRAY_REGEX = /^?[ =>]\[(('|")[^('|")]+('|")(, ?)?)+\]/
+
+      def inspect(file, source, tokens, sexp)
+        source.each_with_index do |line, index|
+          add_offence(:convention, index + 1, ERROR_MESSAGE) if line =~
+            LITERAL_ARRAY_REGEX
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cops/avoid_literal_string_array_spec.rb
+++ b/spec/rubocop/cops/avoid_literal_string_array_spec.rb
@@ -1,0 +1,74 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+module Rubocop
+  module Cop
+    describe AvoidLiteralStringArray do
+      let(:string_array) { AvoidLiteralStringArray.new }
+
+      it 'registers an offence for literal string array with double quotes' do
+        inspect_source(string_array,
+                       'file.rb',
+                       ['STATES = ["draft", "open", "closed"]'])
+        expect(string_array.offences.size).to eq(1)
+        expect(string_array.offences.map(&:message))
+          .to eq([AvoidLiteralStringArray::ERROR_MESSAGE])
+      end
+
+      it 'registers an offence for literal string array with single quotes' do
+        inspect_source(string_array,
+                       'file.rb',
+                       ['STATES = [\'draft\', \'open\', \'closed\']'])
+        expect(string_array.offences.size).to eq(1)
+        expect(string_array.offences.map(&:message))
+          .to eq([AvoidLiteralStringArray::ERROR_MESSAGE])
+      end
+
+      it 'registers an offence for literal string array with size 2' do
+        inspect_source(string_array,
+                       'file.rb',
+                       ['STATES = ["draft", "open"]'])
+        expect(string_array.offences.size).to eq(1)
+        expect(string_array.offences.map(&:message))
+          .to eq([AvoidLiteralStringArray::ERROR_MESSAGE])
+      end
+
+      it 'registers an offence for literal string array with size 1' do
+        inspect_source(string_array,
+                       'file.rb',
+                       ['STATES = ["draft"]'])
+        expect(string_array.offences.size).to eq(1)
+        expect(string_array.offences.map(&:message))
+          .to eq([AvoidLiteralStringArray::ERROR_MESSAGE])
+      end
+
+      it 'does not register an offence for literal array for not string' do
+        inspect_source(string_array,
+                       'file.rb',
+                       ['STATES = ["draft", 1, "closed"]'])
+        expect(string_array.offences.size).to eq(0)
+        expect(string_array.offences.map(&:message))
+          .to be_empty
+      end
+      
+      it 'does not register an offence for selecting a value from hash' do
+        inspect_source(string_array,
+                       'file.rb',
+                       ['STATES = Brazil["MG"]'])
+        expect(string_array.offences.size).to eq(0)
+        expect(string_array.offences.map(&:message))
+          .to be_empty
+      end
+
+      it 'does not register an offence for the ideal syntax' do
+        inspect_source(string_array,
+                       'file.rb',
+                       ['STATES = w%(draft open closed)'])
+        expect(string_array.offences.size).to eq(0)
+        expect(string_array.offences.map(&:message))
+          .to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
**VALID EXAMPLES:**
- `STATES = w%(draft open closed)`
- `STATES = brazil["MG"]`
- `STATES = ["draft", 1, "closed"]`

**INVALID EXAMPLES:**
- `STATES = ["draft", "open", "closed"]`
- `STATES = ['draft', 'open', 'closed']`
- `STATES = ["draft", "open"]`
- `STATES = ["draft"]`
