### PR TITLE
Let the Debugger cop also check for byebug calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#969](https://github.com/bbatsov/rubocop/issues/969): Let the `Debugger` cop check for forgotten calls to byebug. ([@bquorning][])
+
 ### Bugs fixed
 
 * [#800](https://github.com/bbatsov/rubocop/issues/800): Do not report `[Corrected]` in `--auto-correct` mode if correction wasn't done. ([@jonas054][])

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -12,6 +12,11 @@ module Rubocop
         # (send nil :debugger)
         DEBUGGER_NODE = s(:send, nil, :debugger)
 
+        # byebug call node
+        #
+        # (send nil :byebug)
+        BYEBUG_NODE = s(:send, nil, :byebug)
+
         # binding.pry node
         #
         # (send
@@ -24,7 +29,12 @@ module Rubocop
         #   (send nil :binding) :remote_pry)
         REMOTE_PRY_NODE = s(:send, s(:send, nil, :binding), :remote_pry)
 
-        DEBUGGER_NODES = [DEBUGGER_NODE, PRY_NODE, REMOTE_PRY_NODE]
+        DEBUGGER_NODES = [
+          DEBUGGER_NODE,
+          BYEBUG_NODE,
+          PRY_NODE,
+          REMOTE_PRY_NODE
+        ]
 
         def on_send(node)
           add_offense(node, :selector) if DEBUGGER_NODES.include?(node)

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -11,6 +11,12 @@ describe Rubocop::Cop::Lint::Debugger do
     expect(cop.offenses.size).to eq(1)
   end
 
+  it 'reports an offense for a byebug call' do
+    src = ['byebug']
+    inspect_source(cop, src)
+    expect(cop.offenses.size).to eq(1)
+  end
+
   it 'reports an offense for pry bindings' do
     src = ['binding.pry',
            'binding.remote_pry']
@@ -24,16 +30,19 @@ describe Rubocop::Cop::Lint::Debugger do
     expect(cop.offenses).to be_empty
   end
 
-  it 'does not report an offense for debugger in comments' do
-    src = ['# debugger']
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+  %w(debugger byebug).each do |comment|
+    it "does not report an offense for #{comment} in comments" do
+      src = ["# #{comment}"]
+      inspect_source(cop, src)
+      expect(cop.offenses).to be_empty
+    end
   end
 
-  it 'does not report an offense for a debugger or pry method' do
-    src = ['code.debugger',
-           'door.pry']
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+  %w(debugger byebug pry).each do |method_name|
+    it "does not report an offense for a #{method_name} method" do
+      src = ["code.#{method_name}"]
+      inspect_source(cop, src)
+      expect(cop.offenses).to be_empty
+    end
   end
 end


### PR DESCRIPTION
[Byebug](https://github.com/deivid-rodriguez/byebug) is a popular debugger that works with Ruby 2 (which [Debugger](https://github.com/cldwalker/debugger) doesn’t). Would it be ok to add a `byebug` as we’ve done here, or should it rather be a separate cop?
