### PR TITLE
add option to show cops disabed by inline comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * `NegatedWhile` cop does auto-correction. ([@bbatsov][])
 * New lint cop `SpaceBeforeFirstArg` checks for space between the method name and the first argument in method calls without parentheses. ([@jonas054][])
 * New style cop `SingleSpaceBeforeFirstArg` checks that no more than one space is used between the method name and the first argument in method calls without parentheses. ([@jonas054][])
+* New formatter `disabled_lines` displays cops and line ranges disabled by inline comments. ([@fshowalter][])
 
 ### Changes
 
@@ -820,3 +821,4 @@
 [@mockdeep]: https://github.com/mockdeep
 [@hiroponz]: https://github.com/hiroponz
 [@tamird]: https://github.com/tamird
+[@fshowalter]: https://github.com/fshowalter

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -236,6 +236,7 @@ require 'rubocop/cop/rails/validation'
 
 require 'rubocop/formatter/base_formatter'
 require 'rubocop/formatter/simple_text_formatter'
+require 'rubocop/formatter/disabled_lines_formatter'
 require 'rubocop/formatter/disabled_config_formatter'
 require 'rubocop/formatter/emacs_style_formatter'
 require 'rubocop/formatter/clang_style_formatter'

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -20,11 +20,11 @@ module Rubocop
       disabled_line_ranges.none? { |range| range.include?(line_number) }
     end
 
-    private
-
     def cop_disabled_line_ranges
       @cop_disabled_line_ranges ||= analyze
     end
+
+    private
 
     def analyze
       disabled_line_ranges = Hash.new { |hash, key| hash[key] = [] }
@@ -54,6 +54,8 @@ module Rubocop
 
     def each_mentioned_cop
       all_cop_names = nil # For performance improvement
+
+      return if processed_source.comments.nil?
 
       processed_source.comments.each do |comment|
         match = comment.text.match(COMMENT_DIRECTIVE_REGEXP)

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -23,15 +23,7 @@ module Rubocop
         @options[:debug]
       end
 
-      def inspect_file(file)
-        begin
-          processed_source = SourceParser.parse_file(file)
-        rescue Encoding::UndefinedConversionError, ArgumentError => e
-          range = Struct.new(:line, :column, :source_line).new(1, 0, '')
-          return [Offense.new(:fatal, range, e.message.capitalize + '.',
-                              'Parser')]
-        end
-
+      def inspect_file(processed_source)
         # If we got any syntax errors, return only the syntax offenses.
         # Parser may return nil for AST even though there are no syntax errors.
         # e.g. sources which contain only comments
@@ -42,7 +34,8 @@ module Rubocop
 
         commissioner = Commissioner.new(cops)
         offenses = commissioner.investigate(processed_source)
-        process_commissioner_errors(file, commissioner.errors)
+        process_commissioner_errors(
+          processed_source.file_path, commissioner.errors)
         autocorrect(processed_source.buffer, cops)
         offenses
       end

--- a/lib/rubocop/formatter/disabled_lines_formatter.rb
+++ b/lib/rubocop/formatter/disabled_lines_formatter.rb
@@ -1,0 +1,56 @@
+# encoding: utf-8
+module Rubocop
+  module Formatter
+    # A basic formatter that displays the lines disabled
+    # inline comments.
+    class DisabledLinesFormatter < BaseFormatter
+      include PathUtil
+      include Colorizable
+
+      attr_reader :cop_disabled_line_ranges
+
+      def started(target_files)
+        @cop_disabled_line_ranges = {}
+      end
+
+      def file_started(file, options)
+        return unless options[:cop_disabled_line_ranges]
+
+        @cop_disabled_line_ranges[file] =
+          options[:cop_disabled_line_ranges]
+      end
+
+      def finished(inspected_files)
+        cops_disabled_in_comments_summary
+      end
+
+      private
+
+      def cops_disabled_in_comments_summary
+        summary = "\nCops disabled line ranges:\n\n"
+
+        @cop_disabled_line_ranges.each do |file, disabled_cops|
+          disabled_cops.each do |cop, line_ranges|
+            line_ranges.each do |line_range|
+              file = cyan(smart_path(file))
+              summary << "#{file}:#{line_range}: #{cop}\n"
+            end
+          end
+        end
+
+        output.puts summary
+      end
+
+      def smart_path(path)
+        # Ideally, we calculate this relative to the project root.
+        base_dir = Dir.pwd
+
+        if path.start_with? base_dir
+          relative_path(path, base_dir)
+        else
+          path
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -14,7 +14,8 @@ module Rubocop
         'emacs'    => EmacsStyleFormatter,
         'json'     => JSONFormatter,
         'files'    => FileListFormatter,
-        'offenses' => OffenseCountFormatter
+        'offenses' => OffenseCountFormatter,
+        'disabled' => DisabledLinesFormatter
       }
 
       FORMATTER_APIS = [:started, :file_started, :file_finished, :finished]

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -67,6 +67,7 @@ module Rubocop
                    '  [p]rogress (default)',
                    '  [s]imple',
                    '  [c]lang',
+                   '  [d]isabled cops via inline comments',
                    '  [fu]ubar',
                    '  [e]macs',
                    '  [j]son',

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -17,6 +17,10 @@ module Rubocop
       @comment_config = CommentConfig.new(self)
     end
 
+    def disabled_line_ranges
+      comment_config.cop_disabled_line_ranges
+    end
+
     def lines
       if @lines
         @lines
@@ -41,6 +45,10 @@ module Rubocop
 
     def valid_syntax?
       @diagnostics.none? { |d| [:error, :fatal].include?(d.level) }
+    end
+
+    def file_path
+      @buffer.name
     end
 
     private

--- a/rubocop-todo.yml
+++ b/rubocop-todo.yml
@@ -8,7 +8,7 @@
 # Offense count: 6
 # Configuration parameters: CountComments.
 ClassLength:
-  Max: 145
+  Max: 146
 
 # Offense count: 16
 CyclomaticComplexity:

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -40,7 +40,9 @@ describe Rubocop::Cop::Team do
     include FileHelper
 
     let(:file_path) { '/tmp/example.rb' }
-    let(:offenses) { team.inspect_file(file_path) }
+    let(:offenses) do
+      team.inspect_file(Rubocop::SourceParser.parse_file(file_path))
+    end
 
     before do
       create_file(file_path, [
@@ -52,22 +54,6 @@ describe Rubocop::Cop::Team do
     it 'returns offenses' do
       expect(offenses).not_to be_empty
       expect(offenses.all? { |o| o.is_a?(Rubocop::Cop::Offense) }).to be_true
-    end
-
-    context 'when Parser cannot parse the file' do
-      before do
-        create_file(file_path, [
-          '#' * 90,
-          'class Test'
-        ])
-      end
-
-      it 'returns only error offenses' do
-        expect(offenses.size).to eq(1)
-        offense = offenses.first
-        expect(offense.cop_name).to eq('Syntax')
-        expect(offense.severity).to eq(:error)
-      end
     end
 
     context 'when Parser reports non-fatal warning for the file' do
@@ -101,7 +87,7 @@ describe Rubocop::Cop::Team do
       end
 
       it 'does autocorrection' do
-        team.inspect_file(file_path)
+        team.inspect_file(Rubocop::SourceParser.parse_file(file_path))
         corrected_source = File.read(file_path)
         expect(corrected_source).to eq([
           '# encoding: utf-8',

--- a/spec/rubocop/file_inspector_spec.rb
+++ b/spec/rubocop/file_inspector_spec.rb
@@ -18,6 +18,10 @@ describe Rubocop::FileInspector do
     $stdout = StringIO.new
     $stderr = StringIO.new
 
+    allow(inspector).to receive(:process_source) do
+      [double('ProcessedSource').as_null_object, []]
+    end
+
     allow(inspector).to receive(:inspect_file) do
       inspector.errors = errors
       [offenses, !:updated_source_file]

--- a/spec/rubocop/formatter/disabled_lines_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_lines_formatter_spec.rb
@@ -1,0 +1,69 @@
+# encoding: utf-8
+
+require 'spec_helper'
+require 'stringio'
+require 'tempfile'
+
+module Rubocop
+  module Formatter
+    describe DisabledLinesFormatter do
+      subject(:formatter) { described_class.new(output) }
+      let(:output) { StringIO.new }
+
+      let(:files) do
+        %w(lib/rubocop.rb spec/spec_helper.rb bin/rubocop).map do |path|
+          File.expand_path(path)
+        end
+      end
+
+      let(:file_started) do
+        formatter.file_started(files.first, cop_disabled_line_ranges)
+      end
+
+      describe '#file_started' do
+        before { formatter.started(files) }
+
+        context 'when no disable cop comments are detected' do
+          let(:cop_disabled_line_ranges) { {} }
+          it 'shouldn\'t add to cop_disabled_line_ranges' do
+            expect { file_started }.to_not(
+            change { formatter.cop_disabled_line_ranges })
+          end
+        end
+
+        context 'when any disable cop comments are detected' do
+          let(:cop_disabled_line_ranges) do
+            { cop_disabled_line_ranges: { 'LineLength' => [1..1] } }
+          end
+          it 'should merge the changes into cop_disabled_line_ranges' do
+            expect { file_started }.to(
+            change { formatter.cop_disabled_line_ranges })
+          end
+        end
+      end
+
+      describe '#finished' do
+        context 'when there disabled cops detected' do
+          let(:cop_disabled_line_ranges) do
+            { cop_disabled_line_ranges: { 'LineLength' => [1..1] } }
+          end
+
+          before do
+            formatter.started(files)
+            formatter.file_started('lib/rubocop.rb', cop_disabled_line_ranges)
+          end
+
+          it 'lists disabled cops by file' do
+            formatter.finished(files)
+            expect(output.string).to eq(
+            ['',
+             'Cops disabled line ranges:',
+             '',
+             'lib/rubocop.rb:1..1: LineLength',
+             ''].join("\n"))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -49,6 +49,7 @@ Usage: rubocop [options] [file1, file2, ...]
                                        [p]rogress (default)
                                        [s]imple
                                        [c]lang
+                                       [d]isabled cops via inline comments
                                        [fu]ubar
                                        [e]macs
                                        [j]son


### PR DESCRIPTION
Sometimes its tempting for developers, especially juniors who may have trouble understanding some of RuboCop's warnings, to abuse the `# rubocop:disable` functionality. This pull request adds an option (`-x` or `--show-disabled`) that, after a run, prints a list of all the files, line ranges and corresponding cops that were ignored during the run due to `# rubocop:disable` comments. 
