### PR TITLE
Also check for usage of 'validates_uniqueness_of' when using '--rails'

### DIFF
--- a/lib/rubocop/cop/rails/validation.rb
+++ b/lib/rubocop/cop/rails/validation.rb
@@ -15,7 +15,8 @@ module Rubocop
                      :validates_length_of,
                      :validates_numericality_of,
                      :validates_presence_of,
-                     :validates_size_of]
+                     :validates_size_of,
+                     :validates_uniqueness_of]
 
         def on_send(node)
           receiver, method_name, *_args = *node


### PR DESCRIPTION
I noticed that 'validates_uniqueness_of' was missing from the blacklist when running --rails checks. 
