### PR TITLE
`Style::EmptyLinesAroundAccessModifier` cop does auto-correction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#835](https://github.com/bbatsov/rubocop/issues/835): New cop `PercentQLiterals` checks if use of `%Q` and `%q` matches configuration. ([@jonas054][])
 * [#835](https://github.com/bbatsov/rubocop/issues/835): New cop `BarePercentLiterals` checks if usage of `%()` or `%Q()` matches configuration. ([@jonas054][])
 * [#1079](https://github.com/bbatsov/rubocop/pull/1079): New cop `MultilineBlockLayout` checks if a multiline block has an extpression on the same line as the start of the block. ([@barunio][])
+* [#1217](https://github.com/bbatsov/rubocop/pull/1217): `Style::EmptyLinesAroundAccessModifier` cop does auto-correction. ([@tamird][])
 
 ### Bugs fixed
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -203,6 +203,7 @@ describe RuboCop::CLI, :isolated_environment do
         expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
                                              'class Dsl',
                                              '  private',
+                                             '',
                                              '  A = %w(git path)',
                                              'end'].join("\n") + "\n")
         e = abs('example.rb')
@@ -211,14 +212,25 @@ describe RuboCop::CLI, :isolated_environment do
                   'comment.',
                   "#{e}:3:1: C: [Corrected] Indent access modifiers like " \
                   '`private`.',
+                  "#{e}:3:1: C: [Corrected] Keep a blank line before and " \
+                  'after `private`.',
                   "#{e}:3:3: W: Useless `private` access modifier.",
-                  "#{e}:3:3: C: Keep a blank line before and after `private`.",
+                  "#{e}:3:3: C: [Corrected] Keep a blank line before and " \
+                  'after `private`.',
                   "#{e}:4:7: C: [Corrected] Use `%w` or `%W` " \
                   'for array of words.',
                   "#{e}:4:8: C: [Corrected] Prefer single-quoted strings " \
                   "when you don't need string interpolation or special " \
                   'symbols.',
                   "#{e}:4:15: C: [Corrected] Prefer single-quoted strings " \
+                  "when you don't need string interpolation or special " \
+                  'symbols.',
+                  "#{e}:5:7: C: [Corrected] Use `%w` or `%W` " \
+                  'for array of words.',
+                  "#{e}:5:8: C: [Corrected] Prefer single-quoted strings " \
+                  "when you don't need string interpolation or special " \
+                  'symbols.',
+                  "#{e}:5:15: C: [Corrected] Prefer single-quoted strings " \
                   "when you don't need string interpolation or special " \
                   'symbols.',
                   ''].join("\n"))

--- a/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
@@ -32,6 +32,40 @@ describe RuboCop::Cop::Style::EmptyLinesAroundAccessModifier do
         .to eq(["Keep a blank line before and after `#{access_modifier}`."])
     end
 
+    it "autocorrects blank line before #{access_modifier}" do
+      corrected = autocorrect_source(cop,
+                                     ['class Test',
+                                      '  something',
+                                      "  #{access_modifier}",
+                                      '',
+                                      '  def test; end',
+                                      'end'])
+      expect(corrected).to eq(['class Test',
+                               '  something',
+                               '',
+                               "  #{access_modifier}",
+                               '',
+                               '  def test; end',
+                               'end'].join("\n"))
+    end
+
+    it 'autocorrects blank line after #{access_modifier}' do
+      corrected = autocorrect_source(cop,
+                                     ['class Test',
+                                      '  something',
+                                      '',
+                                      "  #{access_modifier}",
+                                      '  def test; end',
+                                      'end'])
+      expect(corrected).to eq(['class Test',
+                               '  something',
+                               '',
+                               "  #{access_modifier}",
+                               '',
+                               '  def test; end',
+                               'end'].join("\n"))
+    end
+
     it 'accepts missing blank line when at the beginning of class/module' do
       inspect_source(cop,
                      ['class Test',


### PR DESCRIPTION
@bbatsov
