### PR TITLE
[Fix #764] Handle heredocs in TrailingComma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * [#762](https://github.com/bbatsov/rubocop/issues/762): Support Rainbow gem both 1.99.x and 2.x. ([@yujinakayama][])
 
+### Bugs fixed
+
+* [#764](https://github.com/bbatsov/rubocop/issues/764): Handle heredocs in `TrailingComma`. ([@jonas054][])
+
 ## 0.17.0 (25/01/2014)
 
 ### New features

--- a/lib/rubocop/cop/style/trailing_comma.rb
+++ b/lib/rubocop/cop/style/trailing_comma.rb
@@ -48,6 +48,9 @@ module Rubocop
         def check(node, items, kind, begin_pos, end_pos)
           sb = items.first.loc.expression.source_buffer
           after_last_item = Parser::Source::Range.new(sb, begin_pos, end_pos)
+
+          return if heredoc?(after_last_item.source)
+
           comma_offset = after_last_item.source =~ /,/
           should_have_comma = style == :comma && multiline?(node)
           if comma_offset
@@ -58,6 +61,10 @@ module Rubocop
           elsif should_have_comma
             put_comma(items, kind, sb)
           end
+        end
+
+        def heredoc?(source_after_last_item)
+          source_after_last_item =~ /\w/
         end
 
         # Returns true if the node has round/square/curly brackets.

--- a/spec/rubocop/cop/style/trailing_comma_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_spec.rb
@@ -130,6 +130,16 @@ describe Rubocop::Cop::Style::TrailingComma, :config do
                              '           )'])
         expect(cop.offences).to be_empty
       end
+
+      it 'accepts comma inside a heredoc' +
+        ' parameters at the end' do
+        inspect_source(cop, ['route(help: {',
+                             "  'auth' => <<-HELP.chomp",
+                             ',',
+                             'HELP',
+                             '})'])
+        expect(cop.offences).to be_empty
+      end
     end
 
     context 'when EnforcedStyleForMultiline is comma' do
@@ -193,6 +203,17 @@ describe Rubocop::Cop::Style::TrailingComma, :config do
                              '              c: 0,',
                              '              d: 1,',
                              '           )'])
+        expect(cop.offences).to be_empty
+      end
+
+      it 'accepts missing comma after a heredoc' do
+        # A heredoc that's the last item in a literal or parameter list can not
+        # have a trailing comma. It's a syntax error.
+        inspect_source(cop, ['route(help: {',
+                             "  'auth' => <<-HELP.chomp",
+                             '...',
+                             'HELP',
+                             '},)']) # We still need a comma after the hash.
         expect(cop.offences).to be_empty
       end
     end


### PR DESCRIPTION
There was a bug that made the cop consider commas inside heredocs as
trailing commas if the heredoc was part of the last item in a list.
