### PR TITLE
[Fix #529] Add EnforcedStyle config param to SpaceAroundBlockBraces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 * [#524](https://github.com/bbatsov/rubocop/issues/524) - Added a config option to `Semicolon` to allow the use of `;` as an expression separator.
 * [#525](https://github.com/bbatsov/rubocop/issues/525) - `SignalException` cop is now configurable and can enforce the semantic rule or an exclusive use of `raise` or `fail`.
 * `LambdaCall` is now configurable and enforce either `Proc#call` or `Proc#()`.
+* [#529](https://github.com/bbatsov/rubocop/issues/529) - Added config option `EnforcedStyle` to `SpaceAroundBraces`.
+* [#529](https://github.com/bbatsov/rubocop/issues/529) - Changed config option `NoSpaceBeforeBlockParameters` to `SpaceBeforeBlockParameters`.
 
 ### Bugs fixed
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -140,7 +140,10 @@ StringLiterals:
   EnforcedStyle: single_quotes
 
 SpaceAroundBlockBraces:
-  NoSpaceBeforeBlockParameters: false
+  # Valid values are: space_inside_braces, no_space_inside_braces
+  EnforcedStyle: space_inside_braces
+  # Space between { and |. Overrides EnforcedStyle if there is a conflict.
+  SpaceBeforeBlockParameters: true
 
 SpaceInsideHashLiteralBraces:
   EnforcedStyleIsWithSpaces: true

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -362,7 +362,10 @@ SpaceAroundOperators:
   Enabled: true
 
 SpaceAroundBlockBraces:
-  Description: 'Use spaces around { and before } in blocks.'
+  Description: >
+                 Checks that block braces have or don't have surrounding space.
+                 For blocks taking parameters, checks that the left brace has
+                 or doesn't have trailing space.
   Enabled: true
 
 SpaceInsideParens:

--- a/lib/rubocop/cop/style/surrounding_space.rb
+++ b/lib/rubocop/cop/style/surrounding_space.rb
@@ -174,14 +174,11 @@ module Rubocop
         end
       end
 
-      # Checks that block braces have surrounding space. For blocks taking
-      # parameters, it check that the left brace has or doesn't have trailing
-      # space depending on configuration.
+      # Checks that block braces have or don't have surrounding space depending
+      # on configuration. For blocks taking parameters, it checks that the left
+      # brace has or doesn't have trailing space depending on configuration.
       class SpaceAroundBlockBraces < Cop
         include SurroundingSpace
-        MSG_LEFT = "Surrounding space missing for '{'."
-        MSG_RIGHT = "Space missing to the left of '}'."
-        MSG_PIPE = 'Space between { and | detected.'
 
         def investigate(processed_source)
           return unless processed_source.ast
@@ -191,15 +188,15 @@ module Rubocop
             next if ([t1.pos, t2.pos] - positions_not_to_check).size < 2
 
             type1, type2 = t1.type, t2.type
-            check(t1, t2, MSG_LEFT) if type2 == :tLCURLY
-            if type1 == :tLCURLY
-              if type2 == :tPIPE && cop_config['NoSpaceBeforeBlockParameters']
-                check_pipe(t1, t2, MSG_PIPE)
+            if [:tLCURLY, :tRCURLY].include?(type2)
+              check(t1, t2)
+            elsif type1 == :tLCURLY
+              if type2 == :tPIPE
+                check_pipe(t1, t2)
               else
-                check(t1, t2, MSG_LEFT)
+                check(t1, t2)
               end
             end
-            check(t1, t2, MSG_RIGHT) if type2 == :tRCURLY
           end
         end
 
@@ -229,15 +226,65 @@ module Rubocop
           end
         end
 
-        def check(t1, t2, msg)
+        def check(t1, t2)
+          if cop_config['EnforcedStyle'] == 'space_inside_braces'
+            check_space_inside_braces(t1, t2)
+          else
+            check_no_space_inside_braces(t1, t2)
+          end
+          check_space_outside_left_brace(t1, t2)
+        end
+
+        def check_space_inside_braces(t1, t2)
           unless space_between?(t1, t2)
-            brace_token = t1.text == '{' ? t1 : t2
-            convention(nil, brace_token.pos, msg)
+            if t1.text == '{'
+              convention(nil, t1.pos, 'Space missing inside {.')
+            elsif t2.text == '}'
+              convention(nil, t2.pos, 'Space missing inside }.')
+            end
           end
         end
 
-        def check_pipe(t1, t2, msg)
-          convention(nil, t1.pos, msg) if space_between?(t1, t2)
+        def check_no_space_inside_braces(t1, t2)
+          if t1.text == '{' || t2.text == '}'
+            if space_between?(t1, t2)
+              if t1.text == '{'
+                convention(nil, space_range(t1), 'Space inside { detected.')
+              elsif t2.text == '}'
+                convention(nil, space_range(t2), 'Space inside } detected.')
+              end
+            end
+          end
+        end
+
+        def check_space_outside_left_brace(t1, t2)
+          if t2.text == '{' && !space_between?(t1, t2)
+            convention(nil, t2.pos, 'Space missing to the left of {.')
+          end
+        end
+
+        def check_pipe(t1, t2)
+          if cop_config['SpaceBeforeBlockParameters']
+            unless space_between?(t1, t2)
+              convention(nil, t1.pos, 'Space between { and | missing.')
+            end
+          elsif space_between?(t1, t2)
+            convention(nil, space_range(t1), 'Space between { and | detected.')
+          end
+        end
+
+        def space_range(token)
+          src = @processed_source.buffer.source
+          if token.text == '{'
+            b = token.pos.begin_pos + 1
+            e = b + 1
+            e += 1 while src[e] =~ /\s/
+          else
+            e = token.pos.begin_pos
+            b = e - 1
+            b -= 1 while src[b - 1] =~ /\s/
+          end
+          Parser::Source::Range.new(@processed_source.buffer, b, e)
         end
       end
 

--- a/spec/rubocop/cop/style/space_around_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_around_block_braces_spec.rb
@@ -4,7 +4,12 @@ require 'spec_helper'
 
 describe Rubocop::Cop::Style::SpaceAroundBlockBraces, :config do
   subject(:cop) { described_class.new(config) }
-  let(:cop_config) { { 'NoSpaceBeforeBlockParameters' => false } }
+  let(:cop_config) do
+    {
+      'EnforcedStyle' => 'space_inside_braces',
+      'SpaceBeforeBlockParameters' => true
+    }
+  end
 
   it 'accepts braces surrounded by spaces' do
     inspect_source(cop, ['each { puts }'])
@@ -14,19 +19,19 @@ describe Rubocop::Cop::Style::SpaceAroundBlockBraces, :config do
 
   it 'registers an offence for left brace without outer space' do
     inspect_source(cop, ['each{ puts }'])
-    expect(cop.messages).to eq(["Surrounding space missing for '{'."])
+    expect(cop.messages).to eq(['Space missing to the left of {.'])
     expect(cop.highlights).to eq(['{'])
   end
 
   it 'registers an offence for left brace without inner space' do
     inspect_source(cop, ['each {puts }'])
-    expect(cop.messages).to eq(["Surrounding space missing for '{'."])
+    expect(cop.messages).to eq(['Space missing inside {.'])
     expect(cop.highlights).to eq(['{'])
   end
 
   it 'registers an offence for right brace without inner space' do
     inspect_source(cop, ['each { puts}'])
-    expect(cop.messages).to eq(["Space missing to the left of '}'."])
+    expect(cop.messages).to eq(['Space missing inside }.'])
     expect(cop.highlights).to eq(['}'])
   end
 
@@ -39,23 +44,92 @@ describe Rubocop::Cop::Style::SpaceAroundBlockBraces, :config do
 
     it 'registers an offence for left brace without inner space' do
       inspect_source(cop, ['each {|x| puts }'])
-      expect(cop.messages).to eq(["Surrounding space missing for '{'."])
+      expect(cop.messages).to eq(['Space between { and | missing.'])
       expect(cop.highlights).to eq(['{'])
     end
 
-    context 'space before block parameters not allowed' do
-      let(:cop_config) { { 'NoSpaceBeforeBlockParameters' => true } }
+    context 'and space before block parameters not allowed' do
+      let(:cop_config) do
+        {
+          'EnforcedStyle' => 'space_inside_braces',
+          'SpaceBeforeBlockParameters' => false
+        }
+      end
 
       it 'registers an offence for left brace with inner space' do
         inspect_source(cop, ['each { |x| puts }'])
         expect(cop.messages).to eq(['Space between { and | detected.'])
-        expect(cop.highlights).to eq(['{'])
+        expect(cop.highlights).to eq([' '])
       end
 
       it 'accepts left brace without inner space' do
         inspect_source(cop, ['each {|x| puts }'])
         expect(cop.messages).to be_empty
         expect(cop.highlights).to be_empty
+      end
+    end
+  end
+
+  context 'configured with no_space_inside_braces' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'no_space_inside_braces',
+        'SpaceBeforeBlockParameters' => true
+      }
+    end
+
+    it 'accepts braces without spaces inside' do
+      inspect_source(cop, ['each {puts}'])
+      expect(cop.messages).to be_empty
+      expect(cop.highlights).to be_empty
+    end
+
+    it 'registers an offence for left brace with inner space' do
+      inspect_source(cop, ['each { puts}'])
+      expect(cop.messages).to eq(['Space inside { detected.'])
+      expect(cop.highlights).to eq([' '])
+    end
+
+    it 'registers an offence for right brace with inner space' do
+      inspect_source(cop, ['each {puts  }'])
+      expect(cop.messages).to eq(['Space inside } detected.'])
+      expect(cop.highlights).to eq(['  '])
+    end
+
+    it 'registers an offence for left brace without outer space' do
+      inspect_source(cop, ['each{puts}'])
+      expect(cop.messages).to eq(['Space missing to the left of {.'])
+      expect(cop.highlights).to eq(['{'])
+    end
+
+    context 'with passed in parameters' do
+      context 'and space before block parameters allowed' do
+        it 'accepts left brace with inner space' do
+          inspect_source(cop, ['each { |x| puts}'])
+          expect(cop.messages).to eq([])
+          expect(cop.highlights).to eq([])
+        end
+
+        it 'registers an offence for left brace without inner space' do
+          inspect_source(cop, ['each {|x| puts}'])
+          expect(cop.messages).to eq(['Space between { and | missing.'])
+          expect(cop.highlights).to eq(['{'])
+        end
+      end
+
+      context 'and space before block parameters not allowed' do
+        let(:cop_config) do
+          {
+            'EnforcedStyle' => 'no_space_inside_braces',
+            'SpaceBeforeBlockParameters' => false
+          }
+        end
+
+        it 'registers an offence for left brace with inner space' do
+          inspect_source(cop, ['each { |x| puts}'])
+          expect(cop.messages).to eq(['Space between { and | detected.'])
+          expect(cop.highlights).to eq([' '])
+        end
       end
     end
   end


### PR DESCRIPTION
`EnforcedStyle` can be `space_inside_braces` or `no_space_inside_braces`.
Changed `NoSpaceBeforeBlockParameters` to `SpaceBeforeBlockParameters`. It was just too confusing otherwise.
