### PR TITLE
Don't display "Offences:" if there's no offence with progress formatter

### DIFF
--- a/lib/rubocop/formatter/progress_formatter.rb
+++ b/lib/rubocop/formatter/progress_formatter.rb
@@ -28,12 +28,14 @@ module Rubocop
 
         return unless reports_summary?
 
-        output.puts
-        output.puts 'Offences:'
-
-        @offences_for_files.each do |file, offences|
+        unless @offences_for_files.empty?
           output.puts
-          report_file(file, offences.sort)
+          output.puts 'Offences:'
+
+          @offences_for_files.each do |file, offences|
+            output.puts
+            report_file(file, offences.sort)
+          end
         end
 
         report_summary(inspected_files.count, @total_offence_count)


### PR DESCRIPTION
``` bash
$ ./bin/rubocop --format progress
Inspecting 195 files
................................................................................
................................................................................
...................................

Offences: # <- This one

195 files inspected, no offences detected
```
