### PR TITLE
Fix: register an offence when the last hash parameter has braces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs fixed
 
 * [#561](https://github.com/bbatsov/rubocop/pull/561) - Handle properly negative literals in `NumericLiterals` cop.
+* [#567](https://github.com/bbatsov/rubocop/pull/567) - Register an offence when the last hash parameter has braces in `BracesAroundHashParameters` cop.
 
 ## 0.14.1 (10/10/2013)
 

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -8,19 +8,19 @@ module Rubocop
         def on_send(node)
           _receiver, method_name, *args = *node
 
-          return unless args.size == 1
           # discard attr writer methods.
           return if method_name.to_s.end_with?('=')
           # discard operator methods
           return if OPERATOR_METHODS.include?(method_name)
 
           # we care only for the first argument
-          arg = args.first
+          arg = args.last
           return unless arg && arg.type == :hash && arg.children.any?
 
           has_braces = !arg.loc.begin.nil?
+          all_hashes = args.length > 1 && args.all? { |a| a.type == :hash }
 
-          if style == :no_braces && has_braces
+          if style == :no_braces && has_braces && !all_hashes
             convention(arg,
                        :expression,
                        'Redundant curly braces around a hash parameter.')

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -71,14 +71,17 @@ describe Rubocop::Cop::Style::BracesAroundHashParameters, :config do
         expect(cop.highlights).to be_empty
       end
 
-      it 'one non-hash parameter followed by a hash parameter with braces' do
-        inspect_source(cop, ['where(1, { y: 2 })'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
-      end
     end
 
     describe 'registers an offence for' do
+      it 'one non-hash parameter followed by a hash parameter with braces' do
+        inspect_source(cop, ['where(1, { y: 2 })'])
+        expect(cop.messages).to eq([
+          'Redundant curly braces around a hash parameter.'
+        ])
+        expect(cop.highlights).to eq(['{ y: 2 }'])
+      end
+
       it 'one object method hash parameter with braces' do
         inspect_source(cop, ['x.func({ y: "z" })'])
         expect(cop.messages).to eq([

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -5,33 +5,31 @@ require 'spec_helper'
 describe Rubocop::Cop::Style::SymbolArray do
   subject(:cop) { described_class.new }
 
-  it 'registers an offence for arrays of symbols', { ruby: 2.0 } do
+  it 'registers an offence for arrays of symbols', ruby: 2.0 do
     inspect_source(cop,
                    ['[:one, :two, :three]'])
     expect(cop.offences.size).to eq(1)
   end
 
-  it 'does not reg an offence for array with non-syms', { ruby: 2.0 } do
+  it 'does not reg an offence for array with non-syms', ruby: 2.0 do
     inspect_source(cop,
                    ['[:one, :two, "three"]'])
     expect(cop.offences).to be_empty
   end
 
-  it 'does not reg an offence for array starting with %i',
-     { ruby: 2.0 } do
+  it 'does not reg an offence for array starting with %i', ruby: 2.0 do
     inspect_source(cop,
                    ['%i(one two three)'])
     expect(cop.offences).to be_empty
   end
 
-  it 'does not reg an offence for array with one element',
-     { ruby: 2.0 } do
+  it 'does not reg an offence for array with one element', ruby: 2.0 do
     inspect_source(cop,
                    ['[:three]'])
     expect(cop.offences).to be_empty
   end
 
-  it 'does nothing on Ruby 1.9', { ruby: 1.9 } do
+  it 'does nothing on Ruby 1.9', ruby: 1.9 do
     inspect_source(cop,
                    ['[:one, :two, :three]'])
     expect(cop.offences).to be_empty

--- a/spec/rubocop/formatter/json_formatter_spec.rb
+++ b/spec/rubocop/formatter/json_formatter_spec.rb
@@ -76,7 +76,7 @@ module Rubocop
       it 'outputs #output_hash as JSON' do
         formatter.finished(files)
         json = output.string
-        restored_hash = JSON.parse(json, { symbolize_names: true })
+        restored_hash = JSON.parse(json, symbolize_names: true)
         expect(restored_hash).to eq(formatter.output_hash)
       end
     end


### PR DESCRIPTION
The following code will now register an offence, see discussion in https://github.com/bbatsov/rubocop/pull/551/files#r6921166.

``` ruby
where(1, { y: 2 })
```

However, when you have multiple hash parameters, it will not to avoid the ugly

``` ruby
where({ x: 1 }, y: 2)
```
