### PR TITLE
Align hashes with some line breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#1348](https://github.com/bbatsov/rubocop/issues/1348):  New cop `ElseAlignment` checks alignment of `else` and `elsif` keywords. ([@jonas054][])
 
+### Bugs fixed
+
+* `AlignHash` no longer skips multiline hashes that contain some elements on the same line. ([@mvz][])
+
 ## 0.26.1 (18/09/2014)
 
 ### Bugs fixed
@@ -1107,3 +1111,4 @@
 [@jspanjers]: https://github.com/jspanjers
 [@sch1zo]: https://github.com/sch1zo
 [@smangelsdorf]: https://github.com/smangelsdorf
+[@mvz]: https://github.com/mvz

--- a/lib/rubocop/cop/style/align_hash.rb
+++ b/lib/rubocop/cop/style/align_hash.rb
@@ -199,12 +199,11 @@ module RuboCop
           node.loc.begin
         end
 
-        # Returns true if the hash spans multiple lines, and each key-value
-        # pair following the first is on a new line.
+        # Returns true if the hash spans multiple lines
         def multiline?(node)
           return false unless node.loc.expression.source.include?("\n")
 
-          return false if node.children[1..-1].find do |child|
+          return false if node.children[1..-1].all? do |child|
             !begins_its_line?(child.loc.expression)
           end
 

--- a/spec/rubocop/cop/style/align_hash_spec.rb
+++ b/spec/rubocop/cop/style/align_hash_spec.rb
@@ -129,6 +129,12 @@ describe RuboCop::Cop::Style::AlignHash, :config do
                                     "'dddd'  =>  2"])
     end
 
+    it 'registers an offense for misaligned mixed multiline hash keys' do
+      inspect_source(cop, ['hash = { a: 1, b: 2,',
+                           '        c: 3 }'])
+      expect(cop.offenses.size).to eq(1)
+    end
+
     it 'accepts aligned hash keys' do
       inspect_source(cop, ['hash1 = {',
                            '  a: 0,',
@@ -191,6 +197,13 @@ describe RuboCop::Cop::Style::AlignHash, :config do
                                 # Separator and value are not corrected
                                 # in 'key' mode.
                                 '          :ccc  =>2 }'].join("\n"))
+    end
+
+    it 'auto-corrects alignment for mixed multiline hash keys' do
+      new_sources = autocorrect_source(cop, ['hash = { a: 1, b: 2,',
+                                             '        c: 3 }'])
+      expect(new_sources).to eq(['hash = { a: 1, b: 2,',
+                                 '         c: 3 }'].join("\n"))
     end
   end
 


### PR DESCRIPTION
This pull request fixes a bug in AlignHash where code like the following would not be flagged or corrected:

``` ruby
hash = { a: 1, b: 2,
        c: 3 }
```
