### PR TITLE
Add -F/--fail-fast option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#835](https://github.com/bbatsov/rubocop/issues/835): New cop `UnneededPercentX` checks for `%x` when backquotes would do. ([@jonas054][])
 * Add auto-correct to `UnusedBlockArgument` and `UnusedMethodArgument` cops. ([@hannestyden][])
 * [#1074](https://github.com/bbatsov/rubocop/issues/1074): New cop `SpaceBeforeComment` checks for missing space between code and a comment on the same line. ([@jonas054][])
+* [#1089](https://github.com/bbatsov/rubocop/pull/1089): New option `-F`/`--fail-fast` inspects files in modification time order and stop after the first file with offenses. ([@jonas054][])
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Command flag              | Description
 --------------------------|------------------------------------------------------------
 `-v/--version`            | Displays the current version and exits
 `-V/--verbose-version`    | Displays the current version plus the version of Parser and Ruby
+`-F/--fail-fast`          | Inspects in modification time order and stops after first file with offenses
 `-d/--debug`              | Displays some extra debug output
 `-D/--display-cop-names`  | Displays cop names in offense messages.
 `-c/--config`             | Run with specified config file

--- a/lib/rubocop/file_inspector.rb
+++ b/lib/rubocop/file_inspector.rb
@@ -26,6 +26,7 @@ module Rubocop
           o.severity >= fail_level
         end
         inspected_files << file
+        break if @options[:fail_fast] && any_failed
       end
 
       formatter_set.finished(inspected_files.freeze)

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -35,6 +35,9 @@ module Rubocop
       show_cops:        ['Shows the given cops, or all cops by',
                          'default, and their configurations for the',
                          'current directory.'],
+      fail_fast:        ['Inspect files in order of modification',
+                         'time and stop after the first file',
+                         'containing offenses.'],
       debug:             'Display debug info.',
       display_cop_names: 'Display cop names in offense messages.',
       rails:             'Run extra Rails cops.',
@@ -126,6 +129,7 @@ module Rubocop
     end
 
     def add_boolean_flags(opts)
+      option(opts, '-F', '--fail-fast')
       option(opts, '-d', '--debug')
       option(opts, '-D', '--display-cop-names')
       option(opts, '-R', '--rails')

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -6,7 +6,11 @@ module Rubocop
   class TargetFinder
     def initialize(config_store, options = {})
       @config_store = config_store
-      @options = { force_exclusion: false, debug: false }.merge(options)
+      @options = {
+        force_exclusion: false,
+        debug: false,
+        fail_level: false
+      }.merge(options)
     end
 
     def force_exclusion?
@@ -15,6 +19,10 @@ module Rubocop
 
     def debug?
       @options[:debug]
+    end
+
+    def fail_fast?
+      @options[:fail_fast]
     end
 
     # Generate a list of target files by expanding globbing patterns
@@ -60,6 +68,9 @@ module Rubocop
         next true if ruby_executable?(file)
         @config_store.for(file).file_to_include?(file)
       end
+
+      # Most recently modified file first.
+      target_files.sort_by! { |path| -File.mtime(path).to_i } if fail_fast?
 
       target_files
     end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -65,6 +65,9 @@ Usage: rubocop [options] [file1, file2, ...]
         --show-cops [COP1,COP2,...]  Shows the given cops, or all cops by
                                      default, and their configurations for the
                                      current directory.
+    -F, --fail-fast                  Inspect files in order of modification
+                                     time and stop after the first file
+                                     containing offenses.
     -d, --debug                      Display debug info.
     -D, --display-cop-names          Display cop names in offense messages.
     -R, --rails                      Run extra Rails cops.


### PR DESCRIPTION
This is something that I have found useful when working with correcting offenses (in RuboCop itself). I have an external program that monitors file changes in the directory tree and re-runs `./bin/rubocop` when something changes. When I save a file it is the first one checked in the next run, and execution stops at the first file with offenses.

There's some overlap of functionality between [guard-rubocop](https://github.com/yujinakayama/guard-rubocop) and this option, but I just found that adding this functionality inside RuboCop itself solved my problem. I'd like to hear what @yujinakayama thinks, and @bbatsov of course.
