### PR TITLE
Allow some semicolons for one line definitions.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -203,6 +203,10 @@ VariableInterpolation:
 # Don't use semicolons to terminate expressions.
 Semicolon:
   Enabled: true
+  # For example; def area(height, width); height * width end
+  AllowAfterParameterListInOneLineMethods: false
+  # For example; def area(height, width) height * width; end
+  AllowBeforeEndInOneLineMethods: true
 
 # Use sprintf instead of %
 FavorSprintf:

--- a/lib/rubocop/cop/semicolon.rb
+++ b/lib/rubocop/cop/semicolon.rb
@@ -6,12 +6,90 @@ module Rubocop
       ERROR_MESSAGE = 'Do not use semicolons to terminate expressions.'
 
       def inspect(file, source, tokens, sexp)
-        tokens.each_index do |ix|
-          t = tokens[ix]
+        @tokens = tokens
+        already_checked_line = nil
+        tokens.each_with_index do |t, ix|
           if t.type == :on_semicolon
-            add_offence(:convention, t.pos.lineno, ERROR_MESSAGE)
+            next if t.pos.lineno == already_checked_line # fast-forward
+            token_1_ix = index_of_first_token_on_line(ix, t.pos.lineno)
+            if %w(def class module).include?(tokens[token_1_ix].text)
+              handle_exceptions_to_the_rule(token_1_ix)
+              if source[t.pos.lineno - 1] =~ /;\s*(#.*)?$/
+                # Semicolons at end of a lines are always reported.
+                add_offence(:convention, t.pos.lineno, ERROR_MESSAGE)
+              end
+              # When dealing with these one line definitions, we check
+              # the whole line at once. That's why we use the variable
+              # already_checked_line to know when to fast-forward past
+              # the current line.
+              already_checked_line = t.pos.lineno
+            else
+              add_offence(:convention, t.pos.lineno, ERROR_MESSAGE)
+            end
           end
         end
+      end
+
+      def index_of_first_token_on_line(ix, lineno)
+        # Index of last token on the previous line
+        prev_line_ix =
+          @tokens[0...ix].rindex { |t| t.pos.lineno < lineno } || 0
+        # Index of first non-whitespace token on the current line.
+        prev_line_ix + @tokens[prev_line_ix..ix].index { |t| !whitespace?(t) }
+      end
+
+      def handle_exceptions_to_the_rule(token_1_ix)
+        # We only do further checking of the def case, which means
+        # that there are some cases of semicolon usage within
+        # non-empty one-line class or method definitions that we don't
+        # catch, but these should be rare.
+        if @tokens[token_1_ix].text == 'def'
+          state = :initial
+          @tokens[token_1_ix..-1].each do |t|
+            state = next_state(state, t) || state
+            break if t.text == 'end'
+          end
+        end
+      end
+
+      def next_state(state, token)
+        return nil if whitespace?(token) # no state change for whitespace
+
+        case state
+        when :initial
+          :def_kw if token.type == :on_kw
+        when :def_kw
+          :method_name if token.type == :on_ident
+        when :method_name
+          case token.type
+          when :on_lparen then :inside_param_list
+          when :on_semicolon then :method_body
+          end
+        when :inside_param_list
+          :right_after_param_list if token.type == :on_rparen
+        when :right_after_param_list
+          if token.type == :on_semicolon
+            unless Semicolon.allowed('AfterParameterListInOneLineMethods',
+                                     true)
+              add_offence(:convention, token.pos.lineno, ERROR_MESSAGE)
+            end
+          end
+          :method_body
+        when :method_body
+          :semicolon_used if token.type == :on_semicolon
+        when :semicolon_used
+          if token.text != 'end' ||
+              !Semicolon.allowed('BeforeEndInOneLineMethods', true)
+            add_offence(:convention, token.pos.lineno, ERROR_MESSAGE)
+          end
+          :method_body
+        end
+      end
+
+      def self.allowed(option_name, default_value)
+        return default_value if Semicolon.config.nil?
+        value = Semicolon.config['Allow' + option_name]
+        value.nil? ? default_value : value
       end
     end
   end

--- a/spec/rubocop/cops/semicolon_spec.rb
+++ b/spec/rubocop/cops/semicolon_spec.rb
@@ -24,6 +24,82 @@ module Rubocop
         expect(s.offences.map(&:message))
           .to eq([Semicolon::ERROR_MESSAGE])
       end
+
+      it 'registers an offence for one line method with two statements' do
+        inspect_source(s,
+                       'file.rb',
+                       ['def foo(a) x(1); y(2); z(3); end'])
+        expect(s.offences.size).to eq(2)
+      end
+
+      it 'registers an offence for semicolon before end if so configured' do
+        Semicolon.config = { 'AllowBeforeEndInOneLineMethods' => false }
+        inspect_source(s,
+                       'file.rb',
+                       ['def foo(a) z(3); end'])
+        expect(s.offences.size).to eq(1)
+      end
+
+      it 'accepts semicolon before end if so configured' do
+        Semicolon.config = { 'AllowBeforeEndInOneLineMethods' => true }
+        inspect_source(s,
+                       'file.rb',
+                       ['def foo(a) z(3); end'])
+        expect(s.offences.size).to eq(0)
+      end
+
+      it 'registers an offence for semicolon after params if so configured' do
+        Semicolon.config = {
+          'AllowAfterParameterListInOneLineMethods' => false
+        }
+        inspect_source(s,
+                       'file.rb',
+                       ['def foo(a); y(2); z(3) end',
+                        'def bar(a) y(2); z(3) end'])
+        expect(s.offences.size).to eq(3)
+      end
+
+      it 'accepts semicolon after params if so configured' do
+        Semicolon.config = {
+          'AllowAfterParameterListInOneLineMethods' => true
+        }
+        inspect_source(s,
+                       'file.rb',
+                       ['def foo(a); z(3) end'])
+        expect(s.offences.size).to eq(0)
+      end
+
+      it 'accepts one line method definitions' do
+        inspect_source(s,
+                       'file.rb',
+                       ['def foo1; x(3) end',
+                        'def initialize(*_); end',
+                        'def foo2() x(3); end',
+                        'def foo3; x(3); end'])
+        expect(s.offences.size).to eq(0)
+      end
+
+      it 'accepts one line empty class definitions' do
+        inspect_source(s,
+                       'file.rb',
+                       ['  class Foo < Exception; end',
+                        '  class Bar; end'])
+        expect(s.offences.size).to eq(0)
+      end
+
+      it 'accepts one line empty module definitions' do
+        inspect_source(s,
+                       'file.rb',
+                       ['module Foo; end'])
+        expect(s.offences.size).to eq(0)
+      end
+
+      it 'registers an offence for semicolon at the end no matter what' do
+        inspect_source(s,
+                       'file.rb',
+                       ['module Foo; end;'])
+        expect(s.offences.size).to eq(1)
+      end
     end
   end
 end


### PR DESCRIPTION
This is a fix for #96 that also has some bearing on #77.

Configurable checking of one line methods. Also allowing one line
classes and modules.

This turned out to be complicated. I hope that goes for the problem, and not only my solution. :-)

The PR only modifies the `Semicolon` cop. New cops for reporting use of one line methods etc have not been added yet.
