### PR TITLE
Fix auto-correction `RedundantBegin` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#1263](https://github.com/bbatsov/rubocop/issues/1263): Do not report `%W` literals with special escaped characters in `UnneededCapitalW`. ([@jonas054][])
 * [#1286](https://github.com/bbatsov/rubocop/issues/1286): Fix a false positive in `VariableName`. ([@bbatsov][])
 * [#1211](https://github.com/bbatsov/rubocop/issues/1211): Fix false negative in `UselessAssignment` when there's a reference for the variable in an exclusive branch. ([@yujinakayama][])
+* [#1307](https://github.com/bbatsov/rubocop/issues/1307): Fix auto-correction of `RedundantBegin` cop deletes new line. ([@yous][])
 
 ## 0.25.0 (15/08/2014)
 

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -41,7 +41,7 @@ module RuboCop
               range_with_surrounding_space(node.loc.expression),
               range_with_surrounding_space(
                 child.loc.expression
-              ).source.gsub(/^\s{#{indent_diff}}/, '')
+              ).source.gsub(/^[ \t]{#{indent_diff}}/, '')
             )
           end
         end

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -86,4 +86,36 @@ describe RuboCop::Cop::Style::RedundantBegin do
     new_source = autocorrect_source(cop, src)
     expect(new_source).to eq(result_src)
   end
+
+  it "doesn't modify spacing when auto-correcting" do
+    src = ['def method',
+           '  begin',
+           '    BlockA do |strategy|',
+           '      foo',
+           '    end',
+           '',
+           '    BlockB do |portfolio|',
+           '      foo',
+           '    end',
+           '',
+           '  rescue => e',
+           '    bar',
+           '  end',
+           'end']
+
+    result_src = ['def method',
+                  '  BlockA do |strategy|',
+                  '    foo',
+                  '  end',
+                  '',
+                  '  BlockB do |portfolio|',
+                  '    foo',
+                  '  end',
+                  '',
+                  'rescue => e',
+                  '  bar',
+                  'end'].join("\n")
+    new_source = autocorrect_source(cop, src)
+    expect(new_source).to eq(result_src)
+  end
 end


### PR DESCRIPTION
Auto-correction of `Style/RedundantBegin` cop have treated new line as indentation and deleted them.

Fix #1307.
