### PR TITLE
Do autocorrect in AndOr only if it doesn't change meaning of code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Fix bug in favor_modifier.rb regarding missed offences after else etc.
 * [#393](https://github.com/bbatsov/rubocop/issues/393) - Retract support for multiline chaining of blocks (which fixed [#346](https://github.com/bbatsov/rubocop/issues/346)), thus rejecting issue 346.
 * [#389](https://github.com/bbatsov/rubocop/issues/389) - Ignore symbols that are arguments to Module#private_constant in `SymbolName` cop.
+* [#387](https://github.com/bbatsov/rubocop/issues/387) - Do autocorrect in `AndOr` cop only if it does not change the meaning of the code.
 
 ## 0.10.0 (17/07/2013)
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Command flag           | Description
 `-r/--require`         | Require Ruby file
 `-R/--rails`           | Run extra Rails cops
 `-l/--lint`            | Run only lint cops
-`-a/--auto-correct`    | Auto-correct certain offences
+`-a/--auto-correct`    | Auto-correct certain offences *Note:* Experimental - use with caution
 `-s/--silent`          | Suppress the final summary
 `--only`               | Run only the specified cop
 `--auto-gen-config`    | Generate a configuration file acting as a TODO list

--- a/spec/rubocop/cops/style/and_or_spec.rb
+++ b/spec/rubocop/cops/style/and_or_spec.rb
@@ -43,6 +43,18 @@ module Rubocop
           new_source = autocorrect_source(cop, 'true or false')
           expect(new_source).to eq('true || false')
         end
+
+        it 'leaves *or* as is if auto-correction changes the meaning' do
+          src = "teststring.include? 'a' or teststring.include? 'b'"
+          new_source = autocorrect_source(cop, src)
+          expect(new_source).to eq(src)
+        end
+
+        it 'leaves *and* as is if auto-correction changes the meaning' do
+          src = 'x = a + b and return x'
+          new_source = autocorrect_source(cop, src)
+          expect(new_source).to eq(src)
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #387.
It's not a complete solution for the future. Only the `AndOr` problem is addressed. But I think that's enough for now.
