### PR TITLE
[Fix #1416] Handle begin/rescue/else/end in ElseAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#1411](https://github.com/bbatsov/rubocop/issues/1411): Handle lambda calls without a selector in `MultilineOperationIndentation`. ([@bbatsov][])
 * [#1401](https://github.com/bbatsov/rubocop/issues/1401): Files in hidden directories, i.e. ones beginning with dot, can now be selected through configuration, but are still not included by default. ([@jonas054][])
 * [#1415](https://github.com/bbatsov/rubocop/issues/1415): String literals concatenated with backslashes are now handled correctly by `StringLiteralsInInterpolation`. ([@jonas054][])
+* [#1416](https://github.com/bbatsov/rubocop/issues/1416): Fix handling of `begin/rescue/else/end` in `ElseAlignment`. ([@jonas054][])
 
 ## 0.27.0 (30/10/2014)
 

--- a/spec/rubocop/cop/style/else_alignment_spec.rb
+++ b/spec/rubocop/cop/style/else_alignment_spec.rb
@@ -417,6 +417,18 @@ describe RuboCop::Cop::Style::ElseAlignment do
                       'end'])
       expect(cop.messages).to eq(['Align `else` with `begin`.'])
     end
+
+    it 'accepts a correctly aligned else' do
+      inspect_source(cop,
+                     ['begin',
+                      "  raise StandardError.new('Fail') if rand(2).odd?",
+                      'rescue StandardError => error',
+                      '  $stderr.puts error.message',
+                      'else',
+                      "  $stdout.puts 'Lucky you!'",
+                      'end'])
+      expect(cop.offenses).to be_empty
+    end
   end
 
   context 'with def/rescue/else/end' do


### PR DESCRIPTION
A spec example for correctly aligned `else` in `begin/rescue/end` was missing, so a bug slipped through.
