### PR TITLE
Fix alignment of the hash in one line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Bugs fixed
 
+* [#514](https://github.com/bbatsov/rubocop/issues/514) - Fix alignment of the hash containing different key lengths in one line
 * [#496](https://github.com/bbatsov/rubocop/issues/496) - Fix corner case crash in `AlignHash` cop: single key/value pair when configuration is `table` for '=>' and `separator` for `:`.
 * [#502](https://github.com/bbatsov/rubocop/issues/502) - Don't check non-decimal literals with `NumericLiterals`
 * [#448](https://github.com/bbatsov/rubocop/issues/448) - Fix auto-correction of parameters spanning more than one line in `AlignParameters` cop.

--- a/lib/rubocop/cop/style/align_hash.rb
+++ b/lib/rubocop/cop/style/align_hash.rb
@@ -14,12 +14,22 @@ module Rubocop
 
           if [cop_config['EnforcedHashRocketStyle'],
               cop_config['EnforcedColonStyle']].include?('table')
+
+            lines_of_the_children = node.children.map do |pair|
+              key, _value = *pair
+              key.loc.line
+            end
+            on_the_same_line = lines_of_the_children.uniq.size == 1
+            return if on_the_same_line
+
             key_widths = node.children.map do |pair|
               key, _value = *pair
               key.loc.expression.source.length
             end
             @max_key_width = key_widths.max
-            if first_pair && value_delta(nil, first_pair, @max_key_width) != 0
+            if first_pair && !on_the_same_line &&
+              value_delta(nil, first_pair, @max_key_width) != 0
+
               @column_deltas = {}
               convention(first_pair, :expression)
             end

--- a/spec/rubocop/cop/style/align_hash_spec.rb
+++ b/spec/rubocop/cop/style/align_hash_spec.rb
@@ -107,6 +107,17 @@ describe Rubocop::Cop::Style::AlignHash, :config do
       }
     end
 
+    it 'accepts single line hash' do
+      inspect_source(cop, 'func(a: 0, bb: 1)')
+      expect(cop.offences).to be_empty
+    end
+
+    it 'accepts several pairs per line' do
+      inspect_source(cop, ['func(a:   1, bb:   2',
+                           '     ccc: 3, dddd: 4)'])
+      expect(cop.offences).to be_empty
+    end
+
     it 'accepts aligned hash keys' do
       inspect_source(cop, ['hash1 = {',
                            "  'a'   => 0,",


### PR DESCRIPTION
This fixes incorrect behavior in the case, when hash is written in one line with different length of keys.
