### PR TITLE
Fix Exclude configuration not working on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Fix `AlignParameters` `with_fixed_indentation` for multi-line method calls. ([@molawson][])
 * Fix problem that appears in some installations when reading empty YAML files. ([@jonas054][])
 * [#1022](https://github.com/bbatsov/rubocop/issues/1022): A Cop will no longer auto-correct a file that's excluded through an `Exclude` setting in the cop's configuration. ([@jonas054][])
+* Fix paths in `Exclude` config section not being recognized on Windows. ([@wndhydrnt][])
 
 ## 0.21.0 (24/04/2014)
 
@@ -929,3 +930,4 @@
 [@biinari]: https://github.com/biinari
 [@barunio]: https://github.com/barunio
 [@molawson]: https://github.com/molawson
+[@wndhydrnt]: https://github.com/wndhydrnt

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -115,7 +115,6 @@ module Rubocop
     end
 
     def file_to_exclude?(file)
-      file = File.join(Dir.pwd, file) unless file.start_with?('/')
       file = File.expand_path(file)
       patterns_to_exclude.any? do |pattern|
         match_path?(pattern, file, loaded_path)

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -107,7 +107,10 @@ describe Rubocop::Config do
     let(:hash) do
       {
         'AllCops' => {
-          'Exclude' => ['/home/foo/project/log/*']
+          'Exclude' => [
+            "#{Dir.pwd}/log/**/*",
+            '**/bar.rb'
+          ]
         }
       }
     end
@@ -116,15 +119,23 @@ describe Rubocop::Config do
 
     context 'when the passed path matches any of patterns to exclude' do
       it 'returns true' do
-        file_path = '/home/foo/project/log/foo.rb'
+        file_path = "#{Dir.pwd}/log/foo.rb"
         expect(configuration.file_to_exclude?(file_path)).to be_true
+
+        expect(configuration.file_to_exclude?('log/foo.rb')).to be_true
+
+        expect(configuration.file_to_exclude?('bar.rb')).to be_true
       end
     end
 
     context 'when the passed path does not match any of patterns to exclude' do
       it 'returns false' do
-        file_path = '/home/foo/project/log_file.rb'
+        file_path = "#{Dir.pwd}/log_file.rb"
         expect(configuration.file_to_exclude?(file_path)).to be_false
+
+        expect(configuration.file_to_exclude?('app/controller.rb')).to be_false
+
+        expect(configuration.file_to_exclude?('baz.rb')).to be_false
       end
     end
   end


### PR DESCRIPTION
Check for an absolute in Windows style to avoid prefixing it with the current directory.

Before this fix every path got prefixed with the current working directory resulting in strings like `C:/path/to/cookbook/C:/path/to/cookbook/metadata.rb` which was never matched by any regex.
