### PR TITLE
Properly handle file inclusion/exclusion rules when using -c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * Handle properly heredocs in `StringLiterals` cop. ([@bbatsov][])
 * Fix `SpaceAroundOperators` to not report missing space around operator for `def self.method *args`. ([@jonas054][])
+* Properly handle ['AllCops']['Includes'] and ['AllCops']['Excludes'] when passing config via -c. ([@fancyremarker][])
 
 ## 0.15.0 (06/11/2013)
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -25,9 +25,8 @@ module Rubocop
       trap_interrupt
 
       @options, remaining_args = Options.new.parse(args)
-      target_files = target_finder.find(remaining_args)
-
       act_on_options(remaining_args)
+      target_files = target_finder.find(remaining_args)
 
       any_failed = process_files(target_files)
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1114,6 +1114,24 @@ describe Rubocop::CLI, :isolated_environment do
                 abs('example/.rubocop.yml'),
                 ''].join("\n"))
     end
+
+    it 'works when a configuration file passed by -c specifies Excludes' do
+      create_file('example/example1.rb', [
+                                          '# encoding: utf-8',
+                                          '#' * 90
+                                         ])
+
+      create_file('rubocop.yml', [
+                                           'AllCops:',
+                                           '  Excludes:',
+                                           '    - !ruby/regexp /example1\.rb$/'
+                                          ])
+
+      cli.run(%w(--format simple -c rubocop.yml))
+      expect($stdout.string)
+        .to eq(['', '0 files inspected, no offences detected',
+                ''].join("\n"))
+    end
   end
 
   describe '#display_error_summary' do


### PR DESCRIPTION
A regression introduced in e4f1d427937a993bf1c894afe0782a4fae785455 caused file inclusion/exclusion rules (like `['AllCops']['Excludes']`) to be ignored when specified in a configuration file passed via -c. This fixes that by correcting the order of operations.

Fixes #620.
