### PR TITLE
Fix PercentLiteralDelimiters auto-correct for regular expression with interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * [#862](https://github.com/bbatsov/rubocop/issues/862): Fix a bug where single line `rubocop:disable` comments with indentations were treated as multiline cop disabling comments. ([@yujinakayama][])
 * Fix a bug where `rubocop:disable` comments with a cop name including `all` (e.g. `MethodCallParentheses`) were disabling all cops. ([@yujinakayama][])
 * Fix a bug where string and regexp literals including `# rubocop:disable` were confused with real comments. ([@yujinakayama][])
+* [#877](https://github.com/bbatsov/rubocop/issues/877): Fix bug in `PercentLiteralDelimiters` concerning auto-correct of regular expressions with interpolation. ([@hannestyden][])
 
 ## 0.18.1 (02/02/2014)
 

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -236,6 +236,18 @@ describe Rubocop::Cop::Style::PercentLiteralDelimiters, :config do
       expect(new_source).to eq('%r[.*]')
     end
 
+    it 'fixes a string with interpolation' do
+      original_source = '%Q|#{with_interpolation}|'
+      new_source = autocorrect_source(cop, original_source)
+      expect(new_source).to eq('%Q[#{with_interpolation}]')
+    end
+
+    it 'fixes a regular expression with interpolation' do
+      original_source = '%r|#{with_interpolation}|'
+      new_source = autocorrect_source(cop, original_source)
+      expect(new_source).to eq('%r[#{with_interpolation}]')
+    end
+
     it 'fixes a regular expression with option' do
       original_source = '%r(.*)i'
       new_source = autocorrect_source(cop, original_source)


### PR DESCRIPTION
This is a fix for the problem when auto-correcting regular expression with interpolation reported in #877.

I'm not very pleased with the source extraction methods (`contents` and `source`). I would really appreciate hints to a better way of doing that.
