### PR TITLE
[Fix #512] Fix bug causing crash in AndOr auto-correction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 * [#448](https://github.com/bbatsov/rubocop/issues/448) - Fix auto-correction of parameters spanning more than one line in `AlignParameters` cop.
 * [#493](https://github.com/bbatsov/rubocop/issues/493) - Support disabling `Syntax` offences with `warning` severity
 * Fix bug appearing when there were different values for the `AllCops`/`RunRailsCops` configuration parameter in different directories.
+* [#512](https://github.com/bbatsov/rubocop/issues/512) - Fix bug causing crash in AndOr auto-correction.
+
 
 ## 0.13.1 (19/09/2013)
 

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -40,8 +40,10 @@ module Rubocop
         end
 
         it 'auto-corrects "or" with ||' do
-          new_source = autocorrect_source(cop, 'true or false')
-          expect(new_source).to eq('true || false')
+          new_source = autocorrect_source(cop, ['x = 12345',
+                                                'true or false'])
+          expect(new_source).to eq(['x = 12345',
+                                    'true || false'].join("\n"))
         end
 
         it 'leaves *or* as is if auto-correction changes the meaning' do


### PR DESCRIPTION
When checking if auto-correction changes the grammatical meaning of the node, we used the original node whose ranges refer to the whole file. Must use the new node we get from parsing the and/or expression.
