### PR TITLE
Fix PercentLiteralDelimiters auto-correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Bugs fixed
 
+* [#1251](https://github.com/bbatsov/rubocop/issues/1251): Fix `PercentLiteralDelimiters` auto-correct indentation error. ([@hannestyden][])
 * [#1197](https://github.com/bbatsov/rubocop/issues/1197): Fix false positive for new lambda syntax in `SpaceInsideBlockBraces`. ([@jonas054][])
 * [#1201](https://github.com/bbatsov/rubocop/issues/1201): Fix error at anonymous keyword splat arguments in some variable cops. ([@yujinakayama][])
 * Fix false positive in `UnneededPercentQ` for `/%Q(something)/`. ([@jonas054][])

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -258,5 +258,39 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
       new_source = autocorrect_source(cop, ['%w(', 'some', 'words', ')'])
       expect(new_source).to eq("%w[\nsome\nwords\n]")
     end
+
+    it 'preserves indentation when correcting a multiline array' do
+      original_source = [
+        '  array = %w(',
+        '    first',
+        '    second',
+        '  )'
+      ]
+      corrected_source = [
+        '  array = %w[',
+        '    first',
+        '    second',
+        '  ]'
+      ].join("\n")
+      new_source = autocorrect_source(cop, original_source)
+      expect(new_source).to eq(corrected_source)
+    end
+
+    it 'preserves irregular indentation when correcting a multiline array' do
+      original_source = [
+        '  array = %w(',
+        '    first',
+        '  second',
+        ')'
+      ]
+      corrected_source = [
+        '  array = %w[',
+        '    first',
+        '  second',
+        ']'
+      ].join("\n")
+      new_source = autocorrect_source(cop, original_source)
+      expect(new_source).to eq(corrected_source)
+    end
   end
 end


### PR DESCRIPTION
Make PercentLiteralDelimiters preserve the indentation of the contained expression.
