### PR TITLE
Stabilize semantics of NonNilCheck autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changes
 
+* `NonNilCheck` offense reporting and autocorrect are configurable to include semantic changes. ([@hannestyden][])
 * The parameters `AllCops/Excludes` and `AllCops/Includes` with final `s` only give a warning and don't halt `rubocop` execution. ([@jonas054][])
 
 ### Bugs fixed

--- a/config/default.yml
+++ b/config/default.yml
@@ -279,6 +279,15 @@ Next:
     - skip_modifier_ifs
     - always
 
+NonNilCheck:
+  # With `IncludeSemanticChanges` set to `true`, this cop reports offences for
+  # `!x.nil?` and autocorrects that and `x != nil` to solely `x`, which is
+  # **usually** OK, but might change behavior.
+  #
+  # With `IncludeSemanticChanges` set to `false`, this cop does not report
+  # offences for `!x.nil?` and does no changes that might change behavior.
+  IncludeSemanticChanges: false
+
 MethodDefParentheses:
   EnforcedStyle: require_parentheses
   SupportedStyles:

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -2,8 +2,14 @@
 
 require 'spec_helper'
 
-describe Rubocop::Cop::Style::NonNilCheck do
-  subject(:cop) { described_class.new }
+describe Rubocop::Cop::Style::NonNilCheck, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:cop_config) do
+    {
+      'IncludeSemanticChanges' => false
+    }
+  end
 
   it 'registers an offense for != nil' do
     inspect_source(cop, 'x != nil')
@@ -11,16 +17,14 @@ describe Rubocop::Cop::Style::NonNilCheck do
     expect(cop.highlights).to eq(['!='])
   end
 
-  it 'registers an offense for !x.nil?' do
+  it 'does not register an offense for !x.nil?' do
     inspect_source(cop, '!x.nil?')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['!x.nil?'])
+    expect(cop.offenses).to be_empty
   end
 
-  it 'registers an offense for not x.nil?' do
+  it 'does not register an offense for not x.nil?' do
     inspect_source(cop, 'not x.nil?')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['not x.nil?'])
+    expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense if only expression in predicate' do
@@ -53,18 +57,45 @@ describe Rubocop::Cop::Style::NonNilCheck do
     expect(cop.offenses).to be_empty
   end
 
-  it 'autocorrects by removing != nil' do
+  it 'autocorrects by changing `!= nil` to `!x.nil?`' do
     corrected = autocorrect_source(cop, 'x != nil')
-    expect(corrected).to eq 'x'
+    expect(corrected).to eq '!x.nil?'
   end
 
-  it 'autocorrects by removing non-nil (!x.nil?) check' do
+  it 'does not autocorrect by removing non-nil (!x.nil?) check' do
     corrected = autocorrect_source(cop, '!x.nil?')
-    expect(corrected).to eq 'x'
+    expect(corrected).to eq '!x.nil?'
   end
 
   it 'does not blow up when autocorrecting implicit receiver' do
     corrected = autocorrect_source(cop, '!nil?')
-    expect(corrected).to eq 'self'
+    expect(corrected).to eq '!nil?'
+  end
+
+  context 'when allowing semantic changes' do
+    subject(:cop) { described_class.new(config) }
+
+    let(:cop_config) do
+      {
+        'IncludeSemanticChanges' => true
+      }
+    end
+
+    it 'registers an offense for `!x.nil?`' do
+      inspect_source(cop, '!x.nil?')
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.highlights).to eq(['!x.nil?'])
+    end
+
+    it 'registers an offense for `not x.nil?`' do
+      inspect_source(cop, 'not x.nil?')
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.highlights).to eq(['not x.nil?'])
+    end
+
+    it 'autocorrects by changing `x != nil` to `x`' do
+      corrected = autocorrect_source(cop, 'x != nil')
+      expect(corrected).to eq 'x'
+    end
   end
 end


### PR DESCRIPTION
`a` and `!a.nil?` are not semantically equivalent, this should be respected by autocorrect for `NonNilCheck`.

The cop description and message even says that explicit checks (emphasis added)

> are **usually** redundant. 
