### PR TITLE
Do not check for space around operators called with method syntax.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [#235](https://github.com/bbatsov/rubocop/issues/235) - handle multiple constant assignment in ConstantName cop
 * [#246](https://github.com/bbatsov/rubocop/issues/246) - correct handling of unicode escapes within double quotes
 * Fix crashes in Blocks, CaseEquality, CaseIndentation, ClassAndModuleCamelCase, ClassMethods, CollectionMethods, and ColonMethodCall.
+* [#263](https://github.com/bbatsov/rubocop/issues/263) - do not check for space around operators called with method syntax
 
 ## 0.8.2 (06/05/2013)
 

--- a/lib/rubocop/cop/surrounding_space.rb
+++ b/lib/rubocop/cop/surrounding_space.rb
@@ -57,6 +57,7 @@ module Rubocop
 
         tokens.each_cons(3) do |token_before, token, token_after|
           next if token_before.type == :kDEF # TODO: remove?
+          next if token_before.type == :tDOT # Called as method.
           next if positions_not_to_check.include?(token.pos)
 
           case token.type

--- a/spec/rubocop/cops/space_around_operators_spec.rb
+++ b/spec/rubocop/cops/space_around_operators_spec.rb
@@ -134,6 +134,11 @@ module Rubocop
         expect(space.offences).to be_empty
       end
 
+      it 'accepts an operator called with method syntax' do
+        inspect_source(space, ['Date.today.+(1).to_s'])
+        expect(space.offences).to be_empty
+      end
+
       it 'registers an offence for operators without spaces' do
         inspect_source(space,
                        ['x+= a+b-c*d/e%f^g|h&i||j',


### PR DESCRIPTION
Fix for #263.
