### PR TITLE
facilitate integration into ci build

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Apart from reporting problems in your code, RuboCop can also
 automatically fix some of the problems for you.
 
 - [Installation](#installation)
-- [Basic Usage](#basic-usage)
+- [Basic Usage](#basic-usage)  
+	- [CI Build Integration](#ci-build-integration)
 	- [Cops](#cops)
 		- [Style](#style)
 		- [Lint](#lint)
@@ -129,6 +130,10 @@ Command flag              | Description
 `--only`                  | Run only the specified cop
 `--auto-gen-config`       | Generate a configuration file acting as a TODO list
 `--show-cops`             | Shows available cops and their configuration
+
+### CI Build Integration
+
+RuboCop can also be integrated into an existing CI build process by adding sample_spec/rubocop_spec.rb to your existing RSpec test suite. This will cause RuboCop checks to be treated like RSpec tests.
 
 ### Cops
 

--- a/sample_spec/rubocop_spec.rb
+++ b/sample_spec/rubocop_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'Check for Ruby style errors in' do
+  ignored_file_paths = []
+  ignored_file_paths << Dir[Rails.root.to_s + '/db/**/*.rb']
+  ignored_file_paths << Dir[Rails.root.to_s + '/tmp/**/*.rb']
+  ignored_file_paths << Dir[Rails.root.to_s + '/public/assets/**/*.rb']
+
+  rubocop_config = Rails.root.to_s + '/.rubocop.yml'
+  file_paths = Dir[Rails.root.to_s + '/**/*.rb'] - ignored_file_paths.flatten
+  output = `rubocop #{file_paths.join(' ')} --format simple`
+
+  file_path = nil
+  errors = output.lines.each_with_object({}) do |line, errors|
+    line.chomp!
+    if line.start_with?('== ') && line.end_with?(' ==')
+      file_path = line.gsub('== ', '').gsub(' ==', '')
+      errors[file_path] = []
+    elsif line.blank?
+      file_path = nil
+    else
+      errors[file_path] << line if !file_path.nil?
+    end
+  end
+
+  errors.each do |file_path, lines|
+    it file_path do
+      lines.should be_empty, lines.join("\n")
+    end
+  end
+end


### PR DESCRIPTION
Hi there,

thank you for this useful gem :). We've found that incorporating these kinds of tests into our rspec coverage is often the easiest way to incorporate such checks into an existing CI build process. The code here is nothing special, it just facilitates setting up such a thing as much as possible.
