### PR TITLE
[Fix #1326] Add other kind of parenthesis in SpaceInsideParens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#1326](https://github.com/bbatsov/rubocop/issues/1326): Fix problem in `SpaceInsideParens` with detecting space inside parentheses used for grouping expressions. ([@jonas054][])
+
 ## 0.26.0 (03/09/2014)
 
 ### New features

--- a/lib/rubocop/cop/style/space_inside_parens.rb
+++ b/lib/rubocop/cop/style/space_inside_parens.rb
@@ -8,7 +8,7 @@ module RuboCop
         include SpaceInside
 
         def specifics
-          [:tLPAREN2, :tRPAREN, 'parentheses']
+          [[:tLPAREN, :tLPAREN2], :tRPAREN, 'parentheses']
         end
       end
     end

--- a/spec/rubocop/cop/style/space_inside_parens_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_parens_spec.rb
@@ -7,10 +7,8 @@ describe RuboCop::Cop::Style::SpaceInsideParens do
 
   it 'registers an offense for spaces inside parens' do
     inspect_source(cop, ['f( 3)',
-                         'g(3 )'])
-    expect(cop.messages).to eq(
-      ['Space inside parentheses detected.',
-       'Space inside parentheses detected.'])
+                         'g = (a + 3 )'])
+    expect(cop.messages).to eq(['Space inside parentheses detected.'] * 2)
   end
 
   it 'accepts parentheses in block parameter list' do
@@ -39,8 +37,8 @@ describe RuboCop::Cop::Style::SpaceInsideParens do
 
   it 'auto-corrects unwanted space' do
     new_source = autocorrect_source(cop, ['f( 3)',
-                                          'g(3 )'])
+                                          'g = ( a + 3 )'])
     expect(new_source).to eq(['f(3)',
-                              'g(3)'].join("\n"))
+                              'g = (a + 3)'].join("\n"))
   end
 end


### PR DESCRIPTION
We only detected space inside method call parentheses for the left hand side. Add parentheses used for grouping expressions.
