### PR TITLE
Enable coverage builds again.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * `AccessControl` cop is now configurable with the `EnforcedStyle` option. ([@sds][])
 * Split `AccessControl` cop to `AccessModifierIndentation` and `EmptyLinesAroundAccessModifier`. ([@bbatsov][])
 * [#594](https://github.com/bbatsov/rubocop/pull/594): Add configuration parameter `EnforcedStyleForEmptyBraces` to `SpaceInsideHashLiteralBraces` cop, and change `EnforcedStyleIsWithSpaces` (values `true`, `false`) to `EnforcedStyle` (values `space`, `no_space`) ([@jonas054][])
+* Coverage builds linked from the README page are enabled again.
 
 ### Bugs fixed
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,24 +12,19 @@ if ENV['TRAVIS'] && RUBY_ENGINE == 'jruby'
   ENV['TMPDIR'] = non_world_writable_tmp_dir
 end
 
-# Temporary disable the coverage report until Coveralls fix
-# their API or we find a way to not break the TRAVIS build
-# when Coveralls report error.
-# SimpleCov raises similar IOError - stream closed when ran
-# on Rubinius.
-# if ENV['TRAVIS'] || ENV['COVERAGE']
-  # require 'simplecov'
+if ENV['TRAVIS'] || ENV['COVERAGE']
+  require 'simplecov'
 
-  # if ENV['TRAVIS']
-  #   require 'coveralls'
-  #   SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-  # end
+  if ENV['TRAVIS']
+    require 'coveralls'
+    SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+  end
 
-  # SimpleCov.start do
-    # add_filter '/spec/'
-    # add_filter '/vendor/bundle/'
-  # end
-# end
+  SimpleCov.start do
+    add_filter '/spec/'
+    add_filter '/vendor/bundle/'
+  end
+end
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))


### PR DESCRIPTION
I've checked what happens if I set up Travis and Coveralls from my fork of RuboCop. There are no failures on Travis. On Coveralls we get 0% coverage in jruby for some reason. Other than that, things are fine.

So it looks like the problems that forced us to comment out the coverage code in `spec_helper.rb` are gone.
