### PR TITLE
Fix off-by-one error in favor_modifier.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * [#239](https://github.com/bbatsov/rubocop/issues/239) - fixed double quotes false positives
 * [#233](https://github.com/bbatsov/rubocop/issues/233) - report syntax cop offences
+* Fix off-by-one error in favor_modifier.
 
 ## 0.8.2 (06/05/2013)
 

--- a/lib/rubocop/cop/favor_modifier.rb
+++ b/lib/rubocop/cop/favor_modifier.rb
@@ -14,12 +14,19 @@ module Rubocop
         if length(sexp) > 3
           false
         else
-          indentation = sexp.loc.keyword.column
-          cond_length = sexp.loc.keyword.size + cond.loc.expression.size + 1
           body_length = body_length(body)
 
-          body_length > 0 &&
-            (indentation + cond_length + body_length) <= LineLength.max
+          if body_length == 0
+            false
+          else
+            indentation = sexp.loc.keyword.column
+            kw_length = sexp.loc.keyword.size
+            cond_length = cond.loc.expression.size
+            space = 1
+            total = indentation + body_length + space + kw_length + space +
+              cond_length
+            total <= LineLength.max
+          end
         end
       end
 

--- a/spec/rubocop/cops/favor_modifier_spec.rb
+++ b/spec/rubocop/cops/favor_modifier_spec.rb
@@ -11,10 +11,14 @@ module Rubocop
 
       it 'registers an offence for multiline if that fits on one line' do
         # This if statement fits exactly on one line if written as a modifier.
+        condition = 'a' * 38
+        body = 'b' * 35
+        expect("  #{body} if #{condition}".length).to eq(79)
+
         inspect_source(if_unless,
-                       ['if a_condition_that_is_just_short_enough',
-                        '  some_long_metod_name(followed_by_args)',
-                        'end'])
+                       ["  if #{condition}",
+                        "    #{body}",
+                        '  end'])
         expect(if_unless.offences.map(&:message)).to eq(
           ['Favor modifier if/unless usage when you have a single-line body.' +
            ' Another good alternative is the usage of control flow &&/||.'])
@@ -126,11 +130,17 @@ module Rubocop
       end
 
       def check_too_long(cop, keyword)
+        # This statement is one character too long to fit.
+        condition = 'a' * (40 - keyword.length)
+        body = 'b' * 36
+        expect("  #{body} #{keyword} #{condition}".length).to eq(80)
+
         inspect_source(cop,
-                       ["  #{keyword} a_lengthy_condition_that_goes_on_and_on",
-                        '    some_long_metod_name(followed_by_args)',
+                       ["  #{keyword} #{condition}",
+                        "    #{body}",
                         '  end'])
-        expect(cop.offences.map(&:message)).to be_empty
+
+        expect(cop.offences).to be_empty
       end
 
       def check_short_multiline(cop, keyword)


### PR DESCRIPTION
This was corrected earlier, but I didn't get it quite right that time.
There were instances when `IfUnlessModifier` reported a violation, but
fixing the violation would make the line too long.
