### PR TITLE
Recognize some Ruby files related with Chef: Berksfile, Cheffile, ...

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -221,16 +221,9 @@ Style/Encoding:
     - always
 
 Style/FileName:
-  Exclude:
-    - '**/Rakefile'
-    - '**/Gemfile'
-    - '**/Capfile'
-    - '**/Vagrantfile'
-    - '**/Podfile'
-    - '**/Thorfile'
-    - '**/Berksfile'
-    - '**/Cheffile'
-    - '**/Vagabondfile'
+  # File names listed in AllCops:Include are excluded by default. Add extra
+  # excludes here.
+  Exclude: []
 
 # Checks use of for or each in multiline loops.
 Style/For:


### PR DESCRIPTION
Some files used with [Chef](https://www.getchef.com) cookbooks are Ruby files. It might be interesting to scan them by default.
## Berksfile
- Used by [Berkshelf](http://berkshelf.com/)
- Official documentation: http://berkshelf.com/#the-berksfile
- Related information: https://sethvargo.com/berksfile-magic/

> Because the Berksfile is evaluated as Ruby, you have the ability to write pure Ruby code that will be evaluated at runtime.
## Cheffile
- Used by [Librarian-Chef](https://github.com/applicationsonline/librarian-chef)
- Official documentation: https://github.com/applicationsonline/librarian-chef#the-cheffile
## Vaganbondfile
- Used by [Vagabond](https://github.com/chrisroberts/vagabond)
- Official documentation: https://github.com/chrisroberts/vagabond#how-does-it-work

>  The file is Ruby though, so you can do lots of crazy stuff to build the Hash you return.

By the way, thanks for all your work! RuboCop is so amazing :heart_eyes:
