### PR TITLE
fix useless_access_modifier bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#940](https://github.com/bbatsov/rubocop/issues/940): Fixed `UselessAccessModifier` not handling attr_* correctly. ([@fshowalter][])
+
 ## 0.20.0 (02/04/2014)
 
 ### New features

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -21,7 +21,7 @@ module Rubocop
           body_nodes = body.type == :begin ? body.children : [body]
 
           body_nodes.each do |child_node|
-            check_for_access_modifier(child_node)
+            check_for_access_modifier(child_node) ||
             check_for_instance_method(child_node)
           end
 
@@ -39,7 +39,8 @@ module Rubocop
         end
 
         def check_for_instance_method(node)
-          return unless node.type == :def
+          return unless node.type == :def ||
+            node.type == :send
 
           @access_modifier_node = nil
         end

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -49,6 +49,44 @@ describe Rubocop::Cop::Lint::UselessAccessModifier do
     end
   end
 
+  context 'when an access modifier is followed by attr_*' do
+    let(:source) do
+      [
+        'class SomeClass',
+        '  protected',
+        '  attr_accessor :some_property',
+        'end'
+      ]
+    end
+
+    it 'does not register an offense' do
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(0)
+    end
+  end
+
+  context 'when an access modifier is followed by a ' \
+    'class method defined on constant' do
+    let(:source) do
+      [
+        'class SomeClass',
+        '  protected',
+        '  def SomeClass.some_method',
+        '  end',
+        'end'
+      ]
+    end
+
+    it 'registers an offense' do
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.offenses.first.message)
+        .to eq('Useless `protected` access modifier.')
+      expect(cop.offenses.first.line).to eq(2)
+      expect(cop.highlights).to eq(['protected'])
+    end
+  end
+
   context 'when consecutive access modifiers' do
     let(:source) do
       [


### PR DESCRIPTION
This fixes the bug, adds the test case, as well as an additional one where def is used with an explicit constant.
