### PR TITLE
[Fix #1425] Find included files in a simpler way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#1343](https://github.com/bbatsov/rubocop/issues/1343): Remove auto-correct from `RescueException` cop. ([@bbatsov][])
+* [#1425](https://github.com/bbatsov/rubocop/issues/1425): `AllCops/Include` configuration parameters are only taken from the project `.rubocop.yml` and files it inherits from, not from `.rubocop.yml` files in subdirectories. ([@jonas054][])
 
 ### Bugs fixed
 

--- a/README.md
+++ b/README.md
@@ -313,12 +313,12 @@ correct way to match the file in any directory, including the current, is
 `config`, but this pattern style is deprecated and should be replaced by
 `config/**/*`.
 
-**Note**: The `Exclude` parameter is special. It is valid for the
-directory tree starting where it is defined. It is not shadowed by the
-setting of `Exclude` in other `.rubocop.yml` files in
-subdirectories. This is different from all other parameters, who
-follow RuboCop's general principle that configuration for an inspected
-file is taken from the nearest `.rubocop.yml`, searching upwards.
+**Note**: The `Include` and `Exclude` parameters are special. They are
+valid for the directory tree starting where they are defined. They are not
+shadowed by the setting of `Include` and `Exclude` in other `.rubocop.yml`
+files in subdirectories. This is different from all other parameters, who
+follow RuboCop's general principle that configuration for an inspected file
+is taken from the nearest `.rubocop.yml`, searching upwards.
 
 Cops can be run only on specific sets of files when that's needed (for
 instance you might want to run some Rails model checks only on files whose


### PR DESCRIPTION
Only look in the "base" configuration when finding the target files, not in the configuration associated with each file under consideration. This removes a feature that has existed for a long time, but hopefully isn't used by many people (the ability to have `AllCops/Include` parameters in `.rubocop.yml` files in subdirectories). We didn't cover the existing behavior in specs, but the new behavior is covered.

Also includes an optimization (the use of `Set` in `TargetFinder#target_files_in_dir`) that's aimed at #1427. I've measured a 3 fold speed increase for the file finding phase when I had a hidden directory containing 12000 files. Down to 6s from the original 18s.
