### PR TITLE
Fix default exclusion of vendor directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#912](https://github.com/bbatsov/rubocop/issues/912): Handle top-level constant resolution in `DeprecatedClassMethods` (e.g. `::File.exists?`). ([@bbatsov][])
 * [#914](https://github.com/bbatsov/rubocop/issues/914): Fixed rdoc error during gem installation. ([@bbatsov][])
 * The `--only` option now enables the given cop in case it is disabled in configuration. ([@jonas054][])
+* Fix path resolution so that the default exclusion of `vendor` directories works. ([@jonas054][])
 
 ## 0.19.1 (17/03/2014)
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -88,17 +88,19 @@ module Rubocop
     end
 
     def path_relative_to_config(path)
-      # Paths specified in .rubocop.yml files are relative to the directory
-      # where that file is. Paths in other config files are relative to the
-      # current directory. This is so that paths in config/default.yml, for
-      # example, are not relative to RuboCop's config directory since that
-      # wouldn't work.
-      base_dir = if File.basename(loaded_path) == ConfigLoader::DOTFILE
-                   File.dirname(loaded_path)
-                 else
-                   Dir.pwd
-                 end
-      relative_path(path, base_dir)
+      relative_path(path, base_dir_for_path_parameters)
+    end
+
+    # Paths specified in .rubocop.yml files are relative to the directory where
+    # that file is. Paths in other config files are relative to the current
+    # directory. This is so that paths in config/default.yml, for example, are
+    # not relative to RuboCop's config directory since that wouldn't work.
+    def base_dir_for_path_parameters
+      if File.basename(loaded_path) == ConfigLoader::DOTFILE
+        File.dirname(loaded_path)
+      else
+        Dir.pwd
+      end
     end
   end
 end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1538,6 +1538,17 @@ describe Rubocop::CLI, :isolated_environment do
                 ''].join("\n"))
     end
 
+    it 'excludes the vendor directory by default' do
+      create_file('vendor/ex.rb',
+                  ['# encoding: utf-8',
+                   '#' * 90])
+
+      cli.run(%w(--format simple))
+      expect($stdout.string)
+        .to eq(['', '0 files inspected, no offenses detected',
+                ''].join("\n"))
+    end
+
     # Being immune to bad configuration files in excluded directories has
     # become important due to a bug in rubygems
     # (https://github.com/rubygems/rubygems/issues/680) that makes


### PR DESCRIPTION
Found out in discussion around #900 that @fshowalter had to add his own configuration to exclude `vendor`.

Excluding directories from a `.rubocop.yml` file works, but before this fix, the setting of `AllCops`/`Excludes` in `default.yml` didn't have any effect. I've found that this bug has existed ever since `vendor/**` was added in `default.yml`.

The problem was that `Excludes` paths from `default.yml`, and other files not named `.rubocop.yml`, were not made absolute. They need to be since `AllCops`/`Excludes` has special handling and is always matched with an absolute path.
