### PR TITLE
Add MaxLength parameter to IfUnlessModifier and WhileUntilModifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#797](https://github.com/bbatsov/rubocop/issues/797): New cop `IndentHash` checks the indentation of the first key in multi-line hash literals. ([@jonas054][])
 * [#797](https://github.com/bbatsov/rubocop/issues/797): New cop `IndentArray` checks the indentation of the first element in multi-line array literals. ([@jonas054][])
 * [#806](https://github.com/bbatsov/rubocop/issues/806): Now excludes files in `vendor/**` by default. ([@jeremyolliver][])
+* [#795](https://github.com/bbatsov/rubocop/issues/795): `IfUnlessModifier` and `WhileUntilModifier` supports `MaxLineLength`, which is independent of `LineLength` parameter `Max`. ([@agrimm][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -148,6 +148,9 @@ HashSyntax:
     - ruby19
     - hash_rockets
 
+IfUnlessModifier:
+  MaxLineLength: 79
+
 # Checks the indentation of the first key in a hash literal.
 IndentHash:
   # The value `special_inside_parentheses` means that hash literals with braces
@@ -300,6 +303,9 @@ VariableName:
   SupportedStyles:
     - snake_case
     - camelCase
+
+WhileUntilModifier:
+  MaxLineLength: 79
 
 WordArray:
   MinSize: 0

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -34,6 +34,7 @@ module Rubocop
       end
 
       def max_line_length
+        cop_config && cop_config['MaxLineLength'] ||
         config.for_cop('LineLength')['Max']
       end
 

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -5,6 +5,7 @@ module Rubocop
     module Style
       # Checks for if and unless statements that would fit on one line
       # if written as a modifier if/unless.
+      # The maximum line length is configurable.
       class IfUnlessModifier < Cop
         include StatementModifier
 

--- a/lib/rubocop/cop/style/while_until_modifier.rb
+++ b/lib/rubocop/cop/style/while_until_modifier.rb
@@ -5,6 +5,7 @@ module Rubocop
     module Style
       # Checks for while and until statements that would fit on one line
       # if written as a modifier while/until.
+      # The maximum line length is configurable.
       class WhileUntilModifier < Cop
         include StatementModifier
 

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -124,5 +124,23 @@ describe Rubocop::Cop::Style::IfUnlessModifier do
         expect(cop.offenses).to be_empty
       end
     end
+
+    context 'when the maximum line length is specified by the cop itself' do
+      let(:config) do
+        hash = {
+          'LineLength' => { 'Max' => 100 },
+          'IfUnlessModifier' => { 'MaxLineLength' => 79 }
+        }
+        Rubocop::Config.new(hash)
+      end
+
+      it "accepts multiline if that doesn't fit on one line" do
+        check_too_long(cop, 'if')
+      end
+
+      it "accepts multiline unless that doesn't fit on one line" do
+        check_too_long(cop, 'unless')
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/style/while_until_modifier_spec.rb
+++ b/spec/rubocop/cop/style/while_until_modifier_spec.rb
@@ -72,4 +72,22 @@ describe Rubocop::Cop::Style::WhileUntilModifier do
     inspect_source(cop, ['ala until bala'])
     expect(cop.offenses).to be_empty
   end
+
+  context 'when the maximum line length is specified by the cop itself' do
+    let(:config) do
+      hash = {
+        'LineLength' => { 'Max' => 100 },
+        'WhileUntilModifier' => { 'MaxLineLength' => 79 }
+      }
+      Rubocop::Config.new(hash)
+    end
+
+    it "accepts multiline while that doesn't fit on one line" do
+      check_too_long(cop, 'while')
+    end
+
+    it "accepts multiline until that doesn't fit on one line" do
+      check_too_long(cop, 'until')
+    end
+  end
 end


### PR DESCRIPTION
Currently, if you have a high value for `Max` in `LineLength`, then the `IfUnlessModifier` and `WhileUntilModifier` cops will suggest a modifier style, even if it results in a very long line.

This change means you can specify a maximum length for these specific cops.
