### PR TITLE
[WiP] Fail on missing configuration options

### DIFF
--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -5,6 +5,13 @@ module Rubocop
     module Style
       # This cop enforces the consitent useage of `%`-literal delimiters.
       class PercentLiteralDelimiters < Cop
+        IncorrectConfigurationError = Class.new(StandardError)
+
+        def initialize(configuration = {}, *_)
+          verify_configuration(configuration)
+          super
+        end
+
         def on_array(node)
           process(node, '%w', '%W', '%i')
         end
@@ -35,6 +42,20 @@ module Rubocop
         end
 
         private
+
+        def verify_configuration(configuration)
+          required_delimiters = %w(% %i %q %Q %r %s %w %W %x)
+
+          if (cop_config = configuration['PercentLiteralDelimiters'])
+            configured_delimiters = cop_config['PreferredDelimiters'].keys
+            missing_delimiters = required_delimiters - configured_delimiters
+
+            unless missing_delimiters.empty?
+              fail IncorrectConfigurationError,
+                   "missing configuration for #{missing_delimiters}"
+            end
+          end
+        end
 
         def autocorrect(node)
           type = type(node)

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -5,6 +5,21 @@ require 'spec_helper'
 describe Rubocop::Cop::Style::PercentLiteralDelimiters, :config do
   subject(:cop) { described_class.new(config) }
 
+  context 'with missing configuration' do
+    let(:cop_config) do
+      {
+        'PreferredDelimiters' => {
+          '%'  => '[]'
+        }
+      }
+    end
+
+    it 'warns about missing options' do
+      expect { cop }.to \
+        raise_error(Rubocop::Cop::Style::PercentLiteralDelimiters::IncorrectConfigurationError) # rubocop:disable LineLength
+    end
+  end
+
   let(:cop_config) do
     {
       'PreferredDelimiters' => {


### PR DESCRIPTION
NB: This is **work in progress**.

This change raises an exception when required configuration options are missing.

Advice on how to better inform the user is highly appreciated.
