### PR TITLE
Fix failing specs that break in PathUtil.relative_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,14 +259,14 @@ follow RuboCop's general principle that configuration for an inspected
 file is taken from the nearest `.rubocop.yml`, searching upwards.
 
 Cops can be run only on specific sets of files when that's needed (for
-instance you might want to run some Rails model checks only on files,
-which paths match `app/models/*.rb`). All cops support the
+instance you might want to run some Rails model checks only on files whose
+paths match `app/models/*.rb`). All cops support the
 `Include` param.
 
 ```yaml
 DefaultScope:
   Include:
-    - app/models
+    - app/models/*.rb
 ```
 
 Cops can also exclude only specific sets of files when that's needed (for

--- a/config/default.yml
+++ b/config/default.yml
@@ -427,25 +427,25 @@ ActionFilter:
     - action
     - filter
   Include:
-    -app/controllers
+    - app/controllers/*.rb
 
 DefaultScope:
   Include:
-    - app/models
+    - app/models/*.rb
 
 HasAndBelongsToMany:
   Include:
-    - app/models
+    - app/models/*.rb
 
 ReadAttribute:
   Include:
-    - app/models
+    - app/models/*.rb
 
 ScopeArgs:
   Include:
-    - app/models
+    - app/models/*.rb
 
 Validation:
   Include:
-    - app/models
+    - app/models/*.rb
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1110,11 +1110,19 @@ describe Rubocop::CLI, :isolated_environment do
       create_file('dir1/app/models/example1.rb', ['# encoding: utf-8',
                                                   'read_attribute(:test)'])
       create_file('dir1/.rubocop.yml', ['AllCops:',
-                                        '  RunRailsCops: true'])
+                                        '  RunRailsCops: true',
+                                        '',
+                                        'ReadAttribute:',
+                                        '  Include:',
+                                        '    - dir1/app/models/*.rb'])
       create_file('dir2/app/models/example2.rb', ['# encoding: utf-8',
                                                   'read_attribute(:test)'])
       create_file('dir2/.rubocop.yml', ['AllCops:',
-                                        '  RunRailsCops: false'])
+                                        '  RunRailsCops: false',
+                                        '',
+                                        'ReadAttribute:',
+                                        '  Include:',
+                                        '    - dir2/app/models/*.rb'])
       expect(cli.run(%w(--format simple dir1 dir2))).to eq(1)
       expect($stdout.string)
         .to eq(['== dir1/app/models/example1.rb ==',

--- a/spec/rubocop/cop/rails/action_filter_spec.rb
+++ b/spec/rubocop/cop/rails/action_filter_spec.rb
@@ -10,28 +10,28 @@ describe Rubocop::Cop::Rails::ActionFilter, :config do
 
     described_class::FILTER_METHODS.each do |method|
       it "registers an offense for #{method}" do
-        inspect_source(cop,
-                       ["#{method} :name"])
+        inspect_source_file(cop,
+                            ["#{method} :name"])
         expect(cop.offenses.size).to eq(1)
       end
 
       it "registers an offense for #{method} with block" do
-        inspect_source(cop,
-                       ["#{method} { |controller| something }"])
+        inspect_source_file(cop,
+                            ["#{method} { |controller| something }"])
         expect(cop.offenses.size).to eq(1)
       end
     end
 
     described_class::ACTION_METHODS.each do |method|
       it "accepts #{method}" do
-        inspect_source(cop,
-                       ["#{method} :something"])
+        inspect_source_file(cop,
+                            ["#{method} :something"])
         expect(cop.offenses).to be_empty
       end
     end
 
     it 'auto-corrects to preferred method' do
-      new_source = autocorrect_source(cop, 'before_filter :test')
+      new_source = autocorrect_source_file(cop, 'before_filter :test')
       expect(new_source).to eq('before_action :test')
     end
   end
@@ -41,28 +41,28 @@ describe Rubocop::Cop::Rails::ActionFilter, :config do
 
     described_class::ACTION_METHODS.each do |method|
       it "registers an offense for #{method}" do
-        inspect_source(cop,
-                       ["#{method} :name"])
+        inspect_source_file(cop,
+                            ["#{method} :name"])
         expect(cop.offenses.size).to eq(1)
       end
 
       it "registers an offense for #{method} with block" do
-        inspect_source(cop,
-                       ["#{method} { |controller| something }"])
+        inspect_source_file(cop,
+                            ["#{method} { |controller| something }"])
         expect(cop.offenses.size).to eq(1)
       end
     end
 
     described_class::FILTER_METHODS.each do |method|
       it "accepts #{method}" do
-        inspect_source(cop,
-                       ["#{method} :something"])
+        inspect_source_file(cop,
+                            ["#{method} :something"])
         expect(cop.offenses).to be_empty
       end
     end
 
     it 'auto-corrects to preferred method' do
-      new_source = autocorrect_source(cop, 'before_action :test')
+      new_source = autocorrect_source_file(cop, 'before_action :test')
       expect(new_source).to eq('before_filter :test')
     end
   end

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -39,7 +39,7 @@ describe Rubocop::Cop::Team do
   describe '#inspect_file', :isolated_environment do
     include FileHelper
 
-    let(:file_path) { 'example.rb' }
+    let(:file_path) { '/tmp/example.rb' }
     let(:offenses) { team.inspect_file(file_path) }
 
     before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,9 +110,13 @@ def parse_source(source, file = nil)
   end
 end
 
-def autocorrect_source(cop, source)
+def autocorrect_source_file(cop, source)
+  Tempfile.open('tmp') { |f| autocorrect_source(cop, source, f) }
+end
+
+def autocorrect_source(cop, source, file = nil)
   cop.instance_variable_get(:@options)[:auto_correct] = true
-  processed_source = parse_source(source)
+  processed_source = parse_source(source, file)
   _investigate(cop, processed_source)
 
   corrector =


### PR DESCRIPTION
@bbatsov @yujinakayama I found the problem with the specs.

When `Include` and `Exclude` configuration parameters were added in `default.yml`, some specs could no longer run with the default buffer name `"(string)"` or `"example.rb"`. They need an absolute path.

Fixing this revealed some other problems; that `app/models` must be changed to `app/models/*.rb` for example. Also, the paths given in `Include` are not interpreted as relative to the configuration file. They should be.

This PR should make all the specs pass again, but some work on the handling of paths from configuration is still needed.
