### PR TITLE
VariableName supports an enforced style of white space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * New lint cop `SpaceBeforeFirstArg` checks for space between the method name and the first argument in method calls without parentheses. ([@jonas054][])
 * New style cop `SingleSpaceBeforeFirstArg` checks that no more than one space is used between the method name and the first argument in method calls without parentheses. ([@jonas054][])
 * New formatter `disabled_lines` displays cops and line ranges disabled by inline comments. ([@fshowalter][])
+* `VariableName` supports EnforcedStyle white space. ([@agrimm][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -412,6 +412,7 @@ VariableName:
   SupportedStyles:
     - snake_case
     - camelCase
+    - white space
 
 WhileUntilModifier:
   MaxLineLength: 79

--- a/lib/rubocop/cop/mixin/configurable_enforced_style.rb
+++ b/lib/rubocop/cop/mixin/configurable_enforced_style.rb
@@ -10,6 +10,12 @@ module Rubocop
         both_styles_detected if config_to_allow_offenses['Enabled']
       end
 
+      def different_style_detected(different_style)
+        self.config_to_allow_offenses ||=
+          { parameter_name => different_style.to_s }
+        both_styles_detected if config_to_allow_offenses['Enabled']
+      end
+
       def correct_style_detected
         # Enabled:true indicates, later when the opposite style is detected,
         # that the correct style is used somewhere.

--- a/lib/rubocop/cop/mixin/configurable_naming.rb
+++ b/lib/rubocop/cop/mixin/configurable_naming.rb
@@ -9,6 +9,7 @@ module Rubocop
 
       SNAKE_CASE = /^@?[\da-z_]+[!?=]?$/
       CAMEL_CASE = /^@?[a-z][\da-zA-Z]+[!?=]?$/
+      WHITE_SPACE = /^@?[\da-z[:space:]]+[!?=]?$/
 
       def check(node, range)
         return unless range
@@ -18,15 +19,32 @@ module Rubocop
 
         if matches_config?(name)
           correct_style_detected
+        elsif (different_style = matches_any_config?(name))
+          add_offense(node, range, message(style)) do
+            different_style_detected(different_style)
+          end
         else
           add_offense(node, range, message(style)) do
-            opposite_style_detected
+            unrecognized_style_detected
           end
         end
       end
 
+      def matches_any_config?(name)
+        case name
+        when SNAKE_CASE then :snake_case
+        when CAMEL_CASE then :camelCase
+        when WHITE_SPACE then :"white space"
+        else nil
+        end
+      end
+
       def matches_config?(name)
-        name =~ (style == :snake_case ? SNAKE_CASE : CAMEL_CASE)
+        name =~ case style
+                when :snake_case then SNAKE_CASE
+                when :camelCase then CAMEL_CASE
+                when :"white space" then WHITE_SPACE
+                end
       end
 
       # Returns a range containing the method name after the given regexp and

--- a/lib/rubocop/cop/style/variable_name.rb
+++ b/lib/rubocop/cop/style/variable_name.rb
@@ -4,7 +4,7 @@ module Rubocop
   module Cop
     module Style
       # This cop makes sure that all variables use the configured style,
-      # snake_case or camelCase, for their names.
+      # snake_case or camelCase or white space, for their names.
       class VariableName < Cop
         include ConfigurableNaming
 

--- a/spec/rubocop/cop/style/variable_name_spec.rb
+++ b/spec/rubocop/cop/style/variable_name_spec.rb
@@ -96,6 +96,60 @@ describe Rubocop::Cop::Style::VariableName, :config do
     include_examples 'always accepted'
   end
 
+  context 'when configured for white space' do
+    let(:cop_config) { { 'EnforcedStyle' => 'white space' } }
+
+    it 'registers an offense for snake case in local variable name' do
+      inspect_source(cop, 'my_local = 1')
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.highlights).to eq(['my_local'])
+      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
+                                                 'snake_case')
+    end
+
+    it 'registers an offense for opposite + correct' do
+      inspect_source(cop, ['my local = 1',
+                           'myLocal = 1'])
+      expect(cop.highlights).to eq(['myLocal'])
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+    end
+
+    it 'registers an offense for snake case in instance variable name' do
+      inspect_source(cop, '@my_attribute = 3')
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.highlights).to eq(['@my_attribute'])
+    end
+
+    it 'registers an offense for snake case in setter name' do
+      inspect_source(cop, 'self.my_setter = 2')
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.highlights).to eq(['my_setter'])
+    end
+
+    it 'accepts white space in local variable name' do
+      inspect_source(cop, 'my local = 1')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts white space in instance variable name' do
+      inspect_source(cop, '@my attribute = 3')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts white space in setter name' do
+      inspect_source(cop, 'self.my setter = 2')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense for an unrecognised style' do
+      inspect_source(cop, 'my_Local = 1')
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.highlights).to eq(['my_Local'])
+    end
+
+    include_examples 'always accepted'
+  end
+
   context 'when configured with a bad value' do
     let(:cop_config) { { 'EnforcedStyle' => 'other' } }
 


### PR DESCRIPTION
Underscores are so ugly

```
my_variable = 2
```

The enforced style white space will enable

```
my variable = 2
```

Merge this in today!
