### PR TITLE
Set config in all cop classes before inspect is called.

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -96,9 +96,10 @@ module Rubocop
       # filter out Rails cops unless requested
       @cops.reject! { |cop_klass| cop_klass.rails? } unless @options[:rails]
 
+      set_config_for_all_cops(config)
+
       @cops.reduce(syntax_offences) do |offences, cop_class|
         cop_name = cop_class.cop_name
-        cop_class.config = config.for_cop(cop_name)
         if config.cop_enabled?(cop_name)
           cop = setup_cop(cop_class, disabled_lines)
           if !@options[:only] || @options[:only] == cop_name
@@ -113,6 +114,12 @@ module Rubocop
           offences.concat(cop.offences)
         end
         offences
+      end
+    end
+
+    def set_config_for_all_cops(config)
+      @cops.each do |cop_class|
+        cop_class.config = config.for_cop(cop_class.cop_name)
       end
     end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -232,13 +232,20 @@ Usage: rubocop [options] [file1, file2, ...]
     end
 
     it 'runs just one cop if --only is passed' do
-      create_file('example.rb', ['#' * 90,
-                                 "\ty"])
+      create_file('example.rb', ['if x== 0 ',
+                                 "\ty",
+                                 'end'])
+      # IfUnlessModifier depends on the configuration of LineLength.
+      # That configuration might have been set by other spec examples
+      # so we reset it to emulate a start from scratch.
+      Cop::Style::LineLength.config = nil
 
-      expect(cli.run(['--only', 'LineLength', 'example.rb'])).to eq(1)
+      expect(cli.run(['--only', 'IfUnlessModifier', 'example.rb'])).to eq(1)
       expect($stdout.string)
         .to eq(['== example.rb ==',
-                'C:  1: 80: Line is too long. [90/79]',
+                'C:  1:  1: Favor modifier if/unless usage when you have a ' +
+                'single-line body. Another good alternative is the usage of ' +
+                'control flow &&/||.',
                 '',
                 '1 file inspected, 1 offence detected',
                 ''].join("\n"))


### PR DESCRIPTION
Also restore spec "runs just one cop if --only is passed" to previous.
