### PR TITLE
[Fix #516] Fix RedundantReturn auto-correction bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix bug appearing when there were different values for the `AllCops`/`RunRailsCops` configuration parameter in different directories.
 * [#512](https://github.com/bbatsov/rubocop/issues/512) - Fix bug causing crash in AndOr auto-correction.
 * [#515](https://github.com/bbatsov/rubocop/issues/515) - Fix bug causing AlignParameters and AlignArray auto-correction to destroy code.
+* [#516](https://github.com/bbatsov/rubocop/issues/516) - Fix bug causing RedundantReturn auto-correction to produce invalid code.
 
 
 ## 0.13.1 (19/09/2013)

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -39,8 +39,10 @@ module Rubocop
 
         def autocorrect(node)
           @corrections << lambda do |corrector|
-            corrector.replace(node.loc.expression,
-                              node.loc.expression.source.sub('return ', ''))
+            expr = node.loc.expression
+            replacement = expr.source.sub(/return\s*/, '')
+            replacement = "[#{replacement}]" if node.children.size > 1
+            corrector.replace(expr, replacement)
           end
         end
 

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -73,6 +73,17 @@ module Rubocop
           new_source = autocorrect_source(cop, src)
           expect(new_source).to eq(result_src)
         end
+
+        it 'auto-corrects by making implicit arrays explicit' do
+          src = ['def func',
+                 '  return  1, 2',
+                 'end'].join("\n")
+          result_src = ['def func',
+                        '  [1, 2]', # Just 1, 2 is not valid Ruby.
+                        'end'].join("\n")
+          new_source = autocorrect_source(cop, src)
+          expect(new_source).to eq(result_src)
+        end
       end
     end
   end


### PR DESCRIPTION
Would generate invlid Ruby for `return` with an implicit array.
