### PR TITLE
Fix autocorrect for SpecialGlobalVars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#557](https://github.com/bbatsov/rubocop/pull/557): Configuration files for excluded files are no longer loaded. ([@jonas054](https://github.com/jonas054))
 * New cop `Output` checks for calls to print, puts, etc. in Rails
+* [#565](https://github.com/bbatsov/rubocop/pull/565) - `$GLOBAL_VAR from English library` should no longer be inserted when autocorrecting short-form global variables like `$!`.
 * [#566](https://github.com/bbatsov/rubocop/pull/566) - Methods that just assign a splat to an ivar are no longer considered trivial writers.
 
 ### Bugs fixed

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -2,6 +2,7 @@
 
 require 'rainbow'
 require 'English'
+require 'set'
 require 'parser/current'
 require 'ast/sexp'
 require 'powerpack'

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -30,8 +30,13 @@ describe Rubocop::Cop::Style::SpecialGlobalVars do
     inspect_source(cop, ['puts $$'])
     expect(cop.offences.size).to eq(1)
     expect(cop.messages)
-      .to eq(['Prefer $PID or $PROCESS_ID from English library' +
-        ' over $$.'])
+      .to eq(['Prefer $PROCESS_ID or $PID from the English library over $$.'])
+  end
+
+  it 'is clear about variables from the English library vs those not' do
+    inspect_source(cop, ['puts $*'])
+    expect(cop.messages)
+      .to eq(['Prefer $ARGV from the English library, or ARGV over $*.'])
   end
 
   it 'does not register an offence for backrefs like $1' do
@@ -42,5 +47,10 @@ describe Rubocop::Cop::Style::SpecialGlobalVars do
   it 'auto-corrects $: to $LOAD_PATH' do
     new_source = autocorrect_source(cop, '$:')
     expect(new_source).to eq('$LOAD_PATH')
+  end
+
+  it 'auto-corrects $/ to $INPUT_RECORD_SEPARATOR' do
+    new_source = autocorrect_source(cop, '$/')
+    expect(new_source).to eq('$INPUT_RECORD_SEPARATOR')
   end
 end


### PR DESCRIPTION
It was replacing $! with "$ERROR_INFO from English library", for example.
