### PR TITLE
Fix indentation when chaining on end

### DIFF
--- a/lib/rubocop/cop/lint/end_alignment.rb
+++ b/lib/rubocop/cop/lint/end_alignment.rb
@@ -44,6 +44,14 @@ module Rubocop
         private
 
         def check_assignment(node, rhs)
+          # If there are method calls chained to the right hand side of the
+          # assignment, we let rhs be the receiver of those method calls before
+          # we check if it's an if/unless/while/until.
+          while rhs && rhs.type == :send
+            receiver, _method_name, _args = *rhs
+            rhs = receiver
+          end
+
           return unless rhs
 
           case rhs.type

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -97,6 +97,14 @@ module Rubocop
         private
 
         def check_assignment(node, rhs)
+          # If there are method calls chained to the right hand side of the
+          # assignment, we let rhs be the receiver of those method calls before
+          # we check its indentation.
+          while rhs && rhs.type == :send
+            receiver, _method_name, _args = *rhs
+            rhs = receiver
+          end
+
           if rhs && rhs.type == :if
             on_if(rhs, rhs.loc.column - node.loc.column)
             ignore_node(rhs)

--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -76,13 +76,13 @@ describe Rubocop::Cop::Lint::EndAlignment, :config do
       include_examples 'aligned', 'var = unless', 'test', 'end'
       include_examples 'aligned', 'var = while',  'test', 'end'
       include_examples 'aligned', 'var = until',  'test', 'end'
-      include_examples 'aligned', 'var = until',  'test', 'end.join("")'
+      include_examples 'aligned', 'var = until',  'test', 'end.abc.join("")'
 
       include_examples 'misaligned', 'var = if',     'test', '      end'
       include_examples 'misaligned', 'var = unless', 'test', '      end'
       include_examples 'misaligned', 'var = while',  'test', '      end'
       include_examples 'misaligned', 'var = until',  'test', '      end'
-      include_examples 'misaligned', 'var = until',  'test', '      end.join("")'
+      include_examples 'misaligned', 'var = until',  'test', '      end.join'
 
       include_examples 'aligned', '@var = if',  'test', 'end'
       include_examples 'aligned', '$var = if',  'test', 'end'

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -148,13 +148,14 @@ describe Rubocop::Cop::Style::IndentationWidth do
       expect(cop.offences).to be_empty
     end
 
-    it 'accepts an if/else in assignment with end aligned with variable and chaining after the end' do
+    it 'accepts an if/else in assignment with end aligned with variable ' +
+      'and chaining after the end' do
       inspect_source(cop,
                      ['var = if a',
                       '  0',
                       'else',
                       '  1',
-                      'end.join("")'])
+                      'end.abc.join("")'])
       expect(cop.offences).to be_empty
     end
 


### PR DESCRIPTION
Fixes #670 and closes #672.
No update of CHANGELOG since this is a fix for an unreleased feature.
