### PR TITLE
Fix tests in the presences of `ast` 2.0.0

### DIFF
--- a/lib/rubocop/cop/ignored_node.rb
+++ b/lib/rubocop/cop/ignored_node.rb
@@ -5,26 +5,26 @@ module Rubocop
     # Handles adding and checking ignored nodes.
     module IgnoredNode
       def ignore_node(node)
-        @ignored_nodes ||= []
-        @ignored_nodes << node
+        ignored_nodes << node
       end
 
       def part_of_ignored_node?(node)
-        return false unless @ignored_nodes
         expression = node.loc.expression
-        @ignored_nodes.each do |ignored_node|
-          if ignored_node.loc.expression.begin_pos <= expression.begin_pos &&
+        ignored_nodes.any? do |ignored_node|
+          ignored_node.loc.expression.begin_pos <= expression.begin_pos &&
             ignored_node.loc.expression.end_pos >= expression.end_pos
-            return true
-          end
         end
-
-        false
       end
 
       def ignored_node?(node)
         # Same object found in array?
-        @ignored_nodes && @ignored_nodes.any? { |n| n.eql?(node) }
+        ignored_nodes.any? { |n| n.equal?(node) }
+      end
+
+      private
+
+      def ignored_nodes
+        @ignored_nodes ||= []
       end
     end
   end


### PR DESCRIPTION
@bbatsov

`AST::Node` now implements `#eql?` which allows node equality checking.
Unfortunately this is not what was intended in Rubocop, so now we must
check object identity explicitly.
