### PR TITLE
Support empty elsif in MultilineIfThen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#1401](https://github.com/bbatsov/rubocop/issues/1401): Files in hidden directories, i.e. ones beginning with dot, can now be selected through configuration, but are still not included by default. ([@jonas054][])
 * [#1415](https://github.com/bbatsov/rubocop/issues/1415): String literals concatenated with backslashes are now handled correctly by `StringLiteralsInInterpolation`. ([@jonas054][])
 * [#1416](https://github.com/bbatsov/rubocop/issues/1416): Fix handling of `begin/rescue/else/end` in `ElseAlignment`. ([@jonas054][])
+* [#1413](https://github.com/bbatsov/rubocop/issues/1413): Support empty elsif branches in `MultilineIfThen`. ([@janraasch][], [@jonas054][])
 
 ## 0.27.0 (30/10/2014)
 
@@ -1145,3 +1146,4 @@
 [@smangelsdorf]: https://github.com/smangelsdorf
 [@mvz]: https://github.com/mvz
 [@jfelchner]: https://github.com/jfelchner
+[@janraasch]: https://github.com/janraasch

--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -26,7 +26,20 @@ describe RuboCop::Cop::Style::MultilineIfThen do
                          'end',
                          'if cond then # bad',
                          'end'])
-    expect(cop.offenses.map(&:line)).to eq([1, 3, 5, 7, 10])
+    expect(cop.offenses.map(&:line)).to eq([1, 3, 5, 8, 10])
+    expect(cop.highlights).to eq(['then'] * 5)
+    expect(cop.messages).to eq(['Never use `then` for multi-line `if`.'] * 5)
+  end
+
+  it 'registers an offense for then in multiline elsif' do
+    inspect_source(cop, ['if cond1',
+                         '  a',
+                         'elsif cond2 then',
+                         '  b',
+                         'end'])
+    expect(cop.offenses.map(&:line)).to eq([3])
+    expect(cop.highlights).to eq(['then'])
+    expect(cop.messages).to eq(['Never use `then` for multi-line `elsif`.'])
   end
 
   it 'accepts multiline if without then' do


### PR DESCRIPTION
It turns out that the implementation of `MultilineIfThen` was much more complicated than it needed to be. Thanks for the failing test, @janraasch!
