### PR TITLE
Make exception for JRuby in setting yamler to syck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#1104](https://github.com/bbatsov/rubocop/issues/1104): Fix `EachWithObject` with modifier if as body. ([@geniou][])
 * [#1106](https://github.com/bbatsov/rubocop/issues/1106): Fix `EachWithObject` with single method call as body. ([@geniou][])
+* Avoid the warning about ignoring syck YAML engine from JRuby. ([@jonas054][])
 
 ## 0.22.0 (20/04/2014)
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -5,8 +5,10 @@ require 'pathname'
 
 # Psych can give an error when reading an empty file, so we use syck in Ruby
 # versions where it's available. Also, the problem with empty files does not
-# appear in Ruby 2.
-YAML::ENGINE.yamler = 'syck' if RUBY_VERSION < '2.0.0'
+# appear in Ruby 2 or in JRuby 1.9 mode.
+if RUBY_VERSION < '2.0.0' && RUBY_PLATFORM != 'java'
+  YAML::ENGINE.yamler = 'syck'
+end
 
 module Rubocop
   # This class represents the configuration of the RuboCop application


### PR DESCRIPTION
I hadn't noticed that #1080 added a warning to the output when running on JRuby.

This fix removes the warning
"JRuby 1.9 mode only supports the `psych` YAML engine; ignoring `syck`"
