### PR TITLE
Add CyclomaticComplexity cop.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,6 @@ MethodLength:
 
 ClassLength:
   Max: 160
+
+CyclomaticComplexity:
+  Max: 12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * `TrailingWhitespace` cop does auto-correction. ([@jonas054][])
 * `TrailingBlankLines` cop does auto-correction. ([@jonas054][])
 * `FinalNewline` cop does auto-correction. ([@jonas054][])
+* New cop `CyclomaticComplexity` checks the cyclomatic complexity of methods against a configurable max value. ([@jonas054][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -77,6 +77,10 @@ CommentAnnotation:
     - HACK
     - REVIEW
 
+# Avoid complex methods.
+CyclomaticComplexity:
+  Max: 6
+
 # Multi-line method chaining should be done with leading dots.
 DotPosition:
   Style: 'leading'

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -101,6 +101,10 @@ ConstantName:
   Description: 'Constants should use SCREAMING_SNAKE_CASE.'
   Enabled: true
 
+CyclomaticComplexity:
+  Description: 'Avoid complex methods.'
+  Enabled: true
+
 DefWithParentheses:
   Description: 'Use def with parentheses when there are arguments.'
   Enabled: true

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -45,6 +45,7 @@ require 'rubocop/cop/lint/void'
 
 require 'rubocop/cop/style/autocorrect_alignment'
 require 'rubocop/cop/style/configurable_naming'
+require 'rubocop/cop/style/cyclomatic_complexity'
 require 'rubocop/cop/style/string_help'
 require 'rubocop/cop/style/access_modifier_indentation'
 require 'rubocop/cop/style/alias'

--- a/lib/rubocop/cop/style/cyclomatic_complexity.rb
+++ b/lib/rubocop/cop/style/cyclomatic_complexity.rb
@@ -1,0 +1,46 @@
+# encoding: utf-8
+
+module Rubocop
+  module Cop
+    module Style
+      # This cop checks that the cyclomatic complexity of methods is not higher
+      # than the configured maximum. The cyclomatic complexity is the number of
+      # linearly independent paths through a method. The algorithm counts
+      # decision points and adds one.
+      #
+      # An if statement (or unless or ?:) increases the complexity by one. An
+      # else branch does not, since it doesn't add a decision point. The &&
+      # operator (or keyword and) can be converted to a nested if statement,
+      # and ||/or is shorthand for a sequence of ifs, so they also add one.
+      # Loops can be said to have an exit condition, so they add one.
+      class CyclomaticComplexity < Cop
+        MSG = 'Cyclomatic complexity for %s is too high. [%d/%d]'
+        DECISION_POINT_NODES = [:if, :while, :until, :for, :rescue, :when,
+                                :and, :or]
+
+        def on_def(node)
+          method_name, _args, _body = *node
+          check(node, method_name)
+        end
+
+        def on_defs(node)
+          _scope, method_name, _args, _body = *node
+          check(node, method_name)
+        end
+
+        private
+
+        def check(node, method_name)
+          complexity = 1
+          on_node(DECISION_POINT_NODES, node) { complexity += 1 }
+
+          max = cop_config['Max']
+          if complexity > max
+            convention(node, :keyword,
+                       sprintf(MSG, method_name, complexity, max))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/style/cyclomatic_complexity_spec.rb
+++ b/spec/rubocop/cop/style/cyclomatic_complexity_spec.rb
@@ -1,0 +1,203 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Rubocop::Cop::Style::CyclomaticComplexity, :config do
+  subject(:cop) { described_class.new(config) }
+
+  context 'when Max is 1' do
+    let(:cop_config) { { 'Max' => 1 } }
+
+    it 'accepts a method with no decision points' do
+      inspect_source(cop, ['def method_name',
+                           '  call_foo',
+                           'end'])
+      expect(cop.offences).to be_empty
+    end
+
+    it 'accepts complex code outside of methods' do
+      inspect_source(cop,
+                     ['def method_name',
+                      '  call_foo',
+                      'end',
+                      '',
+                      'if first_condition then',
+                      '  call_foo if second_condition && third_condition',
+                      '  call_bar if fourth_condition || fifth_condition',
+                      'end'])
+      expect(cop.offences).to be_empty
+    end
+
+    it 'registers an offence for an if modifier' do
+      inspect_source(cop, ['def self.method_name',
+                           '  call_foo if some_condition',
+                           'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
+      expect(cop.highlights).to eq(['def'])
+    end
+
+    it 'registers an offence for an unless modifier' do
+      inspect_source(cop, ['def method_name',
+                           '  call_foo unless some_condition',
+                           'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
+    end
+
+    it 'registers an offence for an elsif block' do
+      inspect_source(cop, ['def method_name',
+                           '  if first_condition then',
+                           '    call_foo',
+                           '  elsif second_condition then',
+                           '    call_bar',
+                           '  else',
+                           '    call_bam',
+                           '  end',
+                           'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name is too high. [3/1]'])
+    end
+
+    it 'registers an offence for a ternary operator' do
+      inspect_source(cop, ['def method_name',
+                           '  value = some_condition ? 1 : 2',
+                           'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
+    end
+
+    it 'registers an offence for a while block' do
+      inspect_source(cop, ['def method_name',
+                           '  while some_condition do',
+                           '    call_foo',
+                           '  end',
+                           'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
+    end
+
+    it 'registers an offence for an until block' do
+      inspect_source(cop, ['def method_name',
+                           '  until some_condition do',
+                           '    call_foo',
+                           '  end',
+                           'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
+    end
+
+    it 'registers an offence for a for block' do
+      inspect_source(cop, ['def method_name',
+                           '  for i in 1..2 do',
+                           '    call_method',
+                           '  end',
+                           'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
+    end
+
+    it 'registers an offence for a rescue block' do
+      inspect_source(cop, ['def method_name',
+                           '  begin',
+                           '    call_foo',
+                           '  rescue Exception',
+                           '    call_bar',
+                           '  end',
+                           'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
+    end
+
+    it 'registers an offence for a case/when block' do
+      inspect_source(cop, ['def method_name',
+                           '  case value',
+                           '  when 1',
+                           '    call_foo',
+                           '  when 2',
+                           '    call_bar',
+                           '  end',
+                           'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name is too high. [3/1]'])
+    end
+
+    it 'registers an offence for &&' do
+      inspect_source(cop, ['def method_name',
+                           '  call_foo && call_bar',
+                           'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
+    end
+
+    it 'registers an offence for and' do
+      inspect_source(cop, ['def method_name',
+                           '  call_foo and call_bar',
+                           'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
+    end
+
+    it 'registers an offence for ||' do
+      inspect_source(cop, ['def method_name',
+                           '  call_foo || call_bar',
+                           'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
+    end
+
+    it 'registers an offence for or' do
+      inspect_source(cop, ['def method_name',
+                           '  call_foo or call_bar',
+                           'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
+    end
+
+    it 'deals with nested if blocks containing && and ||' do
+      inspect_source(cop,
+                     ['def method_name',
+                      '  if first_condition then',
+                      '    call_foo if second_condition && third_condition',
+                      '    call_bar if fourth_condition || fifth_condition',
+                      '  end',
+                      'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name is too high. [6/1]'])
+    end
+
+    it 'counts only a single method' do
+      inspect_source(cop, ['def method_name_1',
+                           '  call_foo if some_condition',
+                           'end',
+                           '',
+                           'def method_name_2',
+                           '  call_foo if some_condition',
+                           'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name_1 is too high. [2/1]',
+                'Cyclomatic complexity for method_name_2 is too high. [2/1]'])
+    end
+  end
+
+  context 'when Max is 2' do
+    let(:cop_config) { { 'Max' => 2 } }
+
+    it 'counts stupid nested if and else blocks' do
+      inspect_source(cop, ['def method_name',
+                           '  if first_condition then',
+                           '    call_foo',
+                           '  else',
+                           '    if second_condition then',
+                           '      call_bar',
+                           '    else',
+                           '      call_bam if third_condition',
+                           '    end',
+                           '    call_baz if fourth_condition',
+                           '  end',
+                           'end'])
+      expect(cop.messages)
+        .to eq(['Cyclomatic complexity for method_name is too high. [5/2]'])
+    end
+  end
+end


### PR DESCRIPTION
Fixes #579.

The specs are more or less "stolen" from https://github.com/roodi/roodi/blob/master/spec/roodi/checks/cyclomatic_complexity_method_check_spec.rb. Roodi is a tool that RuboCop already has a bit of overlap with. Their definition of cyclomatic complexity seems sound. I've only changed one thing. In a `case`/`when`, only `when` should add to the complexity number, I think. So a `case` with two `when`s adds 2, not 3, to the complexity number.

I've chosen `6` as the default `Max`. Accoring to a comment in https://github.com/roodi/roodi/blob/master/lib/roodi/checks/cyclomatic_complexity_method_check.rb 1-4 is considered good, 5-8 ok. Note that RuboCop itself has some way to go before coming down to that number.

Only methods are checked for cyclomatic complexity. Code outside of methods are not checked.
