### PR TITLE
[Fix #1243] Fix multiline-block cop which errors out on empty blocks

### DIFF
--- a/lib/rubocop/cop/style/multiline_block_layout.rb
+++ b/lib/rubocop/cop/style/multiline_block_layout.rb
@@ -40,6 +40,7 @@ module RuboCop
           # the arguments, and the expression. We care if the block start
           # and the expression start on the same line.
           last_expression = node.children.last
+          return unless last_expression
           expression_loc = last_expression.loc
           return unless do_loc.line == expression_loc.line
 

--- a/spec/rubocop/cop/style/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_block_layout_spec.rb
@@ -60,6 +60,14 @@ describe RuboCop::Cop::Style::MultilineBlockLayout do
     expect(cop.offenses).to be_empty
   end
 
+  it 'does not error out when the block is empty' do
+    inspect_source(cop,
+                   ['test do |x|',
+                    'end'
+                   ])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'does not register offenses when there is a newline for {} block' do
     inspect_source(cop,
                    ['test {',


### PR DESCRIPTION
Currently, the multiline block cop errors out when it encounters code like this

```
x do
end
```

This commit checks for such blocks, and handles the condition correctly.
