### PR TITLE
Speeding up Travis-CI, fix Rubinius.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
+sudo: false
+
 language: ruby
+
 rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
   - ruby-head
   - jruby-19mode
-  - rbx-2
+  - jruby-head
+  - rbx-2.2.10
+
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: rbx-2
-before_install: gem update --remote bundler
-install:
-  - bundle install --retry=3
+    - rvm: jruby-head
+
 script:
   - bundle exec rspec
   - bundle exec rubocop


### PR DESCRIPTION
The new `sudo false` environment is faster to boot on Travis, it runs builds without sudo access.

Removed unnecessary things in the .travis.yml that Travis does well without asking.

Locked Rubinius at 2.2.10, which passes the build. The current rbx-2 is 2.4.1 which fails (eg. in https://travis-ci.org/bbatsov/rubocop/builds/43870749) for an obscure reason. I think rbx-2 is too generic and will continue incrementing. The MRI versions for example are locked specifically, except for 2.1. 
