### PR TITLE
Fix bug concerning different RunRailsCops in different directories.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#502](https://github.com/bbatsov/rubocop/issues/502) - Don't check non-decimal literals with `NumericLiterals`
 * [#448](https://github.com/bbatsov/rubocop/issues/448) - Fix auto-correction of parameters spanning more than one line in `AlignParameters` cop.
 * [#493](https://github.com/bbatsov/rubocop/issues/493) - Support disabling `Syntax` offences with `warning` severity
+* Fix bug appearing when there were different values for the `AllCops`/`RunRailsCops` configuration parameter in different directories.
 
 ## 0.13.1 (19/09/2013)
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -64,7 +64,8 @@ module Rubocop
     end
 
     def mobilized_cop_classes(config)
-      @mobilized_cop_classes ||= begin
+      @mobilized_cop_classes ||= {}
+      @mobilized_cop_classes[config.object_id] ||= begin
         cop_classes = Cop::Cop.all
 
         if @options[:only]

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -788,15 +788,27 @@ Usage: rubocop [options] [file1, file2, ...]
         expect($stdout.string).to include('Prefer self[:attribute]')
       end
 
-      it 'with configation option true runs rails cops' do
-        create_file('example1.rb', ['# encoding: utf-8',
-                                    'read_attribute(:test)'])
-        create_file('.rubocop.yml', [
-                                     'AllCops:',
-                                     '  RunRailsCops: true',
-                                    ])
-        expect(cli.run(['--format', 'simple', 'example1.rb'])).to eq(1)
-        expect($stdout.string).to include('Prefer self[:attribute]')
+      it 'with configation option true in one dir runs rails cops there' do
+        create_file('dir1/example1.rb', ['# encoding: utf-8',
+                                         'read_attribute(:test)'])
+        create_file('dir1/.rubocop.yml', [
+                                          'AllCops:',
+                                          '  RunRailsCops: true',
+                                         ])
+        create_file('dir2/example2.rb', ['# encoding: utf-8',
+                                         'read_attribute(:test)'])
+        create_file('dir2/.rubocop.yml', [
+                                          'AllCops:',
+                                          '  RunRailsCops: false',
+                                         ])
+        expect(cli.run(['--format', 'simple', 'dir1', 'dir2'])).to eq(1)
+        expect($stdout.string)
+          .to eq(['== dir1/example1.rb ==',
+                  'C:  2:  1: Prefer self[:attribute] over read_attribute' +
+                  '(:attribute).',
+                  '',
+                  '2 files inspected, 1 offence detected',
+                  ''].join("\n"))
       end
 
       it 'with configation option false but -R given runs rails cops' do


### PR DESCRIPTION
Before this fix, the value of RunRailsCops for the first inspected file would be used for all files. The bug was found by @yujinakayama and mentioned in https://github.com/bbatsov/rubocop/commit/b587f3a840652aba0871319d5659329538858c83#commitcomment-4183846.

I measured and found that the memoization does give a small increase in performance in some cases, so I made it incorporate the given method argument rather than removing it altogether.
