### PR TITLE
Make tests run and pass in random orders

### DIFF
--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -559,6 +559,11 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     describe '--auto-gen-config' do
+      before(:each) do
+        RuboCop::Formatter::DisabledConfigFormatter
+          .config_to_allow_offenses = {}
+      end
+
       it 'overwrites an existing todo file' do
         create_file('example1.rb', ['# encoding: utf-8',
                                     'x= 0 ',
@@ -718,6 +723,7 @@ describe RuboCop::CLI, :isolated_environment do
       end
 
       it 'generates a todo list that removes the reports' do
+        RuboCop::Cop::Style::RegexpLiteral.slash_count = 0
         create_file('example.rb', ['# encoding: utf-8',
                                    'y.gsub!(%r{abc/xyz}, "#{x}")'])
         expect(cli.run(%w(--format emacs))).to eq(1)
@@ -736,8 +742,9 @@ describe RuboCop::CLI, :isolated_environment do
            'again.',
            '',
            '# Offense count: 1',
+           '# Configuration parameters: MaxSlashes.',
            'Style/RegexpLiteral:',
-           '  MaxSlashes: 0']
+           '  Enabled: false']
         actual = IO.read('.rubocop_todo.yml').split($RS)
         expected.each_with_index do |line, ix|
           if line.is_a?(String)

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -124,12 +124,17 @@ describe RuboCop::Cop::Team do
     end
 
     context 'when some classes are disabled with config' do
-      before do
-        %w(Lint/Void Metrics/LineLength).each do |cop_name|
-          config.for_cop(cop_name)['Enabled'] = false
+      let(:disabled_config) do
+        %w(
+          Lint/Void
+          Metrics/LineLength
+        ).each_with_object({}) do |cop_name, accum|
+          accum[cop_name] = { 'Enabled' => false }
         end
       end
-
+      let(:config) do
+        RuboCop::ConfigLoader.merge_with_default(disabled_config, '')
+      end
       let(:cop_names) { cops.map(&:name) }
 
       it 'does not return intances of the classes' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,7 @@ RSpec.configure do |config|
   # get run.
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
+  config.order = :random
 
   broken_filter = lambda do |v|
     v.is_a?(Symbol) ? RUBY_ENGINE == v.to_s : v


### PR DESCRIPTION
Running tests in random order exposes potential dependencies to stale data.
- Clear out some class-level variables that cache values from previous tests
- Don't mutate the configuration object in tests:
  - Mutating the global config object affects other tests. Tests should be able
    to be run in random order. This fixes errors that surfaced when running in
    random order.
