### PR TITLE
New cop  checks for braces in function calls with hash arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#551](https://github.com/bbatsov/rubocop/pull/551) - New cop `BracesAroundHashParameters` checks for braces in function calls with hash parameters.
+
 ### Bugs fixed
 
 * Fix bug concerning table and separator alignment of multi-line hash with multiple keys on the same line.

--- a/config/default.yml
+++ b/config/default.yml
@@ -184,3 +184,7 @@ TrivialAccessors:
 VariableName:
   # Valid values are: snake_case, camelCase
   EnforcedStyle: snake_case
+
+BracesAroundHashParameters:
+  # Valid values are: braces, no_braces
+  EnforcedStyle: no_braces

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -482,6 +482,10 @@ WhileUntilDo:
   Description: 'Checks for redundant do after while or until.'
   Enabled: true
 
+BracesAroundHashParameters:
+  Description: 'Enforce braces style inside hash parameters.'
+  Enabled: true
+
 #################### Lint ################################
 ### Warnings
 

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -142,6 +142,7 @@ require 'rubocop/cop/style/variable_name'
 require 'rubocop/cop/style/when_then'
 require 'rubocop/cop/style/while_until_do'
 require 'rubocop/cop/style/word_array'
+require 'rubocop/cop/style/braces_around_hash_parameters'
 
 require 'rubocop/cop/rails/has_and_belongs_to_many'
 require 'rubocop/cop/rails/read_attribute'

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -1,0 +1,40 @@
+# encoding: utf-8
+
+module Rubocop
+  module Cop
+    module Style
+      # This cop checks for braces in method calls with hash parameters.
+      class BracesAroundHashParameters < Cop
+
+        def on_send(node)
+          _, method_name, *args = *node
+          return unless args.length == 1
+          return if method_name.to_s.end_with?('=')
+          return if OPERATOR_METHODS.include?(method_name)
+          arg = args.first
+          return unless arg && arg.type == :hash && arg.children.any?
+          has_braces = !! arg.loc.begin
+          if style == :no_braces && has_braces
+            convention(arg,
+                       :expression,
+                       'Unnecessary braces around a hash parameter.')
+          elsif style == :braces && ! has_braces
+            convention(arg,
+                       :expression,
+                       'Missing braces around a hash parameter.')
+          end
+        end
+
+        private
+
+        def style
+          case cop_config['EnforcedStyle']
+          when 'braces' then :braces
+          when 'no_braces' then :no_braces
+          else fail 'Unknown style selected!'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -240,9 +240,9 @@ describe Rubocop::ConfigLoader do
         '  Enabled: true',
       ])
       configuration = load_file
-      expect(configuration['Encoding']).to eq({
+      expect(configuration['Encoding']).to eq(
         'Enabled' => true
-      })
+      )
     end
   end
 

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -1,0 +1,207 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Rubocop::Cop::Style::BracesAroundHashParameters, :config do
+  subject(:cop) { described_class.new(config) }
+
+  context 'no_braces' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'no_braces'
+      }
+    end
+
+    describe 'accepts' do
+
+      it 'one non-hash parameter' do
+        inspect_source(cop, ['where(2)'])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'one empty hash parameter' do
+        inspect_source(cop, ['where({})'])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'one hash parameter with separators' do
+        inspect_source(cop, ["where(  {     \n }\t   )  "])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'multiple non-hash parameters' do
+        inspect_source(cop, ['where(1, "2")'])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'one hash parameter without braces' do
+        inspect_source(cop, ['where(x: "y")'])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'one hash parameter without braces and multiple keys' do
+        inspect_source(cop, ['where(x: "y", foo: "bar")'])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'one hash parameter without braces and one hash value' do
+        inspect_source(cop, ['where(x: { "y" => "z" })'])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'multiple hash parameters with braces' do
+        inspect_source(cop, ['where({ x: 1 }, { y: 2 })'])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'property assignment with braces' do
+        inspect_source(cop, ['x.z = { y: "z" }'])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'operator with a hash parameter with braces' do
+        inspect_source(cop, ['x.z - { y: "z" }'])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'one non-hash parameter followed by a hash parameter with braces' do
+        inspect_source(cop, ['where(1, { y: 2 })'])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+    end
+
+    describe 'registers an offence for' do
+
+      it 'one object method hash parameter with braces' do
+        inspect_source(cop, ['x.func({ y: "z" })'])
+        expect(cop.messages).to eq([
+          'Unnecessary braces around a hash parameter.'
+        ])
+        expect(cop.highlights).to eq(['{ y: "z" }'])
+      end
+
+      it 'one hash parameter with braces' do
+        inspect_source(cop, ['where({ x: 1 })'])
+        expect(cop.messages).to eq([
+          'Unnecessary braces around a hash parameter.'
+        ])
+        expect(cop.highlights).to eq(['{ x: 1 }'])
+      end
+
+      it 'one hash parameter with braces and separators' do
+        inspect_source(cop, ["where(  \n { x: 1 }   )"])
+        expect(cop.messages).to eq([
+          'Unnecessary braces around a hash parameter.'
+        ])
+        expect(cop.highlights).to eq(['{ x: 1 }'])
+      end
+
+      it 'one hash parameter with braces and multiple keys' do
+        inspect_source(cop, ['where({ x: 1, foo: "bar" })'])
+        expect(cop.messages).to eq([
+          'Unnecessary braces around a hash parameter.'
+        ])
+        expect(cop.highlights).to eq(['{ x: 1, foo: "bar" }'])
+      end
+
+    end
+
+  end
+
+  context 'braces' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'braces'
+      }
+    end
+
+    describe 'accepts' do
+
+      it 'an empty hash parameter' do
+        inspect_source(cop, ['where({})'])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'one non-hash parameter' do
+        inspect_source(cop, ['where(2)'])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'multiple non-hash parameters' do
+        inspect_source(cop, ['where(1, "2")'])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'one hash parameter with braces' do
+        inspect_source(cop, ['where({ x: 1 })'])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'multiple hash parameters with braces' do
+        inspect_source(cop, ['where({ x: 1 }, { y: 2 })'])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'one hash parameter with braces and spaces around it' do
+        inspect_source(cop, [
+          'where(     {  x: 1  }   )'
+        ])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'one hash parameter with braces and separators around it' do
+        inspect_source(cop, ["where( \t    {  x: 1 \n  }   )"])
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+    end
+
+    describe 'registers an offence for' do
+
+      it 'one hash parameter without braces' do
+        inspect_source(cop, ['where(x: "y")'])
+        expect(cop.messages).to eq([
+          'Missing braces around a hash parameter.'
+        ])
+        expect(cop.highlights).to eq(['x: "y"'])
+      end
+
+      it 'one hash parameter with multiple keys and without braces' do
+        inspect_source(cop, ['where(x: "y", foo: "bar")'])
+        expect(cop.messages).to eq([
+          'Missing braces around a hash parameter.'
+        ])
+        expect(cop.highlights).to eq(['x: "y", foo: "bar"'])
+      end
+
+      it 'one hash parameter without braces with one hash value' do
+        inspect_source(cop, ['where(x: { "y" => "z" })'])
+        expect(cop.messages).to eq([
+          'Missing braces around a hash parameter.'
+        ])
+        expect(cop.highlights).to eq(['x: { "y" => "z" }'])
+      end
+
+    end
+
+  end
+end


### PR DESCRIPTION
It's quite common to make function calls such as `where({ x: 1 })`, in which case the curly braces are not required and you can write `where(x: 1)`. The `BracesInHashParameters` supports both a `required` (default) and a `none` style, keeping things consistent either way.
