### PR TITLE
[Fix #724] Allow colon for required keyword argument without space.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * `SpaceAroundOperators` now reports an offence for `@@a=0`. ([@jonas054][])
 * [#707](https://github.com/bbatsov/rubocop/issues/707): Fix error on operator assignments in top level scope in `UselessAssignment`. ([@yujinakayama][])
 * Fix a bug where some offences were discarded when any cop that has specific target file path (by `Include` or `Exclude` under each cop configuration) had run. ([@yujinakayama][])
+* [#724](https://github.com/bbatsov/rubocop/issues/724): Accept colons denoting required keyword argument (a new feature in Ruby 2.1) without trailing space in `SpaceAfterColon`. ([@jonas054][])
 
 ## 0.16.0 (25/12/2013)
 

--- a/spec/rubocop/cop/style/space_after_colon_spec.rb
+++ b/spec/rubocop/cop/style/space_after_colon_spec.rb
@@ -9,16 +9,24 @@ describe Rubocop::Cop::Style::SpaceAfterColon do
     # TODO: There is double reporting of the last colon (also from
     # SpaceAroundOperators).
     inspect_source(cop, ['x = w ? {a:3}:4'])
-    expect(cop.messages).to eq(
-      ['Space missing after colon.'] * 2)
+    expect(cop.messages).to eq(['Space missing after colon.'] * 2)
+    expect(cop.highlights).to eq([':'] * 2)
   end
 
-  it 'allows the colons in symbols' do
+  it 'accepts colons in symbols' do
     inspect_source(cop, ['x = :a'])
     expect(cop.messages).to be_empty
   end
 
-  it 'allows colons in strings' do
+  if RUBY_VERSION >= '2.1'
+    it 'accepts colons denoting required keyword argument' do
+      inspect_source(cop, ['def initialize(table:, nodes:)',
+                           'end'])
+      expect(cop.messages).to be_empty
+    end
+  end
+
+  it 'accepts colons in strings' do
     inspect_source(cop, ["str << ':'"])
     expect(cop.messages).to be_empty
   end


### PR DESCRIPTION
Rewrite `SpaceAfterColon` cop basing it on node traversal rather than iteration over tokens.
