### PR TITLE
[Fix #1011] Add pattern matching with Dir#[] for config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Changes
 
 * Removed `FinalNewline` cop as its check is now performed by `TrailingBlankLines`. ([@jonas054][])
+* [#1011](https://github.com/bbatsov/rubocop/issues/1011): Pattern matching with `Dir#[]` for config parameters added. ([@jonas054][])
 
 ### Bugs fixed
 

--- a/README.md
+++ b/README.md
@@ -250,9 +250,9 @@ AllCops:
     - Rakefile
     - config.ru
   Exclude:
-    - db/**
-    - config/**
-    - script/**
+    - db/**/*
+    - config/**/*
+    - script/**/*
     - !ruby/regexp /old_and_unused\.rb$/
 
 # other configuration
@@ -260,6 +260,15 @@ AllCops:
 ```
 
 Files and directories are specified relative to the `.rubocop.yml` file.
+
+**Note**: Patterns that are just a file name, e.g. `Rakefile`, will match
+that file name in any directory, but this pattern style deprecated. The
+correct way to match the file in any directory, including the current, is
+`**/Rakefile`.
+
+**Note**: The pattern 'config/**' will match any file reqursively under
+`config`, but this pattern style is deprecated and should be replaced by
+`config/**/*`.
 
 **Note**: The `Exclude` parameter is special. It is valid for the
 directory tree starting where it is defined. It is not shadowed by the

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -104,14 +104,16 @@ module Rubocop
     def file_to_include?(file)
       relative_file_path = path_relative_to_config(file)
       patterns_to_include.any? do |pattern|
-        match_path?(pattern, relative_file_path)
+        match_path?(pattern, relative_file_path, loaded_path)
       end
     end
 
     def file_to_exclude?(file)
       file = File.join(Dir.pwd, file) unless file.start_with?('/')
       file = File.expand_path(file)
-      patterns_to_exclude.any? { |pattern| match_path?(pattern, file) }
+      patterns_to_exclude.any? do |pattern|
+        match_path?(pattern, file, loaded_path)
+      end
     end
 
     def patterns_to_include

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -172,7 +172,9 @@ module Rubocop
         patterns = cop_config && cop_config[parameter]
         return default_result unless patterns
         path = config.path_relative_to_config(file)
-        patterns.any? { |pattern| match_path?(pattern, path) }
+        patterns.any? do |pattern|
+          match_path?(pattern, path, config.loaded_path)
+        end
       end
 
       def enabled_line?(line_number)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1809,7 +1809,7 @@ describe Rubocop::CLI, :isolated_environment do
       create_file('.rubocop.yml',
                   ['AllCops:',
                    '  Exclude:',
-                   '    - vendor/**'])
+                   '    - vendor/**/*'])
 
       cli.run(%w(--format simple))
       expect($stderr.string).to eq('')

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -101,6 +101,9 @@ describe Rubocop::Config do
   end
 
   describe '#file_to_exclude?' do
+    before { $stderr = StringIO.new }
+    after { $stderr = STDERR }
+
     let(:hash) do
       {
         'AllCops' => {

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -15,28 +15,62 @@ describe Rubocop::PathUtil do
     end
   end
 
-  describe '#match_path?' do
-    it 'matches strings to the basename' do
-      expect(subject.match_path?('file', '/dir/file')).to be_true
-      expect(subject.match_path?('file', '/dir/files')).to be_false
-      expect(subject.match_path?('dir', '/dir/file')).to be_false
+  describe '#match_path?', :isolated_environment do
+    include FileHelper
+
+    before do
+      create_file('file', '')
+      create_file('dir/file', '')
+      create_file('dir/files', '')
+      create_file('dir/dir/file', '')
+      create_file('dir/sub/file', '')
+      $stderr = StringIO.new
+    end
+
+    after { $stderr = STDERR }
+
+    context 'with deprecated patterns' do
+      it 'matches dir/** and prints warning' do
+        expect(subject.match_path?('dir/**', 'dir/sub/file', '.rubocop.yml'))
+          .to be_true
+        expect($stderr.string)
+          .to eq("Warning: Deprecated pattern style 'dir/**' in " \
+                 ".rubocop.yml. Change to 'dir/**/*'.\n")
+      end
+
+      it 'matches strings to the basename and prints warning' do
+        expect(subject.match_path?('file', 'dir/file', '.rubocop.yml'))
+          .to be_true
+        expect($stderr.string)
+          .to eq("Warning: Deprecated pattern style 'file' in .rubocop.yml. " \
+                 "Change to '**/file'.\n")
+
+        expect(subject.match_path?('file', 'dir/files', '')).to be_false
+        expect(subject.match_path?('dir', 'dir/file', '')).to be_false
+      end
     end
 
     it 'matches strings to the full path' do
-      expect(subject.match_path?('/dir/file', '/dir/file')).to be_true
-      expect(subject.match_path?('/dir/file', '/dir/dir/file')).to be_false
+      expect(subject.match_path?("#{Dir.pwd}/dir/file",
+                                 "#{Dir.pwd}/dir/file", '')).to be_true
+      expect(subject.match_path?("#{Dir.pwd}/dir/file",
+                                 "#{Dir.pwd}/dir/dir/file", '')).to be_false
     end
 
     it 'matches glob expressions' do
-      expect(subject.match_path?('dir/*', 'dir/file')).to be_true
-      expect(subject.match_path?('dir/*', 'dir/sub/file')).to be_true
-      expect(subject.match_path?('dir/**/*', 'dir/sub/file')).to be_true
-      expect(subject.match_path?('sub/*', 'dir/sub/file')).to be_false
+      expect(subject.match_path?('dir/*',    'dir/file', '')).to be_true
+      expect(subject.match_path?('dir/*/*',  'dir/sub/file', '')).to be_true
+      expect(subject.match_path?('dir/**/*', 'dir/sub/file', '')).to be_true
+      expect(subject.match_path?('dir/**/*', 'dir/file', '')).to be_true
+      expect(subject.match_path?('**/*',     'dir/sub/file', '')).to be_true
+      expect(subject.match_path?('**/file',  'file', '')).to be_true
+
+      expect(subject.match_path?('sub/*',    'dir/sub/file', '')).to be_false
     end
 
     it 'matches regexps' do
-      expect(subject.match_path?(/^d.*e$/, 'dir/file')).to be_true
-      expect(subject.match_path?(/^d.*e$/, 'dir/filez')).to be_false
+      expect(subject.match_path?(/^d.*e$/, 'dir/file', '')).to be_true
+      expect(subject.match_path?(/^d.*e$/, 'dir/filez', '')).to be_false
     end
   end
 end


### PR DESCRIPTION
But keep backwards compatibility and issue deprecation warnings for problematic patterns such as bare file names and patterns ending with `**`.
