### PR TITLE
Fix bug concerning table alignment of colon separated hash entries.

### DIFF
--- a/lib/rubocop/cop/style/align_hash.rb
+++ b/lib/rubocop/cop/style/align_hash.rb
@@ -92,8 +92,16 @@ module Rubocop
                    else
                      key_end_column(first_pair) - key_end_column(current_pair)
                    end,
-              separator: (first_pair.loc.operator.column -
-                          current_pair.loc.operator.column),
+              separator: if current_pair.loc.operator.is?(':') &&
+                             enforced_style == 'table'
+                           # Colon follows directly after key
+                           (key_end_column(current_pair) -
+                            current_pair.loc.operator.column)
+                         else
+                           # Aligned separator
+                           (first_pair.loc.operator.column -
+                            current_pair.loc.operator.column)
+                         end,
               value: value_delta(first_pair, current_pair, max_key_width)
             }
           end

--- a/spec/rubocop/cop/style/align_hash_spec.rb
+++ b/spec/rubocop/cop/style/align_hash_spec.rb
@@ -11,23 +11,27 @@ module Rubocop
 
         context 'with default configuration' do
           it 'registers an offence for misaligned hash keys' do
-            inspect_source(cop, ['hash = {',
+            inspect_source(cop, ['hash1 = {',
                                  '  a: 0,',
-                                 '   bb: 1,',
-                                 " 'ccc' => 2,",
-                                 "  'dddd'  =>  2", # correctly aligned
+                                 '   bb: 1',
+                                 '}',
+                                 'hash2 = {',
+                                 "  'ccc' => 2,",
+                                 " 'dddd'  =>  2",
                                  '}'])
             expect(cop.messages).to eq(['Align the elements of a hash ' +
                                         'literal if they span more than ' +
                                         'one line.'] * 2)
             expect(cop.highlights).to eq(['bb: 1',
-                                          "'ccc' => 2"])
+                                          "'dddd'  =>  2"])
           end
 
           it 'accepts aligned hash keys' do
-            inspect_source(cop, ['hash = {',
+            inspect_source(cop, ['hash1 = {',
                                  '  a: 0,',
                                  '  bb: 1,',
+                                 '}',
+                                 'hash2 = {',
                                  "  'ccc' => 2,",
                                  "  'dddd'  =>  2",
                                  '}'])
@@ -97,20 +101,30 @@ module Rubocop
           let(:cop_config) { { 'EnforcedStyle' => 'table' } }
 
           it 'accepts aligned hash keys' do
-            inspect_source(cop, ['hash = {',
+            inspect_source(cop, ['hash1 = {',
                                  "  'a'   => 0,",
                                  "  'bbb' => 1",
-                                 '}'])
+                                 '}',
+                                 'hash2 = {',
+                                 '  a:   0,',
+                                 '  bbb: 1',
+                                 '}',
+                                ])
             expect(cop.offences).to be_empty
           end
 
           it 'registers an offence for misaligned hash values' do
-            inspect_source(cop, ['hash = {',
+            inspect_source(cop, ['hash1 = {',
                                  "  'a'   =>  0,",
                                  "  'bbb' => 1",
-                                 '}'])
-            expect(cop.offences).to have(1).item
-            expect(cop.highlights).to eq(["'a'   =>  0"])
+                                 '}',
+                                 'hash2 = {',
+                                 '  a:   0,',
+                                 '  bbb:1',
+                                 '}',
+                                ])
+            expect(cop.highlights).to eq(["'a'   =>  0",
+                                          'bbb:1'])
           end
 
           it 'registers an offence for misaligned hash rockets' do


### PR DESCRIPTION
Table alignment required the colon to be detached from the key, which
is a syntax error.

Also, colon and hash rocket are not mixed in the specs anymore. We don't
have full support for that kind of mix, so let's not make readers believe
that we do.

I have some changes lined up to take care of concerns raised in #471,
but first I want to add this bugfix.
