### PR TITLE
make file inspection parallel

### DIFF
--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -98,6 +98,7 @@ module Rubocop
       option(opts, '-R', '--rails', 'Run extra Rails cops.')
       option(opts, '-l', '--lint', 'Run only lint cops.')
       option(opts, '-a', '--auto-correct', 'Auto-correct offenses.')
+      option(opts, '-p', '--parallel', 'Run in parallel (no progress bar)')
 
       @options[:color] = true
       opts.on('-n', '--no-color', 'Disable color output.') do

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('yard', '~> 0.8')
   s.add_development_dependency('bundler', '~> 1.3')
   s.add_development_dependency('simplecov', '~> 0.7')
+  s.add_development_dependency('parallel', '~> 1.0.0')
 end


### PR DESCRIPTION
@bbatsov
optionally run in parallel (does not support progressbar formatter since file is processed in a new process)
I also tried threads but did not see any speedup

```
[~/Code/tools/rubocop (grosser/parallel2)☃] ➔ time be ./bin/rubocop spec/**/*
Inspecting 207 files
...............................................................................................................................................................................................................

207 files inspected, no offenses detected

real    0m16.797s
user    0m16.380s
sys 0m0.408s
[~/Code/tools/rubocop (grosser/parallel2)☃] ➔ time be ./bin/rubocop spec/**/* -p
Inspecting 207 files
...............................................................................................................................................................................................................

207 files inspected, no offenses detected

real    0m10.103s
user    0m29.090s
sys 0m1.078s
[~/Code/tools/rubocop (grosser/parallel2)☃] ➔
```
