### PR TITLE
Add a CopCount formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### New features
 
-* [#395] Added `--show-cops` option to show available cops.
+* [#439](https://github.com/bbatsov/rubocop/issues/439) Added formatter 'CopCount' which outputs a summary list of cops and their offence count
+* [#395](https://github.com/bbatsov/rubocop/issues/395) Added `--show-cops` option to show available cops.
 * New cop `NilComparison` keeps track of comparisons like `== nil`
 * New cop `EvenOdd` keeps track of occasions where `Fixnum#even?` or `Fixnum#odd?` should have been used (like `x % 2 == 0`)
 * New cop `IndentationWidth` checks for files using indentation that is not two spaces.

--- a/README.md
+++ b/README.md
@@ -315,6 +315,30 @@ The JSON structure is like the following example:
 }
 ```
 
+### CopCount Formmater
+
+Sometimes when first applying RuboCop to a codebase, it's nice to be able to
+see where most of your style cleanup is going to be spent.
+
+With this in mind, you can use the cop count formatter to outline the offended
+cops and the number of offences found for each by running:
+
+```
+rubocop --format copcount
+
+(87)  Documentation
+(12)  DotPosition
+(8)   AvoidGlobalVars
+(7)   EmptyLines
+(6)   AssignmentInCondition
+(4)   Blocks
+(4)   CommentAnnotation
+(3)   BlockAlignment
+(1)   IndentationWidth
+(1)   AvoidPerlBackrefs
+(1)   ColonMethodCall
+```
+
 ### Custom Formatters
 
 You can customize RuboCop's output format with custom formatter.

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -127,6 +127,7 @@ require 'rubocop/formatter/clang_style_formatter'
 require 'rubocop/formatter/progress_formatter'
 require 'rubocop/formatter/json_formatter'
 require 'rubocop/formatter/file_list_formatter'
+require 'rubocop/formatter/cop_count_formatter'
 require 'rubocop/formatter/formatter_set'
 
 require 'rubocop/config'

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -223,6 +223,7 @@ module Rubocop
                 '  [e]macs',
                 '  [j]son',
                 '  [f]iles',
+                '  [cop]count',
                 '  custom formatter class name') do |key|
           @options[:formatters] ||= []
           @options[:formatters] << [key]

--- a/lib/rubocop/formatter/cop_count_formatter.rb
+++ b/lib/rubocop/formatter/cop_count_formatter.rb
@@ -1,0 +1,50 @@
+# encoding: utf-8
+
+module Rubocop
+  module Formatter
+    # This formatter displays the list of offended cops with a count of how
+    # many offences of their kind were found. Ordered by desc offence count
+    #
+    # Here's the format:
+    #
+    # (26)  LineLength
+    # (3)   OneLineConditional
+    class CopCountFormatter < BaseFormatter
+
+      attr_reader :cop_offences
+
+      def started(target_files)
+        super
+        @cop_offences = Hash.new(0)
+      end
+
+      def file_finished(file, offences)
+        offences.each { |o| @cop_offences[o.cop_name] += 1 }
+      end
+
+      def finished(inspected_files)
+        report_summary(inspected_files.count,
+                       ordered_cop_offences(@cop_offences))
+      end
+
+      def report_summary(file_count, cop_offences)
+        output.puts
+
+        offence_count = total_offence_count(cop_offences)
+        cop_offences.each do |cop_name, count|
+          count_string = "(#{count.to_s})"
+          output.puts "#{count_string.ljust(offence_count + 4)}#{cop_name}\n"
+        end
+        output.puts
+      end
+
+      def ordered_cop_offences(cop_offences)
+        Hash[cop_offences.sort_by { |k, v| v }.reverse]
+      end
+
+      def total_offence_count(cop_offences = {})
+        cop_offences.values.inject(0, :+)
+      end
+    end
+  end
+end

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -12,7 +12,8 @@ module Rubocop
         'clang'    => ClangStyleFormatter,
         'emacs'    => EmacsStyleFormatter,
         'json'     => JSONFormatter,
-        'files'    => FileListFormatter
+        'files'    => FileListFormatter,
+        'copcount' => CopCountFormatter
       }
 
       FORMATTER_APIS = [:started, :file_started, :file_finished, :finished]

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -55,6 +55,7 @@ Usage: rubocop [options] [file1, file2, ...]
                                        [e]macs
                                        [j]son
                                        [f]iles
+                                       [cop]count
                                        custom formatter class name
     -o, --out FILE                   Write output to a file instead of STDOUT.
                                      This option applies to the previously

--- a/spec/rubocop/formatter/cop_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/cop_count_formatter_spec.rb
@@ -1,0 +1,52 @@
+# encoding: utf-8
+
+require 'spec_helper'
+require 'stringio'
+require 'tempfile'
+
+module Rubocop
+  module Formatter
+    describe SimpleTextFormatter do
+      subject(:formatter) { Formatter::CopCountFormatter.new(output) }
+      let(:output) { StringIO.new }
+
+      let(:files) do
+        %w(lib/rubocop.rb spec/spec_helper.rb bin/rubocop).map do |path|
+          File.expand_path(path)
+        end
+      end
+
+      describe '#file_finished' do
+        before { formatter.started(files) }
+
+        let(:finish) { formatter.file_finished(files.first, offences) }
+
+        context 'when no offences are detected' do
+          let(:offences) { [] }
+          it 'shouldn\'t add to cop_offences' do
+            expect { finish }.to_not change { formatter.cop_offences }
+          end
+        end
+
+        context 'when any offences are detected' do
+          let(:offences) { [double('offence', cop_name: 'OffendedCop')] }
+          it 'should increment the count for the cop in cop_offences' do
+            expect { finish }.to change { formatter.cop_offences }
+          end
+        end
+      end
+
+      describe '#report_summary' do
+        context 'when a offence detected' do
+          let(:cop_counts) { { 'OffendedCop' => 1 } }
+          it 'shows the cop and the offence count' do
+            formatter.report_summary(1, cop_counts)
+            expect(output.string).to include(
+              "\n(1)  OffendedCop")
+          end
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Allows you to see a list of cops with offences, ordered by offence count.

e.g.

```
❯ be rubocop -f p -f copcount app/controllers
Inspecting 98 files
CCCCCCCCCCCCCCCWCCCCC..CCCCCC.CCCCCCCC.CCWWCCCCCC.CCCCW..CCCCCWCCCCCCCCCWCCCC.CWCCCC.CCCCCCCCWCCCC

Offences: ...SNIP...

98 files inspected, 134 offences detected

(87)  Documentation
(12)  DotPosition
(8)   AvoidGlobalVars
(7)   EmptyLines
(6)   AssignmentInCondition
(4)   Blocks
(4)   CommentAnnotation
(3)   BlockAlignment
(1)   IndentationWidth
(1)   AvoidPerlBackrefs
(1)   ColonMethodCall
```
