### PR TITLE
Fix crash in LineLength cop when AllowURI option is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#1176](https://github.com/bbatsov/rubocop/issues/1176): Fix `--auto-correct` crash in `IndentationWidth`. ([@jonas054][])
 * [#1177](https://github.com/bbatsov/rubocop/issues/1177): Avoid suggesting underscore-prefixed name for unused keyword arguments and auto-correcting in that way. ([@yujinakayama][])
 * [#1157](https://github.com/bbatsov/rubocop/issues/1157): Validate `--only` arguments later when all cop names are known. ([@jonas054][])
+* [#1188](https://github.com/bbatsov/rubocop/issues/1188), [#1190](https://github.com/bbatsov/rubocop/issues/1190): Fix crash in `LineLength` cop when `AllowURI` option is enabled. ([@yujinakayama][])
 
 ## 0.24.0 (25/06/2014)
 

--- a/lib/rubocop/cop/style/line_length.rb
+++ b/lib/rubocop/cop/style/line_length.rb
@@ -79,7 +79,7 @@ module RuboCop
         def valid_uri?(uri_ish_string)
           URI.parse(uri_ish_string)
           true
-        rescue URI::InvalidURIError
+        rescue
           false
         end
       end

--- a/spec/rubocop/cop/style/line_length_spec.rb
+++ b/spec/rubocop/cop/style/line_length_spec.rb
@@ -76,6 +76,19 @@ describe RuboCop::Cop::Style::LineLength, :config do
         expect(cop.highlights).to eq([' and'])
       end
     end
+
+    context 'and an error other than URI::InvalidURIError is raised ' \
+            'while validating an URI-ish string' do
+      # rubocop:disable Style/LineLength
+      let(:source) { <<-END }
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxzxxxxxxxxxxx = LDAP::DEFAULT_GROUP_UNIQUE_MEMBER_LIST_KEY
+      END
+      # rubocop:enable Style/LineLength
+
+      it 'does not crash' do
+        expect { inspect_source(cop, source) }.not_to raise_error
+      end
+    end
   end
 
   context 'when AllowURI option is disabled' do


### PR DESCRIPTION
This fixes #1188 and #1190.
