### PR TITLE
New Cop - Number of LOC (lines of code) in method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,11 @@ LineLength:
   Enabled: true
   Max: 79
 
+# Avoid methods longer than 10 lines of code 
+MethodLength:
+  Enabled: true
+  Max: 65
+
 # No hard tabs.
 Tab:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* New cop `MethodLength` tracks number of LOC (lines of code) in methods
 * New cop `RescueModifier` tracks uses of `rescue` in modifier form.
 * New cop `PercentLiterals` tracks uses of `%q`, `%Q`, `%s` and `%x`.
 * New cop `BraceAfterPercent` tracks uses of % literals with

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -56,6 +56,7 @@ require 'rubocop/cop/rescue_exception'
 require 'rubocop/cop/ascii_identifiers_and_comments'
 require 'rubocop/cop/hash_literal'
 require 'rubocop/cop/array_literal'
+require 'rubocop/cop/method_length'
 
 require 'rubocop/report/report'
 require 'rubocop/report/plain_text'

--- a/lib/rubocop/cop/method_length.rb
+++ b/lib/rubocop/cop/method_length.rb
@@ -1,0 +1,46 @@
+# encoding: utf-8
+
+module Rubocop
+  module Cop
+    class MethodLength < Cop
+      ERROR_MESSAGE = 'Method has too many lines. [%d/%d]'
+
+      def inspect(file, source, tokens, sexp)
+        def_token_indices(tokens, source).each do |t_ix|
+          def_lineno, end_lineno = def_and_end_lines(tokens, t_ix)
+          length = source[def_lineno..(end_lineno - 2)].reject(&:empty?).size
+
+          if length > MethodLength.max
+            message = sprintf(ERROR_MESSAGE, length, MethodLength.max)
+            add_offence(:convention, def_lineno, message)
+          end
+        end
+      end
+
+      def self.max
+        MethodLength.config ? MethodLength.config['Max'] || 10 : 10
+      end
+
+      private
+
+      def def_token_indices(tokens, source)
+        tokens.each_index.select do |ix|
+          # Need to check if the previous character is a ':'
+          # to prevent matching ':def' symbols
+          [tokens[ix].type, tokens[ix].text] == [:on_kw, 'def'] &&
+            source[tokens[ix].pos.lineno - 1][tokens[ix].pos.column - 1] != ':'
+        end
+      end
+
+      # Find the matching 'end' based on the indentation of 'def'
+      # Fall back to last token if indentation cannot be matched
+      def def_and_end_lines(tokens, t_ix)
+        t1 = tokens[t_ix]
+        t2 = tokens[(t_ix + 1)..-1].find(-> { tokens[-1] }) do |t|
+          [t1.pos.column, t.type, t.text] == [t.pos.column, :on_kw, 'end']
+        end
+        [t1.pos.lineno, t2.pos.lineno]
+      end
+    end
+  end
+end

--- a/spec/rubocop/cops/method_length_spec.rb
+++ b/spec/rubocop/cops/method_length_spec.rb
@@ -1,0 +1,133 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+module Rubocop
+  module Cop
+    describe MethodLength do
+      let(:method_length) { MethodLength.new }
+      before { MethodLength.stub(:max).and_return(10) }
+
+      it 'rejects a method with more than 10 lines' do
+        inspect_source(method_length, '', ['class K',
+                                           '  def m()',
+                                           '    a = 1',
+                                           '    a = 2',
+                                           '    a = 3',
+                                           '    #a = 4',
+                                           '    a = 5',
+                                           '    a = 6',
+                                           '    a = 7',
+                                           '    a = 8',
+                                           '    #a = 9',
+                                           '    a = 10',
+                                           '    a = 11',
+                                           '  end',
+                                           'end'])
+        expect(method_length.offences.size).to eq(1)
+        expect(method_length.offences.map(&:line_number).sort).to eq([2])
+      end
+
+      it 'accepts a method with less than 10 lines' do
+        inspect_source(method_length, '', ['class K',
+                                           '  def m()',
+                                           '    a = 1',
+                                           '    a = 2',
+                                           '    a = 3',
+                                           '    a = 4',
+                                           '  end',
+                                           'end'])
+        expect(method_length.offences).to be_empty
+      end
+
+      it 'does not count blank lines' do
+        inspect_source(method_length, '', ['class K',
+                                           '  def m()',
+                                           '    a = 1',
+                                           '    a = 2',
+                                           '    a = 3',
+                                           '    a = 4',
+                                           '',
+                                           '',
+                                           '    a = 7',
+                                           '    a = 8',
+                                           '',
+                                           '    a = 10',
+                                           '    a = 11',
+                                           '  end',
+                                           'end'])
+        expect(method_length.offences).to be_empty
+      end
+
+      it 'accepts empty methods' do
+        inspect_source(method_length, '', ['class K',
+                                           '  def m()',
+                                           '  end',
+                                           'end'])
+        expect(method_length.offences).to be_empty
+      end
+
+      it 'checks class methods, syntax #1' do
+        inspect_source(method_length, '', ['class K',
+                                           '  def self.m()',
+                                           '    a = 1',
+                                           '    a = 2',
+                                           '    a = 3',
+                                           '    #a = 4',
+                                           '    a = 5',
+                                           '    a = 6',
+                                           '    a = 7',
+                                           '    a = 8',
+                                           '    #a = 9',
+                                           '    a = 10',
+                                           '    a = 11',
+                                           '  end',
+                                           'end'])
+        expect(method_length.offences.size).to eq(1)
+        expect(method_length.offences.map(&:line_number).sort).to eq([2])
+      end
+
+      it 'checks class methods, syntax #2' do
+        inspect_source(method_length, '', ['class K',
+                                           '  class << self',
+                                           '    def m()',
+                                           '      a = 1',
+                                           '      a = 2',
+                                           '      a = 3',
+                                           '      #a = 4',
+                                           '      a = 5',
+                                           '      a = 6',
+                                           '      a = 7',
+                                           '      a = 8',
+                                           '      #a = 9',
+                                           '      a = 10',
+                                           '      a = 11',
+                                           '    end',
+                                           '  end',
+                                           'end'])
+        expect(method_length.offences.size).to eq(1)
+        expect(method_length.offences.map(&:line_number).sort).to eq([3])
+      end
+
+      it 'properly counts lines when method ends with block' do
+        inspect_source(method_length, '', ['class K',
+                                            '  def m()',
+                                            '    do',
+                                            '      a = 2',
+                                            '      a = 3',
+                                            '      a = 4',
+                                            '      a = 5',
+                                            '      a = 6',
+                                            '      a = 7',
+                                            '      a = 8',
+                                            '      a = 9',
+                                            '      a = 10',
+                                            '    end',
+                                            '  end',
+                                            'end'])
+         expect(method_length.offences.size).to eq(1)
+         expect(method_length.offences.map(&:line_number).sort).to eq([2])
+       end
+    end
+  end
+end


### PR DESCRIPTION
Hey Guys,

I've added this cop as described in #60:
-  Avoid methods longer than 10 LOC (lines of code). Ideally, most methods will be shorter than 5 LOC. Empty lines do not contribute to the relevant LOC. (this cop should have configurable max length)
### Issues
1.  I had to configure the number of LOC limit to 65 in order to get everything passing for the Rubocop source code.  If you'd like, I can go through and refactor/ignore the longer methods, but I wanted to get your opinion first.
2.  2abb4a5 - I had some trouble locating the "end" token that is associated with each "def".  The line counts are conservative in some cases

For example:

``` ruby
def example(a, y)
  if a == y
    puts "yes"
  end
end
```

My code currently finds the line # of the `"yes"` and adds one to it in order to find the `end`.  In this example, though, that guess is incorrect because the `if` statement is closing on the next line.  Like I said, I couldn't think of a way to explicitly find the proper `end`, please let me know if you have any ideas.
I have a pending test for this particular case.

Please be gentle, this is my first open source contribution!  Any feedback or general tips are very much welcome.
Thanks
