### PR TITLE
Tab cop does auto-correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * New cop `InfiniteLoop` checks for places where `Kernel#loop` should have been used. ([@bbatsov][])
 * New cop `SymbolProc` checks for places where a symbol can be used as proc instead of a block. ([@bbatsov][])
 * `UselessAssignment` cop now suggests a variable name for possible typos if there's a variable-ish identifier similar to the unused variable name in the same scope. ([@yujinakayama][])
+* [#1272](https://github.com/bbatsov/rubocop/issues/1272): `Tab` cop does auto-correction. ([@yous][])
 
 ### Bugs fixed
 

--- a/lib/rubocop/cop/style/tab.rb
+++ b/lib/rubocop/cop/style/tab.rb
@@ -9,16 +9,24 @@ module RuboCop
 
         def investigate(processed_source)
           processed_source.lines.each_with_index do |line, index|
-            match = line.match(/^( *)\t/)
+            match = line.match(/^( *)[\t ]*\t/)
             next unless match
 
             spaces = match.captures[0]
 
             range = source_range(processed_source.buffer,
                                  index + 1,
-                                 spaces.length)
+                                 (spaces.length)...(match.end(0)))
 
-            add_offense(nil, range, MSG)
+            add_offense(range, range, MSG)
+          end
+        end
+
+        private
+
+        def autocorrect(range)
+          @corrections << lambda do |corrector|
+            corrector.replace(range, range.source.gsub(/\t/, '  '))
           end
         end
       end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -667,6 +667,7 @@ describe RuboCop::CLI, :isolated_environment do
            '  Enabled: false',
            '',
            '# Offense count: 1',
+           '# Cop supports --auto-correct.',
            'Style/Tab:',
            '  Enabled: false',
            '',
@@ -713,6 +714,7 @@ describe RuboCop::CLI, :isolated_environment do
            '  Enabled: false',
            '',
            '# Offense count: 1',
+           '# Cop supports --auto-correct.',
            'Style/Tab:',
            '  Enabled: false']
         actual = IO.read('.rubocop_todo.yml').split($RS)
@@ -1063,7 +1065,8 @@ describe RuboCop::CLI, :isolated_environment do
         let(:cop_list) { ['Style/Tab'] }
 
         it 'prints that cop and nothing else' do
-          expect(stdout).to eq(['Style/Tab:',
+          expect(stdout).to eq(['# Supports --auto-correct',
+                                'Style/Tab:',
                                 '  Description: No hard tabs.',
                                 '  Enabled: true',
                                 '',
@@ -1082,7 +1085,8 @@ describe RuboCop::CLI, :isolated_environment do
         let(:cop_list) { ['Style/Tab,Lint/X123'] }
 
         it 'skips the unknown cop' do
-          expect(stdout).to eq(['Style/Tab:',
+          expect(stdout).to eq(['# Supports --auto-correct',
+                                'Style/Tab:',
                                 '  Description: No hard tabs.',
                                 '  Enabled: true',
                                 '',

--- a/spec/rubocop/cop/style/tab_spec.rb
+++ b/spec/rubocop/cop/style/tab_spec.rb
@@ -10,8 +10,38 @@ describe RuboCop::Cop::Style::Tab do
     expect(cop.offenses.size).to eq(1)
   end
 
+  it 'registers an offence for a line indented with multiple tabs' do
+    inspect_source(cop, ["\t\t\tx = 0"])
+    expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'registers an offence for a line indented with mixed whitespace' do
+    inspect_source(cop, [" \tx = 0"])
+    expect(cop.offenses.size).to eq(1)
+  end
+
   it 'accepts a line with tab in a string' do
     inspect_source(cop, ["(x = \"\t\")"])
     expect(cop.offenses).to be_empty
+  end
+
+  it 'auto-corrects a line indented with tab' do
+    new_source = autocorrect_source(cop, ["\tx = 0"])
+    expect(new_source).to eq('  x = 0')
+  end
+
+  it 'auto-corrects a line indented with multiple tabs' do
+    new_source = autocorrect_source(cop, ["\t\t\tx = 0"])
+    expect(new_source).to eq('      x = 0')
+  end
+
+  it 'auto-corrects a line indented with mixed whitespace' do
+    new_source = autocorrect_source(cop, [" \tx = 0"])
+    expect(new_source).to eq('   x = 0')
+  end
+
+  it 'auto-corrects a line with tab in a string indented with tab' do
+    new_source = autocorrect_source(cop, ["\t(x = \"\t\")"])
+    expect(new_source).to eq("  (x = \"\t\")")
   end
 end


### PR DESCRIPTION
Also Tab cop adds an offense with range position to auto-correct multiple leading tabs.

Fix #1272.
