### PR TITLE
Correct a bug in Cop#keywords.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * [#155](https://github.com/bbatsov/rubocop/issues/155) 'Do not use semicolons to terminate expressions.' is not implemented correctly
 * `OpMethod` now handles definition of unary operators without crashing.
+* [#159](https://github.com/bbatsov/rubocop/issues/159) AvoidFor cop misses many violations
 
 ## 0.7.1 (05/11/2013)
 

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -116,17 +116,17 @@ module Rubocop
       end
 
       def keywords(tokens)
-        # we need to keep track of the previous token to avoid
-        # interpreting :some_keyword as the keyword some_keyword
+        # We need to keep track of the previous token to avoid
+        # interpreting :some_keyword as the keyword some_keyword.
         prev = Token.new(0, :init, '')
-        # same goes for defs so we need to track those as well
+        # Same goes for defs so we need to track those as well.
         keywords = []
 
-        tokens.each do |t|
-          keywords << t if prev.type != :on_symbeg && t.type == :on_kw
-          # def with name that's a kw confuses Ripper.lex
-          penultimate = keywords[-2]
-          keywords.pop if penultimate && penultimate.text == 'def'
+        tokens.reject { |t| whitespace?(t) }.each do |t|
+          if prev.type != :on_symbeg && t.type == :on_kw &&
+              [prev.type, prev.text] != [:on_kw, 'def']
+            keywords << t
+          end
           prev = t
         end
 

--- a/spec/rubocop/cops/avoid_for_spec.rb
+++ b/spec/rubocop/cops/avoid_for_spec.rb
@@ -10,8 +10,10 @@ module Rubocop
       it 'registers an offence for for' do
         inspect_source(af,
                        'file.rb',
-                       ['for n in [1, 2, 3] do',
-                        '  puts n',
+                       ['def func',
+                        '  for n in [1, 2, 3] do',
+                        '    puts n',
+                        '  end',
                         'end'])
         expect(af.offences.size).to eq(1)
         expect(af.offences.map(&:message))


### PR DESCRIPTION
Fix for #159. 

In the old code we get stuck pushing and popping keywords when 'def'
is the last keyword in the list. Reworked the algorithm a bit.
