### PR TITLE
Issue warning when configuration contains an unrecognized name.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,11 @@
 # This is the default configuration file with all checking enabled. It is also
 # the configuration used to check the rubocop source code.
 
+# Common configuration.
+AllCops:
+  # Directories that are not checked.
+  NoGoZone: []
+
 # Use UTF-8 as the source file encoding.
 Encoding:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#108](https://github.com/bbatsov/rubocop/issues/108) New cop `SpaceInsideHashLiteralBraces` checks for spaces inside hash literal braces - style is configurable
 * New cop `LineContinuation` tracks uses of the line continuation character (`\`)
 * New cop `SymbolArray` tracks arrays of symbols.
+* Print warnings for unrecognized names in configuration files.
 
 ### Bugs fixed
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -233,7 +233,7 @@ module Rubocop
           f.puts('Encoding:',
                  '  Enabled: false',
                  '',
-                 'Indentation:',
+                 'CaseIndentation:',
                  '  Enabled: false')
         end
         begin
@@ -257,7 +257,7 @@ module Rubocop
           f.puts('Encoding:',
                  '  Enabled: false',
                  '',
-                 'Indentation:',
+                 'CaseIndentation:',
                  '  Enabled: false')
         end
         begin
@@ -381,6 +381,62 @@ module Rubocop
         end
       end
 
+      it 'prints a warning for an unrecognized cop name in .rubocop.yml' do
+        FileUtils.mkdir_p 'example'
+        File.open('example/example1.rb', 'w') do |f|
+          f.puts '# encoding: utf-8'
+          f.puts '#' * 90
+        end
+
+        File.open('example/.rubocop.yml', 'w') do |f|
+          f.puts('LyneLenth:',
+                 '  Enabled: true',
+                 '  Max: 100')
+        end
+
+        begin
+          expect(cli.run(['example'])).to eq(1)
+          expect($stdout.string).to eq(
+            ['Warning: unrecognized cop LyneLenth found in example/' +
+             '.rubocop.yml',
+             '== example/example1.rb ==',
+             'C:  2: Line is too long. [90/79]',
+             '',
+             '1 file inspected, 1 offence detected',
+             ''].join("\n"))
+        ensure
+          FileUtils.rm_rf 'example'
+        end
+      end
+
+      it 'prints a warning for an unrecognized configuration parameter' do
+        FileUtils.mkdir_p 'example'
+        File.open('example/example1.rb', 'w') do |f|
+          f.puts '# encoding: utf-8'
+          f.puts '#' * 90
+        end
+
+        File.open('example/.rubocop.yml', 'w') do |f|
+          f.puts('LineLength:',
+                 '  Enabled: true',
+                 '  Min: 10')
+        end
+
+        begin
+          expect(cli.run(['example'])).to eq(1)
+          expect($stdout.string).to eq(
+            ['Warning: unrecognized parameter LineLength:Min found in ' +
+             'example/.rubocop.yml',
+             '== example/example1.rb ==',
+             'C:  2: Line is too long. [90/79]',
+             '',
+             '1 file inspected, 1 offence detected',
+             ''].join("\n"))
+        ensure
+          FileUtils.rm_rf 'example'
+        end
+      end
+
       it 'finds no violations when checking the rubocop source code' do
         # Need to pass an empty array explicitly
         # so that the CLI does not refer arguments of `rspec`
@@ -426,7 +482,8 @@ module Rubocop
         cop_names = Cop::Cop.all.map do |cop_class|
           cop_class.name.split('::').last
         end
-        expect(YAML.load_file('.rubocop.yml').keys.sort).to eq(cop_names.sort)
+        expect(YAML.load_file('.rubocop.yml').keys.sort)
+          .to eq((['AllCops'] + cop_names).sort)
       end
 
       it 'can have all cops disabled in a code section' do


### PR DESCRIPTION
Check cop names and parameter names. Fixes part of #116.
