### PR TITLE
Make --only enable the given cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#912](https://github.com/bbatsov/rubocop/issues/912): Fix a false positive in `LineEndConcatenation` for `%` string literals. ([@bbatsov][])
 * [#912](https://github.com/bbatsov/rubocop/issues/912): Handle top-level constant resolution in `DeprecatedClassMethods` (e.g. `::File.exists?`). ([@bbatsov][])
 * [#914](https://github.com/bbatsov/rubocop/issues/914): Fixed rdoc error during gem installation. ([@bbatsov][])
+* The `--only` option now enables the given cop in case it is disabled in configuration. ([@jonas054][])
 
 ## 0.19.1 (17/03/2014)
 

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -49,14 +49,20 @@ module Rubocop
 
       def cops
         @cops ||= begin
-          @cop_classes.reduce([]) do |instances, cop_class|
-            next instances unless @config.cop_enabled?(cop_class)
-            instances << cop_class.new(@config, @options)
+          @cop_classes.each_with_object([]) do |cop_class, instances|
+            if cop_enabled?(cop_class)
+              instances << cop_class.new(@config, @options)
+            end
           end
         end
       end
 
       private
+
+      def cop_enabled?(cop_class)
+        @config.cop_enabled?(cop_class) ||
+          cop_class.cop_name == @options[:only]
+      end
 
       def autocorrect(buffer, cops)
         @updated_source_file = false

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -515,6 +515,27 @@ describe Rubocop::CLI, :isolated_environment do
                   '1 file inspected, 1 offense detected',
                   ''].join("\n"))
       end
+
+      it 'enables the given cop' do
+        create_file('example.rb', ['x = 0 ',
+                                   # Disabling comments still apply.
+                                   '# rubocop:disable TrailingWhitespace',
+                                   'y = 1  '])
+
+        create_file('.rubocop.yml', ['TrailingWhitespace:',
+                                     '  Enabled: false'])
+
+        expect(cli.run(['--format', 'simple',
+                        '--only', 'TrailingWhitespace',
+                        'example.rb'])).to eq(1)
+        expect($stderr.string).to eq('')
+        expect($stdout.string)
+          .to eq(['== example.rb ==',
+                  'C:  1:  6: Trailing whitespace detected.',
+                  '',
+                  '1 file inspected, 1 offense detected',
+                  ''].join("\n"))
+      end
     end
 
     describe '--lint' do


### PR DESCRIPTION
It was said in #900 that it is a bug for `--only` to not enable the cop.
