### PR TITLE
[WIP] Adds failing specs for indentation/alignment cops when chaining onto `end`

### DIFF
--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -76,11 +76,13 @@ describe Rubocop::Cop::Lint::EndAlignment, :config do
       include_examples 'aligned', 'var = unless', 'test', 'end'
       include_examples 'aligned', 'var = while',  'test', 'end'
       include_examples 'aligned', 'var = until',  'test', 'end'
+      include_examples 'aligned', 'var = until',  'test', 'end.join("")'
 
       include_examples 'misaligned', 'var = if',     'test', '      end'
       include_examples 'misaligned', 'var = unless', 'test', '      end'
       include_examples 'misaligned', 'var = while',  'test', '      end'
       include_examples 'misaligned', 'var = until',  'test', '      end'
+      include_examples 'misaligned', 'var = until',  'test', '      end.join("")'
 
       include_examples 'aligned', '@var = if',  'test', 'end'
       include_examples 'aligned', '$var = if',  'test', 'end'

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -148,6 +148,16 @@ describe Rubocop::Cop::Style::IndentationWidth do
       expect(cop.offences).to be_empty
     end
 
+    it 'accepts an if/else in assignment with end aligned with variable and chaining after the end' do
+      inspect_source(cop,
+                     ['var = if a',
+                      '  0',
+                      'else',
+                      '  1',
+                      'end.join("")'])
+      expect(cop.offences).to be_empty
+    end
+
     it 'accepts an if in assignment with end aligned with if' do
       inspect_source(cop,
                      ['var = if a',


### PR DESCRIPTION
@jonas054 I'm opening this PR as a place for us to collaborate on the solution. So far I've added failing specs for the two use cases I've experienced thus far.
