### PR TITLE
[Fix #1181] Don't report strings in interpolations in StringLiterals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Bugs fixed
 
+* [#1181](https://github.com/bbatsov/rubocop/issues/1181): *(fix again)* `Style/StringLiterals` cop stays away from strings inside interpolated expressions. ([@jonas054][])
+
 ## 0.27.1 (08/11/2014)
 
 ### Changes

--- a/lib/rubocop/cop/mixin/string_help.rb
+++ b/lib/rubocop/cop/mixin/string_help.rb
@@ -27,6 +27,15 @@ module RuboCop
       def on_regexp(node)
         ignore_node(node)
       end
+
+      def inside_interpolation?(node)
+        # A :begin node inside a :dstr node is an interpolation.
+        begin_found = false
+        node.each_ancestor.find do |a|
+          begin_found = true if a.type == :begin
+          begin_found && a.type == :dstr
+        end
+      end
     end
   end
 end

--- a/lib/rubocop/cop/style/string_literals.rb
+++ b/lib/rubocop/cop/style/string_literals.rb
@@ -8,17 +8,6 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include StringLiteralsHelp
 
-        def on_dstr(node)
-          # A dstr node with dstr and str children is a concatenated
-          # string. Don't ignore the whole thing.
-          return if node.children.find { |child| child.type == :str }
-
-          # Dynamic strings can not use single quotes, and quotes inside
-          # interpolation expressions are checked by the
-          # StringLiteralsInInterpolation cop, so ignore.
-          ignore_node(node)
-        end
-
         private
 
         def message(*)
@@ -32,6 +21,10 @@ module RuboCop
         end
 
         def offense?(node)
+          # If it's a string within an interpolation, then it's not an offense
+          # for this cop.
+          return false if inside_interpolation?(node)
+
           wrong_quotes?(node, style)
         end
       end

--- a/lib/rubocop/cop/style/string_literals_in_interpolation.rb
+++ b/lib/rubocop/cop/style/string_literals_in_interpolation.rb
@@ -19,13 +19,8 @@ module RuboCop
 
         def offense?(node)
           # If it's not a string within an interpolation, then it's not an
-          # offense for this cop. A :begin node inside a :dstr node is an
-          # interpolation.
-          begin_found = false
-          return false unless node.each_ancestor.find do |a|
-            begin_found = true if a.type == :begin
-            begin_found && a.type == :dstr
-          end
+          # offense for this cop.
+          return false unless inside_interpolation?(node)
 
           wrong_quotes?(node, style)
         end

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -39,6 +39,11 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts single quotes in interpolation' do
+      inspect_source(cop, [%q("hello#{hash['there']}")])
+      expect(cop.offenses).to be_empty
+    end
+
     it 'accepts %q and %Q quotes' do
       inspect_source(cop, ['a = %q(x) + %Q[x]'])
       expect(cop.offenses).to be_empty
@@ -95,7 +100,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
       expect(cop.offenses).to be_empty
     end
 
-    it 'accepts double quotes within embedded expression' do
+    it 'accepts double quotes in interpolation' do
       src = ['"#{"A"}"']
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
@@ -154,6 +159,11 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
 
     it 'accepts double quotes' do
       inspect_source(cop, ['a = "x"'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts single quotes in interpolation' do
+      inspect_source(cop, [%q("hello#{hash['there']}")])
       expect(cop.offenses).to be_empty
     end
 


### PR DESCRIPTION
Second fix for 1181. Strings inside interpolations are handled by `StringLiteralsInInterpolation`, to `StringLiterals` should stay away from them.
