### PR TITLE
[Fix #1441] Compare AST for whole buffer in AutocorrectUnlessChangingAST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changes
 
 * [#801](https://github.com/bbatsov/rubocop/issues/801): New style `context_dependent` for `Style/BracesAroundHashParameters` looks at preceding parameter to determine if braces should be used for final parameter. ([@jonas054][])
+* [#1441](https://github.com/bbatsov/rubocop/issues/1441): Correct the logic used by `Style/Blocks` and other cops to determine if an auto-correction would alter the meaning of the code. ([@jonas054][])
+
+### Bugs fixed
 
 ## 0.27.1 (08/11/2014)
 

--- a/spec/rubocop/cop/style/blocks_spec.rb
+++ b/spec/rubocop/cop/style/blocks_spec.rb
@@ -33,6 +33,14 @@ describe RuboCop::Cop::Style::Blocks do
     expect(new_source).to eq(src)
   end
 
+  it 'does not auto-correct {} if do-end would change the meaning' do
+    src = ['foo :bar, :baz, qux: lambda { |a|',
+           '  bar a',
+           '}'].join("\n")
+    new_source = autocorrect_source(cop, src)
+    expect(new_source).to eq(src)
+  end
+
   context 'when there are braces around a multi-line block' do
     it 'registers an offense in the simple case' do
       inspect_source(cop, ['each { |x|',


### PR DESCRIPTION
I didn't expect this to still be a problem... Oh, well.

We were already re-parsing the whole buffer to check for syntax errors. If we check for AST equality instead, we don't need to check the syntax.
