### PR TITLE
Port surrounding_space cops to Parser.

### DIFF
--- a/lib/rubocop/cop/surrounding_space.rb
+++ b/lib/rubocop/cop/surrounding_space.rb
@@ -3,39 +3,281 @@
 module Rubocop
   module Cop
     module SurroundingSpace
-      def inspect(file, source, tokens, ast)
-        # TODO
+      def space_between?(t1, t2)
+        char_preceding_2nd_token =
+          @source[t2.pos.lineno - 1][t2.pos.column - 1]
+        if char_preceding_2nd_token == '+' && t1.type != :tPLUS
+          # Special case. A unary plus is not present in the tokens.
+          char_preceding_2nd_token =
+            @source[t2.pos.lineno - 1][t2.pos.column - 2]
+        end
+        t2.pos.lineno > t1.pos.lineno || char_preceding_2nd_token == ' '
+      end
+
+      def index_of_first_token(node, tokens)
+        @tok_table ||= build_tok_table(tokens)
+        b = node.src.expression.begin
+        @tok_table[[b.line, b.column]]
+      end
+
+      def index_of_last_token(node, tokens)
+        @tok_table ||= build_tok_table(tokens)
+        e = node.src.expression.end
+        ix = @tok_table[[e.line, e.column]]
+        (ix || tokens.size) - 1
+      end
+
+      def build_tok_table(tokens)
+        table = {}
+        tokens.each_with_index do |t, ix|
+          table[[t.pos.lineno, t.pos.column]] = ix
+        end
+        table
       end
     end
 
     class SpaceAroundOperators < Cop
       include SurroundingSpace
-      MSG = 'Surrounding space missing for operator '
+      MSG_MISSING = "Surrounding space missing for operator '%s'."
+      MSG_DETECTED = 'Space around operator ** detected.'
+
+      BINARY_OPERATORS =
+        [:tEQL,    :tAMPER2,  :tPIPE,  :tCARET, :tPLUS,  :tMINUS, :tSTAR2,
+         :tDIVIDE, :tPERCENT, :tEH,    :tCOLON, :tANDOP, :tOROP,  :tMATCH,
+         :tNMATCH, :tEQ,      :tNEQ,   :tGT,    :tRSHFT, :tGEQ,   :tLT,
+         :tLSHFT,  :tLEQ,     :tASSOC, :tEQQ,   :tCMP,   :tOP_ASGN]
+
+      def inspect(file, source, tokens, sexp)
+        @source = source
+        positions_not_to_check = get_positions_not_to_check(tokens, sexp)
+
+        tokens.each_cons(3) do |token_before, token, token_after|
+          next if token_before.type == :kDEF # TODO: remove?
+          next if positions_not_to_check.include?(token.pos)
+
+          case token.type
+          when :tPOW
+            if has_space?(token_before, token, token_after)
+              add_offence(:convention, token.pos.lineno, MSG_DETECTED)
+            end
+          when *BINARY_OPERATORS
+            check_missing_space(token_before, token, token_after)
+          end
+        end
+      end
+
+      # Returns an array of positions marking the tokens that this cop
+      # should not check, either because the token is not an operator
+      # or because another cop does the check.
+      def get_positions_not_to_check(tokens, sexp)
+        positions_not_to_check = []
+        do_not_check_block_arg_pipes(sexp, positions_not_to_check)
+        do_not_check_param_default(tokens, sexp, positions_not_to_check)
+        do_not_check_class_lshift_self(tokens, sexp, positions_not_to_check)
+        do_not_check_def_things(tokens, sexp, positions_not_to_check)
+        do_not_check_singleton_operator_defs(tokens, sexp,
+                                             positions_not_to_check)
+        positions_not_to_check
+      end
+
+      def do_not_check_block_arg_pipes(sexp, positions_not_to_check)
+        # each { |a| }
+        #        ^ ^
+        on_node(:block, sexp) do |b|
+          on_node(:args, b) do |a|
+            if a.src.begin
+              positions_not_to_check << Position.new(a.src.begin.line,
+                                                     a.src.begin.column)
+              positions_not_to_check << Position.new(a.src.end.line,
+                                                     a.src.end.column)
+            end
+          end
+        end
+      end
+
+      def do_not_check_param_default(tokens, sexp, positions_not_to_check)
+        # func(a, b=nil)
+        #          ^
+        on_node(:optarg, sexp) do |optarg|
+          _arg, equals, _value = tokens[index_of_first_token(optarg, tokens),
+                                        3]
+          positions_not_to_check << equals.pos
+        end
+      end
+
+      def do_not_check_class_lshift_self(tokens, sexp, positions_not_to_check)
+        # class <<self
+        #       ^
+        on_node(:sclass, sexp) do |sclass|
+          ix = index_of_first_token(sclass, tokens)
+          if tokens[ix, 2].map(&:type) == [:kCLASS, :tLSHFT]
+            positions_not_to_check << tokens[ix + 1].pos
+          end
+        end
+      end
+
+      def do_not_check_def_things(tokens, sexp, positions_not_to_check)
+        # def +(other)
+        #     ^
+        on_node(:def, sexp) do |def_node|
+          # def each &block
+          #          ^
+          # def each *args
+          #          ^
+          on_node([:blockarg, :restarg], def_node) do |arg_node|
+            positions_not_to_check << tokens[index_of_first_token(arg_node,
+                                                                  tokens)].pos
+          end
+          positions_not_to_check <<
+            tokens[index_of_first_token(def_node, tokens) + 1].pos
+        end
+      end
+
+      def do_not_check_singleton_operator_defs(tokens, sexp,
+                                               positions_not_to_check)
+        # def self.===(other)
+        #          ^
+        on_node(:defs, sexp) do |defs_node|
+          _receiver, name, _args = *defs_node
+          ix = index_of_first_token(defs_node, tokens)
+          name_token = tokens[ix..-1].find { |t| t.text == name.to_s }
+          positions_not_to_check << name_token.pos
+        end
+      end
+
+      def check_missing_space(token_before, token, token_after)
+        unless has_space?(token_before, token, token_after)
+          text = token.text.to_s + (token.type == :tOP_ASGN ? '=' : '')
+          add_offence(:convention, token.pos.lineno, MSG_MISSING % text)
+        end
+      end
+
+      def has_space?(token_before, token, token_after)
+        space_between?(token_before, token) && space_between?(token,
+                                                              token_after)
+      end
     end
 
     class SpaceAroundBraces < Cop
       include SurroundingSpace
+      MSG_LEFT = "Surrounding space missing for '{'."
+      MSG_RIGHT = "Space missing to the left of '}'."
+
+      def inspect(file, source, tokens, sexp)
+        @source = source
+        positions_not_to_check = get_positions_not_to_check(tokens, sexp)
+        tokens.each_cons(2) do |t1, t2|
+          next if ([t1.pos, t2.pos] - positions_not_to_check).size < 2
+
+          type1, type2 = t1.type, t2.type
+          # :tLBRACE in hash literals, :tLCURLY otherwise.
+          next if [:tLCURLY, :tLBRACE].include?(type1) && type2 == :tRCURLY
+          check(t1, t2, MSG_LEFT) if type1 == :tLCURLY || type2 == :tLCURLY
+          check(t1, t2, MSG_RIGHT) if type2 == :tRCURLY
+        end
+      end
+
+      def get_positions_not_to_check(tokens, sexp)
+        positions_not_to_check = []
+
+        on_node(:hash, sexp) do |hash|
+          b_ix = index_of_first_token(hash, tokens)
+          e_ix = index_of_last_token(hash, tokens)
+          positions_not_to_check << tokens[b_ix].pos << tokens[e_ix].pos
+        end
+
+        # TODO: Check braces inside string/symbol/regexp/xstr interpolation.
+        on_node([:dstr, :dsym, :regexp, :xstr], sexp) do |s|
+          b_ix = index_of_first_token(s, tokens)
+          e_ix = index_of_last_token(s, tokens)
+          tokens[b_ix..e_ix].each do |t|
+            positions_not_to_check << t.pos if t.type == :tRCURLY
+          end
+        end
+
+        positions_not_to_check
+      end
+
+      def check(t1, t2, msg)
+        unless space_between?(t1, t2)
+          add_offence(:convention, t1.pos.lineno, msg)
+        end
+      end
     end
 
     module SpaceInside
       include SurroundingSpace
+      MSG = 'Space inside %s detected.'
+
+      def inspect(file, source, tokens, sexp)
+        @source = source
+        left, right, kind = specifics
+        tokens.each_cons(2) do |t1, t2|
+          if t1.type == left || t2.type == right
+            if t2.pos.lineno == t1.pos.lineno && space_between?(t1, t2)
+              add_offence(:convention, t1.pos.lineno, MSG % kind)
+            end
+          end
+        end
+      end
     end
 
     class SpaceInsideParens < Cop
       include SpaceInside
+
+      def specifics
+        [:tLPAREN2, :tRPAREN, 'parentheses']
+      end
     end
 
     class SpaceInsideBrackets < Cop
       include SpaceInside
+
+      def specifics
+        [:tLBRACK, :tRBRACK, 'square brackets']
+      end
     end
 
     class SpaceInsideHashLiteralBraces < Cop
       include SurroundingSpace
+      MSG = 'Space inside hash literal braces %s.'
+
+      def inspect(file, source, tokens, sexp)
+        @source = source
+        on_node(:hash, sexp) do |hash|
+          b_ix = index_of_first_token(hash, tokens)
+          e_ix = index_of_last_token(hash, tokens)
+          check(tokens[b_ix], tokens[b_ix + 1])
+          check(tokens[e_ix - 1], tokens[e_ix])
+        end
+      end
+
+      def check(t1, t2)
+        types = [t1, t2].map(&:type)
+        braces = [:tLBRACE, :tRCURLY]
+        return if types == braces || (braces - types).size == 2
+        has_space = space_between?(t1, t2)
+        is_offence, word = if self.class.config['EnforcedStyleIsWithSpaces']
+                             [!has_space, 'missing']
+                           else
+                             [has_space, 'detected']
+                           end
+        add_offence(:convention, t1.pos.lineno, MSG % word) if is_offence
+      end
     end
 
     class SpaceAroundEqualsInParameterDefault < Cop
-      def inspect(file, source, tokens, ast)
-        # TODO
+      include SurroundingSpace
+      MSG = 'Surrounding space missing in default value assignment.'
+
+      def inspect(file, source, tokens, sexp)
+        @source = source
+        on_node(:optarg, sexp) do |optarg|
+          arg, equals, value = tokens[index_of_first_token(optarg, tokens), 3]
+          unless space_between?(arg, equals) && space_between?(equals, value)
+            add_offence(:convention, equals.pos.lineno, MSG)
+          end
+        end
       end
     end
   end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -144,11 +144,12 @@ module Rubocop
         .to eq(
         ['example1.rb:1: C: Missing utf-8 encoding comment.',
          'example1.rb:1: C: Trailing whitespace detected.',
+         "example1.rb:1: C: Surrounding space missing for operator '='.",
          'example1.rb:2: C: Trailing whitespace detected.',
          'example2.rb:1: C: Missing utf-8 encoding comment.',
          'example2.rb:1: C: Tab detected.',
          '',
-         '2 files inspected, 5 offences detected',
+         '2 files inspected, 6 offences detected',
          ''].join("\n"))
     end
 
@@ -166,10 +167,11 @@ module Rubocop
       expect($stdout.string)
         .to eq(
         ['example1.rb:1: C: Trailing whitespace detected.',
+         "example1.rb:1: C: Surrounding space missing for operator '='.",
          'example1.rb:2: C: Trailing whitespace detected.',
          'example2.rb:1: C: Tab detected.',
          '',
-         '2 files inspected, 3 offences detected',
+         '2 files inspected, 4 offences detected',
          ''].join("\n"))
     end
 

--- a/spec/rubocop/cops/space_around_braces_spec.rb
+++ b/spec/rubocop/cops/space_around_braces_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module Rubocop
   module Cop
-    describe SpaceAroundBraces, broken: true do
+    describe SpaceAroundBraces do
       let(:space) { SpaceAroundBraces.new }
 
       it 'registers an offence for left brace without spaces' do
@@ -25,6 +25,21 @@ module Rubocop
                         'end',
                         '@views = {}',
                         ''])
+        expect(space.offences.map(&:message)).to be_empty
+      end
+
+      it 'accepts string interpolation braces with no space inside' do
+        inspect_source(space, 'file.rb',
+                       ['"A=#{a}"',
+                        ':"#{b}"',
+                        '/#{c}/',
+                        '`#{d}`',
+                        'sprintf("#{message.gsub(/%/, \'%%\')}", line)'])
+        expect(space.offences.map(&:message)).to be_empty
+      end
+
+      it 'accepts braces around a hash literal argument' do
+        inspect_source(space, 'file.rb', ["new({'user' => user_params})"])
         expect(space.offences.map(&:message)).to be_empty
       end
     end

--- a/spec/rubocop/cops/space_around_equals_in_default_parameter_spec.rb
+++ b/spec/rubocop/cops/space_around_equals_in_default_parameter_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module Rubocop
   module Cop
-    describe SpaceAroundEqualsInParameterDefault, broken: true do
+    describe SpaceAroundEqualsInParameterDefault do
       let(:space) { SpaceAroundEqualsInParameterDefault.new }
 
       it 'registers an offence for default value assignment without space' do

--- a/spec/rubocop/cops/space_inside_brackets_spec.rb
+++ b/spec/rubocop/cops/space_inside_brackets_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module Rubocop
   module Cop
-    describe SpaceInsideBrackets, broken: true do
+    describe SpaceInsideBrackets do
       let(:space) { SpaceInsideBrackets.new }
 
       it 'registers an offence for an array literal with spaces inside' do
@@ -13,6 +13,12 @@ module Rubocop
         expect(space.offences.map(&:message)).to eq(
           ['Space inside square brackets detected.',
            'Space inside square brackets detected.'])
+      end
+
+      it 'accepts space inside strings within square brackets' do
+        inspect_source(space, 'file.rb', ["['Encoding:',",
+                                          " '  Enabled: false']"])
+        expect(space.offences.map(&:message)).to be_empty
       end
 
       it 'accepts space inside square brackets if on its own row' do

--- a/spec/rubocop/cops/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cops/space_inside_hash_literal_braces_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module Rubocop
   module Cop
-    describe SpaceInsideHashLiteralBraces, broken: true do
+    describe SpaceInsideHashLiteralBraces do
       let(:sihlb) { SpaceInsideHashLiteralBraces.new }
       before do
         SpaceInsideHashLiteralBraces.config = {
@@ -14,7 +14,7 @@ module Rubocop
 
       it 'registers an offence for hashes with no spaces by default' do
         inspect_source(sihlb, '',
-                       ['h = {a: 1, b: 2}',
+                       ['h = {a: 1, b: :two}',
                         'h = {a => 1 }'])
         expect(sihlb.offences.map(&:message)).to eq(
           ['Space inside hash literal braces missing.'] * 3)
@@ -67,6 +67,11 @@ module Rubocop
 
       it 'accepts empty hashes without spaces even if configured true' do
         inspect_source(sihlb, '', ['h = {}'])
+        expect(sihlb.offences).to be_empty
+      end
+
+      it 'accepts hash literals with no braces' do
+        inspect_source(sihlb, '', ['x(a: b.c)'])
         expect(sihlb.offences).to be_empty
       end
     end

--- a/spec/rubocop/cops/space_inside_parens_spec.rb
+++ b/spec/rubocop/cops/space_inside_parens_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module Rubocop
   module Cop
-    describe SpaceInsideParens, broken: true do
+    describe SpaceInsideParens do
       let(:space) { SpaceInsideParens.new }
 
       it 'registers an offence for spaces inside parens' do
@@ -22,6 +22,10 @@ module Rubocop
         expect(space.offences.map(&:message)).to be_empty
       end
 
+      it 'accepts parentheses with no spaces' do
+        inspect_source(space, 'file.rb', ['split("\n")'])
+        expect(space.offences.map(&:message)).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
Ported cops are `SpaceAroundOperators`, `SpaceAroundBraces`,
`SpaceInsideParens`, `SpaceInsideBrackets`, `SpaceInsideHashLiteralBraces`,
`SpaceAroundEqualsInParameterDefault`.

There are still some differences when I run these cops on a large code base and compare the result to the latest gem version, but I don't want to wait too long. It's better to make the PR now and get some feedback and/or help.
