### PR TITLE
Make SignalException find raise not only in begin sections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#515](https://github.com/bbatsov/rubocop/issues/515) - Fix bug causing AlignParameters and AlignArray auto-correction to destroy code.
 * [#516](https://github.com/bbatsov/rubocop/issues/516) - Fix bug causing RedundantReturn auto-correction to produce invalid code.
 * [#527](https://github.com/bbatsov/rubocop/issues/527) - Handle `!=` expressions in `EvenOdd` cop
+* `SignalException` cop now finds `raise` calls anywhere, not only in `begin` sections.
 
 ## 0.13.1 (19/09/2013)
 

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -161,7 +161,7 @@ module Rubocop
       end
 
       def ignored_node?(node)
-        @ignored_nodes.include?(node)
+        @ignored_nodes.any? { |n| n.eql?(node) } # Same object found in array?
       end
 
       def on_node(syms, sexp, excludes = [])

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -38,7 +38,7 @@ describe Rubocop::Cop::Commissioner do
     end
 
     it 'stores all errors raised by the cops' do
-      cop.stub(:on_def) { raise RuntimeError }
+      cop.stub(:on_def) { fail RuntimeError }
 
       commissioner = described_class.new([cop])
       source = ['def method', '1', 'end']
@@ -52,7 +52,7 @@ describe Rubocop::Cop::Commissioner do
 
     context 'when passed :raise_error option' do
       it 're-raises the exception received while processing' do
-        cop.stub(:on_def) { raise RuntimeError }
+        cop.stub(:on_def) { fail RuntimeError }
 
         commissioner = described_class.new([cop], raise_error: true)
         source = ['def method', '1', 'end']


### PR DESCRIPTION
Includes a fix for `Cop#ignored_node?` that I think is needed for all cops.
