### PR TITLE
Don't look at tokens past EOF in SpaceAfterCommaEtc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs fixed
 
 * [#90](https://github.com/bbatsov/rubocop/issues/90) Two cops crash when scanning code using super
+* [#93](https://github.com/bbatsov/rubocop/issues/93) Issue with whitespace?': undefined method
 * [#97](https://github.com/bbatsov/rubocop/issues/97) Build fails
 
 ### Misc

--- a/lib/rubocop/cop/space_after_comma_etc.rb
+++ b/lib/rubocop/cop/space_after_comma_etc.rb
@@ -6,11 +6,10 @@ module Rubocop
       ERROR_MESSAGE = 'Space missing after %s.'
 
       def inspect(file, source, tokens, sexp)
-        tokens.each_index do |ix|
-          t = tokens[ix]
-          if kind(t) && !whitespace?(tokens[ix + 1])
-            add_offence(:convention, t.pos.lineno,
-                        sprintf(ERROR_MESSAGE, kind(t)))
+        tokens.each_cons(2) do |t1, t2|
+          if kind(t1) && !whitespace?(t2)
+            add_offence(:convention, t1.pos.lineno,
+                        sprintf(ERROR_MESSAGE, kind(t1)))
           end
         end
       end

--- a/spec/rubocop/cops/space_after_semicolon_spec.rb
+++ b/spec/rubocop/cops/space_after_semicolon_spec.rb
@@ -12,6 +12,11 @@ module Rubocop
         expect(space.offences.map(&:message)).to eq(
           ['Space missing after semicolon.'])
       end
+
+      it 'does not crash if semicolon is the last character of the file' do
+        inspect_source(space, 'file.rb', ['x = 1;'])
+        expect(space.offences.map(&:message)).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
Solves issue #93. A semicolon as the last character in a an
examined file caused a NoMethodError.
