### PR TITLE
Allow self.Foo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * All cops now support the `Include` param, which specifies the files on which they should operate. ([@bbatsov][])
 * All cops now support the `Exclude` param, which specifies the files on which they should not operate. ([@bbatsov][])
 * [#631](https://github.com/bbatsov/rubocop/issues/631): `IndentationWidth` cop now detects inconsistent indentation between lines that should have the same indentation. ([@jonas054][])
+* Allow `self.Foo` in `RedundantSelf` cop. ([@chulkilee][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -94,6 +94,7 @@ module Rubocop
           receiver, method_name, *_args = *node
           if receiver && receiver.type == :self
             unless operator?(method_name) || keyword?(method_name) ||
+                constant_name?(method_name) ||
                 @allowed_send_nodes.include?(node) ||
                 @local_variables.include?(method_name)
               convention(node, :expression)
@@ -126,6 +127,10 @@ module Rubocop
            :next, :nil, :not, :or, :redo, :rescue, :retry, :return, :self,
            :super, :then, :true, :undef, :unless, :until, :when, :while,
            :yield].include?(method_name)
+        end
+
+        def constant_name?(method_name)
+          method_name.match(/^[A-Z]/)
         end
 
         def allow_self(node)

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -120,6 +120,12 @@ describe Rubocop::Cop::Style::RedundantSelf do
     expect(cop.offences).to be_empty
   end
 
+  it 'accepts a self receiver used to distinguish from constant' do
+    src = ['self.Foo']
+    inspect_source(cop, src)
+    expect(cop.offences).to be_empty
+  end
+
   it 'auto-corrects by removing redundant self' do
     new_source = autocorrect_source(cop, ['self.x'])
     expect(new_source).to eq('x')


### PR DESCRIPTION
omitting `self` in `self.Foo` gives uninitialized constant NameError
