### PR TITLE
[Fix #1350] Check that Blocks cop doesn't create syntax errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * `AlignHash` no longer skips multiline hashes that contain some elements on the same line. ([@mvz][])
 * [#1349](https://github.com/bbatsov/rubocop/issues/1349): `BracesAroundHashParameters` no longer cleans up whitespace in autocorrect, as these extra corrections are likely to interfere with other cops' corrections. ([@jonas054][])
+* [#1350](https://github.com/bbatsov/rubocop/issues/1350): Guard against `Blocks` cop introducing syntax errors in auto-correct. ([@jonas054][])
 
 ## 0.26.1 (18/09/2014)
 

--- a/spec/rubocop/cop/style/blocks_spec.rb
+++ b/spec/rubocop/cop/style/blocks_spec.rb
@@ -101,5 +101,13 @@ describe RuboCop::Cop::Style::Blocks do
       new_source = autocorrect_source(cop, source)
       expect(new_source).to eq(expected_source)
     end
+
+    it 'does not auto-correct {} if do-end would introduce a syntax error' do
+      src = ['my_method :arg1, arg2: proc {',
+             '  something',
+             '}, arg3: :another_value'].join("\n")
+      new_source = autocorrect_source(cop, src)
+      expect(new_source).to eq(src)
+    end
   end
 end


### PR DESCRIPTION
The cops `AndOr` and `Not` share the same logic, but it looks like their `autocorrect` methods are not capable of introducing syntax errors.
