### PR TITLE
Correct some special cases of block end alignment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#318](https://github.com/bbatsov/rubocop/issues/318) - correct some special cases of block end alignment
+
 ## 0.9.0 (01/07/2013)
 
 ### New features

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -116,8 +116,8 @@ module Rubocop
                        column_count)
         newline_length = 1
         begin_pos = preceding_lines.reduce(0) do |a, e|
-                      a + e.length + newline_length
-                    end + begin_column
+          a + e.length + newline_length
+        end + begin_column
         Parser::Source::Range.new(source_buffer, begin_pos,
                                   begin_pos + column_count)
       end

--- a/spec/rubocop/cops/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cops/lint/end_alignment_spec.rb
@@ -77,6 +77,19 @@ module Rubocop
           expect(cop.offences.size).to eq(1)
         end
 
+        context 'when the block is a logical operand' do
+          it 'accepts a correctly aligned block end' do
+            inspect_source(cop,
+                           ['(value.is_a? Array) && value.all? do |subvalue|',
+                            '  type_check_value(subvalue, array_type)',
+                            'end',
+                            'a || b do',
+                            'end',
+                           ])
+            expect(cop.offences).to be_empty
+          end
+        end
+
         context 'with BlockAlignSchema set to StartOfAssignment' do
           before do
             EndAlignment.config = { 'BlockAlignSchema' => 'StartOfAssignment' }
@@ -88,6 +101,17 @@ module Rubocop
                             'end'
                            ])
             expect(cop.offences).to be_empty
+          end
+
+          context 'and the block is an operand' do
+            it 'accepts end aligned with a variable' do
+              inspect_source(cop,
+                             ['b = 1 + preceding_line.reduce(0) do |a, e|',
+                              '  a + e.length + newline_length',
+                              'end + 1'
+                             ])
+              expect(cop.offences).to be_empty
+            end
           end
 
           it 'registers an offence for mismatched block end with a variable' do
@@ -260,6 +284,17 @@ module Rubocop
                             '           end'
                            ])
             expect(cop.offences).to be_empty
+          end
+
+          context 'and the block is an operand' do
+            it 'accepts end aligned with a variable' do
+              inspect_source(cop,
+                             ['b = 1 + preceding_line.reduce(0) do |a, e|',
+                              '          a + e',
+                              '        end + 1'
+                             ])
+              expect(cop.offences).to be_empty
+            end
           end
 
           it 'registers an offence for mismatched block end with the method that invokes the block' do

--- a/spec/rubocop/cops/offence_spec.rb
+++ b/spec/rubocop/cops/offence_spec.rb
@@ -102,8 +102,8 @@ module Rubocop
           source_buffer = Parser::Source::Buffer.new('test', 1)
           source_buffer.source = source.join("\n")
           begin_pos = source[0...(line - 1)].reduce(0) do |a, e|
-                        a + e.length + "\n".length
-                      end + column
+            a + e.length + "\n".length
+          end + column
           Parser::Source::Range.new(source_buffer, begin_pos, begin_pos + 1)
         end
 


### PR DESCRIPTION
When the method with a block is an operand in a binary operation.
Fix for #318 and another case that I ran into in our own code.
There may still be more special cases that we don't support, but none that I know of.
