### PR TITLE
Print relative paths with the simple/progress formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Changes
 
 * Deprecated `-e`/`--emacs` option. (Use `--format emacs` instead)
+* The default output formatter (`--format simple`) now prints relative file paths if the paths are under the current working directory.
 
 ### Bugs fixed
 

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -23,7 +23,7 @@ module Rubocop
       end
 
       def report_file(file, offences)
-        output.puts "== #{file} ==".color(:yellow)
+        output.puts "== #{smart_path(file)} ==".color(:yellow)
         output.puts offences.join("\n")
       end
 
@@ -43,6 +43,16 @@ module Rubocop
 
         output.puts
         output.puts summary
+      end
+
+      protected
+
+      def smart_path(path)
+        if path.start_with?(Dir.pwd)
+          Pathname.new(path).relative_path_from(Pathname.getwd).to_s
+        else
+          path
+        end
       end
     end
   end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -135,7 +135,7 @@ Usage: rubocop [options] [file1, file2, ...]
       ])
       expect(cli.run(['example.rb'])).to eq(1)
       expect($stdout.string)
-        .to eq ["== #{abs('example.rb')} ==",
+        .to eq ['== example.rb ==',
                 'C:  2:  5: Trailing whitespace detected.',
                 '',
                 '1 file inspected, 1 offence detected',
@@ -203,7 +203,7 @@ Usage: rubocop [options] [file1, file2, ...]
 
       expect(cli.run(['--only', 'IfUnlessModifier', 'example.rb'])).to eq(1)
       expect($stdout.string)
-        .to eq(["== #{abs('example.rb')} ==",
+        .to eq(['== example.rb ==',
                 'C:  1:  0: Favor modifier if/unless usage when you have a ' +
                 'single-line body. Another good alternative is the usage of ' +
                 'control flow &&/||.',
@@ -270,7 +270,7 @@ Usage: rubocop [options] [file1, file2, ...]
       ])
       expect(cli.run(['-c', 'rubocop.yml', 'example1.rb'])).to eq(1)
       expect($stdout.string).to eq(
-        ["== #{abs('example1.rb')} ==",
+        ['== example1.rb ==',
          'C:  1:  6: Trailing whitespace detected.',
          '',
          '1 file inspected, 1 offence detected',
@@ -290,7 +290,7 @@ Usage: rubocop [options] [file1, file2, ...]
       ])
       result = cli.run(['-c', 'rubocop.yml', 'example1.rb'])
       expect($stdout.string).to eq(
-        ["== #{abs('example1.rb')} ==",
+        ['== example1.rb ==',
          'C:  1:  0: Favor modifier if/unless usage when you have a single-line ' +
          'body. Another good alternative is the usage of control flow &&/||.',
          '',
@@ -310,7 +310,7 @@ Usage: rubocop [options] [file1, file2, ...]
       ])
       expect(cli.run(['example_src/example1.rb'])).to eq(1)
       expect($stdout.string).to eq(
-        ["== #{abs('example_src/example1.rb')} ==",
+        ['== example_src/example1.rb ==',
          'C:  1:  6: Trailing whitespace detected.',
          '',
          '1 file inspected, 1 offence detected',
@@ -347,7 +347,7 @@ Usage: rubocop [options] [file1, file2, ...]
       ])
       expect(cli.run(['example'])).to eq(1)
       expect($stdout.string).to eq(
-        ["== #{abs('example/lib/example1.rb')} ==",
+        ['== example/lib/example1.rb ==',
          'C:  2: 79: Line is too long. [90/79]',
          '',
          '2 files inspected, 1 offence detected',
@@ -393,7 +393,7 @@ Usage: rubocop [options] [file1, file2, ...]
 
       expect(cli.run(['example'])).to eq(1)
       expect($stdout.string).to eq(
-        ["== #{abs('example/tmp/test/example1.rb')} ==",
+        ['== example/tmp/test/example1.rb ==',
          'C:  2: 79: Line is too long. [90/79]',
          '',
          '1 file inspected, 1 offence detected',
@@ -416,7 +416,7 @@ Usage: rubocop [options] [file1, file2, ...]
       expect($stdout.string).to eq(
         ['Warning: unrecognized cop LyneLenth found in ' +
          File.expand_path('example/.rubocop.yml'),
-         "== #{abs('example/example1.rb')} ==",
+         '== example/example1.rb ==',
          'C:  2: 79: Line is too long. [90/79]',
          '',
          '1 file inspected, 1 offence detected',
@@ -439,7 +439,7 @@ Usage: rubocop [options] [file1, file2, ...]
       expect($stdout.string).to eq(
         ['Warning: unrecognized parameter LineLength:Min found in ' +
          File.expand_path('example/.rubocop.yml'),
-         "== #{abs('example/example1.rb')} ==",
+         '== example/example1.rb ==',
          'C:  2: 79: Line is too long. [90/79]',
          '',
          '1 file inspected, 1 offence detected',
@@ -682,7 +682,7 @@ Usage: rubocop [options] [file1, file2, ...]
     end
 
     describe '-f/--format option' do
-      let(:target_file) { File.expand_path('example.rb') }
+      let(:target_file) { 'example.rb' }
 
       before do
         create_file(target_file, [
@@ -706,7 +706,7 @@ Usage: rubocop [options] [file1, file2, ...]
           it 'outputs with emacs format' do
             cli.run(['--format', 'emacs', 'example.rb'])
             expect($stdout.string)
-              .to include("#{target_file}:2:79: C: Line is too long. [90/79]")
+              .to include("#{abs(target_file)}:2:79: C: Line is too long. [90/79]")
           end
         end
 
@@ -721,6 +721,8 @@ Usage: rubocop [options] [file1, file2, ...]
       end
 
       describe 'custom formatter' do
+        let(:target_file) { abs('example.rb') }
+
         context 'when a class name is specified' do
           it 'uses the class as a formatter' do
             module ::MyTool
@@ -769,7 +771,7 @@ Usage: rubocop [options] [file1, file2, ...]
         expect($stdout.string).to include([
           "== #{target_file} ==",
           'C:  2: 79: Line is too long. [90/79]',
-          "#{target_file}:2:79: C: Line is too long. [90/79]"
+          "#{abs(target_file)}:2:79: C: Line is too long. [90/79]"
         ].join("\n"))
       end
     end
@@ -785,7 +787,7 @@ Usage: rubocop [options] [file1, file2, ...]
     end
 
     describe '-o/--out option' do
-      let(:target_file) { File.expand_path('example.rb') }
+      let(:target_file) { 'example.rb' }
 
       before do
         create_file(target_file, [
@@ -815,7 +817,7 @@ Usage: rubocop [options] [file1, file2, ...]
         ].join("\n"))
 
         expect(File.read('emacs_output.txt')).to eq([
-          "#{target_file}:2:79: C: Line is too long. [90/79]",
+          "#{abs(target_file)}:2:79: C: Line is too long. [90/79]",
           '',
           '1 file inspected, 1 offence detected',
           ''

--- a/spec/rubocop/formatter/progress_formatter_spec.rb
+++ b/spec/rubocop/formatter/progress_formatter_spec.rb
@@ -8,16 +8,22 @@ module Rubocop
     let(:formatter) { Formatter::ProgressFormatter.new(output) }
     let(:output) { StringIO.new }
 
+    let(:files) do
+      %w(lib/rubocop.rb spec/spec_helper.rb bin/rubocop).map do |path|
+        File.expand_path(path)
+      end
+    end
+
     describe '#file_finished' do
       before do
-        formatter.started(['/path/to/file'])
-        formatter.file_started('/path/to/file', {})
+        formatter.started(files)
+        formatter.file_started(files.first, {})
       end
 
       shared_examples 'calls #report_file_as_mark' do
         it 'calls #report_as_with_mark' do
           formatter.should_receive(:report_file_as_mark)
-          formatter.file_finished('/path/to/file', offences)
+          formatter.file_finished(files.first, offences)
         end
       end
 
@@ -34,7 +40,7 @@ module Rubocop
 
     describe '#report_file_as_mark' do
       before do
-        formatter.report_file_as_mark('path/to/file', offences)
+        formatter.report_file_as_mark(files.first, offences)
       end
 
       def offence_with_severity(severity)
@@ -80,8 +86,6 @@ module Rubocop
     end
 
     describe '#finished' do
-      let(:files) { %w(file1.rb file2.rb file3.rb) }
-
       before do
         formatter.reports_summary = true
 
@@ -103,10 +107,10 @@ module Rubocop
       it 'reports all detected offences for all failed files' do
         formatter.finished(files)
         expect(output.string).to include([
-          '== file1.rb ==',
+          '== lib/rubocop.rb ==',
           'C:  2:  2: foo',
           '',
-          '== file3.rb ==',
+          '== bin/rubocop ==',
           'E:  5:  1: bar',
           'C:  6:  0: foo'
         ].join("\n"))

--- a/spec/rubocop/formatter/simple_text_formatter_spec.rb
+++ b/spec/rubocop/formatter/simple_text_formatter_spec.rb
@@ -2,12 +2,39 @@
 
 require 'spec_helper'
 require 'stringio'
+require 'tempfile'
 
 module Rubocop
   module Formatter
     describe SimpleTextFormatter do
       subject(:formatter) { SimpleTextFormatter.new(output) }
       let(:output) { StringIO.new }
+
+      describe '#report_file' do
+        before do
+          formatter.report_file(file, [])
+        end
+
+        context 'the file is under the current working directory' do
+          let(:file) { File.expand_path('spec/spec_helper.rb') }
+
+          it 'prints as relative path' do
+            expect(output.string).to include('== spec/spec_helper.rb ==')
+          end
+        end
+
+        context 'the file is outside of the current working directory' do
+          let(:file) do
+            tempfile = Tempfile.new('')
+            tempfile.close
+            File.expand_path(tempfile.path)
+          end
+
+          it 'prints as absolute path' do
+            expect(output.string).to include("== #{file} ==")
+          end
+        end
+      end
 
       describe '#report_summary' do
         context 'when no files inspected' do


### PR DESCRIPTION
Currently  `simple` and `progress` formatters print absolutes paths. This is verbose for human, so I've changed them to print relative paths to the working directory.

This does not affect to the `emacs` formatter.
