### PR TITLE
add link for tips on installing rbx on OSX

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ $ rubocop -V
   you want to have your own version, or is otherwise necessary, that
   is fine, but please isolate to its own commit so I can cherry-pick
   around it.
-* Make sure the test suite is passing and the code you wrote doesn't produce
+* Make sure the test suite is passing ([including rbx and jruby][7]) and the code you wrote doesn't produce
   RuboCop offences.
 * [Squash related commits together][5].
 * Open a [pull request][4] that relates to *only* one subject with a clear title
@@ -65,3 +65,4 @@ Here are a few examples:
 [4]: https://help.github.com/articles/using-pull-requests
 [5]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html
 [6]: http://daringfireball.net/projects/markdown/syntax
+[7]: http://blog.stwrt.ca/2013/09/06/installing-rubinius-with-rbenv


### PR DESCRIPTION
JRuby and RBX have bugs not present in MRI, and installing recent builds on recent builds of OSX can be tricky. This link gives a good step-by step and even includes integration with rbenv. At the very least it reminds folks that just because their patch passes MRI, doesn't mean it won't break the build.
