### PR TITLE
[Fix #1449] Detect unrecognized style in MultilineOperationIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#801](https://github.com/bbatsov/rubocop/issues/801): New style `context_dependent` for `Style/BracesAroundHashParameters` looks at preceding parameter to determine if braces should be used for final parameter. ([@jonas054][])
 * [#1441](https://github.com/bbatsov/rubocop/issues/1441): Correct the logic used by `Style/Blocks` and other cops to determine if an auto-correction would alter the meaning of the code. ([@jonas054][])
 * [#1427](https://github.com/bbatsov/rubocop/issues/1427): Excluding directories on the top level is now done earlier, so that these file trees are not searched, thus saving time when inspecting projects with many excluded files. ([@jonas054][])
+* [#1449](https://github.com/bbatsov/rubocop/issues/1449): Handle the case in `MultilineOperationIndentation` where instances of both correct style and unrecognized (plain wrong) style are detected during an `--auto-gen-config` run. ([@jonas054][])
 
 ### Bugs fixed
 

--- a/lib/rubocop/cop/style/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/style/multiline_operation_indentation.rb
@@ -51,7 +51,9 @@ module RuboCop
 
         def incorrect_style_detected(range, node, lhs, rhs)
           add_offense(range, range, message(node, lhs, rhs)) do
-            unless offending_range(node, lhs, rhs, alternative_style)
+            if offending_range(node, lhs, rhs, alternative_style)
+              unrecognized_style_detected
+            else
               opposite_style_detected
             end
           end

--- a/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
@@ -198,7 +198,7 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
                                   '`unless` statement spanning multiple ' \
                                   'lines.'])
       expect(cop.highlights).to eq(['.b'])
-      expect(cop.config_to_allow_offenses).to be_nil
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for misaligned operands in while condition' do
@@ -397,6 +397,18 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
                       "  .gsub(/...(?=.)/, '\&_')",
                       '  .reverse'])
       expect(cop.messages).to be_empty
+    end
+
+    it 'registers an offense for correct + unrecognized style' do
+      inspect_source(cop,
+                     ['a ||',
+                      '  b',
+                      'c and',
+                      '    d'])
+      expect(cop.messages).to eq(['Use 2 (not 4) spaces for indenting an ' \
+                                  'expression spanning multiple lines.'])
+      expect(cop.highlights).to eq(%w(d))
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for aligned operatiors in assignment' do


### PR DESCRIPTION
It's when we forget to call `unrecognized_style_detected` that we can get the strange `Enabled: true` setting in a `.rubocop_todo.yml` file.
