### PR TITLE
Handle case statements with nothing after the case keyword

### DIFF
--- a/lib/rubocop/cop/lint/literal_in_condition.rb
+++ b/lib/rubocop/cop/lint/literal_in_condition.rb
@@ -44,7 +44,14 @@ module Rubocop
         end
 
         def on_case(node)
-          check_for_literal(node)
+          cond, *whens, _else = *node
+          if cond
+            handle_node(cond)
+          else
+            whens.each do |when_node|
+              check_for_literal(when_node)
+            end
+          end
         end
 
         def message(node)

--- a/spec/rubocop/cop/lint/literal_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_condition_spec.rb
@@ -42,6 +42,25 @@ describe Rubocop::Cop::Lint::LiteralInCondition do
       expect(cop.offenses.size).to eq(1)
     end
 
+    it "registers an offense for literal #{lit} in a when " \
+       'of a case without anything after case keyword' do
+      inspect_source(cop,
+                     ['case',
+                      "when #{lit} then top",
+                      'end'])
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it "accepts literal #{lit} in a when of a case with " \
+       'something after case keyword' do
+      inspect_source(cop,
+                     ['case x',
+                      "when #{lit} then top",
+                      'end'
+                     ])
+      expect(cop.offenses).to be_empty
+    end
+
     it "registers an offense for literal #{lit} in &&" do
       inspect_source(cop,
                      ["if x && #{lit}",


### PR DESCRIPTION
Previously, rubocop checked for literals after the case keyword

Now it knows how to handle case statements with nothing after the case keyword, by checking for literals after the when keyword.
