### PR TITLE
[Fix #1289] Use utf-8 as default encoding for inspected files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 * [#1277](https://github.com/bbatsov/rubocop/issues/1277): `SpaceBeforeFirstArg` cop does auto-correction. ([@yous][])
 * [#1310](https://github.com/bbatsov/rubocop/issues/1310): Handle `module_function` in `Style/AccessModifierIndentation` and `Style/EmptyLinesAroundAccessModifier`. ([@bbatsov][])
 
+### Changes
+
+* [#1289](https://github.com/bbatsov/rubocop/issues/1289): Use utf-8 as default encoding for inspected files. ([@jonas054][])
+
 ### Bugs fixed
 
 * [#1263](https://github.com/bbatsov/rubocop/issues/1263): Do not report `%W` literals with special escaped characters in `UnneededCapitalW`. ([@jonas054][])

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -16,6 +16,11 @@ module RuboCop
     end
 
     def initialize(source, path = nil)
+      # In Ruby 2, source code encoding defaults to UTF-8. We follow the same
+      # principle regardless of which Ruby version we're running under.
+      # Encoding comments will override this setting.
+      source.force_encoding(Encoding::UTF_8)
+
       @raw_source = source
       @path = path
       @diagnostics = []

--- a/spec/rubocop/processed_source_spec.rb
+++ b/spec/rubocop/processed_source_spec.rb
@@ -81,6 +81,22 @@ describe RuboCop::ProcessedSource do
       end
     end
 
+    context 'when the source lacks encoding comment and is really utf-8 ' \
+            'encoded but has been read as US-ASCII' do
+      let(:source) do
+        # When files are read into RuboCop, the encoding of source code lacking
+        # an encoding comment will default to the external encoding, which
+        # could for example be US-ASCII if the LC_ALL environment variable is
+        # set to "C".
+        '号码 = 3'.force_encoding('US-ASCII')
+      end
+
+      it 'is nil' do
+        # ProcessedSource#parse sets UTF-8 as default encoding, so no error.
+        expect(processed_source.parser_error).to be_nil
+      end
+    end
+
     context 'when the source could not be parsed due to encoding error' do
       include_context 'invalid encoding source'
 


### PR DESCRIPTION
For all Ruby versions.
