### PR TITLE
Add configuration option to AlignHash cop making it ignore last argument hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * New Rails cop `ActionFilter` enforces the use of `_filter` or `_action` action filter methods. ([@bbatsov][])
 * New Rails cop `ScopeArgs` makes sure you invoke the `scope` method properly. ([@bbatsov][])
 * Add `with_fixed_indentation` style to `AlignParameters` cop. ([@hannestyden][])
+* Add `IgnoreLastArgumentHash` option to `AlignHash` cop. ([@hannestyden][])
 * [#743](https://github.com/bbatsov/rubocop/issues/743): `SingleLineMethods` cop does auto-correction. ([@jonas054][])
 * [#743](https://github.com/bbatsov/rubocop/issues/743): `Semicolon` cop does auto-correction. ([@jonas054][])
 * [#743](https://github.com/bbatsov/rubocop/issues/743): `EmptyLineBetweenDefs` cop does auto-correction. ([@jonas054][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -50,6 +50,43 @@ AlignHash:
   #   a:  0
   #   bb: 1
   EnforcedColonStyle: key
+  # Select whether hashes that are the last argument in a method call should be
+  # inspected? Valid values are:
+  #
+  # always_inspect - Inspect both implicit and explicit hashes.
+  #   Registers and offence for:
+  #     function(a: 1,
+  #       b: 2)
+  #   Registers an offence for:
+  #     function({a: 1,
+  #       b: 2})
+  # always_ignore - Ignore both implicit and explicit hashes.
+  #   Accepts:
+  #     function(a: 1,
+  #       b: 2)
+  #   Accepts:
+  #     function({a: 1,
+  #       b: 2})
+  # ignore_implicit - Ingore only implicit hashes.
+  #   Accepts:
+  #     function(a: 1,
+  #       b: 2)
+  #   Registers an offence for:
+  #     function({a: 1,
+  #       b: 2})
+  # ignore_explicit - Ingore only explicit hashes.
+  #   Accepts:
+  #     function({a: 1,
+  #       b: 2})
+  #   Registers an offence for:
+  #     function(a: 1,
+  #       b: 2)
+  EnforcedLastArgumentHashStyle: always_inspect
+  SupportedLastArgumentHashStyles:
+    - always_inspect
+    - always_ignore
+    - ignore_implicit
+    - ignore_explicit
 
 AlignParameters:
   # Alignment of parameters in multi-line method calls.

--- a/spec/rubocop/cop/style/align_hash_spec.rb
+++ b/spec/rubocop/cop/style/align_hash_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 describe Rubocop::Cop::Style::AlignHash, :config do
+  subject(:cop) { described_class.new(config) }
+
   shared_examples 'not on separate lines' do
     it 'accepts single line hash' do
       inspect_source(cop, 'func(a: 0, bb: 1)')
@@ -16,7 +18,86 @@ describe Rubocop::Cop::Style::AlignHash, :config do
     end
   end
 
-  subject(:cop) { described_class.new(config) }
+  context 'always inspect last argument hash' do
+    let(:cop_config) do
+      {
+        'EnforcedLastArgumentHashStyle' => 'always_inspect'
+      }
+    end
+
+    it 'registers offence for misaligned keys in implicit hash' do
+      inspect_source(cop, ['func(a: 0,',
+                           '  b: 1)'])
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'registers offence for misaligned keys in explicit hash' do
+      inspect_source(cop, ['func({a: 0,',
+                           '  b: 1})'])
+      expect(cop.offenses.size).to eq(1)
+    end
+  end
+
+  context 'always ignore last argument hash' do
+    let(:cop_config) do
+      {
+        'EnforcedLastArgumentHashStyle' => 'always_ignore'
+      }
+    end
+
+    it 'accepts misaligned keys in implicit hash' do
+      inspect_source(cop, ['func(a: 0,',
+                           '  b: 1)'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts misaligned keys in explicit hash' do
+      inspect_source(cop, ['func({a: 0,',
+                           '  b: 1})'])
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'ignore implicit last argument hash' do
+    let(:cop_config) do
+      {
+        'EnforcedLastArgumentHashStyle' => 'ignore_implicit'
+      }
+    end
+
+    it 'accepts misaligned keys in implicit hash' do
+      inspect_source(cop, ['func(a: 0,',
+                           '  b: 1)'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers offence for misaligned keys in explicit hash' do
+      inspect_source(cop, ['func({a: 0,',
+                           '  b: 1})'])
+      expect(cop.offenses.size).to eq(1)
+    end
+  end
+
+  context 'ignore explicit last argument hash' do
+    let(:cop_config) do
+      {
+        'EnforcedLastArgumentHashStyle' => 'ignore_explicit'
+      }
+    end
+
+    it 'registers offence for misaligned keys in implicit hash' do
+      inspect_source(cop, ['func(a: 0,',
+                           '  b: 1)'])
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'accepts misaligned keys in explicit hash' do
+      inspect_source(cop, ['func({a: 0,',
+                           '  b: 1})'])
+      expect(cop.offenses).to be_empty
+    end
+  end
+
   let(:cop_config) do
     {
       'EnforcedHashRocketStyle' => 'key',
@@ -62,7 +143,7 @@ describe Rubocop::Cop::Style::AlignHash, :config do
       expect(cop.highlights).to eq(["'bbb' => 1"])
     end
 
-    context 'with braceless hash as last argument' do
+    context 'with implicit hash as last argument' do
       it 'registers an offense for misaligned hash keys' do
         inspect_source(cop, ['func(a: 0,',
                              '  b: 1)'])


### PR DESCRIPTION
This change adds a configuration option to the `AlignHash` cop making it ignore last argument hashes.
