### PR TITLE
Highlight only first line if source spans multiple lines in clang formatter 

### DIFF
--- a/lib/rubocop/formatter/clang_style_formatter.rb
+++ b/lib/rubocop/formatter/clang_style_formatter.rb
@@ -12,19 +12,23 @@ module Rubocop
                         smart_path(file).color(:cyan), o.line, o.real_column,
                         colored_severity_code(o), message(o))
 
-          location = o.location
-          source_line = location.source_line
+          source_line = o.location.source_line
 
-          # FIXME: Per the discussion below, we should not have to guard
-          # against Parser::Source::Range#column_range raising an error
-          # on multiline source ranges here -- followup needed.
-          # https://github.com/bbatsov/rubocop/pull/549#issuecomment-25955658
-          if !source_line.blank? && location.begin.line == location.end.line
+          unless source_line.blank?
             output.puts(source_line)
-            output.puts(' ' * o.location.column +
-                        '^' * o.location.column_range.count)
+            output.puts(highlight_line(o.location))
           end
         end
+      end
+
+      def highlight_line(location)
+        column_length = if location.begin.line == location.end.line
+                          location.column_range.count
+                        else
+                          location.source_line.length - location.column
+                        end
+
+        ' ' * location.column + '^' * column_length
       end
     end
   end

--- a/spec/rubocop/formatter/clang_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/clang_style_formatter_spec.rb
@@ -53,16 +53,25 @@ module Rubocop
         end
 
         context 'when the offending source spans multiple lines' do
-          it 'does not display the source line' do
-            cop = Cop::Cop.new
+          it 'displays the first line' do
+            source = ['do_something([this,',
+                      '              is,',
+                      '              target])'].join($RS)
+
             source_buffer = Parser::Source::Buffer.new('test', 1)
-            source_buffer.source = %w(foobar bazbop).to_a.join($RS)
-            cop.add_offence(:convention, nil,
-                            Parser::Source::Range.new(source_buffer, 5, 10),
-                            'message 1')
+            source_buffer.source = source
+
+            location = Parser::Source::Range.new(source_buffer,
+                                                 source.index('['),
+                                                 source.index(']') + 1)
+
+            cop = Cop::Cop.new
+            cop.add_offence(:convention, nil, location, 'message 1')
 
             formatter.report_file('test', cop.offences)
-            expect(output.string).to eq ['test:1:6: C: message 1',
+            expect(output.string).to eq ['test:1:14: C: message 1',
+                                         'do_something([this,',
+                                         '             ^^^^^^',
                                          ''].join("\n")
           end
         end


### PR DESCRIPTION
Follow-up fix for #549.
