### PR TITLE
Fix redundant self cop for arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * `HashSyntax` cop does auto-correction.
+* Allow calls to self to fix name clash with argument [#484](https://github.com/bbatsov/rubocop/pull/484)
 
 ### Bugs fixed
 

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -92,6 +92,24 @@ module Rubocop
           expect(cop.offences).to be_empty
         end
 
+        it 'accepts a self receiver used to distinguish from blockarg' do
+          src = ['def requested_specs(&groups)',
+                 '  some_method(self.groups)',
+                 'end',
+                ]
+          inspect_source(cop, src)
+          expect(cop.offences).to be_empty
+        end
+
+        it 'accepts a self receiver used to distinguish from argument' do
+          src = ['def requested_specs(groups)',
+                 '  some_method(self.groups)',
+                 'end',
+                ]
+          inspect_source(cop, src)
+          expect(cop.offences).to be_empty
+        end
+
         it 'accepts a self receiver used to distinguish from local variable' do
           src = ['def requested_specs',
                  '  @requested_specs ||= begin',


### PR DESCRIPTION
IMHO using the `self` keyword is legit to evade a name clash with arguments.

Also I added a more verbose description of this cop and the nuances that must be taken into account when  dealing with self.

Best,

Markus
