### PR TITLE
Fix double reporting in EmptyLinesAroundBody for empty class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* Remove double reporting in `EmptyLinesAroundBody` of empty line inside otherwise empty class/module/method that caused crash in autocorrect. ([@jonas054][])
+
 ## 0.18.0 (30/01/2014)
 
 ### New features

--- a/lib/rubocop/cop/style/empty_lines_around_body.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_body.rb
@@ -55,20 +55,17 @@ module Rubocop
         end
 
         def check_source(start_line, end_line)
-          if processed_source.lines[start_line].empty?
-            range = source_range(processed_source.buffer,
-                                 processed_source[0...start_line],
-                                 0,
-                                 1)
-            add_offence(range, range, MSG_BEG)
-          end
+          check_line(start_line, MSG_BEG)
+          check_line(end_line - 2, MSG_END) unless end_line - 2 == start_line
+        end
 
-          if processed_source.lines[end_line - 2].empty?
+        def check_line(line, msg)
+          if processed_source.lines[line].empty?
             range = source_range(processed_source.buffer,
-                                 processed_source[0...(end_line - 2)],
+                                 processed_source[0...line],
                                  0,
                                  1)
-            add_offence(range, range, MSG_END)
+            add_offence(range, range, msg)
           end
         end
       end

--- a/spec/rubocop/cop/style/empty_lines_around_body_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_body_spec.rb
@@ -85,6 +85,15 @@ describe Rubocop::Cop::Style::EmptyLinesAroundBody do
     expect(cop.offences.size).to eq(1)
   end
 
+  it 'autocorrects class body containing only a blank' do
+    corrected = autocorrect_source(cop,
+                                   ['class SomeClass',
+                                    '',
+                                    'end'])
+    expect(corrected).to eq ['class SomeClass',
+                             'end'].join("\n")
+  end
+
   it 'registers an offence for module body starting with a blank' do
     inspect_source(cop,
                    ['module SomeModule',


### PR DESCRIPTION
A class, module, or method that had only one empty line and nothing else inside it would get that line reported twice. This lead to a crash in autocorrect.
