### PR TITLE
Change name of Rubocop::Config.validate! to validate.

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -123,13 +123,13 @@ module Rubocop
     end
 
     def warn_unless_valid
-      validate!
+      validate
     rescue Config::ValidationError => e
       puts "Warning: #{e.message}".color(:red)
     end
 
     # TODO: This should be a private method
-    def validate!
+    def validate
       # Don't validate RuboCop's own files. Avoids inifinite recursion.
       return if @loaded_path.start_with?(RUBOCOP_HOME)
 

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -208,7 +208,7 @@ describe Rubocop::Config do
     end
   end
 
-  describe '#validate!', :isolated_environment do
+  describe '#validate', :isolated_environment do
     # TODO: Because Config.load_file now outputs the validation warning,
     #       it is inserting text into the rspec test output here.
     #       The next 2 lines should be removed eventually.
@@ -232,7 +232,7 @@ describe Rubocop::Config do
 
       it 'raises validation error' do
         expect do
-          configuration.validate!
+          configuration.validate
         end.to raise_error(Rubocop::Config::ValidationError) do |error|
           expect(error.message).to start_with('unrecognized cop LyneLenth')
         end
@@ -250,7 +250,7 @@ describe Rubocop::Config do
 
       it 'raises validation error' do
         expect do
-          configuration.validate!
+          configuration.validate
         end.to raise_error(Rubocop::Config::ValidationError) do |error|
           expect(error.message).to
             start_with('unrecognized parameter LineLength:Min')


### PR DESCRIPTION
This is not a more dangerous version of another `validate` method so
there should be no exclamation point.
