### PR TITLE
Add failing specs for chaining onto an 'end' with a block

### DIFF
--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -77,6 +77,7 @@ describe Rubocop::Cop::Lint::EndAlignment, :config do
       include_examples 'aligned', 'var = while',  'test', 'end'
       include_examples 'aligned', 'var = until',  'test', 'end'
       include_examples 'aligned', 'var = until',  'test', 'end.abc.join("")'
+      include_examples 'aligned', 'var = until',  'test', 'end.abc.tap {}'
 
       include_examples 'misaligned', 'var = if',     'test', '      end'
       include_examples 'misaligned', 'var = unless', 'test', '      end'

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -159,6 +159,17 @@ describe Rubocop::Cop::Style::IndentationWidth do
       expect(cop.offences).to be_empty
     end
 
+    it 'accepts an if/else in assignment with end aligned with variable ' +
+      'and chaining with a block after the end' do
+      inspect_source(cop,
+                     ['var = if a',
+                      '  0',
+                      'else',
+                      '  1',
+                      'end.abc.tap {}'])
+      expect(cop.offences).to be_empty
+    end
+
     it 'accepts an if in assignment with end aligned with if' do
       inspect_source(cop,
                      ['var = if a',


### PR DESCRIPTION
@jonas054 Just ran into another issue with chaining onto `end`. This time its when the method you're chaining accepts a block:

``` ruby
var = if a
  0
else
  1
end.abc.tap {}
```

Here's failing specs for `IndentationWidth` and `EndAlignment`
