### PR TITLE
allow specifying file line numbers, e.g. "rubocop file:5:30"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * `RedundantReturn` cop does auto-correction.
 * `Blocks` cop does auto-correction.
 * New cop `AlignHash` keeps track of bad alignment in multi-line hash literals.
+* New option to specify which line numbers to parse, e.g. `rubocop some/file:10:30 will parse lines 10 through 30 (inclusive)
 
 ### Changes
 

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -21,9 +21,9 @@ module Rubocop
         @options[:debug]
       end
 
-      def inspect_file(file)
+      def inspect_file(file, from = nil, to = nil)
         begin
-          processed_source = SourceParser.parse_file(file)
+          processed_source = SourceParser.parse_file(file, from, to)
         rescue Encoding::UndefinedConversionError, ArgumentError => e
           handle_error(e,
                        "An error occurred while parsing #{file}.".color(:red))

--- a/lib/rubocop/source_parser.rb
+++ b/lib/rubocop/source_parser.rb
@@ -18,8 +18,14 @@ module Rubocop
       processed_source
     end
 
-    def parse_file(path)
-      parse(File.read(path), path)
+    def parse_file(path, from = nil, to = nil)
+      to_parse = nil
+      if !from.nil? && !to.nil?
+        to_parse = File.readlines(path)[from..to].join
+      else
+        to_parse = File.read(path)
+      end
+      parse(to_parse, path)
     end
 
     def parse_with_parser(string, name)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -38,7 +38,7 @@ module Rubocop
         end
 
         expected_help = <<-END
-Usage: rubocop [options] [file1, file2, ...]
+Usage: rubocop [options] [file1, file2:from:to, ...]
     -d, --debug                      Display debug info.
     -c, --config FILE                Specify configuration file.
         --only COP                   Run just one cop.

--- a/spec/rubocop/source_parser_spec.rb
+++ b/spec/rubocop/source_parser_spec.rb
@@ -81,6 +81,16 @@ module Rubocop
               .to be_a(Parser::Diagnostic)
           end
         end
+
+        context 'when the from and to lines are specified' do
+          let(:processed_source) do
+            SourceParser.parse_file(file, 2, 4)
+          end
+
+          it 'only parses the specified lines' do
+            expect(processed_source.lines).to eq(source[2..4])
+          end
+        end
       end
     end
 


### PR DESCRIPTION
refs issue #473
