### PR TITLE
[#884] Fix --auto-gen-config for `NumericLiterals` so MinDigits is correct.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* [#884](https://github.com/bbatsov/rubocop/issues/884): Fix --auto-gen-config for `NumericLiterals` so MinDigits is correct. ([@tmorris-fiksu][])
 * [#879](https://github.com/bbatsov/rubocop/issues/879): Fix --auto-gen-config for `RegexpLiteral` so we don't generate illegal values for `MaxSlashes`. ([@jonas054][])
 * Fix the name of the `Include` param in the default config of the Rails cops. ([@bbatsov][])
 * [#878](https://github.com/bbatsov/rubocop/pull/878): Blacklist `Rakefile`, `Gemfile` and `Capfile` by default in the `FileName` cop. ([@bbatsov][])
@@ -766,3 +767,4 @@
 [@hannestyden]: https://github.com/hannestyden
 [@geniou]: https://github.com/geniou
 [@jkogara]: https://github.com/jkogara
+[@tmorris-fiksu]: https://github.com/tmorris-fiksu

--- a/lib/rubocop/cop/style/numeric_literals.rb
+++ b/lib/rubocop/cop/style/numeric_literals.rb
@@ -37,7 +37,7 @@ module Rubocop
           if int.size >= min_digits
             case int
             when /^\d+$/
-              add_offense(node, :expression) { self.max = int.size }
+              add_offense(node, :expression) { self.max = int.size + 1 }
             when /\d{4}/, /_\d{1,2}_/
               add_offense(node, :expression) do
                 self.config_to_allow_offenses = { 'Enabled' => false }

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -6,10 +6,18 @@ describe Rubocop::Cop::Style::NumericLiterals, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) { { 'MinDigits' => 5 } }
 
-  it 'registers an offense for a long integer without underscores' do
-    inspect_source(cop, ['a = 123456'])
+  it 'registers an offense for a long undelimited integer' do
+    inspect_source(cop, ['a = 12345'])
     expect(cop.offenses.size).to eq(1)
     expect(cop.config_to_allow_offenses).to eq('MinDigits' => 6)
+  end
+
+  it 'registers an offense for a float with a long undelimited integer part' do
+    pending 'Though the offense message implies that floats are checked, ' \
+            'currently the cop only detects integers.'
+    inspect_source(cop, ['a = 123456.789'])
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.config_to_allow_offenses).to eq('MinDigits' => 7)
   end
 
   it 'registers an offense for an integer with misplaced underscore' do


### PR DESCRIPTION
Fixes: https://github.com/bbatsov/rubocop/issues/884

I added a pending spec showing that floats are not supported, despite being alluded to in the cop message.
