### PR TITLE
Add support for string source in EndOfLine cop

### DIFF
--- a/lib/rubocop/cop/style/end_of_line.rb
+++ b/lib/rubocop/cop/style/end_of_line.rb
@@ -8,27 +8,16 @@ module RuboCop
         MSG = 'Carriage return character detected.'
 
         def investigate(processed_source)
-          buffer = processed_source.buffer
-          original_source = IO.read(buffer.name, encoding: 'ascii-8bit')
-          change_encoding(original_source)
-
-          original_source.lines.each_with_index do |line, index|
+          processed_source.raw_source.each_line.with_index do |line, index|
             next unless line =~ /\r$/
 
-            range = source_range(buffer, index + 1, 0, line.length)
+            range =
+              source_range(processed_source.buffer, index + 1, 0, line.length)
             add_offense(nil, range, MSG)
             # Usually there will be carriage return characters on all or none
             # of the lines in a file, so we report only one offense.
             break
           end
-        end
-
-        private
-
-        def change_encoding(string)
-          recognized_encoding =
-            Parser::Source::Buffer.recognize_encoding(string)
-          string.force_encoding(recognized_encoding) if recognized_encoding
         end
       end
     end

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -5,14 +5,16 @@ module RuboCop
   # and other information such as disabled lines for cops.
   # It also provides a convenient way to access source lines.
   class ProcessedSource
+    STRING_SOURCE_NAME = '(string)'
     attr_reader :path, :buffer, :ast, :comments, :tokens, :diagnostics,
-                :parser_error
+                :parser_error, :raw_source
 
     def self.from_file(path)
       new(File.read(path), path)
     end
 
     def initialize(source, path = nil)
+      @raw_source = source
       @path = path
       @diagnostics = []
       parse(source)
@@ -27,21 +29,7 @@ module RuboCop
     end
 
     def lines
-      if @lines
-        @lines
-      else
-        init_lines
-        @lines
-      end
-    end
-
-    def raw_lines
-      if @raw_lines
-        @raw_lines
-      else
-        init_lines
-        @raw_lines
-      end
+      @lines ||= raw_source.lines.map(&:chomp)
     end
 
     def [](*args)
@@ -56,7 +44,7 @@ module RuboCop
     private
 
     def parse(source)
-      buffer_name = @path || '(string)'
+      buffer_name = @path || STRING_SOURCE_NAME
       @buffer = Parser::Source::Buffer.new(buffer_name, 1)
 
       begin
@@ -89,11 +77,6 @@ module RuboCop
           @diagnostics << diagnostic
         end
       end
-    end
-
-    def init_lines
-      @raw_lines = @buffer.source.lines
-      @lines = @raw_lines.map(&:chomp)
     end
   end
 end

--- a/spec/rubocop/cop/style/end_of_line_spec.rb
+++ b/spec/rubocop/cop/style/end_of_line_spec.rb
@@ -54,4 +54,12 @@ describe RuboCop::Cop::Style::EndOfLine do
 
     include_examples 'iso-8859-15'
   end
+
+  context 'when source is a string' do
+    it 'registers an offence' do
+      inspect_source(cop, ["x=0\r"])
+
+      expect(cop.messages).to eq(['Carriage return character detected.'])
+    end
+  end
 end


### PR DESCRIPTION
`ProcessedSource` supports string sources, but `EndOfLine` cop would fail. This
ensures that `EndOfLine` cop supports strings.
- expose original source of `ProcessedSource`
- simplify `EndOfLine` cop logic
