### PR TITLE
Support mocked file paths in the spec helper's parse_source

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,7 +91,9 @@ end
 
 def parse_source(source, file = nil)
   source = source.join($RS) if source.is_a?(Array)
-  if file
+  if file.is_a? String
+    Rubocop::SourceParser.parse(source, file)
+  elsif file
     file.write(source)
     file.rewind
     Rubocop::SourceParser.parse(source, file.path)


### PR DESCRIPTION
This is to support the rubocop-rspec gem mentioned in #731, and just generally helpful for cops that need to check a file's path
