### PR TITLE
[Fix #1473] Recognize operator []= in MultilineOperationIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#1470](https://github.com/bbatsov/rubocop/issues/1470): Handle `elsif` + `else` in `ElseAlignment`. ([@jonas054][])
 * [#1474](https://github.com/bbatsov/rubocop/issues/1474): Multiline string with both `<<` and `\` caught by `Style/LineEndConcatenation` cop. ([@katieschilling][])
 * [#1485](https://github.com/bbatsov/rubocop/issues/1485): Ignore procs in `SymbolProc`. ([@bbatsov][])
+* [#1473](https://github.com/bbatsov/rubocop/issues/1473): `Style/MultilineOperationIndentation` doesn't recognize assignment to array/hash element. ([@jonas054][])
 
 ## 0.27.1 (08/11/2014)
 

--- a/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
@@ -188,6 +188,27 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'indented')
     end
 
+    it 'registers an offense for misaligned string operand when the first ' \
+       'operand has backslash continuation' do
+      inspect_source(cop,
+                     ["flash[:error] = 'Here is a string ' \\",
+                      "                'That spans' <<",
+                      "  'multiple lines'"])
+      expect(cop.messages).to eq(['Align the operands of an expression in an ' \
+                                  'assignment spanning multiple lines.'])
+      expect(cop.highlights).to eq(["'multiple lines'"])
+    end
+
+    it 'registers an offense for misaligned string operand when plus is used' do
+      inspect_source(cop,
+                     ["flash[:error] = 'Here is a string ' +",
+                      "                'That spans' <<",
+                      "  'multiple lines'"])
+      expect(cop.messages).to eq(['Align the operands of an expression in an ' \
+                                  'assignment spanning multiple lines.'])
+      expect(cop.highlights).to eq(["'multiple lines'"])
+    end
+
     it 'registers an offense for misaligned operands in unless condition' do
       inspect_source(cop,
                      ['unless a',


### PR DESCRIPTION
The `[]=` operator is a form of assignment and should be recognized as such in `MultilineOperationIndentation` where assignment is handled in a special way.
