### PR TITLE
Restrict valid schemes for LineLength/AllowURI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 * [#1326](https://github.com/bbatsov/rubocop/issues/1326): Fix problem in `SpaceInsideParens` with detecting space inside parentheses used for grouping expressions. ([@jonas054][])
+* [#1335](https://github.com/bbatsov/rubocop/issues/1335): Restrict URI schemes permitted by `LineLength` when `AllowURI` is enabled. ([@smangelsdorf][])
 * [#1339](https://github.com/bbatsov/rubocop/issues/1339): Handle `eql?` and `equal?` in `OpMethod`. ([@bbatsov][])
 
 ## 0.26.0 (03/09/2014)
@@ -1098,3 +1099,4 @@
 [@SkuliOskarsson]: https://github.com/SkuliOskarsson
 [@jspanjers]: https://github.com/jspanjers
 [@sch1zo]: https://github.com/sch1zo
+[@smangelsdorf]: https://github.com/smangelsdorf

--- a/config/default.yml
+++ b/config/default.yml
@@ -503,6 +503,9 @@ Metrics/CyclomaticComplexity:
 Metrics/LineLength:
   Max: 80
   AllowURI: true
+  URISchemes:
+    - http
+    - https
 
 Metrics/MethodLength:
   CountComments: false  # count full line comments?

--- a/lib/rubocop/cop/metrics/line_length.rb
+++ b/lib/rubocop/cop/metrics/line_length.rb
@@ -64,7 +64,7 @@ module RuboCop
           unscanned_position = 0
 
           loop do
-            match_data = string.match(URI.regexp, unscanned_position)
+            match_data = string.match(uri_regexp, unscanned_position)
             break unless match_data
 
             uri_ish_string = match_data[0]
@@ -81,6 +81,10 @@ module RuboCop
           true
         rescue
           false
+        end
+
+        def uri_regexp
+          URI.regexp(cop_config['URISchemes'])
         end
       end
     end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -589,7 +589,7 @@ describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(['--auto-gen-config'])).to eq(1)
         expect(IO.readlines('.rubocop_todo.yml')[7..-1].map(&:chomp))
           .to eq(['# Offense count: 1',
-                  '# Configuration parameters: AllowURI.',
+                  '# Configuration parameters: AllowURI, URISchemes.',
                   'Metrics/LineLength:',
                   '  Max: 85',
                   '',
@@ -652,7 +652,7 @@ describe RuboCop::CLI, :isolated_environment do
            'again.',
            '',
            '# Offense count: 2',
-           '# Configuration parameters: AllowURI.',
+           '# Configuration parameters: AllowURI, URISchemes.',
            'Metrics/LineLength:',
            '  Max: 90',
            '',

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -195,7 +195,8 @@ describe RuboCop::ConfigLoader do
               'https://github.com/bbatsov/ruby-style-guide#80-character-limits',
               'Enabled' => true,
               'Max' => 77,
-              'AllowURI' => true
+              'AllowURI' => true,
+              'URISchemes' => %w(http https)
             },
             'Metrics/MethodLength' => {
               'Description' =>


### PR DESCRIPTION
I propose this as a solution for #1335

I've adjusted the URI matcher to use `URI.regexp` with configured schemes, which default to 'http' and 'https'. Of course, these are the most common cases, but having this as configurable seemed most appropriate.

Thoughts? Happy to work on this if it's not quite right.
