### PR TITLE
Support Rainbow gem both 1.99.x and 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#762](https://github.com/bbatsov/rubocop/issues/762): Support Rainbow gem both 1.99.x and 2.x. ([@yujinakayama][])
+
 ## 0.17.0 (25/01/2014)
 
 ### New features

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -1,6 +1,9 @@
 # encoding: utf-8
 
 require 'rainbow'
+# Rainbow 2.0 does not load the monkey-patch for String by default.
+require 'rainbow/ext/string' unless String.respond_to?(:color)
+
 require 'English'
 require 'set'
 require 'parser/current'

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = '1.8.23'
   s.summary = 'Automatic Ruby code style checking tool.'
 
-  s.add_runtime_dependency('rainbow', '~> 1.99.1')
+  s.add_runtime_dependency('rainbow', '>= 1.99.1', '< 3.0')
   s.add_runtime_dependency('parser', '~> 2.1.3')
   s.add_runtime_dependency('powerpack', '~> 0.0.6')
   s.add_runtime_dependency('json', '~> 1.8')


### PR DESCRIPTION
This fixes #762.
