### PR TITLE
Add space after '# rubocop:'

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,24 +304,24 @@ One or more individual cops can be disabled locally in a section of a
 file by adding a comment such as
 
 ```ruby
-# rubocop:disable LineLength, StringLiterals
+# rubocop: disable LineLength, StringLiterals
 [...]
-# rubocop:enable LineLength, StringLiterals
+# rubocop: enable LineLength, StringLiterals
 ```
 
 You can also disable *all* cops with
 
 ```ruby
-# rubocop:disable all
+# rubocop: disable all
 [...]
-# rubocop:enable all
+# rubocop: enable all
 ```
 
 One or more cops can be disabled on a single line with an end-of-line
 comment.
 
 ```ruby
-for x in (0..19) # rubocop:disable AvoidFor
+for x in (0..19) # rubocop: disable AvoidFor
 ```
 
 ## Formatters


### PR DESCRIPTION
When the option to disable/enable cops inline via comments is applied without a space after '# rubocop:', the CommentAnnotation cop registers an offence.
