### PR TITLE
add autocorrect for UselessAccessModifier cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#1279](https://github.com/bbatsov/rubocop/issues/1279): `DotPosition` cop does auto-correction. ([@yous][])
 * [#1277](https://github.com/bbatsov/rubocop/issues/1277): `SpaceBeforeFirstArg` cop does auto-correction. ([@yous][])
 * [#1310](https://github.com/bbatsov/rubocop/issues/1310): Handle `module_function` in `Style/AccessModifierIndentation` and `Style/EmptyLinesAroundAccessModifier`. ([@bbatsov][])
+* [#1320](https://github.com/bbatsov/rubocop/pull/1320): `UselessAccessModifiers` cop does auto-correction. ([@sch1zo][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -30,6 +30,18 @@ module RuboCop
           add_offense_for_access_modifier
         end
 
+        def autocorrect(node)
+          @corrections << lambda do |corrector|
+            line = Parser::Source::Range.new(
+              processed_source.buffer,
+              node.loc.expression.begin_pos - node.loc.column,
+              node.loc.expression.end_pos + 1
+            )
+
+            corrector.remove(line)
+          end
+        end
+
         private
 
         def add_offense_for_access_modifier

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -201,13 +201,12 @@ describe RuboCop::CLI, :isolated_environment do
         create_file('example.rb', ['# encoding: utf-8',
                                    'class Dsl',
                                    'private',
+                                   '',
                                    '  A = ["git", "path",]',
                                    'end'])
         expect(cli.run(%w(--auto-correct --format emacs))).to eq(1)
         expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
                                              'class Dsl',
-                                             '  private',
-                                             '',
                                              '  A = %w(git path)',
                                              'end',
                                              ''].join("\n"))
@@ -215,13 +214,21 @@ describe RuboCop::CLI, :isolated_environment do
         expect($stdout.string)
           .to eq(["#{e}:2:1: C: Missing top-level class documentation " \
                   'comment.',
+                  "#{e}:3:1: W: [Corrected] Useless `private` access modifier.",
                   "#{e}:3:1: C: [Corrected] Indent access modifiers like " \
                   '`private`.',
-                  "#{e}:3:1: C: [Corrected] Keep a blank line before and " \
-                  'after `private`.',
-                  "#{e}:3:3: W: Useless `private` access modifier.",
-                  "#{e}:3:3: C: [Corrected] Keep a blank line before and " \
-                  'after `private`.',
+                  "#{e}:3:1: C: [Corrected] Extra empty line detected at " \
+                  'body beginning.',
+                  "#{e}:3:7: C: [Corrected] Use `%w` or `%W` " \
+                  'for array of words.',
+                  "#{e}:3:8: C: [Corrected] Prefer single-quoted strings " \
+                  "when you don't need string interpolation or special " \
+                  'symbols.',
+                  "#{e}:3:15: C: [Corrected] Prefer single-quoted strings " \
+                  "when you don't need string interpolation or special " \
+                  'symbols.',
+                  "#{e}:3:21: C: [Corrected] Avoid comma after the last item " \
+                  'of an array.',
                   "#{e}:4:7: C: [Corrected] Use `%w` or `%W` " \
                   'for array of words.',
                   "#{e}:4:8: C: [Corrected] Prefer single-quoted strings " \

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -189,4 +189,29 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
       end
     end
   end
+
+  context 'autocorrect' do
+    it 'should remove the complete line with the useless modifier' do
+      corrected = autocorrect_source(cop,
+                                     ['class Test',
+                                      '  something',
+                                      '',
+                                      '  private',
+                                      'end'])
+      expect(corrected).to eq(['class Test',
+                               '  something',
+                               '',
+                               'end'].join("\n"))
+    end
+    it 'should not remove the line if the access modifier is not useless' do
+      source = ['class SomeClass',
+                '  def some_method',
+                '    puts 10',
+                '  end',
+                '  private :some_method',
+                'end']
+      corrected = autocorrect_source(cop, source)
+      expect(corrected).to eq(source.join("\n"))
+    end
+  end
 end


### PR DESCRIPTION
as mentioned in #1287 it would be great it `UselessAccessModifier` could do auto-correction.

Is there a better way to get the whole line of the issue which can be passed to `corrector.remove`? Or is it better to just remove the access modifier and let other cops deal with trailing spaces and multiple blank lines?
