### PR TITLE
Remove unnecessary hash merge in TargetFinder

### DIFF
--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -6,11 +6,7 @@ module Rubocop
   class TargetFinder
     def initialize(config_store, options = {})
       @config_store = config_store
-      @options = {
-        force_exclusion: false,
-        debug: false,
-        fail_level: false
-      }.merge(options)
+      @options = options
     end
 
     def force_exclusion?


### PR DESCRIPTION
The typo `fail_level` instead of `fail_fast` (introduced in #1089) didn't affect function, so that whole thing is unnecessary. Let values default to `nil` instead of `false`. Works the same.
