### PR TITLE
[Fix #1415] Handle backslash-concatenation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#1411](https://github.com/bbatsov/rubocop/issues/1411): Handle lambda calls without a selector in `MultilineOperationIndentation`. ([@bbatsov][])
 * [#1401](https://github.com/bbatsov/rubocop/issues/1401): Files in hidden directories, i.e. ones beginning with dot, can now be selected through configuration, but are still not included by default. ([@jonas054][])
+* [#1415](https://github.com/bbatsov/rubocop/issues/1415): String literals concatenated with backslashes are now handled correctly by `StringLiteralsInInterpolation`. ([@jonas054][])
 
 ## 0.27.0 (30/10/2014)
 

--- a/lib/rubocop/cop/style/string_literals_in_interpolation.rb
+++ b/lib/rubocop/cop/style/string_literals_in_interpolation.rb
@@ -18,11 +18,13 @@ module RuboCop
         end
 
         def offense?(node)
-          # If it's not a string within a dynamic string, i.e. part of an
-          # expression in an interpolation, then it's not an offense for this
-          # cop.
+          # If it's not a string within an interpolation, then it's not an
+          # offense for this cop. A :begin node inside a :dstr node is an
+          # interpolation.
+          begin_found = false
           return false unless node.each_ancestor.find do |a|
-            a.type == :dstr && within_node?(node, a)
+            begin_found = true if a.type == :begin
+            begin_found && a.type == :dstr
           end
 
           wrong_quotes?(node, style)

--- a/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
@@ -8,8 +8,18 @@ describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
   context 'configured with single quotes preferred' do
     let(:cop_config) { { 'EnforcedStyle' => 'single_quotes' } }
 
-    it 'detects unneeded double quotes within embedded expression' do
+    it 'registers an offense for double quotes within embedded expression' do
       src = ['"#{"A"}"']
+      inspect_source(cop, src)
+      expect(cop.messages)
+        .to eq(['Prefer single-quoted strings inside interpolations.'])
+    end
+
+    it 'registers an offense for double quotes within embedded expression in ' \
+       'a heredoc string' do
+      src = ['<<END',
+             '#{"A"}',
+             'END']
       inspect_source(cop, src)
       expect(cop.messages)
         .to eq(['Prefer single-quoted strings inside interpolations.'])
@@ -17,6 +27,22 @@ describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
 
     it 'accepts double quotes on a static string' do
       src = ['"A"']
+      inspect_source(cop, src)
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts double quotes on a broken static string' do
+      src = ['"A" \\',
+             '  "B"']
+      inspect_source(cop, src)
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts double quotes on static strings within a method' do
+      src = ['def m',
+             '  puts "A"',
+             '  puts "B"',
+             'end']
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -46,6 +72,16 @@ describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
 
     it 'registers an offense for single quotes within embedded expression' do
       src = %q("#{'A'}")
+      inspect_source(cop, src)
+      expect(cop.messages)
+        .to eq(['Prefer double-quoted strings inside interpolations.'])
+    end
+
+    it 'registers an offense for single quotes within embedded expression in ' \
+       'a heredoc string' do
+      src = ['<<END',
+             '#{\'A\'}',
+             'END']
       inspect_source(cop, src)
       expect(cop.messages)
         .to eq(['Prefer double-quoted strings inside interpolations.'])


### PR DESCRIPTION
In `StringLiteralsInInterpolation` it's not enough to check if a string is within a `:dstr` node. It must be inside a `:begin` node that's inside a `:dstr` node. That's what constitutes an interpolation.

Add spec examples for some cases that were missing.
