### PR TITLE
Port CaseIndentation to Parser.

### DIFF
--- a/lib/rubocop/cop/case_indentation.rb
+++ b/lib/rubocop/cop/case_indentation.rb
@@ -11,11 +11,10 @@ module Rubocop
 
       def inspect(file, source, tokens, sexp)
         on_node(:case, sexp) do |case_node|
-          _, *bodies = *case_node
-          when_nodes = bodies[0..-2]
+          _condition, *whens, _else = *case_node
 
           case_column = case_node.source_map.keyword.column
-          when_nodes.each do |when_node|
+          whens.each do |when_node|
             pos = when_node.src.keyword
             if pos.column != case_column
               add_offence(:convention, pos.line, ERROR_MESSAGE)

--- a/lib/rubocop/cop/syntax.rb
+++ b/lib/rubocop/cop/syntax.rb
@@ -27,8 +27,13 @@ module Rubocop
         stderr.each_line do |line|
           # discard lines that are not containing relevant info
           if line =~ /.+:(\d+): (.+)/
-            line_no, severity, message = process_line(line)
-            add_offence(severity, line_no, message)
+            # Assignment to unused variables beginning with underscore
+            # is reported by Ruby 1.9, but not 2.0. Make 1.9 behave
+            # like 2.0.
+            unless line =~ /assigned but unused variable - _\w+/
+              line_no, severity, message = process_line(line)
+              add_offence(severity, line_no, message)
+            end
           end
         end
       end


### PR DESCRIPTION
Here it is. Not sure if I understood what @whitequark meant by [the antipattern of unpacking via children](https://github.com/bbatsov/rubocop/pull/164/files#r4200081), but I took some lines from `Parser::AST:Processor`.
