### PR TITLE
RegexpLiteral slash counter corner case test

### DIFF
--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -51,6 +51,11 @@ describe Rubocop::Cop::Style::RegexpLiteral, :config do
         inspect_source(cop, ['x =~ %r(/home)'])
         expect(cop.offences).to be_empty
       end
+      
+      it 'ignores slashes do not belong regexp' do
+        inspect_source(cop, ['x =~ /\s{#{x[/\s+/].length}}/'])
+        expect(cop.offences).to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
Added test case for regexps instantiated using string interpolation syntax.
