### PR TITLE
[Fix #674] Do not issue warning for Exclude and Include config params.

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -12,7 +12,7 @@ module Rubocop
   class Config < DelegateClass(Hash)
     class ValidationError < StandardError; end
 
-    COMMON_PARAMS = %w(Severity)
+    COMMON_PARAMS = %w(Exclude Include Severity)
 
     attr_reader :loaded_path
     attr_accessor :contains_auto_generated_config

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -53,6 +53,25 @@ describe Rubocop::Config do
                           /^unrecognized parameter LineLength:Min/)
       end
     end
+
+    context 'when the configuration includes any common parameter' do
+      # Common parameters are parameters that are not in the default
+      # configuration, but are nonetheless allowed for any cop.
+      before do
+        create_file(configuration_path, [
+          'LineLength:',
+          '  Exclude:',
+          '    - lib/file.rb',
+          '  Include:',
+          '    - lib/file.xyz',
+          '  Severity: warning',
+        ])
+      end
+
+      it 'does not raise validation error' do
+        expect { configuration.validate }.to_not raise_error
+      end
+    end
   end
 
   describe '#file_to_include?' do


### PR DESCRIPTION
Correction for an unreleased feature.
