### PR TITLE
Add `and` and `or` to list of keywords for redundant_self to skip

### DIFF
--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -68,7 +68,7 @@ module Rubocop
         end
 
         def keyword?(method_name)
-          [:class, :for].include?(method_name)
+          [:class, :for, :and, :or].include?(method_name)
         end
 
         def allow_self(node)

--- a/spec/rubocop/cops/style/redundant_self_spec.rb
+++ b/spec/rubocop/cops/style/redundant_self_spec.rb
@@ -52,7 +52,9 @@ module Rubocop
 
         it 'accepts a self receiver for methods named like ruby keywords' do
           src = ['a = self.class',
-                 'self.for(deps, [], true)'
+                 'self.for(deps, [], true)',
+                 'self.and(other)',
+                 'self.or(other)'
                 ]
           inspect_source(cop, src)
           expect(cop.offences).to be_empty


### PR DESCRIPTION
This branch fixes the redundant_self cop to treat `and` and `or` as keywords.
