### PR TITLE
Fix false positive in UnneededPercentQ for /%Q(something)/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,16 @@
 # Change log
 
+## master (unreleased)
+
 ### New features
 
 * [#835](https://github.com/bbatsov/rubocop/issues/835): New cop `PercentQLiterals` checks if use of `%Q` and `%q` matches configuration. ([@jonas054][])
-
-## master (unreleased)
 
 ### Bugs fixed
 
 * [#1197](https://github.com/bbatsov/rubocop/issues/1197): Fix false positive for new lambda syntax in `SpaceInsideBlockBraces`. ([@jonas054][])
 * [#1201](https://github.com/bbatsov/rubocop/issues/1201): Fix error at anonymous keyword splat arguments in some variable cops. ([@yujinakayama][])
+* Fix false positive in `UnneededPercentQ` for `/%Q(something)/`. ([@jonas054][])
 
 ## 0.24.1 (03/07/2014)
 

--- a/lib/rubocop/cop/style/unneeded_percent_q.rb
+++ b/lib/rubocop/cop/style/unneeded_percent_q.rb
@@ -17,9 +17,17 @@ module RuboCop
           check(node)
         end
 
+        # We process regexp nodes because the inner str nodes can cause
+        # confusion in on_str if they start with %( or %Q(.
+        def on_regexp(node)
+          string_parts = node.children.select { |child| child.type == :str }
+          string_parts.each { |s| ignore_node(s) }
+        end
+
         private
 
         def check(node)
+          return if ignored_node?(node)
           src = node.loc.expression.source
           return unless src =~ /^%q/i
           return if src =~ /'/ && src =~ /"/

--- a/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
@@ -52,6 +52,11 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts regular expressions starting with %Q' do
+      inspect_source(cop, '/%Q?/')
+      expect(cop.offenses).to be_empty
+    end
+
     it 'auto-corrects static %Q to double quotes' do
       new_source = autocorrect_source(cop, '%Q(hi)')
       # One could argue that the double quotes are not necessary for a static


### PR DESCRIPTION
Regular expressions starting with `%` or `%Q` were treated as string literals starting with those delimiters.

This bug does not occur in other cops as far as I can see.

Related to #835.
