### PR TITLE
[Fix #668] Use encoding from Parser in call to IO.read in EndOfLine.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Fix error on implicit match conditionals (e.g. `if /pattern/; end`) in `MultilineIfThen`. ([@agrimm][])
 * [#651](https://github.com/bbatsov/rubocop/issues/651): Handle properly method arguments in `RedundantSelf`. ([@bbatsov][])
 * [#628](https://github.com/bbatsov/rubocop/issues/628): Allow `self.Foo` in `RedundantSelf` cop. ([@chulkilee][])
+* [#668](https://github.com/bbatsov/rubocop/issues/668): Fix crash in `EndOfLine` that occurs when default encoding is `US_ASCII` and an inspected file has non-ascii characters. ([@jonas054][])
 
 ## 0.15.0 (06/11/2013)
 

--- a/lib/rubocop/cop/style/end_of_line.rb
+++ b/lib/rubocop/cop/style/end_of_line.rb
@@ -8,11 +8,13 @@ module Rubocop
         MSG = 'Carriage return character detected.'
 
         def investigate(processed_source)
-          original_source = IO.read(processed_source.buffer.name)
+          buffer = processed_source.buffer
+          original_source = IO.read(buffer.name,
+                                    encoding: buffer.source.encoding)
           original_source.lines.each_with_index do |line, index|
             if line =~ /\r$/
               add_offence(nil,
-                          source_range(processed_source.buffer,
+                          source_range(buffer,
                                        processed_source[0...index],
                                        0, line.length),
                           MSG)

--- a/spec/rubocop/cop/style/end_of_line_spec.rb
+++ b/spec/rubocop/cop/style/end_of_line_spec.rb
@@ -27,4 +27,21 @@ describe Rubocop::Cop::Style::EndOfLine do
       expect(cop.messages.size).to eq(1)
     end
   end
+
+  context 'when the default external encoding is US_ASCII' do
+    before(:each) do
+      @orig_encoding = Encoding.default_external
+      Encoding.default_external = Encoding::US_ASCII
+    end
+    after(:each) { Encoding.default_external = @orig_encoding }
+
+    it 'does not crash on UTF-8 encoded non-ascii characters' do
+      inspect_source_file(cop,
+                          ['# encoding: UTF-8',
+                           'class Epd::ReportsController < EpdAreaController',
+                           "  'terecht bij uw ROM-coördinator.'",
+                           'end'].join("\n"))
+      expect(cop.offences).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
The `Source::Buffer` object we get from Parser has an encoding that has been
figured out based on BOM and magic encoding comment. Use it.
