### PR TITLE
accept dot position on same line for trailing style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix `SpaceAroundOperators` to not report missing space around operator for `def self.method *args`. ([@jonas054][])
 * Properly handle ['AllCops']['Includes'] and ['AllCops']['Excludes'] when passing config via -c. ([@fancyremarker][])
 * [#611](https://github.com/bbatsov/rubocop/pull/611): Fix crash when loading an empty config file ([@sinisterchipmunk][])
+* Fix `DotPosition` cop with `trailing` style for method calls on same line. ([@vonTronje][])
 
 ## 0.15.0 (06/11/2013)
 

--- a/lib/rubocop/cop/style/dot_position.rb
+++ b/lib/rubocop/cop/style/dot_position.rb
@@ -27,9 +27,13 @@ module Rubocop
 
           case cop_config['Style'].downcase
           when 'leading' then dot_line == selector_line
-          when 'trailing' then dot_line != selector_line
+          when 'trailing' then dot_line != selector_line || same_line?(node)
           else fail 'Unknown dot position style selected.'
           end
+        end
+
+        def same_line?(node)
+          node.loc.dot.line == node.loc.line
         end
       end
     end

--- a/spec/rubocop/cop/style/dot_position_spec.rb
+++ b/spec/rubocop/cop/style/dot_position_spec.rb
@@ -55,6 +55,11 @@ describe Rubocop::Cop::Style::DotPosition, :config do
       inspect_source(cop, ['l', '.(1)'])
       expect(cop.offences.size).to eq(1)
     end
+
+    it 'does not err on method call on same line' do
+      inspect_source(cop, ['something.method_name'])
+      expect(cop.offences).to be_empty
+    end
   end
 
   context 'Unknown style' do


### PR DESCRIPTION
Hi,

I ran into trouble today when I tried to use the trailing style with the DotPosition cop. The cop only accepts notation where the dot and the method name are on different lines. Even with single line expressions like 'object.method'. 
To fix it I added a check to see if multiple lines are involved. The test I added works just fine.

However I know next to nothing about the ast and parser gems and it is thus very likely a better solution exists.
Anyway I hope this helps resolving the mentioned issue.

Cheers,
Hagen
