### PR TITLE
Fix braces around hash parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bugs fixed
 
 * [#498](https://github.com/bbatsov/rubocop/issues/498): Disable terminal ANSI escape sequences when a formatter's output is not a TTY. ([@yujinakayama][])
+* [#703](https://github.com/bbatsov/rubocop/issues/703): BracesAroundHashParameters auto-correction broken with trailing comma. ([@jonas054][])
 
 ## 0.16.0 (25/12/2013)
 

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -48,10 +48,25 @@ module Rubocop
             if style == :no_braces
               corrector.remove(node.loc.begin)
               corrector.remove(node.loc.end)
+              remove_trailing_comma(node, corrector)
             elsif style == :braces
               corrector.insert_before(node.loc.expression, '{')
               corrector.insert_after(node.loc.expression, '}')
             end
+          end
+        end
+
+        def remove_trailing_comma(node, corrector)
+          sb = node.loc.end.source_buffer
+          pos_after_last_pair = node.children.last.loc.expression.end_pos
+          range_after_last_pair =
+            Parser::Source::Range.new(sb, pos_after_last_pair,
+                                      node.loc.end.begin_pos)
+          trailing_comma_offset = range_after_last_pair.source =~ /,/
+          if trailing_comma_offset
+            comma_begin = pos_after_last_pair + trailing_comma_offset
+            corrector.remove(Parser::Source::Range.new(sb, comma_begin,
+                                                       comma_begin + 1))
           end
         end
 

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -161,8 +161,8 @@ describe Rubocop::Cop::Style::BracesAroundHashParameters, :config do
       end
 
       it 'one hash parameter with braces and a trailing comma' do
-        corrected = autocorrect_source(cop, ["where({ x: 1, y: 2, })"])
-        expect(corrected).to eq "where( x: 1, y: 2 )"
+        corrected = autocorrect_source(cop, ['where({ x: 1, y: 2, })'])
+        expect(corrected).to eq 'where( x: 1, y: 2 )'
       end
     end
   end


### PR DESCRIPTION
Just remove the trailing comma if present.
