### PR TITLE
New rule: Avoid single-line methods.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -275,3 +275,8 @@ FavorPercentR:
 # Use self when defining module/class methods.
 ClassMethods:
   Enabled: true
+
+# Avoid single-line methods.
+SingleLineMethods:
+  Enabled: true
+  AllowIfMethodIsEmpty: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Relax semicolon rule for one line methods, classes and modules
 * New cop ClassMethods checks for uses for class/module names in definitions of class/module methods
+* New cop SingleLineMethods checks for methods implemented on a single line
 
 ### Bugs fixed
 

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -59,6 +59,7 @@ require 'rubocop/cop/reduce_arguments'
 require 'rubocop/cop/percent_r'
 require 'rubocop/cop/favor_percent_r'
 require 'rubocop/cop/class_methods'
+require 'rubocop/cop/single_line_methods'
 
 require 'rubocop/report/report'
 require 'rubocop/report/plain_text'

--- a/lib/rubocop/cop/single_line_methods.rb
+++ b/lib/rubocop/cop/single_line_methods.rb
@@ -1,0 +1,63 @@
+# encoding: utf-8
+
+module Rubocop
+  module Cop
+    class SingleLineMethods < Cop
+      ERROR_MESSAGE = 'Avoid single-line methods.'
+
+      def inspect(file, source, tokens, sexp)
+        if SingleLineMethods.allow_if_method_is_empty
+          is_empty = empty_methods(sexp)
+        end
+
+        lineno_of_def = nil
+        possible_offence = false
+
+        tokens.each_with_index do |token, ix|
+          if possible_offence
+            if token.pos.lineno > lineno_of_def
+              possible_offence = false
+            elsif [token.type, token.text] == [:on_kw, 'end']
+              add_offence(:convention, lineno_of_def, ERROR_MESSAGE)
+            end
+          end
+
+          if [token.type, token.text] == [:on_kw, 'def']
+            lineno_of_def = token.pos.lineno
+            name_pos = tokens[ix..-1].find { |t| t.type == :on_ident }.pos
+            possible_offence = if SingleLineMethods.allow_if_method_is_empty
+                                 !is_empty[name_pos]
+                               else
+                                 true
+                               end
+          end
+        end
+      end
+
+      def self.allow_if_method_is_empty
+        return true if SingleLineMethods.config.nil?
+        allow = SingleLineMethods.config['AllowIfMethodIsEmpty']
+        allow.nil? || allow
+      end
+
+      private
+
+      # Returns a hash mapping positions of method names to booleans
+      # saying whether or not the method is empty.
+      def empty_methods(sexp)
+        is_empty = {}
+        # Since def is a keyword, def: can confuse the editor. Hence
+        # Ruby 1.8 hash syntax is used here.
+        # rubocop:disable HashSyntax
+        { :def => [1, 3], :defs => [3, 5] }.each do |key, offsets|
+          each(key, sexp) do |d|
+            method_name_pos = d[offsets.first][-1]
+            is_empty[method_name_pos] =
+              (d[offsets.last] == [:bodystmt, [[:void_stmt]], nil, nil, nil])
+          end
+        end
+        is_empty
+      end
+    end
+  end
+end

--- a/spec/rubocop/cops/single_line_methods_spec.rb
+++ b/spec/rubocop/cops/single_line_methods_spec.rb
@@ -1,0 +1,49 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+module Rubocop
+  module Cop
+    describe SingleLineMethods do
+      let(:slm) { SingleLineMethods.new }
+
+      it 'registers an offence for a single-line method' do
+        inspect_source(slm, '',
+                       ['def some_method; body end',
+                        'def link_to(name, url); {:name => name}; end',
+                        'def @table.columns; super; end'])
+        expect(slm.offences.map(&:message)).to eq(
+          [SingleLineMethods::ERROR_MESSAGE] * 3)
+      end
+
+      it 'registers an offence for an empty method if so configured' do
+        SingleLineMethods.config = { 'AllowIfMethodIsEmpty' => false }
+        inspect_source(slm, '', ['def no_op; end',
+                                 'def self.resource_class=(klass); end',
+                                 'def @table.columns; end'])
+        expect(slm.offences.size).to eq(3)
+      end
+
+      it 'accepts a single-line empty method if so configured' do
+        SingleLineMethods.config = { 'AllowIfMethodIsEmpty' => true }
+        inspect_source(slm, '', ['def no_op; end',
+                                 'def self.resource_class=(klass); end',
+                                 'def @table.columns; end'])
+        expect(slm.offences).to be_empty
+      end
+
+      it 'accepts a single-line empty method by default' do
+        SingleLineMethods.config = {}
+        inspect_source(slm, '', ['def no_op; end'])
+        expect(slm.offences).to be_empty
+      end
+
+      it 'accepts a multi-line method' do
+        inspect_source(slm, '', ['def some_method',
+                                 '  body',
+                                 'end'])
+        expect(slm.offences).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix for #77.

SingleLineMethods reports methods implemented on a single line. It has
a configuration option called AllowIfMethodIsEmpty, which is true by
default.
