### PR TITLE
[Fix #718] Don't regard annotations as class/module documentation

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -30,6 +30,7 @@ require 'rubocop/cop/variable_inspector/reference'
 require 'rubocop/cop/variable_inspector/scope'
 require 'rubocop/cop/variable_inspector/variable_table'
 
+require 'rubocop/cop/mixin/annotation_comment'
 require 'rubocop/cop/mixin/array_syntax'
 require 'rubocop/cop/mixin/autocorrect_alignment'
 require 'rubocop/cop/mixin/check_assignment'

--- a/lib/rubocop/cop/mixin/annotation_comment.rb
+++ b/lib/rubocop/cop/mixin/annotation_comment.rb
@@ -1,0 +1,37 @@
+# encoding: utf-8
+
+module Rubocop
+  module Cop
+    module Style
+      # Common functionality related to annotation comments.
+      module AnnotationComment
+        private
+
+        def annotation?(comment)
+          _margin, first_word, colon, space, note = split_comment(comment)
+          keyword_appearance?(first_word, colon, space) &&
+            !just_first_word_of_sentence?(first_word, colon, space, note)
+        end
+
+        def split_comment(comment)
+          match = comment.text.match(/^(# ?)([A-Za-z]+)(\s*:)?(\s+)?(\S+)?/)
+          return false unless match
+          margin, first_word, colon, space, note = *match.captures
+          [margin, first_word, colon, space, note]
+        end
+
+        def keyword_appearance?(first_word, colon, space)
+          first_word && keyword?(first_word.upcase) && (colon || space)
+        end
+
+        def just_first_word_of_sentence?(first_word, colon, space, note)
+          first_word == first_word.capitalize && !colon && space && note
+        end
+
+        def keyword?(word)
+          config.for_cop('CommentAnnotation')['Keywords'].include?(word)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/style/comment_annotation.rb
+++ b/lib/rubocop/cop/style/comment_annotation.rb
@@ -6,52 +6,30 @@ module Rubocop
       # This cop checks that comment annotation keywords are written according
       # to guidelines.
       class CommentAnnotation < Cop
+        include AnnotationComment
+
         MSG = 'Annotation keywords should be all upper case, followed by a ' \
               'colon and a space, then a note describing the problem.'
 
         def investigate(processed_source)
           processed_source.comments.each do |comment|
-            match = comment.text.match(/^(# ?)([A-Za-z]+)(\s*:)?(\s+)?(\S+)?/)
-            if match
-              margin, first_word, colon, space, note = *match.captures
-              if annotation?(first_word, colon, space, note) &&
-                  !correct_annotation?(first_word, colon, space, note)
-                start = comment.loc.expression.begin_pos + margin.length
-                length = first_word.length + (colon || '').length
-                range = Parser::Source::Range.new(processed_source.buffer,
-                                                  start,
-                                                  start + length)
-                add_offence(nil, range)
-              end
+            margin, first_word, colon, space, note = split_comment(comment)
+            if annotation?(comment) && !correct_annotation?(first_word, colon,
+                                                            space, note)
+              start = comment.loc.expression.begin_pos + margin.length
+              length = first_word.length + (colon || '').length
+              range = Parser::Source::Range.new(processed_source.buffer,
+                                                start,
+                                                start + length)
+              add_offence(nil, range)
             end
           end
         end
 
-        def keywords
-          cop_config['Keywords']
-        end
-
         private
-
-        def annotation?(first_word, colon, space, note)
-          keyword_appearance?(first_word, colon, space) &&
-            !just_first_word_of_sentence?(first_word, colon, space, note)
-        end
-
-        def keyword_appearance?(first_word, colon, space)
-          keyword?(first_word.upcase) && (colon || space)
-        end
-
-        def just_first_word_of_sentence?(first_word, colon, space, note)
-          first_word == first_word.capitalize && !colon && space && note
-        end
 
         def correct_annotation?(first_word, colon, space, note)
           keyword?(first_word) && (colon && space && note || !colon && !note)
-        end
-
-        def keyword?(word)
-          keywords.include?(word)
         end
       end
     end

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -8,6 +8,8 @@ module Rubocop
       # check and so are namespace modules - modules that have nothing in
       # their bodies except classes or other other modules.
       class Documentation < Cop
+        include AnnotationComment
+
         MSG = 'Missing top-level %s documentation comment.'
 
         def investigate(processed_source)
@@ -55,12 +57,16 @@ module Rubocop
           end
         end
 
-        # Returns true if the node has a comment on the line above it.
+        # Returns true if the node has a comment on the line above it that
+        # isn't an annotation.
         def associated_comment?(node, ast_with_comments)
+          return false if ast_with_comments[node].empty?
+
           preceding_comment = ast_with_comments[node].last
-          return false if preceding_comment.nil?
           distance = node.loc.keyword.line - preceding_comment.loc.line
-          distance == 1
+          return false if distance > 1
+
+          !annotation?(preceding_comment)
         end
       end
     end

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -3,7 +3,13 @@
 require 'spec_helper'
 
 describe Rubocop::Cop::Style::Documentation do
-  subject(:cop) { described_class.new }
+
+  subject(:cop) { described_class.new(config) }
+  let(:config) do
+    Rubocop::Config.new('CommentAnnotation' => {
+                          'Keywords' => %w(TODO FIXME OPTIMIZE HACK REVIEW)
+                        })
+  end
 
   it 'registers an offence for non-empty class' do
     inspect_source(cop,
@@ -54,6 +60,16 @@ describe Rubocop::Cop::Style::Documentation do
                     'end'
                    ])
     expect(cop.offences).to be_empty
+  end
+
+  it 'registers an offence for non-empty class with annotation comment' do
+    inspect_source(cop,
+                   ['# OPTIMIZE: Make this faster.',
+                    'class My_Class',
+                    '  TEST = 20',
+                    'end'
+                   ])
+    expect(cop.offences.size).to eq(1)
   end
 
   it 'accepts non-empty module with documentation' do


### PR DESCRIPTION
I've chosed to base the distinction of what is an annotation comment only on the last line. Another alternative is to say that a comment is not a class documentation comment if there is an annotation _anywhere_ in it. But I thought that a comment such as https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/one_line_conditional.rb#L6-L7 was reasonable.
