### PR TITLE
Add and enable rubocop-spec in project

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
 # This is the configuration used to check the rubocop source code.
 
 inherit_from: .rubocop_todo.yml
+require: rubocop-rspec

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('yard', '~> 0.8')
   s.add_development_dependency('bundler', '~> 1.3')
   s.add_development_dependency('simplecov', '~> 0.7')
+  s.add_development_dependency('rubocop-rspec', '~> 1.1')
 end

--- a/spec/isolated_environment_spec.rb
+++ b/spec/isolated_environment_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 
+# rubocop:disable RSpec/DescribeClass
 describe 'isolated environment', :isolated_environment do
   include FileHelper
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'RuboCop Project' do
+describe 'RuboCop Project' do # rubocop:disable RSpec/DescribeClass
   describe 'default configuration file' do
     let(:cop_names) { RuboCop::Cop::Cop.all.map(&:cop_name) }
 


### PR DESCRIPTION
I think `rubocop-rspec` is a nice extension of RuboCop and brings useful checks to the project.
