### PR TITLE
Fix bug concerning nested defs in `EmptyLineBetweenDefs` cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#391](https://github.com/bbatsov/rubocop/issues/391) - Fix bug in counting slashes in a regexp.
 * [#394](https://github.com/bbatsov/rubocop/issues/394) - `DotPosition` cop handles correctly code like `l.(1)`
 * [#390](https://github.com/bbatsov/rubocop/issues/390) - `CommentAnnotation` cop allows keywords (e.g. Review, Optimize) if they just begin a sentence.
+* [#400](https://github.com/bbatsov/rubocop/issues/400) - Fix bug concerning nested defs in `EmptyLineBetweenDefs` cop.
 
 ## 0.10.0 (17/07/2013)
 

--- a/lib/rubocop/cop/style/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/style/empty_line_between_defs.rb
@@ -12,7 +12,7 @@ module Rubocop
           def_start = node.loc.keyword.line
           def_end = node.loc.end.line
 
-          if @prev_def_end && (def_start - @prev_def_end) < 2
+          if @prev_def_end && (def_start - @prev_def_end) == 1
             add_offence(:convention, node.loc.keyword, MSG)
           end
 

--- a/spec/rubocop/cops/style/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cops/style/empty_line_between_defs_spec.rb
@@ -79,6 +79,18 @@ module Rubocop
           inspect_source(empty_lines, source)
           expect(empty_lines.offences.map(&:message)).to be_empty
         end
+
+        it 'accepts a nested def' do
+          source = ['def mock_model(*attributes)',
+                    '  Class.new do',
+                    '    def initialize(attrs)',
+                    '    end',
+                    '  end',
+                    'end',
+                   ]
+          inspect_source(empty_lines, source)
+          expect(empty_lines.offences.map(&:message)).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #400.

Avoids the problem with nested `def`s by only checking if the `def` line is the next line from the previous method `end`. I figure that if the `def`s are on the _same_ line, that's not this cop's problem. Nested `def`s can still mean that we miss some offences. This change at least removes the false positives.
