### PR TITLE
[Fix #997] Make sure paths are on normal form for exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [#968](https://github.com/bbatsov/rubocop/issues/968): Fix bug when running Rubocop with `-c .rubocop.yml`. ([@bquorning][])
 * [#975](https://github.com/bbatsov/rubocop/pull/975): Fix infinite correction in `IndentationWidth`. ([@jonas054][])
 * [#986](https://github.com/bbatsov/rubocop/issues/986): When `--lint` is used together with `--only`, all lint cops are run in addition to the given cops. ([@jonas054][])
+* [#997](https://github.com/bbatsov/rubocop/issues/997): Fix handling of file paths for matching against `Exclude` property when `rubocop .` is called. ([@jonas054][])
 
 ## 0.20.1 (05/04/2014)
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -76,6 +76,7 @@ module Rubocop
 
     def file_to_exclude?(file)
       file = File.join(Dir.pwd, file) unless file.start_with?('/')
+      file = File.expand_path(file)
       patterns_to_exclude.any? { |pattern| match_path?(pattern, file) }
     end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1513,6 +1513,27 @@ describe Rubocop::CLI, :isolated_environment do
                 ''].join("\n"))
     end
 
+    it 'matches included/excluded files corectly when . argument is given' do
+      create_file('example.rb', 'x = 0')
+      create_file('special.dsl', ['# encoding: utf-8',
+                                  'setup { "stuff" }'
+                                 ])
+      create_file('.rubocop.yml', ['AllCops:',
+                                   '  Include:',
+                                   '    - "*.dsl"',
+                                   '  Exclude:',
+                                   '    - example.rb'
+                                  ])
+      expect(cli.run(%w(--format simple .))).to eq(1)
+      expect($stdout.string)
+        .to eq(['== special.dsl ==',
+                "C:  2:  9: Prefer single-quoted strings when you don't " \
+                "need string interpolation or special symbols.",
+                '',
+                '1 file inspected, 1 offense detected',
+                ''].join("\n"))
+    end
+
     # With rubinius 2.0.0.rc1 + rspec 2.13.1,
     # File.stub(:open).and_call_original causes SystemStackError.
     it 'does not read files in excluded list', broken: :rbx do


### PR DESCRIPTION
Calling `rubocop .` would result in absolute paths with `/./` in them and matching against `Exclude` properties failed.
