### PR TITLE
Handle arrays with character literals in WordArray.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [#270](https://github.com/bbatsov/rubocop/issues/270) - fixed a false positive in ParenthesesAroundCondition
 * [#288](https://github.com/bbatsov/rubocop/issues/288) - get config parameter AllCops/Excludes from highest config file in path
 * [#276](https://github.com/bbatsov/rubocop/issues/276) - let columns start at 1 instead of 0 in all output of column numbers
+* Fix crashes in WordArray on arrays of character literals such as `[?\r, ?\n]`
 
 ## 0.8.2 (06/05/2013)
 

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -29,8 +29,11 @@ module Rubocop
 
         def complex_content?(arr_sexp)
           arr_sexp.each do |s|
-            str_content = Util.strip_quotes(s.loc.expression.source)
-            return true unless str_content =~ /\A[\w-]+\z/
+            source = s.loc.expression.source
+            unless source.start_with?('?') # %W(\r \n) can replace [?\r, ?\n]
+              str_content = Util.strip_quotes(source)
+              return true unless str_content =~ /\A[\w-]+\z/
+            end
           end
 
           false

--- a/spec/rubocop/cops/style/word_array_spec.rb
+++ b/spec/rubocop/cops/style/word_array_spec.rb
@@ -20,9 +20,21 @@ module Rubocop
           expect(wa.offences.size).to eq(1)
         end
 
+        it 'registers an offence for arrays with character constants' do
+          inspect_source(wa,
+                         ['["one", ?\n]'])
+          expect(wa.offences.size).to eq(1)
+        end
+
         it 'does not register an offence for array of non-words' do
           inspect_source(wa,
                          ['["one space", "two", "three"]'])
+          expect(wa.offences).to be_empty
+        end
+
+        it 'does not register an offence for array containing non-string' do
+          inspect_source(wa,
+                         ['["one", "two", 3]'])
           expect(wa.offences).to be_empty
         end
 


### PR DESCRIPTION
For example `[?\r, ?\n]` caused a crash. Now treated as an offence.
