### PR TITLE
Skip ensure return check when ensure has no body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#316](https://github.com/bbatsov/rubocop/issues/316) - Correct nested postfix unless in `MultilineIfThen`
 * [#327](https://github.com/bbatsov/rubocop/issues/327) - Fix false offences for block expression that span on two lines in `EndAlignment`
 * [#332](https://github.com/bbatsov/rubocop/issues/332) - Fix exception of `UnusedLocalVariable` and `ShadowingOuterLocalVariable` when inspecting named captures
+* [#333](https://github.com/bbatsov/rubocop/issues/333) - Fix a case that `EnsureReturn` throws an exception when ensure has no body
 
 ## 0.9.0 (01/07/2013)
 

--- a/lib/rubocop/cop/lint/ensure_return.rb
+++ b/lib/rubocop/cop/lint/ensure_return.rb
@@ -12,7 +12,7 @@ module Rubocop
 
           on_node(:return, ensure_body) do |e|
             add_offence(:warning, e.loc.expression, MSG)
-          end
+          end if ensure_body
 
           super
         end

--- a/spec/rubocop/cops/lint/ensure_return_spec.rb
+++ b/spec/rubocop/cops/lint/ensure_return_spec.rb
@@ -31,6 +31,17 @@ module Rubocop
                           'end'])
           expect(er.offences).to be_empty
         end
+
+        it 'does not check when ensure block has no body' do
+          expect do
+            inspect_source(er,
+                           ['begin',
+                            '  something',
+                            'ensure',
+                            'end'])
+          end.to_not raise_exception
+
+        end
       end
     end
   end


### PR DESCRIPTION
This PR should fix a case that `Lint::EnsureReturn` throws an exception when ensure clause has no body like

``` ruby
begin
  something
ensure
end
```
