### PR TITLE
Add autocorrect support in AlignParameters cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   [#369](https://github.com/bbatsov/rubocop/issues/369)).
 * The list of annotation keywords recognized by the `CommentAnnotation` cop is now configurable.
 * Configuration file names are printed as they are loaded in `--debug` mode.
+* Auto-correct support added in `AlignParameters` cop.
 
 ### Bugs fixed
 

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -73,11 +73,11 @@ module Rubocop
         @corrections = []
       end
 
-      def do_autocorrect(node)
-        autocorrect_action(node) if autocorrect
+      def do_autocorrect(node, *args)
+        autocorrect_action(node, *args) if autocorrect
       end
 
-      def autocorrect_action(node)
+      def autocorrect_action(node, *args)
       end
 
       def add_offence(severity, location, message)

--- a/spec/rubocop/cops/style/align_parameters_spec.rb
+++ b/spec/rubocop/cops/style/align_parameters_spec.rb
@@ -193,6 +193,15 @@ module Rubocop
           inspect_source(align, src)
           expect(align.offences).to be_empty
         end
+
+        it 'auto-corrects alignment' do
+          new_source = autocorrect_source(align, ['func(a,',
+                                                  '       b,',
+                                                  'c)'])
+          expect(new_source.split("\n")).to eq(['func(a,',
+                                                '     b,',
+                                                '     c)'])
+        end
       end
     end
   end


### PR DESCRIPTION
Added possibility to send arbitrary arguments to `autocorrect_action`.

Maybe this automatic correction will screw up the corrected code a bit by making very long lines. But you could say that's the user's fault for not disabling these offences.
