### PR TITLE
Add Code Climate badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Gem Version](https://badge.fury.io/rb/rubocop.png)](http://badge.fury.io/rb/rubocop)
 [![Build Status](https://travis-ci.org/bbatsov/rubocop.png?branch=master)](https://travis-ci.org/bbatsov/rubocop)
 [![Coverage Status](https://coveralls.io/repos/bbatsov/rubocop/badge.png?branch=master)](https://coveralls.io/r/bbatsov/rubocop)
+[![Code Climate](https://codeclimate.com/github/bbatsov/rubocop.png)](https://codeclimate.com/github/bbatsov/rubocop)
 
 # RuboCop
 


### PR DESCRIPTION
Hi Bozhidar,

Thanks for this great project. I’m one of the founders at Code Climate and I’m always happy to see tools which help teams write better code.

It looks like someone, maybe you, added Rubocop to Code Climate recently and it grades very well. You can see the analysis here:

https://codeclimate.com/github/bbatsov/rubocop

This pull request adds our badge to your README.md so you can show off your GPA and make this information available to your users and contributors. It’s a bit ‘meta’ I suppose.

By the way, I saw that you have your own style guide — have you seen Xavier Shay’s?

http://xaviershay.github.io/writing/docs/ruby_style_guide.html

Best,

Noah
