### PR TITLE
Fix up typos in default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -54,7 +54,7 @@ AlignHash:
   # inspected? Valid values are:
   #
   # always_inspect - Inspect both implicit and explicit hashes.
-  #   Registers and offence for:
+  #   Registers an offence for:
   #     function(a: 1,
   #       b: 2)
   #   Registers an offence for:
@@ -97,8 +97,8 @@ AlignParameters:
   #     method_call(a,
   #                 b)
   #
-  # The `with_fixed_indentation` style alignes the following lines with one
-  # level of indenation relative to the start of the line with the method call.
+  # The `with_fixed_indentation` style aligns the following lines with one
+  # level of indentation relative to the start of the line with the method call.
   #
   #     method_call(a,
   #       b)
@@ -133,7 +133,7 @@ ClassAndModuleChildren:
   #
   # Basically there are two different styles:
   #
-  # `nested` - have each child on a separat line
+  # `nested` - have each child on a separate line
   #   class Foo
   #     class Bar
   #     end
@@ -276,7 +276,7 @@ LineLength:
   Max: 79
 
 Next:
-  # With `always` all conditions at the end of an interation needs to be
+  # With `always` all conditions at the end of an iteration needs to be
   # replace by next - with `skip_modifier_ifs` the modifier if like this one
   # are ignored: [1, 2].each { |a| return 'yes' if a == 1 }
   EnforcedStyle: skip_modifier_ifs


### PR DESCRIPTION
Fix:
- 'and' -> 'an'
- 'alignes' -> 'aligns'
- 'indenation' -> 'indentation'
- 'separat' -> 'separate'
- 'interation' -> 'iteration'
