### PR TITLE
Support class/module defined with Class.new/Module.new in AccessControl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bugs fixed
 
 * [#432](https://github.com/bbatsov/rubocop/issues/432) - Fix false positive for constant assignments when rhs is a method call with block in `ConstantName`
+* [#434](https://github.com/bbatsov/rubocop/issues/434) - Support classes and modules defined with `Class.new`/`Module.new` in `AccessControl`
 
 ## 0.11.1 (12/08/2013)
 

--- a/lib/rubocop/cop/lint/rescue_exception.rb
+++ b/lib/rubocop/cop/lint/rescue_exception.rb
@@ -16,10 +16,7 @@ module Rubocop
         end
 
         def targets_exception?(rescue_arg_node)
-          return false unless rescue_arg_node.type == :const
-          namespace, klass_name = *rescue_arg_node
-          return false unless namespace.nil? || namespace.type == :cbase
-          klass_name == :Exception
+          Util.const_name(rescue_arg_node) == 'Exception'
         end
       end
     end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -22,6 +22,23 @@ module Rubocop
       def block_length(block_node)
         block_node.loc.end.line - block_node.loc.begin.line
       end
+
+      def const_name(node)
+        return nil if node.nil? || node.type != :const
+
+        const_names = []
+        const_node = node
+
+        loop do
+          namespace_node, name = *const_node
+          const_names << name
+          break unless namespace_node
+          break if namespace_node.type == :cbase
+          const_node = namespace_node
+        end
+
+        const_names.reverse.join('::')
+      end
     end
   end
 end

--- a/spec/rubocop/cop/style/access_control_spec.rb
+++ b/spec/rubocop/cop/style/access_control_spec.rb
@@ -47,6 +47,34 @@ module Rubocop
             .to eq([format(AccessControl::INDENT_MSG, 'private')])
         end
 
+        it 'registers an offence for misaligned private in class ' +
+           'defined with Class.new' do
+          inspect_source(a,
+                         ['Test = Class.new do',
+                          '',
+                          'private',
+                          '',
+                          '  def test; end',
+                          'end'])
+          expect(a.offences.size).to eq(1)
+          expect(a.offences.map(&:message))
+            .to eq([format(AccessControl::INDENT_MSG, 'private')])
+        end
+
+        it 'registers an offence for misaligned private in module ' +
+           'defined with Module.new' do
+          inspect_source(a,
+                         ['Test = Module.new do',
+                          '',
+                          'private',
+                          '',
+                          '  def test; end',
+                          'end'])
+          expect(a.offences.size).to eq(1)
+          expect(a.offences.map(&:message))
+            .to eq([format(AccessControl::INDENT_MSG, 'private')])
+        end
+
         it 'registers an offence for misaligned protected' do
           inspect_source(a,
                          ['class Test',


### PR DESCRIPTION
This fixes #434.

I'll rebase this branch once #433 is merged.
