### PR TITLE
`TrailingComma` now treats all multilines equally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * [#1220](https://github.com/bbatsov/rubocop/issues/1220): New namespace `Metrics` created and some `Style` cops moved there. ([@jonas054][])
 * Drop support for Ruby 1.9.2 in accordance with [the end of the security maintenance extension](https://www.ruby-lang.org/en/news/2014/07/01/eol-for-1-8-7-and-1-9-2/). ([@yujinakayama][])
+* [#1257](https://github.com/bbatsov/rubocop/issues/1257): `TrailingComma` now treats all multilines equally. ([@tamird][])
 
 ### Bugs fixed
 

--- a/lib/rubocop/cop/style/trailing_comma.rb
+++ b/lib/rubocop/cop/style/trailing_comma.rb
@@ -108,9 +108,8 @@ module RuboCop
                      else
                        node.children
                      end
-          items = [*elements.map { |e| e.loc.expression }, node.loc.end]
-          items.each_cons(2) { |a, b| return false if on_same_line?(a, b) }
-          true
+          items = elements.map { |e| e.loc.expression }
+          items.each_cons(2).any? { |a, b| !on_same_line?(a, b) }
         end
 
         def on_same_line?(a, b)

--- a/spec/rubocop/cop/style/trailing_comma_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_spec.rb
@@ -221,12 +221,13 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'comma' } }
 
       context 'when closing bracket is on same line as last value' do
-        it 'accepts Array literal with no trailing comma' do
+        it 'registers an offense for an Array literal with no trailing comma' do
           inspect_source(cop, ['VALUES = [',
                                '           1001,',
                                '           2020,',
                                '           3333]'])
-          expect(cop.offenses).to be_empty
+          expect(cop.messages)
+            .to eq(['Put a comma after the last item of a multiline array.'])
         end
 
         it 'accepts a method call with Hash as last parameter split on ' \
@@ -240,20 +241,19 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
       it 'accepts Array literal with two of the values on the same line' do
         inspect_source(cop, ['VALUES = [',
                              '           1001, 2020,',
-                             '           3333',
+                             '           3333,',
                              '         ]'])
         expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for an Array literal with two of the values ' \
-         'on the same line and a trailing comma' do
+         'on the same line and no trailing comma' do
         inspect_source(cop, ['VALUES = [',
                              '           1001, 2020,',
-                             '           3333,',
+                             '           3333',
                              '         ]'])
         expect(cop.messages)
-          .to eq(['Avoid comma after the last item of an array, unless each ' \
-                  'item is on its own line.'])
+          .to eq(['Put a comma after the last item of a multiline array.'])
       end
 
       it 'registers an offense for no trailing comma in a Hash literal' do
@@ -338,11 +338,11 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
          ' line and a trailing comma' do
         new_source = autocorrect_source(cop, ['VALUES = [',
                                               '           1001, 2020,',
-                                              '           3333,',
+                                              '           3333',
                                               '         ]'])
         expect(new_source).to eq(['VALUES = [',
                                   '           1001, 2020,',
-                                  '           3333',
+                                  '           3333,',
                                   '         ]'].join("\n"))
       end
 


### PR DESCRIPTION
Any element with a line break in its declaration is now considered to
be multiline, which results in more consistent behaviour for this cop.
