### PR TITLE
move cache responsibilities to config_store.rb

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -79,6 +79,7 @@ require 'rubocop/report/report'
 require 'rubocop/report/plain_text'
 require 'rubocop/report/emacs_style'
 
-require 'rubocop/configuration'
+require 'rubocop/config'
+require 'rubocop/config_store'
 require 'rubocop/cli'
 require 'rubocop/version'

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 require 'pathname'
 require 'optparse'
-require 'yaml'
 require_relative 'cop/grammar'
 
 module Rubocop
@@ -21,7 +20,7 @@ module Rubocop
       @total_offences = 0
       @errors_count = 0
       @options = { mode: :default }
-      Configuration.prepare
+      ConfigStore.prepare
     end
 
     # Entry point for the application logic. Here we
@@ -43,7 +42,7 @@ module Rubocop
       target_files(args).each do |file|
         break if wants_to_quit?
 
-        config = Configuration.for(file)
+        config = ConfigStore.for(file)
         report = Report.create(file, @options[:mode])
         source = read_source(file)
 
@@ -124,7 +123,7 @@ module Rubocop
         end
         opts.on('-c FILE', '--config FILE', 'Configuration file') do |f|
           @options[:config] = f
-          Configuration.set_options_config(@options[:config])
+          ConfigStore.set_options_config(@options[:config])
         end
         opts.on('--only COP', 'Run just one cop') do |s|
           @options[:only] = s
@@ -267,12 +266,12 @@ module Rubocop
       end
 
       rb += files.select do |file|
-        config = Configuration.for(file)
+        config = ConfigStore.for(file)
         config.file_to_include?(file)
       end
 
       rb.reject do |file|
-        config = Configuration.for(file)
+        config = ConfigStore.for(file)
         config.file_to_exclude?(file)
       end.uniq
     end

--- a/lib/rubocop/config_store.rb
+++ b/lib/rubocop/config_store.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+
+module Rubocop
+  module ConfigStore
+    module_function
+
+    def prepare
+      # @options_config stores a config that is specified in the command line.
+      # This takes precedence over configs located in any directories
+      @options_config = nil
+
+      # @config_cache is a cache that maps directories to
+      # configurations. We search for .rubocop.yml only if we haven't
+      # already found it for the given directory.
+      @config_cache = {}
+    end
+
+    def set_options_config(options_config)
+      @options_config = Config.load_file(options_config)
+    end
+
+    def for(file)
+      return @options_config if @options_config
+
+      dir = File.dirname(file)
+      return @config_cache[dir] if @config_cache[dir]
+
+      config = Config.configuration_for_path(dir)
+      @config_cache[dir] = config if config
+
+      config or Config.new
+    end
+  end
+end

--- a/spec/rubocop/config_store_spec.rb
+++ b/spec/rubocop/config_store_spec.rb
@@ -1,0 +1,51 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+module Rubocop
+  describe ConfigStore do
+    before(:each) { ConfigStore.prepare }
+    before do
+      Config.stub(:configuration_for_path) { nil }
+      Config.stub(:configuration_for_path).with('valid') { :config }
+      Config.stub(:load_file) { |arg| "#{arg}_loaded" }
+      Config.stub(:default_config) { :default_config }
+    end
+
+    describe '.prepare' do
+      it 'resets @options_config' do
+        ConfigStore.set_options_config(:options_config)
+        ConfigStore.prepare
+        Config.should_receive(:new)
+        ConfigStore.for('invalid/file')
+      end
+
+      it 'resets @config_cache' do
+        ConfigStore.for('valid/file')
+        ConfigStore.prepare
+        Config.should_receive(:configuration_for_path)
+        ConfigStore.for('valid/file')
+      end
+    end
+
+    describe '.for' do
+      it 'always uses config specified in command line' do
+        ConfigStore.set_options_config(:options_config)
+        expect(ConfigStore.for('valid/file')).to eq('options_config_loaded')
+      end
+
+      context 'when no config specified in command line' do
+        it 'gets config from cache if available' do
+          ConfigStore.for('valid/file')
+          Config.should_not_receive(:configuration_for_path)
+          ConfigStore.for('valid/file')
+        end
+
+        it 'searches for config if not available in cache' do
+          Config.should_receive(:configuration_for_path)
+          ConfigStore.for('valid/file')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This continues refactoring the configuration functionality.
-  It adds a singleton class `ConfigCache` that is responsible for selecting which `Config` instance is used for a given file.
-  For consistency with the new class and brevity, `Configuration` is renamed to `Config`
-  We no longer need to require `yaml` in `CLI`

Hopefully we can continue to improve the `Config` and `ConfigCache` classes and tests, and then we won't have to do so much fine grained testing for the CLI class (so we can more easily add additional functionality to CLI later on).
