### PR TITLE
failing spec for EmptyLineBetweenDefs

### DIFF
--- a/spec/rubocop/cop/style/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/style/empty_line_between_defs_spec.rb
@@ -91,6 +91,14 @@ module Rubocop
           inspect_source(empty_lines, source)
           expect(empty_lines.offences.map(&:message)).to be_empty
         end
+
+        it 'accepts adjacent one-liner defs' do
+          source = ['def m; end',
+                    'def n; end',
+                   ]
+          inspect_source(empty_lines, source)
+          expect(empty_lines.offences.map(&:message)).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
Currently, EmptyLineBetweenDefs rejects adjacent one-liner defs, which I believe are acceptable (but please correct me if I'm mistaken). This PR adds a failing test case.
