### PR TITLE
exclude reader methods that ends with a question mark

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -56,3 +56,10 @@ BlockNesting:
 # character.
 RegexpLiteral:
   MaxSlashes: 1
+
+# Allow trivial attribute accessors when they end in a question
+# mark ('?').
+# An alternate way of doing this is to use `alias_method` to add
+# an alias ending with a question mark for the accessor.
+TrivialAccessors:
+  AllowPredicates: false

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -11,7 +11,7 @@ module Rubocop
         def on_def(node)
           method_name, args, body = *node
 
-          kind = if body && body.type == :ivar && method_name[-1] != '?'
+          kind = if body && body.type == :ivar && predicate?(method_name)
                    'reader'
                  elsif args.children.size == 1 &&
                        body && body.type == :ivasgn &&
@@ -25,6 +25,16 @@ module Rubocop
           end
 
           super
+        end
+
+        private
+
+        def predicate?(method_name)
+          !(method_name[-1] == '?' || TrivialAccessors.allow_predicates)
+        end
+
+        def self.allow_predicates
+          TrivialAccessors.config['AllowPredicates']
         end
       end
     end

--- a/spec/rubocop/cops/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cops/style/trivial_accessors_spec.rb
@@ -9,6 +9,7 @@ module Rubocop
         let(:trivial_accessors_finder) { TrivialAccessors.new }
 
         before :each do
+          described_class.config = { 'AllowPredicates' => false }
           trivial_accessors_finder.offences.clear
         end
 
@@ -333,12 +334,18 @@ module Rubocop
           expect(trivial_accessors_finder.offences).to be_empty
         end
 
-        it 'ignores trivial accessors that ends with a question mark' do
-          inspect_source(trivial_accessors_finder,
-                         [' def foo?',
-                          '   @foo',
-                          ' end'])
-          expect(trivial_accessors_finder.offences).to be_empty
+        context 'with predicates allowed' do
+          before do
+            described_class.config['AllowPredicates'] = true
+          end
+
+          it 'ignores accessors ending with a question mark' do
+            inspect_source(trivial_accessors_finder,
+                           [' def foo?',
+                            '   @foo',
+                            ' end'])
+            expect(trivial_accessors_finder.offences).to be_empty
+          end
         end
       end
     end


### PR DESCRIPTION
As attr_reader can't deal with variables ending with '?'

Another possible  work around it is to use:
class Foo
  attr_reader :empty
  alias_method :empty?, :empty
end
