### PR TITLE
Enable inspection of old code with config AllCops/Excludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* The parameters `AllCops/Excludes` and `AllCops/Includes` with final `s` only give a warning and don't halt `rubocop` execution. ([@jonas054][])
+
 ### Bugs fixed
 
 * Fix `Delegate` for delegation with assignment or constant. ([@geniou][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -50,11 +50,16 @@ module Rubocop
     end
 
     def deprecation_check
-      return unless self['AllCops']
-      if self['AllCops']['Excludes']
-        yield 'AllCops/Excludes was renamed to AllCops/Exclude'
-      elsif self['AllCops']['Includes']
-        yield 'AllCops/Includes was renamed to AllCops/Include'
+      all_cops = self['AllCops']
+      return unless all_cops
+
+      %w(Exclude Include).each do |key|
+        plural = "#{key}s"
+        if all_cops[plural]
+          all_cops[key] = all_cops[plural] # Stay backwards compatible.
+          all_cops.delete(plural)
+          yield "AllCops/#{plural} was renamed to AllCops/#{key}"
+        end
       end
     end
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -34,7 +34,6 @@ module Rubocop
 
         config.deprecation_check do |deprecation_message|
           warn("#{path} - #{deprecation_message}")
-          exit(-1)
         end
 
         config.warn_unless_valid


### PR DESCRIPTION
... and `AllCops/Includes`. We stay backwards compatible, allowing the old names instead of stopping, so that it's possible to inspect for example old gems containing these parameters in their `.rubocop.yml`.

This is a fix for something that became a problem for me when I wanted to test `rubocop` by running it on installed gems.
