### PR TITLE
UnderscorePrefixedVariableName does not work with `super`

### DIFF
--- a/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
+++ b/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
@@ -9,6 +9,20 @@ describe Rubocop::Cop::Lint::UnderscorePrefixedVariableName do
     inspect_source(cop, source)
   end
 
+  context 'when an underscore-prefixed argument is unused' do
+    context 'in a method calling super' do
+      let(:source) { <<-END }
+        def some_method(*_)
+          super
+        end
+      END
+
+      it 'does not register an offense' do
+        expect(cop.offenses).to be_empty
+      end
+    end
+  end
+
   context 'when an underscore-prefixed variable is used' do
     let(:source) { <<-END }
       def some_method


### PR DESCRIPTION
@yujinakayama @bbatsov looks like this new cop doesn't play nice with `super`.
