### PR TITLE
Fix block autocorrect clash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#611](https://github.com/bbatsov/rubocop/pull/611): Fix crash when loading an empty config file ([@sinisterchipmunk][])
 * Fix `DotPosition` cop with `trailing` style for method calls on same line. ([@vonTronje][])
 * [#627](https://github.com/bbatsov/rubocop/pull/627): Fix counting of slashes in complicated regexps in `RegexpLiteral` cop. ([@jonas054][])
+* [#638](https://github.com/bbatsov/rubocop/issues/638): Fix bug in auto-correct that changes `each{ |x|` to `each d o |x|`. ([@jonas054][])
 
 ## 0.15.0 (06/11/2013)
 

--- a/lib/rubocop/cop/style/space_around_block_braces.rb
+++ b/lib/rubocop/cop/style/space_around_block_braces.rb
@@ -14,6 +14,14 @@ module Rubocop
         def on_block(node)
           return if node.loc.begin.is?('do') # No braces.
 
+          # If braces are on separate lines, and the Blocks cop is enabled,
+          # those braces will be changed to do..end by the user or by
+          # auto-correct, so reporting space issues is not useful, and it
+          # creates auto-correct conflicts.
+          if config.for_cop('Blocks')['Enabled'] && Util.block_length(node) > 0
+            return
+          end
+
           left_brace, right_brace = node.loc.begin, node.loc.end
           sb = node.loc.expression.source_buffer
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -33,6 +33,22 @@ describe Rubocop::CLI, :isolated_environment do
       end
     end
 
+    describe '--auto-correct' do
+      it 'can correct two problems with blocks' do
+        # {} should be do..end and space is missing.
+        create_file('example.rb', ['# encoding: utf-8',
+                                   '(1..10).each{ |i|',
+                                   '  puts i',
+                                   '}'])
+        expect(cli.run(['--auto-correct'])).to eq(1)
+        expect(IO.read('example.rb'))
+          .to eq(['# encoding: utf-8',
+                  '(1..10).each do |i|',
+                  '  puts i',
+                  'end'].join("\n") + "\n")
+      end
+    end
+
     describe '--auto-gen-config' do
       it 'exits with error if asked to re-generate a todo list that is in ' +
         'use' do

--- a/spec/rubocop/cop/style/space_around_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_around_block_braces_spec.rb
@@ -26,6 +26,7 @@ describe Rubocop::Cop::Style::SpaceAroundBlockBraces do
     it 'registers an offence for empty braces with space inside' do
       inspect_source(cop, ['each { }'])
       expect(cop.messages).to eq(['Space inside empty braces detected.'])
+      expect(cop.highlights).to eq([' '])
     end
 
     it 'auto-corrects unwanted space' do
@@ -45,6 +46,7 @@ describe Rubocop::Cop::Style::SpaceAroundBlockBraces do
     it 'registers an offence for empty braces with no space inside' do
       inspect_source(cop, ['each {}'])
       expect(cop.messages).to eq(['Space missing inside empty braces.'])
+      expect(cop.highlights).to eq(['{}'])
     end
 
     it 'auto-corrects missing space' do
@@ -98,6 +100,28 @@ describe Rubocop::Cop::Style::SpaceAroundBlockBraces do
     it 'auto-corrects missing space' do
       new_source = autocorrect_source(cop, 'each{|x| puts }')
       expect(new_source).to eq('each { |x| puts }')
+    end
+
+    context 'and Blocks cop enabled' do
+      let(:config) do
+        Rubocop::Config.new('Blocks'                 => { 'Enabled' => true },
+                            'SpaceAroundBlockBraces' => cop_config)
+      end
+
+      it 'does auto-correction for single-line blocks' do
+        new_source = autocorrect_source(cop, 'each{|x| puts}')
+        expect(new_source).to eq('each { |x| puts }')
+      end
+
+      it 'does not do auto-correction for multi-line blocks' do
+        # {} will be changed to do..end by the Blocks cop, and then this cop is
+        # not relevant anymore.
+        old_source = ['each{|x|',
+                      '  puts',
+                      '}']
+        new_source = autocorrect_source(cop, old_source)
+        expect(new_source).to eq(old_source.join("\n"))
+      end
     end
 
     context 'and space before block parameters not allowed' do


### PR DESCRIPTION
Another refactoring from Ripper style to Parser style, which made the correction easier, and then the correction.

Fixes #638.
