### PR TITLE
Fix SymbolProc autocorrect with multiple offenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#1181](https://github.com/bbatsov/rubocop/issues/1181): *(fix again)* `Style/StringLiterals` cop stays away from strings inside interpolated expressions. ([@jonas054][])
 * [#1441](https://github.com/bbatsov/rubocop/issues/1441): Correct the logic used by `Style/Blocks` and other cops to determine if an auto-correction would alter the meaning of the code. ([@jonas054][])
 * [#1449](https://github.com/bbatsov/rubocop/issues/1449): Handle the case in `MultilineOperationIndentation` where instances of both correct style and unrecognized (plain wrong) style are detected during an `--auto-gen-config` run. ([@jonas054][])
+* [#1456](https://github.com/bbatsov/rubocop/pull/1456): Fix autocorrect in `SymbolProc` when there are multiple offenses on the same line. ([@jcarbo][])
 
 ## 0.27.1 (08/11/2014)
 
@@ -1161,3 +1162,4 @@
 [@mvz]: https://github.com/mvz
 [@jfelchner]: https://github.com/jfelchner
 [@janraasch]: https://github.com/janraasch
+[@jcarbo]: https://github.com/jcarbo

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -36,13 +36,16 @@ module RuboCop
 
         def autocorrect(node)
           @corrections << lambda do |corrector|
-            block_method, _block_args, block_body = *node
+            _block_method, _block_args, block_body = *node
             _receiver, method_name, _args = *block_body
 
-            replacement = "#{block_method.loc.expression.source}" \
-                          "(&:#{method_name})"
+            block_range =
+              Parser::Source::Range.new(node.loc.expression.source_buffer,
+                                        node.loc.begin.begin_pos,
+                                        node.loc.end.end_pos)
 
-            corrector.replace(node.loc.expression, replacement)
+            corrector.replace(range_with_surrounding_space(block_range, :left),
+                              "(&:#{method_name})")
           end
         end
 

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -74,6 +74,12 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
     expect(corrected).to eq 'coll.map(&:upcase)'
   end
 
+  it 'autocorrects multiple aliases with symbols as proc' do
+    corrected = autocorrect_source(cop, ['coll.map { |s| s.upcase }' \
+                                         '.map { |s| s.downcase }'])
+    expect(corrected).to eq 'coll.map(&:upcase).map(&:downcase)'
+  end
+
   it 'does not crash with a bare method call' do
     run = -> { inspect_source(cop, ['coll.map { |s| bare_method }']) }
     expect(&run).not_to raise_error


### PR DESCRIPTION
When there were multiple offenses for the SymbolProc cop (e.g.
`coll.map { |s| s.upcase }.map { |s| s.downcase }`) the cop would
raise an error: `Parser::Source::Rewriter detected clobbering`.

Digging into relevant commits I found some inspiration from
@jonas054 (#569). This commit changes the autocorrect for the
SymbolProc cop to be a little more precise in determining what to
correct. There's a new spec that I wrote that fails on master and
passes on this branch.
