### PR TITLE
Method Length Cop - Added option to ingore full line comments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ LineLength:
 # Avoid methods longer than 10 lines of code 
 MethodLength:
   Enabled: true
+  CountComments: false  # count full line comments?
   Max: 65
 
 # No hard tabs.

--- a/spec/rubocop/cops/method_length_spec.rb
+++ b/spec/rubocop/cops/method_length_spec.rb
@@ -6,85 +6,64 @@ module Rubocop
   module Cop
     describe MethodLength do
       let(:method_length) { MethodLength.new }
-      before { MethodLength.stub(:max).and_return(10) }
-
-      it 'rejects a method with more than 10 lines' do
-        inspect_source(method_length, '', ['class K',
-                                           '  def m()',
-                                           '    a = 1',
-                                           '    a = 2',
-                                           '    a = 3',
-                                           '    #a = 4',
-                                           '    a = 5',
-                                           '    a = 6',
-                                           '    a = 7',
-                                           '    a = 8',
-                                           '    #a = 9',
-                                           '    a = 10',
-                                           '    a = 11',
-                                           '  end',
-                                           'end'])
-        expect(method_length.offences.size).to eq(1)
-        expect(method_length.offences.map(&:line_number).sort).to eq([2])
+      before do
+        MethodLength.stub(:max).and_return(5)
+        MethodLength.stub(:count_comments?).and_return(false)
       end
 
-      it 'accepts a method with less than 10 lines' do
-        inspect_source(method_length, '', ['class K',
-                                           '  def m()',
-                                           '    a = 1',
-                                           '    a = 2',
-                                           '    a = 3',
-                                           '    a = 4',
-                                           '  end',
+      it 'rejects a method with more than 5 lines' do
+        inspect_source(method_length, '', ['def m()',
+                                           '  a = 1',
+                                           '  a = 2',
+                                           '  a = 3',
+                                           '  a = 4',
+                                           '  a = 5',
+                                           '  a = 6',
+                                           'end'])
+        expect(method_length.offences.size).to eq(1)
+        expect(method_length.offences.map(&:line_number).sort).to eq([1])
+      end
+
+      it 'accepts a method with less than 5 lines' do
+        inspect_source(method_length, '', ['def m()',
+                                           '  a = 1',
+                                           '  a = 2',
+                                           '  a = 3',
+                                           '  a = 4',
                                            'end'])
         expect(method_length.offences).to be_empty
       end
 
       it 'does not count blank lines' do
-        inspect_source(method_length, '', ['class K',
-                                           '  def m()',
-                                           '    a = 1',
-                                           '    a = 2',
-                                           '    a = 3',
-                                           '    a = 4',
+        inspect_source(method_length, '', ['def m()',
+                                           '  a = 1',
+                                           '  a = 2',
+                                           '  a = 3',
+                                           '  a = 4',
                                            '',
                                            '',
-                                           '    a = 7',
-                                           '    a = 8',
-                                           '',
-                                           '    a = 10',
-                                           '    a = 11',
-                                           '  end',
+                                           '  a = 7',
                                            'end'])
         expect(method_length.offences).to be_empty
       end
 
       it 'accepts empty methods' do
-        inspect_source(method_length, '', ['class K',
-                                           '  def m()',
-                                           '  end',
+        inspect_source(method_length, '', ['def m()',
                                            'end'])
         expect(method_length.offences).to be_empty
       end
 
       it 'checks class methods, syntax #1' do
-        inspect_source(method_length, '', ['class K',
-                                           '  def self.m()',
-                                           '    a = 1',
-                                           '    a = 2',
-                                           '    a = 3',
-                                           '    #a = 4',
-                                           '    a = 5',
-                                           '    a = 6',
-                                           '    a = 7',
-                                           '    a = 8',
-                                           '    #a = 9',
-                                           '    a = 10',
-                                           '    a = 11',
-                                           '  end',
+        inspect_source(method_length, '', ['def self.m()',
+                                           '  a = 1',
+                                           '  a = 2',
+                                           '  a = 3',
+                                           '  a = 4',
+                                           '  a = 5',
+                                           '  a = 6',
                                            'end'])
         expect(method_length.offences.size).to eq(1)
-        expect(method_length.offences.map(&:line_number).sort).to eq([2])
+        expect(method_length.offences.map(&:line_number).sort).to eq([1])
       end
 
       it 'checks class methods, syntax #2' do
@@ -94,14 +73,9 @@ module Rubocop
                                            '      a = 1',
                                            '      a = 2',
                                            '      a = 3',
-                                           '      #a = 4',
+                                           '      a = 4',
                                            '      a = 5',
                                            '      a = 6',
-                                           '      a = 7',
-                                           '      a = 8',
-                                           '      #a = 9',
-                                           '      a = 10',
-                                           '      a = 11',
                                            '    end',
                                            '  end',
                                            'end'])
@@ -110,24 +84,43 @@ module Rubocop
       end
 
       it 'properly counts lines when method ends with block' do
-        inspect_source(method_length, '', ['class K',
-                                            '  def m()',
-                                            '    do',
-                                            '      a = 2',
-                                            '      a = 3',
-                                            '      a = 4',
-                                            '      a = 5',
-                                            '      a = 6',
-                                            '      a = 7',
-                                            '      a = 8',
-                                            '      a = 9',
-                                            '      a = 10',
-                                            '    end',
-                                            '  end',
-                                            'end'])
-         expect(method_length.offences.size).to eq(1)
-         expect(method_length.offences.map(&:line_number).sort).to eq([2])
-       end
+        inspect_source(method_length, '', ['def m()',
+                                           '  do',
+                                           '    a = 2',
+                                           '    a = 3',
+                                           '    a = 4',
+                                           '    a = 5',
+                                           '  end',
+                                           'end'])
+        expect(method_length.offences.size).to eq(1)
+        expect(method_length.offences.map(&:line_number).sort).to eq([1])
+      end
+
+      it 'does not count commented lines by default' do
+        inspect_source(method_length, '', ['def m()',
+                                           '  a = 1',
+                                           '  #a = 2',
+                                           '  a = 3',
+                                           '  #a = 4',
+                                           '  a = 5',
+                                           '  a = 6',
+                                           'end'])
+        expect(method_length.offences).to be_empty
+      end
+
+      it 'has the option of counting commented lines' do
+        MethodLength.stub(:count_comments?).and_return(true)
+        inspect_source(method_length, '', ['def m()',
+                                           '  a = 1',
+                                           '  #a = 2',
+                                           '  a = 3',
+                                           '  #a = 4',
+                                           '  a = 5',
+                                           '  a = 6',
+                                           'end'])
+        expect(method_length.offences.size).to eq(1)
+        expect(method_length.offences.map(&:line_number).sort).to eq([1])
+      end
     end
   end
 end


### PR DESCRIPTION
This gives the option of ignoring comments in the line count.  I don't think it's a good idea to discourage people from commenting code.

I also refactored the tests a bit.
