### PR TITLE
[Fix #448] Auto-correct multi-line parameters in AlignParameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#496](https://github.com/bbatsov/rubocop/issues/496) - Fix corner case crash in `AlignHash` cop: single key/value pair when configuration is `table` for '=>' and `separator` for `:`.
 * [#502](https://github.com/bbatsov/rubocop/issues/502) - Don't check non-decimal literals with `NumericLiterals`
+* [#448](https://github.com/bbatsov/rubocop/issues/448) - Fix auto-correction of parameters spanning more than one line in `AlignParameters` cop.
 
 ## 0.13.1 (19/09/2013)
 

--- a/spec/rubocop/cop/style/align_parameters_spec.rb
+++ b/spec/rubocop/cop/style/align_parameters_spec.rb
@@ -198,9 +198,37 @@ module Rubocop
           new_source = autocorrect_source(align, ['func(a,',
                                                   '       b,',
                                                   'c)'])
-          expect(new_source.split("\n")).to eq(['func(a,',
-                                                '     b,',
-                                                '     c)'])
+          expect(new_source).to eq(['func(a,',
+                                    '     b,',
+                                    '     c)'].join("\n"))
+        end
+
+        it 'auto-corrects each line of a multi-line parameter to the right' do
+          new_source =
+            autocorrect_source(align,
+                               ['create :transaction, :closed,',
+                                '      account:          account,',
+                                '      open_price:       1.29,',
+                                '      close_price:      1.30'])
+          expect(new_source)
+            .to eq(['create :transaction, :closed,',
+                    '       account:          account,',
+                    '       open_price:       1.29,',
+                    '       close_price:      1.30'].join("\n"))
+        end
+
+        it 'auto-corrects each line of a multi-line parameter to the left' do
+          new_source =
+            autocorrect_source(align,
+                               ['create :transaction, :closed,',
+                                '         account:          account,',
+                                '         open_price:       1.29,',
+                                '         close_price:      1.30'])
+          expect(new_source)
+            .to eq(['create :transaction, :closed,',
+                    '       account:          account,',
+                    '       open_price:       1.29,',
+                    '       close_price:      1.30'].join("\n"))
         end
       end
     end


### PR DESCRIPTION
A known weakness is that cops don't cooperate with auto-correction, so if a hash starts in the wrong column and then is incorrectly aligned within itself, auto-correction can not fix the problem in one invocation of `rubocop`.
