### PR TITLE
Allow braces around multi-line blocks if do-end would change the meaning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#373](https://github.com/bbatsov/rubocop/issues/373) - allow braces around
+  multi-line blocks if `do`-`end` would change the meaning of the code
+
 ## 0.10.0 (17/07/2013)
 
 ### New features

--- a/lib/rubocop/cop/style/blocks.rb
+++ b/lib/rubocop/cop/style/blocks.rb
@@ -9,12 +9,29 @@ module Rubocop
         MULTI_LINE_MSG = 'Avoid using {...} for multi-line blocks.'
         SINGLE_LINE_MSG = 'Prefer {...} over do...end for single-line blocks.'
 
+        def investigate(processed_source)
+          @allowed_with_braces = []
+        end
+
+        def on_send(node)
+          _receiver, method_name, *args = *node
+          if args.any? && args.last.type == :block
+            unless node.loc.expression.source =~ /#{method_name}\s*\(/
+              # If there are no parentheses around the arguments, then do-end
+              # would change the meaning of the code, so we allow the braces.
+              @allowed_with_braces << args.last
+            end
+          end
+        end
+
         def on_block(node)
           block_length = Util.block_length(node)
           block_begin = node.loc.begin.source
 
           if block_length > 0 && block_begin == '{'
-            add_offence(:convention, node.loc.begin, MULTI_LINE_MSG)
+            unless @allowed_with_braces.include?(node)
+              add_offence(:convention, node.loc.begin, MULTI_LINE_MSG)
+            end
           elsif block_length == 0 && block_begin != '{'
             add_offence(:convention, node.loc.begin, SINGLE_LINE_MSG)
           end

--- a/spec/rubocop/cops/style/blocks_spec.rb
+++ b/spec/rubocop/cops/style/blocks_spec.rb
@@ -6,28 +6,55 @@ module Rubocop
   module Cop
     module Style
       describe Blocks do
-        let(:blocks) { Blocks.new }
-
-        it 'registers an offence for a multiline block with braces' do
-          inspect_source(blocks, ['each { |x|',
-                                  '}'])
-          expect(blocks.messages).to eq([Blocks::MULTI_LINE_MSG])
-        end
+        let(:cop) { Blocks.new }
 
         it 'accepts a multiline block with do-end' do
-          inspect_source(blocks, ['each do |x|',
-                                  'end'])
-          expect(blocks.offences.map(&:message)).to be_empty
+          inspect_source(cop, ['each do |x|',
+                               'end'])
+          expect(cop.offences).to be_empty
         end
 
         it 'registers an offence for a single line block with do-end' do
-          inspect_source(blocks, ['each do |x| end'])
-          expect(blocks.messages).to eq([Blocks::SINGLE_LINE_MSG])
+          inspect_source(cop, ['each do |x| end'])
+          expect(cop.messages).to eq([Blocks::SINGLE_LINE_MSG])
         end
 
         it 'accepts a single line block with braces' do
-          inspect_source(blocks, ['each { |x| }'])
-          expect(blocks.offences.map(&:message)).to be_empty
+          inspect_source(cop, ['each { |x| }'])
+          expect(cop.offences).to be_empty
+        end
+
+        context 'when there are braces around a multi-line block' do
+          it 'registers an offence in the simple case' do
+            inspect_source(cop, ['each { |x|',
+                                 '}'])
+            expect(cop.messages).to eq([Blocks::MULTI_LINE_MSG])
+          end
+
+          it 'accepts braces if do-end would change the meaning' do
+            src = ['scope :foo, lambda { |f|',
+                   '  where(condition: "value")',
+                   '}',
+                   '',
+                   'expect { something }.to raise_error(ErrorClass) { |error|',
+                   '  # ...',
+                   '}']
+            inspect_source(cop, src)
+            expect(cop.offences).to be_empty
+          end
+
+          it 'registers an offence for braces if do-end would not change ' +
+            'the meaning' do
+            src = ['scope :foo, (lambda { |f|',
+                   '  where(condition: "value")',
+                   '})',
+                   '',
+                   'expect { something }.to(raise_error(ErrorClass) { |error|',
+                   '  # ...',
+                   '})']
+            inspect_source(cop, src)
+            expect(cop.offences).to have(2).items
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #373.
