### PR TITLE
Fix autocorrect for SpecialGlobalVars

### DIFF
--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -5,31 +5,31 @@ module Rubocop
     module Style
       # This cop looks for uses of Perl-style global variables.
       class SpecialGlobalVars < Cop
-        MSG = 'Prefer %s over %s.'
+        MSG = 'Prefer %s from English library over %s.'
 
         PREFERRED_VARS = {
-          '$:' => '$LOAD_PATH',
-          '$"' => '$LOADED_FEATURES',
-          '$0' => '$PROGRAM_NAME',
-          '$!' => '$ERROR_INFO from English library',
-          '$@' => '$ERROR_POSITION from English library',
-          '$;' => '$FS or $FIELD_SEPARATOR from English library',
-          '$,' => '$OFS or $OUTPUT_FIELD_SEPARATOR from English library',
-          '$/' => '$RS or $INPUT_RECORD_SEPARATOR from English library',
-          '$\\' => '$ORS or $OUTPUT_RECORD_SEPARATOR from English library',
-          '$.' => '$NR or $INPUT_LINE_NUMBER from English library',
-          '$_' => '$LAST_READ_LINE from English library',
-          '$>' => '$DEFAULT_OUTPUT from English library',
-          '$<' => '$DEFAULT_INPUT from English library',
-          '$$' => '$PID or $PROCESS_ID from English library',
-          '$?' => '$CHILD_STATUS from English library',
-          '$~' => '$LAST_MATCH_INFO from English library',
-          '$=' => '$IGNORECASE from English library',
-          '$*' => '$ARGV from English library or ARGV constant',
-          '$&' => '$MATCH from English library',
-          '$`' => '$PREMATCH from English library',
-          '$\'' => '$POSTMATCH from English library',
-          '$+' => '$LAST_PAREN_MATCH from English library'
+          '$:' => ['$LOAD_PATH'],
+          '$"' => ['$LOADED_FEATURES'],
+          '$0' => ['$PROGRAM_NAME'],
+          '$!' => ['$ERROR_INFO'],
+          '$@' => ['$ERROR_POSITION'],
+          '$;' => ['$FIELD_SEPARATOR', '$FS'],
+          '$,' => ['$OUTPUT_FIELD_SEPARATOR', '$OFS'],
+          '$/' => ['$INPUT_RECORD_SEPARATOR', '$RS'],
+          '$\\' => ['$OUTPUT_RECORD_SEPARATOR', '$ORS'],
+          '$.' => ['$INPUT_LINE_NUMBER', '$NR'],
+          '$_' => ['$LAST_READ_LINE'],
+          '$>' => ['$DEFAULT_OUTPUT'],
+          '$<' => ['$DEFAULT_INPUT'],
+          '$$' => ['$PROCESS_ID', '$PID'],
+          '$?' => ['$CHILD_STATUS'],
+          '$~' => ['$LAST_MATCH_INFO'],
+          '$=' => ['$IGNORECASE'],
+          '$*' => ['$ARGV', 'ARGV'],
+          '$&' => ['$MATCH'],
+          '$`' => ['$PREMATCH'],
+          '$\'' => ['$POSTMATCH'],
+          '$+' => ['$LAST_PAREN_MATCH']
         }.symbolize_keys
 
         def on_gvar(node)
@@ -40,7 +40,7 @@ module Rubocop
 
         def message(node)
           global_var, = *node
-          MSG.format(PREFERRED_VARS[global_var], global_var)
+          MSG.format(PREFERRED_VARS[global_var].join(' or '), global_var)
         end
 
         def autocorrect(node)
@@ -48,7 +48,7 @@ module Rubocop
             global_var, = *node
 
             corrector.replace(node.loc.expression,
-                              PREFERRED_VARS[global_var])
+                              PREFERRED_VARS[global_var].first)
           end
         end
       end

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -30,8 +30,7 @@ describe Rubocop::Cop::Style::SpecialGlobalVars do
     inspect_source(cop, ['puts $$'])
     expect(cop.offences.size).to eq(1)
     expect(cop.messages)
-      .to eq(['Prefer $PID or $PROCESS_ID from English library' +
-        ' over $$.'])
+      .to eq(['Prefer $PROCESS_ID or $PID over $$.'])
   end
 
   it 'does not register an offence for backrefs like $1' do
@@ -42,5 +41,10 @@ describe Rubocop::Cop::Style::SpecialGlobalVars do
   it 'auto-corrects $: to $LOAD_PATH' do
     new_source = autocorrect_source(cop, '$:')
     expect(new_source).to eq('$LOAD_PATH')
+  end
+
+  it 'auto-corrects $/ to $INPUT_RECORD_SEPARATOR' do
+    new_source = autocorrect_source(cop, '$/')
+    expect(new_source).to eq('$INPUT_RECORD_SEPARATOR')
   end
 end


### PR DESCRIPTION
It was replacing $! with "$ERROR_INFO from English library", for example.
