### PR TITLE
[Fix #1430] Add option --except for disabling cops on command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#1430](https://github.com/bbatsov/rubocop/issues/1430): Add `--except` option for disabling cops on the command line. ([@jonas054][])
+
 ### Bugs fixed
 
 * Handle element assignment in `Lint/AssignmentInCondition`. ([@jonas054][])

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Command flag              | Description
 `-l/--lint`               | Run only lint cops
 `-a/--auto-correct`       | Auto-correct certain offenses *Note:* Experimental - use with caution
 `--only`                  | Run only the specified cop(s)
+`--except`                | Run all cops enabled by configuration except the specified one(s)
 `--auto-gen-config`       | Generate a configuration file acting as a TODO list
 `--show-cops`             | Shows available cops and their configuration
 `--fail-level`            | Minimum severity for exit with error code

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -9,6 +9,7 @@ module RuboCop
       only:              'Run only the given cop(s).',
       only_guide_cops:  ['Run only cops for rules that link to a',
                          'style guide.'],
+      except:            'Disable the given cop(s).',
       require:           'Require Ruby file.',
       config:            'Specify configuration file.',
       auto_gen_config:  ['Generate a configuration file acting as a',
@@ -96,13 +97,17 @@ module RuboCop
     end
 
     def add_only_options(opts)
-      option(opts, '--only [COP1,COP2,...]') do |list|
-        @options[:only] = list.split(',').map do |c|
-          Cop::Cop.qualified_cop_name(c, '--only option')
+      add_cop_selection_csv_option('except', opts)
+      add_cop_selection_csv_option('only', opts)
+      option(opts, '--only-guide-cops')
+    end
+
+    def add_cop_selection_csv_option(option, opts)
+      option(opts, "--#{option} [COP1,COP2,...]") do |list|
+        @options[:"#{option}"] = list.split(',').map do |c|
+          Cop::Cop.qualified_cop_name(c, "--#{option} option")
         end
       end
-
-      option(opts, '--only-guide-cops')
     end
 
     def add_configuration_options(opts, args)

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -36,6 +36,7 @@ describe RuboCop::Options, :isolated_environment do
 
         expected_help = <<-END
 Usage: rubocop [options] [file1, file2, ...]
+        --except [COP1,COP2,...]     Disable the given cop(s).
         --only [COP1,COP2,...]       Run only the given cop(s).
         --only-guide-cops            Run only cops for rules that link to a
                                      style guide.


### PR DESCRIPTION
Add a companion to the `--only` option. This option will disable the given cops (comma separated list).
