### PR TITLE
Fix infinite correction in IndentationWidth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#976](https://github.com/bbatsov/rubocop/issues/976): Fix `IndentationWidth` not handling element assignment correctly. ([@tamird][])
 * [#800](https://github.com/bbatsov/rubocop/issues/800): Do not report `[Corrected]` in `--auto-correct` mode if correction wasn't done. ([@jonas054][])
 * [#968](https://github.com/bbatsov/rubocop/issues/968): Fix bug when running Rubocop with `-c .rubocop.yml`. ([@bquorning][])
+* [#975](https://github.com/bbatsov/rubocop/pull/975): Fix infinite correction in `IndentationWidth`. ([@jonas054][])
 
 ## 0.20.1 (05/04/2014)
 

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -27,8 +27,11 @@ module Rubocop
         def on_block(node)
           _method, _args, body = *node
           # Check body against end/} indentation. Checking against variable
-          # assignments, etc, would be more difficult.
-          check_indentation(node.loc.end, body)
+          # assignments, etc, would be more difficult. The end/} must be at the
+          # beginning of its line.
+          if begins_its_line?(node.loc.end)
+            check_indentation(node.loc.end, body)
+          end
         end
 
         def on_module(node)
@@ -91,6 +94,11 @@ module Rubocop
         end
 
         private
+
+        def begins_its_line?(range)
+          source_before_end = range.source_buffer.source[0...range.begin_pos]
+          source_before_end =~ /\n\s*\Z/
+        end
 
         def check_assignment(node, rhs)
           # If there are method calls chained to the right hand side of the

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -650,5 +650,15 @@ describe Rubocop::Cop::Style::IndentationWidth do
                       'end'])
       expect(cop.offenses).to be_empty
     end
+
+    # The cop uses the block end/} as the base for indentation, so if it's not
+    # on its own line, all bets are off.
+    it 'accepts badly indented code if block end is not on separate line' do
+      inspect_source(cop,
+                     ['foo {',
+                      'def baz',
+                      'end }'])
+      expect(cop.offenses).to be_empty
+    end
   end
 end


### PR DESCRIPTION
The solution is to not report indentation offenses in blocks where the `end`/`}` does not start the line that it's on.

Closes #975.
