### PR TITLE
[Fix #1001] Fix --auto-gen-config logic for RegexpLiteral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [#986](https://github.com/bbatsov/rubocop/issues/986): When `--lint` is used together with `--only`, all lint cops are run in addition to the given cops. ([@jonas054][])
 * [#997](https://github.com/bbatsov/rubocop/issues/997): Fix handling of file paths for matching against `Exclude` property when `rubocop .` is called. ([@jonas054][])
 * [#1000](https://github.com/bbatsov/rubocop/issues/1000): Support modifier (e.g., `private`) and `def` on the same line (Ruby >= 2.1) in `IndentationWidth`. ([@jonas054][])
+* [#1001](https://github.com/bbatsov/rubocop/issues/1001): Fix `--auto-gen-config` logic for `RegexpLiteral`. ([@jonas054][])
 
 ## 0.20.1 (05/04/2014)
 

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -22,7 +22,6 @@ describe Rubocop::Cop::Style::RegexpLiteral, :config do
       expect(cop.messages)
         .to eq(['Use %r for regular expressions matching more ' \
                 "than 0 '/' characters."])
-      expect(cop.config_to_allow_offenses).to eq('MaxSlashes' => 1)
     end
 
     it 'accepts zero slashes in // regexp' do
@@ -35,12 +34,30 @@ describe Rubocop::Cop::Style::RegexpLiteral, :config do
       expect(cop.messages)
         .to eq(['Use %r only for regular expressions matching more ' \
                 "than 0 '/' characters."])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts %r regexp with one slash' do
       inspect_source(cop, ['x =~ %r(/home)'])
       expect(cop.offenses).to be_empty
+    end
+
+    describe '--auto-gen-config' do
+      subject(:cop) { described_class.new(config, auto_gen_config: true) }
+
+      it 'sets MaxSlashes: 1 for one slash in // regexp' do
+        inspect_source(cop, ['x =~ /home\//'])
+        expect(cop.config_to_allow_offenses).to eq('MaxSlashes' => 1)
+      end
+
+      it 'disables the cop for zero slashes in %r regexp' do
+        inspect_source(cop, ['y =~ %r(etc)'])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
+
+      it 'generates nothing if there are no offenses' do
+        inspect_source(cop, ['x =~ %r(/home)'])
+        expect(cop.config_to_allow_offenses).to eq(nil)
+      end
     end
   end
 
@@ -53,24 +70,23 @@ describe Rubocop::Cop::Style::RegexpLiteral, :config do
       expect(cop.messages)
         .to eq(['Use %r for regular expressions matching more ' \
                 "than 1 '/' character."] * 2)
-      expect(cop.config_to_allow_offenses).to eq('MaxSlashes' => 2)
     end
 
-    it 'registers offenses for slashes with too many and %r with too few' do
-      inspect_source(cop, ['x =~ /home\/\//',
+    it 'registers offenses for slashes with too many' do
+      inspect_source(cop, 'x =~ /home\/\/\//')
+      expect(cop.messages)
+        .to eq(['Use %r for regular expressions matching more ' \
+                "than 1 '/' character."])
+    end
+
+    it 'registers offenses for %r with too few' do
+      inspect_source(cop, ['x =~ /home\/\/\//',
                            'y =~ %r{home}'])
       expect(cop.messages)
         .to eq(['Use %r for regular expressions matching more ' \
                 "than 1 '/' character.",
                 'Use %r only for regular expressions matching more ' \
                 "than 1 '/' character."])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-    end
-
-    it 'registers offenses for %r with too few and slashes with too many' do
-      inspect_source(cop, ['y =~ %r{home}',
-                           'x =~ /home\/\//'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts zero or one slash in // regexp' do
@@ -92,13 +108,67 @@ describe Rubocop::Cop::Style::RegexpLiteral, :config do
       expect(cop.messages)
         .to eq(['Use %r only for regular expressions matching more ' \
                 "than 1 '/' character."] * 2)
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts %r regexp with two or more slashes' do
       inspect_source(cop, ['x =~ %r(/home/)',
                            'y =~ %r(/////)'])
       expect(cop.offenses).to be_empty
+    end
+
+    describe '--auto-gen-config' do
+      subject(:cop) { described_class.new(config, auto_gen_config: true) }
+
+      it 'sets MaxSlashes: 2 for two slashes in // and 3 in %r' do
+        inspect_source(cop, ['x =~ /home\/\//',
+                             'y =~ %r{/usr/lib/ext}'])
+        expect(cop.config_to_allow_offenses).to eq('MaxSlashes' => 2)
+      end
+
+      it 'sets MaxSlashes: 0 for one slash in %r regexp' do
+        inspect_source(cop, 'x =~ %r{/home}')
+        expect(cop.config_to_allow_offenses).to eq('MaxSlashes' => 0)
+      end
+
+      it 'disables the cop for zero or one slash in %r regexp' do
+        inspect_source(cop, ['x =~ %r(/home)',
+                             'y =~ %r(etc)'])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
+
+      it 'disables the cop for // with too many and %r with too few' do
+        inspect_source(cop, ['x =~ /home\/\/\//',
+                             'y =~ %r{home}'])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
+
+      it 'disables the cop for %r with too few and // with too many' do
+        inspect_source(cop, ['y =~ %r{home}',
+                             'x =~ /home\/\//'])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
+
+      context 'when Enabled has been set to false' do
+        before do
+          inspect_source(cop, ['x =~ /home\/\/\//',
+                               'y =~ %r{/home/}'])
+        end
+
+        it 'does not change it' do
+          inspect_source(cop, 'x =~ %r{/home}')
+          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        end
+      end
+    end
+
+    context 'when --auto-gen-config is not given' do
+      subject(:cop) { described_class.new(config) }
+
+      it 'does not set MaxSlashes' do
+        inspect_source(cop, ['x =~ /home\/\//',
+                             'y =~ %r{/usr/lib/ext}'])
+        expect(cop.config_to_allow_offenses).to eq(nil)
+      end
     end
   end
 end


### PR DESCRIPTION
A lot of different cases to consider, so more spec examples added.
