### PR TITLE
Fix English

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 ### Changes
 
 * [#557](https://github.com/bbatsov/rubocop/pull/557): Configuration files for excluded files are no longer loaded. ([@jonas054][])
-* [#571](https://github.com/bbatsov/rubocop/pull/571): The default rake task now runs RuboCop over its self! ([@nevir][])
+* [#571](https://github.com/bbatsov/rubocop/pull/571): The default rake task now runs RuboCop over itself! ([@nevir][])
 * Encoding errors are reported as fatal offences rather than printed with red text. ([@jonas054][])
 * `AccessControl` cop is now configurable with the `EnforcedStyle` option. ([@sds][])
 * Split `AccessControl` cop to `AccessModifierIndentation` and `EmptyLinesAroundAccessModifier`. ([@bbatsov][])


### PR DESCRIPTION
I can't find any definitive resources on the English language saying that it should be "itself" rather than "its self", but if you do a google search for "its self", you only get hits for phrases like "its self-foo", such as "Foursquare Opens Up Its Self-Serve Ad Platform - AllThingsD", or people asking about "its self" versus "itself".
