### PR TITLE
BracesAroundHashParameters auto-correction broken with trailing comma

### DIFF
--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -159,6 +159,11 @@ describe Rubocop::Cop::Style::BracesAroundHashParameters, :config do
         corrected = autocorrect_source(cop, ['where({ x: 1, foo: "bar" })'])
         expect(corrected).to eq 'where( x: 1, foo: "bar" )'
       end
+
+      it 'one hash parameter with braces and a trailing comma' do
+        corrected = autocorrect_source(cop, ["where({ x: 1, y: 2, })"])
+        expect(corrected).to eq "where( x: 1, y: 2 )"
+      end
     end
   end
 


### PR DESCRIPTION
Hello! Here's a failing test case for a misbehaving BracesAroundHashParameters auto-correction that I discovered this morning. WDYT?
