### PR TITLE
Fix percent literal delimiter multiline autocorrect

### DIFF
--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -241,5 +241,10 @@ describe Rubocop::Cop::Style::PercentLiteralDelimiters, :config do
       new_source = autocorrect_source(cop, original_source)
       expect(new_source).to eq('%r[.*]i')
     end
+
+    it 'preserves line breaks when fixing a multiline array' do
+      new_source = autocorrect_source(cop, ['%w(', 'some', 'words', ')'])
+      expect(new_source).to eq("%w[\nsome\nwords\n]")
+    end
   end
 end


### PR DESCRIPTION
This change preserves line breaks when correcting `%`-literals.
