### PR TITLE
We want to make the output match the yml expectations

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -85,7 +85,7 @@ module Rubocop
         coptypes = cops.with_type(type).sort_by!(&:cop_name)
         puts "Type '#{type.to_s.capitalize}' (#{coptypes.size}):"
         coptypes.each do |cop|
-          puts " - #{cop.cop_name}"
+          puts "#{cop.cop_name}:"
           cnf = dirconf.for_cop(cop).dup
           print_conf_option('Description',
                             cnf.delete('Description') { 'None' })
@@ -97,7 +97,7 @@ module Rubocop
     end
 
     def print_conf_option(option, value)
-      puts  "    - #{option}: #{value}"
+      puts  "  #{option}: #{value}"
     end
 
     def target_finder


### PR DESCRIPTION
I want this change so that if I need to modify a cop I can use
—show-cop, find the right one, and then copy/paste the body into the
yml and do no extra work to format it for YAML documents.

You'll notice the failing test. I attempted to fix it but the test is really clunky and apparently iterates through a series of expectations. One of these expectations fails in a way that doesn't make sense (expecting the wrong cop description).
