### PR TITLE
Keep line length to 80

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -100,8 +100,8 @@ Style/AlignHash:
 Style/AlignParameters:
   # Alignment of parameters in multi-line method calls.
   #
-  # The `with_first_parameter` style aligns the following lines along the same column
-  # as the first parameter.
+  # The `with_first_parameter` style aligns the following lines along the same
+  # column as the first parameter.
   #
   #     method_call(a,
   #                 b)

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-# rubocop:disable Metrics/LineLength
 
 require 'spec_helper'
 
@@ -44,7 +43,8 @@ describe RuboCop::Cop::Commissioner do
       commissioner.investigate(processed_source)
     end
 
-    it 'passes the input params to all cops/forces that implement their own #investigate method' do
+    it 'passes the input params to all cops/forces that implement their own' \
+       ' #investigate method' do
       source = []
       processed_source = parse_source(source)
       expect(cop).to receive(:investigate).with(processed_source)

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-# rubocop:disable Metrics/LineLength
 
 require 'spec_helper'
 
@@ -82,7 +81,8 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                       '    end'
                      ])
       expect(cop.messages)
-        .to eq(['`end` at 2, 4 is not aligned with `a = b = c = test do |ala|` at 1, 0'])
+        .to eq(['`end` at 2, 4 is not aligned with' \
+                ' `a = b = c = test do |ala|` at 1, 0'])
     end
 
     it 'accepts end aligned with the first variable' do
@@ -122,7 +122,8 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                     '  end'
                    ])
     expect(cop.messages)
-      .to eq(['`end` at 2, 2 is not aligned with `variable = test do |ala|` at 1, 0'])
+      .to eq(['`end` at 2, 2 is not aligned with `variable = test do |ala|`' \
+              ' at 1, 0'])
   end
 
   context 'when the block is defined on the next line' do
@@ -144,8 +145,8 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                       'end'
                      ])
       expect(cop.messages)
-        .to eq(['`end` at 4, 0 is not aligned with `a_long_method_that_dont_fit_on_the_line ' \
-                'do |v|` at 2, 2'])
+        .to eq(['`end` at 4, 0 is not aligned with' \
+                ' `a_long_method_that_dont_fit_on_the_line do |v|` at 2, 2'])
     end
 
     it 'auto-corrects alignment' do
@@ -169,41 +170,43 @@ describe RuboCop::Cop::Lint::BlockAlignment do
   context 'when the method part is a call chain that spans several lines' do
     # Example from issue 346 of bbatsov/rubocop on github:
     it 'accepts pretty alignment style' do
-      src = ['def foo(bar)',
-             '  bar.get_stuffs',
-             '      .reject do |stuff| ',
-             '        stuff.with_a_very_long_expression_that_doesnt_fit_the_line',
-             '      end.select do |stuff|',
-             '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
-             '      end',
-             '      .select do |stuff|',
-             '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
-             '      end',
-             'end']
+      src = [
+        'def foo(bar)',
+        '  bar.get_stuffs',
+        '      .reject do |stuff| ',
+        '        stuff.with_a_very_long_expression_that_doesnt_fit_the_line',
+        '      end.select do |stuff|',
+        '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
+        '      end',
+        '      .select do |stuff|',
+        '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
+        '      end',
+        'end']
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'registers offenses for misaligned ends' do
-      src = ['def foo(bar)',
-             '  bar.get_stuffs',
-             '      .reject do |stuff|',
-             '        stuff.with_a_very_long_expression_that_doesnt_fit_the_line',
-             '        end.select do |stuff|',
-             '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
-             '    end',
-             '      .select do |stuff|',
-             '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
-             '        end',
-             'end']
+      src = [
+        'def foo(bar)',
+        '  bar.get_stuffs',
+        '      .reject do |stuff|',
+        '        stuff.with_a_very_long_expression_that_doesnt_fit_the_line',
+        '        end.select do |stuff|',
+        '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
+        '    end',
+        '      .select do |stuff|',
+        '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
+        '        end',
+        'end']
       inspect_source(cop, src)
       expect(cop.messages)
-        .to eq(['`end` at 5, 8 is not aligned with `bar.get_stuffs` at 2, 2 or' \
-                ' `.reject do |stuff|` at 3, 6',
-                '`end` at 7, 4 is not aligned with `bar.get_stuffs` at 2, 2 or' \
-                ' `end.select do |stuff|` at 5, 8',
-                '`end` at 10, 8 is not aligned with `bar.get_stuffs` at 2, 2 or' \
-                ' `.select do |stuff|` at 8, 6'])
+        .to eq(['`end` at 5, 8 is not aligned with `bar.get_stuffs` at 2, 2' \
+                ' or `.reject do |stuff|` at 3, 6',
+                '`end` at 7, 4 is not aligned with `bar.get_stuffs` at 2, 2' \
+                ' or `end.select do |stuff|` at 5, 8',
+                '`end` at 10, 8 is not aligned with `bar.get_stuffs` at 2, 2' \
+                ' or `.select do |stuff|` at 8, 6'])
     end
 
     # Example from issue 393 of bbatsov/rubocop on github:
@@ -242,17 +245,18 @@ describe RuboCop::Cop::Lint::BlockAlignment do
     end
 
     it 'auto-corrects misaligned ends with the start of the expression' do
-      src = ['def foo(bar)',
-             '  bar.get_stuffs',
-             '      .reject do |stuff|',
-             '        stuff.with_a_very_long_expression_that_doesnt_fit_the_line',
-             '        end.select do |stuff|',
-             '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
-             '    end',
-             '      .select do |stuff|',
-             '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
-             '        end',
-             'end']
+      src = [
+        'def foo(bar)',
+        '  bar.get_stuffs',
+        '      .reject do |stuff|',
+        '        stuff.with_a_very_long_expression_that_doesnt_fit_the_line',
+        '        end.select do |stuff|',
+        '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
+        '    end',
+        '      .select do |stuff|',
+        '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
+        '        end',
+        'end']
 
       aligned_src = [
         'def foo(bar)',
@@ -289,7 +293,8 @@ describe RuboCop::Cop::Lint::BlockAlignment do
              '    end']
       inspect_source(cop, src)
       expect(cop.messages)
-        .to eq(['`end` at 4, 4 is not aligned with `e,` at 1, 0 or `f = [5, 6].map do |i|` at 2, 0'])
+        .to eq(['`end` at 4, 4 is not aligned with `e,` at 1, 0 or' \
+                ' `f = [5, 6].map do |i|` at 2, 0'])
     end
 
     it 'can not auto-correct' do
@@ -311,13 +316,15 @@ describe RuboCop::Cop::Lint::BlockAlignment do
     expect(cop.offenses).to be_empty
   end
 
-  it 'registers an offense for mismatched block end with an instance variable' do
+  it 'registers an offense for mismatched block end with' \
+     ' an instance variable' do
     inspect_source(cop,
                    ['@variable = test do |ala|',
                     '  end'
                    ])
     expect(cop.messages)
-      .to eq(['`end` at 2, 2 is not aligned with `@variable = test do |ala|` at 1, 0'])
+      .to eq(['`end` at 2, 2 is not aligned with `@variable = test do |ala|`' \
+              ' at 1, 0'])
   end
 
   it 'accepts end aligned with a class variable' do
@@ -334,7 +341,8 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                     '  end'
                    ])
     expect(cop.messages)
-      .to eq(['`end` at 2, 2 is not aligned with `@@variable = test do |ala|` at 1, 0'])
+      .to eq(['`end` at 2, 2 is not aligned with `@@variable = test do |ala|`' \
+              ' at 1, 0'])
   end
 
   it 'accepts end aligned with a global variable' do
@@ -351,7 +359,8 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                     '  end'
                    ])
     expect(cop.messages)
-      .to eq(['`end` at 2, 2 is not aligned with `$variable = test do |ala|` at 1, 0'])
+      .to eq(['`end` at 2, 2 is not aligned with `$variable = test do |ala|`' \
+              ' at 1, 0'])
   end
 
   it 'accepts end aligned with a constant' do
@@ -368,7 +377,8 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                     '  end'
                    ])
     expect(cop.messages)
-      .to eq(['`end` at 2, 2 is not aligned with `Module::CONSTANT = test do |ala|` at 1, 0'])
+      .to eq(['`end` at 2, 2 is not aligned with' \
+              ' `Module::CONSTANT = test do |ala|` at 1, 0'])
   end
 
   it 'accepts end aligned with a method call' do
@@ -387,7 +397,8 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                     '  end'
                    ])
     expect(cop.messages)
-      .to eq(['`end` at 3, 2 is not aligned with `parser.childs << lambda do |token|` at 1, 0'])
+      .to eq(['`end` at 3, 2 is not aligned with' \
+              ' `parser.childs << lambda do |token|` at 1, 0'])
   end
 
   it 'accepts end aligned with a method call with arguments' do
@@ -399,14 +410,16 @@ describe RuboCop::Cop::Lint::BlockAlignment do
     expect(cop.offenses).to be_empty
   end
 
-  it 'registers an offense for mismatched end with a method call with arguments' do
+  it 'registers an offense for mismatched end with a method call' \
+     ' with arguments' do
     inspect_source(cop,
                    ['@h[:f] = f.each_pair.map do |f, v|',
                     '  v = 1',
                     '  end'
                    ])
     expect(cop.messages)
-      .to eq(['`end` at 3, 2 is not aligned with `@h[:f] = f.each_pair.map do |f, v|` at 1, 0'])
+      .to eq(['`end` at 3, 2 is not aligned with' \
+              ' `@h[:f] = f.each_pair.map do |f, v|` at 1, 0'])
   end
 
   it 'does not raise an error for nested block in a method call' do
@@ -425,15 +438,16 @@ describe RuboCop::Cop::Lint::BlockAlignment do
     expect(cop.offenses).to be_empty
   end
 
-  it 'registers an offense for mismatched end not aligned with the block that is an argument' do
+  it 'registers an offense for mismatched end not aligned with the block' \
+     ' that is an argument' do
     inspect_source(cop,
                    ['expect(arr.all? do |o|',
                     '  o.valid?',
                     '  end)'
                    ])
     expect(cop.messages)
-      .to eq(['`end` at 3, 2 is not aligned with `arr.all? do |o|` at 1, 7 or ' \
-              '`expect(arr.all? do |o|` at 1, 0'])
+      .to eq(['`end` at 3, 2 is not aligned with `arr.all? do |o|` at 1, 7 or' \
+              ' `expect(arr.all? do |o|` at 1, 0'])
   end
 
   it 'accepts end aligned with an op-asgn (+=, -=)' do
@@ -469,7 +483,8 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                     '  end'
                    ])
     expect(cop.messages)
-      .to eq(['`end` at 2, 2 is not aligned with `variable &&= test do |ala|` at 1, 0'])
+      .to eq(['`end` at 2, 2 is not aligned with `variable &&= test do |ala|`' \
+              ' at 1, 0'])
   end
 
   it 'accepts end aligned with an or-asgn (||=)' do
@@ -486,7 +501,8 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                     '  end'
                    ])
     expect(cop.messages)
-      .to eq(['`end` at 2, 2 is not aligned with `variable ||= test do |ala|` at 1, 0'])
+      .to eq(['`end` at 2, 2 is not aligned with `variable ||= test do |ala|`' \
+              ' at 1, 0'])
   end
 
   it 'accepts end aligned with a mass assignment' do


### PR DESCRIPTION
Using `:vimgrep /.\{81\}/ config/**/* lib/**/* spec/**/*`.

I think we have to figure out why RuboCop doesn't register an offense for `spec/**/*` files.
