### PR TITLE
Fix EmptyLinesAroundBody so it doesn't report blank lines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Inspected projects that lack a `.rubocop.yml` file, and therefore get their configuration from RuboCop's `config/default.yml`, no longer get configuration from RuboCop's `.rubocop.yml` and `rubocop-todo.yml`.
 * [#730](https://github.com/bbatsov/rubocop/issues/730): `EndAlignment` now handles for example `private def some_method`, which is allowed in Ruby 2.1. It requires `end` to be aligned with `private`, not `def`, in such cases. ([@jonas054][])
 * [#744](https://github.com/bbatsov/rubocop/issues/744): Any new offences created by `--auto-correct` are now handled immediately and corrected when possible, so running `--auto-correct` once is enough. ([@jonas054][])
+* [#748](https://github.com/bbatsov/rubocop/pull/748): Auto-correction conflict between `EmptyLinesAroundBody` and `TrailingWhitespace` resolved. ([@jonas054][])
 
 ## 0.16.0 (25/12/2013)
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -144,7 +144,7 @@ EmptyLinesAroundAccessModifier:
   Enabled: true
 
 EmptyLinesAroundBody:
-  Description: "Keeps track of blank lines around expression bodies."
+  Description: "Keeps track of empty lines around expression bodies."
   Enabled: true
 
 EmptyLiteral:

--- a/lib/rubocop/cop/style/empty_lines_around_body.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_body.rb
@@ -3,7 +3,7 @@
 module Rubocop
   module Cop
     module Style
-      # This cops checks redundant blanks lines around the bodies of classes,
+      # This cops checks redundant empty lines around the bodies of classes,
       # modules & methods.
       #
       # @example
@@ -24,8 +24,8 @@ module Rubocop
       class EmptyLinesAroundBody < Cop
         include CheckMethods
 
-        MSG_BEG = 'Extra blank line detected at body beginning.'
-        MSG_END = 'Extra blank line detected at body end.'
+        MSG_BEG = 'Extra empty line detected at body beginning.'
+        MSG_END = 'Extra empty line detected at body end.'
 
         def on_class(node)
           check(node)
@@ -55,7 +55,7 @@ module Rubocop
         end
 
         def check_source(start_line, end_line)
-          if processed_source.lines[start_line].blank?
+          if processed_source.lines[start_line].empty?
             range = source_range(processed_source.buffer,
                                  processed_source[0...start_line],
                                  0,
@@ -63,7 +63,7 @@ module Rubocop
             add_offence(range, range, MSG_BEG)
           end
 
-          if processed_source.lines[end_line - 2].blank?
+          if processed_source.lines[end_line - 2].empty?
             range = source_range(processed_source.buffer,
                                  processed_source[0...(end_line - 2)],
                                  0,

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -81,6 +81,42 @@ describe Rubocop::CLI, :isolated_environment do
                   'corrected',
                   ''].join("\n"))
       end
+
+      # Thanks to repeated auto-correction, we can get rid of the trailing
+      # spaces, and then the extra empty line.
+      it 'can correct two problems in the same place' do
+        create_file('example.rb',
+                    ['# encoding: utf-8',
+                     '# Example class.',
+                     'class Klass',
+                     '  ',
+                     '  def f',
+                     '  end',
+                     'end'])
+        expect(cli.run(['--auto-correct'])).to eq(1)
+        expect(IO.read('example.rb'))
+          .to eq(['# encoding: utf-8',
+                  '# Example class.',
+                  'class Klass',
+                  '  def f',
+                  '  end',
+                  'end'].join("\n") + "\n")
+        expect($stderr.string).to eq('')
+        expect($stdout.string)
+          .to eq(['Inspecting 1 file',
+                  'C',
+                  '',
+                  'Offences:',
+                  '',
+                  'example.rb:4:1: C: [Corrected] Trailing whitespace ' +
+                  'detected.',
+                  'example.rb:4:1: C: [Corrected] Extra empty line detected ' +
+                  'at body beginning.',
+                  '',
+                  '1 file inspected, 2 offences detected, 2 offences ' +
+                  'corrected',
+                  ''].join("\n"))
+      end
     end
 
     describe '--auto-gen-config' do

--- a/spec/rubocop/cop/style/empty_lines_around_body_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_body_spec.rb
@@ -14,6 +14,19 @@ describe Rubocop::Cop::Style::EmptyLinesAroundBody do
     expect(cop.offences.size).to eq(1)
   end
 
+  # The cop only registers an offence if the extra line is completely emtpy. If
+  # there is trailing whitespace, then that must be dealt with first. Having
+  # two cops registering offence for the line with only spaces would cause
+  # havoc in auto-correction.
+  it 'accepts method body starting with a line with spaces' do
+    inspect_source(cop,
+                   ['def some_method',
+                    '  ',
+                    '  do_something',
+                    'end'])
+    expect(cop.offences).to be_empty
+  end
+
   it 'autocorrects method body starting with a blank' do
     corrected = autocorrect_source(cop,
                                    ['def some_method',


### PR DESCRIPTION
This resolves a conflict ("clobbering") between `EmptyLinesAroundBody` and `TrailingWhitespace`. An extra blank line containing whitespace would cause them to try to remove the same characters in `--auto-correct`. The solution is to divide the offences between them. `EmptyLinesAroundBody` doesn't report offences for lines containing spaces now.
