### PR TITLE
[Fix #1255] Compare without context in AutocorrectUnlessChangingAST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#1227](https://github.com/bbatsov/rubocop/issues/1227): Don't permanently change yamler as it can affect other apps. ([@jonas054][])
 * [#1184](https://github.com/bbatsov/rubocop/issues/1184): Fix a false positive in `Output` cop. ([@bbatsov][])
 * [#1256](https://github.com/bbatsov/rubocop/issues/1256): Ignore block-pass in `TrailingComma`. ([@tamird][])
+* [#1255](https://github.com/bbatsov/rubocop/issues/1255): Compare without context in `AutocorrectUnlessChangingAST`. ([@jonas054][])
 
 ## 0.24.1 (03/07/2014)
 

--- a/lib/rubocop/cop/mixin/autocorrect_unless_changing_ast.rb
+++ b/lib/rubocop/cop/mixin/autocorrect_unless_changing_ast.rb
@@ -10,12 +10,20 @@ module RuboCop
         c = correction(node)
         new_source = rewrite_node(node)
 
-        # Make the correction only if it doesn't change the AST.
-        if node != ProcessedSource.new(new_source).ast
+        # Make the correction only if it doesn't change the AST. Regenerate the
+        # AST for `node` so we get it without context. Otherwise the comparison
+        # could be misleading.
+        if ast_for(node.loc.expression.source) != ast_for(new_source)
           fail CorrectionNotPossible
         end
 
         @corrections << c
+      end
+
+      private
+
+      def ast_for(source)
+        ProcessedSource.new(source).ast
       end
 
       def rewrite_node(node)

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -118,6 +118,15 @@ describe RuboCop::Cop::Style::AndOr, :config do
                                 'true || false'].join("\n"))
     end
 
+    it 'auto-corrects "or" with || inside def' do
+      new_source = autocorrect_source(cop, ['def z(a, b)',
+                                            '  return true if a or b',
+                                            'end'])
+      expect(new_source).to eq(['def z(a, b)',
+                                '  return true if a || b',
+                                'end'].join("\n"))
+    end
+
     it 'leaves *or* as is if auto-correction changes the meaning' do
       src = "teststring.include? 'a' or teststring.include? 'b'"
       new_source = autocorrect_source(cop, src)


### PR DESCRIPTION
For example, if the operands of `and`/`or` are local variables, the syntax tree for the new source code (that has no context) would be different from the original, but not in a meaningful way. The correction might still be valid.
