### PR TITLE
Show encoding errors as offences.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#557](https://github.com/bbatsov/rubocop/pull/557): Configuration files for excluded files are no longer loaded. ([@jonas054][])
 * [#571](https://github.com/bbatsov/rubocop/pull/571): The default rake task now runs RuboCop over its self! ([@nevir][])
+* Encoding errors are reported as fatal offences rather than printed with red text.
 
 ### Bugs fixed
 

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -25,9 +25,9 @@ module Rubocop
         begin
           processed_source = SourceParser.parse_file(file)
         rescue Encoding::UndefinedConversionError, ArgumentError => e
-          handle_error(e,
-                       "An error occurred while parsing #{file}.".color(:red))
-          return []
+          range = Struct.new(:line, :column, :source_line).new(1, 0, '')
+          return [Offence.new(:fatal, range, e.message.capitalize + '.',
+                              'Parser')]
         end
 
         # If we got any syntax errors, return only the syntax offences.

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -498,7 +498,10 @@ describe Rubocop::CLI, :isolated_environment do
                                '# encoding: utf-8',
                                "# #{'f9'.hex.chr}#{'29'.hex.chr}"
                               ])
-    expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(0)
+    expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
+    expect($stdout.string)
+      .to eq(["#{abs('example.rb')}:1:1: F: Invalid byte sequence in utf-8.",
+              ''].join("\n"))
   end
 
   describe 'rubocop:disable comment' do


### PR DESCRIPTION
They are errors in the inspected files, not bugs in RuboCop, so it makes more sense to report them in this way. An example where this occurs is gems/builder-3.0.4/test/performance.rb.
