### PR TITLE
Enable rubocop-rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
 # This is the configuration used to check the rubocop source code.
 
 inherit_from: .rubocop_todo.yml
+
+require: rubocop-rspec

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('yard', '~> 0.8')
   s.add_development_dependency('bundler', '~> 1.3')
   s.add_development_dependency('simplecov', '~> 0.7')
+  s.add_development_dependency('rubocop-rspec', '~> 1.0.rc3')
 end


### PR DESCRIPTION
**This is work-in-progress**

I try to enable `rubocop-rspec` in `rubocop` but keep on getting an error: `Unable to activate rubocop-0.23.0, because parser-2.2.0.pre.1 conflicts with parser (~> 2.1.9) (Gem::LoadError)` - it seams to have something to do with cfc2a31741b0f32d03907d8d9b5169290f7b8f29, but I don't know how to solve it.

Any ideas?
