### PR TITLE
Fix parsing of the --no-color option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#707](https://github.com/bbatsov/rubocop/issues/707): Fix error on operator assignments in top level scope in `UselessAssignment`. ([@yujinakayama][])
 * Fix a bug where some offences were discarded when any cop that has specific target file path (by `Include` or `Exclude` under each cop configuration) had run. ([@yujinakayama][])
 * [#724](https://github.com/bbatsov/rubocop/issues/724): Accept colons denoting required keyword argument (a new feature in Ruby 2.1) without trailing space in `SpaceAfterColon`. ([@jonas054][])
+* The `--no-color` option works again. ([@jonas054][])
 
 ## 0.16.0 (25/12/2013)
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -60,7 +60,7 @@ module Rubocop
 
       @config_store.options_config = @options[:config] if @options[:config]
 
-      Rainbow.enabled = false if @options[:no_color]
+      Rainbow.enabled = false unless @options[:color]
 
       puts Rubocop::Version.version(false) if @options[:version]
       puts Rubocop::Version.version(true) if @options[:verbose_version]

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -92,7 +92,12 @@ module Rubocop
       option(opts, '-R', '--rails', 'Run extra Rails cops.')
       option(opts, '-l', '--lint', 'Run only lint cops.')
       option(opts, '-a', '--auto-correct', 'Auto-correct offences.')
-      option(opts, '-n', '--no-color', 'Disable color output.')
+
+      @options[:color] = true
+      opts.on('-n', '--no-color', 'Disable color output.') do
+        @options[:color] = false
+      end
+
       option(opts, '-v', '--version', 'Display version.')
       option(opts, '-V', '--verbose-version', 'Display verbose version.')
     end


### PR DESCRIPTION
The `--no-color` option hasn't worked for a while (since #601, my fault). This fixes it.

The solution is simple but will have to be changed if we ever introduce a `--[no-]something` option. An alternative solution would be to do that now and change it to `--[no-]color`. I prefer this way.

We don't have any specs for coloring and I found it difficult to add any.
