### PR TITLE
Change encoding cop to accept utf comment by magic_encoding gem

### DIFF
--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -14,7 +14,7 @@ module Rubocop
           unless RUBY_VERSION >= '2.0.0'
             expected_line = 0
             expected_line += 1 if source[expected_line] =~ /^#!/
-            unless source[expected_line] =~ /#.*coding: (UTF|utf)-8/
+            unless source[expected_line] =~ /#.*coding\s?: (UTF|utf)-8/
               add_offence(:convention,
                           source_range(source_buffer,
                                        source[0...expected_line],

--- a/spec/rubocop/cops/style/encoding_spec.rb
+++ b/spec/rubocop/cops/style/encoding_spec.rb
@@ -43,6 +43,13 @@ module Rubocop
 
           expect(encoding.offences).to be_empty
         end
+
+        it 'accepts encoding inserted by magic_encoding gem', ruby: 1.9 do
+          inspect_source(encoding, ['# -*- encoding : utf-8 -*-',
+                                    'def foo() end'])
+
+          expect(encoding.offences.map(&:message)).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
magic_encoding generates crazy utf-8 comment but and someone(like me) can stuck with this.

Sorry for not changing changelog, but i don't know where to write it.
