### PR TITLE
Fix most cases of offense being spelled as offence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ $ rubocop -V
   is fine, but please isolate to its own commit so I can cherry-pick
   around it.
 * Make sure the test suite is passing ([including rbx and jruby][7]) and the code you wrote doesn't produce
-  RuboCop offences.
+  RuboCop offenses.
 * [Squash related commits together][5].
 * Open a [pull request][4] that relates to *only* one subject with a clear title
   and description in grammatically correct, complete sentences.

--- a/config/default.yml
+++ b/config/default.yml
@@ -54,10 +54,10 @@ Style/AlignHash:
   # inspected? Valid values are:
   #
   # always_inspect - Inspect both implicit and explicit hashes.
-  #   Registers an offence for:
+  #   Registers an offense for:
   #     function(a: 1,
   #       b: 2)
-  #   Registers an offence for:
+  #   Registers an offense for:
   #     function({a: 1,
   #       b: 2})
   # always_ignore - Ignore both implicit and explicit hashes.
@@ -71,14 +71,14 @@ Style/AlignHash:
   #   Accepts:
   #     function(a: 1,
   #       b: 2)
-  #   Registers an offence for:
+  #   Registers an offense for:
   #     function({a: 1,
   #       b: 2})
   # ignore_explicit - Ignore only explicit hashes.
   #   Accepts:
   #     function({a: 1,
   #       b: 2})
-  #   Registers an offence for:
+  #   Registers an offense for:
   #     function(a: 1,
   #       b: 2)
   EnforcedLastArgumentHashStyle: always_inspect
@@ -275,12 +275,12 @@ Style/Next:
     - always
 
 Style/NonNilCheck:
-  # With `IncludeSemanticChanges` set to `true`, this cop reports offences for
+  # With `IncludeSemanticChanges` set to `true`, this cop reports offenses for
   # `!x.nil?` and autocorrects that and `x != nil` to solely `x`, which is
   # **usually** OK, but might change behavior.
   #
   # With `IncludeSemanticChanges` set to `false`, this cop does not report
-  # offences for `!x.nil?` and does no changes that might change behavior.
+  # offenses for `!x.nil?` and does no changes that might change behavior.
   IncludeSemanticChanges: false
 
 Style/MethodDefParentheses:

--- a/spec/rubocop/cop/style/align_hash_spec.rb
+++ b/spec/rubocop/cop/style/align_hash_spec.rb
@@ -25,13 +25,13 @@ describe RuboCop::Cop::Style::AlignHash, :config do
       }
     end
 
-    it 'registers offence for misaligned keys in implicit hash' do
+    it 'registers offense for misaligned keys in implicit hash' do
       inspect_source(cop, ['func(a: 0,',
                            '  b: 1)'])
       expect(cop.offenses.size).to eq(1)
     end
 
-    it 'registers offence for misaligned keys in explicit hash' do
+    it 'registers offense for misaligned keys in explicit hash' do
       inspect_source(cop, ['func({a: 0,',
                            '  b: 1})'])
       expect(cop.offenses.size).to eq(1)
@@ -71,7 +71,7 @@ describe RuboCop::Cop::Style::AlignHash, :config do
       expect(cop.offenses).to be_empty
     end
 
-    it 'registers offence for misaligned keys in explicit hash' do
+    it 'registers offense for misaligned keys in explicit hash' do
       inspect_source(cop, ['func({a: 0,',
                            '  b: 1})'])
       expect(cop.offenses.size).to eq(1)
@@ -85,7 +85,7 @@ describe RuboCop::Cop::Style::AlignHash, :config do
       }
     end
 
-    it 'registers offence for misaligned keys in implicit hash' do
+    it 'registers offense for misaligned keys in implicit hash' do
       inspect_source(cop, ['func(a: 0,',
                            '  b: 1)'])
       expect(cop.offenses.size).to eq(1)

--- a/spec/rubocop/cop/style/align_parameters_spec.rb
+++ b/spec/rubocop/cop/style/align_parameters_spec.rb
@@ -322,7 +322,7 @@ describe RuboCop::Cop::Style::AlignParameters, :config do
         expect(cop.offenses).to be_empty
       end
 
-      it 'registers offences for double indentation from relevant method' do
+      it 'registers offenses for double indentation from relevant method' do
         inspect_source(cop, [' something',
                              '   .method_name(',
                              '       a,',


### PR DESCRIPTION
The only cases of "offence" left in the repository are in the changelog and the release notes for version 0.19.0.
