### PR TITLE
Make EndOfLine cop work again.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#585](https://github.com/bbatsov/rubocop/pull/585): `MethodCallParentheses` should allow methods starting with uppercase letter. ([@bbatsov][])
 * [#574](https://github.com/bbatsov/rubocop/issues/574): Fix error on multiple-assignment with non-array right hand side in `UselessSetterCall`. ([@yujinakayama][])
 * [#576](https://github.com/bbatsov/rubocop/issues/576): Output config validation warning to STDERR so that it won't be mixed up with formatter's output. ([@yujinakayama][])
+* [#599](https://github.com/bbatsov/rubocop/pull/599): `EndOfLine` cop is operational again. ([@jonas054][])
 
 ## 0.14.1 (10/10/2013)
 

--- a/lib/rubocop/cop/style/end_of_line.rb
+++ b/lib/rubocop/cop/style/end_of_line.rb
@@ -8,13 +8,17 @@ module Rubocop
         MSG = 'Carriage return character detected.'
 
         def investigate(processed_source)
-          processed_source.lines.each_with_index do |line, index|
+          original_source = IO.read(processed_source.buffer.name)
+          original_source.lines.each_with_index do |line, index|
             if line =~ /\r$/
               convention(nil,
                          source_range(processed_source.buffer,
                                       processed_source[0...index],
-                                      line.length - 1, 1),
+                                      0, line.length),
                          MSG)
+              # Usually there will be carriage return characters on all or none
+              # of the lines in a file, so we report only one offence.
+              break
             end
           end
         end

--- a/spec/rubocop/cop/style/end_of_line_spec.rb
+++ b/spec/rubocop/cop/style/end_of_line_spec.rb
@@ -1,21 +1,30 @@
 # encoding: utf-8
 
 require 'spec_helper'
+require 'tempfile'
 
 describe Rubocop::Cop::Style::EndOfLine do
   subject(:cop) { described_class.new }
 
   it 'registers an offence for CR+LF' do
-    pending 'Fails after upgdate to parser-2.0.0.pre3.'
-    inspect_source(cop, ["x=0\r", ''])
-    expect(cop.messages).to eq(
-      ['Carriage return character detected.'])
+    inspect_source_file(cop, ['x=0', '', "y=1\r"])
+    expect(cop.messages).to eq(['Carriage return character detected.'])
+  end
+
+  it 'highlights the whole offendng line' do
+    inspect_source_file(cop, ['x=0', '', "y=1\r"])
+    expect(cop.highlights).to eq(["y=1\r"])
   end
 
   it 'registers an offence for CR at end of file' do
-    pending
-    inspect_source(cop, ["x=0\r"])
-    expect(cop.messages).to eq(
-      ['Carriage return character detected.'])
+    inspect_source_file(cop, ["x=0\r"])
+    expect(cop.messages).to eq(['Carriage return character detected.'])
+  end
+
+  context 'when there are many lines ending with CR+LF' do
+    it 'registers only one offence' do
+      inspect_source_file(cop, ['x=0', '', 'y=1'].join("\r\n"))
+      expect(cop.messages.size).to eq(1)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,15 +79,25 @@ RSpec.configure do |config|
   config.include(ExitCodeMatchers)
 end
 
-def inspect_source(cop, source)
-  processed_source = parse_source(source)
+def inspect_source_file(cop, source)
+  Tempfile.open('tmp') { |f| inspect_source(cop, source, f) }
+end
+
+def inspect_source(cop, source, file = nil)
+  processed_source = parse_source(source, file)
   fail 'Error parsing example code' unless processed_source.valid_syntax?
   _investigate(cop, processed_source)
 end
 
-def parse_source(source)
+def parse_source(source, file = nil)
   source = source.join($RS) if source.is_a?(Array)
-  Rubocop::SourceParser.parse(source)
+  if file
+    file.write(source)
+    file.rewind
+    Rubocop::SourceParser.parse(source, file.path)
+  else
+    Rubocop::SourceParser.parse(source)
+  end
 end
 
 def autocorrect_source(cop, source)


### PR DESCRIPTION
When Parser started processing line endings, the `EndOfLine` cop stopped working. Fix by reading file again.

This means that each file is read an extra time. I've checked if it affects performance, but couldn't see any difference.
