### PR TITLE
Fix condition for special cases in MultilineOperationIndentation

### DIFF
--- a/lib/rubocop/cop/style/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/style/multiline_operation_indentation.rb
@@ -146,11 +146,22 @@ module RuboCop
         end
 
         def not_for_this_cop?(node)
-          node.each_ancestor.find do |a|
-            # Grouped expressions are aligned, but that's a different rule.
-            (a.type == :begin && a.loc.respond_to?(:begin) && a.loc.begin) ||
-              (a.type == :send && a.loc.begin && a.loc.begin.is?('('))
+          node.each_ancestor.find do |ancestor|
+            grouped_expression?(ancestor) ||
+              inside_arg_list_parentheses?(node, ancestor)
           end
+        end
+
+        def grouped_expression?(node)
+          node.type == :begin && node.loc.respond_to?(:begin) && node.loc.begin
+        end
+
+        def inside_arg_list_parentheses?(node, ancestor)
+          a = ancestor.loc
+          return false unless ancestor.type == :send && a.begin &&
+                              a.begin.is?('(')
+          n = node.loc.expression
+          n.begin_pos > a.begin.begin_pos && n.end_pos < a.end.end_pos
         end
       end
     end

--- a/spec/rubocop/cop/style/case_indentation_spec.rb
+++ b/spec/rubocop/cop/style/case_indentation_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Style::CaseIndentation do
   subject(:cop) { described_class.new(config) }
   let(:config) do
     merged = RuboCop::ConfigLoader
-      .default_configuration['Style/CaseIndentation'].merge(cop_config)
+             .default_configuration['Style/CaseIndentation'].merge(cop_config)
     RuboCop::Config.new('Style/CaseIndentation' => merged)
   end
 

--- a/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
@@ -80,13 +80,23 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation, :config do
       expect(cop.highlights).to eq(['b'])
     end
 
-    it 'accepts aligned operands assignment' do
+    it 'accepts aligned operands in assignment' do
       inspect_source(cop,
                      ['formatted_int = int_part',
                       '                .to_s',
                       '                .reverse',
                       "                .gsub(/...(?=.)/, '\&_')"])
       expect(cop.messages).to be_empty
+    end
+
+    it 'registers an offense for unaligned operands in assignment' do
+      inspect_source(cop,
+                     ['bar = Foo',
+                      '  .a',
+                      '      .b(c)'])
+      expect(cop.messages).to eq(['Align the operands of an expression in an ' \
+                                  'assignment spanning multiple lines.'])
+      expect(cop.highlights).to eq(['.a'])
     end
 
     it 'auto-corrects' do
@@ -111,6 +121,28 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation, :config do
                       '  something',
                       'end'])
       expect(cop.messages).to be_empty
+    end
+
+    it 'registers an offense for badly indented operands in chained ' \
+       'method call' do
+      inspect_source(cop,
+                     ['Foo',
+                      '.a',
+                      '  .b'])
+      expect(cop.messages).to eq(['Use 2 (not 0) spaces for indenting an ' \
+                                  'expression spanning multiple lines.'])
+      expect(cop.highlights).to eq(['.a'])
+    end
+
+    it 'registers an offense for badly indented operands in chained ' \
+       'method call' do
+      inspect_source(cop,
+                     ['Foo',
+                      '.a',
+                      '  .b(c)'])
+      expect(cop.messages).to eq(['Use 2 (not 0) spaces for indenting an ' \
+                                  'expression spanning multiple lines.'])
+      expect(cop.highlights).to eq(['.a'])
     end
 
     it 'registers an offense for aligned operands in if condition' do

--- a/spec/rubocop/cop/style/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_before_block_braces_spec.rb
@@ -6,7 +6,8 @@ describe RuboCop::Cop::Style::SpaceBeforeBlockBraces do
   subject(:cop) { described_class.new(config) }
   let(:config) do
     merged = RuboCop::ConfigLoader
-      .default_configuration['Style/SpaceBeforeBlockBraces'].merge(cop_config)
+             .default_configuration['Style/SpaceBeforeBlockBraces']
+             .merge(cop_config)
     RuboCop::Config.new('Style/Blocks' => { 'Enabled' => false },
                         'Style/SpaceBeforeBlockBraces' => merged)
   end

--- a/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
@@ -8,7 +8,8 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
   subject(:cop) { described_class.new(config) }
   let(:config) do
     merged = RuboCop::ConfigLoader
-      .default_configuration['Style/SpaceInsideBlockBraces'].merge(cop_config)
+             .default_configuration['Style/SpaceInsideBlockBraces']
+             .merge(cop_config)
     RuboCop::Config.new('Style/Blocks' => { 'Enabled' => false },
                         'Style/SpaceInsideBlockBraces' => merged)
   end


### PR DESCRIPTION
Some expressions inside parentheses should not be checked by this cop, and the logic for finding these cases was faulty.

Fixes an unreleased feature, so no update of the change log.
