### PR TITLE
[Fix #1427] Exclude top level directories early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#801](https://github.com/bbatsov/rubocop/issues/801): New style `context_dependent` for `Style/BracesAroundHashParameters` looks at preceding parameter to determine if braces should be used for final parameter. ([@jonas054][])
 * [#1441](https://github.com/bbatsov/rubocop/issues/1441): Correct the logic used by `Style/Blocks` and other cops to determine if an auto-correction would alter the meaning of the code. ([@jonas054][])
+* [#1427](https://github.com/bbatsov/rubocop/issues/1427): Excluding directories on the top level is now done earlier, so that these file trees are not searched, thus saving time when inspecting projects with many excluded files. ([@jonas054][])
 
 ### Bugs fixed
 


### PR DESCRIPTION
Based on an idea from @bquorning. I expect that this problem with large `vendor` directories could affect more people.

Take the excluded top level directories out of the equation altogether so that they are not searched for files. This is an optimization to speed up the target file search phase when there is, for example, a vendor directory with a lot of files in it (a top level vendor directory is excluded by default).
