### PR TITLE
`TrivialAccessors` accepts DSL-style writers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#963](https://github.com/bbatsov/rubocop/issues/963): Add `AllowDSLWriters` options to `TrivialAccessors`. ([@tamird][])
 * [#969](https://github.com/bbatsov/rubocop/issues/969): Let the `Debugger` cop check for forgotten calls to byebug. ([@bquorning][])
 
 ### Bugs fixed

--- a/config/default.yml
+++ b/config/default.yml
@@ -388,6 +388,15 @@ TrailingComma:
 TrivialAccessors:
   ExactNameMatch: false
   AllowPredicates: false
+  # Allows trivial writers that don't end in an equal sign. e.g.
+  #
+  # def on_exception(action)
+  #   @on_exception=action
+  # end
+  # on_exception :restart
+  #
+  # Commonly used in DSLs
+  AllowDSLWriters: false
   Whitelist:
     - to_ary
     - to_a

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -32,6 +32,10 @@ module Rubocop
           cop_config['AllowPredicates']
         end
 
+        def allow_dsl_writers?
+          cop_config['AllowDSLWriters']
+        end
+
         def whitelist
           whitelist = cop_config['Whitelist']
           Array(whitelist).map(&:to_sym) + [:initialize]
@@ -41,9 +45,14 @@ module Rubocop
           method_name[-1] == '?'
         end
 
+        def dsl_writer?(method_name)
+          !method_name.to_s.end_with?('=')
+        end
+
         def trivial_reader?(method_name, args, body)
           looks_like_trivial_reader?(args, body) &&
-            !allowed_method?(method_name, body)
+            !allowed_method?(method_name, body) &&
+            !allowed_reader?(method_name)
         end
 
         def looks_like_trivial_reader?(args, body)
@@ -51,20 +60,28 @@ module Rubocop
         end
 
         def trivial_writer?(method_name, args, body)
-          looks_like_trivial_writer?(args, body) &&
-            !allowed_method?(method_name, body)
+          looks_like_trivial_writer?(method_name, args, body) &&
+            !allowed_method?(method_name, body) &&
+            !allowed_writer?(method_name)
         end
 
-        def looks_like_trivial_writer?(args, body)
+        def looks_like_trivial_writer?(method_name, args, body)
           args.children.size == 1 && args.children[0].type != :restarg &&
             body && body.type == :ivasgn &&
             body.children[1] && body.children[1].type == :lvar
         end
 
         def allowed_method?(method_name, body)
-          allow_predicates? && predicate?(method_name) ||
-            whitelist.include?(method_name) ||
+          whitelist.include?(method_name) ||
             exact_name_match? && !names_match?(method_name, body)
+        end
+
+        def allowed_writer?(method_name)
+          allow_dsl_writers? && dsl_writer?(method_name)
+        end
+
+        def allowed_reader?(method_name)
+          allow_predicates? && predicate?(method_name)
         end
 
         def names_match?(method_name, body)

--- a/spec/rubocop/cop/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cop/style/trivial_accessors_spec.rb
@@ -241,6 +241,16 @@ describe Rubocop::Cop::Style::TrivialAccessors, :config do
              .map(&:line).sort).to eq([1])
   end
 
+  it 'finds DSL-style trivial writer' do
+    inspect_source(cop,
+                   ['def foo(val)',
+                    ' @foo = val',
+                    'end'])
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.offenses
+             .map(&:line).sort).to eq([1])
+  end
+
   it 'finds trivial writer in a class' do
     inspect_source(cop,
                    ['class TrivialFoo',
@@ -412,6 +422,18 @@ describe Rubocop::Cop::Style::TrivialAccessors, :config do
                      [' def bar=(bar)',
                       '   @bar = bar',
                       ' end'])
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'with DSL writers allowed' do
+    let(:cop_config) { { 'AllowDSLWriters' => true } }
+
+    it 'does not find DSL-style writer' do
+      inspect_source(cop,
+                     ['def foo(val)',
+                      ' @foo = val',
+                      'end'])
       expect(cop.offenses).to be_empty
     end
   end


### PR DESCRIPTION
@bbatsov what do you think of this change?
