### PR TITLE
Fix crash in AlignHash cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#496](https://github.com/bbatsov/rubocop/issues/496) - Fix corner case crash in `AlignHash` cop: single key/value pair when configuration is `table` for '=>' and `separator` for `:`.
+
 ## 0.13.1 (19/09/2013)
 
 ### New features

--- a/lib/rubocop/cop/style/align_hash.rb
+++ b/lib/rubocop/cop/style/align_hash.rb
@@ -120,6 +120,8 @@ module Rubocop
                                    key.loc.column +
                                      spaced_separator(current_pair).length +
                                      max_key_width
+                                 elsif first_pair.nil? # Only one pair?
+                                   value.loc.column
                                  else
                                    _key1, value1 = *first_pair
                                    value1.loc.column

--- a/spec/rubocop/cop/style/align_hash_spec.rb
+++ b/spec/rubocop/cop/style/align_hash_spec.rb
@@ -161,6 +161,20 @@ module Rubocop
           end
         end
 
+        context 'with table+separator alignment configuration' do
+          let(:cop_config) do
+            {
+              'EnforcedHashRocketStyle' => 'table',
+              'EnforcedColonStyle' => 'separator'
+            }
+          end
+
+          it 'accepts a single method argument entry with colon' do
+            inspect_source(cop, ['merge(parent: nil)'])
+            expect(cop.offences).to be_empty
+          end
+        end
+
         context 'with invalid configuration' do
           let(:cop_config) do
             {


### PR DESCRIPTION
Single key/value pair when configuration is `table` for `=>` and `separator` for `:`.

Fixes #496.
