### PR TITLE
Make AccessControl indent depth configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#557](https://github.com/bbatsov/rubocop/pull/557): Configuration files for excluded files are no longer loaded. ([@jonas054][])
 * [#571](https://github.com/bbatsov/rubocop/pull/571): The default rake task now runs RuboCop over its self! ([@nevir][])
 * Encoding errors are reported as fatal offences rather than printed with red text.
+* `AccessControl` cop is now configurable with the `IndentDepth` option
 
 ### Bugs fixed
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -16,6 +16,10 @@ AllCops:
   # directory .rubocop.yml files, or by giving the -R/--rails option.
   RunRailsCops: false
 
+# Indent private/protected as deep as method definitions
+AccessControl:
+  IndentDepth: method
+
 # Align the elements of a hash literal if they span more than one line.
 AlignHash:
   # Alignment of entries using hash rocket as separator. Valid values are:

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -2,8 +2,8 @@
 
 AccessControl:
   Description: >
-                  Indent private/protected as deep as defs and keep blank
-                  lines around them.
+                  Check indentation of private/protected visibility modifiers
+                  and ensure there are blank lines before and after.
   Enabled: true
 
 Alias:

--- a/spec/rubocop/cop/style/access_control_spec.rb
+++ b/spec/rubocop/cop/style/access_control_spec.rb
@@ -2,163 +2,310 @@
 
 require 'spec_helper'
 
-describe Rubocop::Cop::Style::AccessControl do
-  subject(:cop) { described_class.new }
+describe Rubocop::Cop::Style::AccessControl, :config do
+  subject(:cop) { described_class.new(config) }
 
-  it 'registers an offence for misaligned private' do
-    inspect_source(cop,
-                   ['class Test',
-                    '',
-                    'private',
-                    '',
-                    '  def test; end',
-                    'end'])
-    expect(cop.offences.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Indent private as deep as method definitions.'])
+  context 'when IndentDepth is set to method' do
+    let(:cop_config) { { 'IndentDepth' => 'method' } }
+
+    it 'registers an offence for misaligned private' do
+      inspect_source(cop,
+                     ['class Test',
+                      '',
+                      'private',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages)
+        .to eq(['Indent private as deep as method definitions.'])
+    end
+
+    it 'registers an offence for misaligned private in module' do
+      inspect_source(cop,
+                     ['module Test',
+                      '',
+                      'private',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages)
+        .to eq(['Indent private as deep as method definitions.'])
+    end
+
+    it 'registers an offence for misaligned private in singleton class' do
+      inspect_source(cop,
+                     ['class << self',
+                      '',
+                      'private',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages)
+        .to eq(['Indent private as deep as method definitions.'])
+    end
+
+    it 'registers an offence for misaligned private in class ' +
+       'defined with Class.new' do
+      inspect_source(cop,
+                     ['Test = Class.new do',
+                      '',
+                      'private',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages)
+        .to eq(['Indent private as deep as method definitions.'])
+    end
+
+    it 'registers an offence for misaligned private in module ' +
+       'defined with Module.new' do
+      inspect_source(cop,
+                     ['Test = Module.new do',
+                      '',
+                      'private',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages)
+        .to eq(['Indent private as deep as method definitions.'])
+    end
+
+    it 'registers an offence for misaligned protected' do
+      inspect_source(cop,
+                     ['class Test',
+                      '',
+                      'protected',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages)
+        .to eq(['Indent protected as deep as method definitions.'])
+    end
+
+    it 'accepts properly indented private' do
+      inspect_source(cop,
+                     ['class Test',
+                      '',
+                      '  private',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences).to be_empty
+    end
+
+    it 'accepts properly indented protected' do
+      inspect_source(cop,
+                     ['class Test',
+                      '',
+                      '  protected',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences).to be_empty
+    end
+
+    it 'handles properly nested classes' do
+      inspect_source(cop,
+                     ['class Test',
+                      '',
+                      '  class Nested',
+                      '',
+                      '  private',
+                      '',
+                      '    def a; end',
+                      '  end',
+                      '',
+                      '  protected',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages)
+        .to eq(['Indent private as deep as method definitions.'])
+    end
+
+    it 'requires blank line before private/protected' do
+      inspect_source(cop,
+                     ['class Test',
+                      '  protected',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages)
+        .to eq(['Keep a blank line before and after protected.'])
+    end
+
+    it 'requires blank line after private/protected' do
+      inspect_source(cop,
+                     ['class Test',
+                      '',
+                      '  protected',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages)
+        .to eq(['Keep a blank line before and after protected.'])
+    end
+
+    it 'recognizes blank lines with DOS style line endings' do
+      inspect_source(cop,
+                     ["class Test\r",
+                      "\r",
+                      "  protected\r",
+                      "\r",
+                      "  def test; end\r",
+                      "end\r"])
+      expect(cop.offences.size).to eq(0)
+    end
   end
 
-  it 'registers an offence for misaligned private in module' do
-    inspect_source(cop,
-                   ['module Test',
-                    '',
-                    'private',
-                    '',
-                    '  def test; end',
-                    'end'])
-    expect(cop.offences.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Indent private as deep as method definitions.'])
-  end
+  context 'when IndentDepth is set to class' do
+    let(:cop_config) { { 'IndentDepth' => 'class' } }
+    let(:indent_msg) { 'Indent private as deep as class definitions.' }
+    let(:blank_msg) { 'Keep a blank line before and after private.' }
 
-  it 'registers an offence for misaligned private in singleton class' do
-    inspect_source(cop,
-                   ['class << self',
-                    '',
-                    'private',
-                    '',
-                    '  def test; end',
-                    'end'])
-    expect(cop.offences.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Indent private as deep as method definitions.'])
-  end
+    it 'registers offence for private indented to method depth in a class' do
+      inspect_source(cop,
+                     ['class Test',
+                      '',
+                      '  private',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages).to eq([indent_msg])
+    end
 
-  it 'registers an offence for misaligned private in class ' +
-     'defined with Class.new' do
-    inspect_source(cop,
-                   ['Test = Class.new do',
-                    '',
-                    'private',
-                    '',
-                    '  def test; end',
-                    'end'])
-    expect(cop.offences.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Indent private as deep as method definitions.'])
-  end
+    it 'registers offence for private indented to method depth in a module' do
+      inspect_source(cop,
+                     ['module Test',
+                      '',
+                      '  private',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages).to eq([indent_msg])
+    end
 
-  it 'registers an offence for misaligned private in module ' +
-     'defined with Module.new' do
-    inspect_source(cop,
-                   ['Test = Module.new do',
-                    '',
-                    'private',
-                    '',
-                    '  def test; end',
-                    'end'])
-    expect(cop.offences.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Indent private as deep as method definitions.'])
-  end
+    it 'registers offence for private indented to method depth in singleton' +
+       'class' do
+      inspect_source(cop,
+                     ['class << self',
+                      '',
+                      '  private',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages).to eq([indent_msg])
+    end
 
-  it 'registers an offence for misaligned protected' do
-    inspect_source(cop,
-                   ['class Test',
-                    '',
-                    'protected',
-                    '',
-                    '  def test; end',
-                    'end'])
-    expect(cop.offences.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Indent protected as deep as method definitions.'])
-  end
+    it 'registers offence for private indented to method depth in class ' +
+       'defined with Class.new' do
+      inspect_source(cop,
+                     ['Test = Class.new do',
+                      '',
+                      '  private',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages).to eq([indent_msg])
+    end
 
-  it 'accepts properly indented private' do
-    inspect_source(cop,
-                   ['class Test',
-                    '',
-                    '  private',
-                    '',
-                    '  def test; end',
-                    'end'])
-    expect(cop.offences).to be_empty
-  end
+    it 'registers offence for private indented to method depth in module ' +
+       'defined with Module.new' do
+      inspect_source(cop,
+                     ['Test = Module.new do',
+                      '',
+                      '  private',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages).to eq([indent_msg])
+    end
 
-  it 'accepts properly indented protected' do
-    inspect_source(cop,
-                   ['class Test',
-                    '',
-                    '  protected',
-                    '',
-                    '  def test; end',
-                    'end'])
-    expect(cop.offences).to be_empty
-  end
+    it 'accepts private indented to the containing class indent level' do
+      inspect_source(cop,
+                     ['class Test',
+                      '',
+                      'private',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences).to be_empty
+    end
 
-  it 'handles properly nested classes' do
-    inspect_source(cop,
-                   ['class Test',
-                    '',
-                    '  class Nested',
-                    '',
-                    '  private',
-                    '',
-                    '    def a; end',
-                    '  end',
-                    '',
-                    '  protected',
-                    '',
-                    '  def test; end',
-                    'end'])
-    expect(cop.offences.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Indent private as deep as method definitions.'])
-  end
+    it 'accepts protected indented to the containing class indent level' do
+      inspect_source(cop,
+                     ['class Test',
+                      '',
+                      'protected',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences).to be_empty
+    end
 
-  it 'requires blank line before private/protected' do
-    inspect_source(cop,
-                   ['class Test',
-                    '  protected',
-                    '',
-                    '  def test; end',
-                    'end'])
-    expect(cop.offences.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Keep a blank line before and after protected.'])
-  end
+    it 'handles properly nested classes' do
+      inspect_source(cop,
+                     ['class Test',
+                      '',
+                      '  class Nested',
+                      '',
+                      '    private',
+                      '',
+                      '    def a; end',
+                      '  end',
+                      '',
+                      'protected',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages).to eq([indent_msg])
+    end
 
-  it 'requires blank line after private/protected' do
-    inspect_source(cop,
-                   ['class Test',
-                    '',
-                    '  protected',
-                    '  def test; end',
-                    'end'])
-    expect(cop.offences.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Keep a blank line before and after protected.'])
-  end
+    it 'requires blank line before private/protected' do
+      inspect_source(cop,
+                     ['class Test',
+                      'private',
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages).to eq([blank_msg])
+    end
 
-  it 'recognizes blank lines with DOS style line endings' do
-    inspect_source(cop,
-                   ["class Test\r",
-                    "\r",
-                    "  protected\r",
-                    "\r",
-                    "  def test; end\r",
-                    "end\r"])
-    expect(cop.offences.size).to eq(0)
+    it 'requires blank line after private/protected' do
+      inspect_source(cop,
+                     ['class Test',
+                      '',
+                      'private',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offences.size).to eq(1)
+      expect(cop.messages).to eq([blank_msg])
+    end
+
+    it 'recognizes blank lines with DOS style line endings' do
+      inspect_source(cop,
+                     ["class Test\r",
+                      "\r",
+                      "protected\r",
+                      "\r",
+                      "  def test; end\r",
+                      "end\r"])
+      expect(cop.offences.size).to eq(0)
+    end
   end
 end


### PR DESCRIPTION
Add the ability for the `AccessControl` cop to respect the new
`IndentDepth` configuration parameter, which specifies whether
`private`/`protected` keywords are indented to the same indentation as
the class or methods within that class.

Valid values for `IndentDepth` are 'class' and 'method'. The default
is 'method', which maintains existing behavior.

The justification for allowing this to be configurable is that some
codebases prefer indenting these modifiers at the same level as the
containing class. The reason for this is that it visually separates
"sections" of methods with different visibilities, and is easier pick
out visually when viewing a file as there is a horizontal shift in
position from that of the rest of the method `def`initions, making it
stand out.
