### PR TITLE
Fix Parser dependency to 2.0.0.beta6

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.summary = 'Automatic Ruby code style checking tool.'
 
   s.add_runtime_dependency('rainbow', '>= 1.1.4')
-  s.add_runtime_dependency('parser', ['>= 2.0.0.beta1', '<= 2.0.0'])
+  s.add_runtime_dependency('parser', '2.0.0.beta6')
   s.add_development_dependency('rake', '~> 10.0')
   s.add_development_dependency('rspec', '~> 2.13')
   s.add_development_dependency('yard', '~> 0.8')


### PR DESCRIPTION
Parser 2.0.0 is still beta release.
This means backward compatibility is not always kept,
and RuboCop may break if the dependency version is unfixed.
In development of RuboCop, we need to differentiate
the cause of broken specs. Otherwise we cannot rely on specs.

When a new beta version of Parser is released,
we can check whether RuboCop works properly with the new version
and fix if needed, then update the version of the dependency.

After Parser 2.0.0 official release is done,
we would specify the dependency as range like '~> 2.0'.
