### PR TITLE
Correct handling of unicode escapes within double quotes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fix off-by-one error in favor_modifier.
 * [#229](https://github.com/bbatsov/rubocop/issues/229) - recognize a line with CR+LF as a blank line in AccessControl cop.
 * [#235](https://github.com/bbatsov/rubocop/issues/235) - handle multiple constant assignment in ConstantName cop
+* [#246](https://github.com/bbatsov/rubocop/issues/246) - correct handling of unicode escapes within double quotes
 
 ## 0.8.2 (06/05/2013)
 

--- a/lib/rubocop/cop/string_literals.rb
+++ b/lib/rubocop/cop/string_literals.rb
@@ -7,15 +7,14 @@ module Rubocop
         'string interpolation or special symbols.'
 
       def on_str(node)
-        text, = *node
-
         # Constants like __FILE__ and __DIR__ are created as strings,
         # but don't respond to begin.
         return unless node.loc.respond_to?(:begin)
 
         # regex matches IF there is a ' or there is a \\ in the string that is
         # not preceeded/followed by another \\ (e.g. `"\\x34"`) but not `"\\\\"`
-        if text.inspect !~ /('|([^\\]|\A)\\([^\\]|\Z))/ && node.loc.begin.source == '"'
+        if node.loc.expression.source !~ /('|([^\\]|\A)\\([^\\]|\Z))/ &&
+            node.loc.begin.source == '"'
           add_offence(:convention, node.loc, MSG)
         end
       end

--- a/spec/rubocop/cops/string_literals_spec.rb
+++ b/spec/rubocop/cops/string_literals_spec.rb
@@ -32,7 +32,8 @@ module Rubocop
       it 'accepts double quotes with some other special symbols' do
         # "Substitutions in double-quoted strings"
         # http://www.ruby-doc.org/docs/ProgrammingRuby/html/language.html
-        src = ['g = "\xf9"']
+        src = ['g = "\xf9"',
+               'copyright = "\u00A9"']
         inspect_source(sl, src)
         expect(sl.offences).to be_empty
       end


### PR DESCRIPTION
Fix for #246.

The problem with unpacking a `str` node was that unicode escape sequences
are translated to unicode UTF-8 bytes in the text value. We must look
at the original source code, which we can get from the node too.
