### PR TITLE
[Fix #1418] Avoid deprecation warning for hidden directories

### DIFF
--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -26,9 +26,14 @@ module RuboCop
           # though. Not what we want to handle here. And this is a match that
           # we overrule. Only patterns like dir/**/.* can be used to match dot
           # files.
-          return false if File.basename(path).start_with?('.')
+          return false if basename.start_with?('.')
 
-          issue_deprecation_warning(basename, pattern, config_path)
+          # Hidden directories (starting with a dot) will also produce an old
+          # match, just like hidden files. A deprecation warning would be wrong
+          # for these.
+          if path.split(File::SEPARATOR).none? { |s| s.start_with?('.') }
+            issue_deprecation_warning(basename, pattern, config_path)
+          end
         end
         old_match || new_match
       when Regexp

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2071,9 +2071,12 @@ describe RuboCop::CLI, :isolated_environment do
     it 'can exclude directories relative to .rubocop.yml' do
       %w(src etc/test etc/spec tmp/test tmp/spec).each do |dir|
         create_file("example/#{dir}/example1.rb", ['# encoding: utf-8',
-                                                   '#' * 90
-                                                  ])
+                                                   '#' * 90])
       end
+
+      # Hidden subdirectories should also be excluded.
+      create_file('example/etc/.dot/example1.rb', ['# encoding: utf-8',
+                                                   '#' * 90])
 
       create_file('example/.rubocop.yml', ['AllCops:',
                                            '  Exclude:',
@@ -2082,8 +2085,8 @@ describe RuboCop::CLI, :isolated_environment do
                                            '    - tmp/spec/**'])
 
       expect(cli.run(%w(--format simple example))).to eq(1)
-      expect($stdout.string).to eq(
-                                   ['== example/tmp/test/example1.rb ==',
+      expect($stderr.string).to eq('')
+      expect($stdout.string).to eq(['== example/tmp/test/example1.rb ==',
                                     'C:  2: 81: Line is too long. [90/80]',
                                     '',
                                     '1 file inspected, 1 offense detected',


### PR DESCRIPTION
Even the recommended pattern style would generate "Warning: Deprecated pattern style" before this fix. Hidden directories are not matched with the new style of matching, but that's intentional, so there should be no warning. Hidden directories must be explicitly added in `Include` parameters in order to be inspected.

Fixes an unreleased bug, so no change log entry.
