### PR TITLE
[Fix #1167] Fix handling of multi-line parameters in TrailingComma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#1158](https://github.com/bbatsov/rubocop/issues/1158): Fix auto-correction of floating-point numbers. ([@bbatsov][])
 * [#1159](https://github.com/bbatsov/rubocop/issues/1159): Fix checking of `begin`..`end` structures, blocks, and parenthesized expressions in `IndentationWidth`. ([@jonas054][])
 * [#1159](https://github.com/bbatsov/rubocop/issues/1159): More rigid conditions for when `attr` is considered an offense. ([@jonas054][])
+* [#1167](https://github.com/bbatsov/rubocop/issues/1167): Fix handling of parameters spanning multiple lines in `TrailingComma`. ([@jonas054][])
 
 ## 0.23.0 (02/06/2014)
 

--- a/lib/rubocop/cop/style/trailing_comma.rb
+++ b/lib/rubocop/cop/style/trailing_comma.rb
@@ -114,7 +114,7 @@ module RuboCop
         end
 
         def on_same_line?(a, b)
-          [a, b].map(&:line).uniq.size == 1
+          a.line + a.source.count("\n") == b.line
         end
 
         def avoid_comma(kind, comma_begin_pos, sb, extra_info)

--- a/spec/rubocop/cop/style/trailing_comma_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_spec.rb
@@ -160,13 +160,21 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
     context 'when EnforcedStyleForMultiline is comma' do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'comma' } }
 
-      it 'accepts Array literal with no trailing comma when closing bracket ' \
-         'is on same line as last value' do
-        inspect_source(cop, ['VALUES = [',
-                             '           1001,',
-                             '           2020,',
-                             '           3333]'])
-        expect(cop.offenses).to be_empty
+      context 'when closing bracket is on same line as last value' do
+        it 'accepts Array literal with no trailing comma' do
+          inspect_source(cop, ['VALUES = [',
+                               '           1001,',
+                               '           2020,',
+                               '           3333]'])
+          expect(cop.offenses).to be_empty
+        end
+
+        it 'accepts a method call with Hash as last parameter split on ' \
+           'multiple lines' do
+          inspect_source(cop, ['some_method(a: "b",',
+                               '            c: "d")'])
+          expect(cop.offenses).to be_empty
+        end
       end
 
       it 'accepts Array literal with two of the values on the same line' do
@@ -262,7 +270,7 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
                              "  'auth' => <<-HELP.chomp",
                              '...',
                              'HELP',
-                             '},)']) # We still need a comma after the hash.
+                             '})'])
         expect(cop.offenses).to be_empty
       end
     end


### PR DESCRIPTION
Hashes and other items spanning more than one line were not handled correctly when it came to checking if the closing bracket was on the same line.
