### PR TITLE
Fix the isolated environment spec on OS X

### DIFF
--- a/spec/support/isolated_environment.rb
+++ b/spec/support/isolated_environment.rb
@@ -8,6 +8,10 @@ shared_context 'isolated environment', :isolated_environment do
     Dir.mktmpdir do |tmpdir|
       original_home = ENV['HOME']
 
+      # Make sure to expand all symlinks in the path first. Otherwise we may
+      # get mismatched pathnames when loading config files later on.
+      tmpdir = File.realpath(tmpdir)
+
       # Make upwards search for .rubocop.yml files stop at this directory.
       Rubocop::ConfigLoader.root_level = tmpdir
 


### PR DESCRIPTION
The reason this spec was failing is that on OS X the temp directory is
actually something like this:

```
/var/folders/bg/8sxn6p0j5kv0j1z__3hwz5nm0000gn/T/
```

However, /var is not an actual folder, but a symlink to /private/var and
that causes the check for root_level in `ConfigLoader.dirs_to_search()` to
fail and the ascend to continue.
