### PR TITLE
Remove JSON dependency

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '~> 1.99.1')
   s.add_runtime_dependency('parser', '~> 2.1.3')
   s.add_runtime_dependency('powerpack', '~> 0.0.6')
-  s.add_runtime_dependency('json', '~> 1.8')
   s.add_development_dependency('rake', '~> 10.1')
   s.add_development_dependency('rspec', '~> 2.14')
   s.add_development_dependency('yard', '~> 0.8')


### PR DESCRIPTION
Ruby 1.9 has JSON included, and Rubocop requires Ruby 1.9+ already. This added dependency makes it difficult to use Rubocop in the same bundle as other libraries that depend on older versions of JSON.
