### PR TITLE
Fix message from EndAlignment when AlignWith is keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Auto-correction is now more robust and less likely to die because of `RangeError` or "clobbering". ([@jonas054][])
 * Offenses always reported in order of position in file, also during `--auto-correct` runs. ([@jonas054][])
 * Fix problem with `[Corrected]` tag sometimes missing in output from `--auto-correct` runs. ([@jonas054][])
+* Fix message from `EndAlignment` cop when `AlignWith` is `keyword`. ([@jonas054][])
 
 ## 0.18.1 (02/02/2014)
 

--- a/lib/rubocop/cop/lint/end_alignment.rb
+++ b/lib/rubocop/cop/lint/end_alignment.rb
@@ -80,15 +80,17 @@ module Rubocop
           when :if, :while, :until
             return if rhs.loc.respond_to?(:question) # ternary
 
-            offset = if style == :variable
-                       rhs.loc.keyword.column - node.loc.expression.column
-                     else
-                       0
-                     end
-            expr = node.loc.expression
-            range = Parser::Source::Range.new(expr.source_buffer,
-                                              expr.begin_pos,
-                                              rhs.loc.keyword.end_pos)
+            if style == :variable
+              expr = node.loc.expression
+              range = Parser::Source::Range.new(expr.source_buffer,
+                                                expr.begin_pos,
+                                                rhs.loc.keyword.end_pos)
+              offset = rhs.loc.keyword.column - node.loc.expression.column
+            else
+              range = rhs.loc.keyword
+              offset = 0
+            end
+
             check_offset(rhs, range.source, offset)
             ignore_node(rhs) # Don't check again.
           end

--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -4,16 +4,15 @@ require 'spec_helper'
 
 describe Rubocop::Cop::Lint::EndAlignment, :config do
   subject(:cop) { described_class.new(config) }
-  let(:cop_config) { {} }
   let(:cop_config) { { 'AlignWith' => 'keyword' } }
   let(:opposite) do
     cop_config['AlignWith'] == 'keyword' ? 'variable' : 'keyword'
   end
 
-  shared_examples 'misaligned' do |alignment_base, arg, end_kw, name|
+  shared_examples 'misaligned' do |prefix, alignment_base, arg, end_kw, name|
     name ||= alignment_base
     it "registers an offense for mismatched #{name} ... end" do
-      inspect_source(cop, ["#{alignment_base} #{arg}",
+      inspect_source(cop, ["#{prefix}#{alignment_base} #{arg}",
                            end_kw])
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages.first)
@@ -32,14 +31,14 @@ describe Rubocop::Cop::Lint::EndAlignment, :config do
     end
   end
 
-  include_examples 'misaligned', 'class',  'Test',      '  end'
-  include_examples 'misaligned', 'module', 'Test',      '  end'
-  include_examples 'misaligned', 'def',    'test',      '  end'
-  include_examples 'misaligned', 'def',    'Test.test', '  end', 'defs'
-  include_examples 'misaligned', 'if',     'test',      '  end'
-  include_examples 'misaligned', 'unless', 'test',      '  end'
-  include_examples 'misaligned', 'while',  'test',      '  end'
-  include_examples 'misaligned', 'until',  'test',      '  end'
+  include_examples 'misaligned', '', 'class',  'Test',      '  end'
+  include_examples 'misaligned', '', 'module', 'Test',      '  end'
+  include_examples 'misaligned', '', 'def',    'test',      '  end'
+  include_examples 'misaligned', '', 'def',    'Test.test', '  end', 'defs'
+  include_examples 'misaligned', '', 'if',     'test',      '  end'
+  include_examples 'misaligned', '', 'unless', 'test',      '  end'
+  include_examples 'misaligned', '', 'while',  'test',      '  end'
+  include_examples 'misaligned', '', 'until',  'test',      '  end'
 
   include_examples 'aligned', 'class',  'Test',      'end'
   include_examples 'aligned', 'module', 'Test',      'end'
@@ -56,16 +55,16 @@ describe Rubocop::Cop::Lint::EndAlignment, :config do
     include_examples 'aligned', 'private def',         'test', 'end'
     include_examples 'aligned', 'module_function def', 'test', 'end'
 
-    include_examples('misaligned',
+    include_examples('misaligned', '',
                      'public def', 'test',
                      '       end')
-    include_examples('misaligned',
+    include_examples('misaligned', '',
                      'protected def', 'test',
                      '          end')
-    include_examples('misaligned',
+    include_examples('misaligned', '',
                      'private def', 'test',
                      '        end')
-    include_examples('misaligned',
+    include_examples('misaligned', '',
                      'module_function def', 'test',
                      '                end')
   end
@@ -89,17 +88,17 @@ describe Rubocop::Cop::Lint::EndAlignment, :config do
                          'end'])
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages.first)
-      .to eq('end at 6, 0 is not aligned with y = if at 4, 4')
+      .to eq('end at 6, 0 is not aligned with if at 4, 4')
     expect(cop.highlights.first).to eq('end')
     expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
   end
 
   context 'regarding assignment' do
     context 'when AlignWith is keyword' do
-      include_examples 'misaligned', 'var = if',     'test', 'end'
-      include_examples 'misaligned', 'var = unless', 'test', 'end'
-      include_examples 'misaligned', 'var = while',  'test', 'end'
-      include_examples 'misaligned', 'var = until',  'test', 'end'
+      include_examples 'misaligned', 'var = ', 'if',     'test', 'end'
+      include_examples 'misaligned', 'var = ', 'unless', 'test', 'end'
+      include_examples 'misaligned', 'var = ', 'while',  'test', 'end'
+      include_examples 'misaligned', 'var = ', 'until',  'test', 'end'
 
       include_examples 'aligned', 'var = if',     'test', '      end'
       include_examples 'aligned', 'var = unless', 'test', '      end'
@@ -117,11 +116,11 @@ describe Rubocop::Cop::Lint::EndAlignment, :config do
       include_examples 'aligned', 'var = until',  'test', 'end.abc.join("")'
       include_examples 'aligned', 'var = until',  'test', 'end.abc.tap {}'
 
-      include_examples 'misaligned', 'var = if',     'test', '      end'
-      include_examples 'misaligned', 'var = unless', 'test', '      end'
-      include_examples 'misaligned', 'var = while',  'test', '      end'
-      include_examples 'misaligned', 'var = until',  'test', '      end'
-      include_examples 'misaligned', 'var = until',  'test', '      end.join'
+      include_examples 'misaligned', '', 'var = if',     'test', '      end'
+      include_examples 'misaligned', '', 'var = unless', 'test', '      end'
+      include_examples 'misaligned', '', 'var = while',  'test', '      end'
+      include_examples 'misaligned', '', 'var = until',  'test', '      end'
+      include_examples 'misaligned', '', 'var = until',  'test', '      end.j'
 
       include_examples 'aligned', '@var = if',  'test', 'end'
       include_examples 'aligned', '@@var = if', 'test', 'end'


### PR DESCRIPTION
The `var =` was incorrectly included in the message.  For example:

```
/tmp/a.rb:3:1: W: EndAlignment: end at 3, 0 is not aligned with var = if at 1, 6
end
^^^
```
