### PR TITLE
Ignore arguments to Module#private_constant in SymbolName cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#399](https://github.com/bbatsov/rubocop/issues/399) - Allow assignment inside blocks in `AssignmentInCondition` cop.
 * Fix bug in favor_modifier.rb regarding missed offences after else etc.
 * [#393](https://github.com/bbatsov/rubocop/issues/393) - Retract support for multiline chaining of blocks (which fixed [#346](https://github.com/bbatsov/rubocop/issues/346)), thus rejecting issue 346.
+* [#389](https://github.com/bbatsov/rubocop/issues/389) - Ignore symbols that are arguments to Module#private_constant in `SymbolName` cop.
 
 ## 0.10.0 (17/07/2013)
 

--- a/lib/rubocop/cop/style/symbol_name.rb
+++ b/lib/rubocop/cop/style/symbol_name.rb
@@ -14,7 +14,18 @@ module Rubocop
           self.class.config['AllowCamelCase']
         end
 
+        def on_send(node)
+          receiver, method_name, *args = *node
+          # Arguments to Module#private_constant are symbols referring to
+          # existing constants, so they will start with an upper case letter.
+          # We ignore these symbols.
+          if receiver.nil? && method_name == :private_constant
+            args.each { |a| ignore_node(a) }
+          end
+        end
+
         def on_sym(node)
+          return if ignored_node?(node)
           sym_name = node.to_a[0]
           return unless sym_name =~ /^[a-zA-Z]/
           return if sym_name =~ SNAKE_CASE

--- a/spec/rubocop/cops/style/symbol_name_spec.rb
+++ b/spec/rubocop/cops/style/symbol_name_spec.rb
@@ -105,6 +105,19 @@ module Rubocop
           expect(symbol_name.offences).to be_empty
         end
 
+        it 'accepts non snake case arguments to private_constant' do
+          inspect_source(symbol_name,
+                         ['private_constant :NORMAL_MODE, :ADMIN_MODE'])
+          expect(symbol_name.offences).to be_empty
+        end
+
+        it 'registers an offence for non snake case symbol near ' +
+            'private_constant' do
+          inspect_source(symbol_name,
+                         ['private_constant f(:ADMIN_MODE)'])
+          expect(symbol_name.offences.size).to eq(1)
+        end
+
         it 'can handle an alias of and operator without crashing' do
           inspect_source(symbol_name,
                          ['alias + add'])


### PR DESCRIPTION
Fixes #389.
