### PR TITLE
[Fix #1340] Handle call with no receiver correctly in Style/SymbolProc cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1326](https://github.com/bbatsov/rubocop/issues/1326): Fix problem in `SpaceInsideParens` with detecting space inside parentheses used for grouping expressions. ([@jonas054][])
 * [#1335](https://github.com/bbatsov/rubocop/issues/1335): Restrict URI schemes permitted by `LineLength` when `AllowURI` is enabled. ([@smangelsdorf][])
 * [#1339](https://github.com/bbatsov/rubocop/issues/1339): Handle `eql?` and `equal?` in `OpMethod`. ([@bbatsov][])
+* [#1340](https://github.com/bbatsov/rubocop/issues/1340): Fix crash in `Style/SymbolProc` cop when the block calls a method with no explicit receiver. ([@smangelsdorf][])
 
 ## 0.26.0 (03/09/2014)
 

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -73,4 +73,9 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
     corrected = autocorrect_source(cop, ['coll.map { |s| s.upcase }'])
     expect(corrected).to eq 'coll.map(&:upcase)'
   end
+
+  it 'does not crash with a bare method call' do
+    run = -> { inspect_source(cop, ['coll.map { |s| bare_method }']) }
+    expect(&run).not_to raise_error
+  end
 end


### PR DESCRIPTION
Per #1340

I hit a cyclomatic complexity violation after 7deddbf, so needed to do a minor refactor to get things green again.
