### PR TITLE
Add TextMate2 as an editor to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,14 +613,16 @@ If you're a ST user you might find the
 useful.
 
 ### Brackets
+
 The [brackets-rubocop](https://github.com/smockle/brackets-rubocop)
 extension displays RuboCop results in Brackets.
 It can be installed via the extension manager in Brackets.
 
 ### TextMate2
+
 The [textmate2-rubocop](https://github.com/mrdougal/textmate2-rubocop)
 bundle displays formatted RuboCop results in a new window.
-Installation instructions can be found [here](https://github.com/mrdougal/textmate2-rubocop#installation)
+Installation instructions can be found [here](https://github.com/mrdougal/textmate2-rubocop#installation).
 
 ### Other Editors
 


### PR DESCRIPTION
I have created a TextMate2 bundle for running and displaying analysis from rubocop.
- update to the readme, with a link to [the bundle source](https://github.com/mrdougal/textmate2-rubocop). 
