### PR TITLE
[Fix #943] Fix auto-correct interference with SpaceAfterComma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * `NegatedIf` properly handles negated `unless` condition. ([@bbatsov][])
 * `NegatedWhile` properly handles negated `until` condition. ([@bbatsov][])
 * [#925](https://github.com/bbatsov/rubocop/issues/925): Do not disable the `Syntax` cop in output from `--auto-gen-config`. ([@jonas054][])
+* [#943](https://github.com/bbatsov/rubocop/issues/943): Fix auto-correction interference problem between `SpaceAfterComma` and other cops. ([@jonas054][])
 
 ## 0.20.0 (02/04/2014)
 

--- a/lib/rubocop/cop/mixin/space_after_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_after_punctuation.rb
@@ -25,7 +25,7 @@ module Rubocop
 
       def autocorrect(token)
         @corrections << lambda do |corrector|
-          corrector.insert_after(token.pos, ' ')
+          corrector.replace(token.pos, token.pos.source + ' ')
         end
       end
     end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -271,6 +271,44 @@ describe Rubocop::CLI, :isolated_environment do
                   ''].join("\n"))
       end
 
+      it 'can correct WordArray and SpaceAfterComma offenses' do
+        create_file('example.rb',
+                    ['# encoding: utf-8',
+                     "f(type: ['offline','offline_payment'],",
+                     "  bar_colors: ['958c12','953579','ff5800','0085cc'])"])
+        expect(cli.run(%w(-D --auto-correct --format o))).to eq(1)
+        expect($stdout.string)
+          .to eq(['',
+                  '4  SpaceAfterComma',
+                  '2  WordArray',
+                  '--',
+                  '6  Total',
+                  '',
+                  ''].join("\n"))
+        expect(IO.read('example.rb'))
+          .to eq(['# encoding: utf-8',
+                  'f(type: %w(offline offline_payment),',
+                  '  bar_colors: %w(958c12 953579 ff5800 0085cc))',
+                  ''].join("\n"))
+      end
+
+      it 'can correct SpaceAfterComma and HashSyntax offenses' do
+        create_file('example.rb',
+                    ['# encoding: utf-8',
+                     "I18n.t('description',:property_name => property.name)"])
+        expect(cli.run(%w(-D --auto-correct --format emacs))).to eq(1)
+        expect($stdout.string)
+          .to eq(["#{abs('example.rb')}:2:21: C: [Corrected] " \
+                  "SpaceAfterComma: Space missing after comma.",
+                  "#{abs('example.rb')}:2:22: C: [Corrected] " \
+                  "HashSyntax: Use the new Ruby 1.9 hash syntax.",
+                  ''].join("\n"))
+        expect(IO.read('example.rb'))
+          .to eq(['# encoding: utf-8',
+                  "I18n.t('description', property_name: property.name)",
+                  ''].join("\n"))
+      end
+
       it 'can correct HashSyntax and SpaceAroundOperators offenses' do
         create_file('example.rb',
                     ['# encoding: utf-8',


### PR DESCRIPTION
The `SpaceAfterComma` (and possibly other cops that include
`SpaceAfterPunctuation`) can destroy code if other cops are auto-
correcting in the same area. The solution is to make a bigger
substitution, so conflict resolution logic kicks in.
