### PR TITLE
remove fancy quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,7 +349,7 @@
 
 * [#449](https://github.com/bbatsov/rubocop/issues/449): Remove whitespaces between condition and `do` with `WhileUntilDo` auto-correction.
 * Continue with file inspection after parser warnings. Give up only on syntax errors.
-* Don’t trigger the HashSyntax cop on digit-starting keys.
+* Don't trigger the HashSyntax cop on digit-starting keys.
 * Fix crashes while inspecting class definition subclassing another class stored in a local variable in `UselessAssignment` (formerly of `UnusedLocalVariable`) and `ShadowingOuterLocalVariable` (like `clazz = Array; class SomeClass < clazz; end`).
 * [#463](https://github.com/bbatsov/rubocop/issues/463): Do not warn if using destructuring in second `reduce` argument (`ReduceArguments`).
 


### PR DESCRIPTION
The curly quote in `CHANGELOG.md` caused rspec to fail as follows:

```
  1) RuboCop Project changelog has link definitions for all implicit links
     Failure/Error: implicit_link_names = changelog.scan(/\[([^\]]+)\]\[\]/).flatten.uniq
     ArgumentError:
       invalid byte sequence in US-ASCII
rspec ./spec/project_spec.rb:32 # RuboCop Project changelog has link definitions for all implicit links
```

As you can see from this, I'm running on OS X:

``` bash
$ be rubocop -V
0.19.0 (using Parser 2.1.7, running on ruby 1.9.3 x86_64-darwin12.5.0)
```
