### PR TITLE
Add printing total count when `rubocop --format offences`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#793](https://github.com/bbatsov/rubocop/issues/793): Add printing total count when `rubocop --format offences`. ([@ma2gedev][])
+
 ### Bugs fixed
 
 * [#790](https://github.com/bbatsov/rubocop/issues/790): Fix auto-correction interference problem between `MethodDefParentheses` and other cops. ([@jonas054][])
@@ -696,3 +700,4 @@
 [@claco]: http://github.com/claco
 [@rifraf]: http://github.com/rifraf
 [@scottmatthewman]: https://github.com/scottmatthewman
+[@ma2gedev]: http://github.com/ma2gedev

--- a/README.md
+++ b/README.md
@@ -448,17 +448,19 @@ cops and the number of offences found for each by running:
 ```
 rubocop --format offences
 
-(87)  Documentation
-(12)  DotPosition
-(8)   AvoidGlobalVars
-(7)   EmptyLines
-(6)   AssignmentInCondition
-(4)   Blocks
-(4)   CommentAnnotation
-(3)   BlockAlignment
-(1)   IndentationWidth
-(1)   AvoidPerlBackrefs
-(1)   ColonMethodCall
+87   Documentation
+12   DotPosition
+8    AvoidGlobalVars
+7    EmptyLines
+6    AssignmentInCondition
+4    Blocks
+4    CommentAnnotation
+3    BlockAlignment
+1    IndentationWidth
+1    AvoidPerlBackrefs
+1    ColonMethodCall
+--
+134  Total
 ```
 
 ### Custom Formatters

--- a/lib/rubocop/formatter/offence_count_formatter.rb
+++ b/lib/rubocop/formatter/offence_count_formatter.rb
@@ -7,8 +7,10 @@ module Rubocop
     #
     # Here's the format:
     #
-    # (26)  LineLength
-    # (3)   OneLineConditional
+    # 26  LineLength
+    # 3   OneLineConditional
+    # --
+    # 29  Total
     class OffenceCountFormatter < BaseFormatter
       attr_reader :offence_counts
 
@@ -34,6 +36,9 @@ module Rubocop
           output.puts "#{count.to_s.ljust(offence_count.to_s.length + 2)}" +
                       "#{cop_name}\n"
         end
+        output.puts '--'
+        output.puts "#{offence_count}  Total"
+
         output.puts
       end
 

--- a/spec/rubocop/formatter/offence_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/offence_count_formatter_spec.rb
@@ -42,7 +42,7 @@ module Rubocop
           it 'shows the cop and the offence count' do
             formatter.report_summary(1, cop_counts)
             expect(output.string).to include(
-              "\n1  OffendedCop")
+              "\n1  OffendedCop\n--\n1  Total")
           end
         end
       end


### PR DESCRIPTION
I would like to know total count when `rubocop --format offences` so print total offence counts.
## BEFORE

```
1  Proc
1  WordArray
```
## AFTER

```
1  Proc
1  WordArray
--
2  Total
```
