### PR TITLE
New rule: use spaces inside hash literal braces, or don't.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -296,3 +296,8 @@ SingleLineMethods:
 # Use %w or %W for arrays of words.
 WordArray:
   Enabled: true
+
+# Use spaces inside hash literal braces - or don't.
+SpaceInsideHashLiteralBraces:
+  Enabled: true
+  EnforcedStyleIsWithSpaces: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * New cop `BlockComments` tracks uses of block comments(`=begin/=end` comments)
 * New cop `EmptyLines` tracks consecutive blank lines
 * New cop `WordArray` tracks arrays of words.
+* [#108](https://github.com/bbatsov/rubocop/issues/108) New cop `SpaceInsideHashLiteralBraces` checks for spaces inside hash literal braces - style is configurable
 
 ### Bugs fixed
 

--- a/lib/rubocop/cop/grammar.rb
+++ b/lib/rubocop/cop/grammar.rb
@@ -18,6 +18,7 @@ module Rubocop
         @special = {
           assign:      [[:on_op,     '=']],
           brace_block: [[:on_lbrace, '{']],
+          hash:        [[:on_lbrace, '{']],
           ifop:        [[:on_op, '?'], [:on_op, ':']]
         }
       end

--- a/spec/rubocop/cops/brace_after_percent_spec.rb
+++ b/spec/rubocop/cops/brace_after_percent_spec.rb
@@ -10,7 +10,7 @@ module Rubocop
 
       literals.each do |literal|
         # %i and %I are new in ruby 2.0
-        tag = literal.downcase == 'i' ? {ruby: 2.0} : {}
+        tag = literal.downcase == 'i' ? { ruby: 2.0 } : {}
 
         it "registers an offence for %#{literal}[", tag  do
           inspect_source(bap,

--- a/spec/rubocop/cops/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cops/space_inside_hash_literal_braces_spec.rb
@@ -1,0 +1,80 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+module Rubocop
+  module Cop
+    describe SpaceInsideHashLiteralBraces do
+      let(:sihlb) { SpaceInsideHashLiteralBraces.new }
+
+      it 'registers an offence for hashes with no spaces by default' do
+        SpaceInsideHashLiteralBraces.config = {}
+        inspect_source(sihlb, '',
+                       ['h = {a: 1, b: 2}',
+                        'h = {a => 1 }'])
+        expect(sihlb.offences.map(&:message)).to eq(
+          ['Space inside hash literal braces missing.'] * 3)
+      end
+
+      it 'registers an offence for hashes with no spaces if so configured' do
+        SpaceInsideHashLiteralBraces.config = {
+          'EnforcedStyleIsWithSpaces' => true
+        }
+        inspect_source(sihlb, '',
+                       ['h = {a: 1, b: 2}',
+                        'h = {a => 1 }'])
+        expect(sihlb.offences.map(&:message)).to eq(
+          ['Space inside hash literal braces missing.'] * 3)
+      end
+
+      it 'registers an offence for hashes with spaces if so configured' do
+        SpaceInsideHashLiteralBraces.config = {
+          'EnforcedStyleIsWithSpaces' => false
+        }
+        inspect_source(sihlb, '',
+                       ['h = { a: 1, b: 2 }'])
+        expect(sihlb.offences.map(&:message)).to eq(
+          ['Space inside hash literal braces detected.'] * 2)
+      end
+
+      it 'accepts hashes with spaces by default' do
+        SpaceInsideHashLiteralBraces.config = nil
+        inspect_source(sihlb, '',
+                       ['h = { a: 1, b: 2 }',
+                        'h = { a => 1 }'])
+        expect(sihlb.offences.map(&:message)).to be_empty
+      end
+
+      it 'accepts hashes with no spaces if so configured' do
+        SpaceInsideHashLiteralBraces.config = {
+          'EnforcedStyleIsWithSpaces' => false
+        }
+        inspect_source(sihlb, '',
+                       ['h = {a: 1, b: 2}',
+                        'h = {a => 1}'])
+        expect(sihlb.offences.map(&:message)).to be_empty
+      end
+
+      it 'accepts empty hashes without spaces by default' do
+        inspect_source(sihlb, '', ['h = {}'])
+        expect(sihlb.offences).to be_empty
+      end
+
+      it 'accepts empty hashes without spaces if configured false' do
+        SpaceInsideHashLiteralBraces.config = {
+          'EnforcedStyleIsWithSpaces' => false
+        }
+        inspect_source(sihlb, '', ['h = {}'])
+        expect(sihlb.offences).to be_empty
+      end
+
+      it 'accepts empty hashes without spaces even if configured true' do
+        SpaceInsideHashLiteralBraces.config = {
+          'EnforcedStyleIsWithSpaces' => true
+        }
+        inspect_source(sihlb, '', ['h = {}'])
+        expect(sihlb.offences).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Which style to use is configurable. Default is with spaces. Fixes #108.

I named the cop class and configuration option differently from the suggestion, to improve consistency with other surrounding space cops, and for clarity.
