### PR TITLE
Deal with all cli options that result in exit together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+* Fix a bug where multiple cli options that result in exit can be specified at once (e.g. -vV -v -show-cops). ([@jkogara][])
+
 ## 0.19.0 (13/03/2014)
 
 ### New features
@@ -757,3 +760,4 @@
 [@jeremyolliver]: https://github.com/jeremyolliver
 [@hannestyden]: https://github.com/hannestyden
 [@geniou]: https://github.com/geniou
+[@jkogara]: https://github.com/jkogara

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -52,10 +52,7 @@ module Rubocop
     private
 
     def act_on_options(args)
-      if @options[:show_cops]
-        print_available_cops
-        exit(0)
-      end
+      handle_exiting_options
 
       ConfigLoader.debug = @options[:debug]
       ConfigLoader.auto_gen_config = @options[:auto_gen_config]
@@ -63,10 +60,15 @@ module Rubocop
       @config_store.options_config = @options[:config] if @options[:config]
 
       Rainbow.enabled = false unless @options[:color]
+    end
+
+    def handle_exiting_options
+      return unless Options::EXITING_OPTIONS.any? { |o| @options.key? o }
 
       puts Rubocop::Version.version(false) if @options[:version]
       puts Rubocop::Version.version(true) if @options[:verbose_version]
-      exit(0) if @options[:version] || @options[:verbose_version]
+      print_available_cops if @options[:show_cops]
+      exit(0)
     end
 
     def print_available_cops

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -6,6 +6,7 @@ module Rubocop
   # This class handles command line options.
   class Options
     DEFAULT_FORMATTER = 'progress'
+    EXITING_OPTIONS = [:version, :verbose_version, :show_cops]
 
     def initialize
       @options = {}
@@ -33,6 +34,10 @@ module Rubocop
         add_flags_with_optional_args(opts)
         add_boolean_flags(opts)
       end.parse!(args)
+
+      if (incompat = @options.keys & EXITING_OPTIONS).size > 1
+        fail ArgumentError, "Incompatible cli options: #{incompat.inspect}"
+      end
 
       [@options, args]
     end

--- a/rubocop-todo.yml
+++ b/rubocop-todo.yml
@@ -8,7 +8,7 @@
 # Offense count: 6
 # Configuration parameters: CountComments.
 ClassLength:
-  Max: 125
+  Max: 130
 
 # Offense count: 16
 CyclomaticComplexity:

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -99,6 +99,33 @@ Usage: rubocop [options] [file1, file2, ...]
       end
     end
 
+    describe 'incompatible cli options' do
+      it 'fails with argument correct error' do
+        msg = 'Incompatible cli options: [:version, :verbose_version]'
+        expect { options.parse %w(-vV) }
+          .to raise_error(ArgumentError, msg)
+      end
+
+      it 'fails with argument correct error' do
+        msg = 'Incompatible cli options: [:version, :show_cops]'
+        expect { options.parse %w(-v --show-cops) }
+          .to raise_error(ArgumentError, msg)
+      end
+
+      it 'fails with argument correct error' do
+        msg = 'Incompatible cli options: [:verbose_version, :show_cops]'
+        expect { options.parse %w(-V --show-cops) }
+          .to raise_error(ArgumentError, msg)
+      end
+
+      it 'fails with argument correct error' do
+        msg = ['Incompatible cli options: [:version, :verbose_version,',
+               ' :show_cops]'].join
+        expect { options.parse %w(-vV --show-cops) }
+          .to raise_error(ArgumentError, msg)
+      end
+    end
+
     describe '--only' do
       it 'exits with error if an incorrect cop name is passed' do
         expect { options.parse(%w(--only 123)) }


### PR DESCRIPTION
When using rubocop with syntastic vim plugin I've found the `--version` option can take 5+ seconds to return. This commit ensures that any option that results in `exit(0)` is dealt with before any other cli options.
