### PR TITLE
[Fix #1459] Handle parentheses around condition in NegatedWhile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#1441](https://github.com/bbatsov/rubocop/issues/1441): Correct the logic used by `Style/Blocks` and other cops to determine if an auto-correction would alter the meaning of the code. ([@jonas054][])
 * [#1449](https://github.com/bbatsov/rubocop/issues/1449): Handle the case in `MultilineOperationIndentation` where instances of both correct style and unrecognized (plain wrong) style are detected during an `--auto-gen-config` run. ([@jonas054][])
 * [#1456](https://github.com/bbatsov/rubocop/pull/1456): Fix autocorrect in `SymbolProc` when there are multiple offenses on the same line. ([@jcarbo][])
+* [#1459](https://github.com/bbatsov/rubocop/issues/1459): Handle parenthesis around the condition in `--auto-correct` for `NegatedWhile`. ([@jonas054][])
 
 ## 0.27.1 (08/11/2014)
 

--- a/lib/rubocop/cop/style/negated_while.rb
+++ b/lib/rubocop/cop/style/negated_while.rb
@@ -30,7 +30,9 @@ module RuboCop
         def autocorrect(node)
           @corrections << lambda do |corrector|
             condition, _body, _rest = *node
-            # unwrap the negated portion of the condition (a send node)
+            # Look inside parentheses around the condition, if any.
+            condition, _ = *condition while condition.type == :begin
+            # Unwrap the negated portion of the condition (a send node).
             pos_condition, _method, = *condition
             corrector.replace(
               node.loc.keyword,

--- a/spec/rubocop/cop/style/negated_while_spec.rb
+++ b/spec/rubocop/cop/style/negated_while_spec.rb
@@ -51,8 +51,10 @@ describe RuboCop::Cop::Style::NegatedWhile do
   end
 
   it 'autocorrects by replacing while not with until' do
-    corrected = autocorrect_source(cop, 'something while !x.even?')
-    expect(corrected).to eq 'something until x.even?'
+    corrected = autocorrect_source(cop, ['something while !x.even?',
+                                         'something while(!x.even?)'])
+    expect(corrected).to eq ['something until x.even?',
+                             'something until(x.even?)'].join("\n")
   end
 
   it 'autocorrects by replacing until not with while' do


### PR DESCRIPTION
In `autocorrect`, not handling the parentheses produced incorrect code. Semantically different and/or syntactically wrong.
