### PR TITLE
Debugger Cop: Added cop to check for debug calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#501](https://github.com/bbatsov/rubocop/issues/501) - `simple`/`clang`/`progress` formatters now print count of auto-corrected offences in the final summary.
 * [#501](https://github.com/bbatsov/rubocop/issues/501) - `json` formatter now outputs `corrected` key with boolean value in offence objects whether the offence is automatically corrected.
 * New cop `ClassLength` checks for overly long class definitions
+* New cop `Debugger` checks for forgotten calls to debugger or pry
 
 ### Changes
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -491,6 +491,10 @@ CommentAnnotation:
                  (TODO, FIXME, OPTIMIZE, HACK, REVIEW).
   Enabled: true
 
+Debugger:
+  Description: 'Check for debugger calls.'
+  Enabled: true
+
 EmptyEnsure:
   Description: 'Checks for empty ensure block.'
   Enabled: true

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -25,6 +25,7 @@ require 'rubocop/cop/variable_inspector/variable_table'
 
 require 'rubocop/cop/lint/assignment_in_condition'
 require 'rubocop/cop/lint/block_alignment'
+require 'rubocop/cop/lint/debugger'
 require 'rubocop/cop/lint/empty_ensure'
 require 'rubocop/cop/lint/end_alignment'
 require 'rubocop/cop/lint/end_in_method'

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+
+module Rubocop
+  module Cop
+    module Lint
+      # This cop checks for calls to debugger or pry.
+      class Debugger < Cop
+        MSG = 'Remove calls to debugger.'
+
+        # debugger call node
+        #
+        # (send nil :debugger)
+        DEBUGGER_NODE = s(:send, nil, :debugger)
+
+        # binding.pry node
+        #
+        # (send
+        #   (send nil :binding) :pry)
+        PRY_NODE = s(:send, s(:send, nil, :binding), :pry)
+
+        # binding.remote_pry node
+        #
+        # (send
+        #   (send nil :binding) :remote_pry)
+        REMOTE_PRY_NODE = s(:send, s(:send, nil, :binding), :remote_pry)
+
+        DEBUGGER_NODES = [DEBUGGER_NODE, PRY_NODE, REMOTE_PRY_NODE]
+
+        def on_send(node)
+          warning(node, :selector) if DEBUGGER_NODES.include?(node)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -1,0 +1,39 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Rubocop::Cop::Lint::Debugger do
+  subject(:cop) { described_class.new  }
+
+  it 'reports an offence for a debugger call' do
+    src = ['debugger']
+    inspect_source(cop, src)
+    expect(cop.offences.size).to eq(1)
+  end
+
+  it 'reports an offence for pry bindings' do
+    src = ['binding.pry',
+           'binding.remote_pry']
+    inspect_source(cop, src)
+    expect(cop.offences.size).to eq(2)
+  end
+
+  it 'does not report an offence for non-pry binding' do
+    src = ['binding.pirate']
+    inspect_source(cop, src)
+    expect(cop.offences).to be_empty
+  end
+
+  it 'does not report an offence for debugger in comments' do
+    src = ['# debugger']
+    inspect_source(cop, src)
+    expect(cop.offences).to be_empty
+  end
+
+  it 'does not report an offence for a debugger or pry method' do
+    src = ['code.debugger',
+           'door.pry']
+    inspect_source(cop, src)
+    expect(cop.offences).to be_empty
+  end
+end


### PR DESCRIPTION
This addresses the first part of #534. I just called the cop `Debugger`. Also, I am checking for binding._pry_ but let me know if I should be more explicit. Thanks!
