### PR TITLE
Give a positive alternative to reduntant begin/rescue/end blocks

### DIFF
--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -9,13 +9,20 @@ module RuboCop
       #
       # @example
       #
-      #   def test
+      #   def redundant
       #     begin
       #       ala
       #       bala
       #     rescue StandardError => e
       #       something
       #     end
+      #   end
+      #
+      #   def preferred
+      #     ala
+      #     bala
+      #   rescue StandardError => e
+      #     something
       #   end
       class RedundantBegin < Cop
         include OnMethod


### PR DESCRIPTION
People who use the redundant syntax probably do not know the correct alternative,
so suggest the correct form in the documentation.
