### PR TITLE
[Fix #790] Make smaller replace in MethodDefParentheses autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#790](https://github.com/bbatsov/rubocop/issues/790): Fix auto-correction interference problem between `MethodDefParentheses` and other cops. ([@jonas054][])
+
 ## 0.18.1 (02/02/2014)
 
 ### Bugs fixed

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -33,11 +33,13 @@ module Rubocop
         def autocorrect(node)
           @corrections << lambda do |corrector|
             if style == :require_parentheses
-
-              corrector.insert_after(args_node(node).loc.expression, ')')
-              expression = node.loc.expression
-              replacement = expression.source.sub(/(def\s+\S+)\s+/, '\1(')
-              corrector.replace(expression, replacement)
+              args_expr = args_node(node).loc.expression
+              args_with_space = range_with_surrounding_space(args_expr, :left)
+              just_space = Parser::Source::Range.new(args_expr.source_buffer,
+                                                     args_with_space.begin_pos,
+                                                     args_expr.begin_pos)
+              corrector.replace(just_space, '(')
+              corrector.insert_after(args_expr, ')')
             elsif style == :require_no_parentheses
               corrector.replace(node.loc.begin, ' ')
               corrector.remove(node.loc.end)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -117,6 +117,39 @@ describe Rubocop::CLI, :isolated_environment do
                   'corrected',
                   ''].join("\n"))
       end
+
+      it 'can correct MethodDefParentheses and other offence' do
+        create_file('example.rb',
+                    ['# encoding: utf-8',
+                     'def primes limit',
+                     '  1.upto(limit).find_all { |i| is_prime[i] }',
+                     'end'])
+        expect(cli.run(%w(-D --auto-correct))).to eq(1)
+        expect($stderr.string).to eq('')
+        expect(IO.read('example.rb'))
+          .to eq(['# encoding: utf-8',
+                  'def primes(limit)',
+                  '  1.upto(limit).select { |i| is_prime[i] }',
+                  'end'].join("\n") + "\n")
+        expect($stdout.string)
+          .to eq(['Inspecting 1 file',
+                  'C',
+                  '',
+                  'Offences:',
+                  '',
+                  'example.rb:2:12: C: [Corrected] MethodDefParentheses: ' \
+                  'Use def with parentheses when there are parameters.',
+                  'def primes limit',
+                  '           ^^^^^',
+                  'example.rb:3:17: C: [Corrected] CollectionMethods: ' \
+                  'Prefer select over find_all.',
+                  '  1.upto(limit).find_all { |i| is_prime[i] }',
+                  '                ^^^^^^^^',
+                  '',
+                  '1 file inspected, 2 offences detected, 2 offences ' \
+                  'corrected',
+                  ''].join("\n"))
+      end
     end
 
     describe '--auto-gen-config' do


### PR DESCRIPTION
Replacing the entire method definition gives the error `#<Parser::Source::Range ...> spans more than one line` if there is another auto-correction within that method. So we replace the smallest ranges we can.
