### PR TITLE
Fix autocorrect for MethodDefParentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@
 * [#651](https://github.com/bbatsov/rubocop/issues/651): Handle properly method arguments in `RedundantSelf`. ([@bbatsov][])
 * [#628](https://github.com/bbatsov/rubocop/issues/628): Allow `self.Foo` in `RedundantSelf` cop. ([@chulkilee][])
 * [#668](https://github.com/bbatsov/rubocop/issues/668): Fix crash in `EndOfLine` that occurs when default encoding is `US_ASCII` and an inspected file has non-ascii characters. ([@jonas054][])
-* [#664](https://github.com/bbatsov/rubocop/issues/664): Accept oneline while when condition has local variable assignment ([@emou][])
+* [#664](https://github.com/bbatsov/rubocop/issues/664): Accept oneline while when condition has local variable assignment. ([@emou][])
+* Fix auto-correct for `MethodDefParentheses` when parentheses are required. ([@skanev][])
 
 ## 0.15.0 (06/11/2013)
 

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -8,12 +8,12 @@ module Rubocop
       class MethodDefParentheses < Cop
         include CheckMethods
 
-        def check(_node, _method_name, args, _body)
+        def check(node, _method_name, args, _body)
           if style == :require_parentheses &&
               has_arguments?(args) &&
               !has_parentheses?(args)
-            add_offence(args,
-                        :expression,
+            add_offence(node,
+                        args.loc.expression,
                         'Use def with parentheses when there are parameters.')
           elsif style == :require_no_parentheses && has_parentheses?(args)
             add_offence(args,
@@ -25,8 +25,10 @@ module Rubocop
         def autocorrect(node)
           @corrections << lambda do |corrector|
             if style == :require_parentheses
-              corrector.insert_before(node.loc.expression, '(')
-              corrector.insert_after(node.loc.expression, ')')
+              corrector.insert_after(node.children[1].loc.expression, ')')
+              expression = node.loc.expression
+              replacement = expression.source.sub(/(def\s+\S+)\s+/, '\1(')
+              corrector.replace(expression, replacement)
             elsif style == :require_no_parentheses
               corrector.replace(node.loc.begin, ' ')
               corrector.remove(node.loc.end)

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -31,7 +31,12 @@ describe Rubocop::Cop::Style::MethodDefParentheses, :config do
 
     it 'auto-adds required parens' do
       new_source = autocorrect_source(cop, 'def test param; end')
-      expect(new_source).to eq('def test (param); end')
+      expect(new_source).to eq('def test(param); end')
+    end
+
+    it 'auto-adds required parens to argument lists on multiple lines' do
+      new_source = autocorrect_source(cop, ['def test one,', 'two', 'end'])
+      expect(new_source).to eq("def test(one,\ntwo)\nend")
     end
   end
 


### PR DESCRIPTION
Before this change, auto-correcting MethodDefParentheses "fixes" the
following code:

```
def columnsort array, size
end
```

...with:

```
def columnsort (array, size)
end
```

This change remove the empty space between the method name and the
parameter list.
