### PR TITLE
Expand base dir to avoid exception from Pathname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 * [#800](https://github.com/bbatsov/rubocop/issues/800): Do not report `[Corrected]` in `--auto-correct` mode if correction wasn't done. ([@jonas054][])
+* [#968](https://github.com/bbatsov/rubocop/issues/968): Fix bug when running Rubocop with `-c .rubocop.yml`. ([@bquorning][])
 
 ## 0.20.1 (05/04/2014)
 
@@ -853,3 +854,4 @@
 [@tamird]: https://github.com/tamird
 [@fshowalter]: https://github.com/fshowalter
 [@cschramm]: https://github.com/cschramm
+[@bquorning]: https://github.com/bquorning

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -97,7 +97,7 @@ module Rubocop
     # not relative to RuboCop's config directory since that wouldn't work.
     def base_dir_for_path_parameters
       if File.basename(loaded_path) == ConfigLoader::DOTFILE
-        File.dirname(loaded_path)
+        File.expand_path(File.dirname(loaded_path))
       else
         Dir.pwd
       end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1407,6 +1407,19 @@ describe Rubocop::CLI, :isolated_environment do
   end
 
   describe 'configuration from file' do
+    it 'allows the default configuration file as the -c argument' do
+      create_file('example.rb', ['# encoding: utf-8',
+                                 'x = 0',
+                                 'puts x'
+                                ])
+      create_file('.rubocop.yml', [])
+
+      expect(cli.run(%w(--format simple -c .rubocop.yml))).to eq(0)
+      expect($stdout.string)
+        .to eq(['', '1 file inspected, no offenses detected',
+                ''].join("\n"))
+    end
+
     it 'finds included files' do
       create_file('example', ['# encoding: utf-8',
                               'x = 0',


### PR DESCRIPTION
I have a `.rubocop.yml` in my project’s main folder, and a `.rubocop.yml` in my spec folder. After upgrading from 0.19.1 to 0.20.1, I have this issue when running Rubocop from my spec folder:

```
~$ cd spec && rubocop -c ./.rubocop.yml
different prefix: "/" and "."
/Users/bquorning/.rubies/ruby-2.1.0/lib/ruby/2.1.0/pathname.rb:500:in `relative_path_from'
/Users/bquorning/.gem/ruby/2.1.0/gems/rubocop-0.20.1/lib/rubocop/path_util.rb:10:in `relative_path'
/Users/bquorning/.gem/ruby/2.1.0/gems/rubocop-0.20.1/lib/rubocop/config.rb:91:in `path_relative_to_config'
/Users/bquorning/.gem/ruby/2.1.0/gems/rubocop-0.20.1/lib/rubocop/config.rb:71:in `file_to_include?'
/Users/bquorning/.gem/ruby/2.1.0/gems/rubocop-0.20.1/lib/rubocop/target_finder.rb:61:in `block in target_files_in_dir'
/Users/bquorning/.gem/ruby/2.1.0/gems/rubocop-0.20.1/lib/rubocop/target_finder.rb:57:in `select'
/Users/bquorning/.gem/ruby/2.1.0/gems/rubocop-0.20.1/lib/rubocop/target_finder.rb:57:in `target_files_in_dir'
/Users/bquorning/.gem/ruby/2.1.0/gems/rubocop-0.20.1/lib/rubocop/target_finder.rb:25:in `find'
/Users/bquorning/.gem/ruby/2.1.0/gems/rubocop-0.20.1/lib/rubocop/cli.rb:28:in `run'
/Users/bquorning/.gem/ruby/2.1.0/gems/rubocop-0.20.1/bin/rubocop:14:in `block in <top (required)>'
/Users/bquorning/.rubies/ruby-2.1.0/lib/ruby/2.1.0/benchmark.rb:294:in `realtime'
/Users/bquorning/.gem/ruby/2.1.0/gems/rubocop-0.20.1/bin/rubocop:13:in `<top (required)>'
/Users/bquorning/.gem/ruby/2.1.0/bin/rubocop:23:in `load'
/Users/bquorning/.gem/ruby/2.1.0/bin/rubocop:23:in `<main>'
```

Always using an expanded path solves the problem.

cc/ @jonas054
