### PR TITLE
Fix an error in MultilineIfThen cop that occurs in some special cases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Bug fixes
 
 * Correct calculation of whether a modifier version of a conditional statement will fit.
+* Fix an error in `MultilineIfThen` cop that occurred in some special cases.
 
 ## 0.8.1 (05/30/2013)
 

--- a/lib/rubocop/cop/if_then_else.rb
+++ b/lib/rubocop/cop/if_then_else.rb
@@ -40,8 +40,18 @@ module Rubocop
       include IfThenElse
 
       def offending_line(node)
-        if node.loc.expression.source =~ /\bthen\s*(#.*)?\s*$/
-          node.loc.begin.line
+        condition, body = *node
+        next_thing = if body && body.loc.expression
+                       body.loc.expression.begin
+                     else
+                       node.loc.end # No body, use "end".
+                     end
+        right_after_cond =
+          Parser::Source::Range.new(next_thing.source_buffer,
+                                    condition.loc.expression.end.end_pos,
+                                    next_thing.begin_pos)
+        if right_after_cond.source =~ /\A\s*then\s*(#.*)?\s*\n/
+          node.loc.expression.begin.line
         end
       end
 

--- a/spec/rubocop/cops/multiline_if_then_spec.rb
+++ b/spec/rubocop/cops/multiline_if_then_spec.rb
@@ -16,15 +16,18 @@ module Rubocop
                              'end',
                              'if cond then  ',
                              'end',
+                             'if cond',
+                             'then',
+                             'end',
                              'if cond then # bad',
                              'end'])
-        expect(mit.offences.map(&:line_number)).to eq([1, 3, 5, 7])
+        expect(mit.offences.map(&:line_number)).to eq([1, 3, 5, 7, 10])
       end
 
       it 'accepts multiline if without then' do
         inspect_source(mit, ['if cond',
                              'end'])
-        expect(mit.offences.map(&:message)).to be_empty
+        expect(mit.offences).to be_empty
       end
 
       it 'accepts table style if/then/elsif/ends' do
@@ -34,7 +37,27 @@ module Rubocop
                         'elsif @io == $stderr then str << "$stderr"',
                         'else                      str << @io.class.to_s',
                         'end'])
-        expect(mit.offences.map(&:message)).to be_empty
+        expect(mit.offences).to be_empty
+      end
+
+      it 'does not get confused by a then in a when' do
+        inspect_source(mit,
+                       ['if a',
+                        '  case b',
+                        '  when c then',
+                        '  end',
+                        'end'])
+        expect(mit.offences).to be_empty
+      end
+
+      it 'does not get confused by a commented-out then' do
+        inspect_source(mit,
+                       ['if a # then',
+                        '  b',
+                        'end',
+                        'if c # then',
+                        'end'])
+        expect(mit.offences).to be_empty
       end
 
       # unless
@@ -49,7 +72,7 @@ module Rubocop
       it 'accepts multiline unless without then' do
         inspect_source(mit, ['unless cond',
                              'end'])
-        expect(mit.offences.map(&:message)).to be_empty
+        expect(mit.offences).to be_empty
       end
     end
   end


### PR DESCRIPTION
Fixes these cases:
- there's a `when`...`then` inside the body of an `if`
- there's a commented-out `then` after an `if`
- `then` is on its own line
