### PR TITLE
Allow calling constructor methods with double colon.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#425](https://github.com/bbatsov/rubocop/issues/425) - `
+  ColonMethodCalls` now allows
+  constructor methods (like `Nokogiri::HTML()` to be called with double colon.
+
 ### Bugs fixed
 
 * [#427](https://github.com/bbatsov/rubocop/issues/427) - FavorUnlessOverNegatedIf triggered when using elsifs

--- a/lib/rubocop/cop/style/colon_method_call.rb
+++ b/lib/rubocop/cop/style/colon_method_call.rb
@@ -12,10 +12,15 @@ module Rubocop
           receiver, _method_name, *_args = *node
 
           # discard methods with nil receivers and op methods(like [])
-          if receiver && node.loc.dot && node.loc.dot.is?('::')
-            add_offence(:convention, node.loc.dot, MSG)
-            do_autocorrect(node)
-          end
+          return unless receiver && node.loc.dot && node.loc.dot.is?('::')
+          return if allowed_name(_method_name.to_s)
+
+          add_offence(:convention, node.loc.dot, MSG)
+          do_autocorrect(node)
+        end
+
+        def allowed_name(method_name)
+          method_name.match(/^[A-Z]/)
         end
 
         def autocorrect_action(node)

--- a/spec/rubocop/cop/style/colon_method_call_spec.rb
+++ b/spec/rubocop/cop/style/colon_method_call_spec.rb
@@ -6,7 +6,10 @@ module Rubocop
   module Cop
     module Style
       describe ColonMethodCall do
-        let(:cop) { ColonMethodCall.new }
+        subject(:cop) { described_class.new }
+        before do
+          described_class.config = {}
+        end
 
         it 'registers an offence for instance method call' do
           inspect_source(cop,
@@ -47,6 +50,12 @@ module Rubocop
         it 'does not register an offence for op methods' do
           inspect_source(cop,
                          ['Tip::Top.some_method[3]'])
+          expect(cop.offences).to be_empty
+        end
+
+        it 'does not register an offence when for constructor methods' do
+          inspect_source(cop,
+                         ['Tip::Top(some_arg)'])
           expect(cop.offences).to be_empty
         end
 


### PR DESCRIPTION
fixes #425

(If you don't agree with the issue, feel free to close. It felt so simple, that I could just as well create a PR)
