### PR TITLE
Autocorrect BracesAroundHashParameters cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+# [#612](https://github.com/bbatsov/rubocop/pull/612): `BracesAroundHashParameters` cop does auto-correction. [@dblock]().
+
 ## 0.15.0 (06/11/2013)
 
 ### New features

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -31,6 +31,18 @@ module Rubocop
           end
         end
 
+        def autocorrect(node)
+          @corrections << lambda do |corrector|
+            if style == :no_braces
+              corrector.remove(node.loc.begin)
+              corrector.remove(node.loc.end)
+            elsif style == :braces
+              corrector.insert_before(node.loc.expression, '{')
+              corrector.insert_after(node.loc.expression, '}')
+            end
+          end
+        end
+
         private
 
         def style

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -114,6 +114,33 @@ describe Rubocop::Cop::Style::BracesAroundHashParameters, :config do
         expect(cop.highlights).to eq(['{ x: 1, foo: "bar" }'])
       end
     end
+
+    describe 'auto-corrects' do
+      it 'one non-hash parameter followed by a hash parameter with braces' do
+        corrected = autocorrect_source(cop, ['where(1, { y: 2 })'])
+        expect(corrected).to eq 'where(1,  y: 2 )'
+      end
+
+      it 'one object method hash parameter with braces' do
+        corrected = autocorrect_source(cop, ['x.func({ y: "z" })'])
+        expect(corrected).to eq 'x.func( y: "z" )'
+      end
+
+      it 'one hash parameter with braces' do
+        corrected = autocorrect_source(cop, ['where({ x: 1 })'])
+        expect(corrected).to eq 'where( x: 1 )'
+      end
+
+      it 'one hash parameter with braces and separators' do
+        corrected = autocorrect_source(cop, ["where(  \n { x: 1 }   )"])
+        expect(corrected).to eq "where(  \n  x: 1    )"
+      end
+
+      it 'one hash parameter with braces and multiple keys' do
+        corrected = autocorrect_source(cop, ['where({ x: 1, foo: "bar" })'])
+        expect(corrected).to eq 'where( x: 1, foo: "bar" )'
+      end
+    end
   end
 
   context 'braces' do
@@ -190,6 +217,23 @@ describe Rubocop::Cop::Style::BracesAroundHashParameters, :config do
           'Missing curly braces around a hash parameter.'
         ])
         expect(cop.highlights).to eq(['x: { "y" => "z" }'])
+      end
+    end
+
+    describe 'auto-corrects' do
+      it 'one hash parameter without braces' do
+        corrected = autocorrect_source(cop, ['where(x: "y")'])
+        expect(corrected).to eq 'where({x: "y"})'
+      end
+
+      it 'one hash parameter with multiple keys and without braces' do
+        corrected = autocorrect_source(cop, ['where(x: "y", foo: "bar")'])
+        expect(corrected).to eq 'where({x: "y", foo: "bar"})'
+      end
+
+      it 'one hash parameter without braces with one hash value' do
+        corrected = autocorrect_source(cop, ['where(x: { "y" => "z" })'])
+        expect(corrected).to eq 'where({x: { "y" => "z" }})'
       end
     end
   end


### PR DESCRIPTION
Pretty straightforward. I think the autocorrect could also get rid of the extra spacing, but I couldn't get that to work.
