### PR TITLE
Handle rescue var::SomeError.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * [#599](https://github.com/bbatsov/rubocop/pull/599): `EndOfLine` cop is operational again. ([@jonas054][])
 * [#604](https://github.com/bbatsov/rubocop/issues/604): Fix error on implicit match conditionals (e.g. `if /pattern/; end`) in `FavorModifier`. ([@yujinakayama][])
 * [#600](https://github.com/bbatsov/rubocop/pull/600): Don't require an empty line for access modifiers at the beginning of class/module body.
+* [#608](https://github.com/bbatsov/rubocop/pull/608): `RescueException` no longer crashes when the namespace of a rescued class is in a local variable. ([@jonas054][])
 
 ## 0.14.1 (10/10/2013)
 

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -62,6 +62,7 @@ module Rubocop
           namespace_node, name = *const_node
           const_names << name
           break unless namespace_node
+          break unless namespace_node.is_a?(Parser::AST::Node)
           break if namespace_node.type == :cbase
           const_node = namespace_node
         end

--- a/spec/rubocop/cop/lint/rescue_exception_spec.rb
+++ b/spec/rubocop/cop/lint/rescue_exception_spec.rb
@@ -118,4 +118,14 @@ describe Rubocop::Cop::Lint::RescueException do
                     'end'])
     expect(cop.offences).to be_empty
   end
+
+  it 'does not crash when the namespace of a rescued class is in a local ' +
+    'variable' do
+    inspect_source(cop,
+                   ['adapter = current_adapter',
+                    'begin',
+                    'rescue adapter::ParseError',
+                    'end'])
+    expect(cop.offences).to be_empty
+  end
 end


### PR DESCRIPTION
Namespaces that are in a local variable or returned from a method call. That's a special case we need to handle. Otherwise `RescueException` can crash.

This is something that occurs when inspecting `.../gems/multi_json-1.8.1/lib/multi_json.rb`.
