### PR TITLE
Don't report missing space around operator for def self.method *args.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 ### Bugs fixed
 
-* Handle properly heredocs in `StringLiterals` cop.
+* Handle properly heredocs in `StringLiterals` cop. ([@bbatsov][])
+* Fix `SpaceAroundOperators` to not report missing space around operator for `def self.method *args`. ([@jonas054][])
 
 ## 0.15.0 (06/11/2013)
 

--- a/lib/rubocop/cop/style/space_around_operators.rb
+++ b/lib/rubocop/cop/style/space_around_operators.rb
@@ -97,11 +97,15 @@ module Rubocop
           #     ^
           positions = []
           tokens = @processed_source.tokens
-          on_node(:def, @processed_source.ast) do |def_node|
+          on_node([:def, :defs], @processed_source.ast) do |def_node|
             # def each &block
             #          ^
             # def each *args
             #          ^
+            # def self.each &block
+            #               ^
+            # def self.each *args
+            #               ^
             on_node([:blockarg, :restarg], def_node) do |arg_node|
               positions << tokens[index_of_first_token(arg_node)].pos
             end

--- a/spec/rubocop/cop/style/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/style/space_around_operators_spec.rb
@@ -132,6 +132,9 @@ describe Rubocop::Cop::Style::SpaceAroundOperators do
                     '  def each &block',
                     '  end',
                     '',
+                    '  def self.search *args',
+                    '  end',
+                    '',
                     '  def each *args',
                     '  end',
                     ''])


### PR DESCRIPTION
Closes #613.
