### PR TITLE
Fix bug where auto_correct Rake tasks does not take in the options specified in its parent task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#1500](https://github.com/bbatsov/rubocop/issues/1500): Fix crashing `--auto-correct --only IndentationWidth`. ([@jonas054][])
 * [#1512](https://github.com/bbatsov/rubocop/issues/1512): Fix false negative for typical string formatting examples. ([@kakutani][], [@jonas054][])
 * [#1504](https://github.com/bbatsov/rubocop/issues/1504): Fail with a meaningful error if the configuration file is malformed. ([@bquorning][])
+* Fix bug where `auto_correct` Rake tasks does not take in the options specified in its parent task. ([@rrosenblum][])
 
 ## 0.28.0 (10/12/2014)
 
@@ -1209,3 +1210,4 @@
 [@marxarelli]: https://github.com/marxarelli
 [@katieschilling]: https://github.com/katieschilling
 [@kakutani]: https://github.com/kakutani
+[@rrosenblum]: https://github.com/rrosenblum

--- a/lib/rubocop/rake_task.rb
+++ b/lib/rubocop/rake_task.rb
@@ -31,7 +31,7 @@ module RuboCop
         end
       end
 
-      setup_subtasks(name)
+      setup_subtasks(name, *args, &task_block)
     end
 
     def run_main_task(verbose)
@@ -73,11 +73,14 @@ module RuboCop
       @formatters = [RuboCop::Options::DEFAULT_FORMATTER]
     end
 
-    def setup_subtasks(name)
+    def setup_subtasks(name, *args, &task_block)
       namespace name do
         desc 'Auto-correct RuboCop offenses'
 
-        task :auto_correct do
+        task(:auto_correct, *args) do |_, task_args|
+          if task_block
+            task_block.call(*[self, task_args].slice(0, task_block.arity))
+          end
           options = full_options.unshift('--auto-correct')
           run_cli(verbose, options)
         end

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -1,0 +1,122 @@
+# encoding: utf-8
+
+require 'spec_helper'
+require 'rubocop/rake_task'
+
+describe RuboCop::RakeTask do
+  describe 'defining tasks' do
+    it 'creates a rubocop task' do
+      RuboCop::RakeTask.new
+
+      expect(Rake::Task.task_defined?(:rubocop)).to be true
+    end
+
+    it 'creates a rubocop:auto_correct task' do
+      RuboCop::RakeTask.new
+
+      expect(Rake::Task.task_defined?('rubocop:auto_correct')).to be true
+    end
+
+    it 'creates a named task' do
+      RuboCop::RakeTask.new(:lint_lib)
+
+      expect(Rake::Task.task_defined?(:lint_lib)).to be true
+    end
+
+    it 'creates an auto_correct task for the named task' do
+      RuboCop::RakeTask.new(:lint_lib)
+
+      expect(Rake::Task.task_defined?('lint_lib:auto_correct')).to be true
+    end
+  end
+
+  describe 'running tasks' do
+    before(:each) do
+      $stdout = StringIO.new
+      $stderr = StringIO.new
+      Rake::Task['rubocop'].clear if Rake::Task.task_defined?('rubocop')
+    end
+
+    after(:each) do
+      $stdout = STDOUT
+      $stderr = STDERR
+    end
+
+    it 'runs with default options' do
+      RuboCop::RakeTask.new
+
+      cli = double('cli', run: 0)
+      allow(RuboCop::CLI).to receive(:new) { cli }
+      expect(cli).to receive(:run).with(['--format', 'progress'])
+
+      Rake::Task['rubocop'].execute
+    end
+
+    it 'runs with specified options if a block is given' do
+      RuboCop::RakeTask.new do |task|
+        task.patterns = ['lib/**/*.rb']
+        task.formatters = ['files']
+        task.fail_on_error = false
+        task.options = ['--display-cop-names']
+        task.verbose = false
+      end
+
+      cli = double('cli', run: 0)
+      allow(RuboCop::CLI).to receive(:new) { cli }
+      options = ['--format', 'files',  '--display-cop-names', 'lib/**/*.rb']
+      expect(cli).to receive(:run).with(options)
+
+      Rake::Task['rubocop'].execute
+    end
+
+    it 'will not error when result is not 0 and fail_on_error is false' do
+      RuboCop::RakeTask.new do |task|
+        task.fail_on_error = false
+      end
+
+      cli = double('cli', run: 1)
+      allow(RuboCop::CLI).to receive(:new) { cli }
+
+      expect { Rake::Task['rubocop'].execute }.to_not raise_error
+    end
+
+    it 'exits when result is not 0 and fail_on_error is true' do
+      RuboCop::RakeTask.new
+
+      cli = double('cli', run: 1)
+      allow(RuboCop::CLI).to receive(:new) { cli }
+
+      expect { Rake::Task['rubocop'].execute }.to raise_error(SystemExit)
+    end
+
+    context 'auto_correct' do
+      it 'runs with --auto-correct' do
+        RuboCop::RakeTask.new
+
+        cli = double('cli', run: 0)
+        allow(RuboCop::CLI).to receive(:new) { cli }
+        options = ['--auto-correct', '--format', 'progress']
+        expect(cli).to receive(:run).with(options)
+
+        Rake::Task['rubocop:auto_correct'].execute
+      end
+
+      it 'runs with with the options that were passed to its parent task' do
+        RuboCop::RakeTask.new do |task|
+          task.patterns = ['lib/**/*.rb']
+          task.formatters = ['files']
+          task.fail_on_error = false
+          task.options = ['-D']
+          task.verbose = false
+        end
+
+        cli = double('cli', run: 0)
+        allow(RuboCop::CLI).to receive(:new) { cli }
+        options = ['--auto-correct', '--format', 'files',  '-D', 'lib/**/*.rb']
+        expect(cli).to receive(:run).with(options)
+
+        Rake::Task['rubocop:auto_correct'].execute
+      end
+    end
+  end
+end


### PR DESCRIPTION
I noticed an issue where the `auto_correct` Rake task would run against all files even if its parent's task had been given a pattern to run against. 

Using the example task from the README, I would expect `rake rubocop:auto_correct` to run RuboCop using the file pattern 'lib/*_/_.rb'. In actuality, it was running against all files.

``` ruby
require 'rubocop/rake_task'

desc 'Run RuboCop on the lib directory'
RuboCop::RakeTask.new(:rubocop) do |task|
  task.patterns = ['lib/**/*.rb']
  task.formatters = ['files']
  task.fail_on_error = false
end
```

The change allows for the `auto_correct` task to run with the options that were given to the parent task.
