### PR TITLE
fix log exception

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -243,7 +243,7 @@ module Rubocop
 
     def log_error(e, msg='')
       if $options[:debug]
-        error_message = "#{e.class}, #{e.message}"
+        error_message = "#{e.class}, #{e.message if e.respond_to?(:message)}"
         STDERR.puts "#{msg}\t#{error_message}"
       end
     end


### PR DESCRIPTION
I got the following exception when I attempted to run rubocop on one of my projects (Looks like the error didn't have a message?):

```
/Users/ryan/www/gems/rubocop/lib/rubocop/cli.rb:246:in `log_error': undefined method `message' for #<String:0x007ff54b2397c0> (NoMethodError)
from /Users/ryan/www/gems/rubocop/lib/rubocop/cli.rb:234:in `rescue in block in ruby_files'
from /Users/ryan/www/gems/rubocop/lib/rubocop/cli.rb:231:in `block in ruby_files'
from /Users/ryan/www/gems/rubocop/lib/rubocop/cli.rb:229:in `select'
from /Users/ryan/www/gems/rubocop/lib/rubocop/cli.rb:229:in `ruby_files'
from /Users/ryan/www/gems/rubocop/lib/rubocop/cli.rb:200:in `target_files'
from /Users/ryan/www/gems/rubocop/lib/rubocop/cli.rb:44:in `run'
from ../gems/rubocop/bin/rubocop:13:in `block in <main>'
from /Users/ryan/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/benchmark.rb:296:in `realtime'
from ../gems/rubocop/bin/rubocop:12:in `<main>'
```
