### PR TITLE
Fix exception at location.real_column in the JSON formatter

### DIFF
--- a/lib/rubocop/formatter/json_formatter.rb
+++ b/lib/rubocop/formatter/json_formatter.rb
@@ -54,14 +54,15 @@ module Rubocop
           severity: offence.severity,
            message: offence.message,
           cop_name: offence.cop_name,
-          location: hash_for_location(offence.location)
+          location: hash_for_location(offence)
         }
       end
 
-      def hash_for_location(location)
+      # TODO: Consider better solution for Location#real_column.
+      def hash_for_location(offence)
         {
-            line: location.line,
-          column: location.real_column
+            line: offence.line,
+          column: offence.real_column
         }
       end
 


### PR DESCRIPTION
We have defined `Rubocop::Cop::Location#real_column`, but most cases the location attribute value of `Offence` is actually `Parser::Source::Range` and it does not respond to `#real_column`.

Though I think we should handle the location attribute in a better way later, this is a quick fix for now.
