### PR TITLE
Fix counting of slashes in RegexpLiteral.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Properly handle ['AllCops']['Includes'] and ['AllCops']['Excludes'] when passing config via -c. ([@fancyremarker][])
 * [#611](https://github.com/bbatsov/rubocop/pull/611): Fix crash when loading an empty config file ([@sinisterchipmunk][])
 * Fix `DotPosition` cop with `trailing` style for method calls on same line. ([@vonTronje][])
+* [#627](https://github.com/bbatsov/rubocop/pull/627): Fix counting of slashes in complicated regexps in `RegexpLiteral` cop. ([@jonas054][])
 
 ## 0.15.0 (06/11/2013)
 

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -8,9 +8,10 @@ module Rubocop
       # value of the configuration parameter MaxSlashes.
       class RegexpLiteral < Cop
         def on_regexp(node)
-          slashes = node.loc.expression.source.count('/')
+          string_parts = node.children.select { |child| child.type == :str }
+          total_string = string_parts.map { |s| s.loc.expression.source }.join
+          slashes = total_string.count('/')
           msg = if node.loc.begin.is?('/')
-                  slashes -= 2 # subtract delimiters
                   error_message('') if slashes > max_slashes
                 else
                   error_message('only ') if slashes <= max_slashes

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -52,6 +52,11 @@ describe Rubocop::Cop::Style::RegexpLiteral, :config do
         expect(cop.offences).to be_empty
       end
     end
+
+    it 'ignores slashes do not belong regexp' do
+      inspect_source(cop, ['x =~ /\s{#{x[/\s+/].length}}/'])
+      expect(cop.offences).to be_empty
+    end
   end
 
   context 'when a regexp uses %r delimiters' do


### PR DESCRIPTION
Looking only at the string contents. This also means that delimiters don't have to be subtracted.
Copied the failing spec example from PR #627.
