### PR TITLE
[Fix #928] re-word hint on using --config rubocop-todo.yml

### DIFF
--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -38,7 +38,7 @@ module Rubocop
           cfg.each { |key, value| output.puts "  #{key}: #{value}" }
         end
         puts "Created #{output.path}."
-        puts "Run rubocop with --config #{output.path}, or"
+        puts "Run `rubocop --config #{output.path}`, or"
         puts "add inherit_from: #{output.path} in a .rubocop.yml file."
       end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -437,7 +437,7 @@ describe Rubocop::CLI, :isolated_environment do
         expect($stderr.string).to eq('')
         expect($stdout.string)
           .to include(['Created rubocop-todo.yml.',
-                       'Run rubocop with --config rubocop-todo.yml, or',
+                       'Run `rubocop --config rubocop-todo.yml`, or',
                        'add inherit_from: rubocop-todo.yml in a ' \
                        '.rubocop.yml file.',
                        ''].join("\n"))

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -39,7 +39,7 @@ module Rubocop
                                        ''].join("\n"))
           expect($stdout.string)
             .to eq(['Created rubocop-todo.yml.',
-                    'Run rubocop with --config rubocop-todo.yml, or',
+                    'Run `rubocop --config rubocop-todo.yml`, or',
                     'add inherit_from: rubocop-todo.yml in a .rubocop.yml ' \
                     'file.',
                     ''].join("\n"))


### PR DESCRIPTION
Message after running `$ rubocop --auto-gen`, changed from:
`Run rubocop with --config rubocop-todo.yml, or`
to:
`Run `rubocop --config rubocop-todo.yml`, or`
