### PR TITLE
Solve problem with too many parameters in inspect.

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -64,7 +64,7 @@ module Rubocop
 
         syntax_cop = Rubocop::Cop::Syntax.new
         syntax_cop.debug = @options[:debug]
-        syntax_cop.inspect(file, source, nil, nil, nil)
+        syntax_cop.inspect(source, nil, nil, nil)
 
         if syntax_cop.offences.map(&:severity).include?(:error)
           # In case of a syntax error we just report that error and do
@@ -115,7 +115,7 @@ module Rubocop
                           disabled_lines)
           if !@options[:only] || @options[:only] == cop_name
             begin
-              cop.inspect(file, source, tokens, ast, comments)
+              cop.inspect(source, tokens, ast, comments)
             rescue => e
               handle_error(e,
                            "An error occurred while #{cop.name}".color(:red) +

--- a/lib/rubocop/cop/access_control.rb
+++ b/lib/rubocop/cop/access_control.rb
@@ -9,7 +9,7 @@ module Rubocop
       PRIVATE_NODE = s(:send, nil, :private)
       PROTECTED_NODE = s(:send, nil, :protected)
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         on_node([:class, :module, :sclass], ast) do |class_node|
           class_start_col = class_node.loc.expression.column
 

--- a/lib/rubocop/cop/ascii_identifiers.rb
+++ b/lib/rubocop/cop/ascii_identifiers.rb
@@ -7,7 +7,7 @@ module Rubocop
     class AsciiIdentifiers < Cop
       MSG = 'Use only ascii symbols in identifiers.'
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         tokens.each do |t|
           if t.type == :tIDENTIFIER && t.text =~ /[^\x00-\x7f]/
             add_offence(:convention, t.pos.lineno, MSG)

--- a/lib/rubocop/cop/block_comments.rb
+++ b/lib/rubocop/cop/block_comments.rb
@@ -5,7 +5,7 @@ module Rubocop
     class BlockComments < Cop
       MSG = 'Do not use block comments.'
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         source.each_with_index do |line, ix|
           add_offence(:convention, ix, MSG) if line =~ /\A=begin\b/
         end

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -62,7 +62,7 @@ module Rubocop
         !@offences.empty?
       end
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         process(ast)
         comments.each { |c| on_comment(c) }
       end

--- a/lib/rubocop/cop/empty_lines.rb
+++ b/lib/rubocop/cop/empty_lines.rb
@@ -6,7 +6,7 @@ module Rubocop
       MSG = 'Extra blank line detected.'
       LINE_OFFSET = 2
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         return if tokens.empty?
 
         prev_line = 1

--- a/lib/rubocop/cop/empty_literal.rb
+++ b/lib/rubocop/cop/empty_literal.rb
@@ -25,7 +25,7 @@ module Rubocop
       #   (const nil :String) :new)
       STR_NODE = s(:send, s(:const, nil, :String), :new)
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         on_node(:send, ast, :block) do |node|
           if node == ARRAY_NODE
             add_offence(:convention,

--- a/lib/rubocop/cop/encoding.rb
+++ b/lib/rubocop/cop/encoding.rb
@@ -5,7 +5,7 @@ module Rubocop
     class Encoding < Cop
       MSG = 'Missing utf-8 encoding comment.'
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         unless RUBY_VERSION >= '2.0.0'
           expected_line = 0
           expected_line += 1 if source[expected_line] =~ /^#!/

--- a/lib/rubocop/cop/end_of_line.rb
+++ b/lib/rubocop/cop/end_of_line.rb
@@ -5,7 +5,7 @@ module Rubocop
     class EndOfLine < Cop
       MSG = 'Carriage return character detected.'
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         source.each_with_index do |line, index|
           add_offence(:convention, index + 1, MSG) if line =~ /\r$/
         end

--- a/lib/rubocop/cop/favor_modifier.rb
+++ b/lib/rubocop/cop/favor_modifier.rb
@@ -62,7 +62,7 @@ module Rubocop
       MSG =
         'Favor modifier while/until usage when you have a single-line body.'
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         on_node([:while, :until], ast) do |node|
           add_offence(:convention, node.loc.line, MSG) if check(node)
         end

--- a/lib/rubocop/cop/line_continuation.rb
+++ b/lib/rubocop/cop/line_continuation.rb
@@ -5,7 +5,7 @@ module Rubocop
     class LineContinuation < Cop
       MSG = 'Avoid the use of the line continuation character(\).'
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         source.each_with_index do |line, index|
           add_offence(:convention, index, MSG) if line =~ /.*\\\z/
         end

--- a/lib/rubocop/cop/line_length.rb
+++ b/lib/rubocop/cop/line_length.rb
@@ -5,7 +5,7 @@ module Rubocop
     class LineLength < Cop
       MSG = 'Line is too long. [%d/%d]'
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         source.each_with_index do |line, index|
           max = LineLength.max
           if line.length > max

--- a/lib/rubocop/cop/method_and_variable_snake_case.rb
+++ b/lib/rubocop/cop/method_and_variable_snake_case.rb
@@ -12,7 +12,7 @@ module Rubocop
         + - * / % ** ~ +@ -@ [] []= ` ! != !~
       ).map(&:to_sym)
 
-      def inspect(file, source, tokens, node, comments)
+      def inspect(source, tokens, node, comments)
         on_node([:def, :defs, :lvasgn, :ivasgn, :send], node) do |n|
           name = case n.type
                  when :def

--- a/lib/rubocop/cop/parentheses_around_condition.rb
+++ b/lib/rubocop/cop/parentheses_around_condition.rb
@@ -6,7 +6,7 @@ module Rubocop
       MSG = "Don't use parentheses around the condition of an " +
         'if/unless/while/until, unless the condition contains an assignment.'
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         on_node([:if, :while, :until], ast) do |node|
           cond, _body = *node
 

--- a/lib/rubocop/cop/rescue_modifier.rb
+++ b/lib/rubocop/cop/rescue_modifier.rb
@@ -5,7 +5,7 @@ module Rubocop
     class RescueModifier < Cop
       MSG = 'Avoid using rescue in its modifier form.'
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         on_node(:rescue, ast, :begin) do |s|
           add_offence(:convention,
                       s.loc.line,

--- a/lib/rubocop/cop/semicolon.rb
+++ b/lib/rubocop/cop/semicolon.rb
@@ -5,7 +5,7 @@ module Rubocop
     class Semicolon < Cop
       MSG = 'Do not use semicolons to terminate expressions.'
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         on_node(:begin, ast) do |node|
           exprs = node.children
 

--- a/lib/rubocop/cop/space_after_comma_etc.rb
+++ b/lib/rubocop/cop/space_after_comma_etc.rb
@@ -7,7 +7,7 @@ module Rubocop
     module SpaceAfterCommaEtc
       MSG = 'Space missing after %s.'
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         tokens.each_cons(2) do |t1, t2|
           if kind(t1) && t1.pos.lineno == t2.pos.lineno &&
               t2.pos.column == t1.pos.column + offset(t1)

--- a/lib/rubocop/cop/string_literals.rb
+++ b/lib/rubocop/cop/string_literals.rb
@@ -6,7 +6,7 @@ module Rubocop
       MSG = "Prefer single-quoted strings when you don't need " +
         'string interpolation or special symbols.'
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         on_node(:str, ast, :dstr) do |s|
           text = s.to_a[0]
 

--- a/lib/rubocop/cop/surrounding_space.rb
+++ b/lib/rubocop/cop/surrounding_space.rb
@@ -51,7 +51,7 @@ module Rubocop
          :tNMATCH, :tEQ,      :tNEQ,   :tGT,    :tRSHFT, :tGEQ,   :tLT,
          :tLSHFT,  :tLEQ,     :tASSOC, :tEQQ,   :tCMP,   :tOP_ASGN]
 
-      def inspect(file, source, tokens, sexp, comments)
+      def inspect(source, tokens, sexp, comments)
         @source = source
         positions_not_to_check = get_positions_not_to_check(tokens, sexp)
 
@@ -167,7 +167,7 @@ module Rubocop
       MSG_LEFT = "Surrounding space missing for '{'."
       MSG_RIGHT = "Space missing to the left of '}'."
 
-      def inspect(file, source, tokens, sexp, comments)
+      def inspect(source, tokens, sexp, comments)
         @source = source
         positions_not_to_check = get_positions_not_to_check(tokens, sexp)
         tokens.each_cons(2) do |t1, t2|
@@ -213,7 +213,7 @@ module Rubocop
       include SurroundingSpace
       MSG = 'Space inside %s detected.'
 
-      def inspect(file, source, tokens, sexp, comments)
+      def inspect(source, tokens, sexp, comments)
         @source = source
         left, right, kind = specifics
         tokens.each_cons(2) do |t1, t2|
@@ -246,7 +246,7 @@ module Rubocop
       include SurroundingSpace
       MSG = 'Space inside hash literal braces %s.'
 
-      def inspect(file, source, tokens, sexp, comments)
+      def inspect(source, tokens, sexp, comments)
         @source = source
         on_node(:hash, sexp) do |hash|
           b_ix = index_of_first_token(hash, tokens)
@@ -274,7 +274,7 @@ module Rubocop
       include SurroundingSpace
       MSG = 'Surrounding space missing in default value assignment.'
 
-      def inspect(file, source, tokens, sexp, comments)
+      def inspect(source, tokens, sexp, comments)
         @source = source
         on_node(:optarg, sexp) do |optarg|
           arg, equals, value = tokens[index_of_first_token(optarg, tokens), 3]

--- a/lib/rubocop/cop/symbol_array.rb
+++ b/lib/rubocop/cop/symbol_array.rb
@@ -5,7 +5,7 @@ module Rubocop
     class SymbolArray < Cop
       MSG = 'Use %i or %I for array of symbols.'
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         # %i and %I were introduced in Ruby 2.0
         unless RUBY_VERSION < '2.0.0'
           on_node(:array, ast) do |s|

--- a/lib/rubocop/cop/syntax.rb
+++ b/lib/rubocop/cop/syntax.rb
@@ -5,7 +5,7 @@ require 'open3'
 module Rubocop
   module Cop
     class Syntax < Cop
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         # Starting JRuby processes would be extremely slow
         # We need to check if rbx returns nice warning messages
         return unless RUBY_ENGINE == 'ruby'

--- a/lib/rubocop/cop/tab.rb
+++ b/lib/rubocop/cop/tab.rb
@@ -5,7 +5,7 @@ module Rubocop
     class Tab < Cop
       MSG = 'Tab detected.'
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         source.each_with_index do |line, index|
           add_offence(:convention, index + 1, MSG) if line =~ /^ *\t/
         end

--- a/lib/rubocop/cop/trailing_whitespace.rb
+++ b/lib/rubocop/cop/trailing_whitespace.rb
@@ -5,7 +5,7 @@ module Rubocop
     class TrailingWhitespace < Cop
       MSG = 'Trailing whitespace detected.'
 
-      def inspect(file, source, tokens, ast, comments)
+      def inspect(source, tokens, ast, comments)
         source.each_with_index do |line, index|
           add_offence(:convention, index + 1, MSG) if line =~ /.*[ \t]+$/
         end

--- a/spec/rubocop/cops/line_length_spec.rb
+++ b/spec/rubocop/cops/line_length_spec.rb
@@ -9,13 +9,13 @@ module Rubocop
       before { LineLength.config = { 'Max' => 79 } }
 
       it "registers an offence for a line that's 80 characters wide" do
-        ll.inspect('file.rb', ['#' * 80], nil, nil, nil)
+        ll.inspect(['#' * 80], nil, nil, nil)
         expect(ll.offences.size).to eq(1)
         expect(ll.offences.first.message).to eq('Line is too long. [80/79]')
       end
 
       it "accepts a line that's 79 characters wide" do
-        ll.inspect('file.rb', ['#' * 79], nil, nil, nil)
+        ll.inspect(['#' * 79], nil, nil, nil)
         expect(ll.offences).to be_empty
       end
     end

--- a/spec/rubocop/cops/syntax_spec.rb
+++ b/spec/rubocop/cops/syntax_spec.rb
@@ -9,7 +9,7 @@ module Rubocop
 
       if RUBY_ENGINE == 'ruby'
         it 'registers an offence for unused variables', ruby: 2.0 do
-          sc.inspect('file.rb', ['x = 5', 'puts 10'], nil, nil, nil)
+          sc.inspect(['x = 5', 'puts 10'], nil, nil, nil)
           expect(sc.offences.size).to eq(1)
           expect(sc.offences.first.message)
             .to eq('Assigned but unused variable - x')

--- a/spec/rubocop/cops/tab_spec.rb
+++ b/spec/rubocop/cops/tab_spec.rb
@@ -8,12 +8,12 @@ module Rubocop
       let(:tab) { Tab.new }
 
       it 'registers an offence for a line indented with tab' do
-        tab.inspect('file.rb', ["\tx = 0"], nil, nil, nil)
+        tab.inspect(["\tx = 0"], nil, nil, nil)
         expect(tab.offences.size).to eq(1)
       end
 
       it 'accepts a line with tab in a string' do
-        tab.inspect('file.rb', ["(x = \"\t\")"], nil, nil, nil)
+        tab.inspect(["(x = \"\t\")"], nil, nil, nil)
         expect(tab.offences).to be_empty
       end
     end

--- a/spec/rubocop/cops/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cops/trailing_whitespace_spec.rb
@@ -9,17 +9,17 @@ module Rubocop
 
       it 'registers an offence for a line ending with space' do
         source = ['x = 0 ']
-        tws.inspect('file.rb', source, nil, nil, nil)
+        tws.inspect(source, nil, nil, nil)
         expect(tws.offences.size).to eq(1)
       end
 
       it 'registers an offence for a line ending with tab' do
-        tws.inspect('file.rb', ["x = 0\t"], nil, nil, nil)
+        tws.inspect(["x = 0\t"], nil, nil, nil)
         expect(tws.offences.size).to eq(1)
       end
 
       it 'accepts a line without trailing whitespace' do
-        tws.inspect('file.rb', ["x = 0\n"], nil, nil, nil)
+        tws.inspect(["x = 0\n"], nil, nil, nil)
         expect(tws.offences).to be_empty
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 def inspect_source(cop, file, source)
   ast, comments, tokens = Rubocop::CLI.rip_source(source.join("\n"))
-  cop.inspect(file, source, tokens, ast, comments)
+  cop.inspect(source, tokens, ast, comments)
 end
 
 class Rubocop::Cop::Cop


### PR DESCRIPTION
A simple solution. Just remove the `file` parameter, which isn't used
anywhere.
