### PR TITLE
[Fix #1219] Avoid reporting }/end sharing line with something

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#1210](https://github.com/bbatsov/rubocop/issues/1210): Fix false positive in `UnneededPercentQ` for `%Q(\t")`. ([@jonas054][])
 * Fix false positive in `UnneededPercentQ` for heredoc strings with `%q`/`%Q`. ([@jonas054][])
 * [#1214](https://github.com/bbatsov/rubocop/issues/1214): Don't destroy code in `AlignHash` autocorrect. ([@jonas054][])
+* [#1219](https://github.com/bbatsov/rubocop/issues/1219): Don't report bad alignment for `end` or `}` in `BlockAlignment` if it doesn't begin its line. ([@jonas054][])
 
 ## 0.24.1 (03/07/2014)
 

--- a/lib/rubocop/cop/lint/block_alignment.rb
+++ b/lib/rubocop/cop/lint/block_alignment.rb
@@ -102,11 +102,13 @@ module RuboCop
         end
 
         def check_block_alignment(start_node, block_node)
-          start_loc = start_node.loc.expression
           end_loc = block_node.loc.end
-          do_loc = block_node.loc.begin # Actually it's either do or {.
-          return if do_loc.line == end_loc.line # One-liner, not interesting.
+          return unless begins_its_line?(end_loc)
+
+          start_loc = start_node.loc.expression
           return unless start_loc.column != end_loc.column
+
+          do_loc = block_node.loc.begin # Actually it's either do or {.
 
           # We've found that "end" is not aligned with the start node (which
           # can be a block, a variable assignment, etc). But we also allow

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -15,6 +15,14 @@ describe RuboCop::Cop::Lint::BlockAlignment do
       .to eq(['`end` at 2, 2 is not aligned with `test do |ala|` at 1, 0'])
   end
 
+  it 'acepts a block end that does not begin its line' do
+    inspect_source(cop,
+                   ['  scope :bar, lambda { joins(:baz)',
+                    '                       .distinct }'
+                   ])
+    expect(cop.offenses).to be_empty
+  end
+
   context 'when the block is a logical operand' do
     it 'accepts a correctly aligned block end' do
       inspect_source(cop,


### PR DESCRIPTION
For block ends that follow something else on the same line, there's no correct or incorrect alignment.
