### PR TITLE
Whitelist the Rakefile and Gemfile from name check

### DIFF
--- a/lib/rubocop/cop/style/file_name.rb
+++ b/lib/rubocop/cop/style/file_name.rb
@@ -9,6 +9,8 @@ module Rubocop
 
         SNAKE_CASE = /^[\da-z_]+$/
 
+        WHITELIST = %w(Rakefile Gemfile)
+
         def investigate(processed_source)
           file_path = processed_source.buffer.name
 
@@ -16,7 +18,7 @@ module Rubocop
 
           basename = File.basename(file_path).sub(/\.[^\.]+$/, '')
 
-          unless basename =~ SNAKE_CASE
+          unless basename =~ SNAKE_CASE || WHITELIST.include?(basename)
             add_offense(nil,
                         source_range(processed_source.buffer,
                                      processed_source[0..0],

--- a/spec/rubocop/cop/style/file_name_spec.rb
+++ b/spec/rubocop/cop/style/file_name_spec.rb
@@ -56,6 +56,15 @@ describe Rubocop::Cop::Style::FileName do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts offense for camelCase file names within whitelist' do
+    source = ['print 1']
+    processed_source = parse_source(source)
+    allow(processed_source.buffer)
+      .to receive(:name).and_return('/some/dir/Rakefile')
+    _investigate(cop, processed_source)
+    expect(cop.offenses).to be_empty
+  end
+
   context 'when the file is specified in AllCops/Includes' do
     let(:includes) { ['**/Gemfile'] }
 


### PR DESCRIPTION
When building a Ruby project it's very common that you'll have a Rakefile and a Gemfile. These files are normally capitalized, which violates the default Rubocop filename checks. This changeset adds a whitelist for base filenames that should _NOT_ be included in the file_name checks.

This works by adding a constant to the FileName class, WHITELIST, which is an Array that contains the whitelisted basenames. Later on, it will only add an offense if the basename is not snake case, and the basename is not Rakefile or Gemfile.

I've updated the tests for this specific use case and have confirmed that all tests pass on my local system.

-Tim
