### PR TITLE
Fix short call syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs fixed
 
+* Fix `Void` and `SpaceAroundOperators` for short call syntax `lambda.()`. ([@biinari][])
 * Fix `Delegate` for delegation with assignment or constant. ([@geniou][])
 
 ## 0.21.0 (24/04/2014)
@@ -903,3 +904,4 @@
 [@bcobb]: https://github.com/bcobb
 [@irrationalfab]: https://github.com/irrationalfab
 [@sfeldon]: https://github.com/sfeldon
+[@biinari]: https://github.com/biinari

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -29,6 +29,7 @@ module Rubocop
 
         def check_for_void_op(node)
           return unless node.type == :send
+          return unless node.loc.selector
 
           op = node.loc.selector.source
 

--- a/lib/rubocop/cop/style/space_around_operators.rb
+++ b/lib/rubocop/cop/style/space_around_operators.rb
@@ -42,6 +42,7 @@ module Rubocop
 
         def unary_operation?(node)
           whole, selector = node.loc.expression, node.loc.selector
+          return unless selector
           operator?(selector) && whole.begin_pos == selector.begin_pos
         end
 

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -54,4 +54,12 @@ describe Rubocop::Cop::Lint::Void do
     end
   end
 
+  it 'accepts short call syntax' do
+    inspect_source(cop,
+                   ['lambda.(a)',
+                    'top'
+                   ])
+    expect(cop.offenses).to be_empty
+  end
+
 end

--- a/spec/rubocop/cop/style/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/style/space_around_operators_spec.rb
@@ -246,6 +246,7 @@ describe Rubocop::Cop::Style::SpaceAroundOperators do
 
   it 'accepts unary operators without space' do
     inspect_source(cop, ['[].map(&:size)',
+                         'a.(b)',
                          '-3',
                          'arr.collect { |e| -e }',
                          'x = +2'])


### PR DESCRIPTION
Fix `Void` and `SpacesAroundOperators` cops when short call syntax is used, e.g. `lambda.()` instead of
`lambda.call()`.
