### PR TITLE
OpMethod now handles definition of unary operators without crashing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bugs fixed
 
 * [#155](https://github.com/bbatsov/rubocop/issues/155) 'Do not use semicolons to terminate expressions.' is not implemented correctly
+* `OpMethod` now handles definition of unary operators without crashing.
 
 ## 0.7.1 (05/11/2013)
 

--- a/lib/rubocop/cop/op_method.rb
+++ b/lib/rubocop/cop/op_method.rb
@@ -7,20 +7,28 @@ module Rubocop
 
       def inspect(file, source, tokens, sexp)
         each(:def, sexp) do |s|
-          if s[1][0] == :@op && !%w([] []= <<).include?(s[1][1])
-            if s[2][0] == :paren
-              # param is surrounded by braces
-              param = s[2][1][1][0]
-            else
-              param = s[2][1][0]
-            end
-
-            unless param[1] == 'other'
+          if binary_operator?(s) && !%w([] []= <<).include?(s[1][1])
+            params = parameters(s[2])
+            unless params[0][1] == 'other'
               add_offence(:convention,
-                          param[2].lineno,
+                          params[0][2].lineno,
                           sprintf(ERROR_MESSAGE, s[1][1]))
             end
           end
+        end
+      end
+
+      private
+
+      def binary_operator?(def_sexp)
+        def_sexp[1][0] == :@op && parameters(def_sexp[2]).size == 1
+      end
+
+      def parameters(param_sexp)
+        if param_sexp[0] == :paren # param is surrounded by braces?
+          parameters(param_sexp[1])
+        else
+          param_sexp[1] || []
         end
       end
     end

--- a/spec/rubocop/cops/op_method_spec.rb
+++ b/spec/rubocop/cops/op_method_spec.rb
@@ -64,6 +64,22 @@ module Rubocop
                         'end'])
         expect(om.offences).to be_empty
       end
+
+      it 'does not register an offence for non binary operators' do
+        inspect_source(om,
+                       'file.rb',
+                       ['def -@', # Unary minus
+                        'end',
+                        '',
+                        # This + is not a unary operator. It can only be
+                        # called with dot notation.
+                        'def +',
+                        'end',
+                        '',
+                        'def *(a, b)', # Quite strange, but legal ruby.
+                        'end'])
+        expect(om.offences).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
There would be an error in `OpMethod` when scanning, for example

``` ruby
def -@
  # ...
end
```
