### PR TITLE
[Fix #557] Don't load configuration files for excluded files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#557](https://github.com/bbatsov/rubocop/pull/557) - Configuration files for excluded files are no longer loaded.
+
 ## 0.14.1 (10/10/2013)
 
 ### New features

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -42,13 +42,13 @@ module Rubocop
     # @return [Array] Array of filenames
     def target_files_in_dir(base_dir = Dir.pwd)
       files = Dir["#{base_dir}/**/*"].select { |path| FileTest.file?(path) }
+      base_dir_config = @config_store.for("#{base_dir}/foobar.rb")
 
       target_files = files.select do |file|
-        config = @config_store.for(file)
-        next false if config.file_to_exclude?(file)
+        next false if base_dir_config.file_to_exclude?(file)
         next true if File.extname(file) == '.rb'
         next true if ruby_executable?(file)
-        config.file_to_include?(file)
+        @config_store.for(file).file_to_include?(file)
       end
 
       target_files.uniq


### PR DESCRIPTION
When searching recursively for files to inspect, exclude files based on the Excludes parameter for the directory where the search started. The Excludes parameter value would have come from that configuration anyway, but it's best to avoid loading configuration within directories of excluded files.
