### PR TITLE
avoid range error in clang formatter when source spans multiple lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix bug concerning table and separator alignment of multi-line hash with multiple keys on the same line.
 * Fix a bug where `ClassLength` counted lines of inner classes/modules
 * Fix a false positive for namespace class in `Documentation`
+* Fix "Parser::Source::Range spans more than one line" bug in clang formatter
 
 ## 0.14.0 (07/10/2013)
 

--- a/lib/rubocop/formatter/clang_style_formatter.rb
+++ b/lib/rubocop/formatter/clang_style_formatter.rb
@@ -12,9 +12,14 @@ module Rubocop
                         smart_path(file).color(:cyan), o.line, o.real_column,
                         colored_severity_code(o), message(o))
 
-          source_line = o.location.source_line
+          location = o.location
+          source_line = location.source_line
 
-          unless source_line.blank?
+          # FIXME: Per the discussion below, we should not have to guard
+          # against Parser::Source::Range#column_range raising an error
+          # on multiline source ranges here -- followup needed.
+          # https://github.com/bbatsov/rubocop/pull/549#issuecomment-25955658
+          if !source_line.blank? && location.begin.line == location.end.line
             output.puts(source_line)
             output.puts(' ' * o.location.column +
                         '^' * o.location.column_range.count)

--- a/spec/rubocop/formatter/clang_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/clang_style_formatter_spec.rb
@@ -50,6 +50,19 @@ module Rubocop
                                        ''].join("\n")
         end
 
+        it 'does not display offending source line if it is multiline' do
+          cop = Cop::Cop.new
+          source_buffer = Parser::Source::Buffer.new('test', 1)
+          source_buffer.source = %w(foobar bazbop).to_a.join($RS)
+          cop.add_offence(:convention, nil,
+                          Parser::Source::Range.new(source_buffer, 5, 10),
+                          'message 1')
+
+          formatter.report_file('test', cop.offences)
+          expect(output.string).to eq ['test:1:6: C: message 1',
+                                       ''].join("\n")
+        end
+
         let(:file) { '/path/to/file' }
 
         let(:offence) do


### PR DESCRIPTION
Avoid this error in the clang formatter when the source range spans more than one line:

``` Ruby
  1) Rubocop::Formatter::ClangStyleFormatter#report_file does not display offending source line if it is multiline
     Failure/Error: formatter.report_file('test', cop.offences)
     RangeError:
       #<Parser::Source::Range test 5...10> spans more than one line
     # ./lib/rubocop/formatter/clang_style_formatter.rb:20:in `block in report_file'
     # ./lib/rubocop/formatter/clang_style_formatter.rb:10:in `each'
     # ./lib/rubocop/formatter/clang_style_formatter.rb:10:in `report_file'
     # ./spec/rubocop/formatter/clang_style_formatter_spec.rb:61:in `block (3 levels) in <module:Formatter>'
```

Exception source: https://github.com/whitequark/parser/blob/5c3b7b35c7af06f0b76e725bf1da00ada69cec08/lib/parser/source/range.rb#L92 )
