### PR TITLE
Recognize a line with CR+LF as a blank line in AccessControl cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#239](https://github.com/bbatsov/rubocop/issues/239) - fixed double quotes false positives
 * [#233](https://github.com/bbatsov/rubocop/issues/233) - report syntax cop offences
 * Fix off-by-one error in favor_modifier.
+* [#229](https://github.com/bbatsov/rubocop/issues/229) - recognize a line with CR+LF as a blank line in AccessControl cop.
 
 ## 0.8.2 (06/05/2013)
 

--- a/lib/rubocop/cop/access_control.rb
+++ b/lib/rubocop/cop/access_control.rb
@@ -28,7 +28,8 @@ module Rubocop
 
                 send_line = send_node.loc.line
 
-                unless source[send_line].empty? && source[send_line - 2].empty?
+                unless source[send_line].chomp.empty? &&
+                    source[send_line - 2].chomp.empty?
                   add_offence(:convention, send_node.loc, BLANK_MSG)
                 end
               end

--- a/spec/rubocop/cops/access_control_spec.rb
+++ b/spec/rubocop/cops/access_control_spec.rb
@@ -124,6 +124,17 @@ module Rubocop
         expect(a.offences.map(&:message))
           .to eq([AccessControl::BLANK_MSG])
       end
+
+      it 'recognizes blank lines with DOS style line endings' do
+        inspect_source(a,
+                       ["class Test\r",
+                        "\r",
+                        "  protected\r",
+                        "\r",
+                        "  def test; end\r",
+                        "end\r"])
+        expect(a.offences.size).to eq(0)
+      end
     end
   end
 end


### PR DESCRIPTION
Fix for #229.
