### PR TITLE
[Fix #919] Remove auto-correct avoidance in HashSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * The `--only` option now enables the given cop in case it is disabled in configuration. ([@jonas054][])
 * Fix path resolution so that the default exclusion of `vendor` directories works. ([@jonas054][])
 * [#908](https://github.com/bbatsov/rubocop/issues/908): Fixed hanging while auto correct for `SpaceAfterComma` and `SpaceInsideBrackets`. ([@hiroponz][])
+* [#919](https://github.com/bbatsov/rubocop/issues/919): Don't avoid auto-correction in HashSyntax when there is missing space around operator. ([@jonas054][])
 
 ## 0.19.1 (17/03/2014)
 

--- a/lib/rubocop/cop/style/space_around_operators.rb
+++ b/lib/rubocop/cop/style/space_around_operators.rb
@@ -72,8 +72,7 @@ module Rubocop
             when /\*\*/
               corrector.replace(range, '**')
             else
-              corrector.insert_before(range, ' ') unless range.source =~ /^\s/
-              corrector.insert_after(range, ' ') unless range.source =~ /\s$/
+              corrector.replace(range, " #{range.source.strip} ")
             end
           end
         end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -273,7 +273,6 @@ describe Rubocop::CLI, :isolated_environment do
                     ['# encoding: utf-8',
                      '{ :b=>1 }'])
         expect(cli.run(%w(-D --auto-correct --format emacs))).to eq(1)
-        expect($stderr.string).to eq('')
         expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
                                              '{ b: 1 }',
                                              ''].join("\n"))
@@ -283,6 +282,21 @@ describe Rubocop::CLI, :isolated_environment do
                   "#{abs('example.rb')}:2:5: C: [Corrected] " \
                   "SpaceAroundOperators: Surrounding space missing for " \
                   "operator '=>'.",
+                  ''].join("\n"))
+      end
+
+      it 'can correct HashSyntax when --only is used' do
+        create_file('example.rb',
+                    ['# encoding: utf-8',
+                     '{ :b=>1 }'])
+        expect(cli.run(%w(--auto-correct -f emacs --only HashSyntax))).to eq(1)
+        expect($stderr.string).to eq('')
+        expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
+                                             '{ b: 1 }',
+                                             ''].join("\n"))
+        expect($stdout.string)
+          .to eq(["#{abs('example.rb')}:2:3: C: [Corrected] Use the new " \
+                  "Ruby 1.9 hash syntax.",
                   ''].join("\n"))
       end
 

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -72,9 +72,11 @@ describe Rubocop::Cop::Style::HashSyntax, :config do
       expect(new_source).to eq('{ a: 1, b: 2}')
     end
 
-    it 'does not auto-correct if it interferes with SpaceAroundOperators' do
+    it 'auto-corrects even if it interferes with SpaceAroundOperators' do
+      # Clobbering caused by two cops changing in the same range is dealt with
+      # by the auto-correct loop, so there's no reason to avoid a change.
       new_source = autocorrect_source(cop, '{ :a=>1, :b=>2 }')
-      expect(new_source).to eq('{ :a=>1, :b=>2 }')
+      expect(new_source).to eq('{ a: 1, b: 2 }')
     end
 
     context 'with SpaceAroundOperators disabled' do


### PR DESCRIPTION
We have an auto-correct loop that deals with clobbering errors now, so instead of avoiding a correction we just make the correction range a bit larger.
