### PR TITLE
Support named captures in UnusedLocalVariables and ShadowingOuterLocalVariable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#322](https://github.com/bbatsov/rubocop/issues/322) - Fix exception of `UnusedLocalVariable` and `ShadowingOuterLocalVariable` when inspecting keyword splat argument
 * [#316](https://github.com/bbatsov/rubocop/issues/316) - Correct nested postfix unless in `MultilineIfThen`
 * [#327](https://github.com/bbatsov/rubocop/issues/327) - Fix false offences for block expression that span on two lines in `EndAlignment`
+* [#332](https://github.com/bbatsov/rubocop/issues/332) - Fix exception of `UnusedLocalVariable` and `ShadowingOuterLocalVariable` when inspecting named captures
 
 ## 0.9.0 (01/07/2013)
 


### PR DESCRIPTION
This fixes #332.

As noted in `unused_local_variables_spec.rb`, MRI 2.0 warns unused named captures only when they are in top level scope. I have no idea why it does so (probably _the inconsistency_) and I think there's no convincing reason to conform to this behavior, so I didn't let `UnusedLocalVariables` mimic MRI in that case.
