### PR TITLE
Blacklist Vagrantfile like Rakefile in FileName cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -11,6 +11,7 @@ AllCops:
   Include:
     - '**/*.gemspec'
     - '**/Rakefile'
+    - '**/Vagrantfile'
   Exclude:
     - 'vendor/**/*'
   # By default, the rails cops are not run. Override in project or home
@@ -208,6 +209,7 @@ Style/FileName:
     - '**/Rakefile'
     - '**/Gemfile'
     - '**/Capfile'
+    - '**/Vagrantfile'
 
 # Checks use of for or each in multiline loops.
 Style/For:


### PR DESCRIPTION
There may come a time when we fix an error like `Use snake_case for source file names` in default Vagrantfile .

It is as follows:

``` bash
$ mkdir ~/work/vagrant-issue && cd ~/work/vagrant-issue

$ vagrant -v
Vagrant 1.6.1

$ vagrant init
A `Vagrantfile` has been placed in this directory. You are now
ready to `vagrant up` your first virtual environment! Please read
the comments in the Vagrantfile as well as documentation on
`vagrantup.com` for more information on using Vagrant.

$ rubocop -v
0.21.0

$ rubocop Vagrantfile
Inspecting 1 file
C

Offenses:

Vagrantfile:2:1: C: Use snake_case for source file names.
# vi: set ft=ruby :
^
:
```
