### PR TITLE
Fix undefined method `[]' for nil:NilClass from rspec -e.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,10 @@ require 'rubocop/cli'
 # disable colors in specs
 Sickill::Rainbow.enabled = false
 
+# Make sure $options is set for all specs. Important when running
+# rspec -e something.
+$options = {}
+
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }


### PR DESCRIPTION
`$options` was only set in `CLI#run` so running only non-CLI spec examples
could fail because `$options` was nil when the array index operator was
called on it.

This solution is different from [my previous attempt](https://github.com/bbatsov/rubocop/pull/105/files#diff-2). The problem only occurs when running specs so now the solution is under `specs/`.
