### PR TITLE
Fix SpaceInsideHashLiteralBraces to handle string interpolation right.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#211](https://github.com/bbatsov/rubocop/issues/211) - fix a false positive for `initialize` method looking like a trivial writer
 * [#215](https://github.com/bbatsov/rubocop/issues/215) - Fixed a lot of modifier if/unless/while/until issues
 * [#213](https://github.com/bbatsov/rubocop/issues/213) - Make sure even disabled cops get their configuration set
+* [#214](https://github.com/bbatsov/rubocop/issues/214) - Fix SpaceInsideHashLiteralBraces to handle string interpolation right
 
 ## 0.8.0 (05/28/2012)
 

--- a/lib/rubocop/cop/surrounding_space.rb
+++ b/lib/rubocop/cop/surrounding_space.rb
@@ -246,8 +246,10 @@ module Rubocop
         on_node(:hash, sexp) do |hash|
           b_ix = index_of_first_token(hash, tokens)
           e_ix = index_of_last_token(hash, tokens)
-          check(tokens[b_ix], tokens[b_ix + 1])
-          check(tokens[e_ix - 1], tokens[e_ix])
+          if tokens[b_ix].type == :tLBRACE # Hash literal with braces?
+            check(tokens[b_ix], tokens[b_ix + 1])
+            check(tokens[e_ix - 1], tokens[e_ix])
+          end
         end
       end
 

--- a/spec/rubocop/cops/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cops/space_inside_hash_literal_braces_spec.rb
@@ -74,6 +74,13 @@ module Rubocop
         inspect_source(sihlb, ['x(a: b.c)'])
         expect(sihlb.offences).to be_empty
       end
+
+      it 'can handle interpolation in a braceless hash literal' do
+        # A tricky special case where the closing brace of the
+        # interpolation risks getting confused for a hash literal brace.
+        inspect_source(sihlb, ['f(get: "#{x}")'])
+        expect(sihlb.offences).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
The closing brace of #{...} was mistaken for a hash literal closing brace. Solves #214.
