### PR TITLE
[Fix #879] Do not generate RegexpLiteral: MaxSlashes: -1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#879](https://github.com/bbatsov/rubocop/issues/879): Fix --auto-gen-config for `RegexpLiteral` so we don't generate illegal values for `MaxSlashes`. ([@jonas054][])
+
 ## 0.19.0 (13/03/2014)
 
 ### New features

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -61,7 +61,11 @@ module Rubocop
             end
           end
 
-          cfg['MaxSlashes'] = value
+          if value >= 0
+            cfg['MaxSlashes'] = value
+          else
+            self.config_to_allow_offenses = { 'Enabled' => false }
+          end
         end
 
         def error_message(word)

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -35,7 +35,7 @@ describe Rubocop::Cop::Style::RegexpLiteral, :config do
       expect(cop.messages)
         .to eq(['Use %r only for regular expressions matching more ' \
                 "than 0 '/' characters."])
-      expect(cop.config_to_allow_offenses).to eq('MaxSlashes' => -1)
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts %r regexp with one slash' do
@@ -92,7 +92,7 @@ describe Rubocop::Cop::Style::RegexpLiteral, :config do
       expect(cop.messages)
         .to eq(['Use %r only for regular expressions matching more ' \
                 "than 1 '/' character."] * 2)
-      expect(cop.config_to_allow_offenses).to eq('MaxSlashes' => -1)
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts %r regexp with two or more slashes' do


### PR DESCRIPTION
Fix `--auto-gen-config` so the produced `rubocop-todo.yml` doesn't contain an illegal value for `MaxSlashes`.
