### PR TITLE
AllCops deprecation message shows the config path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#967](https://github.com/bbatsov/rubocop/issues/967): `TrivialAccessors` cop does auto-correction. ([@tamird][])
 * [#963](https://github.com/bbatsov/rubocop/issues/963): Add `AllowDSLWriters` options to `TrivialAccessors`. ([@tamird][])
 * [#969](https://github.com/bbatsov/rubocop/issues/969): Let the `Debugger` cop check for forgotten calls to byebug. ([@bquorning][])
+* [#971](https://github.com/bbatsov/rubocop/issues/971): Configuration format deprecation warnings include the path to the problematic config file. ([@bcobb][])
 
 ### Bugs fixed
 
@@ -862,3 +863,4 @@
 [@fshowalter]: https://github.com/fshowalter
 [@cschramm]: https://github.com/cschramm
 [@bquorning]: https://github.com/bquorning
+[@bcobb]: https://github.com/bcobb

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -31,7 +31,12 @@ module Rubocop
 
         hash.delete('inherit_from')
         config = Config.new(hash, path)
-        deprecation_check(config)
+
+        deprecation_check(config) do |deprecation_message|
+          warn("#{path} - #{deprecation_message}")
+          exit(-1)
+        end
+
         config.warn_unless_valid
         make_excludes_absolute(config)
         config
@@ -40,11 +45,9 @@ module Rubocop
       def deprecation_check(config)
         return unless config['AllCops']
         if config['AllCops']['Excludes']
-          warn('AllCops/Excludes was renamed to AllCops/Exclude')
-          exit(-1)
+          yield 'AllCops/Excludes was renamed to AllCops/Exclude'
         elsif config['AllCops']['Includes']
-          warn('AllCops/Includes was renamed to AllCops/Include')
-          exit(-1)
+          yield 'AllCops/Includes was renamed to AllCops/Include'
         end
       end
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -325,4 +325,40 @@ describe Rubocop::ConfigLoader do
       end
     end
   end
+
+  describe '.deprecation_check' do
+    context 'when there is no AllCops configuration' do
+      it 'does not yield' do
+        expect do |b|
+          described_class.deprecation_check({}, &b)
+        end.not_to yield_control
+      end
+    end
+
+    context 'when there is AllCops configuration' do
+      it 'does not yield if there are no Excludes or Includes keys' do
+        config = { 'AllCops' => { 'Exclude' => [], 'Include' => [] } }
+
+        expect do |b|
+          described_class.deprecation_check(config, &b)
+        end.not_to yield_control
+      end
+
+      it 'yields if there are is an Includes key' do
+        config = { 'AllCops' => { 'Includes' => [] } }
+
+        expect do |b|
+          described_class.deprecation_check(config, &b)
+        end.to yield_with_args(String)
+      end
+
+      it 'yields if there are is an Excludes key' do
+        config = { 'AllCops' => { 'Excludes' => [] } }
+
+        expect do |b|
+          described_class.deprecation_check(config, &b)
+        end.to yield_with_args(String)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This was motivated by a project I'm working on that has a couple of `.rubocop.yml` configuration files. I periodically forget about the second of the two, and was initially confused by repeated deprecation warnings after upgrading and fixing what I thought was the only offense. In general, it seems like a nice gesture to provide users with the location of files which contain deprecated syntax.

I can squash in a Changelog update if this is deemed a good change.
