### PR TITLE
SpaceAroundOperators complains about class method with *args

### DIFF
--- a/spec/rubocop/cop/style/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/style/space_around_operators_spec.rb
@@ -134,6 +134,9 @@ describe Rubocop::Cop::Style::SpaceAroundOperators do
                     '',
                     '  def each *args',
                     '  end',
+                    '',
+                    '  def self.search *args',
+                    '  end',
                     ''])
     expect(cop.messages).to be_empty
   end


### PR DESCRIPTION
This is just a failing spec.  In my initial investigation the parsed tokens look like regular multiplication.  I hope I'm overlooking something.
