### PR TITLE
Allow WordArray to support a minimum array size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * `FinalNewline` cop does auto-correction. ([@jonas054][])
 * New cop `CyclomaticComplexity` checks the cyclomatic complexity of methods against a configurable max value. ([@jonas054][])
 * [#594](https://github.com/bbatsov/rubocop/pull/594): New parameter `EnforcedStyleForEmptyBraces` with values `space` and `no_space` (default) added to `SpaceAroundBlockBraces`. ([@jonas054][])
+* [#603](https://github.com/bbatsov/rubocop/pull/603): New parameter `MinSize` added to `WordArray` to allow small string arrays, retaining the default (0). ([@claco][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -55,6 +55,10 @@ AssignmentInCondition:
 BlockNesting:
   Max: 3
 
+BracesAroundHashParameters:
+  # Valid values are: braces, no_braces
+  EnforcedStyle: no_braces
+
 ClassLength:
   CountComments: false  # count full line comments?
   Max: 100
@@ -205,6 +209,5 @@ VariableName:
   # Valid values are: snake_case, camelCase
   EnforcedStyle: snake_case
 
-BracesAroundHashParameters:
-  # Valid values are: braces, no_braces
-  EnforcedStyle: no_braces
+WordArray:
+  MinSize: 0

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -18,7 +18,8 @@ module Rubocop
 
           string_array = array_elems.all? { |e| e.type == :str }
 
-          if string_array && !complex_content?(array_elems)
+          if string_array && !complex_content?(array_elems) &&
+            array_elems.size > min_size
             convention(node, :expression)
           end
         end
@@ -35,6 +36,10 @@ module Rubocop
           end
 
           false
+        end
+
+        def min_size
+          cop_config['MinSize']
         end
       end
     end

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -2,8 +2,9 @@
 
 require 'spec_helper'
 
-describe Rubocop::Cop::Style::WordArray do
-  subject(:cop) { described_class.new }
+describe Rubocop::Cop::Style::WordArray, :config do
+  subject(:cop) { described_class.new(config) }
+  let(:cop_config) { { 'MinSize' => 0 } }
 
   it 'registers an offence for arrays of single quoted strings' do
     inspect_source(cop,
@@ -50,6 +51,14 @@ describe Rubocop::Cop::Style::WordArray do
   it 'does not register an offence for array with empty strings' do
     inspect_source(cop,
                    ['["", "two", "three"]'])
+    expect(cop.offences).to be_empty
+  end
+
+  it 'does not register an offence for array with allowed number of strings' do
+    cop_config['MinSize'] = 3
+
+    inspect_source(cop,
+                   ['["one", "two", "three"]'])
     expect(cop.offences).to be_empty
   end
 end


### PR DESCRIPTION
Sometimes it is preferred to use an array for a small number of strings
and only force the use of %w %W when the item count it large. This
allows the WordArray style to only complain if the number of string
elements are over the set minimum.

Not entirely sure about the setting name. MinSize seems fitting.
