### PR TITLE
Display a list of errors in the summary.

### DIFF
--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -576,27 +576,28 @@ module Rubocop
 
     describe '#display_summary' do
       it 'handles pluralization correctly' do
-        cli.display_summary(0, 0, 0)
+        cli.display_summary(0, 0, [])
         expect($stdout.string).to eq(
           "\n0 files inspected, no offences detected\n")
         $stdout = StringIO.new
-        cli.display_summary(1, 0, 0)
+        cli.display_summary(1, 0, [])
         expect($stdout.string).to eq(
           "\n1 file inspected, no offences detected\n")
         $stdout = StringIO.new
-        cli.display_summary(1, 1, 0)
+        cli.display_summary(1, 1, [])
         expect($stdout.string).to eq(
           "\n1 file inspected, 1 offence detected\n")
         $stdout = StringIO.new
-        cli.display_summary(2, 2, 0)
+        cli.display_summary(2, 2, [])
         expect($stdout.string).to eq(
           "\n2 files inspected, 2 offences detected\n")
       end
 
       it 'displays an error message when errors are present' do
-        cli.display_summary(1, 1, 1)
-        expect($stdout.string.lines.to_a[-3])
-          .to eq("1 error occurred.\n")
+        msg = 'An error occurred while Encoding cop was inspecting file.rb.'
+        cli.display_summary(1, 1, [msg])
+        expect($stdout.string.lines.to_a[-4..-3])
+          .to eq(["1 error occurred:\n", "#{msg}\n"])
       end
     end
   end


### PR DESCRIPTION
If there are errors when running rubocop on a large code base, it can
be difficult to find where errors occurred if you only see the number
of errors in the summary.

Also, red is a better color for these messages than yellow. And the tip
about running with -d should only be printed when not running with -d.
