### PR TITLE
[Fix #800] Do not report [Corrected] if correction wasn't done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#800](https://github.com/bbatsov/rubocop/issues/800): Do not report `[Corrected]` in `--auto-correct` mode if correction wasn't done. ([@jonas054][])
+
 ## 0.20.1 (05/04/2014)
 
 ### Bugs fixed

--- a/lib/rubocop/cop/mixin/autocorrect_unless_changing_ast.rb
+++ b/lib/rubocop/cop/mixin/autocorrect_unless_changing_ast.rb
@@ -11,7 +11,11 @@ module Rubocop
         new_source = rewrite_node(node, c)
 
         # Make the correction only if it doesn't change the AST.
-        @corrections << c if node == SourceParser.parse(new_source).ast
+        if node != SourceParser.parse(new_source).ast
+          fail CorrectionNotPossible
+        end
+
+        @corrections << c
       end
 
       def rewrite_node(node, correction)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -400,6 +400,29 @@ describe Rubocop::CLI, :isolated_environment do
                   ''].join("\n"))
       end
 
+      it 'does not say [Corrected] if correction was avoided' do
+        create_file('example.rb', ['# encoding: utf-8',
+                                   'func a and b',
+                                   'not a && b',
+                                   'func a do b end'])
+        expect(cli.run(%w(-a -f simple))).to eq(1)
+        expect($stderr.string).to eq('')
+        expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
+                                             'func a and b',
+                                             'not a && b',
+                                             'func a do b end',
+                                             ''].join("\n"))
+        expect($stdout.string)
+          .to eq(['== example.rb ==',
+                  'C:  2:  8: Use && instead of and.',
+                  'C:  3:  1: Use ! instead of not.',
+                  'C:  4:  8: Prefer {...} over do...end for single-line ' \
+                  'blocks.',
+                  '',
+                  '1 file inspected, 3 offenses detected',
+                  ''].join("\n"))
+      end
+
       it 'should not hang SpaceAfterPunctuation and SpaceInsideParens' do
         create_file('example.rb',
                     ['# encoding: utf-8',


### PR DESCRIPTION
A few cops that support auto-correction avoid it in certain cases. They should only print `[Corrected]` if a change was made. Solution is to reintroduce the exception `CorrectionNotPossible` that was removed a while back.
