### PR TITLE
[Fix #848] Make --show-cops print current configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * Fix bug in auto-correction of alignment so that only space can be removed. ([@jonas054][])
 * Fix bug in `IndentationWidth` auto-correction so it doesn't correct things that `IndentationConsistency` should correct. ([@jonas054][])
 * [#847](https://github.com/bbatsov/rubocop/issues/847): Fix bug in `RegexpLiteral` concerning `--auto-gen-config`. ([@jonas054][])
+* [#848](https://github.com/bbatsov/rubocop/issues/848): Fix bug in `--show-cops` that made it print the default configuration rather than the current configuration. ([@jonas054][])
 
 ## 0.18.1 (02/02/2014)
 

--- a/lib/rubocop/config_store.rb
+++ b/lib/rubocop/config_store.rb
@@ -26,10 +26,14 @@ module Rubocop
                                                         options_config)
     end
 
-    def for(file)
+    def for(file_or_dir)
       return @options_config if @options_config
 
-      dir = File.dirname(file)
+      dir = if File.directory?(file_or_dir)
+              file_or_dir
+            else
+              File.dirname(file_or_dir)
+            end
       @path_cache[dir] ||= ConfigLoader.configuration_file_for(dir)
       path = @path_cache[dir]
       @object_cache[path] ||= begin

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -560,6 +560,8 @@ describe Rubocop::CLI, :isolated_environment do
       let(:stdout) { $stdout.string }
 
       before do
+        create_file('.rubocop.yml', ['LineLength:',
+                                     '  Max: 110'])
         expect { cli.run ['--show-cops'] + cop_list }.to exit_with_code(0)
       end
 


### PR DESCRIPTION
A bug made it show the configuration for the parent directory of the
current directory (usually that would be the default configuration).
