### PR TITLE
Add 'Delimiters' parameter to WordArray cop autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * New cop `SelfAssignment` checks for places where the self-assignment shorthand should have been used. ([@bbatsov][])
 * New Rails cop `ActionFilter` enforces the use of `_filter` or `_action` action filter methods. ([@bbatsov][])
 * New Rails cop `ScopeArgs` makes sure you invoke the `scope` method properly. ([@bbatsov][])
+* Add configuration option `'Delimiters'` to `WordArray` cop to allow for autocorrecting with delimiters than `(` and `)`. ([@hannestyden][])
 * [#743](https://github.com/bbatsov/rubocop/issues/743): `SingleLineMethods` cop does auto-correction. ([@jonas054][])
 * [#743](https://github.com/bbatsov/rubocop/issues/743): `Semicolon` cop does auto-correction. ([@jonas054][])
 * [#743](https://github.com/bbatsov/rubocop/issues/743): `EmptyLineBetweenDefs` cop does auto-correction. ([@jonas054][])
@@ -732,3 +733,4 @@
 [@scottmatthewman]: https://github.com/scottmatthewman
 [@ma2gedev]: http://github.com/ma2gedev
 [@jeremyolliver]: https://github.com/jeremyolliver
+[@hannestyden]: https://github.com/hannestyden

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -54,6 +54,12 @@ module Rubocop
           cop_config['MinSize']
         end
 
+        def delimiters
+          return @__delimiters if defined?(@delimiters)
+          default = '()'
+          @__delimiters = (cop_config['Delimiters'] || default).split(//)
+        end
+
         def autocorrect(node)
           sb = node.loc.expression.source_buffer
           interpolated = false
@@ -73,7 +79,10 @@ module Rubocop
           char = interpolated ? 'W' : 'w'
 
           @corrections << lambda do |corrector|
-            corrector.replace(node.loc.expression, "%#{char}(#{contents})")
+            corrector.replace(
+              node.loc.expression,
+              "%#{char}#{delimiters.first}#{contents}#{delimiters.last}"
+            )
           end
         end
 

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -85,13 +85,29 @@ describe Rubocop::Cop::Style::WordArray, :config do
     expect(cop.offenses.size).to eq(1)
   end
 
-  it 'auto-corrects an array of words' do
-    new_source = autocorrect_source(cop, "['one', %q(two), 'three']")
-    expect(new_source).to eq('%w(one two three)')
+  context 'with default configuration' do
+    it 'auto-corrects an array of words' do
+      new_source = autocorrect_source(cop, "['one', %q(two), 'three']")
+      expect(new_source).to eq('%w(one two three)')
+    end
+
+    it 'auto-corrects an array of words and character constants' do
+      new_source = autocorrect_source(cop, '[%{one}, %Q(two), ?\n, ?\t]')
+      expect(new_source).to eq('%W(one two \n \t)')
+    end
   end
 
-  it 'auto-corrects an array of words and character constants' do
-    new_source = autocorrect_source(cop, '[%{one}, %Q(two), ?\n, ?\t]')
-    expect(new_source).to eq('%W(one two \n \t)')
+  context 'with custom configuration' do
+    let(:cop_config) { { 'Delimiters' => '[]' } }
+
+    it 'auto-corrects an array of words' do
+      new_source = autocorrect_source(cop, "['one', %q(two), 'three']")
+      expect(new_source).to eq('%w[one two three]')
+    end
+
+    it 'auto-corrects an array of words and character constants' do
+      new_source = autocorrect_source(cop, '[%{one}, %Q(two), ?\n, ?\t]')
+      expect(new_source).to eq('%W[one two \n \t]')
+    end
   end
 end


### PR DESCRIPTION
This changes allows for configuring the autocorrect behavior of the `WordArray` cop. Prior to this change it only supported to correct to word arrays delimited by parentheses. After this change a use can change this setting in order to make the cop autocorrect to any pair of delimiters.
