### PR TITLE
Fix random failure spec

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -124,8 +124,8 @@ module Rubocop
       Signal.trap('INT') do
         exit!(1) if wants_to_quit?
         self.wants_to_quit = true
-        STDERR.puts
-        STDERR.puts 'Exiting... Interrupt again to exit immediately.'
+        $stderr.puts
+        $stderr.puts 'Exiting... Interrupt again to exit immediately.'
       end
     end
 


### PR DESCRIPTION
This is about the random failure specs for interruption with Ctrl-C, failed in #120.
https://travis-ci.org/bbatsov/rubocop/jobs/6877252

The specs were testing real behavior by running rubocop as a child process.
However it seems to be unstable and also cannot be measured in coverage report.
So rewrote them to run in another thread with some stubs and mocks.

I've run rewroted specs 100 times and no failure on OS X 10.8.3 and Travis.
https://travis-ci.org/yujinakayama/rubocop/builds/6883265
