### PR TITLE
Add auto-correction to RedundantBegin cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#964](https://github.com/bbatsov/rubocop/issues/964): `RedundantBegin` cop does auto-correction. ([@tamird][])
 * [#966](https://github.com/bbatsov/rubocop/issues/966): `RescueException` cop does auto-correction. ([@tamird][])
 * [#967](https://github.com/bbatsov/rubocop/issues/967): `TrivialAccessors` cop does auto-correction. ([@tamird][])
 * [#963](https://github.com/bbatsov/rubocop/issues/963): Add `AllowDSLWriters` options to `TrivialAccessors`. ([@tamird][])

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -22,12 +22,28 @@ module Rubocop
 
         MSG = 'Redundant `begin` block detected.'
 
-        private
-
         def check(_node, _method_name, _args, body)
           return unless body && body.type == :kwbegin
 
           add_offense(body, :begin)
+        end
+
+        def autocorrect(node)
+          @corrections << lambda do |corrector|
+            child = node.children.first
+
+            begin_indent = node.loc.column
+            child_indent = child.loc.column
+
+            indent_diff = child_indent - begin_indent
+
+            corrector.replace(
+              range_with_surrounding_space(node.loc.expression),
+              range_with_surrounding_space(
+                child.loc.expression
+              ).source.gsub(/^\s{#{indent_diff}}/, '')
+            )
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -5,6 +5,12 @@ require 'spec_helper'
 describe Rubocop::Cop::Style::RedundantBegin do
   subject(:cop) { described_class.new }
 
+  it 'reports an offense for single line def with redundant begin block' do
+    src = ['  def func; begin; x; y; rescue; z end end']
+    inspect_source(cop, src)
+    expect(cop.offenses.size).to eq(1)
+  end
+
   it 'reports an offense for def with redundant begin block' do
     src = ['def func',
            '  begin',
@@ -53,5 +59,31 @@ describe Rubocop::Cop::Style::RedundantBegin do
            'end']
     inspect_source(cop, src)
     expect(cop.offenses).to be_empty
+  end
+
+  it 'auto-corrects by removing redundant begin blocks' do
+    src = ['  def func',
+           '    begin',
+           '      foo',
+           '      bar',
+           '    rescue',
+           '      baz',
+           '    end',
+           '  end'].join("\n")
+    result_src = ['  def func',
+                  '    foo',
+                  '    bar',
+                  '  rescue',
+                  '    baz',
+                  '  end'].join("\n")
+    new_source = autocorrect_source(cop, src)
+    expect(new_source).to eq(result_src)
+  end
+
+  it 'auto-corrects by removing redundant begin blocks' do
+    src = '  def func; begin; x; y; rescue; z end end'
+    result_src = '  def func; x; y; rescue; z end'
+    new_source = autocorrect_source(cop, src)
+    expect(new_source).to eq(result_src)
   end
 end


### PR DESCRIPTION
This correction leaves some whitespace around, but other cops should handle that, right?
