### PR TITLE
Fix 'Not a block' error for default_scope

### DIFF
--- a/lib/rubocop/cop/rails/default_scope.rb
+++ b/lib/rubocop/cop/rails/default_scope.rb
@@ -25,7 +25,9 @@ module Rubocop
 
           first_arg = args[0]
 
-          add_offence(first_arg, :expression) if lambda_or_proc?(first_arg)
+          if first_arg.type != :block || lambda_or_proc?(first_arg)
+            add_offence(first_arg, :expression)
+          end
         end
       end
     end

--- a/spec/rubocop/cop/rails/default_scope_spec.rb
+++ b/spec/rubocop/cop/rails/default_scope_spec.rb
@@ -23,6 +23,12 @@ describe Rubocop::Cop::Rails::DefaultScope do
     expect(cop.offences.size).to eq(1)
   end
 
+  it 'registers an offence for non blocks' do
+    inspect_source(cop,
+                   ['default_scope order: "position"'])
+    expect(cop.offences.size).to eq(1)
+  end
+
   it 'accepts a block arg' do
     inspect_source(cop,
                    ['default_scope { something }'])


### PR DESCRIPTION
When a block is not used (as shown below), an error occurs instead of adding the missing
block to the list of offenses. Changing the fail statement to return so
that the missing block is reported properly.

``` ruby
default_scope order: 'position'
```

```
$ rubocop -v
0.16.0
```
