### PR TITLE
Support style-guide only usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@
 * New cop `ExtraSpacing` points out unnecessary spacing in files. ([@blainesch][])
 * New cop `EmptyLinesAroundBlockBody` provides same functionality as the EmptyLinesAround(Class|Method|Module)Body but for blocks. ([@jcarbo][])
 * New cop `Style/EmptyElse` checks for empty `else`-clauses. ([@Koronen][])
+* [#1454](https://github.com/bbatsov/rubocop/issues/1454): New `--only-guide-cops` and `AllCops/StyleGuideCopsOnly` options that will only enforce cops that link to a style guide. ([@marxarelli][])
 
 ### Changes
 
 * [#801](https://github.com/bbatsov/rubocop/issues/801): New style `context_dependent` for `Style/BracesAroundHashParameters` looks at preceding parameter to determine if braces should be used for final parameter. ([@jonas054][])
 * [#1427](https://github.com/bbatsov/rubocop/issues/1427): Excluding directories on the top level is now done earlier, so that these file trees are not searched, thus saving time when inspecting projects with many excluded files. ([@jonas054][])
-
 ### Bugs fixed
 
 * Fix `%W[]` auto corrected to `%w(]`. ([@toy][])
@@ -1180,3 +1180,4 @@
 [@toy]: https://github.com/toy
 [@Koronen]: https://github.com/Koronen
 [@blainesch]: https://github.com/blainesch
+[@marxarelli]: https://github.com/marxarelli

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -7,6 +7,8 @@ module RuboCop
   module OptionsHelp
     TEXT = {
       only:              'Run only the given cop(s).',
+      only_guide_cops:  ['Run only cops for rules that link to a',
+                         'style guide.'],
       require:           'Require Ruby file.',
       config:            'Specify configuration file.',
       auto_gen_config:  ['Generate a configuration file acting as a',
@@ -76,12 +78,7 @@ module RuboCop
       OptionParser.new do |opts|
         opts.banner = 'Usage: rubocop [options] [file1, file2, ...]'
 
-        option(opts, '--only [COP1,COP2,...]') do |list|
-          @options[:only] = list.split(',').map do |c|
-            Cop::Cop.qualified_cop_name(c, '--only option')
-          end
-        end
-
+        add_only_options(opts)
         add_configuration_options(opts, args)
         add_formatting_options(opts)
 
@@ -96,6 +93,16 @@ module RuboCop
     def validate_compatibility
       return unless (incompat = @options.keys & EXITING_OPTIONS).size > 1
       fail ArgumentError, "Incompatible cli options: #{incompat.inspect}"
+    end
+
+    def add_only_options(opts)
+      option(opts, '--only [COP1,COP2,...]') do |list|
+        @options[:only] = list.split(',').map do |c|
+          Cop::Cop.qualified_cop_name(c, '--only option')
+        end
+      end
+
+      option(opts, '--only-guide-cops')
     end
 
     def add_configuration_options(opts, args)

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -106,15 +106,24 @@ module RuboCop
             @options[:only].include?(c.cop_name) || @options[:lint] && c.lint?
           end
         else
-          # filter out Rails cops unless requested
-          cop_classes.reject!(&:rails?) unless run_rails_cops?(config)
-
-          # select only lint cops when --lint is passed
-          cop_classes.select!(&:lint?) if @options[:lint]
+          filter_cop_classes(cop_classes, config)
         end
 
         cop_classes
       end
+    end
+
+    def filter_cop_classes(cop_classes, config)
+      # use only cops that link to a style guide if requested
+      if style_guide_cops_only?(config)
+        cop_classes.select! { |cop| config.for_cop(cop)['StyleGuide'] }
+      end
+
+      # filter out Rails cops unless requested
+      cop_classes.reject!(&:rails?) unless run_rails_cops?(config)
+
+      # select only lint cops when --lint is passed
+      cop_classes.select!(&:lint?) if @options[:lint]
     end
 
     def validate_only_option
@@ -126,6 +135,10 @@ module RuboCop
 
     def run_rails_cops?(config)
       @options[:rails] || config['AllCops']['RunRailsCops']
+    end
+
+    def style_guide_cops_only?(config)
+      @options[:only_guide_cops] || config['AllCops']['StyleGuideCopsOnly']
     end
 
     def formatter_set

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -37,6 +37,8 @@ describe RuboCop::Options, :isolated_environment do
         expected_help = <<-END
 Usage: rubocop [options] [file1, file2, ...]
         --only [COP1,COP2,...]       Run only the given cop(s).
+        --only-guide-cops            Run only cops for rules that link to a
+                                     style guide.
     -c, --config FILE                Specify configuration file.
         --auto-gen-config            Generate a configuration file acting as a
                                      TODO list.


### PR DESCRIPTION
Many cops that have been implemented and enabled by default have no
correlation to a style-guide rule: `Metrics/ClassLength`,
`Metrics/AbcSize`, `Metrics/PerceivedComplexity` just to name a few. In
cases where these cops find violations, there's little recourse as the
rules cannot be traced back to a meaningful discussion or consensus.

The `--only-guide-cops` and `AllCops/StyleGuideCopsOnly` options give
users an easy method of invoking RuboCop in a way that's more congruent
with the rules of the style guide.
