### PR TITLE
Fix missing syntax warnings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 * Correct calculation of whether a modifier version of a conditional statement will fit.
 * Fix an error in `MultilineIfThen` cop that occurred in some special cases.
+* Fix missing syntax warning.
 
 ## 0.8.1 (05/30/2013)
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -59,7 +59,7 @@ module Rubocop
                      # and do no more checking in the file.
                      syntax_cop.offences
                    else
-                     inspect_file(file)
+                     inspect_file(file, syntax_cop)
                    end
 
         any_failed = true unless offences.empty?
@@ -81,7 +81,7 @@ module Rubocop
       end
     end
 
-    def inspect_file(file)
+    def inspect_file(file, syntax_cop)
       begin
         ast, comments, tokens, source = CLI.parse(file) do |source_buffer|
           source_buffer.read
@@ -111,6 +111,8 @@ module Rubocop
           end
           offences.concat(cop.offences)
         end
+        offences.concat(syntax_cop.offences)
+        syntax_cop.offences.clear
         offences
       end
     end

--- a/lib/rubocop/cop/syntax.rb
+++ b/lib/rubocop/cop/syntax.rb
@@ -5,6 +5,7 @@ require 'open3'
 module Rubocop
   module Cop
     class Syntax < Cop
+
       def inspect_file(file)
         # Starting JRuby processes would be extremely slow
         # We need to check if rbx returns nice warning messages

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -469,6 +469,22 @@ Usage: rubocop [options] [file1, file2, ...]
          ''].join("\n"))
     end
 
+    it 'registers an offence for syntax warning and usual cop warning' do
+      create_file('example.rb', [
+        '# encoding: utf-8',
+        '1 + 2;'
+      ])
+      expect(cli.run(['example.rb'])).to eq(1)
+      expect($stdout.string).to eq(
+        [
+        "== #{abs('example.rb')} ==",
+         'C:  1:  6: Do not use semicolons to terminate expressions.',
+         'W:  2:  0: Possibly useless use of + in void context',
+         '',
+         '1 file inspected, 2 offences detected',
+         ''].join("\n"))
+    end
+
     it 'can process a file with an invalid UTF-8 byte sequence' do
       pending
       create_file('example.rb', [

--- a/spec/rubocop/formatter/base_formatter_spec.rb
+++ b/spec/rubocop/formatter/base_formatter_spec.rb
@@ -18,7 +18,7 @@ module Rubocop
             '#' * 90
           ])
 
-          create_file('4_offences.rb', [
+          create_file('6_offences.rb', [
             '# encoding: utf-8',
             'camelCaseVariable = 1',
             '1 + 2;',
@@ -72,7 +72,7 @@ module Rubocop
           it 'receives all file paths' do
             expected_paths = [
               '1_offence.rb',
-              '4_offences.rb',
+              '6_offences.rb',
               'no_offence.rb'
             ].map { |path| File.expand_path(path) }.sort
 
@@ -123,7 +123,7 @@ module Rubocop
               .with(File.expand_path('1_offence.rb'), anything)
 
             formatter.should_receive(method_name)
-              .with(File.expand_path('4_offences.rb'), anything)
+              .with(File.expand_path('6_offences.rb'), anything)
 
             formatter.should_receive(method_name)
               .with(File.expand_path('no_offence.rb'), anything)
@@ -151,8 +151,8 @@ module Rubocop
               case File.basename(file)
               when '1_offence.rb'
                 expect(offences).to have(1).item
-              when '4_offences.rb'
-                expect(offences).to have(4).items
+              when '6_offences.rb'
+                expect(offences).to have(6).items
               when 'no_offence.rb'
                 expect(offences).to be_empty
               else


### PR DESCRIPTION
Syntax `ruby -wc` warnings were no more considered as offences.
