### PR TITLE
Specify dependency to parser in a better way.

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.summary = 'Automatic Ruby code style checking tool.'
 
   s.add_runtime_dependency('rainbow', '>= 1.1.4')
-  s.add_runtime_dependency('parser', '~> 2.0.0.beta2')
+  s.add_runtime_dependency('parser', ['>= 2.0.0.beta1', '<= 2.0.0'])
   s.add_development_dependency('rake', '~> 10.0')
   s.add_development_dependency('rspec', '~> 2.13')
   s.add_development_dependency('yard', '~> 0.8')


### PR DESCRIPTION
So we don't have to update the gemspec every time a new beta version
of parser is released.

Suggested by @whitequark [here](https://github.com/jonas054/rubocop/commit/cd48593ecb9d03562d93d1ef8af29cbc4c69421e).
