### PR TITLE
Reintroduce old solution for invalid byte sequences.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * Correct calculation of whether a modifier version of a conditional statement will fit.
+* [#219](https://github.com/bbatsov/rubocop/issues/219) - Reintroduce old solution for invalid byte sequences
 
 ## 0.8.1 (05/30/2013)
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -444,7 +444,6 @@ module Rubocop
     end
 
     it 'can process a file with an invalid UTF-8 byte sequence' do
-      pending
       create_file('example.rb', [
         '# encoding: utf-8',
         "# #{'f9'.hex.chr}#{'29'.hex.chr}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,9 +64,7 @@ end
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 def inspect_source(cop, source)
-  ast, comments, tokens, _ = Rubocop::CLI.parse('(string)') do |source_buffer|
-    source_buffer.source = source.join($RS)
-  end
+  ast, comments, tokens, _ = Rubocop::CLI.parse('(string)', source.join($RS))
   cop.inspect(source, tokens, ast, comments)
 end
 


### PR DESCRIPTION
This means going back to reading files in RuboCop instead of in Parser.
Add (partial) solution for JRuby. It will work when the illegal byte
sequence is in a comment or string, and sometimes in other cases.
Solves #219.
