### PR TITLE
Trivial accessors whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### New features
 
+* [#421](https://github.com/bbatsov/rubocop/issues/421) - `
+  TrivialAccessors` now ignores methods on user-configurable
+  whitelist (such as `to_s` and `to_hash`)
 * New option `--auto-gen-config` outputs RuboCop configuration that disables all
   cops that detect any offences (for
   [#369](https://github.com/bbatsov/rubocop/issues/369)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,5 @@
   you want to have your own version, or is otherwise necessary, that
   is fine, but please isolate to its own commit so I can cherry-pick
   around it.
+* Squash your commits.
+* Create a pull-request.

--- a/config/default.yml
+++ b/config/default.yml
@@ -74,6 +74,24 @@ DotPosition:
 TrivialAccessors:
   ExactNameMatch: false
   AllowPredicates: false
+  Whitelist:
+    - to_ary
+    - to_a
+    - to_c
+    - to_enum
+    - to_h
+    - to_hash
+    - to_i
+    - to_int
+    - to_io
+    - to_open
+    - to_path
+    - to_proc
+    - to_r
+    - to_regexp
+    - to_str
+    - to_s
+    - to_sym
 
 # Allow safe assignment in conditions.
 AssignmentInCondition:

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -43,27 +43,39 @@ module Rubocop
           TrivialAccessors.config['AllowPredicates']
         end
 
+        def whitelist
+          whitelist = TrivialAccessors.config['Whitelist']
+          Array(whitelist).map(&:to_sym) + [:initialize]
+        end
+
         def predicate?(method_name)
           method_name[-1] == '?'
         end
 
         def trivial_reader?(method_name, args, body)
-          return false unless args.children.size == 0
+          looks_like_trivial_reader?(args, body) &&
+            !allowed_method?(method_name, body)
+        end
 
-          return false unless body && body.type == :ivar
-
-          return false if allow_predicates? && predicate?(method_name)
-
-          exact_name_match? ? names_match?(method_name, body) : true
+        def looks_like_trivial_reader?(args, body)
+          args.children.size == 0 && body && body.type == :ivar
         end
 
         def trivial_writer?(method_name, args, body)
-          return false unless args.children.size == 1 &&
-            body && body.type == :ivasgn &&
-            body.children[1] && body.children[1].type == :lvar &&
-            method_name != :initialize
+          looks_like_trivial_writer?(args, body) &&
+            !allowed_method?(method_name, body)
+        end
 
-          exact_name_match? ? names_match?(method_name, body) : true
+        def looks_like_trivial_writer?(args, body)
+          args.children.size == 1 &&
+            body && body.type == :ivasgn &&
+            body.children[1] && body.children[1].type == :lvar
+        end
+
+        def allowed_method?(method_name, body)
+          allow_predicates? && predicate?(method_name) ||
+            whitelist.include?(method_name) ||
+            exact_name_match? && !names_match?(method_name, body)
         end
 
         def names_match?(method_name, body)

--- a/spec/rubocop/cops/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cops/style/trivial_accessors_spec.rb
@@ -6,8 +6,10 @@ module Rubocop
   module Cop
     module Style
       describe TrivialAccessors do
-        TrivialAccessors.config = { 'ExactNameMatch' => false }
-        let(:cop) { TrivialAccessors.new }
+        subject(:cop) { described_class.new }
+        before do
+          described_class.config = {}
+        end
 
         it 'finds trivial reader' do
           inspect_source(cop,
@@ -346,7 +348,7 @@ module Rubocop
         end
 
         context 'exact name match required' do
-          before { TrivialAccessors.config['ExactNameMatch'] = true }
+          before { described_class.config['ExactNameMatch'] = true }
 
           it 'finds only 1 trivial reader' do
             inspect_source(cop,
@@ -386,6 +388,29 @@ module Rubocop
             inspect_source(cop,
                            [' def foo?',
                             '   @foo',
+                            ' end'])
+            expect(cop.offences).to be_empty
+          end
+        end
+
+        context 'with whitelist defined' do
+          before do
+            described_class.config = {
+              'Whitelist' => ['to_foo', 'bar=']
+            }
+          end
+
+          it 'ignores accessors in the whitelist' do
+            inspect_source(cop,
+                           [' def to_foo',
+                            '   @foo',
+                            ' end'])
+            expect(cop.offences).to be_empty
+          end
+          it 'ignores writers in the whitelist' do
+            inspect_source(cop,
+                           [' def bar=(bar)',
+                            '   @bar = bar',
                             ' end'])
             expect(cop.offences).to be_empty
           end


### PR DESCRIPTION
Created a whitelist for trivial accessors. Also cleaned up the trivial accessors cop a bit, because I felt that with this addition the number of checks slapped on to trivial_reader? / trivial_writer? became too much, so split them up in a check to see if it looks like a trivial reader/writer, and a check to see if we allow this method for some reason (whitelist, predicate, initializer, ..)

Fixes #421
