### PR TITLE
Add --only option for running a single cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * Added ability to include or exclude files/directories through `.rubocop.yml`
+* Added option --only for running a single cop.
 * Relax semicolon rule for one line methods, classes and modules
 * New cop `ClassMethods` checks for uses for class/module names in definitions of class/module methods
 * New cop `SingleLineMethods` checks for methods implemented on a single line

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Command flag       | Description
 `-e/--emacs`       | Output the results in Emacs format
 `-c/--config`      | Run with specified config file
 `-s/--silent`      | Suppress the final summary
+`--only`           | Run only the specified cop
 
 ## Configuration
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -33,6 +33,13 @@ module Rubocop
 
       parse_options(args)
 
+      begin
+        handle_only_option if @options[:only]
+      rescue ArgumentError => e
+        puts e.message
+        return 1
+      end
+
       target_files(args).each do |file|
         break if wants_to_quit?
 
@@ -64,6 +71,13 @@ module Rubocop
       end
 
       (@total_offences == 0) && !wants_to_quit ? 0 : 1
+    end
+
+    def handle_only_option
+      @cops = @cops.select { |c| c.cop_name == @options[:only] }
+      if @cops.empty?
+        fail ArgumentError, "Unrecognized cop name: #{@options[:only]}."
+      end
     end
 
     def read_source(file)
@@ -111,6 +125,9 @@ module Rubocop
         opts.on('-c FILE', '--config FILE', 'Configuration file') do |f|
           @options[:config] = f
           Configuration.set_options_config(@options[:config])
+        end
+        opts.on('--only COP', 'Run just one cop') do |s|
+          @options[:only] = s
         end
         opts.on('-s', '--silent', 'Silence summary') do |s|
           @options[:silent] = s

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -19,6 +19,7 @@ module Rubocop
                  '    -d, --debug                      Display debug info',
                  '    -e, --emacs                      Emacs style output',
                  '    -c, --config FILE                Configuration file',
+                 '        --only COP                   Run just one cop',
                  '    -s, --silent                     Silence summary',
                  '    -n, --no-color                   Disable color output',
                  '    -v, --version                    Display version']
@@ -172,6 +173,26 @@ module Rubocop
          '',
          '2 files inspected, 4 offences detected',
          ''].join("\n"))
+    end
+
+    it 'runs just one cop if --only is passed' do
+      create_file('example.rb', [
+        'x= 0 ',
+        'y '
+      ])
+      expect(cli.run(['--only', 'TrailingWhitespace', 'example.rb'])).to eq(1)
+      expect($stdout.string)
+        .to eq(['== example.rb ==',
+                'C:  1: Trailing whitespace detected.',
+                'C:  2: Trailing whitespace detected.',
+                '',
+                '1 file inspected, 2 offences detected',
+                ''].join("\n"))
+    end
+
+    it 'exits with error if an incorrect cop name is passed to --only' do
+      expect(cli.run(['--only', '123'])).to eq(1)
+      expect($stdout.string).to eq("Unrecognized cop name: 123.\n")
     end
 
     it 'ommits summary when --silent passed', ruby: 1.9 do


### PR DESCRIPTION
I found that I needed this while hunting down crashes. I chose not to "use up" -o since this is not an option most people will use frequently, so just the long option name.
