### PR TITLE
Handle block end alignments in method chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Removed the `BlockAlignSchema` configuration option from `EndAlignment`. We now support only the default alignment schema - `StartOfAssignment`.
+
 ### Bugs fixed
 
 * [#318](https://github.com/bbatsov/rubocop/issues/318) - correct some special cases of block end alignment

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -362,7 +362,6 @@ AssignmentInCondition:
 # Align ends correctly.
 EndAlignment:
   Enabled: true
-  BlockAlignSchema: StartOfAssignment
 
 # Possible use of operator/literal/variable in void context.
 Void:

--- a/lib/rubocop/cop/lint/end_alignment.rb
+++ b/lib/rubocop/cop/lint/end_alignment.rb
@@ -5,23 +5,19 @@ module Rubocop
     module Lint
       # This cop checks whether the end keywords are aligned properly.
       #
-      # There are two ways to align the end of a block.
-      # Set BlockAlignSchema to StartOfAssignment if you want to
-      # align the end to the beginning of assignment expression.
-      # This is the default behavior.
+      # For keywords (if, def, etc.) the end is aligned with the start
+      # of the keyword.
+      # For blocks - with the start of the expression where the block
+      # is defined.
+      #
       # @example
+      #
+      #   variable = if true
+      #              end
       #
       #   variable = lambda do |i|
       #     i
       #   end
-      #
-      # Set BlockAlignSchema to StartOfBlockCommand if you want to
-      # align the end to the beginning of the expression that called the block.
-      # @example
-      #
-      #   variable = lambda do |i|
-      #                i
-      #              end
       class EndAlignment < Cop
         MSG = 'end at %d, %d is not aligned with %s at %d, %d'
 
@@ -92,10 +88,8 @@ module Rubocop
         alias_method :on_or, :on_and
 
         def on_lvasgn(node)
-          if align_with_start_of_assignment?
-            _, children = *node
-            process_block_assignment(node, children)
-          end
+          _, children = *node
+          process_block_assignment(node, children)
           super
         end
 
@@ -106,34 +100,26 @@ module Rubocop
         alias_method :on_or_asgn,  :on_lvasgn
 
         def on_casgn(node)
-          if align_with_start_of_assignment?
-            _, _, children = *node
-            process_block_assignment(node, children)
-          end
+          _, _, children = *node
+          process_block_assignment(node, children)
           super
         end
 
         def on_op_asgn(node)
-          if align_with_start_of_assignment?
-            variable, _op, args = *node
-            process_block_assignment(variable, args)
-          end
+          variable, _op, args = *node
+          process_block_assignment(variable, args)
           super
         end
 
         def on_send(node)
-          if align_with_start_of_assignment?
-            _receiver, _method, *args = *node
-            process_block_assignment(node, args.last)
-          end
+          _receiver, _method, *args = *node
+          process_block_assignment(node, args.last)
           super
         end
 
         def on_masgn(node)
-          if align_with_start_of_assignment?
-            variables, args = *node
-            process_block_assignment(variables, args)
-          end
+          variables, args = *node
+          process_block_assignment(variables, args)
           super
         end
 
@@ -188,10 +174,6 @@ module Rubocop
 
         def already_processed_node?(node)
           @inspected_blocks.include?(node)
-        end
-
-        def align_with_start_of_assignment?
-          EndAlignment.config['BlockAlignSchema'] == 'StartOfAssignment'
         end
       end
     end

--- a/spec/rubocop/cops/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cops/lint/end_alignment_spec.rb
@@ -8,10 +8,6 @@ module Rubocop
     module Lint
       describe EndAlignment do
         let(:cop) { EndAlignment.new }
-        before do
-          # TODO: Initialize the config to a default {} value. Currently it's nil.
-          EndAlignment.config = {}
-        end
 
         it 'registers an offence for mismatched class end' do
           inspect_source(cop,
@@ -90,449 +86,224 @@ module Rubocop
           end
         end
 
-        context 'with BlockAlignSchema set to StartOfAssignment' do
-          before do
-            EndAlignment.config = { 'BlockAlignSchema' => 'StartOfAssignment' }
-          end
+        it 'accepts end aligned with a variable' do
+          inspect_source(cop,
+                         ['variable = test do |ala|',
+                         'end'
+                         ])
+          expect(cop.offences).to be_empty
+        end
 
+        context 'and the block is an operand' do
           it 'accepts end aligned with a variable' do
             inspect_source(cop,
-                           ['variable = test do |ala|',
-                            'end'
+                           ['b = 1 + preceding_line.reduce(0) do |a, e|',
+                           '  a + e.length + newline_length',
+                           'end + 1'
                            ])
             expect(cop.offences).to be_empty
-          end
-
-          context 'and the block is an operand' do
-            it 'accepts end aligned with a variable' do
-              inspect_source(cop,
-                             ['b = 1 + preceding_line.reduce(0) do |a, e|',
-                              '  a + e.length + newline_length',
-                              'end + 1'
-                             ])
-              expect(cop.offences).to be_empty
-            end
-          end
-
-          it 'registers an offence for mismatched block end with a variable' do
-            inspect_source(cop,
-                           ['variable = test do |ala|',
-                            '  end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
-
-          it 'accepts end aligned with an instance variable' do
-            inspect_source(cop,
-                           ['@variable = test do |ala|',
-                            'end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
-
-          it 'registers an offence for mismatched block end with an instance variable' do
-            inspect_source(cop,
-                           ['@variable = test do |ala|',
-                            '  end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
-
-          it 'accepts end aligned with a class variable' do
-            inspect_source(cop,
-                           ['@@variable = test do |ala|',
-                            'end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
-
-          it 'registers an offence for mismatched block end with a class variable' do
-            inspect_source(cop,
-                           ['@@variable = test do |ala|',
-                            '  end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
-
-          it 'accepts end aligned with a global variable' do
-            inspect_source(cop,
-                           ['$variable = test do |ala|',
-                            'end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
-
-          it 'registers an offence for mismatched block end with a global variable' do
-            inspect_source(cop,
-                           ['$variable = test do |ala|',
-                            '  end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
-
-          it 'accepts end aligned with a constant' do
-            inspect_source(cop,
-                           ['CONSTANT = test do |ala|',
-                            'end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
-
-          it 'registers an offence for mismatched block end with a constant' do
-            inspect_source(cop,
-                           ['Module::CONSTANT = test do |ala|',
-                            '  end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
-
-          it 'accepts end aligned with a method call' do
-            inspect_source(cop,
-                           ['parser.childs << lambda do |token|',
-                            '  token << 1',
-                            'end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
-
-          it 'registers an offence for mismatched block end with a method call' do
-            inspect_source(cop,
-                           ['parser.childs << lambda do |token|',
-                            '  token << 1',
-                            '  end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
-
-          it 'accepts end aligned with a method call with arguments' do
-            inspect_source(cop,
-                           ['@h[:f] = f.each_pair.map do |f, v|',
-                            '  v = 1',
-                            'end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
-
-          it 'registers an offence for mismatched end with a method call with arguments' do
-            inspect_source(cop,
-                           ['@h[:f] = f.each_pair.map do |f, v|',
-                            '  v = 1',
-                            '  end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
-
-          it 'does not raise an error for nested block in a method call' do
-            inspect_source(cop,
-                           ['expect(arr.all? { |o| o.valid? })'
-                           ])
-            expect(cop.offences).to be_empty
-          end
-
-          it 'accepts end aligned with the outermost method in the method chain that calls the block' do
-            inspect_source(cop,
-                           ['expect(arr.all? do |o|',
-                            '  o.valid?',
-                            'end)'
-                           ])
-            expect(cop.offences).to be_empty
-          end
-
-          it 'registers an offence for mismatched end aligned with the outermost method in the method chain that calls the block' do
-            inspect_source(cop,
-                           ['expect(arr.all? do |o|',
-                            '  o.valid?',
-                            '  end)'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
-
-          it 'accepts end aligned with an op-asgn (+=, -=)' do
-            inspect_source(cop,
-                           ['rb += files.select do |file|',
-                            '  file << something',
-                            'end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
-
-          it 'registers an offence for mismatched block end with an op-asgn (+=, -=)' do
-            inspect_source(cop,
-                           ['rb += files.select do |file|',
-                            '  file << something',
-                            '  end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
-
-          it 'accepts end aligned with an and-asgn (&&=)' do
-            inspect_source(cop,
-                           ['variable &&= test do |ala|',
-                            'end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
-
-          it 'registers an offence for mismatched block end with an and-asgn (&&=)' do
-            inspect_source(cop,
-                           ['variable &&= test do |ala|',
-                            '  end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
-
-          it 'accepts end aligned with an or-asgn (||=)' do
-            inspect_source(cop,
-                           ['variable ||= test do |ala|',
-                            'end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
-
-          it 'registers an offence for mismatched block end with an or-asgn (||=)' do
-            inspect_source(cop,
-                           ['variable ||= test do |ala|',
-                            '  end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
-
-          it 'accepts end aligned with a mass assignment' do
-            inspect_source(cop,
-                           ['var1, var2 = lambda do |test|',
-                            '  [1, 2]',
-                            'end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
-
-          it 'registers an offence for mismatched block end with a mass assignment' do
-            inspect_source(cop,
-                           ['var1, var2 = lambda do |test|',
-                            '  [1, 2]',
-                            '  end'
-                           ])
-            expect(cop.offences.size).to eq(1)
           end
         end
 
-        context 'with BlockAlignSchema set to StartOfBlockCommand' do
-          before do
-            EndAlignment.config = { 'BlockAlignSchema' => 'StartOfBlockCommand' }
-          end
+        it 'registers an offence for mismatched block end with a variable' do
+          inspect_source(cop,
+                         ['variable = test do |ala|',
+                         '  end'
+                         ])
+          expect(cop.offences.size).to eq(1)
+        end
 
-          it 'accepts end aligned with the method that invokes the block' do
-            inspect_source(cop,
-                           ['variable = test do |ala|',
-                            '           end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
+        it 'accepts end aligned with an instance variable' do
+          inspect_source(cop,
+                         ['@variable = test do |ala|',
+                         'end'
+                         ])
+          expect(cop.offences).to be_empty
+        end
 
-          context 'and the block is an operand' do
-            it 'accepts end aligned with a variable' do
-              inspect_source(cop,
-                             ['b = 1 + preceding_line.reduce(0) do |a, e|',
-                              '          a + e',
-                              '        end + 1'
-                             ])
-              expect(cop.offences).to be_empty
-            end
-          end
+        it 'registers an offence for mismatched block end with an instance variable' do
+          inspect_source(cop,
+                         ['@variable = test do |ala|',
+                         '  end'
+                         ])
+          expect(cop.offences.size).to eq(1)
+        end
 
-          it 'registers an offence for mismatched block end with the method that invokes the block' do
-            inspect_source(cop,
-                           ['variable = test do |ala|',
-                            'end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
+        it 'accepts end aligned with a class variable' do
+          inspect_source(cop,
+                         ['@@variable = test do |ala|',
+                         'end'
+                         ])
+          expect(cop.offences).to be_empty
+        end
 
-          it 'accepts end aligned with the method when return value is assigned to instance variable' do
-            inspect_source(cop,
-                           ['@variable = test do |ala|',
-                            '            end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
+        it 'registers an offence for mismatched block end with a class variable' do
+          inspect_source(cop,
+                         ['@@variable = test do |ala|',
+                         '  end'
+                         ])
+          expect(cop.offences.size).to eq(1)
+        end
 
-          it 'registers an offence for mismatched block end when return value is assigned to instance variable' do
-            inspect_source(cop,
-                           ['@variable = test do |ala|',
-                            'end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
+        it 'accepts end aligned with a global variable' do
+          inspect_source(cop,
+                         ['$variable = test do |ala|',
+                         'end'
+                         ])
+          expect(cop.offences).to be_empty
+        end
 
-          it 'accepts end aligned with the method when return value is assigned to class variable' do
-            inspect_source(cop,
-                           ['@@variable = test do |ala|',
-                            '             end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
+        it 'registers an offence for mismatched block end with a global variable' do
+          inspect_source(cop,
+                         ['$variable = test do |ala|',
+                         '  end'
+                         ])
+          expect(cop.offences.size).to eq(1)
+        end
 
-          it 'registers an offence for mismatched block end when return value is assigned to class variable' do
-            inspect_source(cop,
-                           ['@@variable = test do |ala|',
-                            'end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
+        it 'accepts end aligned with a constant' do
+          inspect_source(cop,
+                         ['CONSTANT = test do |ala|',
+                         'end'
+                         ])
+          expect(cop.offences).to be_empty
+        end
 
-          it 'accepts end aligned with the method when return value is assigned to global variable' do
-            inspect_source(cop,
-                           ['$variable = test do |ala|',
-                            '            end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
+        it 'registers an offence for mismatched block end with a constant' do
+          inspect_source(cop,
+                         ['Module::CONSTANT = test do |ala|',
+                         '  end'
+                         ])
+          expect(cop.offences.size).to eq(1)
+        end
 
-          it 'registers an offence for mismatched block end when return value is assigned to global variable' do
-            inspect_source(cop,
-                           ['$variable = test do |ala|',
-                            'end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
+        it 'accepts end aligned with a method call' do
+          inspect_source(cop,
+                         ['parser.childs << lambda do |token|',
+                         '  token << 1',
+                         'end'
+                         ])
+          expect(cop.offences).to be_empty
+        end
 
-          it 'accepts end aligned with the method when return value is assigned to constant' do
-            inspect_source(cop,
-                           ['CONSTANT = test do |ala|',
-                            '           end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
+        it 'registers an offence for mismatched block end with a method call' do
+          inspect_source(cop,
+                         ['parser.childs << lambda do |token|',
+                         '  token << 1',
+                         '  end'
+                         ])
+          expect(cop.offences.size).to eq(1)
+        end
 
-          it 'registers an offence for mismatched block end when return value is assigned to constant' do
-            inspect_source(cop,
-                           ['Module::CONSTANT = test do |ala|',
-                            'end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
+        it 'accepts end aligned with a method call with arguments' do
+          inspect_source(cop,
+                         ['@h[:f] = f.each_pair.map do |f, v|',
+                         '  v = 1',
+                         'end'
+                         ])
+          expect(cop.offences).to be_empty
+        end
 
-          it 'accepts end aligned with a method call' do
-            inspect_source(cop,
-                           ['parser.childs << lambda do |token|',
-                            '                   token << 1',
-                            '                 end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
+        it 'registers an offence for mismatched end with a method call with arguments' do
+          inspect_source(cop,
+                         ['@h[:f] = f.each_pair.map do |f, v|',
+                         '  v = 1',
+                         '  end'
+                         ])
+          expect(cop.offences.size).to eq(1)
+        end
 
-          it 'registers an offence for mismatched block end with a method call' do
-            inspect_source(cop,
-                           ['parser.childs << lambda do |token|',
-                            '  token << 1',
-                            'end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
+        it 'does not raise an error for nested block in a method call' do
+          inspect_source(cop,
+                         ['expect(arr.all? { |o| o.valid? })'
+                         ])
+          expect(cop.offences).to be_empty
+        end
 
-          it 'accepts end aligned with a method call with arguments' do
-            inspect_source(cop,
-                           ['@h[:f] = f.each_pair.map do |f, v|',
-                            '           v = 1',
-                            '         end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
+        it 'accepts end aligned with the outermost method in the method chain that calls the block' do
+          inspect_source(cop,
+                         ['expect(arr.all? do |o|',
+                         '  o.valid?',
+                         'end)'
+                         ])
+          expect(cop.offences).to be_empty
+        end
 
-          it 'registers an offence for mismatched end with a method call with arguments' do
-            inspect_source(cop,
-                           ['@h[:f] = f.each_pair.map do |f, v|',
-                            '  v = 1',
-                            'end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
+        it 'registers an offence for mismatched end aligned with the outermost method in the method chain that calls the block' do
+          inspect_source(cop,
+                         ['expect(arr.all? do |o|',
+                         '  o.valid?',
+                         '  end)'
+                         ])
+          expect(cop.offences.size).to eq(1)
+        end
 
-          it 'accepts end aligned with the outermost method in the method chain that calls the block' do
-            inspect_source(cop,
-                           ['expect(arr.all? do |o|',
-                            '         o.valid?',
-                            '       end)'
-                           ])
-            expect(cop.offences).to be_empty
-          end
+        it 'accepts end aligned with an op-asgn (+=, -=)' do
+          inspect_source(cop,
+                         ['rb += files.select do |file|',
+                         '  file << something',
+                         'end'
+                         ])
+          expect(cop.offences).to be_empty
+        end
 
-          it 'registers an offence for mismatched end aligned with the outermost method in the method chain that calls the block' do
-            inspect_source(cop,
-                           ['expect(arr.all? do |o|',
-                            '  o.valid?',
-                            'end)'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
+        it 'registers an offence for mismatched block end with an op-asgn (+=, -=)' do
+          inspect_source(cop,
+                         ['rb += files.select do |file|',
+                         '  file << something',
+                         '  end'
+                         ])
+          expect(cop.offences.size).to eq(1)
+        end
 
-          it 'accepts end aligned with the method when return value is assigned using op-asgn (+=, -=)' do
-            inspect_source(cop,
-                           ['rb += files.select do |file|',
-                            '        file << something',
-                            '      end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
+        it 'accepts end aligned with an and-asgn (&&=)' do
+          inspect_source(cop,
+                         ['variable &&= test do |ala|',
+                         'end'
+                         ])
+          expect(cop.offences).to be_empty
+        end
 
-          it 'registers an offence for mismatched block end when return value is assigned using op-asgn (+=, -=)' do
-            inspect_source(cop,
-                           ['rb += files.select do |file|',
-                            '  file << something',
-                            'end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
+        it 'registers an offence for mismatched block end with an and-asgn (&&=)' do
+          inspect_source(cop,
+                         ['variable &&= test do |ala|',
+                         '  end'
+                         ])
+          expect(cop.offences.size).to eq(1)
+        end
 
-          it 'accepts end aligned with the method when return value is assigned using and-asgn (&&=)' do
-            inspect_source(cop,
-                           ['variable &&= test do |ala|',
-                            '             end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
+        it 'accepts end aligned with an or-asgn (||=)' do
+          inspect_source(cop,
+                         ['variable ||= test do |ala|',
+                         'end'
+                         ])
+          expect(cop.offences).to be_empty
+        end
 
-          it 'registers an offence for mismatched block end when return value is assigned using and-asgn (&&=)' do
-            inspect_source(cop,
-                           ['variable &&= test do |ala|',
-                            'end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
+        it 'registers an offence for mismatched block end with an or-asgn (||=)' do
+          inspect_source(cop,
+                         ['variable ||= test do |ala|',
+                         '  end'
+                         ])
+          expect(cop.offences.size).to eq(1)
+        end
 
-          it 'accepts end aligned with the method when return value is assigned using or-asgn (||=)' do
-            inspect_source(cop,
-                           ['variable ||= test do |ala|',
-                            '             end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
+        it 'accepts end aligned with a mass assignment' do
+          inspect_source(cop,
+                         ['var1, var2 = lambda do |test|',
+                         '  [1, 2]',
+                         'end'
+                         ])
+          expect(cop.offences).to be_empty
+        end
 
-          it 'registers an offence for mismatched block end when return value is assigned using or-asgn (||=)' do
-            inspect_source(cop,
-                           ['variable ||= test do |ala|',
-                            'end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
-
-          it 'accepts end aligned with the method when return value is assigned using mass assignment' do
-            inspect_source(cop,
-                           ['var1, var2 = lambda do |test|',
-                            '               [1, 2]',
-                            '             end'
-                           ])
-            expect(cop.offences).to be_empty
-          end
-
-          it 'registers an offence for mismatched block end when return value is assigned using mass assignment' do
-            inspect_source(cop,
-                           ['var1, var2 = lambda do |test|',
-                            '  [1, 2]',
-                            'end'
-                           ])
-            expect(cop.offences.size).to eq(1)
-          end
+        it 'registers an offence for mismatched block end with a mass assignment' do
+          inspect_source(cop,
+                         ['var1, var2 = lambda do |test|',
+                         '  [1, 2]',
+                         '  end'
+                         ])
+          expect(cop.offences.size).to eq(1)
         end
       end
     end


### PR DESCRIPTION
Hi guys,

Yet another change to the `EndAlignment` Cop. This handles problems like the one described in https://github.com/bbatsov/rubocop/issues/325#issuecomment-20371748.

The cases that we handle in this Cop are growing and we currently have two schemas for block alignment, but I don't think we need the second one - where we align the end under the start of the block command. My vim doesn't align it that way and I think every other editor actually aligns based on the start of the line where the `do` keyword is found.

I propose that we drop the second schema. This will greatly simplify the code and especially the specs. What do you think ?

Second, there are still problems like the one in https://github.com/bbatsov/rubocop/issues/327. It again shows that
the editors just align at the start of the line. We can try to emulate that logic and find the beginning of the line when the `do` keyword is defined and use that for the starting point. This will simplify the actual code and I think the only case that we need to handle is

```
statement; var = test do |v|
```

Maybe there is a way we can detect these cases. In my vim if I write the above code the block's `end` will align with the `statement`, so I'm unsure if we have to handle the case at all. This is kind of a trade of, but I think we need to address the problem in https://github.com/bbatsov/rubocop/issues/327 and I can't think of a better way.
What is your opinion ?
