### PR TITLE
Don't search for .rubocop.yml above the temporary work directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Fix `DotPosition` cop with `trailing` style for method calls on same line. ([@vonTronje][])
 * [#627](https://github.com/bbatsov/rubocop/pull/627): Fix counting of slashes in complicated regexps in `RegexpLiteral` cop. ([@jonas054][])
 * [#638](https://github.com/bbatsov/rubocop/issues/638): Fix bug in auto-correct that changes `each{ |x|` to `each d o |x|`. ([@jonas054][])
+* [#418](https://github.com/bbatsov/rubocop/issues/418): Stop searching for configuration files above the work directory of the isolated environment when running specs. ([@jonas054][])
 
 ## 0.15.0 (06/11/2013)
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -17,6 +17,7 @@ module Rubocop
 
     class << self
       attr_accessor :debug
+      attr_writer :root_level # The upwards search is stopped at this level.
       alias_method :debug?, :debug
 
       def load_file(path)
@@ -152,6 +153,7 @@ module Rubocop
         dirs_to_search = []
         target_dir_pathname = Pathname.new(File.expand_path(target_dir))
         target_dir_pathname.ascend do |dir_pathname|
+          break if dir_pathname.to_s == @root_level
           dirs_to_search << dir_pathname.to_s
         end
         dirs_to_search << Dir.home

--- a/spec/isolated_environment_spec.rb
+++ b/spec/isolated_environment_spec.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe 'isolated environment', :isolated_environment do
+  include FileHelper
+
+  let(:cli) { Rubocop::CLI.new }
+
+  # Configuration files above the work directory shall not disturb the
+  # tests. This is especially important on Windows where the temporary
+  # directory is under the user's home directory. On any platform we don't want
+  # a .rubocop.yml file in the temporary directory to affect the outcome of
+  # rspec.
+  it 'is not affected by a config file above the work directory' do
+    create_file('../.rubocop.yml', ['inherit_from: missing_file.yml'])
+    create_file('ex.rb', ['# encoding: utf-8'])
+    # A return value of 0 means that the erroneous config file was not read.
+    expect(cli.run([])).to eq(0)
+  end
+end

--- a/spec/support/isolated_environment.rb
+++ b/spec/support/isolated_environment.rb
@@ -8,6 +8,9 @@ shared_context 'isolated environment', :isolated_environment do
     Dir.mktmpdir do |tmpdir|
       original_home = ENV['HOME']
 
+      # Make upwards search for .rubocop.yml files stop at this directory.
+      Rubocop::ConfigLoader.root_level = tmpdir
+
       begin
         virtual_home = File.expand_path(File.join(tmpdir, 'home'))
         Dir.mkdir(virtual_home)


### PR DESCRIPTION
For the specs' isolated environment. Fixes #418.
