### PR TITLE
Fix crash in Documentation on empty modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [#288](https://github.com/bbatsov/rubocop/issues/288) - get config parameter AllCops/Excludes from highest config file in path
 * [#276](https://github.com/bbatsov/rubocop/issues/276) - let columns start at 1 instead of 0 in all output of column numbers
 * Fix crashes in WordArray on arrays of character literals such as `[?\r, ?\n]`
+* Fix crashes in Documentation on empty modules
 
 ## 0.8.2 (06/05/2013)
 

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -35,7 +35,9 @@ module Rubocop
           on_node(:module, ast) do |node|
             _name, body = *node
 
-            if body.type == :begin
+            if body.nil?
+              namespace = false
+            elsif body.type == :begin
               namespace = body.children.all? do |n|
                 [:class, :module].include?(n.type)
               end

--- a/spec/rubocop/cops/style/documentation_spec.rb
+++ b/spec/rubocop/cops/style/documentation_spec.rb
@@ -26,6 +26,16 @@ module Rubocop
           expect(documentation.offences.size).to eq(1)
         end
 
+        it 'registers an offence for empty module without documentation' do
+          # Because why would you have an empty module? It requires some
+          # explanation.
+          inspect_source(documentation,
+                         ['module Test',
+                          'end'
+                         ])
+          expect(documentation.offences.size).to eq(1)
+        end
+
         it 'accepts non-empty class with documentation' do
           inspect_source(documentation,
                          ['# class comment',


### PR DESCRIPTION
Register offence if empty module lacks comment.
