### PR TITLE
Invoke cops' custom callback before processing the AST

### DIFF
--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -50,8 +50,8 @@ module Rubocop
 
       def investigate(source_buffer, source, tokens, ast, comments)
         reset_errors
-        process(ast) if ast
         invoke_cops_callback(source_buffer, source, tokens, ast, comments)
+        process(ast) if ast
         @cops.reduce([]) do |offences, cop|
           offences.concat(cop.offences)
           offences


### PR DESCRIPTION
This allow the cop to obtain additional information or reference
from source_buffer, comments and tokens before we start processing
the AST.
