### PR TITLE
excluding `vendor` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#743](https://github.com/bbatsov/rubocop/issues/743): `EmptyLineBetweenDefs` cop does auto-correction. ([@jonas054][])
 * [#809](https://github.com/bbatsov/rubocop/issues/809): New formatter `fuubar` displays a progress bar and shows details of offenses as soon as they are detected. ([@yujinakayama][])
 * [#797](https://github.com/bbatsov/rubocop/issues/797): New cop `IndentHash` checks the indentation of the first key in multi-line hash literals. ([@jonas054][])
+* [#806](https://github.com/bbatsov/rubocop/issues/806): Now excludes files in `vendor/**` by default. ([@jeremyolliver][])
 
 ### Changes
 
@@ -719,3 +720,4 @@
 [@rifraf]: http://github.com/rifraf
 [@scottmatthewman]: https://github.com/scottmatthewman
 [@ma2gedev]: http://github.com/ma2gedev
+[@jeremyolliver]: https://github.com/jeremyolliver

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,7 +11,8 @@ AllCops:
   Includes:
     - '**/*.gemspec'
     - '**/Rakefile'
-  Excludes: []
+  Excludes:
+    - 'vendor/**'
   # By default, the rails cops are not run. Override in project or home
   # directory .rubocop.yml files, or by giving the -R/--rails option.
   RunRailsCops: false


### PR DESCRIPTION
I'm not sure what the intentions are on providing defaults, I note that there's currently no files excluded from the default configuration. I'm proposing that the rubocop defaults, should exclude files matching `vendor/bundle/**`. The reason for this being that it's a default bundle install location for CI servers (it's the default path bundler uses for the `--deployment` flag, and travis-ci installs the bundle there by default, and that running rubocop over third party dependencies, is not intended at all, as their style preferences are their own, and in any case, not what the user is seeking to check.

I can't think of any really good reasons why `vendor/bundle` would be wanted to be checked, and in any case, seems a logical default setting to me, unless I'm missing something. Anybody care to provide some counter arguments for why not, or does it sound like a good idea?
