### PR TITLE
[Fix #926] BlockNesting was not auto-generating correctly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Bugs fixed
 
+* [#926](https://github.com/bbatsov/rubocop/issues/926): Fixed BlockNesting not auto-generating correctly. ([@tmorris-fiksu][])
 * [#904](https://github.com/bbatsov/rubocop/issues/904): Fixed a NPE in `LiteralInInterpolation`. ([@bbatsov][])
 * [#904](https://github.com/bbatsov/rubocop/issues/904): Fixed a NPE in `StringConversionInInterpolation`. ([@bbatsov][])
 * [#892](https://github.com/bbatsov/rubocop/issues/892): Make sure `Include` and `Exclude` paths in a `.rubocop.yml` are interpreted as relative to the directory of that file. ([@jonas054][])

--- a/lib/rubocop/cop/style/block_nesting.rb
+++ b/lib/rubocop/cop/style/block_nesting.rb
@@ -4,7 +4,7 @@ module Rubocop
   module Cop
     module Style
       # This cop checks for excessive nesting of conditional and looping
-      # constructs. Despite the cop's name, blocks are not considered as a
+      # constructs. Despite the cop's name, blocks are not considered as an
       # extra level of nesting.
       #
       # The maximum level of nesting allowed is configurable.
@@ -27,14 +27,16 @@ module Rubocop
         def check_nesting_level(node, max, current_level)
           if NESTING_BLOCKS.include?(node.type)
             unless node.loc.respond_to?(:keyword) &&
-                node.loc.keyword.is?('elsif')
+                   node.loc.keyword.is?('elsif')
               current_level += 1
             end
-            if current_level == max + 1
-              add_offense(node, :expression, message(max)) do
-                self.max = current_level
+            if current_level > max
+              self.max = current_level
+              unless part_of_ignored_node?(node)
+                add_offense(node, :expression, message(max)) do
+                  ignore_node(node)
+                end
               end
-              return
             end
           end
           node.children.each do |child|

--- a/spec/rubocop/cop/style/block_nesting_spec.rb
+++ b/spec/rubocop/cop/style/block_nesting_spec.rb
@@ -26,7 +26,7 @@ describe Rubocop::Cop::Style::BlockNesting, :config do
     expect_nesting_offenses(source, [3])
   end
 
-  it 'registers a single offense for `Max + 2` levels of `if` nesting' do
+  it 'registers one offense for `Max + 2` levels of `if` nesting' do
     source = ['if a',
               '  if b',
               '    if c',
@@ -36,7 +36,7 @@ describe Rubocop::Cop::Style::BlockNesting, :config do
               '    end',
               '  end',
               'end']
-    expect_nesting_offenses(source, [3])
+    expect_nesting_offenses(source, [3], 4)
   end
 
   it 'registers 2 offenses' do
@@ -144,13 +144,13 @@ describe Rubocop::Cop::Style::BlockNesting, :config do
     expect_nesting_offenses(source, [])
   end
 
-  def expect_nesting_offenses(source, lines, used_nesting_level = 3)
+  def expect_nesting_offenses(source, lines, max_to_allow = 3)
     inspect_source(cop, source)
     expect(cop.offenses.map(&:line)).to eq(lines)
     expect(cop.messages).to eq(
       ['Avoid more than 2 levels of block nesting.'] * lines.length)
     if cop.offenses.size > 0
-      expect(cop.config_to_allow_offenses['Max']).to eq(used_nesting_level)
+      expect(cop.config_to_allow_offenses['Max']).to eq(max_to_allow)
     end
   end
 end


### PR DESCRIPTION
Fixes `rubocop --auto-gen-config` to work correctly with highly nested code.
