### PR TITLE
[Fix #1141] Clarify why trailing comma is not allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changes
 
 * Unused block local variables (`obj.each { |arg; this| }`) are now handled by `UnusedBlockArgument` cop instead of `UselessAssignment` cop. ([@yujinakayama][])
+* [#1141](https://github.com/bbatsov/rubocop/issues/1141): Clarify in the message from `TrailingComma` that a trailing comma is never allowed for lists where some items share a line. ([@jonas054][])
 
 ### Bugs fixed
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -404,6 +404,8 @@ Style/TrailingBlankLines:
     - final_blank_line
 
 Style/TrailingComma:
+  # If EnforcedStyleForMultiline is comma, the cop allows a comma after the
+  # last item of a list, but only for lists where each item is on its own line.
   EnforcedStyleForMultiline: no_comma
   SupportedStyles:
     - comma

--- a/spec/rubocop/cop/style/trailing_comma_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_spec.rb
@@ -5,25 +5,26 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::TrailingComma, :config do
   subject(:cop) { described_class.new(config) }
 
-  shared_examples 'single line lists' do
+  shared_examples 'single line lists' do |extra_info|
     it 'registers an offense for trailing comma in an Array literal' do
       inspect_source(cop, 'VALUES = [1001, 2020, 3333, ]')
       expect(cop.messages)
-        .to eq(['Avoid comma after the last item of an array.'])
+        .to eq(["Avoid comma after the last item of an array#{extra_info}."])
       expect(cop.highlights).to eq([','])
     end
 
     it 'registers an offense for trailing comma in a Hash literal' do
       inspect_source(cop, 'MAP = { a: 1001, b: 2020, c: 3333, }')
       expect(cop.messages)
-        .to eq(['Avoid comma after the last item of a hash.'])
+        .to eq(["Avoid comma after the last item of a hash#{extra_info}."])
       expect(cop.highlights).to eq([','])
     end
 
     it 'registers an offense for trailing comma in a method call' do
       inspect_source(cop, 'some_method(a, b, c, )')
       expect(cop.messages)
-        .to eq(['Avoid comma after the last parameter of a method call.'])
+        .to eq(['Avoid comma after the last parameter of a method ' \
+                "call#{extra_info}."])
       expect(cop.highlights).to eq([','])
     end
 
@@ -31,7 +32,8 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
        ' parameters at the end' do
       inspect_source(cop, 'some_method(a, b, c: 0, d: 1, )')
       expect(cop.messages)
-        .to eq(['Avoid comma after the last parameter of a method call.'])
+        .to eq(['Avoid comma after the last parameter of a method ' \
+                "call#{extra_info}."])
       expect(cop.highlights).to eq([','])
     end
 
@@ -78,12 +80,13 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
   context 'with single line list of values' do
     context 'when EnforcedStyleForMultiline is no_comma' do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'no_comma' } }
-      include_examples 'single line lists'
+      include_examples 'single line lists', ''
     end
 
     context 'when EnforcedStyleForMultiline is comma' do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'comma' } }
-      include_examples 'single line lists'
+      include_examples 'single line lists',
+                       ', unless each item is on its own line'
     end
   end
 
@@ -172,6 +175,17 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
                              '           3333',
                              '         ]'])
         expect(cop.offenses).to be_empty
+      end
+
+      it 'registers an offense for an Array literal with two of the values ' \
+         'on the same line and a trailing comma' do
+        inspect_source(cop, ['VALUES = [',
+                             '           1001, 2020,',
+                             '           3333,',
+                             '         ]'])
+        expect(cop.messages)
+          .to eq(['Avoid comma after the last item of an array, unless each ' \
+                  'item is on its own line.'])
       end
 
       it 'registers an offense for no trailing comma in a Hash literal' do


### PR DESCRIPTION
For lists where some values share a line it is unclear why a comma is not allowed, unless we state it in the message.
