### PR TITLE
[Fix #876] Deep merge hashes in configuration when overriding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#892](https://github.com/bbatsov/rubocop/issues/892): Make sure `Include` and `Exclude` paths in a `.rubocop.yml` are interpreted as relative to the directory of that file. ([@jonas054][])
 * [#906](https://github.com/bbatsov/rubocop/issues/906): Fixed a false positive in `LiteralInInterpolation`. ([@bbatsov][])
 * [#909](https://github.com/bbatsov/rubocop/issues/909): Handle properly multiple `rescue` clauses in `SignalException`. ([@bbatsov][])
+* [#876](https://github.com/bbatsov/rubocop/issues/876): Do a deep merge of hashes when overriding default configuration in a `.rubocop.yml` file. ([@jonas054][])
 
 ## 0.19.1 (17/03/2014)
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -47,15 +47,15 @@ module Rubocop
         end
       end
 
-      # Return an extended merge of two hashes. That is, a normal hash merge,
+      # Return a recursive merge of two hashes. That is, a normal hash merge,
       # with the addition that any value that is a hash, and occurs in both
-      # arguments (i.e., cop names), will also be merged.
+      # arguments, will also be merged. And so on.
       def merge(base_hash, derived_hash)
         result = base_hash.merge(derived_hash)
         keys_appearing_in_both = base_hash.keys & derived_hash.keys
         keys_appearing_in_both.each do |key|
           if base_hash[key].is_a?(Hash)
-            result[key] = base_hash[key].merge(derived_hash[key])
+            result[key] = merge(base_hash[key], derived_hash[key])
           end
         end
         result

--- a/lib/rubocop/cop/style/collection_methods.rb
+++ b/lib/rubocop/cop/style/collection_methods.rb
@@ -12,12 +12,6 @@ module Rubocop
       class CollectionMethods < Cop
         MSG = 'Prefer %s over %s.'
 
-        def preferred_methods
-          if cop_config['PreferredMethods']
-            cop_config['PreferredMethods'].symbolize_keys
-          end
-        end
-
         def on_block(node)
           method, _args, _body = *node
 
@@ -56,6 +50,22 @@ module Rubocop
 
         def preferred_method(method)
           preferred_methods[method.to_sym]
+        end
+
+        def preferred_methods
+          @preferred_methods ||=
+            begin
+              # Make sure default configuration 'foo' => 'bar' is removed from
+              # the total configuration if there is a 'bar' => 'foo' override.
+              default = default_cop_config['PreferredMethods']
+              merged = cop_config['PreferredMethods']
+              overrides = merged.values - default.values
+              merged.reject { |key, _| overrides.include?(key) }.symbolize_keys
+            end
+        end
+
+        def default_cop_config
+          ConfigLoader.default_configuration[cop_name]
         end
       end
     end


### PR DESCRIPTION
Deep (recursive) merge that was removed in #347 is added back. The data structure in the `CollectionMethods` config parameters is changed so `PreferredMethods` holds an array of single key/value hashes instead of a big hash. That way it doesn't get merged. `PercentLiteralDelimiters` will be merged.
