### PR TITLE
`FileName` should accept multiple extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 * [#896](https://github.com/bbatsov/rubocop/issues/896): New option `--fail-level` changes minimum severity for exit with error code. ([@hiroponz][])
 * `VariableInterpolation` cop does auto-correction. ([@bbatsov][])
 
+### Changes
+
+* [#913](https://github.com/bbatsov/rubocop/issues/913): `FileName` accepts multiple extensions. ([@tamird][])
+
 ### Bugs fixed
 
 * [#904](https://github.com/bbatsov/rubocop/issues/904): Fixed a NPE in `LiteralInInterpolation`. ([@bbatsov][])
@@ -793,3 +797,4 @@
 [@tmorris-fiksu]: https://github.com/tmorris-fiksu
 [@mockdeep]: https://github.com/mockdeep
 [@hiroponz]: https://github.com/hiroponz
+[@tamird]: https://github.com/tamird

--- a/lib/rubocop/cop/style/file_name.rb
+++ b/lib/rubocop/cop/style/file_name.rb
@@ -16,7 +16,7 @@ module Rubocop
 
           basename = File.basename(file_path).sub(/\.[^\.]+$/, '')
 
-          unless basename =~ SNAKE_CASE
+          unless basename.split('.').all? { |fragment| fragment =~ SNAKE_CASE }
             add_offense(nil,
                         source_range(processed_source.buffer,
                                      processed_source[0..0],

--- a/spec/rubocop/cop/style/file_name_spec.rb
+++ b/spec/rubocop/cop/style/file_name_spec.rb
@@ -62,6 +62,14 @@ describe Rubocop::Cop::Style::FileName do
     end
   end
 
+  context 'with snake_case file names with multiple extensions' do
+    let(:filename) { 'some/dir/some_view.html.slim_spec.rb' }
+
+    it 'does not report an offense' do
+      expect(cop.offenses).to be_empty
+    end
+  end
+
   context 'when the file is specified in AllCops/Includes' do
     let(:includes) { ['**/Gemfile'] }
 


### PR DESCRIPTION
It's common for rails view specs to be named `foo.html.erb_spec.rb`. Currently, those files will fail this cop.
