### PR TITLE
Fix SymbolArray cop is not disabled by default

### DIFF
--- a/lib/rubocop/configuration.rb
+++ b/lib/rubocop/configuration.rb
@@ -13,6 +13,15 @@ module Rubocop
                                                    '..',
                                                    '..',
                                                    DOTFILE))
+
+    # Probably we should find a better way.
+    # https://github.com/bbatsov/rubocop/issues/137
+    DEFAULT_CONFIGURATION = {
+      'SymbolArray' => {
+        'Enabled' => false
+      }
+    }.freeze
+
     DEFAULT_PATTERNS_TO_INCLUDE = ['**/*.gemspec', '**/Rakefile']
     DEFAULT_PATTERNS_TO_EXCLUDE = []
 
@@ -87,9 +96,9 @@ module Rubocop
     end
 
     def initialize(hash = {}, loaded_path = nil)
-      super(hash)
-      @hash = hash
+      @hash = DEFAULT_CONFIGURATION.merge(hash)
       @loaded_path = loaded_path
+      super(@hash)
     end
 
     def for_cop(cop)

--- a/spec/rubocop/configuration_spec.rb
+++ b/spec/rubocop/configuration_spec.rb
@@ -9,6 +9,8 @@ describe Rubocop::Configuration do
   let(:hash) { {} }
   let(:loaded_path) { 'example/.rubocop.yml' }
 
+  before { Rubocop::Configuration.prepare }
+
   describe '.configuration_for_path', :isolated_environment do
     subject(:configuration_for_path) do
       Rubocop::Configuration.configuration_for_path(file_path)
@@ -269,6 +271,41 @@ describe Rubocop::Configuration do
     context 'when config file does not have AllCops => Excludes key' do
       it 'returns an empty array' do
         expect(patterns_to_exclude).to be_empty
+      end
+    end
+  end
+
+  describe 'configuration for SymbolArray', :isolated_environment do
+    before do
+      create_file('example.rb', '# encoding: utf-8')
+    end
+
+    context 'when no config file exists for the target file' do
+      it 'is disabled' do
+        configuration = Rubocop::Configuration.for('example.rb')
+        expect(configuration.cop_enabled?('SymbolArray')).to be_false
+      end
+    end
+
+    context 'when a config file which does not mention SymbolArray exists' do
+      it 'is disabled' do
+        create_file('.rubocop.yml', [
+          'LineLength:',
+          '  Max: 79'
+        ])
+        configuration = Rubocop::Configuration.for('example.rb')
+        expect(configuration.cop_enabled?('SymbolArray')).to be_false
+      end
+    end
+
+    context 'when a config file which explicitly enables SymbolArray exists' do
+      it 'is enabled' do
+        create_file('.rubocop.yml', [
+          'SymbolArray:',
+          '  Enabled: true'
+        ])
+        configuration = Rubocop::Configuration.for('example.rb')
+        expect(configuration.cop_enabled?('SymbolArray')).to be_true
       end
     end
   end


### PR DESCRIPTION
This fixes #137.
I think this is not elegant way, but properly fixes the bug for now.

I'm not updating changelog because SymbolArray is not yet released.
