### PR TITLE
[Fix #1401] Enable including hidden directories in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 * [#1411](https://github.com/bbatsov/rubocop/issues/1411): Handle lambda calls without a selector in `MultilineOperationIndentation`. ([@bbatsov][])
+* [#1401](https://github.com/bbatsov/rubocop/issues/1401): Files in hidden directories, i.e. ones beginning with dot, can now be selected through configuration, but are still not included by default. ([@jonas054][])
 
 ## 0.27.0 (30/10/2014)
 

--- a/README.md
+++ b/README.md
@@ -275,11 +275,14 @@ directory, `config/default.yml` will be used.
 
 ### Including/Excluding files
 
-RuboCop checks all files recursively within the directory it is run
-on.  However, it only recognizes files ending with `.rb` or
-extensionless files with a `#!.*ruby` declaration as Ruby files. If
-you'd like it to check other files you'll need to manually pass them
-in, or to add entries for them under `AllCops`/`Include`.  Files and
+RuboCop checks all files found by a recursive search starting from the
+directory it is run in, or directories given as command line
+arguments.  However, it only recognizes files ending with `.rb` or
+extensionless files with a `#!.*ruby` declaration as Ruby files.
+Hidden directories (i.e., directories whose names start with a dot)
+are not searched by default.  If you'd like it to check files that are
+not included by default, you'll need to pass them in on the command
+line, or to add entries for them under `AllCops`/`Include`.  Files and
 directories can also be ignored through `AllCops`/`Exclude`.
 
 Here is an example that might be used for a Rails project:

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -21,6 +21,13 @@ module RuboCop
         old_match = basename == pattern || File.fnmatch?(pattern, path)
         new_match = File.fnmatch?(pattern, path, File::FNM_PATHNAME)
         if old_match && !new_match
+          # Patterns like dir/**/* will produce an old match for files
+          # beginning with dot, but not a new match. That's a special case,
+          # though. Not what we want to handle here. And this is a match that
+          # we overrule. Only patterns like dir/**/.* can be used to match dot
+          # files.
+          return false if File.basename(path).start_with?('.')
+
           issue_deprecation_warning(basename, pattern, config_path)
         end
         old_match || new_match

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1777,23 +1777,23 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'finds included files' do
-      create_file('example', ['# encoding: utf-8',
-                              'x = 0',
-                              'puts x'
-                             ])
-      create_file('regexp', ['# encoding: utf-8',
-                             'x = 0',
-                             'puts x'
-                            ])
+      create_file('file.rb', 'x=0') # Included by default
+      create_file('example', 'x=0')
+      create_file('regexp', 'x=0')
+      create_file('.dot1/file.rb', 'x=0') # Hidden but explicitly included
+      create_file('.dot2/file.rb', 'x=0') # Hidden, excluded by default
       create_file('.rubocop.yml', ['AllCops:',
                                    '  Include:',
                                    '    - example',
-                                   '    - !ruby/regexp /regexp$/'
+                                   '    - !ruby/regexp /regexp$/',
+                                   '    - .dot1/**/*'
                                   ])
-      expect(cli.run(%w(--format simple))).to eq(0)
-      expect($stdout.string)
-        .to eq(['', '2 files inspected, no offenses detected',
-                ''].join("\n"))
+      expect(cli.run(%w(--format files))).to eq(1)
+      expect($stderr.string).to eq('')
+      expect($stdout.string.split($RS).sort).to eq([abs('.dot1/file.rb'),
+                                                    abs('example'),
+                                                    abs('file.rb'),
+                                                    abs('regexp')])
     end
 
     it 'ignores excluded files' do


### PR DESCRIPTION
Hidden directories are now searched but files in them are not included by default. It is possible to include them through Include parameters in configuration files.
