### PR TITLE
Add static alignment style to AlignParameters cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * New cop `PercentLiteralDelimiters` enforces consistent usage of `%`-literal delimiters. ([@hannestyden][])
 * New Rails cop `ActionFilter` enforces the use of `_filter` or `_action` action filter methods. ([@bbatsov][])
 * New Rails cop `ScopeArgs` makes sure you invoke the `scope` method properly. ([@bbatsov][])
+* Add `with_fixed_indentation` style to `AlignParameters` cop. ([@hannestyden][])
 * [#743](https://github.com/bbatsov/rubocop/issues/743): `SingleLineMethods` cop does auto-correction. ([@jonas054][])
 * [#743](https://github.com/bbatsov/rubocop/issues/743): `Semicolon` cop does auto-correction. ([@jonas054][])
 * [#743](https://github.com/bbatsov/rubocop/issues/743): `EmptyLineBetweenDefs` cop does auto-correction. ([@jonas054][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -51,6 +51,25 @@ AlignHash:
   #   bb: 1
   EnforcedColonStyle: key
 
+AlignParameters:
+  # Alignment of parameters in multi-line method calls.
+  #
+  # The `with_first_parameter` style aligns the following lines along the same column
+  # as the first parameter.
+  #
+  #     method_call(a,
+  #                 b)
+  #
+  # The `with_fixed_indentation` style alignes the following lines with one
+  # level of indenation relative to the start of the line with the method call.
+  #
+  #     method_call(a,
+  #       b)
+  EnforcedStyle: with_first_parameter
+  SupportedStyles:
+    - with_first_parameter
+    - with_fixed_indentation
+
 # Allow safe assignment in conditions.
 AssignmentInCondition:
   AllowSafeAssignment: true

--- a/lib/rubocop/cop/mixin/autocorrect_alignment.rb
+++ b/lib/rubocop/cop/mixin/autocorrect_alignment.rb
@@ -6,10 +6,11 @@ module Rubocop
     # the left or to the right, amount being determined by the instance
     # variable @column_delta.
     module AutocorrectAlignment
-      def check_alignment(items)
+      def check_alignment(items, base_column = nil)
+        base_column ||= items.first.loc.column unless items.empty?
         items.each_cons(2) do |prev, current|
           if current.loc.line > prev.loc.line && start_of_line?(current.loc)
-            @column_delta = items.first.loc.column - current.loc.column
+            @column_delta = base_column - current.loc.column
             add_offense(current, :expression) if @column_delta != 0
           end
         end

--- a/lib/rubocop/cop/style/align_parameters.rb
+++ b/lib/rubocop/cop/style/align_parameters.rb
@@ -17,7 +17,21 @@ module Rubocop
           return if method == :[]=
           return if args.size <= 1
 
-          check_alignment(args)
+          check_alignment(args, base_column(node, args))
+        end
+
+        private
+
+        def fixed_indentation?
+          cop_config['EnforcedStyle'] == 'with_fixed_indentation'
+        end
+
+        def base_column(node, args)
+          if fixed_indentation?
+            node.loc.column + 2
+          else
+            args.first.loc.column
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/align_parameters_spec.rb
+++ b/spec/rubocop/cop/style/align_parameters_spec.rb
@@ -2,221 +2,294 @@
 
 require 'spec_helper'
 
-describe Rubocop::Cop::Style::AlignParameters do
-  subject(:cop) { described_class.new }
+describe Rubocop::Cop::Style::AlignParameters, :config do
+  subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense for parameters with single indent' do
-    inspect_source(cop, ['function(a,',
-                         '  if b then c else d end)'])
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['if b then c else d end'])
+  context 'aligned with first parameter' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'with_first_parameter'
+      }
+    end
+
+    it 'registers an offense for parameters with single indent' do
+      inspect_source(cop, ['function(a,',
+                           '  if b then c else d end)'])
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.highlights).to eq(['if b then c else d end'])
+    end
+
+    it 'registers an offense for parameters with double indent' do
+      inspect_source(cop, ['function(a,',
+                           '    if b then c else d end)'])
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'accepts multiline []= method call' do
+      inspect_source(cop, ['Test.config["something"] =',
+                           ' true'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts correctly aligned parameters' do
+      inspect_source(cop, ['function(a,',
+                           '         0, 1,',
+                           '         (x + y),',
+                           '         if b then c else d end)'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts calls that only span one line' do
+      inspect_source(cop, ['find(path, s, @special[sexp[0]])'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it "doesn't get confused by a symbol argument" do
+      inspect_source(cop, ['add_offense(index,',
+                           '            MSG % kind)'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it "doesn't get confused by splat operator" do
+      inspect_source(cop, ['func1(*a,',
+                           '      *b,',
+                           '      c)',
+                           'func2(a,',
+                           '     *b,',
+                           '      c)',
+                           'func3(*a)'
+                          ])
+      expect(cop.offenses.map(&:to_s))
+        .to eq(['C:  5:  6: Align the parameters of a method call if ' \
+                'they span more than one line.'])
+      expect(cop.highlights).to eq(['*b'])
+    end
+
+    it "doesn't get confused by extra comma at the end" do
+      inspect_source(cop, ['func1(a,',
+                           '     b,)'])
+      expect(cop.offenses.map(&:to_s))
+        .to eq(['C:  2:  6: Align the parameters of a method call if ' \
+                'they span more than one line.'])
+      expect(cop.highlights).to eq(['b'])
+    end
+
+    it 'can handle a correctly aligned string literal as first argument' do
+      inspect_source(cop, ['add_offense(x,',
+                           '            a)'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'can handle a string literal as other argument' do
+      inspect_source(cop, ['add_offense(',
+                           '            "", a)'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it "doesn't get confused by a line break inside a parameter" do
+      inspect_source(cop, ['read(path, { headers:    true,',
+                           '             converters: :numeric })'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it "doesn't get confused by symbols with embedded expressions" do
+      inspect_source(cop, ['send(:"#{name}_comments_path")'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it "doesn't get confused by regexen with embedded expressions" do
+      inspect_source(cop, ['a(/#{name}/)'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts braceless hashes' do
+      inspect_source(cop, ['run(collection, :entry_name => label,',
+                           '                :paginator  => paginator)'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts the first parameter being on a new row' do
+      inspect_source(cop, ['  match(',
+                           '    a,',
+                           '    b',
+                           '  )'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'can handle heredoc strings' do
+      inspect_source(cop, ['class_eval(<<-EOS, __FILE__, __LINE__ + 1)',
+                           '            def run_#{name}_callbacks(*args)',
+                           '              a = 1',
+                           '              return value',
+                           '            end',
+                           '            EOS'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'can handle a method call within a method call' do
+      inspect_source(cop, ['a(a1,',
+                           '  b(b1,',
+                           '    b2),',
+                           '  a2)'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'can handle a call embedded in a string' do
+      inspect_source(cop, ['model("#{index(name)}", child)'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'can handle do-end' do
+      inspect_source(cop, ['      run(lambda do |e|',
+                           "        w = e['warden']",
+                           '      end)'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'can handle a call with a block inside another call' do
+      src = ['new(table_name,',
+             '    exec_query("info(\'#{row[\'name\']}\')").map { |col|',
+             "      col['name']",
+             '    })']
+      inspect_source(cop, src)
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'can handle a ternary condition with a block reference' do
+      inspect_source(cop, ['cond ? a : func(&b)'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'can handle parentheses used with no parameters' do
+      inspect_source(cop, ['func()'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'can handle a multiline hash as second parameter' do
+      inspect_source(cop, ['tag(:input, {',
+                           '  :value => value',
+                           '})'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'can handle method calls without parentheses' do
+      inspect_source(cop, ['a(b c, d)'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'can handle other method calls without parentheses' do
+      src = ['chars(Unicode.apply_mapping @wrapped_string, :uppercase)']
+      inspect_source(cop, src)
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'auto-corrects alignment' do
+      new_source = autocorrect_source(cop, ['func(a,',
+                                            '       b,',
+                                            'c)'])
+      expect(new_source).to eq(['func(a,',
+                                '     b,',
+                                '     c)'].join("\n"))
+    end
+
+    it 'auto-corrects each line of a multi-line parameter to the right' do
+      new_source =
+        autocorrect_source(cop,
+                           ['create :transaction, :closed,',
+                            '      account:          account,',
+                            '      open_price:       1.29,',
+                            '      close_price:      1.30'])
+      expect(new_source)
+        .to eq(['create :transaction, :closed,',
+                '       account:          account,',
+                '       open_price:       1.29,',
+                '       close_price:      1.30'].join("\n"))
+    end
+
+    it 'auto-corrects each line of a multi-line parameter to the left' do
+      new_source =
+        autocorrect_source(cop,
+                           ['create :transaction, :closed,',
+                            '         account:          account,',
+                            '         open_price:       1.29,',
+                            '         close_price:      1.30'])
+      expect(new_source)
+        .to eq(['create :transaction, :closed,',
+                '       account:          account,',
+                '       open_price:       1.29,',
+                '       close_price:      1.30'].join("\n"))
+    end
+
+    it 'auto-corrects only parameters that begin a line' do
+      original_source = ['foo(:bar, {',
+                         '    whiz: 2, bang: 3 }, option: 3)']
+      new_source = autocorrect_source(cop, original_source)
+      expect(new_source).to eq(original_source.join("\n"))
+    end
   end
 
-  it 'registers an offense for parameters with double indent' do
-    inspect_source(cop, ['function(a,',
-                         '    if b then c else d end)'])
-    expect(cop.offenses.size).to eq(1)
-  end
+  context 'aligned with fixed indentation' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'with_fixed_indentation'
+      }
+    end
 
-  it 'accepts multiline []= method call' do
-    inspect_source(cop, ['Test.config["something"] =',
-                         ' true'])
-    expect(cop.offenses).to be_empty
-  end
+    let(:correct_source) do
+      [
+        'create :transaction, :closed,',
+        '  account:     account,',
+        '  open_price:  1.29,',
+        '  close_price: 1.30'
+      ]
+    end
 
-  it 'accepts correctly aligned parameters' do
-    inspect_source(cop, ['function(a,',
-                         '         0, 1,',
-                         '         (x + y),',
-                         '         if b then c else d end)'])
-    expect(cop.offenses).to be_empty
-  end
+    it 'does not autocorrect correct source' do
+      expect(autocorrect_source(cop, correct_source))
+        .to eq(correct_source.join("\n"))
+    end
 
-  it 'accepts calls that only span one line' do
-    inspect_source(cop, ['find(path, s, @special[sexp[0]])'])
-    expect(cop.offenses).to be_empty
-  end
+    it 'autocorrects by outdenting when indented too far' do
+      original_source = [
+        'create :transaction, :closed,',
+        '       account:     account,',
+        '       open_price:  1.29,',
+        '       close_price: 1.30'
+      ]
 
-  it "doesn't get confused by a symbol argument" do
-    inspect_source(cop, ['add_offense(index,',
-                         '            MSG % kind)'])
-    expect(cop.offenses).to be_empty
-  end
+      expect(autocorrect_source(cop, original_source))
+        .to eq(correct_source.join("\n"))
+    end
 
-  it "doesn't get confused by splat operator" do
-    inspect_source(cop, ['func1(*a,',
-                         '      *b,',
-                         '      c)',
-                         'func2(a,',
-                         '     *b,',
-                         '      c)',
-                         'func3(*a)'
-                        ])
-    expect(cop.offenses.map(&:to_s))
-      .to eq(['C:  5:  6: Align the parameters of a method call if ' \
-              'they span more than one line.'])
-    expect(cop.highlights).to eq(['*b'])
-  end
+    it 'autocorrects by indenting when not indented' do
+      original_source = [
+        'create :transaction, :closed,',
+        'account:     account,',
+        'open_price:  1.29,',
+        'close_price: 1.30'
+      ]
 
-  it "doesn't get confused by extra comma at the end" do
-    inspect_source(cop, ['func1(a,',
-                         '     b,)'])
-    expect(cop.offenses.map(&:to_s))
-      .to eq(['C:  2:  6: Align the parameters of a method call if ' \
-              'they span more than one line.'])
-    expect(cop.highlights).to eq(['b'])
-  end
+      expect(autocorrect_source(cop, original_source))
+        .to eq(correct_source.join("\n"))
+    end
 
-  it 'can handle a correctly aligned string literal as first argument' do
-    inspect_source(cop, ['add_offense(x,',
-                         '            a)'])
-    expect(cop.offenses).to be_empty
-  end
+    it 'autocorrects when first line is indented' do
+      original_source = [
+        '  create :transaction, :closed,',
+        '  account:     account,',
+        '  open_price:  1.29,',
+        '  close_price: 1.30'
+      ]
 
-  it 'can handle a string literal as other argument' do
-    inspect_source(cop, ['add_offense(',
-                         '            "", a)'])
-    expect(cop.offenses).to be_empty
-  end
+      correct_source = [
+        '  create :transaction, :closed,',
+        '    account:     account,',
+        '    open_price:  1.29,',
+        '    close_price: 1.30'
+      ]
 
-  it "doesn't get confused by a line break inside a parameter" do
-    inspect_source(cop, ['read(path, { headers:    true,',
-                         '             converters: :numeric })'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it "doesn't get confused by symbols with embedded expressions" do
-    inspect_source(cop, ['send(:"#{name}_comments_path")'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it "doesn't get confused by regexen with embedded expressions" do
-    inspect_source(cop, ['a(/#{name}/)'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'accepts braceless hashes' do
-    inspect_source(cop, ['run(collection, :entry_name => label,',
-                         '                :paginator  => paginator)'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'accepts the first parameter being on a new row' do
-    inspect_source(cop, ['  match(',
-                         '    a,',
-                         '    b',
-                         '  )'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'can handle heredoc strings' do
-    inspect_source(cop, ['class_eval(<<-EOS, __FILE__, __LINE__ + 1)',
-                         '            def run_#{name}_callbacks(*args)',
-                         '              a = 1',
-                         '              return value',
-                         '            end',
-                         '            EOS'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'can handle a method call within a method call' do
-    inspect_source(cop, ['a(a1,',
-                         '  b(b1,',
-                         '    b2),',
-                         '  a2)'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'can handle a call embedded in a string' do
-    inspect_source(cop, ['model("#{index(name)}", child)'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'can handle do-end' do
-    inspect_source(cop, ['      run(lambda do |e|',
-                         "        w = e['warden']",
-                         '      end)'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'can handle a call with a block inside another call' do
-    src = ['new(table_name,',
-           '    exec_query("info(\'#{row[\'name\']}\')").map { |col|',
-           "      col['name']",
-           '    })']
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'can handle a ternary condition with a block reference' do
-    inspect_source(cop, ['cond ? a : func(&b)'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'can handle parentheses used with no parameters' do
-    inspect_source(cop, ['func()'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'can handle a multiline hash as second parameter' do
-    inspect_source(cop, ['tag(:input, {',
-                         '  :value => value',
-                         '})'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'can handle method calls without parentheses' do
-    inspect_source(cop, ['a(b c, d)'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'can handle other method calls without parentheses' do
-    src = ['chars(Unicode.apply_mapping @wrapped_string, :uppercase)']
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'auto-corrects alignment' do
-    new_source = autocorrect_source(cop, ['func(a,',
-                                          '       b,',
-                                          'c)'])
-    expect(new_source).to eq(['func(a,',
-                              '     b,',
-                              '     c)'].join("\n"))
-  end
-
-  it 'auto-corrects each line of a multi-line parameter to the right' do
-    new_source =
-      autocorrect_source(cop,
-                         ['create :transaction, :closed,',
-                          '      account:          account,',
-                          '      open_price:       1.29,',
-                          '      close_price:      1.30'])
-    expect(new_source)
-      .to eq(['create :transaction, :closed,',
-              '       account:          account,',
-              '       open_price:       1.29,',
-              '       close_price:      1.30'].join("\n"))
-  end
-
-  it 'auto-corrects each line of a multi-line parameter to the left' do
-    new_source =
-      autocorrect_source(cop,
-                         ['create :transaction, :closed,',
-                          '         account:          account,',
-                          '         open_price:       1.29,',
-                          '         close_price:      1.30'])
-    expect(new_source)
-      .to eq(['create :transaction, :closed,',
-              '       account:          account,',
-              '       open_price:       1.29,',
-              '       close_price:      1.30'].join("\n"))
-  end
-
-  it 'auto-corrects only parameters that begin a line' do
-    original_source = ['foo(:bar, {',
-                       '    whiz: 2, bang: 3 }, option: 3)']
-    new_source = autocorrect_source(cop, original_source)
-    expect(new_source).to eq(original_source.join("\n"))
+      expect(autocorrect_source(cop, original_source))
+        .to eq(correct_source.join("\n"))
+    end
   end
 end


### PR DESCRIPTION
This new style allows having static indentation levels for multi-line method call parameters.

Example:

``` Ruby
my_method(:first,
  :second,
  :third)
```
