### PR TITLE
Fix bug with --auto-gen-config and RegexpLiteral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bugs fixed
 
+* [#1126](https://github.com/bbatsov/rubocop/pull/1126): Fix `--auto-gen-config` bug with `RegexpLiteral` where only the last file's results would be used. ([@ggilder][])
 * [#1104](https://github.com/bbatsov/rubocop/issues/1104): Fix `EachWithObject` with modifier if as body. ([@geniou][])
 * [#1106](https://github.com/bbatsov/rubocop/issues/1106): Fix `EachWithObject` with single method call as body. ([@geniou][])
 * Avoid the warning about ignoring syck YAML engine from JRuby. ([@jonas054][])
@@ -955,3 +956,4 @@
 [@barunio]: https://github.com/barunio
 [@molawson]: https://github.com/molawson
 [@wndhydrnt]: https://github.com/wndhydrnt
+[@ggilder]: https://github.com/ggilder

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -7,6 +7,10 @@ module Rubocop
       # on how many escaped slashes there are in the regexp and on the
       # value of the configuration parameter MaxSlashes.
       class RegexpLiteral < Cop
+        class << self
+          attr_accessor :slash_count
+        end
+
         def on_regexp(node)
           string_parts = node.children.select { |child| child.type == :str }
           total_string = string_parts.map { |s| s.loc.expression.source }.join
@@ -35,15 +39,19 @@ module Rubocop
         end
 
         def configure_max(delimiter_start, value)
-          @slash_count ||= { '/' => Set.new([0]), '%' => Set.new([100_000]) }
-          @slash_count[delimiter_start].add(value)
+          self.class.slash_count ||= {
+            '/' => Set.new([0]),
+            '%' => Set.new([100_000])
+          }
+
+          self.class.slash_count[delimiter_start].add(value)
 
           # To avoid reports, MaxSlashes must be set equal to the highest
           # number of slashes used within //, and also one less than the
           # highest number of slashes used within %r{}. If no value can satisfy
           # both requirements, just disable.
-          max = @slash_count['/'].max
-          min = @slash_count['%'].min
+          max = self.class.slash_count['/'].max
+          min = self.class.slash_count['%'].min
 
           self.config_to_allow_offenses = if max > max_slashes
                                             if max < min

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -5,6 +5,8 @@ require 'spec_helper'
 describe Rubocop::Cop::Style::RegexpLiteral, :config do
   subject(:cop) { described_class.new(config) }
 
+  before { described_class.slash_count = nil }
+
   context 'when MaxSlashes is -1' do
     let(:cop_config) { { 'MaxSlashes' => -1 } }
 
@@ -169,6 +171,18 @@ describe Rubocop::Cop::Style::RegexpLiteral, :config do
                              'y =~ %r{/usr/lib/ext}'])
         expect(cop.config_to_allow_offenses).to eq(nil)
       end
+    end
+  end
+
+  context 'across multiple files (instances)' do
+    let(:cop_config) { { 'MaxSlashes' => 0 } }
+
+    it 'preserves slash count for --auto-gen-config' do
+      2.times do |i|
+        cop = described_class.new(config, auto_gen_config: true)
+        inspect_source(cop, "/http:#{'\/' * (i + 1)}/")
+      end
+      expect(described_class.slash_count['/']).to eq(Set.new([0, 1, 2]))
     end
   end
 end


### PR DESCRIPTION
The `RegexpLiteral` cop stores a running tally of slashes found inside
regular expressions, which it uses to determine whether the
auto-generated config should disable the cop completely, or just specify
the maximum number of slashes to make the cop pass.

Previously this tally was stored in an instance variable. However, this
doesn't work when run against a project with multiple files, because a
new instance of the cop is created for each file. Thus, we need to store
the running tally in a class-level variable.

cc @tamird
