### PR TITLE
Allow symbol names such as :'bundle:install'

### DIFF
--- a/lib/rubocop/cop/style/symbol_name.rb
+++ b/lib/rubocop/cop/style/symbol_name.rb
@@ -8,7 +8,7 @@ module Rubocop
       # There's also an option to accept symbol names with dots as well.
       class SymbolName < Cop
         MSG = 'Use snake_case for symbols.'
-        SNAKE_CASE = /^[\da-z_]+[!?=]?$/
+        SNAKE_CASE = /^[\d:a-z_]+[!?=]?$/
         SNAKE_CASE_WITH_DOTS = /^[\da-z_\.]+[!?=]?$/
         CAMEL_CASE = /^[A-Z][A-Za-z\d]*$/
 

--- a/spec/rubocop/cop/style/symbol_name_spec.rb
+++ b/spec/rubocop/cop/style/symbol_name_spec.rb
@@ -91,6 +91,12 @@ describe Rubocop::Cop::Style::SymbolName, :config do
     expect(cop.offences).to be_empty
   end
 
+  it 'accepts snake case string delimited by :' do
+    inspect_source(cop,
+                   ['test = :"good_idea:one"'])
+    expect(cop.offences).to be_empty
+  end
+
   it 'accepts special cases - !, [] and **' do
     inspect_source(cop,
                    ['test = :**',


### PR DESCRIPTION
This is useful when defining rake task dependencies and working with mina, without having to disable the snake case check for symbols.
