### PR TITLE
Fix problem with encoding in WordArray

### DIFF
--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -45,7 +45,7 @@ module RuboCop
             next if source.start_with?('?') # %W(\r \n) can replace [?\r, ?\n]
 
             str_content = Util.strip_quotes(source)
-            return true unless str_content =~ word_regex
+            return true unless str_content =~ word_regex(str_content)
           end
 
           false
@@ -55,8 +55,11 @@ module RuboCop
           cop_config['MinSize']
         end
 
-        def word_regex
-          cop_config['WordRegex']
+        # Returns the regular expression from configuration with the same
+        # encoding as the given string.
+        def word_regex(str)
+          r = cop_config['WordRegex']
+          Regexp.new(r.source.force_encoding(str.encoding), r.options)
         end
 
         def autocorrect(node)

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -19,10 +19,26 @@ describe RuboCop::Cop::Style::WordArray, :config do
     expect(cop.offenses.size).to eq(1)
   end
 
-  it 'registers an offense for arrays of unicode word characters' do
-    inspect_source(cop,
-                   ['["ВУЗ", "вуз", "中文网"]'])
-    expect(cop.offenses.size).to eq(1)
+  shared_examples 'unicode' do
+    it 'registers an offense for arrays of unicode word characters' do
+      inspect_source(cop,
+                     ['["ВУЗ", "вуз", "中文网"]'])
+      expect(cop.offenses.size).to eq(1)
+    end
+  end
+
+  include_examples 'unicode'
+
+  context 'when WordRegex has binary encoding' do
+    # It can happen on some systems with some ruby platforms/versions that the
+    # regular expression taken from a configuration file gets a different,
+    # possibly incompatible, encoding than the inspected source code.
+    let(:cop_config) do
+      re = '\A[\p{Word}]+\z'.force_encoding('ASCII-8BIT')
+      { 'MinSize' => 0, 'WordRegex' => Regexp.new(re) }
+    end
+
+    include_examples 'unicode'
   end
 
   it 'registers an offense for arrays with character constants' do


### PR DESCRIPTION
I started getting exceptions in `WordArray` when inspecting `spec/rubocop/cop/style/encoding_spec.rb` and running under ruby-1.9.3-p547. There are no such problems on Travis for the exact same ruby version, so it must be related to other environment factors, but I have been unable to determine what it is exactly. Anyway, I think this change takes care of the problem.

Force the encoding of the regular expression taken from a configuration file to be the same as for the string from the inspected code. This is to avoid getting the error "incompatible encoding regexp match (ASCII-8BIT regexp with UTF-8 string)".
