### PR TITLE
[Fix #1349] Don't change whitespace in BracesAroundHashParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bugs fixed
 
 * `AlignHash` no longer skips multiline hashes that contain some elements on the same line. ([@mvz][])
+* [#1349](https://github.com/bbatsov/rubocop/issues/1349): `BracesAroundHashParameters` no longer cleans up whitespace in autocorrect, as these extra corrections are likely to interfere with other cops' corrections. ([@jonas054][])
 
 ## 0.26.1 (18/09/2014)
 

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -48,33 +48,11 @@ module RuboCop
             if style == :no_braces
               corrector.remove(node.loc.begin)
               corrector.remove(node.loc.end)
-              remove_leading_whitespace(node, corrector)
-              remove_trailing_comma_and_whitespace(node, corrector)
             elsif style == :braces
               corrector.insert_before(node.loc.expression, '{')
               corrector.insert_after(node.loc.expression, '}')
             end
           end
-        end
-
-        def remove_leading_whitespace(node, corrector)
-          corrector.remove(
-            Parser::Source::Range.new(
-              node.loc.expression.source_buffer,
-              node.loc.begin.end_pos,
-              node.children.first.loc.expression.begin_pos
-            )
-          )
-        end
-
-        def remove_trailing_comma_and_whitespace(node, corrector)
-          corrector.remove(
-            Parser::Source::Range.new(
-              node.loc.expression.source_buffer,
-              node.children.last.loc.expression.end_pos,
-              node.loc.end.begin_pos
-            )
-          )
         end
 
         def non_empty_hash?(arg)

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -137,49 +137,49 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
     describe 'auto-corrects' do
       it 'one non-hash parameter followed by a hash parameter with braces' do
         corrected = autocorrect_source(cop, ['where(1, { y: 2 })'])
-        expect(corrected).to eq 'where(1, y: 2)'
+        expect(corrected).to eq 'where(1,  y: 2 )'
       end
 
       it 'one object method hash parameter with braces' do
         corrected = autocorrect_source(cop, ['x.func({ y: "z" })'])
-        expect(corrected).to eq 'x.func(y: "z")'
+        expect(corrected).to eq 'x.func( y: "z" )'
       end
 
       it 'one hash parameter with braces' do
         corrected = autocorrect_source(cop, ['where({ x: 1 })'])
-        expect(corrected).to eq 'where(x: 1)'
+        expect(corrected).to eq 'where( x: 1 )'
       end
 
       it 'one hash parameter with braces and separators' do
         corrected = autocorrect_source(cop, ['where(  ',
                                              ' { x: 1 }   )'])
         expect(corrected).to eq(['where(  ',
-                                 ' x: 1   )'].join("\n"))
+                                 '  x: 1    )'].join("\n"))
       end
 
       it 'one hash parameter with braces and multiple keys' do
         corrected = autocorrect_source(cop, ['where({ x: 1, foo: "bar" })'])
-        expect(corrected).to eq 'where(x: 1, foo: "bar")'
+        expect(corrected).to eq 'where( x: 1, foo: "bar" )'
       end
 
       it 'one hash parameter with braces and extra leading whitespace' do
         corrected = autocorrect_source(cop, ['where({   x: 1, y: 2 })'])
-        expect(corrected).to eq 'where(x: 1, y: 2)'
+        expect(corrected).to eq 'where(   x: 1, y: 2 )'
       end
 
       it 'one hash parameter with braces and extra trailing whitespace' do
         corrected = autocorrect_source(cop, ['where({ x: 1, y: 2   })'])
-        expect(corrected).to eq 'where(x: 1, y: 2)'
+        expect(corrected).to eq 'where( x: 1, y: 2   )'
       end
 
       it 'one hash parameter with braces and a trailing comma' do
         corrected = autocorrect_source(cop, ['where({ x: 1, y: 2, })'])
-        expect(corrected).to eq 'where(x: 1, y: 2)'
+        expect(corrected).to eq 'where( x: 1, y: 2, )'
       end
 
       it 'one hash parameter with braces and trailing comma and whitespace' do
         corrected = autocorrect_source(cop, ['where({ x: 1, y: 2,   })'])
-        expect(corrected).to eq 'where(x: 1, y: 2)'
+        expect(corrected).to eq 'where( x: 1, y: 2,   )'
       end
     end
   end


### PR DESCRIPTION
The autocorrect should stay away from extra clean-up work as it can interfere with other autocorrections.
