### PR TITLE
Print configuration file names with --debug option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   cops that detect any offences (for
   [#369](https://github.com/bbatsov/rubocop/issues/369)).
 * The list of annotation keywords recognized by the `CommentAnnotation` cop is now configurable.
+* Configuration file names are printed as they are loaded in `--debug` mode.
 
 ### Bugs fixed
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -31,6 +31,8 @@ module Rubocop
 
       parse_options(args)
 
+      Config.debug = @options[:debug]
+
       # filter out Rails cops unless requested
       @cops.reject!(&:rails?) unless @options[:rails]
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -22,9 +22,13 @@ module Rubocop
     attr_accessor :contains_auto_generated_config
 
     class << self
+      attr_accessor :debug
+      alias_method :debug?, :debug
+
       def load_file(path)
         path = File.absolute_path(path)
         hash = YAML.load_file(path)
+        puts "configuration from #{path}" if debug?
         contains_auto_generated_config = false
 
         base_configs(path, hash['inherit_from']).reverse.each do |base_config|
@@ -95,6 +99,7 @@ module Rubocop
                      end
         base_files.map do |f|
           f = File.join(File.dirname(path), f) unless f.start_with?('/')
+          print 'Inheriting ' if debug?
           load_file(f)
         end
       end
@@ -112,6 +117,7 @@ module Rubocop
         config = load_file(config_file)
         found_files = config_files_in_path(config_file)
         if found_files.any? && found_files.last != config_file
+          print 'AllCops/Excludes ' if debug?
           add_excludes_from_higher_level(config, load_file(found_files.last))
         end
         make_excludes_absolute(config)
@@ -133,7 +139,10 @@ module Rubocop
       end
 
       def default_configuration
-        @default_configuration ||= load_file(DEFAULT_FILE)
+        @default_configuration ||= begin
+                                     print 'Default ' if debug?
+                                     load_file(DEFAULT_FILE)
+                                   end
       end
 
       def merge_with_default(config, config_file)

--- a/lib/rubocop/config_store.rb
+++ b/lib/rubocop/config_store.rb
@@ -31,7 +31,10 @@ module Rubocop
       dir = File.dirname(file)
       @path_cache[dir] ||= Config.configuration_file_for(dir)
       path = @path_cache[dir]
-      @object_cache[path] ||= Config.configuration_from_file(path)
+      @object_cache[path] ||= begin
+                                print "For #{dir}: " if Config.debug?
+                                Config.configuration_from_file(path)
+                              end
     end
   end
 end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -13,6 +13,7 @@ module Rubocop
     before(:each) do
       $stdout = StringIO.new
       $stderr = StringIO.new
+      Config.debug = false
     end
 
     after(:each) do
@@ -414,6 +415,22 @@ Usage: rubocop [options] [file1, file2, ...]
         ["#{abs('example1.rb')}:1:7: C: Trailing whitespace detected.",
          "#{abs('example2.rb')}:1:1: C: Tab detected.",
          ''].join("\n"))
+    end
+
+    it 'shows config files when --debug is passed', ruby: 2.0 do
+      create_file('example1.rb', "\tputs 0")
+      expect(cli.run(['--debug', 'example1.rb'])).to eq(1)
+      home = File.dirname(File.dirname(File.dirname(__FILE__)))
+      expect($stdout.string.lines[2, 7].map(&:chomp).join("\n"))
+        .to eq(["For #{abs('')}:" +
+                " configuration from #{home}/config/default.yml",
+                "Inheriting configuration from #{home}/config/enabled.yml",
+                "Inheriting configuration from #{home}/config/disabled.yml",
+                "AllCops/Excludes configuration from #{home}/.rubocop.yml",
+                "Inheriting configuration from #{home}/config/default.yml",
+                "Inheriting configuration from #{home}/config/enabled.yml",
+                "Inheriting configuration from #{home}/config/disabled.yml"
+               ].join("\n"))
     end
 
     it 'shows cop names when --debug is passed', ruby: 2.0 do


### PR DESCRIPTION
A first step towards solving #405. We need more information when there is a problem with configuration.
