### PR TITLE
Handle method names with a capital initial.

### DIFF
--- a/lib/rubocop/cop/method_and_variable_snake_case.rb
+++ b/lib/rubocop/cop/method_and_variable_snake_case.rb
@@ -5,25 +5,26 @@ module Rubocop
     class MethodAndVariableSnakeCase < Cop
       ERROR_MESSAGE = 'Use snake_case for methods and variables.'
       SNAKE_CASE = /^@?[\da-z_]+[!?=]?$/
+      CONSTANT = /^[A-Z]/
 
       def inspect(file, source, tokens, sexp)
-        each(:def, sexp) { |s| check(s[1]) }
+        each(:def, sexp) { |s| check(*s[1]) }
 
         each(:assign, sexp) do |s|
           case s[1][0]
           when :var_field
-            check(s[1][1])
+            check(*s[1][1]) unless s[1][1][1] =~ CONSTANT
           when :field
             if s[1][1][0] == :var_ref && s[1][1][1][0..1] == [:@kw, 'self']
-              check(s[1][3])
+              check(*s[1][3])
             end
           end
         end
       end
 
-      def check(sexp)
-        if [:@ivar, :@ident].include?(sexp[0]) && sexp[1] !~ SNAKE_CASE
-          add_offence(:convention, sexp[2].lineno, ERROR_MESSAGE)
+      def check(type, name, pos)
+        if [:@ivar, :@ident, :@const].include?(type) && name !~ SNAKE_CASE
+          add_offence(:convention, pos.lineno, ERROR_MESSAGE)
         end
       end
     end

--- a/lib/rubocop/cop/single_line_methods.rb
+++ b/lib/rubocop/cop/single_line_methods.rb
@@ -24,10 +24,12 @@ module Rubocop
 
           if [token.type, token.text] == [:on_kw, 'def']
             lineno_of_def = token.pos.lineno
-            name_pos = tokens[ix..-1].find { |t| t.type == :on_ident }.pos
+            name_token = tokens[ix..-1].find do |t|
+              [:on_ident, :on_const].include?(t.type)
+            end
             possible_offence =
               if SingleLineMethods.config['AllowIfMethodIsEmpty']
-                !is_empty[name_pos]
+                !is_empty[name_token.pos]
               else
                 true
               end

--- a/lib/rubocop/cop/trivial_accessors.rb
+++ b/lib/rubocop/cop/trivial_accessors.rb
@@ -70,7 +70,7 @@ module Rubocop
 
       # return true if the sexp has the common shape of an accessor
       def accessor_shape?(sexp)
-        sexp[1][0] == :@ident &&
+        [:@ident, :@const].include?(sexp[1][0]) &&
         sexp[3][0] == :bodystmt &&
         !NON_TRIVIAL_BODYSTMT.include?(sexp[3][1][0][0])
       end

--- a/spec/rubocop/cops/method_and_variable_snake_case_spec.rb
+++ b/spec/rubocop/cops/method_and_variable_snake_case_spec.rb
@@ -19,6 +19,15 @@ module Rubocop
           ['Use snake_case for methods and variables.'] * 4)
       end
 
+      it 'registers an offence for capitalized camel case' do
+        inspect_source(snake_case, 'file.rb',
+                       ['def MyMethod',
+                        'end',
+                       ])
+        expect(snake_case.offences.map(&:message)).to eq(
+          ['Use snake_case for methods and variables.'])
+      end
+
       it 'accepts snake case in names' do
         inspect_source(snake_case, 'file.rb',
                        ['def my_method',
@@ -40,6 +49,17 @@ module Rubocop
 
       it 'accepts screaming snake case globals' do
         inspect_source(snake_case, 'file.rb', ['$MY_GLOBAL = 0'])
+        expect(snake_case.offences.map(&:message)).to be_empty
+      end
+
+      it 'accepts screaming snake case constants' do
+        inspect_source(snake_case, 'file.rb', ['MY_CONSTANT = 0'])
+        expect(snake_case.offences.map(&:message)).to be_empty
+      end
+
+      it 'accepts assigning to camel case constant' do
+        inspect_source(snake_case, 'file.rb',
+                       ['Paren = Struct.new :left, :right, :kind'])
         expect(snake_case.offences.map(&:message)).to be_empty
       end
     end

--- a/spec/rubocop/cops/single_line_methods_spec.rb
+++ b/spec/rubocop/cops/single_line_methods_spec.rb
@@ -39,6 +39,12 @@ module Rubocop
                                  'end'])
         expect(slm.offences).to be_empty
       end
+
+      it 'does not crash on an method with a capitalized name' do
+        inspect_source(slm, '', ['def NoSnakeCase',
+                                 'end'])
+        expect(slm.offences).to be_empty
+      end
     end
   end
 end

--- a/spec/rubocop/cops/trivial_accessors_spec.rb
+++ b/spec/rubocop/cops/trivial_accessors_spec.rb
@@ -11,17 +11,21 @@ module Rubocop
         trivial_accessors_finder.offences.clear
       end
 
-      it 'find trivial reader' do
+      it 'finds trivial reader' do
         inspect_source(trivial_accessors_finder, '',
                        ['def foo',
                         '  @foo',
+                        'end',
+                        '',
+                        'def Foo',
+                        '  @Foo',
                         'end'])
-        expect(trivial_accessors_finder.offences.size).to eq(1)
+        expect(trivial_accessors_finder.offences.size).to eq(2)
         expect(trivial_accessors_finder.offences
-                 .map(&:line_number).sort).to eq([1])
+                 .map(&:line_number).sort).to eq([1, 5])
       end
 
-      it 'find trivial reader in a class' do
+      it 'finds trivial reader in a class' do
         inspect_source(trivial_accessors_finder, '',
                        ['class TrivialFoo',
                         '  def foo',
@@ -36,7 +40,7 @@ module Rubocop
                  .map(&:line_number).sort).to eq([2])
       end
 
-      it 'find trivial reader in a nested class' do
+      it 'finds trivial reader in a nested class' do
         inspect_source(trivial_accessors_finder, '',
                        ['class TrivialFoo',
                         '  class Nested',
@@ -50,7 +54,7 @@ module Rubocop
                  .map(&:line_number).sort).to eq([3])
       end
 
-      it 'find trivial readers in a little less trivial class' do
+      it 'finds trivial readers in a little less trivial class' do
         inspect_source(trivial_accessors_finder, '',
                        ['class TrivialFoo',
                         '  def foo',
@@ -110,7 +114,7 @@ module Rubocop
                  .map(&:line_number).sort).to eq([2, 8])
       end
 
-      it 'find trivial reader with braces' do
+      it 'finds trivial reader with braces' do
         inspect_source(trivial_accessors_finder, '',
                        ['class Test',
                         '  # trivial reader with braces',
@@ -123,7 +127,7 @@ module Rubocop
                  .map(&:line_number).sort).to eq([3])
       end
 
-      it 'find trivial writer without braces' do
+      it 'finds trivial writer without braces' do
         inspect_source(trivial_accessors_finder, '',
                        ['class Test',
                         '  # trivial writer without braces',
@@ -148,7 +152,7 @@ module Rubocop
         expect(trivial_accessors_finder.offences).to be_empty
       end
 
-      it 'find trivials with less peculiar methods' do
+      it 'finds trivials with less peculiar methods' do
         inspect_source(trivial_accessors_finder, '',
                        ['class NilStats',
                         'def most_traded_pair',
@@ -190,7 +194,7 @@ module Rubocop
         expect(trivial_accessors_finder.offences).to be_empty
       end
 
-      it 'find oneliner trivials' do
+      it 'finds oneliner trivials' do
         inspect_source(trivial_accessors_finder, '',
                        ['class Oneliner',
                         '  def foo; @foo; end',
@@ -209,7 +213,7 @@ module Rubocop
         expect(trivial_accessors_finder.offences).to be_empty
       end
 
-      it 'find trivial writer' do
+      it 'finds trivial writer' do
         inspect_source(trivial_accessors_finder, '',
                        ['def foo=(val)',
                         ' @foo = val',
@@ -219,7 +223,7 @@ module Rubocop
                  .map(&:line_number).sort).to eq([1])
       end
 
-      it 'find trivial writer in a class' do
+      it 'finds trivial writer in a class' do
         inspect_source(trivial_accessors_finder, '',
                        ['class TrivialFoo',
                         '  def foo=(val)',
@@ -245,7 +249,7 @@ module Rubocop
                  .map(&:line_number).sort).to eq([2])
       end
 
-      it 'find trivial accessors in a little less trivial class' do
+      it 'finds trivial accessors in a little less trivial class' do
         inspect_source(trivial_accessors_finder, '',
                        ['class TrivialFoo',
                         ' def foo',
@@ -274,7 +278,7 @@ module Rubocop
         expect(trivial_accessors_finder.offences).to be_empty
       end
 
-      it 'find trivial writers in a little less trivial class' do
+      it 'finds trivial writers in a little less trivial class' do
         inspect_source(trivial_accessors_finder, '',
                        ['class TrivialFoo',
                         ' def foo_bar=(foo, bar)',


### PR DESCRIPTION
This is legal ruby even through the method name is a constant
rather than a normal identifier. Fixes #144.
