### PR TITLE
Fix bug in favor_modifier.rb regarding missed offences after else etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#390](https://github.com/bbatsov/rubocop/issues/390) - `CommentAnnotation` cop allows keywords (e.g. Review, Optimize) if they just begin a sentence.
 * [#400](https://github.com/bbatsov/rubocop/issues/400) - Fix bug concerning nested defs in `EmptyLineBetweenDefs` cop.
 * [#399](https://github.com/bbatsov/rubocop/issues/399) - Allow assignment inside blocks in `AssignmentInCondition` cop.
+* Fix bug in favor_modifier.rb regarding missed offences after else etc.
 
 ## 0.10.0 (17/07/2013)
 

--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -70,9 +70,7 @@ module Rubocop
       # its own processing.
       def invoke_cops_callback(processed_source)
         @cops.each do |cop|
-          if cop.respond_to?(:investigate)
-            cop.investigate(processed_source)
-          end
+          cop.investigate(processed_source) if cop.respond_to?(:investigate)
         end
       end
 

--- a/lib/rubocop/cop/style/favor_modifier.rb
+++ b/lib/rubocop/cop/style/favor_modifier.rb
@@ -65,10 +65,10 @@ module Rubocop
           return unless processed_source.ast
           on_node(:if, processed_source.ast) do |node|
             # discard ternary ops, if/else and modifier if/unless nodes
-            return if ternary_op?(node)
-            return if modifier_if?(node)
-            return if elsif?(node)
-            return if if_else?(node)
+            next if ternary_op?(node)
+            next if modifier_if?(node)
+            next if elsif?(node)
+            next if if_else?(node)
 
             if check(node, processed_source.comments)
               add_offence(:convention, node.loc.expression, error_message)

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -59,9 +59,7 @@ module Rubocop
       first_line = File.open(file) { |f| f.readline }
       first_line =~ /#!.*ruby/
     rescue EOFError, ArgumentError => e
-      if @debug
-        warn "Unprocessable file #{file}: #{e.class}, #{e.message}"
-      end
+      warn "Unprocessable file #{file}: #{e.class}, #{e.message}" if @debug
       false
     end
   end

--- a/spec/rubocop/cops/style/favor_modifier_spec.rb
+++ b/spec/rubocop/cops/style/favor_modifier_spec.rb
@@ -27,6 +27,24 @@ module Rubocop
              ' &&/||.'])
         end
 
+        it 'registers an offence for short multiline if near an else etc' do
+           inspect_source(if_unless,
+                          ['if x',
+                           '  y',
+                           'elsif x1',
+                           '  y1',
+                           'else',
+                           '  z',
+                           'end',
+                           'n = a ? 0 : 1',
+                           'm = 3 if m0',
+                           '',
+                           'if a',
+                           '  b',
+                           'end'])
+          expect(if_unless.offences).to have(1).item
+        end
+
         it "accepts multiline if that doesn't fit on one line" do
           check_too_long(if_unless, 'if')
         end


### PR DESCRIPTION
The presence of an `else`, `elsif`, ternary or modifier `if` would cause all subsequent `IfUnlessModifier` offences to be missed.
