### PR TITLE
Fix #1259 : Enable parenthesizing for andor autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1259](https://github.com/bbatsov/rubocop/issues/1259): Allow AndOr cop to autocorrect by adding method call parenthesis. ([@vrthra][])
 * [#1232](https://github.com/bbatsov/rubocop/issues/1232): Add EnforcedStyle option to cop `AndOr` to restrict it to conditionals. ([@vrthra][])
 * [#835](https://github.com/bbatsov/rubocop/issues/835): New cop `PercentQLiterals` checks if use of `%Q` and `%q` matches configuration. ([@jonas054][])
 * [#835](https://github.com/bbatsov/rubocop/issues/835): New cop `BarePercentLiterals` checks if usage of `%()` or `%Q()` matches configuration. ([@jonas054][])

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -514,19 +514,19 @@ describe RuboCop::CLI, :isolated_environment do
 
       it 'does not say [Corrected] if correction was avoided' do
         create_file('example.rb', ['# encoding: utf-8',
-                                   'func a and b',
+                                   'a = c and b',
                                    'not a && b',
                                    'func a do b end'])
         expect(cli.run(%w(-a -f simple))).to eq(1)
         expect($stderr.string).to eq('')
         expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
-                                             'func a and b',
+                                             'a = c and b',
                                              'not a && b',
                                              'func a do b end',
                                              ''].join("\n"))
         expect($stdout.string)
           .to eq(['== example.rb ==',
-                  'C:  2:  8: Use && instead of and.',
+                  'C:  2:  7: Use && instead of and.',
                   'C:  3:  1: Use ! instead of not.',
                   'C:  4:  8: Prefer {...} over do...end for single-line ' \
                   'blocks.',

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -128,7 +128,7 @@ describe RuboCop::Cop::Style::AndOr, :config do
     end
 
     it 'leaves *or* as is if auto-correction changes the meaning' do
-      src = "teststring.include? 'a' or teststring.include? 'b'"
+      src = "x = y or teststring.include? 'b'"
       new_source = autocorrect_source(cop, src)
       expect(new_source).to eq(src)
     end
@@ -193,6 +193,66 @@ describe RuboCop::Cop::Style::AndOr, :config do
                      ['x = a + b until a or b'])
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use `||` instead of `or`.'])
+    end
+
+    it 'auto-corrects "or" with || in method calls' do
+      new_source = autocorrect_source(cop, 'method a or b')
+      expect(new_source).to eq('method(a) || b')
+    end
+
+    it 'auto-corrects "or" with || in method calls (2)' do
+      new_source = autocorrect_source(cop, 'method a,b or b')
+      expect(new_source).to eq('method(a,b) || b')
+    end
+
+    it 'auto-corrects "or" with || in method calls (3)' do
+      new_source = autocorrect_source(cop, 'obj.method a or b')
+      expect(new_source).to eq('obj.method(a) || b')
+    end
+
+    it 'auto-corrects "or" with || in method calls (4)' do
+      new_source = autocorrect_source(cop, 'obj.method a,b or b')
+      expect(new_source).to eq('obj.method(a,b) || b')
+    end
+
+    it 'auto-corrects "or" with || and doesn\'t add extra parenthesis' do
+      new_source = autocorrect_source(cop, 'method(a, b) or b')
+      expect(new_source).to eq('method(a, b) || b')
+    end
+
+    it 'auto-corrects "or" with || and add parenthesis on left expr' do
+      new_source = autocorrect_source(cop, 'b or method a,b')
+      expect(new_source).to eq('b || method(a,b)')
+    end
+
+    it 'auto-corrects "and" with && in method calls' do
+      new_source = autocorrect_source(cop, 'method a and b')
+      expect(new_source).to eq('method(a) && b')
+    end
+
+    it 'auto-corrects "and" with && in method calls (2)' do
+      new_source = autocorrect_source(cop, 'method a,b and b')
+      expect(new_source).to eq('method(a,b) && b')
+    end
+
+    it 'auto-corrects "and" with && in method calls (3)' do
+      new_source = autocorrect_source(cop, 'obj.method a and b')
+      expect(new_source).to eq('obj.method(a) && b')
+    end
+
+    it 'auto-corrects "and" with && in method calls (4)' do
+      new_source = autocorrect_source(cop, 'obj.method a,b and b')
+      expect(new_source).to eq('obj.method(a,b) && b')
+    end
+
+    it 'auto-corrects "and" with && and doesn\'t add extra parenthesis' do
+      new_source = autocorrect_source(cop, 'method(a, b) and b')
+      expect(new_source).to eq('method(a, b) && b')
+    end
+
+    it 'auto-corrects "and" with && and add parenthesis on left expr' do
+      new_source = autocorrect_source(cop, 'b and method a,b')
+      expect(new_source).to eq('b && method(a,b)')
     end
 
   end


### PR DESCRIPTION
This change allows rubocop to parenthesize method calls so that
`method a,b or method c` can be autocorrected to `method(a,b) || method(c)`
