### PR TITLE
[Fix #1090] Correct handling of documentation vs annotation comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#1115](https://github.com/bbatsov/rubocop/issues/1115): Fix `Next` to ignore super nodes. ([@geniou][])
 * [#1117](https://github.com/bbatsov/rubocop/issues/1117): Don't auto-correct indentation in scopes that contain block comments (`=begin`..`=end`). ([@jonas054][])
 * [#1123](https://github.com/bbatsov/rubocop/pull/1123): Support setter calls in safe assignment in `ParenthesesAroundCondition`. ([@jonas054][])
+* [#1090](https://github.com/bbatsov/rubocop/issues/1090): Correct handling of documentation vs annotation comment. ([@jonas054][])
 
 ## 0.22.0 (20/04/2014)
 

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -66,7 +66,9 @@ module Rubocop
           distance = node.loc.keyword.line - preceding_comment.loc.line
           return false if distance > 1
 
-          !annotation?(preceding_comment)
+          # As long as there's at least one comment line that isn't an
+          # annotation, it's OK.
+          ast_with_comments[node].any? { |comment| !annotation?(comment) }
         end
       end
     end

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -72,6 +72,30 @@ describe Rubocop::Cop::Style::Documentation do
     expect(cop.offenses.size).to eq(1)
   end
 
+  it 'accepts non-empty class with annotation comment followed by other ' \
+     'comment' do
+    inspect_source(cop,
+                   ['# OPTIMIZE: Make this faster.',
+                    '# Class comment.',
+                    'class My_Class',
+                    '  TEST = 20',
+                    'end'
+                   ])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts non-empty class with comment that ends with an annotation' do
+    inspect_source(cop,
+                   ['# Does fooing.',
+                    '# FIXME: Not yet implemented.',
+                    'class Foo',
+                    '  def initialize',
+                    '  end',
+                    'end'
+                   ])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'accepts non-empty module with documentation' do
     inspect_source(cop,
                    ['# class comment',


### PR DESCRIPTION
Regard comment as valid documentation comment if at least one line is not an annotation comment.
