### PR TITLE
[Fix #1066] Fix auto-correct of parenthesized condition in NegatedIf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#1032](https://github.com/bbatsov/rubocop/issues/1032): Avoid duplicate reporting when code moves around due to `--auto-correct`. ([@jonas054][])
 * [#1036](https://github.com/bbatsov/rubocop/issues/1036): Handle strings like `__FILE__` in `LineEndConcatenation`. ([@bbatsov][])
 * [#1006](https://github.com/bbatsov/rubocop/issues/1006): Fix LineEndConcatenation to handle chained concatenations. ([@barunio][])
+* [#1066](https://github.com/bbatsov/rubocop/issues/1066): Fix auto-correct for `NegatedIf` when the condition has parentheses around it. ([@jonas054][])
 
 ## 0.21.0 (24/04/2014)
 

--- a/lib/rubocop/cop/style/negated_if.rb
+++ b/lib/rubocop/cop/style/negated_if.rb
@@ -30,6 +30,8 @@ module Rubocop
         def autocorrect(node)
           @corrections << lambda do |corrector|
             condition, _body, _rest = *node
+            # look inside parentheses around the condition
+            condition = condition.children.first while condition.type == :begin
             # unwrap the negated portion of the condition (a send node)
             pos_condition, _method, = *condition
             corrector.replace(

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -90,9 +90,13 @@ describe Rubocop::Cop::Style::NegatedIf do
     expect(corrected).to eq 'something unless x.even?'
   end
 
+  it 'autocorrects by replacing parenthesized if not with unless' do
+    corrected = autocorrect_source(cop, 'something if (!x.even?)')
+    expect(corrected).to eq 'something unless (x.even?)'
+  end
+
   it 'autocorrects by replacing unless not with if' do
     corrected = autocorrect_source(cop, 'something unless !x.even?')
     expect(corrected).to eq 'something if x.even?'
   end
-
 end


### PR DESCRIPTION
The problem was not interference between two cops (as I usually suspect in these cases). It was in `NegatedIf#autocorrect`.
