### PR TITLE
WordArray allows all characters except spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1348](https://github.com/bbatsov/rubocop/issues/1348):  New cop `ElseAlignment` checks alignment of `else` and `elsif` keywords. ([@jonas054][])
 * [#1321](https://github.com/bbatsov/rubocop/issues/1321): New cop `MultilineOperationIndentation` checks indentation/alignment of binary operations if they span more than one line. ([@jonas054][])
 * [#1077](https://github.com/bbatsov/rubocop/issues/1077): New cop `Metrics/AbcSize` checks the ABC metric, based on assignments, branches, and conditions. ([@jonas054][], [@jfelchner][])
+* [#1352](https://github.com/bbatsov/rubocop/issues/1352): `WordArray` is now configurable with the `WordRegex` option. ([@bquorning][])
 
 ### Bugs fixed
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -491,6 +491,8 @@ Style/WhileUntilModifier:
 
 Style/WordArray:
   MinSize: 0
+  # The regular expression WordRegex decides what is considered a word.
+  WordRegex: !ruby/regexp '/\A[\p{Word}]+\z/'
 
 ##################### Metrics ##################################
 

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -45,7 +45,7 @@ module RuboCop
             next if source.start_with?('?') # %W(\r \n) can replace [?\r, ?\n]
 
             str_content = Util.strip_quotes(source)
-            return true unless str_content =~ /\A[\p{Word}]+\z/
+            return true unless str_content =~ word_regex
           end
 
           false
@@ -53,6 +53,10 @@ module RuboCop
 
         def min_size
           cop_config['MinSize']
+        end
+
+        def word_regex
+          cop_config['WordRegex']
         end
 
         def autocorrect(node)

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Style::WordArray, :config do
   subject(:cop) { described_class.new(config) }
-  let(:cop_config) { { 'MinSize' => 0 } }
+  let(:cop_config) { { 'MinSize' => 0, 'WordRegex' => /\A[\p{Word}]+\z/ } }
 
   it 'registers an offense for arrays of single quoted strings' do
     inspect_source(cop,
@@ -99,5 +99,19 @@ describe RuboCop::Cop::Style::WordArray, :config do
   it 'auto-corrects an array of words and character constants' do
     new_source = autocorrect_source(cop, '[%{one}, %Q(two), ?\n, ?\t]')
     expect(new_source).to eq('%W(one two \n \t)')
+  end
+
+  context 'with a custom WordRegex configuration' do
+    let(:cop_config) { { 'MinSize' => 0, 'WordRegex' => /\A[\w@.]+\z/ } }
+
+    it 'registers an offense for arrays of email addresses' do
+      inspect_source(cop, ["['a@example.com', 'b@example.com']"])
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'auto-corrects an array of email addresses' do
+      new_source = autocorrect_source(cop, "['a@example.com', 'b@example.com']")
+      expect(new_source).to eq('%w(a@example.com b@example.com)')
+    end
   end
 end


### PR DESCRIPTION
Fixes #1352.

WordArray would not register an offense for `['a@example.com', 'b@example.com']`, because it checked that each string should consist of word characters. So an email address containing `@` and `.` would not be a candidate for a `%w()`-style array.

As far as I can see, it should be enough to just check that the strings don’t contain spaces.
