### PR TITLE
Fix LineEndConcatenation to handle chained concats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1006](https://github.com/bbatsov/rubocop/issues/1006): Fix LineEndConcatenation to handle chained concatenations. ([@barunio][])
 * [#934](https://github.com/bbatsov/rubocop/issues/934): New cop `UnderscorePrefixedVariableName` checks for `_`-prefixed variables that are actually used. ([@yujinakayama][])
 * [#934](https://github.com/bbatsov/rubocop/issues/934): New cop `UnusedMethodArgument` checks for unused method arguments. ([@yujinakayama][])
 * [#934](https://github.com/bbatsov/rubocop/issues/934): New cop `UnusedBlockArgument` checks for unused block arguments. ([@yujinakayama][])
@@ -883,3 +884,4 @@
 [@bquorning]: https://github.com/bquorning
 [@bcobb]: https://github.com/bcobb
 [@irrationalfab]: https://github.com/irrationalfab
+[@barunio]: https://github.com/barunio

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -41,9 +41,9 @@ module Rubocop
           # TODO: Report Emacs bug.
           return false unless [:+, :<<].include?(method)
 
-          return false unless string_type?(receiver)
+          return false unless terminal_node_is_string_type?(receiver)
 
-          return false unless string_type?(arg)
+          return false unless root_node_is_string_type?(arg)
 
           expression = node.loc.expression.source
           concatenator_at_line_end?(expression)
@@ -59,6 +59,24 @@ module Rubocop
 
           # we care only about quotes-delimited literals
           node.loc.begin && ["'", '"'].include?(node.loc.begin.source)
+        end
+
+        def terminal_node_is_string_type?(node)
+          if node.type == :send
+            _, method, arg = *node
+            [:+, :<<].include?(method) && terminal_node_is_string_type?(arg)
+          else
+            string_type?(node)
+          end
+        end
+
+        def root_node_is_string_type?(node)
+          if node.type == :send
+            receiver, method, _ = *node
+            [:+, :<<].include?(method) && root_node_is_string_type?(receiver)
+          else
+            string_type?(node)
+          end
         end
       end
     end


### PR DESCRIPTION
This fixes an issue where the LineEndConcatenation cop wasn't able to detect or autocorrect multiple offenses for chained string concatenations.
