### PR TITLE
Add optional require directive to .rubocop.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add auto-correct to `UnusedBlockArgument` and `UnusedMethodArgument` cops. ([@hannestyden][])
 * [#1074](https://github.com/bbatsov/rubocop/issues/1074): New cop `SpaceBeforeComment` checks for missing space between code and a comment on the same line. ([@jonas054][])
 * [#1089](https://github.com/bbatsov/rubocop/pull/1089): New option `-F`/`--fail-fast` inspects files in modification time order and stop after the first file with offenses. ([@jonas054][])
+* Add optional `require` directive to `.rubocop.yml` to load custom ruby files. ([@geniou][])
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ automatically fix some of the problems for you.
         - [Rails](#rails)
 - [Configuration](#configuration)
     - [Inheritance](#inheritance)
+    - [Loading Extensions](#loading-extensions)
     - [Defaults](#defaults)
     - [Including/Excluding files](#includingexcluding-files)
     - [Automatically Generated Configuration](#automatically-generated-configuration)
@@ -222,6 +223,17 @@ inheritance is:
 inherit_from:
   - ../.rubocop.yml
   - ../conf/.rubocop.yml
+```
+
+### Loading Extensions
+
+Besides the `--require` command line option you can also specify ruby
+files that should be loaded with the optional `require` directive.
+
+```yaml
+require:
+ - ../my/custom/file.rb
+ - rubocop-extension
 ```
 
 ### Defaults

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -34,6 +34,8 @@ module Rubocop
 
         resolve_inheritance(path, hash)
 
+        Array(hash.delete('require')).each { |r| require(r) }
+
         hash.delete('inherit_from')
         config = Config.new(hash, path)
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -325,4 +325,19 @@ describe Rubocop::ConfigLoader do
       end
     end
   end
+
+  describe 'when a requirement is defined', :isolated_environment do
+    let(:required_file_path) { './required_file.rb' }
+
+    before do
+      create_file('.rubocop.yml', ['require:', "  - #{required_file_path}"])
+      create_file(required_file_path, ['class MyClass', 'end'])
+    end
+
+    it 'requires the passed path' do
+      config_path = described_class.configuration_file_for('.')
+      described_class.configuration_from_file(config_path)
+      expect(defined?(MyClass)).to be_true
+    end
+  end
 end


### PR DESCRIPTION
To enable extensions by default you can specify the requirements in the `.rubocop.yml`.
