### PR TITLE
Correcting the pattern style in example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,8 @@ Here is an example that might be used for a Rails project:
 ```yaml
 AllCops:
   Include:
-    - 'Rakefile'
-    - 'config.ru'
+    - '**/Rakefile'
+    - '**/config.ru'
   Exclude:
     - 'db/**/*'
     - 'config/**/*'


### PR DESCRIPTION
I noticed that the example in the readme uses a pattern style that is deprecated. This corrects that. 

I am also using strings on all the filepaths to keep things consistent. Without that `**/Rakefile` will cause a parsing error. 

```
rubocop -V
0.23.0 (using Parser 2.1.9, running on ruby 2.1.2 x86_64-darwin13.0)
```

If this is something that you want a change log entry for, I can add it in. 
