### PR TITLE
Ignore missing blank line after access modifier at end of block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#1313](https://github.com/bbatsov/rubocop/issues/1313): Fix a false positive in `AndOr` when enforced style is `conditionals`. ([@bbatsov][])
 * Handle post-conditional `while` and `until` in `AndOr` when enforced style is `conditionals`. ([@yujinakayama][])
 * [#1319](https://github.com/bbatsov/rubocop/issues/1319): Fix a false positive in `FormatString`. ([@bbatsov][])
+* [#1287](https://github.com/bbatsov/rubocop/issues/1287): Allow missing blank line for EmptyLinesAroundAccessModifier if next line closes a block. ([@sch1zo][])
 
 ## 0.25.0 (15/08/2014)
 
@@ -1084,3 +1085,4 @@
 [@vrthra]: https://github.com/vrthra
 [@SkuliOskarsson]: https://github.com/SkuliOskarsson
 [@jspanjers]: https://github.com/jspanjers
+[@sch1zo]: https://github.com/sch1zo

--- a/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
@@ -46,7 +46,7 @@ module RuboCop
         end
 
         def next_line_empty?(next_line)
-          next_line.blank?
+          body_end?(next_line.lstrip) || next_line.blank?
         end
 
         def empty_lines_around?(node)
@@ -59,6 +59,10 @@ module RuboCop
 
         def class_def?(line)
           %w(class module).any? { |keyword| line.start_with?(keyword) }
+        end
+
+        def body_end?(line)
+          line.start_with?('end')
         end
 
         def message(node)

--- a/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Style::EmptyLinesAroundAccessModifier do
         .to eq(["Keep a blank line before and after `#{access_modifier}`."])
     end
 
-    it 'requires blank line after #{access_modifier}' do
+    it "requires blank line after #{access_modifier}" do
       inspect_source(cop,
                      ['class Test',
                       '  something',
@@ -72,6 +72,16 @@ describe RuboCop::Cop::Style::EmptyLinesAroundAccessModifier do
                       "  #{access_modifier}",
                       '',
                       '  def test; end',
+                      'end'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts missing blank line when at the end of block' do
+      inspect_source(cop,
+                     ['class Test',
+                      '  def test; end',
+                      '',
+                      "  #{access_modifier}",
                       'end'])
       expect(cop.offenses).to be_empty
     end


### PR DESCRIPTION
EmptyLinesAroundAccessModifier should not complain about a missing blank line after the access modifier if the next line is the end of a block.

This also resolves #1287. 

(It's my first PR for rubocop let me know if I missed something.)
