### PR TITLE
Handle multiple constant assignment in ConstantName cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#233](https://github.com/bbatsov/rubocop/issues/233) - report syntax cop offences
 * Fix off-by-one error in favor_modifier.
 * [#229](https://github.com/bbatsov/rubocop/issues/229) - recognize a line with CR+LF as a blank line in AccessControl cop.
+* [#235](https://github.com/bbatsov/rubocop/issues/235) - handle multiple constant assignment in ConstantName cop
 
 ## 0.8.2 (06/05/2013)
 

--- a/lib/rubocop/cop/constant_name.rb
+++ b/lib/rubocop/cop/constant_name.rb
@@ -9,12 +9,10 @@ module Rubocop
       def on_casgn(node)
         _scope, const_name, value = *node
 
-        # we cannot know the result of method calls line
+        # We cannot know the result of method calls line
         # NewClass = something_that_returns_a_class
-        if value.type != :send && const_name !~ SNAKE_CASE
-          add_offence(:convention,
-                      node.loc.line,
-                      MSG)
+        unless value && value.type == :send
+          add_offence(:convention, node.loc, MSG) if const_name !~ SNAKE_CASE
         end
 
         super

--- a/spec/rubocop/cops/constant_name_spec.rb
+++ b/spec/rubocop/cops/constant_name_spec.rb
@@ -13,6 +13,12 @@ module Rubocop
         expect(const.offences.size).to eq(1)
       end
 
+      it 'registers offences for camel case in multiple const assignment' do
+        inspect_source(const,
+                       ['TopCase, Test2, TEST_3 = 5, 6, 7'])
+        expect(const.offences.size).to eq(2)
+      end
+
       it 'registers an offence for snake case in const name' do
         inspect_source(const,
                        ['TOP_test = 5'])
@@ -22,6 +28,12 @@ module Rubocop
       it 'allows screaming snake case in const name' do
         inspect_source(const,
                        ['TOP_TEST = 5'])
+        expect(const.offences).to be_empty
+      end
+
+      it 'allows screaming snake case in multiple const assignment' do
+        inspect_source(const,
+                       ['TOP_TEST, TEST_2 = 5, 6'])
         expect(const.offences).to be_empty
       end
 


### PR DESCRIPTION
Fix for #235.
