### PR TITLE
Change the way MinDigits variable is used in NumericLiterals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* `NumericLiterals` cop does not add an offense when the size of the integer is equal to MinDigits. ([@asok][])
 * [#884](https://github.com/bbatsov/rubocop/issues/884): Fix --auto-gen-config for `NumericLiterals` so MinDigits is correct. ([@tmorris-fiksu][])
 * [#879](https://github.com/bbatsov/rubocop/issues/879): Fix --auto-gen-config for `RegexpLiteral` so we don't generate illegal values for `MaxSlashes`. ([@jonas054][])
 * Fix the name of the `Include` param in the default config of the Rails cops. ([@bbatsov][])
@@ -769,3 +770,4 @@
 [@geniou]: https://github.com/geniou
 [@jkogara]: https://github.com/jkogara
 [@tmorris-fiksu]: https://github.com/tmorris-fiksu
+[@asok]: https://github.com/asok

--- a/lib/rubocop/cop/style/numeric_literals.rb
+++ b/lib/rubocop/cop/style/numeric_literals.rb
@@ -34,7 +34,7 @@ module Rubocop
           # TODO: handle non-decimal literals as well
           return if int.start_with?('0')
 
-          if int.size >= min_digits
+          if int.size > min_digits
             case int
             when /^\d+$/
               add_offense(node, :expression) { self.max = int.size + 1 }

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -7,9 +7,14 @@ describe Rubocop::Cop::Style::NumericLiterals, :config do
   let(:cop_config) { { 'MinDigits' => 5 } }
 
   it 'registers an offense for a long undelimited integer' do
-    inspect_source(cop, ['a = 12345'])
+    inspect_source(cop, ['a = 123456'])
     expect(cop.offenses.size).to eq(1)
-    expect(cop.config_to_allow_offenses).to eq('MinDigits' => 6)
+    expect(cop.config_to_allow_offenses).to eq('MinDigits' => 7)
+  end
+
+  it 'does not register an offense for an integer with 5 digits' do
+    inspect_source(cop, ['a = 12345'])
+    expect(cop.messages).to be_empty
   end
 
   it 'registers an offense for a float with a long undelimited integer part' do


### PR DESCRIPTION
The offense is added now when the size of the numeric is gt MinDigits.
It is not added when the size of the numeric is equal to MinDigits.

If I understand it correctly this should be a desired behavior. That is when I set the MinDigits to `3` then the integer `401` should not be reported as an offense. Not until it has 4 digits like for example `4010`.
