### PR TITLE
Make sure config descriptions don't have trailing newlines.

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -496,13 +496,13 @@ WordArray:
 ### Warnings
 
 AmbiguousOperator:
-  Description: >
+  Description: >-
                  Checks for ambiguous operators in the first argument of a
                  method invocation without parentheses.
   Enabled: true
 
 AmbiguousRegexpLiteral:
-  Description: >
+  Description: >-
                  Checks for ambiguous regexp literals in the first argument of
                  a method invocation without parenthesis.
   Enabled: true

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -4,16 +4,21 @@ require 'spec_helper'
 
 describe 'RuboCop Project' do
   describe 'default configuration file' do
-    it 'has configuration for all cops' do
-      cop_names = Rubocop::Cop::Cop.all.map(&:cop_name)
-      expect(Rubocop::ConfigLoader.load_file('config/default.yml').keys.sort)
-        .to eq((['AllCops'] + cop_names).sort)
+    let(:cop_names) { Rubocop::Cop::Cop.all.map(&:cop_name) }
+
+    subject(:default_config) do
+      Rubocop::ConfigLoader.load_file('config/default.yml')
     end
-    it 'has a description for all cops' do
-      cop_names = Rubocop::Cop::Cop.all.map(&:cop_name)
-      conf = Rubocop::ConfigLoader.load_file('config/default.yml')
+
+    it 'has configuration for all cops' do
+      expect(default_config.keys.sort).to eq((['AllCops'] + cop_names).sort)
+    end
+
+    it 'has a nicely formatted description for all cops' do
       cop_names.each do |name|
-        expect(conf[name]['Description']).not_to be_nil
+        description = default_config[name]['Description']
+        expect(description).not_to be_nil
+        expect(description).not_to include("\n")
       end
     end
   end


### PR DESCRIPTION
This means using `>-` instead of `>` for descriptions that occupy more than one row. Having no newlines makes the output from `--show-cops` nicer.

Also add an expectation in the specs so future additions are covered.
