### PR TITLE
Remove self-check spec and add self-check command to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ rvm:
   - 2.0.0
   - jruby-19mode
   - rbx-19mode
-script: bundle exec rspec
+script:
+  - bundle exec rspec
+  - bundle exec rubocop

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -10,15 +10,4 @@ describe 'RuboCop Project' do
         .to eq((['AllCops'] + cop_names).sort)
     end
   end
-
-  describe 'source codes' do
-    before { $stdout = StringIO.new }
-    after  { $stdout = STDOUT }
-
-    it 'has no violations' do
-      # Need to pass an empty array explicitly
-      # so that the CLI does not refer arguments of `rspec`
-      expect(Rubocop::CLI.new.run([])).to eq(0)
-    end
-  end
 end


### PR DESCRIPTION
I guess almost always we've been running `rspec spec/rubocop`. :)
