### PR TITLE
[Fix #993] Don't report offenses for an empty file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [#997](https://github.com/bbatsov/rubocop/issues/997): Fix handling of file paths for matching against `Exclude` property when `rubocop .` is called. ([@jonas054][])
 * [#1000](https://github.com/bbatsov/rubocop/issues/1000): Support modifier (e.g., `private`) and `def` on the same line (Ruby >= 2.1) in `IndentationWidth`. ([@jonas054][])
 * [#1001](https://github.com/bbatsov/rubocop/issues/1001): Fix `--auto-gen-config` logic for `RegexpLiteral`. ([@jonas054][])
+* [#993](https://github.com/bbatsov/rubocop/issues/993): Do not report any offenses for the contents of an empty file. ([@jonas054][])
 
 ## 0.20.1 (05/04/2014)
 

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -12,6 +12,7 @@ module Rubocop
 
         def investigate(processed_source)
           unless RUBY_VERSION >= '2.0.0'
+            return if processed_source.buffer.source.empty?
             line_number = 0
             line_number += 1 if processed_source[line_number] =~ /^#!/
             line = processed_source[line_number]

--- a/lib/rubocop/cop/style/trailing_blank_lines.rb
+++ b/lib/rubocop/cop/style/trailing_blank_lines.rb
@@ -10,6 +10,8 @@ module Rubocop
 
         def investigate(processed_source)
           sb = processed_source.buffer
+          return if sb.source.empty?
+
           whitespace_at_end = sb.source[/\s*\Z/]
           blank_lines = whitespace_at_end.count("\n") - 1
           wanted_blank_lines = style == :final_newline ? 0 : 1

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1331,6 +1331,13 @@ describe Rubocop::CLI, :isolated_environment do
       .to eq(['', '1 file inspected, no offenses detected', ''].join("\n"))
   end
 
+  it 'does not register any offenses for an empty file' do
+    create_file('example.rb', '')
+    expect(cli.run(%w(--format simple))).to eq(0)
+    expect($stdout.string)
+      .to eq(['', '1 file inspected, no offenses detected', ''].join("\n"))
+  end
+
   describe 'rails cops' do
     describe 'enabling/disabling' do
       it 'by default does not run rails cops' do

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -12,6 +12,12 @@ describe Rubocop::Cop::Style::Encoding do
       ['Missing utf-8 encoding comment.'])
   end
 
+  it 'accepts an empty file', ruby: 1.9 do
+    inspect_source(cop, '')
+
+    expect(cop.offenses).to be_empty
+  end
+
   it 'accepts encoding on first line', ruby: 1.9 do
     inspect_source(cop, ['# encoding: utf-8',
                          'def foo() end'])

--- a/spec/rubocop/cop/style/trailing_blank_lines_spec.rb
+++ b/spec/rubocop/cop/style/trailing_blank_lines_spec.rb
@@ -13,6 +13,11 @@ describe Rubocop::Cop::Style::TrailingBlankLines, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts an empty file' do
+      inspect_source(cop, '')
+      expect(cop.offenses).to be_empty
+    end
+
     it 'registers an offense for multiple trailing blank lines' do
       inspect_source(cop, ['x = 0', '', '', '', ''])
       expect(cop.offenses.size).to eq(1)

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -11,6 +11,8 @@ module FileHelper
 
     File.open(file_path, 'w') do |file|
       case content
+      when ''
+        # Write nothing. Create empty file.
       when String
         file.puts content
       when Array


### PR DESCRIPTION
Except possibly for the file name.
