### PR TITLE
[Fix #832] Fix SpaceInsideHashLiteralBraces auto-correction bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Handle `case` conditions in `LiteralInCondition`. ([@bbatsov][])
 * [#822](https://github.com/bbatsov/rubocop/issues/822): Fix a false positive in `DotPosition` when enforced style is set to `trailing`. ([@bbatsov][])
 * Handle properly dynamic strings in `LineEndConcatenation`. ([@bbatsov][])
+* [#832](https://github.com/bbatsov/rubocop/issues/832): Fix auto-correction interference problem between `BracesAroundHashParameters` and `SpaceInsideHashLiteralBraces`. ([@jonas054][])
 
 ## 0.18.1 (02/02/2014)
 

--- a/lib/rubocop/cop/style/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/style/space_inside_hash_literal_braces.rb
@@ -66,10 +66,17 @@ module Rubocop
 
         def autocorrect(range)
           @corrections << lambda do |corrector|
+            # It is possible that BracesAroundHashParameters will remove the
+            # braces while this cop inserts spaces. This can lead to unwanted
+            # changes to the inspected code.  If we replace the brace with a
+            # brace plus space (rather than just inserting a space), then any
+            # removal of the same brace will give us a clobbering error. This
+            # in turn will make RuboCop fall back on cop-by-cop
+            # auto-correction.  Problem solved.
             case range.source
             when /\s/ then corrector.remove(range)
-            when '{' then corrector.insert_after(range, ' ')
-            else corrector.insert_before(range, ' ')
+            when '{' then corrector.replace(range, '{ ')
+            else corrector.replace(range, ' }')
             end
           end
         end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -48,6 +48,31 @@ describe Rubocop::CLI, :isolated_environment do
                   'end'].join("\n") + "\n")
       end
 
+      it 'can handle spaces when removing braces' do
+        create_file('example.rb',
+                    ['# encoding: utf-8',
+                     "assert_post_status_code 400, 's', {:type => 'bad'}"])
+        expect(cli.run(%w(--auto-correct --format emacs))).to eq(1)
+        expect(IO.read('example.rb'))
+          .to eq(['# encoding: utf-8',
+                  "assert_post_status_code 400, 's', type: 'bad'",
+                  ''].join("\n"))
+        e = abs('example.rb')
+        expect($stdout.string)
+          .to eq(["#{e}:2:35: C: [Corrected] Redundant curly braces around " \
+                  "a hash parameter.",
+                  "#{e}:2:35: C: [Corrected] Use the new Ruby 1.9 hash " \
+                  "syntax.",
+                  # TODO: Don't report that a problem is corrected when it
+                  # actually went away due to another correction.
+                  "#{e}:2:35: C: [Corrected] Space inside { missing.",
+                  # TODO: Don't report duplicates (HashSyntax in this case).
+                  "#{e}:2:36: C: [Corrected] Use the new Ruby 1.9 hash " \
+                  "syntax.",
+                  "#{e}:2:50: C: [Corrected] Space inside } missing.",
+                  ''].join("\n"))
+      end
+
       # A case where two cops, EmptyLinesAroundBody and EmptyLines, try to
       # remove the same line in autocorrect.
       it 'can correct two empty lines at end of class body' do


### PR DESCRIPTION
`SpaceInsideHashLiteralBraces` and `BracesAroundHashParameters` need to work together.
