### PR TITLE
Mention RunRailsCops configuration directive in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,13 @@ specifically:
 $ rubocop -R
 ```
 
+or add the following directive to your `.rubocop.yml`:
+
+```yaml
+AllCops:
+  RunRailsCops: true
+```
+
 ## Configuration
 
 The behavior of RuboCop can be controlled via the


### PR DESCRIPTION
I noticed that the `RunRailsCops` wasn't documented in the README.
