### PR TITLE
MethodLength Cop - ignore one line methods

### DIFF
--- a/lib/rubocop/cop/method_length.rb
+++ b/lib/rubocop/cop/method_length.rb
@@ -34,18 +34,21 @@ module Rubocop
       def calculate_length(def_lineno, end_lineno, source)
         lines = source[def_lineno..(end_lineno - 2)].reject(&:empty?)
         unless MethodLength.count_comments?
-          comment_line = /^\s*#/
-          lines = lines.reject { |l| l.match comment_line }
+          lines = lines.reject { |line| line =~ /^\s*#/ }
         end
         lines.size
       end
 
       def def_token_indices(tokens, source)
         tokens.each_index.select do |ix|
-          # Need to check if the previous character is a ':'
-          # to prevent matching ':def' symbols
-          [tokens[ix].type, tokens[ix].text] == [:on_kw, 'def'] &&
-            source[tokens[ix].pos.lineno - 1][tokens[ix].pos.column - 1] != ':'
+          t = tokens[ix]
+
+          # Need to check:
+          # 1. if the previous character is a ':' to prevent matching ':def'
+          # 2. if the method is a one line, which we will ignore
+          [t.type, t.text] == [:on_kw, 'def'] &&
+            source[t.pos.lineno - 1][t.pos.column - 1] != ':' &&
+            source[t.pos.lineno - 1] !~ /^\s*def.*(?:\(.*\)|;).*end\s*$/
         end
       end
 

--- a/spec/rubocop/cops/method_length_spec.rb
+++ b/spec/rubocop/cops/method_length_spec.rb
@@ -53,8 +53,20 @@ module Rubocop
         expect(method_length.offences).to be_empty
       end
 
-      it 'is not fooled by one-liner methods' do
+      it 'is not fooled by one-liner methods, syntax #1' do
         inspect_source(method_length, '', ['def one_line; 10 end',
+                                           'def self.m()',
+                                           '  a = 1',
+                                           '  a = 2',
+                                           '  a = 4',
+                                           '  a = 5',
+                                           '  a = 6',
+                                           'end'])
+        expect(method_length.offences).to be_empty
+      end
+
+      it 'is not fooled by one-liner methods, syntax #2' do
+        inspect_source(method_length, '', ['def one_line(test) 10 end',
                                            'def self.m()',
                                            '  a = 1',
                                            '  a = 2',


### PR DESCRIPTION
ec55996 

I implemented a regex to fix this.  Is this ok for now?

I may work in a more robust solution at a later time.
