### PR TITLE
Fix AlignParameters for multi-line method calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#1036](https://github.com/bbatsov/rubocop/issues/1036): Handle strings like `__FILE__` in `LineEndConcatenation`. ([@bbatsov][])
 * [#1006](https://github.com/bbatsov/rubocop/issues/1006): Fix LineEndConcatenation to handle chained concatenations. ([@barunio][])
 * [#1066](https://github.com/bbatsov/rubocop/issues/1066): Fix auto-correct for `NegatedIf` when the condition has parentheses around it. ([@jonas054][])
+* Fix `AlignParameters` `with_fixed_indentation` for multi-line method calls. ([@molawson][])
 
 ## 0.21.0 (24/04/2014)
 
@@ -923,3 +924,4 @@
 [@sfeldon]: https://github.com/sfeldon
 [@biinari]: https://github.com/biinari
 [@barunio]: https://github.com/barunio
+[@molawson]: https://github.com/molawson

--- a/lib/rubocop/cop/style/align_parameters.rb
+++ b/lib/rubocop/cop/style/align_parameters.rb
@@ -28,11 +28,21 @@ module Rubocop
 
         def base_column(node, args)
           if fixed_indentation?
-            line = node.loc.expression.source_buffer.source_line(node.loc.line)
+            lineno = target_method_lineno(node)
+            line = node.loc.expression.source_buffer.source_line(lineno)
             indentation_of_line = /\S.*/.match(line).begin(0)
             indentation_of_line + 2
           else
             args.first.loc.column
+          end
+        end
+
+        def target_method_lineno(node)
+          if node.loc.selector
+            node.loc.selector.line
+          else
+            # l.(1) has no selector, so we use the opening parenthesis instead
+            node.loc.begin.line
           end
         end
       end

--- a/spec/rubocop/cop/style/align_parameters_spec.rb
+++ b/spec/rubocop/cop/style/align_parameters_spec.rb
@@ -311,6 +311,59 @@ describe Rubocop::Cop::Style::AlignParameters, :config do
         .to eq(correct_source.join("\n"))
     end
 
+    context 'multi-line method calls' do
+      it 'can handle existing indentation from multi-line method calls' do
+        inspect_source(cop, [' something',
+                             '   .method_name(',
+                             '     a,',
+                             '     b,',
+                             '     c',
+                             '   )'])
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'registers offences for double indentation from relevant method' do
+        inspect_source(cop, [' something',
+                             '   .method_name(',
+                             '       a,',
+                             '       b,',
+                             '       c',
+                             '   )'])
+        expect(cop.offenses.size).to eq(3)
+      end
+
+      it 'does not err on method call without a method name' do
+        inspect_source(cop, [' something',
+                             '   .(',
+                             '     a,',
+                             '     b,',
+                             '     c',
+                             '   )'])
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'autocorrects relative to position of relevant method call' do
+        original_source = [
+          ' something',
+          '   .method_name(',
+          '       a,',
+          '          b,',
+          '            c',
+          '   )'
+        ]
+        correct_source = [
+          ' something',
+          '   .method_name(',
+          '     a,',
+          '     b,',
+          '     c',
+          '   )'
+        ]
+        expect(autocorrect_source(cop, original_source))
+          .to eq(correct_source.join("\n"))
+      end
+    end
+
     context 'assigned methods' do
       it 'accepts the first parameter being on a new row' do
         inspect_source(cop, [' assigned_value = match(',


### PR DESCRIPTION
### Problem

In an app I'm working on, we have the following in our `.rubocop.yml` file.

``` yaml
AlignParameters:
  EnforcedStyle: with_fixed_indentation
```

When we get in a spot where we need to use both multi-line method calls and multi-line method arguments, we tend to end up with code that looks something like this.

``` ruby
some_object
  .method_without_args
  .method_with_args(
    'this',
    'that',
    'the other'
  )
```

Currently that triggers two offenses in Rubocop for the `'that',` and `'the other'` lines because they are indented 4 spaces from the beginning of the node, `some_object`.  Rubocop autocorrects the code above to this.

``` ruby
some_object
  .method_without_args
  .method_with_args(
    'this',
  'that',
  'the other'
  )
```
### Solution

Assuming that we agree on the first example being the acceptable style, I've updated the `AlignParameters` cop to indent multi-line arguments based on the indentation of the method call that they belong to.

I've written a few tests to demonstrate the desired behavior, and everything seems to be working as intended.

Thanks!
