### PR TITLE
Ignore block-pass in `TrailingComma`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [#1219](https://github.com/bbatsov/rubocop/issues/1219): Don't report bad alignment for `end` or `}` in `BlockAlignment` if it doesn't begin its line. ([@jonas054][])
 * [#1227](https://github.com/bbatsov/rubocop/issues/1227): Don't permanently change yamler as it can affect other apps. ([@jonas054][])
 * [#1184](https://github.com/bbatsov/rubocop/issues/1184): Fix a false positive in `Output` cop. ([@bbatsov][])
+* [#1256](https://github.com/bbatsov/rubocop/issues/1256): Ignore block-pass in `TrailingComma`. ([@tamird][])
 
 ## 0.24.1 (03/07/2014)
 

--- a/lib/rubocop/cop/style/trailing_comma.rb
+++ b/lib/rubocop/cop/style/trailing_comma.rb
@@ -127,7 +127,10 @@ module RuboCop
         end
 
         def put_comma(items, kind, sb)
-          last_expr = items.last.loc.expression
+          last_item = items.last
+          return if last_item.type == :block_pass
+
+          last_expr = last_item.loc.expression
           ix = last_expr.source.rindex("\n") || 0
           ix += last_expr.source[ix..-1] =~ /\S/
           range = Parser::Source::Range.new(sb, last_expr.begin_pos + ix,

--- a/spec/rubocop/cop/style/trailing_comma_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_spec.rb
@@ -314,6 +314,19 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
         expect(cop.offenses).to be_empty
       end
 
+      # this is a sad parse error
+      it 'accepts no trailing comma in a method call with a block' \
+         ' paramter at the end' do
+        inspect_source(cop, ['some_method(',
+                             '              a,',
+                             '              b,',
+                             '              c: 0,',
+                             '              d: 1,',
+                             '              &block',
+                             '           )'])
+        expect(cop.offenses).to be_empty
+      end
+
       it 'accepts a multiline word array' do
         inspect_source(cop, ['ingredients = %w(',
                              '  sausage',


### PR DESCRIPTION
Trailing commas after a block-pass are a parse error, so we must
special-case them. @yous @bbatsov
