### PR TITLE
[Fix #801] Add a `context_dependent` style to BracesAroundHashParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#801](https://github.com/bbatsov/rubocop/issues/801): New style `context_dependent` for `Style/BracesAroundHashParameters` looks at preceding parameter to determine if braces should be used for final parameter. ([@jonas054][])
+
 ## 0.27.1 (08/11/2014)
 
 ### Changes

--- a/config/default.yml
+++ b/config/default.yml
@@ -139,8 +139,16 @@ Style/BarePercentLiterals:
 Style/BracesAroundHashParameters:
   EnforcedStyle: no_braces
   SupportedStyles:
+    # The `braces` style enforces braces around all method parameters that are
+    # hashes.
     - braces
+    # The `no_braces` style checks that the last parameter doesn't have braces
+    # around it.
     - no_braces
+    # The `context_dependent` style checks that the last parameter doesn't have
+    # braces around it, but requires braces if the second to last parameter is
+    # also a hash literal.
+    - context_dependent
 
 # Indentation of `when`.
 Style/CaseIndentation:

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -87,7 +87,7 @@ Style/Blocks:
   Enabled: true
 
 Style/BracesAroundHashParameters:
-  Description: 'Enforce braces style inside hash parameters.'
+  Description: 'Enforce braces style around hash parameters.'
   Enabled: true
 
 Style/CaseEquality:

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -5,297 +5,278 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
   subject(:cop) { described_class.new(config) }
 
-  context 'no_braces' do
-    let(:cop_config) do
-      { 'EnforcedStyle' => 'no_braces' }
+  shared_examples 'general non-offenses' do
+    after(:each) { expect(cop.offenses).to be_empty }
+
+    it 'accepts one non-hash parameter' do
+      inspect_source(cop, ['where(2)'])
     end
 
-    describe 'accepts' do
-      it 'one non-hash parameter' do
-        inspect_source(cop, ['where(2)'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
+    it 'accepts multiple non-hash parameters' do
+      inspect_source(cop, ['where(1, "2")'])
+    end
+
+    it 'accepts one empty hash parameter' do
+      inspect_source(cop, ['where({})'])
+    end
+
+    it 'accepts one empty hash parameter with whitespace' do
+      inspect_source(cop, ['where(  {     ',
+                           " }\t   )  "])
+    end
+  end
+
+  shared_examples 'no_braces and context_dependent non-offenses' do
+    after(:each) { expect(cop.offenses).to be_empty }
+
+    it 'accepts one hash parameter without braces' do
+      inspect_source(cop, ['where(x: "y")'])
+    end
+
+    it 'accepts one hash parameter without braces and with multiple keys' do
+      inspect_source(cop, ['where(x: "y", foo: "bar")'])
+    end
+
+    it 'accepts one hash parameter without braces and with one hash value' do
+      inspect_source(cop, ['where(x: { "y" => "z" })'])
+    end
+
+    it 'accepts property assignment with braces' do
+      inspect_source(cop, ['x.z = { y: "z" }'])
+    end
+
+    it 'accepts operator with a hash parameter with braces' do
+      inspect_source(cop, ['x.z - { y: "z" }'])
+    end
+  end
+
+  shared_examples 'no_braces and context_dependent offenses' do
+    let(:msg) { 'Redundant curly braces around a hash parameter.' }
+
+    it 'registers an offense for one non-hash parameter followed by a hash ' \
+       'parameter with braces' do
+      inspect_source(cop, ['where(1, { y: 2 })'])
+      expect(cop.messages).to eq([msg])
+      expect(cop.highlights).to eq(['{ y: 2 }'])
+    end
+
+    it 'registers an offense for one object method hash parameter with ' \
+       'braces' do
+      inspect_source(cop, ['x.func({ y: "z" })'])
+      expect(cop.messages).to eq([msg])
+      expect(cop.highlights).to eq(['{ y: "z" }'])
+    end
+
+    it 'registers an offense for one hash parameter with braces' do
+      inspect_source(cop, ['where({ x: 1 })'])
+      expect(cop.messages).to eq([msg])
+      expect(cop.highlights).to eq(['{ x: 1 }'])
+    end
+
+    it 'registers an offense for one hash parameter with braces and ' \
+       'whitespace' do
+      inspect_source(cop, ["where(  \n { x: 1 }   )"])
+      expect(cop.messages).to eq([msg])
+      expect(cop.highlights).to eq(['{ x: 1 }'])
+    end
+
+    it 'registers an offense for one hash parameter with braces and multiple ' \
+       'keys' do
+      inspect_source(cop, ['where({ x: 1, foo: "bar" })'])
+      expect(cop.messages).to eq([msg])
+      expect(cop.highlights).to eq(['{ x: 1, foo: "bar" }'])
+    end
+  end
+
+  shared_examples 'no_braces and context_dependent auto-corrections' do
+    it 'corrects one non-hash parameter followed by a hash parameter with ' \
+       'braces' do
+      corrected = autocorrect_source(cop, ['where(1, { y: 2 })'])
+      expect(corrected).to eq('where(1,  y: 2 )')
+    end
+
+    it 'corrects one object method hash parameter with braces' do
+      corrected = autocorrect_source(cop, ['x.func({ y: "z" })'])
+      expect(corrected).to eq('x.func( y: "z" )')
+    end
+
+    it 'corrects one hash parameter with braces' do
+      corrected = autocorrect_source(cop, ['where({ x: 1 })'])
+      expect(corrected).to eq('where( x: 1 )')
+    end
+
+    it 'corrects one hash parameter with braces and whitespace' do
+      corrected = autocorrect_source(cop, ['where(  ',
+                                           ' { x: 1 }   )'])
+      expect(corrected).to eq(['where(  ',
+                               '  x: 1    )'].join("\n"))
+    end
+
+    it 'corrects one hash parameter with braces and multiple keys' do
+      corrected = autocorrect_source(cop, ['where({ x: 1, foo: "bar" })'])
+      expect(corrected).to eq('where( x: 1, foo: "bar" )')
+    end
+
+    it 'corrects one hash parameter with braces and extra leading whitespace' do
+      corrected = autocorrect_source(cop, ['where({   x: 1, y: 2 })'])
+      expect(corrected).to eq('where(   x: 1, y: 2 )')
+    end
+
+    it 'corrects one hash parameter with braces and extra trailing ' \
+       'whitespace' do
+      corrected = autocorrect_source(cop, ['where({ x: 1, y: 2   })'])
+      expect(corrected).to eq('where( x: 1, y: 2   )')
+    end
+
+    it 'corrects one hash parameter with braces and a trailing comma' do
+      corrected = autocorrect_source(cop, ['where({ x: 1, y: 2, })'])
+      expect(corrected).to eq('where( x: 1, y: 2, )')
+    end
+
+    it 'corrects one hash parameter with braces and trailing comma and ' \
+       'whitespace' do
+      corrected = autocorrect_source(cop, ['where({ x: 1, y: 2,   })'])
+      expect(corrected).to eq('where( x: 1, y: 2,   )')
+    end
+  end
+
+  context 'when EnforcedStyle is no_braces' do
+    let(:cop_config) { { 'EnforcedStyle' => 'no_braces' } }
+
+    context 'for correct code' do
+      include_examples 'general non-offenses'
+      include_examples 'no_braces and context_dependent non-offenses'
+    end
+
+    context 'for incorrect code' do
+      include_examples 'no_braces and context_dependent offenses'
+
+      after(:each) do
+        expect(cop.messages)
+          .to eq(['Redundant curly braces around a hash parameter.'])
       end
 
-      it 'one empty hash parameter' do
-        inspect_source(cop, ['where({})'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
-      end
-
-      it 'one hash parameter with separators' do
-        inspect_source(cop, ["where(  {     \n }\t   )  "])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
-      end
-
-      it 'multiple non-hash parameters' do
-        inspect_source(cop, ['where(1, "2")'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
-      end
-
-      it 'one hash parameter without braces' do
-        inspect_source(cop, ['where(x: "y")'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
-      end
-
-      it 'one hash parameter without braces and multiple keys' do
-        inspect_source(cop, ['where(x: "y", foo: "bar")'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
-      end
-
-      it 'one hash parameter without braces and one hash value' do
-        inspect_source(cop, ['where(x: { "y" => "z" })'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
-      end
-
-      it 'multiple hash parameters with braces' do
+      it 'registers an offense for two hash parameters with braces' do
         inspect_source(cop, ['where({ x: 1 }, { y: 2 })'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
-      end
-
-      it 'property assignment with braces' do
-        inspect_source(cop, ['x.z = { y: "z" }'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
-      end
-
-      it 'operator with a hash parameter with braces' do
-        inspect_source(cop, ['x.z - { y: "z" }'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
-      end
-
-    end
-
-    describe 'registers an offense for' do
-      it 'one non-hash parameter followed by a hash parameter with braces' do
-        inspect_source(cop, ['where(1, { y: 2 })'])
-        expect(cop.messages).to eq([
-          'Redundant curly braces around a hash parameter.'
-        ])
         expect(cop.highlights).to eq(['{ y: 2 }'])
-        expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'braces')
-      end
-
-      it 'correct + opposite style' do
-        inspect_source(cop, ['where(1, y: 2)',
-                             'where(1, { y: 2 })'])
-        expect(cop.messages).to eq([
-          'Redundant curly braces around a hash parameter.'
-        ])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-      end
-
-      it 'opposite + correct style' do
-        inspect_source(cop, ['where(1, { y: 2 })',
-                             'where(1, y: 2)'])
-        expect(cop.messages).to eq([
-          'Redundant curly braces around a hash parameter.'
-        ])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-      end
-
-      it 'one object method hash parameter with braces' do
-        inspect_source(cop, ['x.func({ y: "z" })'])
-        expect(cop.messages).to eq([
-          'Redundant curly braces around a hash parameter.'
-        ])
-        expect(cop.highlights).to eq(['{ y: "z" }'])
-      end
-
-      it 'one hash parameter with braces' do
-        inspect_source(cop, ['where({ x: 1 })'])
-        expect(cop.messages).to eq([
-          'Redundant curly braces around a hash parameter.'
-        ])
-        expect(cop.highlights).to eq(['{ x: 1 }'])
-      end
-
-      it 'one hash parameter with braces and separators' do
-        inspect_source(cop, ["where(  \n { x: 1 }   )"])
-        expect(cop.messages).to eq([
-          'Redundant curly braces around a hash parameter.'
-        ])
-        expect(cop.highlights).to eq(['{ x: 1 }'])
-      end
-
-      it 'one hash parameter with braces and multiple keys' do
-        inspect_source(cop, ['where({ x: 1, foo: "bar" })'])
-        expect(cop.messages).to eq([
-          'Redundant curly braces around a hash parameter.'
-        ])
-        expect(cop.highlights).to eq(['{ x: 1, foo: "bar" }'])
       end
     end
 
-    describe 'auto-corrects' do
-      it 'one non-hash parameter followed by a hash parameter with braces' do
-        corrected = autocorrect_source(cop, ['where(1, { y: 2 })'])
-        expect(corrected).to eq 'where(1,  y: 2 )'
+    describe '#autocorrect' do
+      include_examples 'no_braces and context_dependent auto-corrections'
+
+      it 'corrects one hash parameter with braces' do
+        corrected = autocorrect_source(cop, ['where(1, { x: 1 })'])
+        expect(corrected).to eq('where(1,  x: 1 )')
       end
 
-      it 'one object method hash parameter with braces' do
-        corrected = autocorrect_source(cop, ['x.func({ y: "z" })'])
-        expect(corrected).to eq 'x.func( y: "z" )'
-      end
-
-      it 'one hash parameter with braces' do
-        corrected = autocorrect_source(cop, ['where({ x: 1 })'])
-        expect(corrected).to eq 'where( x: 1 )'
-      end
-
-      it 'one hash parameter with braces and separators' do
-        corrected = autocorrect_source(cop, ['where(  ',
-                                             ' { x: 1 }   )'])
-        expect(corrected).to eq(['where(  ',
-                                 '  x: 1    )'].join("\n"))
-      end
-
-      it 'one hash parameter with braces and multiple keys' do
-        corrected = autocorrect_source(cop, ['where({ x: 1, foo: "bar" })'])
-        expect(corrected).to eq 'where( x: 1, foo: "bar" )'
-      end
-
-      it 'one hash parameter with braces and extra leading whitespace' do
-        corrected = autocorrect_source(cop, ['where({   x: 1, y: 2 })'])
-        expect(corrected).to eq 'where(   x: 1, y: 2 )'
-      end
-
-      it 'one hash parameter with braces and extra trailing whitespace' do
-        corrected = autocorrect_source(cop, ['where({ x: 1, y: 2   })'])
-        expect(corrected).to eq 'where( x: 1, y: 2   )'
-      end
-
-      it 'one hash parameter with braces and a trailing comma' do
-        corrected = autocorrect_source(cop, ['where({ x: 1, y: 2, })'])
-        expect(corrected).to eq 'where( x: 1, y: 2, )'
-      end
-
-      it 'one hash parameter with braces and trailing comma and whitespace' do
-        corrected = autocorrect_source(cop, ['where({ x: 1, y: 2,   })'])
-        expect(corrected).to eq 'where( x: 1, y: 2,   )'
+      it 'corrects two hash parameters with braces' do
+        corrected = autocorrect_source(cop, ['where(1, { x: 1 }, { y: 2 })'])
+        expect(corrected).to eq('where(1, { x: 1 },  y: 2 )')
       end
     end
   end
 
-  context 'braces' do
-    let(:cop_config) do
-      { 'EnforcedStyle' => 'braces' }
+  context 'when EnforcedStyle is context_dependent' do
+    let(:cop_config) { { 'EnforcedStyle' => 'context_dependent' } }
+
+    context 'for correct code' do
+      include_examples 'general non-offenses'
+      include_examples 'no_braces and context_dependent non-offenses'
+
+      it 'accepts two hash parameters with braces' do
+        inspect_source(cop, ['where({ x: 1 }, { y: 2 })'])
+        expect(cop.offenses).to be_empty
+      end
     end
 
-    describe 'accepts' do
-      it 'an empty hash parameter' do
-        inspect_source(cop, ['where({})'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
+    context 'for incorrect code' do
+      include_examples 'no_braces and context_dependent offenses'
+
+      it 'registers an offense for one hash parameter with braces and one ' \
+         'without' do
+        inspect_source(cop, ['where({ x: 1 }, y: 2)'])
+        expect(cop.messages)
+          .to eq(['Missing curly braces around a hash parameter.'])
+        expect(cop.highlights).to eq(['y: 2'])
+      end
+    end
+
+    describe '#autocorrect' do
+      include_examples 'no_braces and context_dependent auto-corrections'
+
+      it 'corrects one hash parameter with braces and one without' do
+        corrected = autocorrect_source(cop, ['where(1, { x: 1 }, y: 2)'])
+        expect(corrected).to eq('where(1, { x: 1 }, {y: 2})')
       end
 
-      it 'one non-hash parameter' do
-        inspect_source(cop, ['where(2)'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
+      it 'corrects one hash parameter with braces' do
+        corrected = autocorrect_source(cop, ['where(1, { x: 1 })'])
+        expect(corrected).to eq('where(1,  x: 1 )')
       end
+    end
+  end
 
-      it 'multiple non-hash parameters' do
-        inspect_source(cop, ['where(1, "2")'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
-      end
+  context 'when EnforcedStyle is braces' do
+    let(:cop_config) { { 'EnforcedStyle' => 'braces' } }
 
-      it 'one hash parameter with braces' do
+    context 'for correct code' do
+      include_examples 'general non-offenses'
+
+      after(:each) { expect(cop.offenses).to be_empty }
+
+      it 'accepts one hash parameter with braces' do
         inspect_source(cop, ['where({ x: 1 })'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
       end
 
-      it 'multiple hash parameters with braces' do
+      it 'accepts multiple hash parameters with braces' do
         inspect_source(cop, ['where({ x: 1 }, { y: 2 })'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
       end
 
-      it 'one hash parameter with braces and spaces around it' do
-        inspect_source(cop, [
-          'where(     {  x: 1  }   )'
-        ])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
-      end
-
-      it 'one hash parameter with braces and separators around it' do
+      it 'accepts one hash parameter with braces and whitespace' do
         inspect_source(cop, ["where( \t    {  x: 1 ",
                              '  }   )'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
       end
     end
 
-    describe 'registers an offense for' do
-      it 'one hash parameter without braces' do
+    context 'for incorrect code' do
+      after(:each) do
+        expect(cop.messages)
+          .to eq(['Missing curly braces around a hash parameter.'])
+      end
+
+      it 'registers an offense for one hash parameter without braces' do
         inspect_source(cop, ['where(x: "y")'])
-        expect(cop.messages).to eq([
-          'Missing curly braces around a hash parameter.'
-        ])
         expect(cop.highlights).to eq(['x: "y"'])
-        expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
-                                                   'no_braces')
       end
 
-      it 'opposite + correct style' do
-        inspect_source(cop, ['where(y: 2)',
-                             'where({ y: 2 })'])
-        expect(cop.messages).to eq([
-          'Missing curly braces around a hash parameter.'
-        ])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-      end
-
-      it 'correct + opposite style' do
-        inspect_source(cop, ['where({ y: 2 })',
-                             'where(y: 2)'])
-        expect(cop.messages).to eq([
-          'Missing curly braces around a hash parameter.'
-        ])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-      end
-
-      it 'one hash parameter with multiple keys and without braces' do
+      it 'registers an offense for one hash parameter with multiple keys and ' \
+         'without braces' do
         inspect_source(cop, ['where(x: "y", foo: "bar")'])
-        expect(cop.messages).to eq([
-          'Missing curly braces around a hash parameter.'
-        ])
         expect(cop.highlights).to eq(['x: "y", foo: "bar"'])
       end
 
-      it 'one hash parameter without braces with one hash value' do
+      it 'registers an offense for one hash parameter without braces with ' \
+         'one hash value' do
         inspect_source(cop, ['where(x: { "y" => "z" })'])
-        expect(cop.messages).to eq([
-          'Missing curly braces around a hash parameter.'
-        ])
         expect(cop.highlights).to eq(['x: { "y" => "z" }'])
       end
     end
 
-    describe 'auto-corrects' do
-      it 'one hash parameter without braces' do
+    describe '#autocorrect' do
+      it 'corrects one hash parameter without braces' do
         corrected = autocorrect_source(cop, ['where(x: "y")'])
-        expect(corrected).to eq 'where({x: "y"})'
+        expect(corrected).to eq('where({x: "y"})')
       end
 
-      it 'one hash parameter with multiple keys and without braces' do
+      it 'corrects one hash parameter with multiple keys and without braces' do
         corrected = autocorrect_source(cop, ['where(x: "y", foo: "bar")'])
-        expect(corrected).to eq 'where({x: "y", foo: "bar"})'
+        expect(corrected).to eq('where({x: "y", foo: "bar"})')
       end
 
-      it 'one hash parameter without braces with one hash value' do
+      it 'corrects one hash parameter without braces with one hash value' do
         corrected = autocorrect_source(cop, ['where(x: { "y" => "z" })'])
-        expect(corrected).to eq 'where({x: { "y" => "z" }})'
+        expect(corrected).to eq('where({x: { "y" => "z" }})')
       end
     end
   end


### PR DESCRIPTION
Before this change, the `no_braces` style allowed braces if all parameters in a method call were hash literals. Looking at the second last parameter makes more sense. Now we go for more strict checking, never leaving room for options within one style.
