### PR TITLE
[Fix #1022] Make auto-correct honor Exclude for individual cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#1066](https://github.com/bbatsov/rubocop/issues/1066): Fix auto-correct for `NegatedIf` when the condition has parentheses around it. ([@jonas054][])
 * Fix `AlignParameters` `with_fixed_indentation` for multi-line method calls. ([@molawson][])
 * Fix problem that appears in some installations when reading empty YAML files. ([@jonas054][])
+* [#1022](https://github.com/bbatsov/rubocop/issues/1022): A Cop will no longer auto-correct a file that's excluded through an `Exclude` setting in the cop's configuration. ([@jonas054][])
 
 ## 0.21.0 (24/04/2014)
 

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -69,7 +69,7 @@ module Rubocop
         return unless autocorrect?
 
         corrections = cops.each_with_object([]) do |cop, array|
-          array.concat(cop.corrections)
+          array.concat(cop.corrections) if cop.relevant_file?(buffer.name)
         end
 
         corrector = Corrector.new(buffer, corrections)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -35,6 +35,18 @@ describe Rubocop::CLI, :isolated_environment do
     end
 
     describe '--auto-correct' do
+      it 'honors Exclude settings in individual cops' do
+        source = ['# encoding: utf-8',
+                  'puts %x(ls)']
+        create_file('example.rb', source)
+        create_file('.rubocop.yml', ['UnneededPercentX:',
+                                     '  Exclude:',
+                                     '    - example.rb'])
+        expect(cli.run(['--auto-correct'])).to eq(0)
+        expect($stdout.string).to include('no offenses detected')
+        expect(IO.read('example.rb')).to eq(source.join("\n") + "\n")
+      end
+
       it 'can correct two problems with blocks' do
         # {} should be do..end and space is missing.
         create_file('example.rb', ['# encoding: utf-8',


### PR DESCRIPTION
This fix continues in the tradition of stopping things late. We basically throw away a calculated correction rather than not making it in the first place. But it's a fix in the easiest place, so I think it makes sense at this point. Opportunity for improvement later.
