### PR TITLE
Fix bug in SymbolSnakeCase causing an exception for aliasing operators.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * [#155](https://github.com/bbatsov/rubocop/issues/155) 'Do not use semicolons to terminate expressions.' is not implemented correctly
 * `OpMethod` now handles definition of unary operators without crashing.
+* `SymbolSnakeCase` now handles aliasing of operators without crashing.
 * [#159](https://github.com/bbatsov/rubocop/issues/159) AvoidFor cop misses many violations
 
 ## 0.7.1 (05/11/2013)

--- a/lib/rubocop/cop/symbol_snake_case.rb
+++ b/lib/rubocop/cop/symbol_snake_case.rb
@@ -14,7 +14,7 @@ module Rubocop
 
       def check_for_symbols(sexp)
         each(:symbol_literal, sexp) do |s|
-          symbol_type = s[1][1][0]
+          symbol_type = s[1][0] == :symbol ? s[1][1][0] : s[1][0]
 
           # don't check operators
           next if symbol_type == :@op

--- a/spec/rubocop/cops/symbol_snake_case_spec.rb
+++ b/spec/rubocop/cops/symbol_snake_case_spec.rb
@@ -77,6 +77,12 @@ module Rubocop
         expect(snake_case.offences).to be_empty
       end
 
+      it 'can handle an alias of and operator without crashing' do
+        inspect_source(snake_case, 'file.rb',
+                       ['alias + add'])
+        expect(snake_case.offences).to be_empty
+      end
+      
       it 'registers an offence for SCREAMING_SNAKE_CASE' do
         inspect_source(snake_case, 'file.rb',
                        ['test = :BAD_IDEA'])


### PR DESCRIPTION
The sexp for an alias of an operator (e.g., `alias + add`) has a `:symbol_literal` node that
looks different from a regular symbol literal.
