### PR TITLE
Fix state leak in Cop.all

### DIFF
--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -32,12 +32,15 @@ module Rubocop
       @config = {}
 
       class << self
-        attr_accessor :all
         attr_accessor :config
       end
 
+      def self.all
+        @all.clone
+      end
+
       def self.inherited(subclass)
-        all << subclass
+        @all << subclass
       end
 
       def self.cop_name

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -254,8 +254,6 @@ Usage: rubocop [options] [file1, file2, ...]
     end
 
     it 'runs only lint cops if --lint is passed' do
-      # FIXME state seems to be leaking here
-      pending
       create_file('example.rb', ['if 0 ',
                                  "\ty",
                                  'end'])


### PR DESCRIPTION
Cop.all now returns a copy of the collection that holds all the cops.
This way modifications to it won't affect the global state.
