### PR TITLE
[Fix #1500] Remove double handling of elsif in IndentationWidth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Handle element assignment in `Lint/AssignmentInCondition`. ([@jonas054][])
 * [#1484](https://github.com/bbatsov/rubocop/issues/1484): Fix `EmptyLinesAroundAccessModifier` incorrectly finding a violation inside method calls with names identical to an access modifier. ([@dblock][])
 * Fix bug concerning `Exclude` properties inherited from a higher directory level. ([@jonas054][])
+* [#1500](https://github.com/bbatsov/rubocop/issues/1500): Fix crashing `--auto-correct --only IndentationWidth`. ([@jonas054][])
 
 ## 0.28.0 (10/12/2014)
 

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -128,9 +128,9 @@ module RuboCop
           return if modifier_if?(node)
 
           case node.loc.keyword.source
-          when 'if'     then _condition, body, else_clause = *node
-          when 'unless' then _condition, else_clause, body = *node
-          else               _condition, body = *node
+          when 'if', 'elsif' then _condition, body, else_clause = *node
+          when 'unless'      then _condition, else_clause, body = *node
+          else                    _condition, body = *node
           end
 
           check_if(node, body, else_clause, base.loc) if body
@@ -164,12 +164,11 @@ module RuboCop
           check_indentation(base_loc, body)
           return unless else_clause
 
-          if elsif?(else_clause)
-            _condition, inner_body, inner_else_clause = *else_clause
-            check_if(else_clause, inner_body, inner_else_clause, base_loc)
-          else
-            check_indentation(node.loc.else, else_clause)
-          end
+          # If the else clause is an elsif, it will get its own on_if call so
+          # we don't need to process it here.
+          return if elsif?(else_clause)
+
+          check_indentation(node.loc.else, else_clause)
         end
 
         def check_indentation(base_loc, body_node)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -47,6 +47,27 @@ describe RuboCop::CLI, :isolated_environment do
         expect(uncorrected).to be_empty # Hence exit code 0.
       end
 
+      it 'corrects only IndentationWidth without crashing', :focus do
+        source = ['foo = if bar',
+                  '  something',
+                  'elsif baz',
+                  '  other_thing',
+                  'else',
+                  '  fail',
+                  'end']
+        create_file('example.rb', source)
+        expect(cli.run([%w(--only IndentationWidth --auto-correct)])).to eq(0)
+        corrected = ['foo = if bar',
+                     '        something',
+                     'elsif baz',
+                     '  other_thing',
+                     'else',
+                     '  fail',
+                     'end',
+                     ''].join("\n")
+        expect(IO.read('example.rb')).to eq(corrected)
+      end
+
       it 'corrects complicated cases conservatively' do
         # Two cops make corrections here; Style/BracesAroundHashParameters, and
         # Style/AlignHash. Because they make minimal corrections relating only


### PR DESCRIPTION
The fact that `elsif` bodies were checked twice could cause auto-correction to become unstable and indent indefinitely.

The reason was that one check was relative to the `if` keyword, the other to the `elsif` keyword. So if these were not aligned, and the `ElseAlignment` cop was not enabled, there would always be an offense to correct.
