### PR TITLE
Suppress offences if rhs is block node in ConstantName cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bugs fixed
 
+* [#432](https://github.com/bbatsov/rubocop/issues/432) - Fix false positive for constant assignments when rhs is a method call with block in `ConstantName`
+
 ## 0.11.1 (12/08/2013)
 
 ### Changes

--- a/lib/rubocop/cop/style/constant_name.rb
+++ b/lib/rubocop/cop/style/constant_name.rb
@@ -17,7 +17,7 @@ module Rubocop
 
           # We cannot know the result of method calls line
           # NewClass = something_that_returns_a_class
-          unless value && value.type == :send
+          unless value && [:send, :block].include?(value.type)
             if const_name !~ SNAKE_CASE
               add_offence(:convention, node.loc.name, MSG)
             end

--- a/spec/rubocop/cop/style/constant_name_spec.rb
+++ b/spec/rubocop/cop/style/constant_name_spec.rb
@@ -44,6 +44,15 @@ module Rubocop
           expect(const.offences).to be_empty
         end
 
+        it 'does not check names if rhs is a method call with block' do
+          inspect_source(const,
+                         ['AnythingGoes = test do',
+                          '  do_something',
+                          'end'
+                          ])
+          expect(const.offences).to be_empty
+        end
+
         it 'checks qualified const names' do
           inspect_source(const,
                          ['::AnythingGoes = 30',


### PR DESCRIPTION
This fixes #432.

`ConstantName` cop is already ignoring non `SCREAMING_SNAKE_CASE` name constant assignments when rhs is a send node. This change adds block type to the types to ignore.
