### PR TITLE
Fix calculation of whether a modifier version will fit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug fixes
 
+* Correct calculation of whether a modifier version of a conditional statement will fit.
+
 ## 0.8.1 (05/30/2013)
 
 ### New features

--- a/lib/rubocop/cop/favor_modifier.rb
+++ b/lib/rubocop/cop/favor_modifier.rb
@@ -19,10 +19,12 @@ module Rubocop
         if length(sexp) > 3
           false
         else
+          indentation = sexp.loc.keyword.column
           cond_length = sexp.loc.keyword.size + cond.loc.expression.size + 1
           body_length = body_length(body)
 
-          body_length > 0 && (cond_length + body_length) <= LineLength.max
+          body_length > 0 &&
+            (indentation + cond_length + body_length) <= LineLength.max
         end
       end
 
@@ -32,7 +34,7 @@ module Rubocop
 
       def body_length(body)
         if body && body.loc.expression
-          body.loc.expression.column + body.loc.expression.size
+          body.loc.expression.size
         else
           0
         end

--- a/spec/rubocop/cops/favor_modifier_spec.rb
+++ b/spec/rubocop/cops/favor_modifier_spec.rb
@@ -9,8 +9,7 @@ module Rubocop
       let(:while_until) { WhileUntilModifier.new }
       before { LineLength.config = { 'Max' => 79 } }
 
-      it 'registers an offence for multiline if that fits on one line',
-          broken: true do
+      it 'registers an offence for multiline if that fits on one line' do
         # This if statement fits exactly on one line if written as a modifier.
         inspect_source(if_unless,
                        ['if a_condition_that_is_just_short_enough',


### PR DESCRIPTION
For `IfUnlessModifier` and `WhileUntilModifier`. It's the indentation of
the `if`/`unless`/`while`/`until` keyword that matters, not the indentation of
the body.
