### PR TITLE
[Fix #1227] Don't permanently change yamler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Fix false positive in `UnneededPercentQ` for heredoc strings with `%q`/`%Q`. ([@jonas054][])
 * [#1214](https://github.com/bbatsov/rubocop/issues/1214): Don't destroy code in `AlignHash` autocorrect. ([@jonas054][])
 * [#1219](https://github.com/bbatsov/rubocop/issues/1219): Don't report bad alignment for `end` or `}` in `BlockAlignment` if it doesn't begin its line. ([@jonas054][])
+* [#1227](https://github.com/bbatsov/rubocop/issues/1227): Don't permanently change yamler as it can affect other apps. ([@jonas054][])
 
 ## 0.24.1 (03/07/2014)
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -260,6 +260,12 @@ describe RuboCop::ConfigLoader do
         'Enabled' => true
       )
     end
+
+    it 'returns an empty configuration loaded from an empty file' do
+      create_file(configuration_path, '')
+      configuration = load_file
+      expect(configuration).to eq({})
+    end
   end
 
   describe '.merge' do


### PR DESCRIPTION
It can affect other apps. So we still change it to avoid problems with empty `yml` files, but we change it back.

I can't recreate the original problem with Psych on my machine, so this fix is done "in the dark". Should be okay. :smile: 
