### PR TITLE
[Fix #875] Handle separator style hashes in IndentHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#879](https://github.com/bbatsov/rubocop/issues/879): Fix --auto-gen-config for `RegexpLiteral` so we don't generate illegal values for `MaxSlashes`. ([@jonas054][])
 * Fix the name of the `Include` param in the default config of the Rails cops. ([@bbatsov][])
 * [#878](https://github.com/bbatsov/rubocop/pull/878): Blacklist `Rakefile`, `Gemfile` and `Capfile` by default in the `FileName` cop. ([@bbatsov][])
+* [#875](https://github.com/bbatsov/rubocop/issues/875): Handle `separator` style hashes in `IndentHash`. ([@jonas054][])
 
 ## 0.19.0 (13/03/2014)
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -321,6 +321,30 @@ describe Rubocop::CLI, :isolated_environment do
                   ''].join("\n"))
       end
 
+      it 'can correct IndentHash offenses with separator style' do
+        create_file('example.rb',
+                    ['# encoding: utf-8',
+                     'CONVERSION_CORRESPONDENCE = {',
+                     '              match_for_should: :match,',
+                     '          match_for_should_not: :match_when_negated,',
+                     '    failure_message_for_should: :failure_message,',
+                     'failure_message_for_should_not: :failure_message_when',
+                     '}'])
+        create_file('.rubocop.yml',
+                    ['AlignHash:',
+                     '  EnforcedColonStyle: separator'])
+        expect(cli.run(%w(--auto-correct))).to eq(1)
+        expect(IO.read('example.rb'))
+          .to eq(['# encoding: utf-8',
+                  'CONVERSION_CORRESPONDENCE = {',
+                  '                match_for_should: :match,',
+                  '            match_for_should_not: :match_when_negated,',
+                  '      failure_message_for_should: :failure_message,',
+                  '  failure_message_for_should_not: :failure_message_when',
+                  '}',
+                  ''].join("\n"))
+      end
+
       it 'should not hang SpaceAfterPunctuation and SpaceInsideParens' do
         create_file('example.rb',
                     ['# encoding: utf-8',


### PR DESCRIPTION
The `separator` style in `AlignHash` does not have a straight left margin, so in these hashes it's the longest key that shall be indented and the other ones shall follow.
