### PR TITLE
Add (failing) test for empty elsif branch

### DIFF
--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -7,6 +7,13 @@ describe RuboCop::Cop::Style::MultilineIfThen do
 
   # if
 
+  it 'does not get confused by empty elsif branch' do
+    inspect_source(cop, ['if cond',
+                         'elsif cond',
+                         'end'])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'registers an offense for then in multiline if' do
     inspect_source(cop, ['if cond then',
                          'end',


### PR DESCRIPTION
This used to work in `v0.26.1`.

Not sure exactly where this error was introduced.

Stacktrace:

``` bash
Failure/Error: inspect_source(cop, ['if cond',
     NoMethodError:
       undefined method `source_buffer' for nil:NilClass
     # ./lib/rubocop/cop/style/multiline_if_then.rb:32:in `on_normal_if_unless'
     # ./lib/rubocop/cop/mixin/on_normal_if_unless.rb:20:in `invoke_hook_for_normal_if_unless'
     # ./lib/rubocop/cop/mixin/on_normal_if_unless.rb:10:in `on_if'
     # (eval):5:in `block (2 levels) in on_if'
     # ./lib/rubocop/cop/commissioner.rb:92:in `with_cop_error_handling'
     # (eval):4:in `block in on_if'
     # (eval):2:in `each'
     # (eval):2:in `on_if'
     # (eval):9:in `on_if'
     # ./lib/rubocop/cop/commissioner.rb:52:in `investigate'
     # ./spec/support/cop_helper.rb:51:in `_investigate'
     # ./spec/support/cop_helper.rb:14:in `inspect_source'
     # ./spec/rubocop/cop/style/multiline_if_then_spec.rb:11:in `block (2 levels) in <top (required)>'
```
