### PR TITLE
Fix crash on ternary if in ParenthesesAroundCondition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,11 @@
 * [#724](https://github.com/bbatsov/rubocop/issues/724): Accept colons denoting required keyword argument (a new feature in Ruby 2.1) without trailing space in `SpaceAfterColon`. ([@jonas054][])
 * The `--no-color` option works again. ([@jonas054][])
 * [#716](https://github.com/bbatsov/rubocop/issues/716): Fixed a regression in the auto-correction logic of `MethodDefParentheses`. ([@bbatsov][])
-* Inspected projects that lack a `.rubocop.yml` file, and therefore get their configuration from RuboCop's `config/default.yml`, no longer get configuration from RuboCop's `.rubocop.yml` and `rubocop-todo.yml`.
+* Inspected projects that lack a `.rubocop.yml` file, and therefore get their configuration from RuboCop's `config/default.yml`, no longer get configuration from RuboCop's `.rubocop.yml` and `rubocop-todo.yml`. ([@jonas054][])
 * [#730](https://github.com/bbatsov/rubocop/issues/730): `EndAlignment` now handles for example `private def some_method`, which is allowed in Ruby 2.1. It requires `end` to be aligned with `private`, not `def`, in such cases. ([@jonas054][])
 * [#744](https://github.com/bbatsov/rubocop/issues/744): Any new offences created by `--auto-correct` are now handled immediately and corrected when possible, so running `--auto-correct` once is enough. ([@jonas054][])
 * [#748](https://github.com/bbatsov/rubocop/pull/748): Auto-correction conflict between `EmptyLinesAroundBody` and `TrailingWhitespace` resolved. ([@jonas054][])
+* `ParenthesesAroundCondition` no longer crashes on parentheses around the condition in a ternary if. ([@jonas054][])
 
 ## 0.16.0 (25/12/2013)
 

--- a/lib/rubocop/cop/style/parentheses_around_condition.rb
+++ b/lib/rubocop/cop/style/parentheses_around_condition.rb
@@ -4,11 +4,13 @@ module Rubocop
   module Cop
     module Style
       # This cop checks for the presence of superfluous parentheses around the
-      # condition of if/while/until.
+      # condition of if/unless/while/until.
       class ParenthesesAroundCondition < Cop
+        include IfNode
         include SafeAssignment
 
         def on_if(node)
+          return if ternary_op?(node)
           process_control_op(node)
         end
 
@@ -34,8 +36,9 @@ module Rubocop
         end
 
         def message(node)
-          "Don't use parentheses around the condition of an " \
-          "#{node.loc.keyword.source}."
+          kw = node.loc.keyword.source
+          article = kw == 'while' ? 'a' : 'an'
+          "Don't use parentheses around the condition of #{article} #{kw}."
         end
 
         def autocorrect(node)

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -18,13 +18,14 @@ describe Rubocop::Cop::Style::ParenthesesAroundCondition, :config do
                          'end',
                          'x += 1 if (x < 10)',
                          'x += 1 unless (x < 10)',
-                         'x += 1 while (x < 10)',
-                         'x += 1 until (x < 10)'
+                         'x += 1 until (x < 10)',
+                         'x += 1 while (x < 10)'
                         ])
     expect(cop.offences.size).to eq(9)
-    expect(cop.messages.first).to eq(
-      "Don't use parentheses around the condition of an if."
-    )
+    expect(cop.messages.first)
+      .to eq("Don't use parentheses around the condition of an if.")
+    expect(cop.messages.last)
+      .to eq("Don't use parentheses around the condition of a while.")
   end
 
   it 'auto-corrects parentheses around condition' do
@@ -72,6 +73,11 @@ describe Rubocop::Cop::Style::ParenthesesAroundCondition, :config do
                          'x += 1 while x < 10',
                          'x += 1 until x < 10'
                         ])
+    expect(cop.offences).to be_empty
+  end
+
+  it 'accepts parentheses around condition in a ternary' do
+    inspect_source(cop, '(a == 0) ? b : a')
     expect(cop.offences).to be_empty
   end
 


### PR DESCRIPTION
I don't think we have a rule yet for parentheses around the confition of a ternary. Either way it doesn't belong in this cop as far as I can see.
