### PR TITLE
Typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,8 +538,7 @@ $ rubocop --format offences
 1    IndentationWidth
 1    AvoidPerlBackrefs
 1    ColonMethodCall
---
-134  Total
+
 ```
 
 ### Custom Formatters


### PR DESCRIPTION
Hi, this fixes some typos in the README.

The offences count formatter doesn't output any totals. Made this also clear in the docs.
