### PR TITLE
[Fix #1466] Allow underscored parameters in SingleLineBlockParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#1459](https://github.com/bbatsov/rubocop/issues/1459): Handle parenthesis around the condition in `--auto-correct` for `NegatedWhile`. ([@jonas054][])
 * [#1465](https://github.com/bbatsov/rubocop/issues/1465): Fix autocorrect of code like `#$1` in `PerlBackrefs`. ([@bbatsov][])
 * Fix autocorrect of code like `#$:` in `SpecialGlobalVars`. ([@bbatsov][])
+* [#1466](https://github.com/bbatsov/rubocop/issues/1466): Allow leading underscore for unused parameters in `SingleLineBlockParams`. ([@jonas054][])
 
 ## 0.27.1 (08/11/2014)
 

--- a/lib/rubocop/cop/style/single_line_block_params.rb
+++ b/lib/rubocop/cop/style/single_line_block_params.rb
@@ -53,7 +53,13 @@ module RuboCop
         def args_match?(method_name, args)
           actual_args = args.flat_map(&:to_a)
 
-          actual_args == target_args(method_name).map(&:to_sym)
+          # Prepending an underscore to mark an unused parameter is allowed, so
+          # we remove any leading underscores before comparing.
+          actual_args_no_underscores = actual_args.map do |arg|
+            arg.to_s.sub(/^_+/, '')
+          end
+
+          actual_args_no_underscores == target_args(method_name)
         end
       end
     end

--- a/spec/rubocop/cop/style/single_line_block_params_spec.rb
+++ b/spec/rubocop/cop/style/single_line_block_params_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
     }
   end
 
-  it 'find wrong argument names in calls with different syntax' do
+  it 'finds wrong argument names in calls with different syntax' do
     inspect_source(cop,
                    ['def m',
                     '  [0, 1].reduce { |c, d| c + d }',
@@ -40,6 +40,18 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
                     '  ala.test { |x, y| bala }',
                     'end'])
     expect(cop.offenses).to be_empty
+  end
+
+  it 'allows an unused parameter to have a leading underscore' do
+    inspect_source(cop,
+                   ['File.foreach(filename).reduce(0) { |a, _e| a + 1 }'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'finds incorrectly named parameters with leading underscores' do
+    inspect_source(cop,
+                   ['File.foreach(filename).reduce(0) { |_x, _y| }'])
+    expect(cop.messages).to eq(['Name `reduce` block params `|a, e|`.'])
   end
 
   it 'ignores do..end blocks' do


### PR DESCRIPTION
Allow leading underscores on parameter names, but check them in the normal way apart from the underscores.
