### PR TITLE
[Fix #730] Enforce end aligned with "private def", etc, in Ruby 2.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * The `--no-color` option works again. ([@jonas054][])
 * [#716](https://github.com/bbatsov/rubocop/issues/716): Fixed a regression in the auto-correction logic of `MethodDefParentheses`. ([@bbatsov][])
 * Inspected projects that lack a `.rubocop.yml` file, and therefore get their configuration from RuboCop's `config/default.yml`, no longer get configuration from RuboCop's `.rubocop.yml` and `rubocop-todo.yml`.
+* [#730](https://github.com/bbatsov/rubocop/issues/730): `EndAlignment` now handles for example `private def some_method`, which is allowed in Ruby 2.1. It requires `end` to be aligned with `private`, not `def`, in such cases. ([@jonas054][])
 
 ## 0.16.0 (25/12/2013)
 

--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -17,7 +17,7 @@ describe Rubocop::Cop::Lint::EndAlignment, :config do
                            end_kw])
       expect(cop.offences.size).to eq(1)
       expect(cop.messages.first)
-        .to match(/end at 2, \d is not aligned with #{alignment_base} at 1,/)
+        .to match(/end at 2, \d+ is not aligned with #{alignment_base} at 1,/)
       expect(cop.highlights.first).to eq('end')
       expect(cop.config_to_allow_offences).to eq('AlignWith' => opposite)
     end
@@ -49,6 +49,26 @@ describe Rubocop::Cop::Lint::EndAlignment, :config do
   include_examples 'aligned', 'unless', 'test',      'end'
   include_examples 'aligned', 'while',  'test',      'end'
   include_examples 'aligned', 'until',  'test',      'end'
+
+  context 'in ruby 2.1 or later' do
+    include_examples 'aligned', 'public def',          'test', 'end'
+    include_examples 'aligned', 'protected def',       'test', 'end'
+    include_examples 'aligned', 'private def',         'test', 'end'
+    include_examples 'aligned', 'module_function def', 'test', 'end'
+
+    include_examples('misaligned',
+                     'public def', 'test',
+                     '       end')
+    include_examples('misaligned',
+                     'protected def', 'test',
+                     '          end')
+    include_examples('misaligned',
+                     'private def', 'test',
+                     '        end')
+    include_examples('misaligned',
+                     'module_function def', 'test',
+                     '                end')
+  end
 
   it 'can handle ternary if' do
     inspect_source(cop, 'a = cond ? x : y')


### PR DESCRIPTION
The visibility methods can be on the same line as def and end should be aligned with the beginning of the line in those cases.
