### PR TITLE
Make Debugger cop also check for `binding.pry_remote`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#1079](https://github.com/bbatsov/rubocop/pull/1079): New cop `MultilineBlockLayout` checks if a multiline block has an extpression on the same line as the start of the block. ([@barunio][])
 * [#1217](https://github.com/bbatsov/rubocop/pull/1217): `Style::EmptyLinesAroundAccessModifier` cop does auto-correction. ([@tamird][])
 * [#1220](https://github.com/bbatsov/rubocop/issues/1220): New cop `PerceivedComplexity` is similar to `CyclomaticComplexity`, but reports when methods have a high complexity for a human reader. ([@jonas054][])
+* `Debugger` cop now checks for `binding.pry_remote`. ([@yous][])
 
 ### Changes
 
@@ -1038,3 +1039,4 @@
 [@salbertson]: https://github.com/salbertson
 [@camilleldn]: https://github.com/camilleldn
 [@mcls]: https://github.com/mcls
+[@yous]: https://github.com/yous

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -29,11 +29,18 @@ module RuboCop
         #   (send nil :binding) :remote_pry)
         REMOTE_PRY_NODE = s(:send, s(:send, nil, :binding), :remote_pry)
 
+        # binding.pry_remote node
+        #
+        # (send
+        #   (send nil :binding) :pry_remote)
+        PRY_REMOTE_NODE = s(:send, s(:send, nil, :binding), :pry_remote)
+
         DEBUGGER_NODES = [
           DEBUGGER_NODE,
           BYEBUG_NODE,
           PRY_NODE,
-          REMOTE_PRY_NODE
+          REMOTE_PRY_NODE,
+          PRY_REMOTE_NODE
         ]
 
         def on_send(node)

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -23,13 +23,17 @@ describe RuboCop::Cop::Lint::Debugger do
 
   it 'reports an offense for pry bindings' do
     src = ['binding.pry',
-           'binding.remote_pry']
+           'binding.remote_pry',
+           'binding.pry_remote']
     inspect_source(cop, src)
-    expect(cop.offenses.size).to eq(2)
+    expect(cop.offenses.size).to eq(3)
     expect(cop.messages)
       .to eq(['Remove debugger entry point `binding.pry`.',
-              'Remove debugger entry point `binding.remote_pry`.'])
-    expect(cop.highlights).to eq(['binding.pry', 'binding.remote_pry'])
+              'Remove debugger entry point `binding.remote_pry`.',
+              'Remove debugger entry point `binding.pry_remote`.'])
+    expect(cop.highlights).to eq(['binding.pry',
+                                  'binding.remote_pry',
+                                  'binding.pry_remote'])
   end
 
   it 'does not report an offense for non-pry binding' do
@@ -38,7 +42,7 @@ describe RuboCop::Cop::Lint::Debugger do
     expect(cop.offenses).to be_empty
   end
 
-  %w(debugger byebug).each do |comment|
+  %w(debugger byebug pry remote_pry pry_remote).each do |comment|
     it "does not report an offense for #{comment} in comments" do
       src = ["# #{comment}"]
       inspect_source(cop, src)
@@ -46,7 +50,7 @@ describe RuboCop::Cop::Lint::Debugger do
     end
   end
 
-  %w(debugger byebug pry).each do |method_name|
+  %w(debugger byebug pry remote_pry pry_remote).each do |method_name|
     it "does not report an offense for a #{method_name} method" do
       src = ["code.#{method_name}"]
       inspect_source(cop, src)


### PR DESCRIPTION
Because `pry_remote` is an alias for `remote_pry`.
https://github.com/Mon-Ouie/pry-remote/blob/2557d39e003450a7fc11d4c3e48cc3eb5b01302d/lib/pry-remote.rb#L349
