### PR TITLE
Allow braces around multi-line blocks if do-end would change the meaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## master (unreleased)
 
 ### Bugs fixed
+
 * [#374](https://github.com/bbatsov/rubocop/issues/374) - Fixed error at post condition loop (`begin-end-while`, `begin-end-until`) in `UnusedLocalVariable` and `ShadowingOuterLocalVariable`
+* [#373](https://github.com/bbatsov/rubocop/issues/373) and [#376](https://github.com/bbatsov/rubocop/issues/376) - allow braces around multi-line blocks if `do`-`end` would change the meaning of the code
 
 ## 0.10.0 (17/07/2013)
 

--- a/lib/rubocop/cop/style/blocks.rb
+++ b/lib/rubocop/cop/style/blocks.rb
@@ -9,7 +9,29 @@ module Rubocop
         MULTI_LINE_MSG = 'Avoid using {...} for multi-line blocks.'
         SINGLE_LINE_MSG = 'Prefer {...} over do...end for single-line blocks.'
 
+        def on_send(node)
+          _receiver, method_name, *args = *node
+          if args.any?
+            block = get_block(args.last)
+            if block
+              method_name_regexp = Regexp.escape(method_name)
+              args_regexp = args
+                .map { |arg| Regexp.escape(arg.loc.expression.source) }
+                .join('\s*,\s*')
+              if node.loc.expression.source =~
+                  /#{method_name_regexp}\s+#{args_regexp}/
+                # If there are no parentheses around the arguments, then braces
+                # and do-end have different meaning due to how they bind, so we
+                # allow either.
+                ignore_node(block)
+              end
+            end
+          end
+        end
+
         def on_block(node)
+          return if ignored_node?(node)
+
           block_length = Util.block_length(node)
           block_begin = node.loc.begin.source
 
@@ -17,6 +39,18 @@ module Rubocop
             add_offence(:convention, node.loc.begin, MULTI_LINE_MSG)
           elsif block_length == 0 && block_begin != '{'
             add_offence(:convention, node.loc.begin, SINGLE_LINE_MSG)
+          end
+        end
+
+        private
+
+        def get_block(node)
+          case node.type
+          when :block
+            node
+          when :send
+            receiver, _method_name, *_args = *node
+            get_block(receiver) if receiver
           end
         end
       end

--- a/spec/rubocop/cops/style/blocks_spec.rb
+++ b/spec/rubocop/cops/style/blocks_spec.rb
@@ -6,28 +6,71 @@ module Rubocop
   module Cop
     module Style
       describe Blocks do
-        let(:blocks) { Blocks.new }
-
-        it 'registers an offence for a multiline block with braces' do
-          inspect_source(blocks, ['each { |x|',
-                                  '}'])
-          expect(blocks.messages).to eq([Blocks::MULTI_LINE_MSG])
-        end
+        let(:cop) { Blocks.new }
 
         it 'accepts a multiline block with do-end' do
-          inspect_source(blocks, ['each do |x|',
-                                  'end'])
-          expect(blocks.offences.map(&:message)).to be_empty
+          inspect_source(cop, ['each do |x|',
+                               'end'])
+          expect(cop.offences).to be_empty
         end
 
         it 'registers an offence for a single line block with do-end' do
-          inspect_source(blocks, ['each do |x| end'])
-          expect(blocks.messages).to eq([Blocks::SINGLE_LINE_MSG])
+          inspect_source(cop, ['each do |x| end'])
+          expect(cop.messages).to eq([Blocks::SINGLE_LINE_MSG])
         end
 
         it 'accepts a single line block with braces' do
-          inspect_source(blocks, ['each { |x| }'])
-          expect(blocks.offences.map(&:message)).to be_empty
+          inspect_source(cop, ['each { |x| }'])
+          expect(cop.offences).to be_empty
+        end
+
+        context 'when there are braces around a multi-line block' do
+          it 'registers an offence in the simple case' do
+            inspect_source(cop, ['each { |x|',
+                                 '}'])
+            expect(cop.messages).to eq([Blocks::MULTI_LINE_MSG])
+          end
+
+          it 'accepts braces if do-end would change the meaning' do
+            src = ['scope :foo, lambda { |f|',
+                   '  where(condition: "value")',
+                   '}',
+                   '',
+                   'expect { something }.to raise_error(ErrorClass) { |error|',
+                   '  # ...',
+                   '}',
+                   '',
+                   'expect { x }.to change {',
+                   '  Counter.count',
+                   '}.from(0).to(1)']
+            inspect_source(cop, src)
+            expect(cop.offences).to be_empty
+          end
+
+          it 'registers an offence for braces if do-end would not change ' +
+            'the meaning' do
+            src = ['scope :foo, (lambda { |f|',
+                   '  where(condition: "value")',
+                   '})',
+                   '',
+                   'expect { something }.to(raise_error(ErrorClass) { |error|',
+                   '  # ...',
+                   '})']
+            inspect_source(cop, src)
+            expect(cop.offences).to have(2).items
+          end
+
+          it 'can handle special method names such as []= and done?' do
+            src = ['h2[k2] = Hash.new { |h3,k3|',
+                   '  h3[k3] = 0',
+                   '}',
+                   '',
+                   'x = done? list.reject { |e|',
+                   '  e.nil?',
+                   '}']
+            inspect_source(cop, src)
+            expect(cop.messages).to eq([Blocks::MULTI_LINE_MSG])
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #373.
Also fixes #376.
