### PR TITLE
[Fix #667] Handle public/protected/private in IndentationWidth.

### DIFF
--- a/lib/rubocop/cop/style/access_modifier_indentation.rb
+++ b/lib/rubocop/cop/style/access_modifier_indentation.rb
@@ -27,7 +27,7 @@ module Rubocop
             # except other class/module nodes
             class_node.children.compact.each do |node|
               on_node(:send, node, [:class, :module, :sclass]) do |send_node|
-                if modifier_node?(send_node)
+                if self.class.modifier_node?(send_node)
                   send_start_col = send_node.loc.expression.column
 
                   if send_start_col != class_start_col + expected_indent_offset
@@ -37,6 +37,10 @@ module Rubocop
               end
             end
           end
+        end
+
+        def self.modifier_node?(node)
+          [PRIVATE_NODE, PROTECTED_NODE, PUBLIC_NODE].include?(node)
         end
 
         private
@@ -60,10 +64,6 @@ module Rubocop
           when 'indent' then 2
           else fail 'Unknown EnforcedStyle specified'
           end
-        end
-
-        def modifier_node?(node)
-          [PRIVATE_NODE, PROTECTED_NODE, PUBLIC_NODE].include?(node)
         end
       end
     end

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -421,6 +421,50 @@ describe Rubocop::Cop::Style::IndentationWidth do
                       'end'])
       expect(cop.offences).to be_empty
     end
+
+    it 'accepts indented public, protected, and private' do
+      inspect_source(cop,
+                     ['class Test',
+                      '  public',
+                      '',
+                      '  def e',
+                      '  end',
+                      '',
+                      '  protected',
+                      '',
+                      '  def f',
+                      '  end',
+                      '',
+                      '  private',
+                      '',
+                      '  def g',
+                      '  end',
+                      'end'])
+      expect(cop.offences).to be_empty
+    end
+
+    it 'registers an offence for bad indentation of def but not for ' +
+      'outdented public, protected, and private' do
+      inspect_source(cop,
+                     ['class Test',
+                      'public',
+                      '',
+                      '  def e',
+                      '  end',
+                      '',
+                      'protected',
+                      '',
+                      '  def f',
+                      '  end',
+                      '',
+                      'private',
+                      '',
+                      ' def g',
+                      ' end',
+                      'end'])
+      expect(cop.messages).to eq(['Inconsistent indentation detected.'])
+      expect(cop.highlights).to eq([' '])
+    end
   end
 
   context 'with module' do


### PR DESCRIPTION
Correction for an unreleased feature.
