### PR TITLE
Work with absolute Excludes paths internally.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## master (unreleased)
 
+### New features
+
+### Changes
+
+### Bugs fixed
+
+* [#288](https://github.com/bbatsov/rubocop/issues/288) - work with absolute Excludes paths internally (2nd fix for this issue)
+
 ## 0.9.1 (05/07/2013)
 
 ### New features

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -467,6 +467,56 @@ Usage: rubocop [options] [file1, file2, ...]
          ''].join("\n"))
     end
 
+    it 'can exclude a typical vendor directory' do
+      create_file('vendor/bundle/ruby/1.9.1/gems/parser-2.0.0/.rubocop.yml',
+                  ['AllCops:',
+                   '  Excludes:',
+                   '    - lib/parser/lexer.rb'])
+
+      create_file('vendor/bundle/ruby/1.9.1/gems/parser-2.0.0/lib/ex.rb',
+                  ['# encoding: utf-8',
+                   '#' * 90])
+
+      create_file('.rubocop.yml',
+                  ['AllCops:',
+                   '  Excludes:',
+                   '    - vendor/**'])
+
+      cli.run(%w(--format simple))
+      expect($stdout.string).to eq(
+        ['',
+         '0 files inspected, no offences detected',
+         ''].join("\n"))
+    end
+
+    # Relative exclude paths in .rubocop.yml files are relative to that file,
+    # but in configuration files with other names they will be relative to
+    # whatever file inherits from them.
+    it 'can exclude a vendor directory indirectly' do
+      create_file('vendor/bundle/ruby/1.9.1/gems/parser-2.0.0/.rubocop.yml',
+                  ['AllCops:',
+                   '  Excludes:',
+                   '    - lib/parser/lexer.rb'])
+
+      create_file('vendor/bundle/ruby/1.9.1/gems/parser-2.0.0/lib/ex.rb',
+                  ['# encoding: utf-8',
+                   '#' * 90])
+
+      create_file('.rubocop.yml',
+                  ['inherit_from: config/default.yml'])
+
+      create_file('config/default.yml',
+                  ['AllCops:',
+                   '  Excludes:',
+                   '    - vendor/**'])
+
+      cli.run(%w(--format simple))
+      expect($stdout.string).to eq(
+        ['',
+         '0 files inspected, no offences detected',
+         ''].join("\n"))
+    end
+
     it 'prints a warning for an unrecognized cop name in .rubocop.yml' do
       create_file('example/example1.rb', [
         '# encoding: utf-8',

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -100,9 +100,9 @@ describe Rubocop::Config do
                     ])
       end
 
-      it 'gets AllCops/Exclude from the highest directory level' do
+      it 'gets AllCops/Excludes from the highest directory level' do
         excludes = configuration_from_file['AllCops']['Excludes']
-        expect(excludes).to eq(['../vendor/**'])
+        expect(excludes).to eq([File.expand_path('vendor/**')])
       end
     end
 
@@ -120,9 +120,9 @@ describe Rubocop::Config do
         create_file(file_path, ['inherit_from: ../.rubocop.yml'])
       end
 
-      it 'gets AllCops/Exclude relative to its own directory' do
+      it 'gets an absolute AllCops/Excludes' do
         excludes = configuration_from_file['AllCops']['Excludes']
-        expect(excludes).to eq(['../vendor/**', /[A-Z]/])
+        expect(excludes).to eq([File.expand_path('vendor/**'), /[A-Z]/])
       end
     end
 
@@ -139,9 +139,9 @@ describe Rubocop::Config do
         create_file(file_path, ['inherit_from: ../src/.rubocop.yml'])
       end
 
-      it 'gets AllCops/Exclude relative to its own directory' do
+      it 'gets an absolute AllCops/Exclude' do
         excludes = configuration_from_file['AllCops']['Excludes']
-        expect(excludes).to eq(['../src/vendor/**'])
+        expect(excludes).to eq([File.expand_path('src/vendor/**')])
       end
     end
 
@@ -350,7 +350,7 @@ describe Rubocop::Config do
     let(:hash) do
       {
         'AllCops' => {
-          'Excludes' => ['log/*']
+          'Excludes' => ['/home/foo/project/log/*']
         }
       }
     end


### PR DESCRIPTION
Fix for #288.
This solves the problem with excluding a directory tree that contains
`.rubocop.yml` files. Those configurations would get `Excludes` from a
higher level, let's say `../../vendor/**`, but when comparing relative
file paths to those patterns they would not match.
