### PR TITLE
[Fix #1474] LineEndConcatenation cop catches multiline string with '<<' and '\'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fix autocorrect of code like `#$:` in `SpecialGlobalVars`. ([@bbatsov][])
 * [#1466](https://github.com/bbatsov/rubocop/issues/1466): Allow leading underscore for unused parameters in `SingleLineBlockParams`. ([@jonas054][])
 * [#1470](https://github.com/bbatsov/rubocop/issues/1470): Handle `elsif` + `else` in `ElseAlignment`. ([@jonas054][])
+* [#1474](https://github.com/bbatsov/rubocop/issues/1474): Multiline string with both `<<` and `\` caught by `Style/LineEndConcatenation` cop. ([@katieschilling][])
 
 ## 0.27.1 (08/11/2014)
 
@@ -1183,3 +1184,4 @@
 [@Koronen]: https://github.com/Koronen
 [@blainesch]: https://github.com/blainesch
 [@marxarelli]: https://github.com/marxarelli
+[@katieschilling]: https://github.com/katieschilling

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -63,7 +63,11 @@ module RuboCop
           return false unless node.loc.respond_to?(:begin)
 
           # we care only about quotes-delimited literals
-          node.loc.begin && ["'", '"'].include?(node.loc.begin.source)
+          if node.loc.begin
+            ["'", '"'].include?(node.loc.begin.source)
+          elsif node.children.any?
+            node.children.map { |child| string_type?(child) }.all?
+          end
         end
 
         def final_node_is_string_type?(node)

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -19,6 +19,14 @@ describe RuboCop::Cop::Style::LineEndConcatenation do
     expect(cop.offenses.size).to eq(1)
   end
 
+  it 'registers an offense for string concat with << and \ at line ends' do
+    inspect_source(cop,
+                   ['top = "test " \\',
+                    '"foo" <<',
+                    '"bar"'])
+    expect(cop.offenses.size).to eq(1)
+  end
+
   it 'registers an offense for dynamic string concat at line end' do
     inspect_source(cop,
                    ['top = "test#{x}" +',


### PR DESCRIPTION
Iterates through children of nodes without valid source map beginnings and verifies they are string types.
 `node.loc.begin` for nodes of type `dstr`will sometimes (always?) return `nil`.
This causes any string containing a concatenation with `\\` to pass this cop, as seen in #1474.
If the first test fails, this will iterate through the node's children and recursively check that they all pass it.
