### PR TITLE
Remove the on_comment method.

### DIFF
--- a/lib/rubocop/cop/ascii_comments.rb
+++ b/lib/rubocop/cop/ascii_comments.rb
@@ -5,8 +5,12 @@ module Rubocop
     class AsciiComments < Cop
       MSG = 'Use only ascii symbols in comments.'
 
-      def on_comment(c)
-        add_offence(:convention, c.loc.line, MSG) if c.text =~ /[^\x00-\x7f]/
+      def inspect(source, tokens, ast, comments)
+        comments.each do |comment|
+          if comment.text =~ /[^\x00-\x7f]/
+            add_offence(:convention, comment.loc.line, MSG)
+          end
+        end
       end
     end
   end

--- a/lib/rubocop/cop/block_comments.rb
+++ b/lib/rubocop/cop/block_comments.rb
@@ -5,9 +5,11 @@ module Rubocop
     class BlockComments < Cop
       MSG = 'Do not use block comments.'
 
-      def on_comment(comment)
-        if comment.text.start_with?('=begin')
-          add_offence(:convention, comment.loc.line, MSG)
+      def inspect(source, tokens, ast, comments)
+        comments.each do |comment|
+          if comment.text.start_with?('=begin')
+            add_offence(:convention, comment.loc.line, MSG)
+          end
         end
       end
     end

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -48,10 +48,6 @@ module Rubocop
 
       def inspect(source, tokens, ast, comments)
         process(ast)
-        comments.each { |c| on_comment(c) }
-      end
-
-      def on_comment(comment)
       end
 
       def ignore_node(node)

--- a/lib/rubocop/cop/leading_comment_space.rb
+++ b/lib/rubocop/cop/leading_comment_space.rb
@@ -5,10 +5,12 @@ module Rubocop
     class LeadingCommentSpace < Cop
       MSG = 'Missing space after #.'
 
-      def on_comment(c)
-        if c.text =~ /^#+[^#\s]/
-          unless c.text.start_with?('#!') && c.loc.line == 1
-            add_offence(:convention, c.loc.line, MSG)
+      def inspect(source, tokens, ast, comments)
+        comments.each do |comment|
+          if comment.text =~ /^#+[^#\s]/
+            unless comment.text.start_with?('#!') && comment.loc.line == 1
+              add_offence(:convention, comment.loc.line, MSG)
+            end
           end
         end
       end


### PR DESCRIPTION
A review comment from @whitequark questioned the `on_comment` method.
The name suggests that there are comment nodes in the AST, which is
not true. So it's a bit misleading. Use a plain old `inspect` method.
