### PR TITLE
Fix coverage

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,17 @@
 # encoding: utf-8
 
-if ENV['TRAVIS']
-  require 'coveralls'
-  Coveralls.wear!
-elsif ENV['COVERAGE']
+if ENV['TRAVIS'] || ENV['COVERAGE']
   require 'simplecov'
-  SimpleCov.start
+
+  if ENV['TRAVIS']
+    require 'coveralls'
+    SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+  end
+
+  SimpleCov.start do
+    add_filter '/spec/'
+    add_filter '/vendor/bundle/'
+  end
 end
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))


### PR DESCRIPTION
This includes below changes:
- Fix `rake coverage` does not generate report files
  This problem is caused by Coveralls.
  Coveralls uses SimpleCov internally, and it changes SimpleCov.formatter to Coverall's formatter by overwriting standard HTML formatter.
  So disable Coveralls except in Travis environment.
  Anyway Coveralls does nothing outside of Travis currently.
- Exclude spec files from coverage target for accurate coverage result
  Currently the coverage percentage includes spec files.
  This is not accurate for coverage metrics.
  https://coveralls.io/builds/25201
