### PR TITLE
[Fix #751] Let Documentation cop require class comment to be adjacent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Remove double reporting in `EmptyLinesAroundBody` of empty line inside otherwise empty class/module/method that caused crash in autocorrect. ([@jonas054][])
 * [#779](https://github.com/bbatsov/rubocop/issues/779): Fix a false positive in `LineEndConcatenation`. ([@bbatsov][])
+* [#751](https://github.com/bbatsov/rubocop/issues/751): Fix `Documentation` cop so that a comment followed by an empty line and then a class definition is not considered to be class documentation. ([@jonas054][])
 
 ## 0.18.0 (30/01/2014)
 

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -35,7 +35,7 @@ module Rubocop
 
             next if node.type == :class && !body
             next if namespace?(body)
-            next unless ast_with_comments[node].empty?
+            next if associated_comment?(node, ast_with_comments)
             add_offence(node, :keyword, format(MSG, node.type.to_s))
           end
         end
@@ -53,6 +53,14 @@ module Rubocop
           else
             false
           end
+        end
+
+        # Returns true if the node has a comment on the line above it.
+        def associated_comment?(node, ast_with_comments)
+          preceding_comment = ast_with_comments[node].last
+          return false if preceding_comment.nil?
+          distance = node.loc.keyword.line - preceding_comment.loc.line
+          distance == 1
         end
       end
     end

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -14,6 +14,19 @@ describe Rubocop::Cop::Style::Documentation do
     expect(cop.offences.size).to eq(1)
   end
 
+  it 'does not consider comment followed by empty line to be class ' \
+     'documentation' do
+    inspect_source(cop,
+                   ['# Copyright 2014',
+                    '# Some company',
+                    '',
+                    'class My_Class',
+                    '  TEST = 20',
+                    'end'
+                   ])
+    expect(cop.offences.size).to eq(1)
+  end
+
   it 'registers an offence for non-namespace' do
     inspect_source(cop,
                    ['module My_Class',


### PR DESCRIPTION
If there's an empty line right above the class or module, then there's no class/module documentation.
