### PR TITLE
Fix end alignment of blocks that spawn on two lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#321](https://github.com/bbatsov/rubocop/issues/321) - Ignore variables whose name start with `_` in `ShadowingOuterLocalVariable`
 * [#322](https://github.com/bbatsov/rubocop/issues/322) - Fix exception of `UnusedLocalVariable` and `ShadowingOuterLocalVariable` when inspecting keyword splat argument
 * [#316](https://github.com/bbatsov/rubocop/issues/316) - Correct nested postfix unless in `MultilineIfThen`
+* [#327](https://github.com/bbatsov/rubocop/issues/327) - Fix false offences for block expression that spawn on two lines in `EndAlignment`
 
 ## 0.9.0 (01/07/2013)
 

--- a/lib/rubocop/cop/lint/end_alignment.rb
+++ b/lib/rubocop/cop/lint/end_alignment.rb
@@ -140,6 +140,10 @@ module Rubocop
             end
           end
           if block_node.type == :block
+            # Align with the expression that is on the same line
+            # where the block is defined
+            return if block_is_on_next_line?(begin_node, block_node)
+
             @inspected_blocks << block_node
             check_block_alignment(begin_node.loc.expression, block_node.loc)
           end
@@ -174,6 +178,10 @@ module Rubocop
 
         def already_processed_node?(node)
           @inspected_blocks.include?(node)
+        end
+
+        def block_is_on_next_line?(begin_node, block_node)
+          begin_node.loc.line != block_node.loc.line
         end
       end
     end

--- a/spec/rubocop/cops/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cops/lint/end_alignment_spec.rb
@@ -113,6 +113,28 @@ module Rubocop
           expect(cop.offences.size).to eq(1)
         end
 
+        context 'when the block is defined on the next line' do
+          it 'accepts end aligned with the block expression' do
+            inspect_source(cop,
+                           ['variable =',
+                            '  a_long_method_that_dont_fit_on_the_line do |v|',
+                            '    v.foo',
+                            '  end'
+                           ])
+            expect(cop.offences).to be_empty
+          end
+
+          it 'registers an offences for mismatched end alignment' do
+            inspect_source(cop,
+                           ['variable =',
+                            '  a_long_method_that_dont_fit_on_the_line do |v|',
+                            '    v.foo',
+                            'end'
+                           ])
+            expect(cop.offences.size).to eq(1)
+          end
+        end
+
         it 'accepts end aligned with an instance variable' do
           inspect_source(cop,
                          ['@variable = test do |ala|',


### PR DESCRIPTION
This handle the case where the block command is defined on the next line.

This fixes #327
