### PR TITLE
Expand ~ in inherit_from paths to home directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Encoding errors are reported as fatal offences rather than printed with red text. ([@jonas054][])
 * `AccessControl` cop is now configurable with the `EnforcedStyle` option. ([@sds][])
 * Split `AccessControl` cop to `AccessModifierIndentation` and `EmptyLinesAroundAccessModifier`. ([@bbatsov][])
+* Expand `~` to user's home directory in `inherit_from` paths. ([@sds][])
 
 ### Bugs fixed
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -79,10 +79,16 @@ module Rubocop
 
       def base_configs(path, inherit_from)
         Array(inherit_from).map do |f|
-          f = File.join(File.dirname(path), f) unless f.start_with?('/')
+          f = expand_inherit_from_path(path, f)
           print 'Inheriting ' if debug?
           load_file(f)
         end
+      end
+
+      def expand_inherit_from_path(current_config_path, inherit_from)
+        return inherit_from if inherit_from.start_with?('/')
+        return File.expand_path(inherit_from) if inherit_from.start_with?('~/')
+        File.join(File.dirname(current_config_path), inherit_from)
       end
 
       # Returns the path of .rubocop.yml searching upwards in the

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -227,6 +227,30 @@ describe Rubocop::ConfigLoader do
     end
   end
 
+  describe '.expand_inherit_from_path', :isolated_environment do
+    let(:current_config_path) { '/some/absolute/path/.rubocop.yml' }
+
+    subject do
+      described_class.expand_inherit_from_path(current_config_path,
+                                               inherit_from)
+    end
+
+    context 'when path is relative' do
+      let(:inherit_from) { '../../other.yml' }
+      it { should eq('/some/absolute/path/../../other.yml') }
+    end
+
+    context 'when path is absolute' do
+      let(:inherit_from) { '/absolute/other.yml' }
+      it { should eq('/absolute/other.yml') }
+    end
+
+    context 'when path contains a leading ~ to indicate the home directory' do
+      let(:inherit_from) { '~/home.yml' }
+      it { should eq("#{ENV['HOME']}/home.yml") }
+    end
+  end
+
   describe '.load_file', :isolated_environment do
     subject(:load_file) do
       described_class.load_file(configuration_path)


### PR DESCRIPTION
A common feature in the configuration of many tools is the ability to
use the `~` character to refer to a user's home directory.

Since arbitrary interpolation in Rubocop config files is not yet
supported, implementing this seems like a simple step to providing this
kind of flexibility, which is especially useful for development
environments which have a general set of configuration settings in the
home directory, along with repo-specific configurations in each repo.
