### PR TITLE
enhance debug mode (-d)

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -42,6 +42,8 @@ module Rubocop
       @configs = {}
 
       target_files(args).each do |file|
+        puts "Scanning #{file}" if $options[:debug]
+
         report = Report.create(file, $options[:mode])
         source = File.readlines(file).map do |line|
           get_rid_of_invalid_byte_sequences(line)


### PR DESCRIPTION
This is just a quick enhancement to the -d

It prints out each file name before it scans the file, that way if there is a crash you can quickly see what file caused it.
