### PR TITLE
[Fix #835] Add static choice for Style/StringLiterals:EnforcedStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#835](https://github.com/bbatsov/rubocop/issues/835): Add `static` as choice in configuraton of `Style/Stringliterals` to prefer `%q(')` over `"'"`, etc. ([@jonas054][])
+
 ## 0.26.0 (03/09/2014)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -389,9 +389,15 @@ Style/SingleLineMethods:
 
 Style/StringLiterals:
   EnforcedStyle: single_quotes
+  # The value `single_quotes` means that `'` characters are preferred over `"`.
+  # The value `double_quotes` means that `"` characters are preferred over `'`,
+  # and that `"'"` is preferred over `%q(')`.
+  # The value `static` means that %q() and `'` are preferred over the dynamic
+  # %Q() and "".
   SupportedStyles:
     - single_quotes
     - double_quotes
+    - static
 
 Style/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: space

--- a/lib/rubocop/cop/mixin/configurable_enforced_style.rb
+++ b/lib/rubocop/cop/mixin/configurable_enforced_style.rb
@@ -5,9 +5,13 @@ module RuboCop
     # Handles `EnforcedStyle` configuration parameters.
     module ConfigurableEnforcedStyle
       def opposite_style_detected
-        self.config_to_allow_offenses ||=
-          { parameter_name => alternative_style.to_s }
-        both_styles_detected if config_to_allow_offenses['Enabled']
+        if cop_config['SupportedStyles'].size == 2
+          self.config_to_allow_offenses ||=
+            { parameter_name => alternative_style.to_s }
+          both_styles_detected if config_to_allow_offenses['Enabled']
+        else
+          unrecognized_style_detected
+        end
       end
 
       def correct_style_detected

--- a/lib/rubocop/cop/style/string_literals.rb
+++ b/lib/rubocop/cop/style/string_literals.rb
@@ -10,21 +10,30 @@ module RuboCop
 
         private
 
-        def message(*)
-          if style == :single_quotes
-            "Prefer single-quoted strings when you don't need string " \
-            'interpolation or special symbols.'
-          else
+        def message(node)
+          if style == :double_quotes
             'Prefer double-quoted strings unless you need single quotes to ' \
             'avoid extra backslashes for escaping.'
+          else
+            m = if style == :static && node.loc.expression.source =~ /^.+'.+$/
+                  'Prefer %q strings when the string contains a single ' \
+                  'quote but '
+                else
+                  'Prefer single-quoted strings when '
+                end
+            m + "you don't need string interpolation or special symbols."
           end
         end
 
         def offense?(node)
           src = node.loc.expression.source
-          return false if src =~ /^(%[qQ]?|\?|<<-)/i
-          if style == :single_quotes
+          return false if src =~ /^(%q|\?|<<-)/
+          return false if style != :static && src =~ /^%/
+          case style
+          when :single_quotes
             src !~ /'/ && src !~ StringHelp::ESCAPED_CHAR_REGEXP
+          when :static
+            src =~ /^["%]/ && src !~ StringHelp::ESCAPED_CHAR_REGEXP
           else
             src !~ /" | \\/x
           end
@@ -32,8 +41,13 @@ module RuboCop
 
         def autocorrect(node)
           @corrections << lambda do |corrector|
-            replacement = node.loc.begin.is?('"') ? "'" : '"'
+            replacement = if style == :static
+                            node.loc.expression.source =~ /'/ ? '%q(' : "'"
+                          else
+                            node.loc.begin.is?('"') ? "'" : '"'
+                          end
             corrector.replace(node.loc.begin, replacement)
+            replacement = ')' if replacement == '%q('
             corrector.replace(node.loc.end, replacement)
           end
         end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -35,6 +35,24 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     describe '--auto-correct' do
+      it 'corrects to static strings if so configured' do
+        source = <<-END.strip_indent
+         puts "a" + "'"
+         puts %Q(b) + %Q(')
+         puts %(c) + %(')
+        END
+        corrected_source = <<-END.strip_indent
+         puts 'a' + %q(')
+         puts 'b' + %q(')
+         puts 'c' + %q(')
+        END
+        create_file('example.rb', source)
+        create_file('.rubocop.yml', ['Style/StringLiterals:',
+                                     '  EnforcedStyle: static'])
+        expect(cli.run(['--auto-correct'])).to eq(1)
+        expect(IO.read('example.rb')).to eq(corrected_source)
+      end
+
       it 'honors Exclude settings in individual cops' do
         source = ['# encoding: utf-8',
                   'puts %x(ls)']

--- a/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
@@ -3,35 +3,9 @@
 require 'spec_helper'
 
 describe RuboCop::Cop::Style::UnneededPercentQ do
-  subject(:cop) { described_class.new }
+  subject(:cop) { described_class.new(config) }
 
-  context 'with %q strings' do
-    let(:source) do
-      <<-END.strip_indent
-        %q('hi') # line 1
-        %q("hi")
-        %q(hi)
-        %q('"hi"')
-        %q('hi\\t') # line 5
-      END
-    end
-    let(:corrected) do
-      <<-END.strip_indent
-        "'hi'" # line 1
-        '"hi"'
-        'hi'
-        %q('"hi"')
-        %q('hi\\t') # line 5
-      END
-    end
-    before { inspect_source(cop, source) }
-
-    it 'registers an offense for only single quotes' do
-      expect(cop.offenses.map(&:line)).to include(1)
-      expect(cop.messages).to eq(['Use `%q` only for strings that contain ' \
-                                  'both single quotes and double quotes.'] * 3)
-    end
-
+  shared_examples 'prefers single quotes over %q' do
     it 'registers an offense for only double quotes' do
       expect(cop.offenses.map(&:line)).to include(2)
     end
@@ -54,74 +28,158 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
     end
   end
 
-  context 'with %Q strings' do
-    let(:source) do
-      <<-END.strip_indent
-        %Q(hi) # line 1
-        %Q("hi")
-        %Q(hi\#{4})
-        %Q('"hi"')
-        %Q("\\thi")
-        %Q("hi\#{4}")
-        /%Q?/ # line 7
-      END
-    end
-    let(:corrected) do
-      <<-END.strip_indent
-        "hi" # line 1
-        '"hi"'
-        "hi\#{4}"
-        %Q('"hi"')
-        %Q("\\thi")
-        %Q("hi\#{4}")
-        /%Q?/ # line 7
-      END
-    end
-    before { inspect_source(cop, source) }
+  shared_examples '%Q strings' do
+    context 'with %Q strings' do
+      let(:source) do
+        <<-END.strip_indent
+          %Q(hi) # line 1
+          %Q("hi")
+          %Q(hi\#{4})
+          %Q('"hi"')
+          %Q("\\thi")
+          %Q("hi\#{4}")
+          /%Q?/ # line 7
+        END
+      end
+      let(:corrected) do
+        <<-END.strip_indent
+          "hi" # line 1
+          '"hi"'
+          "hi\#{4}"
+          %Q('"hi"')
+          %Q("\\thi")
+          %Q("hi\#{4}")
+          /%Q?/ # line 7
+        END
+      end
+      before { inspect_source(cop, source) }
 
-    it 'registers an offense for static string without quotes' do
-      expect(cop.offenses.map(&:line)).to include(1)
-      expect(cop.messages).to eq(['Use `%Q` only for strings that contain ' \
-                                  'both single quotes and double quotes, or ' \
-                                  'for dynamic strings that contain double ' \
-                                  'quotes.'] * 3)
-    end
+      it 'registers an offense for static string without quotes' do
+        expect(cop.offenses.map(&:line)).to include(1)
+        expect(cop.messages).to eq(['Use `%Q` only for strings that contain ' \
+                                    'both single quotes and double quotes, ' \
+                                    'or for dynamic strings that contain ' \
+                                    'double quotes.'] * 3)
+      end
 
-    it 'registers an offense for static string with only double quotes' do
-      expect(cop.offenses.map(&:line)).to include(2)
-    end
+      it 'registers an offense for static string with only double quotes' do
+        expect(cop.offenses.map(&:line)).to include(2)
+      end
 
-    it 'registers an offense for dynamic string without quotes' do
-      expect(cop.offenses.map(&:line)).to include(3)
-    end
+      it 'registers an offense for dynamic string without quotes' do
+        expect(cop.offenses.map(&:line)).to include(3)
+      end
 
-    it 'accepts a string with single quotes and double quotes' do
-      expect(cop.offenses.map(&:line)).not_to include(4)
-    end
+      it 'accepts a string with single quotes and double quotes' do
+        expect(cop.offenses.map(&:line)).not_to include(4)
+      end
 
-    it 'accepts a string with double quotes and tab character' do
-      expect(cop.offenses.map(&:line)).not_to include(5)
-    end
+      it 'accepts a string with double quotes and tab character' do
+        expect(cop.offenses.map(&:line)).not_to include(5)
+      end
 
-    it 'accepts a dynamic %Q string with double quotes' do
-      expect(cop.offenses.map(&:line)).not_to include(6)
-    end
+      it 'accepts a dynamic %Q string with double quotes' do
+        expect(cop.offenses.map(&:line)).not_to include(6)
+      end
 
-    it 'accepts regular expressions starting with %Q' do
-      expect(cop.offenses.map(&:line)).not_to include(7)
-    end
+      it 'accepts regular expressions starting with %Q' do
+        expect(cop.offenses.map(&:line)).not_to include(7)
+      end
 
-    it 'auto-corrects' do
-      new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq(corrected)
+      it 'auto-corrects' do
+        new_source = autocorrect_source(cop, source)
+        expect(new_source).to eq(corrected)
+      end
     end
   end
 
-  it 'accepts a heredoc string that contains %q' do
-    inspect_source(cop, ['  s = <<END',
-                         "%q('hi') # line 1",
-                         '%q("hi")',
-                         'END'])
-    expect(cop.offenses).to be_empty
+  context 'when StringLiterals/EnforcedStyle is not static' do
+    let(:config) do
+      RuboCop::Config.new('Style/StringLiterals' => {
+                            'EnforcedStyle' => 'single_quotes'
+                          })
+    end
+
+    context 'with %q strings' do
+      let(:source) do
+        <<-END.strip_indent
+          %q('hi') # line 1
+          %q("hi")
+          %q(hi)
+          %q('"hi"')
+          %q('hi\\t') # line 5
+        END
+      end
+      let(:corrected) do
+        <<-END.strip_indent
+          "'hi'" # line 1
+          '"hi"'
+          'hi'
+          %q('"hi"')
+          %q('hi\\t') # line 5
+        END
+      end
+      before { inspect_source(cop, source) }
+
+      include_examples 'prefers single quotes over %q'
+
+      it 'registers an offense for only single quotes' do
+        expect(cop.offenses.map(&:line)).to include(1)
+        expect(cop.messages)
+          .to eq(['Use `%q` only for strings that contain ' \
+                  'both single quotes and double quotes.'] * 3)
+      end
+    end
+
+    include_examples '%Q strings'
+
+    it 'accepts a heredoc string that contains %q' do
+      inspect_source(cop, ['  s = <<END',
+                           "%q('hi') # line 1",
+                           '%q("hi")',
+                           'END'])
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'when StringLiterals/EnforcedStyle is static' do
+    let(:config) do
+      RuboCop::Config.new('Style/StringLiterals' => {
+                            'EnforcedStyle' => 'static'
+                          })
+    end
+
+    context 'with %q strings' do
+      let(:source) do
+        <<-END.strip_indent
+          %q('hi') # line 1
+          %q("hi")
+          %q(hi)
+          %q('"hi"')
+          %q('hi\\t') # line 5
+        END
+      end
+      let(:corrected) do
+        <<-END.strip_indent
+          %q('hi') # line 1
+          '"hi"'
+          'hi'
+          %q('"hi"')
+          %q('hi\\t') # line 5
+        END
+      end
+      before { inspect_source(cop, source) }
+
+      include_examples 'prefers single quotes over %q'
+
+      it 'registers an offense for only single quotes' do
+        expect(cop.offenses.map(&:line)).not_to include(1)
+        expect(cop.messages)
+          .to eq(['Use `%q` only for strings that contain ' \
+                  'both single quotes and double quotes.'] * 2)
+      end
+    end
+
+    include_examples '%Q strings'
   end
 end


### PR DESCRIPTION
If `%q(')` is preferred over `"'"`, then the value `static` should be used. This also affects the `Style/UnneededPercentQ` cop, which will not report the use of `%q(')` if `Style/StringLiterals` is configured for static strings.
