### PR TITLE
[Fix #1325] Don't consider corrected offenses as failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 * [#801](https://github.com/bbatsov/rubocop/issues/801): New style `context_dependent` for `Style/BracesAroundHashParameters` looks at preceding parameter to determine if braces should be used for final parameter. ([@jonas054][])
 * [#1427](https://github.com/bbatsov/rubocop/issues/1427): Excluding directories on the top level is now done earlier, so that these file trees are not searched, thus saving time when inspecting projects with many excluded files. ([@jonas054][])
+* [#1325](https://github.com/bbatsov/rubocop/issues/1325): When running with `--auto-correct`, only offenses *that can not be corrected* will result in a non-zero exit code. ([@jonas054][])
+
 ### Bugs fixed
 
 * Fix `%W[]` auto corrected to `%w(]`. ([@toy][])

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -157,7 +157,7 @@ module RuboCop
     end
 
     def considered_failure?(offense)
-      offense.severity >= minimum_severity_to_fail
+      !offense.corrected? && offense.severity >= minimum_severity_to_fail
     end
 
     def minimum_severity_to_fail


### PR DESCRIPTION
Disregard corrected offenses when determining the exit code of the program.
