### PR TITLE
[Fix #1283] Fix bug concerning indentation in PercentLiteralDelimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#1286](https://github.com/bbatsov/rubocop/issues/1286): Fix a false positive in `VariableName`. ([@bbatsov][])
 * [#1211](https://github.com/bbatsov/rubocop/issues/1211): Fix false negative in `UselessAssignment` when there's a reference for the variable in an exclusive branch. ([@yujinakayama][])
 * [#1307](https://github.com/bbatsov/rubocop/issues/1307): Fix auto-correction of `RedundantBegin` cop deletes new line. ([@yous][])
+* [#1283](https://github.com/bbatsov/rubocop/issues/1283): Fix auto-correction of indented expressions in `PercentLiteralDelimiters`. ([@jonas054][])
 
 ## 0.25.0 (15/08/2014)
 

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -80,7 +80,9 @@ module RuboCop
           when String
             ''
           when Parser::AST::Node
-            /(\s*)/.match(object.loc.send(part).source_line)[1]
+            part_range = object.loc.send(part)
+            left_of_part = part_range.source_line[0...part_range.column]
+            /^(\s*)$/.match(left_of_part) ? left_of_part : ''
           else
             fail "Unsupported object #{object}"
           end

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -230,6 +230,23 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
       expect(new_source).to eq('%w[some words]')
     end
 
+    it 'fixes a string array in a scope' do
+      new_source = autocorrect_source(cop, ['module Foo',
+                                            '   class Bar',
+                                            '     def baz',
+                                            '       %(one two)',
+                                            '     end',
+                                            '   end',
+                                            ' end'])
+      expect(new_source).to eq(['module Foo',
+                                '   class Bar',
+                                '     def baz',
+                                '       %[one two]',
+                                '     end',
+                                '   end',
+                                ' end'].join("\n"))
+    end
+
     it 'fixes a regular expression' do
       original_source = '%r(.*)'
       new_source = autocorrect_source(cop, original_source)


### PR DESCRIPTION
Indentation for the line containing the closing bracket was added inside the new closing bracket. Which was wrong. We must find the indentation of the closing bracket itself (if it begins its line).
