### PR TITLE
Allow dot-separated snake case symbols.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changes
 
 * [#447](https://github.com/bbatsov/rubocop/issues/447) - `BlockAlignment` cop now allows `end` to be aligned with the start of the line containing `do`.
+* `SymbolName` now has an `AllowDots` config option to allow symbols like `:'whatever.submit_button'`.
 
 ### Bugs fixed
 

--- a/lib/rubocop/cop/style/symbol_name.rb
+++ b/lib/rubocop/cop/style/symbol_name.rb
@@ -5,13 +5,19 @@ module Rubocop
     module Style
       # This cop checks whether symbol names are snake_case.
       # There's also an option to accept CamelCase symbol names as well.
+      # There's also an option to accept symbol names with dots as well.
       class SymbolName < Cop
         MSG = 'Use snake_case for symbols.'
         SNAKE_CASE = /^[\da-z_]+[!?=]?$/
+        SNAKE_CASE_WITH_DOTS = /^[\da-z_\.]+[!?=]?$/
         CAMEL_CASE = /^[A-Z][A-Za-z\d]*$/
 
         def allow_camel_case?
           self.class.config['AllowCamelCase']
+        end
+
+        def allow_dots?
+          self.class.config['AllowDots']
         end
 
         def on_send(node)
@@ -30,6 +36,7 @@ module Rubocop
           return unless sym_name =~ /^[a-zA-Z]/
           return if sym_name =~ SNAKE_CASE
           return if allow_camel_case? && sym_name =~ CAMEL_CASE
+          return if allow_dots? && sym_name =~ SNAKE_CASE_WITH_DOTS
           convention(node, :expression)
         end
       end

--- a/spec/rubocop/cop/style/symbol_name_spec.rb
+++ b/spec/rubocop/cop/style/symbol_name_spec.rb
@@ -42,6 +42,35 @@ module Rubocop
           end
         end
 
+        context 'when AllowDots is true' do
+          before do
+            SymbolName.config = {
+              'AllowDots' => true
+            }
+          end
+
+          it 'does not register an offence for dots in names' do
+            inspect_source(symbol_name,
+                           ['test = :"bad.idea"'])
+            expect(symbol_name.offences).to be_empty
+          end
+        end
+
+        context 'when AllowDots is false' do
+          before do
+            SymbolName.config = {
+              'AllowDots' => false
+            }
+          end
+
+          it 'registers an offence for dots in names' do
+            inspect_source(symbol_name,
+                           ['test = :"bad.idea"'])
+            expect(symbol_name.offences.map(&:message)).to eq(
+              ['Use snake_case for symbols.'])
+          end
+        end
+
         it 'registers an offence for symbol used as hash label' do
           inspect_source(symbol_name,
                          ['{ KEY_ONE: 1, KEY_TWO: 2 }'])


### PR DESCRIPTION
Not sure if it's compliant, but I've happened to write I18n keys with dots in them and were flagged as offense by Rubocop.
