### PR TITLE
[Fix #1075] More strict limits on when to require trailing comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#1097](https://github.com/bbatsov/rubocop/issues/1097): Add optional namespace prefix to cop names: `Style/LineLength` instead of `LineLength` in config files, `--only` argument, `--show-cops` output, and `# rubocop:disable`. ([@jonas054][])
+* [#1075](https://github.com/bbatsov/rubocop/issues/1075): More strict limits on when to require trailing comma. ([@jonas054][])
 
 ### Bugs fixed
 


### PR DESCRIPTION
When `TrailingComma`:`EnforcedStyleForMultiline` is `comma`, we only report an offense for missing comma if each value in the list is on its own line, and the closing round/square/curly bracket is also on its own line (as opposed to sharing a line with the last value).
