### PR TITLE
Do more caching to avoid printing same warning many times.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * `HashLiteral` now properly detects `Hash.new`
 * `VariableInterpolation` now detects regexp back references and doesn't crash.
 * Don't generate pathnames like some/project//some.rb
+* [#151](https://github.com/bbatsov/rubocop/issues/151) Don't print the unrecognized cop warning several times for the same `.rubocop.yml` 
 
 ### Misc
 

--- a/lib/rubocop/config_store.rb
+++ b/lib/rubocop/config_store.rb
@@ -9,10 +9,14 @@ module Rubocop
       # This takes precedence over configs located in any directories
       @options_config = nil
 
-      # @config_cache is a cache that maps directories to
-      # configurations. We search for .rubocop.yml only if we haven't
-      # already found it for the given directory.
-      @config_cache = {}
+      # @path_cache maps directories to configuration paths. We search
+      # for .rubocop.yml only if we haven't already found it for the
+      # given directory.
+      @path_cache = {}
+
+      # @object_cache maps configuration file paths to
+      # configuration objects so we only need to load them once.
+      @object_cache = {}
     end
 
     def set_options_config(options_config)
@@ -25,12 +29,9 @@ module Rubocop
       return @options_config if @options_config
 
       dir = File.dirname(file)
-      return @config_cache[dir] if @config_cache[dir]
-
-      config = Config.configuration_for_path(dir)
-      @config_cache[dir] = config if config
-
-      config or Config.new
+      @path_cache[dir] ||= Config.configuration_file_for(dir)
+      path = @path_cache[dir]
+      @object_cache[path] ||= Config.configuration_from_file(path)
     end
   end
 end

--- a/spec/rubocop/config_store_spec.rb
+++ b/spec/rubocop/config_store_spec.rb
@@ -6,45 +6,59 @@ module Rubocop
   describe ConfigStore do
     before(:each) { ConfigStore.prepare }
     before do
-      Config.stub(:configuration_for_path) { nil }
-      Config.stub(:configuration_for_path).with('valid') { :config }
-      Config.stub(:load_file) { |arg| "#{arg}_loaded" }
-      Config.stub(:merge_with_default) { |config, file| config }
-      Config.stub(:default_config) { :default_config }
+      Config.stub(:configuration_file_for) do |arg|
+        # File tree:
+        # file1
+        # dir/.rubocop.yml
+        # dir/file2
+        # dir/subdir/file3
+        (arg =~ /dir/ ? 'dir' : '.') + '/.rubocop.yml'
+      end
+      Config.stub(:configuration_from_file) { |arg| arg }
+      Config.stub(:load_file) { |arg| "#{arg} loaded" }
+      Config.stub(:merge_with_default) { |config, file| "merged #{config}" }
     end
 
     describe '.prepare' do
       it 'resets @options_config' do
         ConfigStore.set_options_config(:options_config)
         ConfigStore.prepare
-        Config.should_receive(:new)
-        ConfigStore.for('invalid/file')
+        Config.should_receive(:configuration_file_for)
+        ConfigStore.for('file1')
       end
 
       it 'resets @config_cache' do
-        ConfigStore.for('valid/file')
+        ConfigStore.for('file1')
         ConfigStore.prepare
-        Config.should_receive(:configuration_for_path)
-        ConfigStore.for('valid/file')
+        Config.should_receive(:configuration_file_for)
+        ConfigStore.for('file1')
       end
     end
 
     describe '.for' do
       it 'always uses config specified in command line' do
         ConfigStore.set_options_config(:options_config)
-        expect(ConfigStore.for('valid/file')).to eq('options_config_loaded')
+        expect(ConfigStore.for('file1')).to eq('merged options_config loaded')
       end
 
       context 'when no config specified in command line' do
-        it 'gets config from cache if available' do
-          ConfigStore.for('valid/file')
-          Config.should_not_receive(:configuration_for_path)
-          ConfigStore.for('valid/file')
+        it 'gets config path and config from cache if available' do
+          Config.should_receive(:configuration_file_for).once.with('dir')
+          Config.should_receive(:configuration_file_for).once.with('dir/' +
+                                                                   'subdir')
+          # The stub returns the same config path for dir and dir/subdir.
+          Config.should_receive(:configuration_from_file).once.
+            with('dir/.rubocop.yml')
+
+          ConfigStore.for('dir/file2')
+          ConfigStore.for('dir/file2')
+          ConfigStore.for('dir/subdir/file3')
         end
 
-        it 'searches for config if not available in cache' do
-          Config.should_receive(:configuration_for_path)
-          ConfigStore.for('valid/file')
+        it 'searches for config path if not available in cache' do
+          Config.should_receive(:configuration_file_for).once
+          Config.should_receive(:configuration_from_file).once
+          ConfigStore.for('file1')
         end
       end
     end


### PR DESCRIPTION
With the addition of support for `inherit_from`, the configuration file
loading became more complicated. A side effect was that the warning
about unrecognized cop would be printed many time per `.rubycop.yml` file.

I've changed the config caching machanism so that one cache holds
config file paths and another holds config objects. The API of the
`Config` class was changed and big changes in specs were necessary.

Fixes #151.
