### PR TITLE
Add class and module documentation where missing.

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -5,6 +5,11 @@ require 'yaml'
 require 'pathname'
 
 module Rubocop
+  # This class represents the configuration of the RuboCop application
+  # and all its cops. A Config is associated with a YAML configuration
+  # file from which it was read. Several different Configs can be used
+  # during a run of the rubocop program, if files in several
+  # directories are inspected.
   class Config < DelegateClass(Hash)
     class ValidationError < StandardError; end
 

--- a/lib/rubocop/config_store.rb
+++ b/lib/rubocop/config_store.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 
 module Rubocop
+  # Handles chaching of configurations and association of inspected
+  # ruby files to configurations.
   module ConfigStore
     module_function
 

--- a/lib/rubocop/cop/style/blocks.rb
+++ b/lib/rubocop/cop/style/blocks.rb
@@ -3,6 +3,8 @@
 module Rubocop
   module Cop
     module Style
+      # Check for uses of braces or do/end around single line or
+      # multi-line blocks.
       class Blocks < Cop
         MULTI_LINE_MSG = 'Avoid using {...} for multi-line blocks.'
         SINGLE_LINE_MSG = 'Prefer {...} over do...end for single-line blocks.'

--- a/lib/rubocop/cop/style/favor_modifier.rb
+++ b/lib/rubocop/cop/style/favor_modifier.rb
@@ -3,6 +3,7 @@
 module Rubocop
   module Cop
     module Style
+      # Common functionality for modifier cops.
       module FavorModifier
         # TODO extremely ugly solution that needs lots of polish
         def check(sexp)
@@ -44,6 +45,8 @@ module Rubocop
         end
       end
 
+      # Checks for if and unless statements that would fit on one line
+      # if written as a modifier if/unless.
       class IfUnlessModifier < Cop
         include FavorModifier
 
@@ -83,6 +86,8 @@ module Rubocop
         end
       end
 
+      # Checks for while and until statements that would fit on one line
+      # if written as a modifier while/until.
       class WhileUntilModifier < Cop
         include FavorModifier
 

--- a/lib/rubocop/cop/style/if_then_else.rb
+++ b/lib/rubocop/cop/style/if_then_else.rb
@@ -3,6 +3,7 @@
 module Rubocop
   module Cop
     module Style
+      # Common functionality for cops checking if and unless statements.
       module IfThenElse
         def on_if(node)
           check(node)
@@ -24,6 +25,7 @@ module Rubocop
         end
       end
 
+      # Checks for uses of semicolon in if statements.
       class IfWithSemicolon < Cop
         include IfThenElse
 
@@ -36,6 +38,7 @@ module Rubocop
         end
       end
 
+      # Checks for uses of then multi-line if statements.
       class MultilineIfThen < Cop
         include IfThenElse
 
@@ -60,6 +63,7 @@ module Rubocop
         end
       end
 
+      # Checks for uses of if/then/else/end on a single line.
       class OneLineConditional < Cop
         include IfThenElse
 

--- a/lib/rubocop/cop/style/space_after_comma_etc.rb
+++ b/lib/rubocop/cop/style/space_after_comma_etc.rb
@@ -5,6 +5,8 @@
 module Rubocop
   module Cop
     module Style
+      # Common functionality for cops checking for missing space after
+      # punctuation.
       module SpaceAfterCommaEtc
         MSG = 'Space missing after %s.'
 
@@ -24,6 +26,7 @@ module Rubocop
         end
       end
 
+      # Checks for comma (,) not follwed by some kind of space.
       class SpaceAfterComma < Cop
         include SpaceAfterCommaEtc
 
@@ -32,6 +35,7 @@ module Rubocop
         end
       end
 
+      # Checks for semicolon (;) not follwed by some kind of space.
       class SpaceAfterSemicolon < Cop
         include SpaceAfterCommaEtc
 
@@ -40,6 +44,7 @@ module Rubocop
         end
       end
 
+      # Checks for colon (:) not follwed by some kind of space.
       class SpaceAfterColon < Cop
         include SpaceAfterCommaEtc
 

--- a/lib/rubocop/cop/style/space_after_control_keyword.rb
+++ b/lib/rubocop/cop/style/space_after_control_keyword.rb
@@ -3,6 +3,7 @@
 module Rubocop
   module Cop
     module Style
+      # Checks for various control keywords missing a space after them.
       class SpaceAfterControlKeyword < Cop
         MSG = 'Use space after control keywords.'
         # elsif and unless are handled by on_if.

--- a/lib/rubocop/cop/style/string_literals.rb
+++ b/lib/rubocop/cop/style/string_literals.rb
@@ -3,6 +3,7 @@
 module Rubocop
   module Cop
     module Style
+      # Checks for uses of double quotes where single quotes would do.
       class StringLiterals < Cop
         MSG = "Prefer single-quoted strings when you don't need " +
           'string interpolation or special symbols.'

--- a/lib/rubocop/cop/style/surrounding_space.rb
+++ b/lib/rubocop/cop/style/surrounding_space.rb
@@ -5,6 +5,7 @@
 module Rubocop
   module Cop
     module Style
+      # Common functionality for checking surrounding space.
       module SurroundingSpace
         def space_between?(t1, t2)
           char_preceding_2nd_token =
@@ -41,6 +42,8 @@ module Rubocop
         end
       end
 
+      # Checks that operators have space around them, except for **
+      # which should not have surrounding space.
       class SpaceAroundOperators < Cop
         include SurroundingSpace
         MSG_MISSING = "Surrounding space missing for operator '%s'."
@@ -163,6 +166,7 @@ module Rubocop
         end
       end
 
+      # Checks that block braces have surrounding space.
       class SpaceAroundBraces < Cop
         include SurroundingSpace
         MSG_LEFT = "Surrounding space missing for '{'."
@@ -209,6 +213,8 @@ module Rubocop
         end
       end
 
+      # Common functionality for checking for spaces inside various
+      # kinds of parentheses.
       module SpaceInside
         include SurroundingSpace
         MSG = 'Space inside %s detected.'
@@ -226,6 +232,7 @@ module Rubocop
         end
       end
 
+      # Checks for spaces inside ordinary round parentheses.
       class SpaceInsideParens < Cop
         include SpaceInside
 
@@ -234,6 +241,7 @@ module Rubocop
         end
       end
 
+      # Checks for spaces inside square brackets.
       class SpaceInsideBrackets < Cop
         include SpaceInside
 
@@ -242,6 +250,8 @@ module Rubocop
         end
       end
 
+      # Checks that braces used for hash literals have or don't have
+      # surrounding space depending on configuration.
       class SpaceInsideHashLiteralBraces < Cop
         include SurroundingSpace
         MSG = 'Space inside hash literal braces %s.'
@@ -275,6 +285,8 @@ module Rubocop
         end
       end
 
+      # Checks that the equals signs in parameter default assignments
+      # have surrounding space.
       class SpaceAroundEqualsInParameterDefault < Cop
         include SurroundingSpace
         MSG = 'Surrounding space missing in default value assignment.'


### PR DESCRIPTION
For #208. Fixed all remaining `Documentation` violations _except_ `unused_local_variable.rb`, which I think @yujinakayama can do much better.
