### PR TITLE
Fix SpaceBeforeFirstArg cop for multiline arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#953](https://github.com/bbatsov/rubocop/pull/953): Fix auto-correction bug in `NonNilCheck`. ([@bbatsov][])
 * [#952](https://github.com/bbatsov/rubocop/pull/952): Handle implicit receiver in `StringConversionInInterpolation`. ([@bbatsov][])
 * [#956](https://github.com/bbatsov/rubocop/pull/956): Apply `ClassMethods` check only on `class`/`module` bodies. ([@bbatsov][])
+* [#945](https://github.com/bbatsov/rubocop/issues/945): Fix SpaceBeforeFirstArg cop for multiline argument and exclude assignments. ([@cschramm][])
 
 ## 0.20.0 (02/04/2014)
 
@@ -842,3 +843,4 @@
 [@hiroponz]: https://github.com/hiroponz
 [@tamird]: https://github.com/tamird
 [@fshowalter]: https://github.com/fshowalter
+[@cschramm]: https://github.com/cschramm

--- a/lib/rubocop/cop/lint/space_before_first_arg.rb
+++ b/lib/rubocop/cop/lint/space_before_first_arg.rb
@@ -20,6 +20,7 @@ module Rubocop
           _receiver, method_name, *args = *node
           return if args.empty?
           return if operator?(method_name)
+          return if method_name.to_s.end_with?('=')
 
           # Setter calls with parentheses are parsed this way. The parentheses
           # belong to the argument, not the send node.
@@ -28,7 +29,7 @@ module Rubocop
           arg1 = args.first.loc.expression
           arg1_with_space = range_with_surrounding_space(arg1, :left)
 
-          add_offense(nil, arg1) if arg1_with_space.source =~ /^\S/
+          add_offense(nil, arg1) if arg1_with_space.source =~ /\A\S/
         end
       end
     end

--- a/spec/rubocop/cop/lint/space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/lint/space_before_first_arg_spec.rb
@@ -26,6 +26,16 @@ describe Rubocop::Cop::Lint::SpaceBeforeFirstArg do
       inspect_source(cop, ['something[:x]'])
       expect(cop.offenses).to be_empty
     end
+
+    it 'accepts a method call with space before a multiline arg' do
+      inspect_source(cop, "something [\n  'foo',\n  'bar'\n]")
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts an assignment without space before first arg' do
+      inspect_source(cop, ['a.something=c', 'a.something,b=c,d'])
+      expect(cop.offenses).to be_empty
+    end
   end
 
   context 'for method calls with parentheses' do


### PR DESCRIPTION
I have this code:

``` ruby
SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
    SimpleCov::Formatter::HTMLFormatter,
    SimpleCov::Formatter::RcovFormatter
]
```

The cop treats everything after the equal sign as `arg1_with_space` and this does in fact start with a space, but the regular expression searches for any line not starting with a whitespace, not just the first one.
