### PR TITLE
Fix auto-correction in AlignParameters.

### DIFF
--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -106,7 +106,7 @@ module Rubocop
         @corrections = []
       end
 
-      def autocorrect_action(node, *args)
+      def autocorrect_action(node)
       end
 
       def message(node = nil)

--- a/lib/rubocop/cop/style/align_parameters.rb
+++ b/lib/rubocop/cop/style/align_parameters.rb
@@ -22,25 +22,31 @@ module Rubocop
 
             if current_pos.line > prev.loc.expression.line &&
                 current_pos.column != first_arg_column
-              convention(nil, current_pos)
-              # do_autocorrect(current, first_arg_column - current_pos.column)
+              @column_delta = first_arg_column - current_pos.column
+              convention(current, current_pos)
             end
           end
         end
 
-        # def autocorrect_action(node, column_delta)
-        #   @corrections << lambda do |corrector|
-        #     expr = node.loc.expression
-        #     if column_delta > 0
-        #       corrector.replace(expr, ' ' * column_delta + expr.source)
-        #     else
-        #       range = Parser::Source::Range.new(expr.source_buffer,
-        #                                         expr.begin_pos+column_delta,
-        #                                         expr.end_pos)
-        #       corrector.replace(range, expr.source)
-        #     end
-        #   end
-        # end
+        def autocorrect_action(node)
+          # We can't use the instance variable inside the lambda. That would
+          # just give each lambda the same reference and they would all get
+          # the last value of @column_delta. A local variable fixes the
+          # problem.
+          column_delta = @column_delta
+
+          @corrections << lambda do |corrector|
+            expr = node.loc.expression
+            if column_delta > 0
+              corrector.replace(expr, ' ' * column_delta + expr.source)
+            else
+              range = Parser::Source::Range.new(expr.source_buffer,
+                                                expr.begin_pos + column_delta,
+                                                expr.end_pos)
+              corrector.replace(range, expr.source)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/rubocop/cop/style/align_parameters_spec.rb
+++ b/spec/rubocop/cop/style/align_parameters_spec.rb
@@ -194,14 +194,14 @@ module Rubocop
           expect(align.offences).to be_empty
         end
 
-        # it 'auto-corrects alignment' do
-        #   new_source = autocorrect_source(align, ['func(a,',
-        #                                           '       b,',
-        #                                           'c)'])
-        #   expect(new_source.split("\n")).to eq(['func(a,',
-        #                                         '     b,',
-        #                                         '     c)'])
-        # end
+        it 'auto-corrects alignment' do
+          new_source = autocorrect_source(align, ['func(a,',
+                                                  '       b,',
+                                                  'c)'])
+          expect(new_source.split("\n")).to eq(['func(a,',
+                                                '     b,',
+                                                '     c)'])
+        end
       end
     end
   end


### PR DESCRIPTION
Code was commented out in a previous refactoring. Using an instance
variable to convey the argument for the auto-correction seems to be
the best solution for the current implementation of the `Cop` class.
