### PR TITLE
Fix bug in SpaceAroundBlockBraces that desetroys code in -a mode.

### DIFF
--- a/lib/rubocop/cop/style/space_around_block_braces.rb
+++ b/lib/rubocop/cop/style/space_around_block_braces.rb
@@ -42,11 +42,13 @@ module Rubocop
             range = Parser::Source::Range.new(sb, left_brace.end_pos,
                                               right_brace.begin_pos)
             inner = range.source
-            if inner =~ /^[ \t]*$/
-              space(style_for_empty_braces, sb, range.begin_pos, range.end_pos,
-                    'Space inside empty braces detected.')
-            else
-              braces_with_contents_inside(node, inner)
+            unless inner =~ /\n/
+              if inner =~ /\S/
+                braces_with_contents_inside(node, inner)
+              else
+                space(style_for_empty_braces, sb, range.begin_pos,
+                      range.end_pos, 'Space inside empty braces detected.')
+              end
             end
           end
         end

--- a/spec/rubocop/cop/style/space_around_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_around_block_braces_spec.rb
@@ -23,6 +23,12 @@ describe Rubocop::Cop::Style::SpaceAroundBlockBraces do
       expect(cop.messages).to be_empty
     end
 
+    it 'accepts empty braces with line break inside' do
+      inspect_source(cop, ['  each {',
+                           '  }'])
+      expect(cop.messages).to be_empty
+    end
+
     it 'registers an offence for empty braces with space inside' do
       inspect_source(cop, ['each { }'])
       expect(cop.messages).to eq(['Space inside empty braces detected.'])
@@ -32,6 +38,16 @@ describe Rubocop::Cop::Style::SpaceAroundBlockBraces do
     it 'auto-corrects unwanted space' do
       new_source = autocorrect_source(cop, 'each { }')
       expect(new_source).to eq('each {}')
+    end
+
+    it 'does not auto-correct when braces are not empty' do
+      old_source = <<-END
+        a {
+          b
+        }
+      END
+      new_source = autocorrect_source(cop, old_source)
+      expect(new_source).to eq(old_source)
     end
   end
 


### PR DESCRIPTION
Multi-line block braces cause autocorrect to behave badly. The solution is to allow multi-line block braces regardless of configuration.

Fixes #645.

The bug is in unreleased code, so no update of CHANGELOG.
