### PR TITLE
Fix bugs in calls to add_offence.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [#229](https://github.com/bbatsov/rubocop/issues/229) - recognize a line with CR+LF as a blank line in AccessControl cop.
 * [#235](https://github.com/bbatsov/rubocop/issues/235) - handle multiple constant assignment in ConstantName cop
 * [#246](https://github.com/bbatsov/rubocop/issues/246) - correct handling of unicode escapes within double quotes
+* Fix crashes in Blocks, CaseEquality, CaseIndentation, ClassAndModuleCamelCase, ClassMethods, CollectionMethods, and ColonMethodCall.
 
 ## 0.8.2 (06/05/2013)
 

--- a/lib/rubocop/cop/blocks.rb
+++ b/lib/rubocop/cop/blocks.rb
@@ -11,9 +11,9 @@ module Rubocop
         block_begin = node.loc.begin.source
 
         if block_length > 0 && block_begin == '{'
-          add_offence(:convention, node.loc.line, MULTI_LINE_MSG)
+          add_offence(:convention, node.loc, MULTI_LINE_MSG)
         elsif block_length == 0 && block_begin != '{'
-          add_offence(:convention, node.loc.line, SINGLE_LINE_MSG)
+          add_offence(:convention, node.loc, SINGLE_LINE_MSG)
         end
 
         super

--- a/lib/rubocop/cop/case_equality.rb
+++ b/lib/rubocop/cop/case_equality.rb
@@ -8,7 +8,7 @@ module Rubocop
       def on_send(node)
         _receiver, method_name, *_args = *node
 
-        add_offence(:convention, node.loc.line, MSG) if method_name == :===
+        add_offence(:convention, node.loc, MSG) if method_name == :===
 
         super
       end

--- a/lib/rubocop/cop/case_indentation.rb
+++ b/lib/rubocop/cop/case_indentation.rb
@@ -12,7 +12,7 @@ module Rubocop
 
         whens.each do |when_node|
           pos = when_node.loc.keyword
-          add_offence(:convention, pos.line, MSG) if pos.column != case_column
+          add_offence(:convention, pos, MSG) if pos.column != case_column
         end
 
         super

--- a/lib/rubocop/cop/class_and_module_camel_case.rb
+++ b/lib/rubocop/cop/class_and_module_camel_case.rb
@@ -22,7 +22,7 @@ module Rubocop
       def check_name(node)
         name = node.loc.name.source
 
-        add_offence(:convention, node.loc.line, MSG) if name =~ /_/
+        add_offence(:convention, node.loc, MSG) if name =~ /_/
       end
     end
   end

--- a/lib/rubocop/cop/class_methods.rb
+++ b/lib/rubocop/cop/class_methods.rb
@@ -8,7 +8,7 @@ module Rubocop
       def on_defs(node)
         definee, _name, _args, _body = *node
 
-        add_offence(:convention, node.loc.line, MSG) if definee.type == :const
+        add_offence(:convention, node.loc, MSG) if definee.type == :const
       end
     end
   end

--- a/lib/rubocop/cop/collection_methods.rb
+++ b/lib/rubocop/cop/collection_methods.rb
@@ -19,7 +19,7 @@ module Rubocop
         if receiver && PREFERRED_METHODS[method_name]
           add_offence(
             :convention,
-            node.loc.line,
+            node.loc,
             sprintf(MSG, PREFERRED_METHODS[method_name], method_name)
           )
         end

--- a/lib/rubocop/cop/colon_method_call.rb
+++ b/lib/rubocop/cop/colon_method_call.rb
@@ -10,7 +10,7 @@ module Rubocop
 
         # discard methods with nil receivers and op methods(like [])
         if receiver && node.loc.dot && node.loc.dot.source == '::'
-          add_offence(:convention, node.loc.line, MSG)
+          add_offence(:convention, node.loc, MSG)
         end
 
         super

--- a/lib/rubocop/cop/offence.rb
+++ b/lib/rubocop/cop/offence.rb
@@ -79,24 +79,22 @@ module Rubocop
       attr_reader :cop_name
 
       # @api private
+      attr_reader :line
+
+      # @api private
+      attr_reader :column
+
+      # @api private
       def initialize(severity, location, message, cop_name)
         unless SEVERITIES.include?(severity)
           fail ArgumentError, "Unknown severity: #{severity}"
         end
         @severity = severity
         @location = location
+        @line = location.line
+        @column = location.column
         @message = message
         @cop_name = cop_name
-      end
-
-      # @api private
-      def line
-        @location.line
-      end
-
-      # @api private
-      def column
-        @location.column
       end
 
       # @api private

--- a/spec/rubocop/cops/offence_spec.rb
+++ b/spec/rubocop/cops/offence_spec.rb
@@ -46,7 +46,8 @@ module Rubocop
 
       describe '#severity_level' do
         subject(:severity_level) do
-          Offence.new(severity, 1, 'message', 'CopName').severity_level
+          Offence.new(severity, Location.new(1, 0), 'message',
+                      'CopName').severity_level
         end
 
         context 'when severity is :refactor' do

--- a/spec/rubocop/formatter/progress_formatter_spec.rb
+++ b/spec/rubocop/formatter/progress_formatter_spec.rb
@@ -38,7 +38,8 @@ module Rubocop
       end
 
       def offence_with_severity(severity)
-        Cop::Offence.new(severity, 1, 'message', 'CopName')
+        Cop::Offence.new(severity, Cop::Location.new(1, 0), 'message',
+                         'CopName')
       end
 
       context 'when no offences are detected' do


### PR DESCRIPTION
There are a number of places where the location argument to `add_offence`
is still the line number. It's supposed to be a location object that
responds to `line` and `column`. The way to catch these errors in our unit
tests is to access `line` and `column` in the `Offence` constructor.
