### PR TITLE
Force to use array join for `\n` in string

### DIFF
--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -103,7 +103,8 @@ describe RuboCop::CLI, :isolated_environment do
                   '      }',
                   '    ]',
                   '  end',
-                  'end'].join("\n") + "\n")
+                  'end',
+                  ''].join("\n"))
       end
 
       it 'can change block comments and indent them' do
@@ -132,7 +133,8 @@ describe RuboCop::CLI, :isolated_environment do
                   '      do_something',
                   '    end',
                   '  end',
-                  'end'].join("\n") + "\n")
+                  'end',
+                  ''].join("\n"))
       end
 
       it 'can correct two problems with blocks' do
@@ -146,7 +148,8 @@ describe RuboCop::CLI, :isolated_environment do
           .to eq(['# encoding: utf-8',
                   '(1..10).each do |i|',
                   '  puts i',
-                  'end'].join("\n") + "\n")
+                  'end',
+                  ''].join("\n"))
       end
 
       it 'can handle spaces when removing braces' do
@@ -188,7 +191,8 @@ describe RuboCop::CLI, :isolated_environment do
         expect(IO.read('example.rb')).to eq(['class Test',
                                              '  def f',
                                              '  end',
-                                             'end'].join("\n") + "\n")
+                                             'end',
+                                             ''].join("\n"))
       end
 
       # A case where WordArray's correction can be clobbered by
@@ -205,7 +209,8 @@ describe RuboCop::CLI, :isolated_environment do
                                              '  private',
                                              '',
                                              '  A = %w(git path)',
-                                             'end'].join("\n") + "\n")
+                                             'end',
+                                             ''].join("\n"))
         e = abs('example.rb')
         expect($stdout.string)
           .to eq(["#{e}:2:1: C: Missing top-level class documentation " \
@@ -248,7 +253,8 @@ describe RuboCop::CLI, :isolated_environment do
                                    'end end'])
         expect(cli.run(['--auto-correct'])).to eq(1)
         expect(IO.read('example.rb')).to eq(['module A module B',
-                                             'end end'].join("\n") + "\n")
+                                             'end end',
+                                             ''].join("\n"))
       end
 
       it 'can correct single line methods' do
@@ -291,8 +297,8 @@ describe RuboCop::CLI, :isolated_environment do
         expect(IO.read('example.rb'))
           .to eq(['# encoding: utf-8',
                   'fail NotImplementedError,',
-                  "     'Method should be overridden in child classes'"]
-                   .join("\n") + "\n")
+                  "     'Method should be overridden in child classes'",
+                  ''].join("\n"))
         expect($stdout.string)
           .to eq(['Inspecting 1 file',
                   'C',
@@ -331,7 +337,8 @@ describe RuboCop::CLI, :isolated_environment do
                   'class Klass',
                   '  def f',
                   '  end',
-                  'end'].join("\n") + "\n")
+                  'end',
+                  ''].join("\n"))
         expect($stderr.string).to eq('')
         expect($stdout.string)
           .to eq(['Inspecting 1 file',
@@ -361,7 +368,8 @@ describe RuboCop::CLI, :isolated_environment do
           .to eq(['# encoding: utf-8',
                   'def primes(limit)',
                   '  1.upto(limit).select { |i| is_prime[i] }',
-                  'end'].join("\n") + "\n")
+                  'end',
+                  ''].join("\n"))
         expect($stdout.string)
           .to eq(['Inspecting 1 file',
                   'C',
@@ -462,7 +470,8 @@ describe RuboCop::CLI, :isolated_environment do
                      '',
                      ''])
         expect(cli.run(%w(--auto-correct --format emacs))).to eq(1)
-        expect(IO.read('example.rb')).to eq("# encoding: utf-8\n")
+        expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
+                                             ''].join("\n"))
         expect($stdout.string)
           .to eq(["#{abs('example.rb')}:2:1: C: [Corrected] 3 trailing " \
                   'blank lines detected.',
@@ -609,8 +618,9 @@ describe RuboCop::CLI, :isolated_environment do
         expect { cli.run(['--auto-gen-config', 'example1.rb']) }
           .to exit_with_code(1)
         expect($stderr.string)
-          .to eq('--auto-gen-config can not be combined with any other ' \
-                 "arguments.\n")
+          .to eq(['--auto-gen-config can not be combined with any other ' \
+                  'arguments.',
+                  ''].join("\n"))
         expect($stdout.string).to eq('')
       end
 
@@ -1301,7 +1311,8 @@ describe RuboCop::CLI, :isolated_environment do
                                       ''].join("\n"))
 
         expect(File.read('emacs_output.txt'))
-          .to eq("#{abs(target_file)}:2:81: C: Line is too long. [90/80]\n")
+          .to eq(["#{abs(target_file)}:2:81: C: Line is too long. [90/80]",
+                  ''].join("\n"))
       end
     end
 
@@ -1402,7 +1413,9 @@ describe RuboCop::CLI, :isolated_environment do
                                'puts x'])
     expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(0)
     expect($stdout.string)
-      .to eq("\n1 file inspected, no offenses detected\n")
+      .to eq(['',
+              '1 file inspected, no offenses detected',
+              ''].join("\n"))
   end
 
   it 'checks a given file with faults and returns 1' do
@@ -1513,8 +1526,9 @@ describe RuboCop::CLI, :isolated_environment do
                    'end'])
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
       expect($stderr.string)
-        .to eq("#{abs('example.rb')}: Style/LineLength has the wrong " \
-               "namespace - should be Metrics\n")
+        .to eq(["#{abs('example.rb')}: Style/LineLength has the wrong " \
+                'namespace - should be Metrics',
+                ''].join("\n"))
       # 3 cops were disabled, then 2 were enabled again, so we
       # should get 2 offenses reported.
       expect($stdout.string)
@@ -2197,9 +2211,10 @@ describe RuboCop::CLI, :isolated_environment do
 
       cli.run(%w(--format simple -c rubocop.yml))
       expect($stderr.string)
-        .to eq("Warning: Invalid severity 'superbad'. " \
-               'Valid severities are refactor, convention, ' \
-               "warning, error, fatal.\n")
+        .to eq(["Warning: Invalid severity 'superbad'. " \
+                'Valid severities are refactor, convention, ' \
+                'warning, error, fatal.',
+                ''].join("\n"))
     end
 
     context 'when a file inherits from the old auto generated file' do
@@ -2216,8 +2231,9 @@ describe RuboCop::CLI, :isolated_environment do
         expect { cli.run(%w(-c .rubocop.yml --auto-gen-config)) }
           .to exit_with_code(1)
         expect($stderr.string)
-          .to eq('Attention: rubocop-todo.yml has been renamed to ' \
-                 ".rubocop_todo.yml\n")
+          .to eq(['Attention: rubocop-todo.yml has been renamed to ' \
+                  '.rubocop_todo.yml',
+                  ''].join("\n"))
       end
     end
   end

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -151,8 +151,10 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       end
 
       it 'one hash parameter with braces and separators' do
-        corrected = autocorrect_source(cop, ["where(  \n { x: 1 }   )"])
-        expect(corrected).to eq "where(  \n  x: 1    )"
+        corrected = autocorrect_source(cop, ['where(  ',
+                                             ' { x: 1 }   )'])
+        expect(corrected).to eq(['where(  ',
+                                 '  x: 1    )'].join("\n"))
       end
 
       it 'one hash parameter with braces and multiple keys' do
@@ -212,7 +214,8 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       end
 
       it 'one hash parameter with braces and separators around it' do
-        inspect_source(cop, ["where( \t    {  x: 1 \n  }   )"])
+        inspect_source(cop, ["where( \t    {  x: 1 ",
+                             '  }   )'])
         expect(cop.messages).to be_empty
         expect(cop.highlights).to be_empty
       end

--- a/spec/rubocop/cop/style/def_with_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/def_with_parentheses_spec.rb
@@ -33,7 +33,11 @@ describe RuboCop::Cop::Style::DefWithParentheses do
   end
 
   it 'auto-removes unneeded parens' do
-    new_source = autocorrect_source(cop, "def test();\nsomething\nend")
-    expect(new_source).to eq("def test;\nsomething\nend")
+    new_source = autocorrect_source(cop, ['def test();',
+                                          'something',
+                                          'end'])
+    expect(new_source).to eq(['def test;',
+                              'something',
+                              'end'].join("\n"))
   end
 end

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -53,7 +53,9 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
 
     it 'auto-adds required parens to argument lists on multiple lines' do
       new_source = autocorrect_source(cop, ['def test one,', 'two', 'end'])
-      expect(new_source).to eq("def test(one,\ntwo)\nend")
+      expect(new_source).to eq(['def test(one,',
+                                'two)',
+                                'end'].join("\n"))
     end
   end
 

--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -109,6 +109,8 @@ describe RuboCop::Cop::Style::MultilineIfThen do
     new_source = autocorrect_source(cop, ['if cond then',
                                           '  something',
                                           'end'])
-    expect(new_source).to eq("if cond\n  something\nend")
+    expect(new_source).to eq(['if cond',
+                              '  something',
+                              'end'].join("\n"))
   end
 end

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -256,7 +256,10 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'preserves line breaks when fixing a multiline array' do
       new_source = autocorrect_source(cop, ['%w(', 'some', 'words', ')'])
-      expect(new_source).to eq("%w[\nsome\nwords\n]")
+      expect(new_source).to eq(['%w[',
+                                'some',
+                                'words',
+                                ']'].join("\n"))
     end
 
     it 'preserves indentation when correcting a multiline array' do

--- a/spec/rubocop/cop/style/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/style/trailing_whitespace_spec.rb
@@ -17,7 +17,8 @@ describe RuboCop::Cop::Style::TrailingWhitespace do
   end
 
   it 'accepts a line without trailing whitespace' do
-    inspect_source(cop, ["x = 0\n"])
+    inspect_source(cop, ['x = 0',
+                         ''])
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/when_then_spec.rb
+++ b/spec/rubocop/cop/style/when_then_spec.rb
@@ -35,6 +35,8 @@ describe RuboCop::Cop::Style::WhenThen do
     new_source = autocorrect_source(cop, ['case a',
                                           'when b; c',
                                           'end'])
-    expect(new_source).to eq("case a\nwhen b then c\nend")
+    expect(new_source).to eq(['case a',
+                              'when b then c',
+                              'end'].join("\n"))
   end
 end

--- a/spec/rubocop/cop/style/while_until_do_spec.rb
+++ b/spec/rubocop/cop/style/while_until_do_spec.rb
@@ -42,12 +42,14 @@ describe RuboCop::Cop::Style::WhileUntilDo do
   it 'auto-corrects the usage of "do" in multiline while' do
     new_source = autocorrect_source(cop, ['while cond do',
                                           'end'])
-    expect(new_source).to eq("while cond\nend")
+    expect(new_source).to eq(['while cond',
+                              'end'].join("\n"))
   end
 
   it 'auto-corrects the usage of "do" in multiline until' do
     new_source = autocorrect_source(cop, ['until cond do',
                                           'end'])
-    expect(new_source).to eq("until cond\nend")
+    expect(new_source).to eq(['until cond',
+                              'end'].join("\n"))
   end
 end

--- a/spec/rubocop/formatter/emacs_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/emacs_style_formatter_spec.rb
@@ -24,7 +24,8 @@ module RuboCop
 
           formatter.file_finished('test', cop.offenses)
           expect(output.string).to eq ['test:1:1: C: message 1',
-                                       "test:3:6: C: message 2\n"].join("\n")
+                                       'test:3:6: C: message 2',
+                                       ''].join("\n")
         end
 
         context 'when the offense is automatically corrected' do

--- a/spec/rubocop/formatter/simple_text_formatter_spec.rb
+++ b/spec/rubocop/formatter/simple_text_formatter_spec.rb
@@ -74,7 +74,9 @@ module RuboCop
           it 'handles pluralization correctly' do
             formatter.report_summary(0, 0, 0)
             expect(output.string).to eq(
-              "\n0 files inspected, no offenses detected\n")
+              ['',
+               '0 files inspected, no offenses detected',
+               ''].join("\n"))
           end
         end
 
@@ -82,7 +84,9 @@ module RuboCop
           it 'handles pluralization correctly' do
             formatter.report_summary(1, 0, 0)
             expect(output.string).to eq(
-              "\n1 file inspected, no offenses detected\n")
+              ['',
+               '1 file inspected, no offenses detected',
+               ''].join("\n"))
           end
         end
 
@@ -90,7 +94,9 @@ module RuboCop
           it 'handles pluralization correctly' do
             formatter.report_summary(1, 1, 0)
             expect(output.string).to eq(
-              "\n1 file inspected, 1 offense detected\n")
+              ['',
+               '1 file inspected, 1 offense detected',
+               ''].join("\n"))
           end
         end
 
@@ -98,7 +104,9 @@ module RuboCop
           it 'handles pluralization correctly' do
             formatter.report_summary(2, 2, 0)
             expect(output.string).to eq(
-              "\n2 files inspected, 2 offenses detected\n")
+              ['',
+               '2 files inspected, 2 offenses detected',
+               ''].join("\n"))
           end
         end
 
@@ -106,7 +114,9 @@ module RuboCop
           it 'prints about correction' do
             formatter.report_summary(1, 1, 1)
             expect(output.string).to eq(
-              "\n1 file inspected, 1 offense detected, 1 offense corrected\n")
+              ['',
+               '1 file inspected, 1 offense detected, 1 offense corrected',
+               ''].join("\n"))
           end
         end
 
@@ -114,7 +124,9 @@ module RuboCop
           it 'handles pluralization correctly' do
             formatter.report_summary(1, 1, 2)
             expect(output.string).to eq(
-              "\n1 file inspected, 1 offense detected, 2 offenses corrected\n")
+              ['',
+               '1 file inspected, 1 offense detected, 2 offenses corrected',
+               ''].join("\n"))
           end
         end
       end

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -33,16 +33,18 @@ describe RuboCop::PathUtil do
         expect(subject.match_path?('dir/**', 'dir/sub/file', '.rubocop.yml'))
           .to be_truthy
         expect($stderr.string)
-          .to eq("Warning: Deprecated pattern style 'dir/**' in " \
-                 ".rubocop.yml. Change to 'dir/**/*'.\n")
+          .to eq(["Warning: Deprecated pattern style 'dir/**' in " \
+                  ".rubocop.yml. Change to 'dir/**/*'.",
+                  ''].join("\n"))
       end
 
       it 'matches strings to the basename and prints warning' do
         expect(subject.match_path?('file', 'dir/file', '.rubocop.yml'))
           .to be_truthy
         expect($stderr.string)
-          .to eq("Warning: Deprecated pattern style 'file' in .rubocop.yml. " \
-                 "Change to '**/file'.\n")
+          .to eq(["Warning: Deprecated pattern style 'file' in .rubocop.yml. " \
+                  "Change to '**/file'.",
+                  ''].join("\n"))
 
         expect(subject.match_path?('file', 'dir/files', '')).to be_falsey
         expect(subject.match_path?('dir', 'dir/file', '')).to be_falsey


### PR DESCRIPTION
``` ruby
['if cond',
 '  something',
 'end'].join("\n")
```

is more readable than

``` ruby
"if cond\n  something\nend"
```
