### PR TITLE
[Fix #1111] Fix reading of non-UTF-8 files in EndOfLine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#1104](https://github.com/bbatsov/rubocop/issues/1104): Fix `EachWithObject` with modifier if as body. ([@geniou][])
 * [#1106](https://github.com/bbatsov/rubocop/issues/1106): Fix `EachWithObject` with single method call as body. ([@geniou][])
 * Avoid the warning about ignoring syck YAML engine from JRuby. ([@jonas054][])
+* [#1111](https://github.com/bbatsov/rubocop/issues/1111): Fix problem in `EndOfLine` with reading non-UTF-8 encoded files. ([@jonas054][])
 
 ## 0.22.0 (20/04/2014)
 

--- a/lib/rubocop/cop/style/end_of_line.rb
+++ b/lib/rubocop/cop/style/end_of_line.rb
@@ -9,8 +9,9 @@ module Rubocop
 
         def investigate(processed_source)
           buffer = processed_source.buffer
-          original_source = IO.read(buffer.name,
-                                    encoding: buffer.source.encoding)
+          original_source = IO.read(buffer.name, encoding: 'ascii-8bit')
+          change_encoding(original_source)
+
           original_source.lines.each_with_index do |line, index|
             next unless line =~ /\r$/
 
@@ -23,6 +24,14 @@ module Rubocop
             # of the lines in a file, so we report only one offense.
             break
           end
+        end
+
+        private
+
+        def change_encoding(string)
+          recognized_encoding =
+            Parser::Source::Buffer.recognize_encoding(string)
+          string.force_encoding(recognized_encoding) if recognized_encoding
         end
       end
     end

--- a/spec/rubocop/cop/style/end_of_line_spec.rb
+++ b/spec/rubocop/cop/style/end_of_line_spec.rb
@@ -21,11 +21,21 @@ describe Rubocop::Cop::Style::EndOfLine do
     expect(cop.messages).to eq(['Carriage return character detected.'])
   end
 
+  shared_examples 'iso-8859-15' do
+    it 'can inspect non-UTF-8 encoded source with proper encoding comment' do
+      inspect_source_file(cop, ['# coding: ISO-8859-15\r',
+                                "# Euro symbol: \xa4\r"])
+      expect(cop.offenses.size).to eq(1)
+    end
+  end
+
   context 'when there are many lines ending with CR+LF' do
     it 'registers only one offense' do
       inspect_source_file(cop, ['x=0', '', 'y=1'].join("\r\n"))
       expect(cop.messages.size).to eq(1)
     end
+
+    include_examples 'iso-8859-15'
   end
 
   context 'when the default external encoding is US_ASCII' do
@@ -41,5 +51,7 @@ describe Rubocop::Cop::Style::EndOfLine do
                            'end'].join("\n"))
       expect(cop.offenses).to be_empty
     end
+
+    include_examples 'iso-8859-15'
   end
 end


### PR DESCRIPTION
The problem was that we used `buffer.source.encoding` as the file's encoding when reading it again, but [Parser](https://github.com/whitequark/parser) has re-encoded the buffer so it's always UTF-8. By first reading the file as `ascii-8bit` ("binary") encoding, and then re-encoding it based on Parser's logic for recognizing encodings, we should be able to match `/\r$/` always.
