### PR TITLE
Remove printout from isolated environment spec.

### DIFF
--- a/spec/isolated_environment_spec.rb
+++ b/spec/isolated_environment_spec.rb
@@ -7,6 +7,9 @@ describe 'isolated environment', :isolated_environment do
 
   let(:cli) { Rubocop::CLI.new }
 
+  before(:each) { $stdout = StringIO.new }
+  after(:each) { $stdout = STDOUT }
+
   # Configuration files above the work directory shall not disturb the
   # tests. This is especially important on Windows where the temporary
   # directory is under the user's home directory. On any platform we don't want


### PR DESCRIPTION
A correction of a mistake I made in #652.

The spec printed some unwanted text on stdout:

```
Inspecting 1 file
.

1 file inspected, no offences detected
```
