### PR TITLE
failing spec for WhileUntilDo auto-correct

### DIFF
--- a/spec/rubocop/cop/style/while_until_do_spec.rb
+++ b/spec/rubocop/cop/style/while_until_do_spec.rb
@@ -45,13 +45,13 @@ module Rubocop
         it 'auto-corrects the usage of "do" in multiline while' do
           new_source = autocorrect_source(cop, ['while cond do',
                                                 'end'])
-          expect(new_source).to eq("while cond \nend")
+          expect(new_source).to eq("while cond\nend")
         end
 
         it 'auto-corrects the usage of "do" in multiline until' do
           new_source = autocorrect_source(cop, ['until cond do',
                                                 'end'])
-          expect(new_source).to eq("until cond \nend")
+          expect(new_source).to eq("until cond\nend")
         end
       end
     end


### PR DESCRIPTION
Currently, WhileUntilDo auto-corrects by stripping `do` off the end of the line, leaving a trailing space. This PR adds a failing test case, but I had no idea how to implement the fix :confused:.

Thanks for writing this awesome gem!
