### PR TITLE
Upgrade parser gem dependency to 2.0.0.pre6

### DIFF
--- a/lib/rubocop/cop/style/character_literal.rb
+++ b/lib/rubocop/cop/style/character_literal.rb
@@ -10,7 +10,7 @@ module Rubocop
         def on_str(node)
           # Constants like __FILE__ are handled as strings,
           # but don't respond to begin.
-          return unless node.loc.respond_to?(:begin)
+          return unless node.loc.respond_to?(:begin) && node.loc.begin
           return if part_of_ignored_node?(node)
 
           # we don't register an offence for things like ?\C-\M-d

--- a/lib/rubocop/cop/style/comment_annotation.rb
+++ b/lib/rubocop/cop/style/comment_annotation.rb
@@ -16,7 +16,7 @@ module Rubocop
               margin, first_word, colon, space, note = *match.captures
               if annotation?(first_word, colon, space, note) &&
                   !correct_annotation?(first_word, colon, space, note)
-                start = comment.loc.begin_pos + margin.length
+                start = comment.loc.expression.begin_pos + margin.length
                 length = first_word.length + (colon || '').length
                 range = Parser::Source::Range.new(processed_source.buffer,
                                                   start,

--- a/lib/rubocop/cop/style/string_literals.rb
+++ b/lib/rubocop/cop/style/string_literals.rb
@@ -18,7 +18,7 @@ module Rubocop
           # is not preceeded/followed by another \\ (e.g. "\\x34") but not
           # "\\\\"
           if node.loc.expression.source !~ /('|([^\\]|\A)\\([^\\]|\Z))/ &&
-              node.loc.begin.is?('"')
+              node.loc.begin && node.loc.begin.is?('"')
             add_offence(:convention, node.loc.expression, MSG)
             do_autocorrect(node)
           end

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.summary = 'Automatic Ruby code style checking tool.'
 
   s.add_runtime_dependency('rainbow', '>= 1.1.4')
-  s.add_runtime_dependency('parser', '2.0.0.pre3')
+  s.add_runtime_dependency('parser', '2.0.0.pre6')
   s.add_runtime_dependency('backports', '~> 3.3.3')
   s.add_runtime_dependency('powerpack', '0.0.1')
   s.add_development_dependency('rake', '~> 10.1')


### PR DESCRIPTION
This branch upgrades parser to 2.0.0.pre6.
