### PR TITLE
Force single-job bundle install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
     - rvm: ruby-head
     - rvm: rbx-2
 before_install: gem update --remote bundler
+install:
+  - bundle install --retry=3
 script:
   - bundle exec rspec
   - bundle exec rubocop


### PR DESCRIPTION
This avoids problems with corrupt gem files.

This override of standard Travis CI configuration will probably no
longer be needed with Rubygems 2.5. See also
https://github.com/rubygems/rubygems/issues/982.
