### PR TITLE
Read, inspect, and write file repeatedly in --auto-correct.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [#716](https://github.com/bbatsov/rubocop/issues/716): Fixed a regression in the auto-correction logic of `MethodDefParentheses`. ([@bbatsov][])
 * Inspected projects that lack a `.rubocop.yml` file, and therefore get their configuration from RuboCop's `config/default.yml`, no longer get configuration from RuboCop's `.rubocop.yml` and `rubocop-todo.yml`.
 * [#730](https://github.com/bbatsov/rubocop/issues/730): `EndAlignment` now handles for example `private def some_method`, which is allowed in Ruby 2.1. It requires `end` to be aligned with `private`, not `def`, in such cases. ([@jonas054][])
+* [#744](https://github.com/bbatsov/rubocop/issues/744): Any new offences created by `--auto-correct` are now handled immediately and corrected when possible, so running `--auto-correct` once is enough. ([@jonas054][])
 
 ## 0.16.0 (25/12/2013)
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -47,6 +47,40 @@ describe Rubocop::CLI, :isolated_environment do
                   '  puts i',
                   'end'].join("\n") + "\n")
       end
+
+      # In this example, the auto-correction (changing "raise" to "fail")
+      # creates a new problem (alignment of parameters), which is also
+      # corrected automatically.
+      it 'can correct a problems and the problem it creates' do
+        create_file('example.rb',
+                    ['# encoding: utf-8',
+                     'raise NotImplementedError,',
+                     "      'Method should be overridden in child classes'"])
+        expect(cli.run(['--auto-correct'])).to eq(1)
+        expect(IO.read('example.rb'))
+          .to eq(['# encoding: utf-8',
+                  'fail NotImplementedError,',
+                  "     'Method should be overridden in child classes'"]
+                   .join("\n") + "\n")
+        expect($stdout.string)
+          .to eq(['Inspecting 1 file',
+                  'C',
+                  '',
+                  'Offences:',
+                  '',
+                  'example.rb:2:1: C: [Corrected] Use `fail` instead of ' +
+                  '`raise` to signal exceptions.',
+                  'raise NotImplementedError,',
+                  '^^^^^',
+                  'example.rb:3:7: C: [Corrected] Align the parameters of a ' +
+                  'method call if they span more than one line.',
+                  "      'Method should be overridden in child classes'",
+                  '      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^',
+                  '',
+                  '1 file inspected, 2 offences detected, 2 offences ' +
+                  'corrected',
+                  ''].join("\n"))
+      end
     end
 
     describe '--auto-gen-config' do


### PR DESCRIPTION
If the file has been auto-corrected, we inspect it again to see if the correction created any new offences. Care is also taken to not report the same offence more than once.
