### PR TITLE
Add pending test about regexp in conditionals

### DIFF
--- a/spec/rubocop/cop/style/favor_modifier_spec.rb
+++ b/spec/rubocop/cop/style/favor_modifier_spec.rb
@@ -89,6 +89,14 @@ describe Rubocop::Cop::Style::IfUnlessModifier do
                          'end'])
     expect(cop.offences).to be_empty
   end
+
+  it 'accepts if with regexp' do
+    pending 'This causes an exception'
+    inspect_source(cop, ['if //',
+                         '  something # A comment',
+                         'end'])
+    expect(cop.offences).to be_empty
+  end
 end
 
 describe Rubocop::Cop::Style::WhileUntilModifier do


### PR DESCRIPTION
If you do

```
if //
end
```

then RuboCop will throw an exception.

The pull request contains a pending test that RuboCop can handle such code.
