### PR TITLE
Handle regexp back references in VariableInterpolation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Fix a false positive in the `Alias` cop. `:alias` is no longer treated as keyword
 * `ArrayLiteral` now properly detects `Array.new`
 * `HashLiteral` now properly detects `Hash.new`
+* `VariableInterpolation` now detects regexp back references and doesn't crash.
 
 ### Misc
 

--- a/lib/rubocop/cop/variable_interpolation.rb
+++ b/lib/rubocop/cop/variable_interpolation.rb
@@ -5,8 +5,9 @@ module Rubocop
     class VariableInterpolation < Cop
       def inspect(file, source, tokens, sexp)
         each(:string_dvar, sexp) do |s|
-          var = s[1][1][1]
-          lineno = s[1][1][2].lineno
+          interpolation = s[1][0] == :@backref ? s[1] : s[1][1]
+          var = interpolation[1]
+          lineno = interpolation[2].lineno
 
           add_offence(
             :convention,

--- a/spec/rubocop/cops/variable_interpolation_spec.rb
+++ b/spec/rubocop/cops/variable_interpolation_spec.rb
@@ -16,6 +16,15 @@ module Rubocop
           .to eq(['Replace interpolated var $test with expression #{$test}.'])
       end
 
+      it 'registers an offence for interpolated regexp back references' do
+        inspect_source(vi,
+                       'file.rb',
+                       ['puts "this is a #$1"'])
+        expect(vi.offences.size).to eq(1)
+        expect(vi.offences.map(&:message))
+          .to eq(['Replace interpolated var $1 with expression #{$1}.'])
+      end
+
       it 'registers an offence for interpolated instance variables' do
         inspect_source(vi,
                        'file.rb',
@@ -37,7 +46,7 @@ module Rubocop
       it 'does not register an offence for variables in expressions' do
         inspect_source(vi,
                        'file.rb',
-                       ['puts "this is a #{@test}"'])
+                       ['puts "this is a #{@test} #{@@t} #{$t} #{$1}"'])
         expect(vi.offences).to be_empty
       end
     end


### PR DESCRIPTION
This is a bug fix. Strings like "#$1" caused a crash earlier.
