### PR TITLE
Override config parameters rather than merging them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * `TrivialAccessors` now detects class attributes as well as instance attributes
 * [#338](https://github.com/bbatsov/rubocop/issues/338) - fix end alignment of blocks in chained assignments
 * [#345](https://github.com/bbatsov/rubocop/issues/345) - add `$SAFE` to the list of built-in global variables
+* [#340](https://github.com/bbatsov/rubocop/issues/340) - override config parameters rather than merging them
 
 ## 0.9.1 (05/07/2013)
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -58,15 +58,15 @@ module Rubocop
         path_name.relative_path_from(Pathname.new(base)).to_s
       end
 
-      # Return a recursive merge of two hashes. That is, a normal hash
-      # merge, with the addition that any value that is a hash, and
-      # occurs in both arguments, will also be merged. And so on.
+      # Return an extended merge of two hashes. That is, a normal hash merge,
+      # with the addition that any value that is a hash, and occurs in both
+      # arguments (i.e., cop names), will also be merged.
       def merge(base_hash, derived_hash)
         result = {}
         base_hash.each do |key, value|
           result[key] = if derived_hash.has_key?(key)
                           if value.is_a?(Hash)
-                            merge(value, derived_hash[key])
+                            value.merge(derived_hash[key])
                           else
                             derived_hash[key]
                           end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -339,6 +339,26 @@ Usage: rubocop [options] [file1, file2, ...]
          ''].join("\n"))
     end
 
+    it 'can be configured to override a parameter that is a hash' do
+      create_file('example1.rb',
+                  ['# encoding: utf-8',
+                   'arr.find_all { |e| e > 0 }.collect { |e| -e }'])
+      # We only care about select over find_all. All other preferred methods
+      # appearing in the default config are gone when we override
+      # PreferredMethods. We get no report about collect.
+      create_file('rubocop.yml',
+                  ['CollectionMethods:',
+                   '  PreferredMethods:',
+                   '    find_all: select'])
+      cli.run(['--format', 'simple', '-c', 'rubocop.yml', 'example1.rb'])
+      expect($stdout.string).to eq(
+        ['== example1.rb ==',
+         'C:  2:  5: Prefer select over find_all.',
+         '',
+         '1 file inspected, 1 offence detected',
+         ''].join("\n"))
+    end
+
     it 'works when a cop that others depend on is disabled' do
       create_file('example1.rb', ['if a',
                                   '  b',


### PR DESCRIPTION
Config parameters were merged recursively down to any depth of hashes.
There's actually no reason to do this. Only one level needs merging,
and that is the parameters under each cop name. The only cop that
currently has a parameter that is a hash, is `CollectionMethods`.

Fixes #340.
