### PR TITLE
Don’t trigger HashSyntax on digit-starting keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * [#449](https://github.com/bbatsov/rubocop/issues/449) - Remove whitespaces between condition and `do` with `WhileUntilDo` auto-correction
 * Continue with file inspection after parser warnings. Give up only on syntax errors.
+* Don’t trigger the HashSyntax cop on digit-starting keys.
 
 ## 0.12.0 (23/08/2013)
 

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -34,7 +34,7 @@ module Rubocop
           if key.type == :sym
             sym_name = key.to_a[0]
 
-            sym_name =~ /\A\w+\z/
+            sym_name =~ /\A[A-Za-z_]\w*\z/
           else
             false
           end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -41,6 +41,17 @@ module Rubocop
           expect(hash_syntax.offences.map(&:message)).to be_empty
         end
 
+        it 'accepts hash rockets when keys start with a digit' do
+          inspect_source(hash_syntax, ['x = { :"1" => 1 }'])
+          expect(hash_syntax.offences.map(&:message)).to be_empty
+        end
+
+        it 'registers offence when keys start with an uppercase letter' do
+          inspect_source(hash_syntax, ['x = { :A => 0 }'])
+          expect(hash_syntax.offences.map(&:message)).to eq(
+            ['Ruby 1.8 hash syntax detected'])
+        end
+
         it 'accepts new syntax in a hash literal' do
           inspect_source(hash_syntax, ['x = { a: 0, b: 1 }'])
           expect(hash_syntax.offences.map(&:message)).to be_empty


### PR DESCRIPTION
Currently the HashSyntax cop is triggered on digit-starting symbol keys – but these keys can’t be written in the new Hash syntax.

This patch fixes the issue; please consider merging it. Thanks! :)
