### PR TITLE
[Fix #1263] Do not report %W literals with special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#1263](https://github.com/bbatsov/rubocop/issues/1263): Do not report `%W` literals with special escaped characters in `UnneededCapitalW`. ([@jonas054][])
+
 ## 0.25.0 (15/08/2014)
 
 ### New features

--- a/lib/rubocop/cop/style/unneeded_capital_w.rb
+++ b/lib/rubocop/cop/style/unneeded_capital_w.rb
@@ -17,8 +17,12 @@ module RuboCop
         private
 
         def on_percent_literal(node)
-          return unless node.children.none? { |x| x.type == :dstr }
-
+          node.children.each do |string|
+            if string.type == :dstr ||
+              string.loc.expression.source =~ StringHelp::ESCAPED_CHAR_REGEXP
+              return
+            end
+          end
           add_offense(node, :expression)
         end
 

--- a/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
@@ -29,6 +29,24 @@ describe RuboCop::Cop::Style::UnneededCapitalW do
     expect(cop.offenses).to be_empty
   end
 
+  it 'registers no offense for %W with special characters' do
+    source = ['def dangerous_characters',
+              '  %W(\000) +',
+              '  %W(\001) +',
+              '  %W(\027) +',
+              '  %W(\002) +',
+              '  %W(\003) +',
+              '  %W(\004) +',
+              '  %W(\005) +',
+              '  %W(\006) +',
+              '  %W(\007) +',
+              '  %W(\00) +',
+              '  %W(\a)',
+              'end']
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
   it 'registers no offense for %w without interpolation' do
     inspect_source(cop,
                    ['%w(cat dog)'])
@@ -74,10 +92,5 @@ describe RuboCop::Cop::Style::UnneededCapitalW do
   it 'auto-corrects an array of words' do
     new_source = autocorrect_source(cop, '%W(one two three)')
     expect(new_source).to eq('%w(one two three)')
-  end
-
-  it 'auto-corrects an array of words and character constants' do
-    new_source = autocorrect_source(cop, '%W(one two ?\n ?\t)')
-    expect(new_source).to eq('%w(one two ?\n ?\t)')
   end
 end


### PR DESCRIPTION
Just like `%W` literals with interpolation can not be changed to `%w`, special escaped characters like `\0000` would also change meaning if changing to lower case `%w`.

There was an invalid spec example for auto-correct. The character sequence `?\n` inside `%W` means a question mark followed by a newline. It's special and should not be reported or auto-corrected.
