### PR TITLE
Fix a problem with empty yaml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#1006](https://github.com/bbatsov/rubocop/issues/1006): Fix LineEndConcatenation to handle chained concatenations. ([@barunio][])
 * [#1066](https://github.com/bbatsov/rubocop/issues/1066): Fix auto-correct for `NegatedIf` when the condition has parentheses around it. ([@jonas054][])
 * Fix `AlignParameters` `with_fixed_indentation` for multi-line method calls. ([@molawson][])
+* Fix problem that appears in some installations when reading empty YAML files. ([@jonas054][])
 
 ## 0.21.0 (24/04/2014)
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -3,6 +3,11 @@
 require 'yaml'
 require 'pathname'
 
+# Psych can give an error when reading an empty file, so we use syck in Ruby
+# versions where it's available. Also, the problem with empty files does not
+# appear in Ruby 2.
+YAML::ENGINE.yamler = 'syck' if RUBY_VERSION < '2.0.0'
+
 module Rubocop
   # This class represents the configuration of the RuboCop application
   # and all its cops. A Config is associated with a YAML configuration


### PR DESCRIPTION
This is a fix for something that I started seeing when an empty configuration file was added in `cli_spec.rb`, but only on ruby 1.9.3p194. 

```
Failures:

  1) Rubocop::CLI configuration from file when a file inherits from the old auto generated file prints no warning when --auto-gen-config is not set
     Failure/Error: expect { cli.run(%w(-c .rubocop.yml)) }.not_to exit_with_code(1)
     Psych::SyntaxError:
       (/tmp/d20140511-12757-h8w3tr/work/rubocop-todo.yml): control characters are not allowed at line 1 column 1
     # ./lib/rubocop/config_loader.rb:27:in `load_file'
     # ./lib/rubocop/config_loader.rb:67:in `block in base_configs'
     # ./lib/rubocop/config_loader.rb:58:in `map'
     # ./lib/rubocop/config_loader.rb:58:in `base_configs'
     # ./lib/rubocop/config_loader.rb:108:in `resolve_inheritance'
     # ./lib/rubocop/config_loader.rb:30:in `load_file'
     # ./lib/rubocop/config_store.rb:23:in `options_config='
     # ./lib/rubocop/cli.rb:60:in `act_on_options'
     # ./lib/rubocop/cli.rb:27:in `run'
     # ./spec/rubocop/cli_spec.rb:1963:in `block (5 levels) in <top (required)>'
     # ./spec/rubocop/cli_spec.rb:1963:in `block (4 levels) in <top (required)>'
     # ./spec/support/isolated_environment.rb:27:in `block (4 levels) in <top (required)>'
     # ./spec/support/isolated_environment.rb:26:in `chdir'
     # ./spec/support/isolated_environment.rb:26:in `block (3 levels) in <top (required)>'
     # ./spec/support/isolated_environment.rb:8:in `block (2 levels) in <top (required)>'
```

It doesn't happen in the Travis builds, so it varies between installations.
