### PR TITLE
[Fix #1214] Require one key per line for inspection in AlignHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix `SpacesInsideBrackets` for `Hash#[]` calls with spaces after left bracket. ([@mcls][])
 * [#1210](https://github.com/bbatsov/rubocop/issues/1210): Fix false positive in `UnneededPercentQ` for `%Q(\t")`. ([@jonas054][])
 * Fix false positive in `UnneededPercentQ` for heredoc strings with `%q`/`%Q`. ([@jonas054][])
+* [#1214](https://github.com/bbatsov/rubocop/issues/1214): Don't destroy code in `AlignHash` autocorrect. ([@jonas054][])
 
 ## 0.24.1 (03/07/2014)
 

--- a/lib/rubocop/cop/style/align_hash.rb
+++ b/lib/rubocop/cop/style/align_hash.rb
@@ -199,8 +199,16 @@ module RuboCop
           node.loc.begin
         end
 
+        # Returns true if the hash spans multiple lines, and each key-value
+        # pair following the first is on a new line.
         def multiline?(node)
-          node.loc.expression.source.include?("\n")
+          return false unless node.loc.expression.source.include?("\n")
+
+          return false if node.children[1..-1].find do |child|
+            !begins_its_line?(child.loc.expression)
+          end
+
+          true
         end
 
         def alignment_for(pair)

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -140,11 +140,6 @@ module RuboCop
 
         private
 
-        def begins_its_line?(range)
-          source_before_end = range.source_buffer.source[0...range.begin_pos]
-          source_before_end =~ /\n\s*\Z/
-        end
-
         def check_assignment(node, rhs)
           # If there are method calls chained to the right hand side of the
           # assignment, we let rhs be the receiver of those method calls before

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -153,6 +153,11 @@ module RuboCop
         Parser::Source::Range.new(@processed_source.buffer, begin_pos, end_pos)
       end
 
+      def begins_its_line?(range)
+        source_before_end = range.source_buffer.source[0...range.begin_pos]
+        source_before_end =~ /\n\s*\Z/
+      end
+
       # Returns, for example, a bare `if` node if the given node is an `if`
       # with calls chained to the end of it.
       def first_part_of_call_chain(node)

--- a/spec/rubocop/cop/style/align_hash_spec.rb
+++ b/spec/rubocop/cop/style/align_hash_spec.rb
@@ -16,6 +16,13 @@ describe RuboCop::Cop::Style::AlignHash, :config do
                            '     ccc: 3, dddd: 4)'])
       expect(cop.offenses).to be_empty
     end
+
+    it "does not auto-correct pairs that don't start a line" do
+      source = ['render :json => {:a => messages,',
+                '                 :b => :json}, :status => 404']
+      new_source = autocorrect_source(cop, source)
+      expect(new_source).to eq(source.join("\n"))
+    end
   end
 
   context 'always inspect last argument hash' do


### PR DESCRIPTION
If some keys don't begin their line, we quit the inspection of that hash.
