### PR TITLE
Categorize 'interpreted as argument prefix' syntax lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * New cop `Output` checks for calls to print, puts, etc. in Rails. ([@daviddavis][])
+* [#581](https://github.com/bbatsov/rubocop/pull/581): The `Syntax` cop now categorizes 'interpreted as argument prefix' warnings.  You can disable them by configuring it with `EnforceArgumentPrefixParentheses: false`.
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -164,6 +164,10 @@ SpaceInsideHashLiteralBraces:
 SymbolName:
   AllowCamelCase: true
 
+Syntax:
+  EnforceArgumentPrefixParentheses: true
+  OtherDiagnostics: true
+
 # TrivialAccessors doesn't require exact name matches and doesn't allow
 # predicated methods by default.
 TrivialAccessors:

--- a/spec/rubocop/cop/lint/syntax_spec.rb
+++ b/spec/rubocop/cop/lint/syntax_spec.rb
@@ -30,4 +30,28 @@ describe Rubocop::Cop::Lint::Syntax do
       expect(offence.cop_name).to eq('Syntax')
     end
   end
+
+  describe 'enforced categories', :config do
+    subject(:cop) { described_class.new(config) }
+    let(:cop_config) { { category => true, 'OtherDiagnostics' => false } }
+
+    describe 'parentheses around calls with argument prefix' do
+      let(:category) { 'EnforceArgumentPrefixParentheses' }
+
+      it 'should categorize "`*\' interpreted as argument prefix" warnings' do
+        inspect_source(cop, ['foo *bar'])
+        expect(cop.offences.size).to eq(1)
+      end
+
+      it 'should categorize "`&\' interpreted as argument prefix" warnings' do
+        inspect_source(cop, ['foo &bar'])
+        expect(cop.offences.size).to eq(1)
+      end
+
+      it 'should not complain when parentheses exist' do
+        inspect_source(cop, ['foo(*bar)', 'foo(&bar)'])
+        expect(cop.offences.size).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
I like to be able to send splats & blocks to DSL-style methods, but the parser dislikes that
