### PR TITLE
[Fix #1157] Validate --only arguments later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1174](https://github.com/bbatsov/rubocop/issues/1174): Fix `--auto-correct` crash in `AlignParameters`. ([@jonas054][])
 * [#1176](https://github.com/bbatsov/rubocop/issues/1176): Fix `--auto-correct` crash in `IndentationWidth`. ([@jonas054][])
 * [#1177](https://github.com/bbatsov/rubocop/issues/1177): Avoid suggesting underscore-prefixed name for unused keyword arguments and auto-correcting in that way. ([@yujinakayama][])
+* [#1157](https://github.com/bbatsov/rubocop/issues/1157): Validate `--only` arguments later when all cop names are known. ([@jonas054][])
 
 ## 0.24.0 (25/06/2014)
 

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -69,7 +69,6 @@ module RuboCop
           @options[:only] = list.split(',').map do |c|
             Cop::Cop.qualified_cop_name(c, '--only option')
           end
-          validate_only_option
         end
 
         add_configuration_options(opts, args)
@@ -191,13 +190,6 @@ module RuboCop
       message << '.'
       message << " Please use #{alternative} instead." if alternative
       warn message
-    end
-
-    def validate_only_option
-      @options[:only].each do |cop_to_run|
-        next unless Cop::Cop.all.none? { |c| c.cop_name == cop_to_run }
-        fail ArgumentError, "Unrecognized cop name: #{cop_to_run}."
-      end
     end
 
     def validate_auto_gen_config_option(args)

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -95,6 +95,8 @@ module RuboCop
         cop_classes = Cop::Cop.all
 
         if @options[:only]
+          validate_only_option
+
           cop_classes.select! do |c|
             @options[:only].include?(c.cop_name) || @options[:lint] && c.lint?
           end
@@ -107,6 +109,13 @@ module RuboCop
         end
 
         cop_classes
+      end
+    end
+
+    def validate_only_option
+      @options[:only].each do |cop_to_run|
+        next unless Cop::Cop.all.none? { |c| c.cop_name == cop_to_run }
+        fail ArgumentError, "Unrecognized cop name: #{cop_to_run}."
       end
     end
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -134,13 +134,6 @@ Usage: rubocop [options] [file1, file2, ...]
       end
     end
 
-    describe '--only' do
-      it 'exits with error if an incorrect cop name is passed' do
-        expect { options.parse(%w(--only 123)) }
-          .to raise_error(ArgumentError, /Unrecognized cop name: 123./)
-      end
-    end
-
     describe '--require' do
       let(:required_file_path) { './path/to/required_file.rb' }
 


### PR DESCRIPTION
Whether cop names given to `--only` are valid or not can not be determined until configuration has been loaded. So we can't do validation during option parsing.

Testing proved difficult and this solution adds a spec example that takes just over 1 second to run on my machine.
