### PR TITLE
Check for non ASCII characters in Encoding cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add `auto_correct` task to Rake integration. ([@irrationalfab][])
 * [#986](https://github.com/bbatsov/rubocop/issues/986): The `--only` option can take a comma-separated list of cops. ([@jonas054][])
 * New Rails cop `Delegate` that checks for delegations that could be replaced by the delegate method. ([@geniou][])
+* Add configuration to `Encoding` cop to only enforce encoding comment if there are non ASCII characters. ([@geniou][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -194,6 +194,13 @@ EmptyLineBetweenDefs:
   # need an empty line between them.
   AllowAdjacentOneLineDefs: false
 
+# Checks whether the source file has a utf-8 encoding comment or not
+Encoding:
+  EnforcedStyle: always
+  SupportedStyles:
+    - when_needed
+    - always
+
 # Align ends correctly.
 EndAlignment:
   # The value `keyword` means that `end` should be aligned with the matching

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -2,61 +2,150 @@
 
 require 'spec_helper'
 
-describe Rubocop::Cop::Style::Encoding do
-  subject(:cop) { described_class.new }
+describe Rubocop::Cop::Style::Encoding, :config do
+  subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when no encoding present', ruby: 1.9 do
-    inspect_source(cop, ['def foo() end'])
+  context 'when_needed' do
+    let(:cop_config) do
+      { 'EnforcedStyle' => 'when_needed' }
+    end
 
-    expect(cop.messages).to eq(
-      ['Missing utf-8 encoding comment.'])
+    it 'registers no offense when no encoding present but only ASCII ' \
+       'characters', ruby: 1.9 do
+      inspect_source(cop, ['def foo() end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense when there is no encoding present but non ' \
+       'ASCII characters', ruby: 1.9 do
+      inspect_source(cop, ['def foo() \'ä\' end'])
+
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages).to eq(
+        ['Missing utf-8 encoding comment.'])
+    end
+
+    it 'registers an offense when encoding present but only ASCII ' \
+       'characters', ruby: 1.9 do
+      inspect_source(cop, ['# encoding: utf-8',
+                           'def foo() end'])
+
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages).to eq(
+        ['Unnecessary utf-8 encoding comment.'])
+    end
+
+    it 'accepts an empty file', ruby: 1.9 do
+      inspect_source(cop, '')
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts encoding on first line', ruby: 1.9 do
+      inspect_source(cop, ['# encoding: utf-8',
+                           'def foo() \'ä\' end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts encoding on second line when shebang present', ruby: 1.9 do
+      inspect_source(cop, ['#!/usr/bin/env ruby',
+                           '# encoding: utf-8',
+                           'def foo() \'ä\' end'])
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'books an offense when encoding is in the wrong place', ruby: 1.9 do
+      inspect_source(cop, ['def foo() \'ä\' end',
+                           '# encoding: utf-8'])
+
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages).to eq(
+        ['Missing utf-8 encoding comment.'])
+    end
+
+    it 'does not register an offense on Ruby 2.0', ruby: 2.0 do
+      inspect_source(cop, ['def foo() \'ä\' end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts encoding inserted by magic_encoding gem', ruby: 1.9 do
+      inspect_source(cop, ['# -*- encoding : utf-8 -*-',
+                           'def foo() \'ä\' end'])
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'accepts vim-style encoding comments', ruby: 1.9 do
+      inspect_source(cop, ['# vim:fileencoding=utf-8',
+                           'def foo() \'ä\' end'])
+      expect(cop.messages).to be_empty
+    end
   end
 
-  it 'accepts an empty file', ruby: 1.9 do
-    inspect_source(cop, '')
+  context 'always' do
+    let(:cop_config) do
+      { 'EnforcedStyle' => 'always' }
+    end
 
-    expect(cop.offenses).to be_empty
-  end
+    it 'registers an offense when no encoding present', ruby: 1.9 do
+      inspect_source(cop, ['def foo() end'])
 
-  it 'accepts encoding on first line', ruby: 1.9 do
-    inspect_source(cop, ['# encoding: utf-8',
-                         'def foo() end'])
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages).to eq(
+        ['Missing utf-8 encoding comment.'])
+    end
 
-    expect(cop.offenses).to be_empty
-  end
+    it 'accepts an empty file', ruby: 1.9 do
+      inspect_source(cop, '')
 
-  it 'accepts encoding on second line when shebang present', ruby: 1.9 do
-    inspect_source(cop, ['#!/usr/bin/env ruby',
-                         '# encoding: utf-8',
-                         'def foo() end'])
+      expect(cop.offenses).to be_empty
+    end
 
-    expect(cop.messages).to be_empty
-  end
+    it 'accepts encoding on first line', ruby: 1.9 do
+      inspect_source(cop, ['# encoding: utf-8',
+                           'def foo() end'])
 
-  it 'books an offense when encoding is in the wrong place', ruby: 1.9 do
-    inspect_source(cop, ['def foo() end',
-                         '# encoding: utf-8'])
+      expect(cop.offenses).to be_empty
+    end
 
-    expect(cop.messages).to eq(
-      ['Missing utf-8 encoding comment.'])
-  end
+    it 'accepts encoding on second line when shebang present', ruby: 1.9 do
+      inspect_source(cop, ['#!/usr/bin/env ruby',
+                           '# encoding: utf-8',
+                           'def foo() end'])
 
-  it 'does not register an offense on Ruby 2.0', ruby: 2.0 do
-    inspect_source(cop, ['def foo() end'])
+      expect(cop.messages).to be_empty
+    end
 
-    expect(cop.offenses).to be_empty
-  end
+    it 'books an offense when encoding is in the wrong place', ruby: 1.9 do
+      inspect_source(cop, ['def foo() end',
+                           '# encoding: utf-8'])
 
-  it 'accepts encoding inserted by magic_encoding gem', ruby: 1.9 do
-    inspect_source(cop, ['# -*- encoding : utf-8 -*-',
-                         'def foo() end'])
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages).to eq(
+        ['Missing utf-8 encoding comment.'])
+    end
 
-    expect(cop.messages).to be_empty
-  end
+    it 'does not register an offense on Ruby 2.0', ruby: 2.0 do
+      inspect_source(cop, ['def foo() end'])
 
-  it 'accepts vim-style encoding comments', ruby: 1.9 do
-    inspect_source(cop, ['# vim:fileencoding=utf-8',
-                         'def foo() end'])
-    expect(cop.messages).to be_empty
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts encoding inserted by magic_encoding gem', ruby: 1.9 do
+      inspect_source(cop, ['# -*- encoding : utf-8 -*-',
+                           'def foo() end'])
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'accepts vim-style encoding comments', ruby: 1.9 do
+      inspect_source(cop, ['# vim:fileencoding=utf-8',
+                           'def foo() end'])
+      expect(cop.messages).to be_empty
+    end
   end
 end


### PR DESCRIPTION
I think the encoding should only be forced if there are non ASCII characters in - otherwise its not needed. This is especially for gem interesting, so that they don't have to pollute there whole code with unneeded endcoding comments if they also support old ruby versions.
