### PR TITLE
Remove arrays wrapping a single string in inspect_source calls

### DIFF
--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -80,13 +80,13 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
 
   it 'accepts = in a block that is called in a condition' do
     inspect_source(cop,
-                   ['return 1 if any_errors? { o = inspect(file) }'])
+                   'return 1 if any_errors? { o = inspect(file) }')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts ||= in condition' do
     inspect_source(cop,
-                   ['raise StandardError unless foo ||= bar'])
+                   'raise StandardError unless foo ||= bar')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/lint/condition_position_spec.rb
+++ b/spec/rubocop/cop/lint/condition_position_spec.rb
@@ -45,7 +45,7 @@ describe RuboCop::Cop::Lint::ConditionPosition do
   end
 
   it 'handles ternary ops' do
-    inspect_source(cop, ['x ? a : b'])
+    inspect_source(cop, 'x ? a : b')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/empty_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/empty_interpolation_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Lint::EmptyInterpolation do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for #{} in interpolation' do
-    inspect_source(cop, ['"this is the #{}"'])
+    inspect_source(cop, '"this is the #{}"')
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['#{}'])
   end

--- a/spec/rubocop/cop/lint/eval_spec.rb
+++ b/spec/rubocop/cop/lint/eval_spec.rb
@@ -7,27 +7,27 @@ describe RuboCop::Cop::Lint::Eval do
 
   it 'registers an offense for eval as function' do
     inspect_source(cop,
-                   ['eval(something)'])
+                   'eval(something)')
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights) .to eq(['eval'])
   end
 
   it 'registers an offense for eval as command' do
     inspect_source(cop,
-                   ['eval something'])
+                   'eval something')
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights) .to eq(['eval'])
   end
 
   it 'does not register an offense for eval as variable' do
     inspect_source(cop,
-                   ['eval = something'])
+                   'eval = something')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for eval as method' do
     inspect_source(cop,
-                   ['something.eval'])
+                   'something.eval')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -8,13 +8,13 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
   %w(1 2.0 [1] {}).each do |lit|
     it "registers an offense for #{lit} in interpolation" do
       inspect_source(cop,
-                     ["\"this is the \#{#{lit}}\""])
+                     "\"this is the \#{#{lit}}\"")
       expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense only for final #{lit} in interpolation" do
       inspect_source(cop,
-                     ["\"this is the \#{#{lit};#{lit}}\""])
+                     "\"this is the \#{#{lit};#{lit}}\"")
       expect(cop.offenses.size).to eq(1)
     end
   end

--- a/spec/rubocop/cop/lint/loop_spec.rb
+++ b/spec/rubocop/cop/lint/loop_spec.rb
@@ -6,22 +6,22 @@ describe RuboCop::Cop::Lint::Loop do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for begin/end/while' do
-    inspect_source(cop, ['begin something; top; end while test'])
+    inspect_source(cop, 'begin something; top; end while test')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for begin/end/until' do
-    inspect_source(cop, ['begin something; top; end until test'])
+    inspect_source(cop, 'begin something; top; end until test')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts normal while' do
-    inspect_source(cop, ['while test; one; two; end'])
+    inspect_source(cop, 'while test; one; two; end')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts normal until' do
-    inspect_source(cop, ['until test; one; two; end'])
+    inspect_source(cop, 'until test; one; two; end')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -7,28 +7,28 @@ describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
 
   it 'registers an offense for method call with space before the ' \
      'parenthesis' do
-    inspect_source(cop, ['a.func (x)'])
+    inspect_source(cop, 'a.func (x)')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for predicate method call with space ' \
      'before the parenthesis' do
-    inspect_source(cop, ['is? (x)'])
+    inspect_source(cop, 'is? (x)')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for math expression' do
-    inspect_source(cop, ['puts (2 + 3) * 4'])
+    inspect_source(cop, 'puts (2 + 3) * 4')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts a method call without arguments' do
-    inspect_source(cop, ['func'])
+    inspect_source(cop, 'func')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a method call with arguments but no parentheses' do
-    inspect_source(cop, ['puts x'])
+    inspect_source(cop, 'puts x')
     expect(cop.offenses).to be_empty
   end
 
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
   end
 
   it 'accepts method with parens as arg to method without' do
-    inspect_source(cop, ['a b(c)'])
+    inspect_source(cop, 'a b(c)')
     expect(cop.offenses).to be_empty
   end
 
@@ -51,7 +51,7 @@ describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
   end
 
   it 'accepts a space inside opening paren followed by left paren' do
-    inspect_source(cop, ['a( (b) )'])
+    inspect_source(cop, 'a( (b) )')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/lint/space_before_first_arg_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Lint::SpaceBeforeFirstArg do
     end
 
     it 'accepts square brackets operator' do
-      inspect_source(cop, ['something[:x]'])
+      inspect_source(cop, 'something[:x]')
       expect(cop.offenses).to be_empty
     end
 
@@ -33,7 +33,8 @@ describe RuboCop::Cop::Lint::SpaceBeforeFirstArg do
     end
 
     it 'accepts an assignment without space before first arg' do
-      inspect_source(cop, ['a.something=c', 'a.something,b=c,d'])
+      inspect_source(cop, ['a.something=c',
+                           'a.something,b=c,d'])
       expect(cop.offenses).to be_empty
     end
 
@@ -53,12 +54,12 @@ describe RuboCop::Cop::Lint::SpaceBeforeFirstArg do
     end
 
     it 'accepts a method call with space after the left parenthesis' do
-      inspect_source(cop, ['something?(  x  )'])
+      inspect_source(cop, 'something?(  x  )')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts setter call' do
-      inspect_source(cop, ['self.class.controller_path=(path)'])
+      inspect_source(cop, 'self.class.controller_path=(path)')
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/lint/useless_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/useless_comparison_spec.rb
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Lint::UselessComparison do
   end
 
   it 'works with lambda.()' do
-    inspect_source(cop, ['a.(x) > a.(x)'])
+    inspect_source(cop, 'a.(x) > a.(x)')
     expect(cop.offenses.size).to eq(1)
   end
 end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -28,7 +28,7 @@ describe RuboCop::Cop::Lint::Void do
 
   described_class::OPS.each do |op|
     it "accepts void op #{op} by itself without a begin block" do
-      inspect_source(cop, ["a #{op} b"])
+      inspect_source(cop, "a #{op} b")
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
   let(:cop_config) { { 'Max' => 80 } }
 
   it "registers an offense for a line that's 81 characters wide" do
-    inspect_source(cop, ['#' * 81])
+    inspect_source(cop, '#' * 81)
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.first.message).to eq('Line is too long. [81/80]')
     expect(cop.config_to_allow_offenses).to eq('Max' => 81)
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
   end
 
   it "accepts a line that's 80 characters wide" do
-    inspect_source(cop, ['#' * 80])
+    inspect_source(cop, '#' * 80)
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/metrics/while_until_modifier_spec.rb
+++ b/spec/rubocop/cop/metrics/while_until_modifier_spec.rb
@@ -64,12 +64,12 @@ describe RuboCop::Cop::Style::WhileUntilModifier do
   end
 
   it 'accepts modifier while' do
-    inspect_source(cop, ['ala while bala'])
+    inspect_source(cop, 'ala while bala')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts modifier until' do
-    inspect_source(cop, ['ala until bala'])
+    inspect_source(cop, 'ala until bala')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/rails/default_scope_spec.rb
+++ b/spec/rubocop/cop/rails/default_scope_spec.rb
@@ -7,31 +7,31 @@ describe RuboCop::Cop::Rails::DefaultScope do
 
   it 'registers an offense for default scope with a lambda arg' do
     inspect_source(cop,
-                   ['default_scope -> { something }'])
+                   'default_scope -> { something }')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for default scope with a proc arg' do
     inspect_source(cop,
-                   ['default_scope proc { something }'])
+                   'default_scope proc { something }')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for default scope with a proc(Proc.new) arg' do
     inspect_source(cop,
-                   ['default_scope Proc.new { something }'])
+                   'default_scope Proc.new { something }')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for non blocks' do
     inspect_source(cop,
-                   ['default_scope order: "position"'])
+                   'default_scope order: "position"')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts a block arg' do
     inspect_source(cop,
-                   ['default_scope { something }'])
+                   'default_scope { something }')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/rails/has_and_belongs_to_many_spec.rb
+++ b/spec/rubocop/cop/rails/has_and_belongs_to_many_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Rails::HasAndBelongsToMany do
 
   it 'registers an offense for has_and_belongs_to_many' do
     inspect_source(cop,
-                   ['has_and_belongs_to_many :groups'])
+                   'has_and_belongs_to_many :groups')
     expect(cop.offenses.size).to eq(1)
   end
 end

--- a/spec/rubocop/cop/rails/scope_args_spec.rb
+++ b/spec/rubocop/cop/rails/scope_args_spec.rb
@@ -7,19 +7,19 @@ describe RuboCop::Cop::Rails::ScopeArgs do
 
   it 'registers an offense a scope with a method arg' do
     inspect_source(cop,
-                   ['scope :active, where(active: true)'])
+                   'scope :active, where(active: true)')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts a lambda arg' do
     inspect_source(cop,
-                   ['scope :active, -> { where(active: true) }'])
+                   'scope :active, -> { where(active: true) }')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a proc arg' do
     inspect_source(cop,
-                   ['scope :active, proc { where(active: true) }'])
+                   'scope :active, proc { where(active: true) }')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/rails/validation_spec.rb
+++ b/spec/rubocop/cop/rails/validation_spec.rb
@@ -8,13 +8,13 @@ describe RuboCop::Cop::Rails::Validation do
   described_class::BLACKLIST.each_with_index do |validation, number|
     it "registers an offense for #{validation}" do
       inspect_source(cop,
-                     ["#{validation} :name"])
+                     "#{validation} :name")
       expect(cop.offenses.size).to eq(1)
     end
 
     it "outputs the correct message for #{validation}" do
       inspect_source(cop,
-                     ["#{validation} :name"])
+                     "#{validation} :name")
       expect(cop.offenses.first.message)
         .to include(described_class::WHITELIST[number])
     end
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Rails::Validation do
 
   it 'accepts new style validations' do
     inspect_source(cop,
-                   ['validates :name'])
+                   'validates :name')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Style::Alias do
 
   it 'registers an offense for alias with symbol args' do
     inspect_source(cop,
-                   ['alias :ala :bala'])
+                   'alias :ala :bala')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['Use `alias_method` instead of `alias`.'])
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Style::Alias do
 
   it 'registers an offense for alias with bareword args' do
     inspect_source(cop,
-                   ['alias ala bala'])
+                   'alias ala bala')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['Use `alias_method` instead of `alias`.'])
@@ -33,19 +33,19 @@ describe RuboCop::Cop::Style::Alias do
 
   it 'does not register an offense for alias_method' do
     inspect_source(cop,
-                   ['alias_method :ala, :bala'])
+                   'alias_method :ala, :bala')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for :alias' do
     inspect_source(cop,
-                   ['[:alias, :ala, :bala]'])
+                   '[:alias, :ala, :bala]')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for alias with gvars' do
     inspect_source(cop,
-                   ['alias $ala $bala'])
+                   'alias $ala $bala')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/align_hash_spec.rb
+++ b/spec/rubocop/cop/style/align_hash_spec.rb
@@ -296,7 +296,7 @@ describe RuboCop::Cop::Style::AlignHash, :config do
     end
 
     it 'accepts a single method argument entry with colon' do
-      inspect_source(cop, ['merge(parent: nil)'])
+      inspect_source(cop, 'merge(parent: nil)')
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/align_parameters_spec.rb
+++ b/spec/rubocop/cop/style/align_parameters_spec.rb
@@ -47,7 +47,7 @@ describe RuboCop::Cop::Style::AlignParameters do
     end
 
     it 'accepts calls that only span one line' do
-      inspect_source(cop, ['find(path, s, @special[sexp[0]])'])
+      inspect_source(cop, 'find(path, s, @special[sexp[0]])')
       expect(cop.offenses).to be_empty
     end
 
@@ -100,12 +100,12 @@ describe RuboCop::Cop::Style::AlignParameters do
     end
 
     it "doesn't get confused by symbols with embedded expressions" do
-      inspect_source(cop, ['send(:"#{name}_comments_path")'])
+      inspect_source(cop, 'send(:"#{name}_comments_path")')
       expect(cop.offenses).to be_empty
     end
 
     it "doesn't get confused by regexen with embedded expressions" do
-      inspect_source(cop, ['a(/#{name}/)'])
+      inspect_source(cop, 'a(/#{name}/)')
       expect(cop.offenses).to be_empty
     end
 
@@ -142,7 +142,7 @@ describe RuboCop::Cop::Style::AlignParameters do
     end
 
     it 'can handle a call embedded in a string' do
-      inspect_source(cop, ['model("#{index(name)}", child)'])
+      inspect_source(cop, 'model("#{index(name)}", child)')
       expect(cop.offenses).to be_empty
     end
 
@@ -163,12 +163,12 @@ describe RuboCop::Cop::Style::AlignParameters do
     end
 
     it 'can handle a ternary condition with a block reference' do
-      inspect_source(cop, ['cond ? a : func(&b)'])
+      inspect_source(cop, 'cond ? a : func(&b)')
       expect(cop.offenses).to be_empty
     end
 
     it 'can handle parentheses used with no parameters' do
-      inspect_source(cop, ['func()'])
+      inspect_source(cop, 'func()')
       expect(cop.offenses).to be_empty
     end
 
@@ -180,7 +180,7 @@ describe RuboCop::Cop::Style::AlignParameters do
     end
 
     it 'can handle method calls without parentheses' do
-      inspect_source(cop, ['a(b c, d)'])
+      inspect_source(cop, 'a(b c, d)')
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -13,8 +13,7 @@ describe RuboCop::Cop::Style::AndOr, :config do
 
     %w(and or).each do |operator|
       it "accepts \"#{operator}\" outside of conditional" do
-        inspect_source(cop,
-                       ["x = a + b #{operator} return x"])
+        inspect_source(cop, "x = a + b #{operator} return x")
         expect(cop.offenses).to be_empty
       end
 
@@ -51,14 +50,12 @@ describe RuboCop::Cop::Style::AndOr, :config do
 
     %w(&& ||).each do |operator|
       it "accepts #{operator} inside of conditional" do
-        inspect_source(cop,
-                       ["test if a #{operator} b"])
+        inspect_source(cop, "test if a #{operator} b")
         expect(cop.offenses).to be_empty
       end
 
       it "accepts #{operator} outside of conditional" do
-        inspect_source(cop,
-                       ["x = a #{operator} b"])
+        inspect_source(cop, "x = a #{operator} b")
         expect(cop.offenses).to be_empty
       end
     end
@@ -73,28 +70,24 @@ describe RuboCop::Cop::Style::AndOr, :config do
     let(:cop_config) { cop_config }
 
     it 'registers an offense for "or"' do
-      inspect_source(cop,
-                     ['test if a or b'])
+      inspect_source(cop, 'test if a or b')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use `||` instead of `or`.'])
     end
 
     it 'registers an offense for "and"' do
-      inspect_source(cop,
-                     ['test if a and b'])
+      inspect_source(cop, 'test if a and b')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use `&&` instead of `and`.'])
     end
 
     it 'accepts ||' do
-      inspect_source(cop,
-                     ['test if a || b'])
+      inspect_source(cop, 'test if a || b')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts &&' do
-      inspect_source(cop,
-                     ['test if a && b'])
+      inspect_source(cop, 'test if a && b')
       expect(cop.offenses).to be_empty
     end
 
@@ -132,57 +125,49 @@ describe RuboCop::Cop::Style::AndOr, :config do
     end
 
     it 'warns on short-circuit (and)' do
-      inspect_source(cop,
-                     ['x = a + b and return x'])
+      inspect_source(cop, 'x = a + b and return x')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use `&&` instead of `and`.'])
     end
 
     it 'also warns on non short-circuit (and)' do
-      inspect_source(cop,
-                     ['x = a + b if a and b'])
+      inspect_source(cop, 'x = a + b if a and b')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use `&&` instead of `and`.'])
     end
 
     it 'also warns on non short-circuit (and) (unless)' do
-      inspect_source(cop,
-                     ['x = a + b unless a and b'])
+      inspect_source(cop, 'x = a + b unless a and b')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use `&&` instead of `and`.'])
     end
 
     it 'warns on short-circuit (or)' do
-      inspect_source(cop,
-                     ['x = a + b or return x'])
+      inspect_source(cop, 'x = a + b or return x')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use `||` instead of `or`.'])
     end
 
     it 'also warns on non short-circuit (or)' do
-      inspect_source(cop,
-                     ['x = a + b if a or b'])
+      inspect_source(cop, 'x = a + b if a or b')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use `||` instead of `or`.'])
     end
 
     it 'also warns on non short-circuit (or) (unless)' do
-      inspect_source(cop,
-                     ['x = a + b unless a or b'])
+      inspect_source(cop, 'x = a + b unless a or b')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use `||` instead of `or`.'])
     end
 
     it 'also warns on while (or)' do
-      inspect_source(cop,
-                     ['x = a + b while a or b'])
+      inspect_source(cop, 'x = a + b while a or b')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use `||` instead of `or`.'])
     end
 
     it 'also warns on until (or)' do
-      inspect_source(cop,
-                     ['x = a + b until a or b'])
+      inspect_source(cop, 'x = a + b until a or b')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use `||` instead of `or`.'])
     end

--- a/spec/rubocop/cop/style/array_join_spec.rb
+++ b/spec/rubocop/cop/style/array_join_spec.rb
@@ -7,23 +7,23 @@ describe RuboCop::Cop::Style::ArrayJoin do
 
   it 'registers an offense for an array followed by string' do
     inspect_source(cop,
-                   ['%w(one two three) * ", "'])
+                   '%w(one two three) * ", "')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'does not register an offense for numbers' do
     inspect_source(cop,
-                   ['%w(one two three) * 4'])
+                   '%w(one two three) * 4')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for ambiguous cases' do
     inspect_source(cop,
-                   ['test * ", "'])
+                   'test * ", "')
     expect(cop.offenses).to be_empty
 
     inspect_source(cop,
-                   ['%w(one two three) * test'])
+                   '%w(one two three) * test')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/ascii_comments_spec.rb
+++ b/spec/rubocop/cop/style/ascii_comments_spec.rb
@@ -15,8 +15,7 @@ describe RuboCop::Cop::Style::AsciiComments do
   end
 
   it 'accepts comments with only ascii chars' do
-    inspect_source(cop,
-                   ['# AZaz1@$%~,;*_`|'])
+    inspect_source(cop, '# AZaz1@$%~,;*_`|')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/ascii_identifiers_spec.rb
+++ b/spec/rubocop/cop/style/ascii_identifiers_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Style::AsciiIdentifiers do
 
   it 'accepts identifiers with only ascii chars' do
     inspect_source(cop,
-                   ['x.empty?'])
+                   'x.empty?')
     expect(cop.offenses).to be_empty
   end
 
@@ -30,7 +30,7 @@ describe RuboCop::Cop::Style::AsciiIdentifiers do
 
   it 'does not get confused by an empty file' do
     inspect_source(cop,
-                   [''])
+                   '')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/block_comments_spec.rb
+++ b/spec/rubocop/cop/style/block_comments_spec.rb
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Style::BlockComments do
 
   it 'accepts regular comments' do
     inspect_source(cop,
-                   ['# comment'])
+                   '# comment')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/style/block_end_newline_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Style::BlockEndNewline do
   subject(:cop) { described_class.new }
 
   it 'does not register an offense for a one-liner' do
-    inspect_source(cop, ['test do foo end'])
+    inspect_source(cop, 'test do foo end')
     expect(cop.messages).to be_empty
   end
 

--- a/spec/rubocop/cop/style/blocks_spec.rb
+++ b/spec/rubocop/cop/style/blocks_spec.rb
@@ -12,13 +12,13 @@ describe RuboCop::Cop::Style::Blocks do
   end
 
   it 'registers an offense for a single line block with do-end' do
-    inspect_source(cop, ['each do |x| end'])
+    inspect_source(cop, 'each do |x| end')
     expect(cop.messages)
       .to eq(['Prefer {...} over do...end for single-line blocks.'])
   end
 
   it 'accepts a single line block with braces' do
-    inspect_source(cop, ['each { |x| }'])
+    inspect_source(cop, 'each { |x| }')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -9,15 +9,15 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
     after(:each) { expect(cop.offenses).to be_empty }
 
     it 'accepts one non-hash parameter' do
-      inspect_source(cop, ['where(2)'])
+      inspect_source(cop, 'where(2)')
     end
 
     it 'accepts multiple non-hash parameters' do
-      inspect_source(cop, ['where(1, "2")'])
+      inspect_source(cop, 'where(1, "2")')
     end
 
     it 'accepts one empty hash parameter' do
-      inspect_source(cop, ['where({})'])
+      inspect_source(cop, 'where({})')
     end
 
     it 'accepts one empty hash parameter with whitespace' do
@@ -30,23 +30,23 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
     after(:each) { expect(cop.offenses).to be_empty }
 
     it 'accepts one hash parameter without braces' do
-      inspect_source(cop, ['where(x: "y")'])
+      inspect_source(cop, 'where(x: "y")')
     end
 
     it 'accepts one hash parameter without braces and with multiple keys' do
-      inspect_source(cop, ['where(x: "y", foo: "bar")'])
+      inspect_source(cop, 'where(x: "y", foo: "bar")')
     end
 
     it 'accepts one hash parameter without braces and with one hash value' do
-      inspect_source(cop, ['where(x: { "y" => "z" })'])
+      inspect_source(cop, 'where(x: { "y" => "z" })')
     end
 
     it 'accepts property assignment with braces' do
-      inspect_source(cop, ['x.z = { y: "z" }'])
+      inspect_source(cop, 'x.z = { y: "z" }')
     end
 
     it 'accepts operator with a hash parameter with braces' do
-      inspect_source(cop, ['x.z - { y: "z" }'])
+      inspect_source(cop, 'x.z - { y: "z" }')
     end
   end
 
@@ -55,34 +55,34 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
 
     it 'registers an offense for one non-hash parameter followed by a hash ' \
        'parameter with braces' do
-      inspect_source(cop, ['where(1, { y: 2 })'])
+      inspect_source(cop, 'where(1, { y: 2 })')
       expect(cop.messages).to eq([msg])
       expect(cop.highlights).to eq(['{ y: 2 }'])
     end
 
     it 'registers an offense for one object method hash parameter with ' \
        'braces' do
-      inspect_source(cop, ['x.func({ y: "z" })'])
+      inspect_source(cop, 'x.func({ y: "z" })')
       expect(cop.messages).to eq([msg])
       expect(cop.highlights).to eq(['{ y: "z" }'])
     end
 
     it 'registers an offense for one hash parameter with braces' do
-      inspect_source(cop, ['where({ x: 1 })'])
+      inspect_source(cop, 'where({ x: 1 })')
       expect(cop.messages).to eq([msg])
       expect(cop.highlights).to eq(['{ x: 1 }'])
     end
 
     it 'registers an offense for one hash parameter with braces and ' \
        'whitespace' do
-      inspect_source(cop, ["where(  \n { x: 1 }   )"])
+      inspect_source(cop, "where(  \n { x: 1 }   )")
       expect(cop.messages).to eq([msg])
       expect(cop.highlights).to eq(['{ x: 1 }'])
     end
 
     it 'registers an offense for one hash parameter with braces and multiple ' \
        'keys' do
-      inspect_source(cop, ['where({ x: 1, foo: "bar" })'])
+      inspect_source(cop, 'where({ x: 1, foo: "bar" })')
       expect(cop.messages).to eq([msg])
       expect(cop.highlights).to eq(['{ x: 1, foo: "bar" }'])
     end
@@ -157,7 +157,7 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       end
 
       it 'registers an offense for two hash parameters with braces' do
-        inspect_source(cop, ['where({ x: 1 }, { y: 2 })'])
+        inspect_source(cop, 'where({ x: 1 }, { y: 2 })')
         expect(cop.highlights).to eq(['{ y: 2 }'])
       end
     end
@@ -185,7 +185,7 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       include_examples 'no_braces and context_dependent non-offenses'
 
       it 'accepts two hash parameters with braces' do
-        inspect_source(cop, ['where({ x: 1 }, { y: 2 })'])
+        inspect_source(cop, 'where({ x: 1 }, { y: 2 })')
         expect(cop.offenses).to be_empty
       end
     end
@@ -195,7 +195,7 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
 
       it 'registers an offense for one hash parameter with braces and one ' \
          'without' do
-        inspect_source(cop, ['where({ x: 1 }, y: 2)'])
+        inspect_source(cop, 'where({ x: 1 }, y: 2)')
         expect(cop.messages)
           .to eq(['Missing curly braces around a hash parameter.'])
         expect(cop.highlights).to eq(['y: 2'])
@@ -226,11 +226,11 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       after(:each) { expect(cop.offenses).to be_empty }
 
       it 'accepts one hash parameter with braces' do
-        inspect_source(cop, ['where({ x: 1 })'])
+        inspect_source(cop, 'where({ x: 1 })')
       end
 
       it 'accepts multiple hash parameters with braces' do
-        inspect_source(cop, ['where({ x: 1 }, { y: 2 })'])
+        inspect_source(cop, 'where({ x: 1 }, { y: 2 })')
       end
 
       it 'accepts one hash parameter with braces and whitespace' do
@@ -246,19 +246,19 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       end
 
       it 'registers an offense for one hash parameter without braces' do
-        inspect_source(cop, ['where(x: "y")'])
+        inspect_source(cop, 'where(x: "y")')
         expect(cop.highlights).to eq(['x: "y"'])
       end
 
       it 'registers an offense for one hash parameter with multiple keys and ' \
          'without braces' do
-        inspect_source(cop, ['where(x: "y", foo: "bar")'])
+        inspect_source(cop, 'where(x: "y", foo: "bar")')
         expect(cop.highlights).to eq(['x: "y", foo: "bar"'])
       end
 
       it 'registers an offense for one hash parameter without braces with ' \
          'one hash value' do
-        inspect_source(cop, ['where(x: { "y" => "z" })'])
+        inspect_source(cop, 'where(x: { "y" => "z" })')
         expect(cop.highlights).to eq(['x: { "y" => "z" }'])
       end
     end

--- a/spec/rubocop/cop/style/case_equality_spec.rb
+++ b/spec/rubocop/cop/style/case_equality_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Style::CaseEquality do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for ===' do
-    inspect_source(cop, ['Array === var'])
+    inspect_source(cop, 'Array === var')
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['==='])
   end

--- a/spec/rubocop/cop/style/character_literal_spec.rb
+++ b/spec/rubocop/cop/style/character_literal_spec.rb
@@ -6,22 +6,22 @@ describe RuboCop::Cop::Style::CharacterLiteral do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for character literals' do
-    inspect_source(cop, ['x = ?x'])
+    inspect_source(cop, 'x = ?x')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for literals like \n' do
-    inspect_source(cop, ['x = ?\n'])
+    inspect_source(cop, 'x = ?\n')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts literals like ?\C-\M-d' do
-    inspect_source(cop, ['x = ?\C-\M-d'])
+    inspect_source(cop, 'x = ?\C-\M-d')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts ? in a %w literal' do
-    inspect_source(cop, ['%w{? A}'])
+    inspect_source(cop, '%w{? A}')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -9,7 +9,8 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'nested' } }
 
     it 'registers an offense for not nested classes' do
-      inspect_source(cop, ['class FooClass::BarClass', 'end'])
+      inspect_source(cop, ['class FooClass::BarClass',
+                           'end'])
 
       expect(cop.offenses.size).to eq 1
       expect(cop.messages).to eq [
@@ -19,7 +20,8 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
     end
 
     it 'registers an offense for not nested modules' do
-      inspect_source(cop, ['module FooModule::BarModule', 'end'])
+      inspect_source(cop, ['module FooModule::BarModule',
+                           'end'])
 
       expect(cop.offenses.size).to eq 1
       expect(cop.messages).to eq [

--- a/spec/rubocop/cop/style/class_vars_spec.rb
+++ b/spec/rubocop/cop/style/class_vars_spec.rb
@@ -6,14 +6,14 @@ describe RuboCop::Cop::Style::ClassVars do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for class variable declaration' do
-    inspect_source(cop, ['class TestClass; @@test = 10; end'])
+    inspect_source(cop, 'class TestClass; @@test = 10; end')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['Replace class var @@test with a class instance var.'])
   end
 
   it 'does not register an offense for class variable usage' do
-    inspect_source(cop, ['@@test.test(20)'])
+    inspect_source(cop, '@@test.test(20)')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/collection_methods_spec.rb
+++ b/spec/rubocop/cop/style/collection_methods_spec.rb
@@ -17,26 +17,26 @@ describe RuboCop::Cop::Style::CollectionMethods, :config do
 
   cop_config['PreferredMethods'].each do |method, preferred_method|
     it "registers an offense for #{method} with block" do
-      inspect_source(cop, ["[1, 2, 3].#{method} { |e| e + 1 }"])
+      inspect_source(cop, "[1, 2, 3].#{method} { |e| e + 1 }")
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Prefer `#{preferred_method}` over `#{method}`."])
     end
 
     it "registers an offense for #{method} with proc param" do
-      inspect_source(cop, ["[1, 2, 3].#{method}(&:test)"])
+      inspect_source(cop, "[1, 2, 3].#{method}(&:test)")
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Prefer `#{preferred_method}` over `#{method}`."])
     end
 
     it "accepts #{method} with more than 1 param" do
-      inspect_source(cop, ["[1, 2, 3].#{method}(other, &:test)"])
+      inspect_source(cop, "[1, 2, 3].#{method}(other, &:test)")
       expect(cop.offenses).to be_empty
     end
 
     it "accepts #{method} without a block" do
-      inspect_source(cop, ["[1, 2, 3].#{method}"])
+      inspect_source(cop, "[1, 2, 3].#{method}")
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/colon_method_call_spec.rb
+++ b/spec/rubocop/cop/style/colon_method_call_spec.rb
@@ -7,49 +7,49 @@ describe RuboCop::Cop::Style::ColonMethodCall do
 
   it 'registers an offense for instance method call' do
     inspect_source(cop,
-                   ['test::method_name'])
+                   'test::method_name')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for instance method call with arg' do
     inspect_source(cop,
-                   ['test::method_name(arg)'])
+                   'test::method_name(arg)')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for class method call' do
     inspect_source(cop,
-                   ['Class::method_name'])
+                   'Class::method_name')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for class method call with arg' do
     inspect_source(cop,
-                   ['Class::method_name(arg, arg2)'])
+                   'Class::method_name(arg, arg2)')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'does not register an offense for constant access' do
     inspect_source(cop,
-                   ['Tip::Top::SOME_CONST'])
+                   'Tip::Top::SOME_CONST')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for nested class' do
     inspect_source(cop,
-                   ['Tip::Top.some_method'])
+                   'Tip::Top.some_method')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for op methods' do
     inspect_source(cop,
-                   ['Tip::Top.some_method[3]'])
+                   'Tip::Top.some_method[3]')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense when for constructor methods' do
     inspect_source(cop,
-                   ['Tip::Top(some_arg)'])
+                   'Tip::Top(some_arg)')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
   end
 
   it 'registers an offense for a missing colon' do
-    inspect_source(cop, ['# TODO make better'])
+    inspect_source(cop, '# TODO make better')
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
     let(:cop_config) { { 'Keywords' => %w(ISSUE) } }
 
     it 'registers an offense for a missing colon after the word' do
-      inspect_source(cop, ['# ISSUE wrong order'])
+      inspect_source(cop, '# ISSUE wrong order')
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
     let(:output) { StringIO.new }
 
     it 'marks the annotation keyword' do
-      inspect_source(cop, ['# TODO:make better'])
+      inspect_source(cop, '# TODO:make better')
       formatter.report_file('t', cop.offenses)
       expect(output.string).to eq(["t:1:3: C: #{described_class::MSG}",
                                    '# TODO:make better',
@@ -37,32 +37,32 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
   end
 
   it 'registers an offense for lower case' do
-    inspect_source(cop, ['# fixme: does not work'])
+    inspect_source(cop, '# fixme: does not work')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for capitalized annotation keyword' do
-    inspect_source(cop, ['# Optimize: does not work'])
+    inspect_source(cop, '# Optimize: does not work')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for upper case with colon but no note' do
-    inspect_source(cop, ['# HACK:'])
+    inspect_source(cop, '# HACK:')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts upper case keyword with colon, space and note' do
-    inspect_source(cop, ['# REVIEW: not sure about this'])
+    inspect_source(cop, '# REVIEW: not sure about this')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts upper case keyword alone' do
-    inspect_source(cop, ['# OPTIMIZE'])
+    inspect_source(cop, '# OPTIMIZE')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a comment that is obviously a code example' do
-    inspect_source(cop, ['# Todo.destroy(1)'])
+    inspect_source(cop, '# Todo.destroy(1)')
     expect(cop.offenses).to be_empty
   end
 
@@ -79,7 +79,7 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
     end
 
     it 'accepts the word without colon' do
-      inspect_source(cop, ['# TODO make better'])
+      inspect_source(cop, '# TODO make better')
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/constant_name_spec.rb
+++ b/spec/rubocop/cop/style/constant_name_spec.rb
@@ -7,37 +7,37 @@ describe RuboCop::Cop::Style::ConstantName do
 
   it 'registers an offense for camel case in const name' do
     inspect_source(cop,
-                   ['TopCase = 5'])
+                   'TopCase = 5')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers offenses for camel case in multiple const assignment' do
     inspect_source(cop,
-                   ['TopCase, Test2, TEST_3 = 5, 6, 7'])
+                   'TopCase, Test2, TEST_3 = 5, 6, 7')
     expect(cop.offenses.size).to eq(2)
   end
 
   it 'registers an offense for snake case in const name' do
     inspect_source(cop,
-                   ['TOP_test = 5'])
+                   'TOP_test = 5')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'allows screaming snake case in const name' do
     inspect_source(cop,
-                   ['TOP_TEST = 5'])
+                   'TOP_TEST = 5')
     expect(cop.offenses).to be_empty
   end
 
   it 'allows screaming snake case in multiple const assignment' do
     inspect_source(cop,
-                   ['TOP_TEST, TEST_2 = 5, 6'])
+                   'TOP_TEST, TEST_2 = 5, 6')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not check names if rhs is a method call' do
     inspect_source(cop,
-                   ['AnythingGoes = test'])
+                   'AnythingGoes = test')
     expect(cop.offenses).to be_empty
   end
 
@@ -52,7 +52,7 @@ describe RuboCop::Cop::Style::ConstantName do
 
   it 'does not check if rhs is another constant' do
     inspect_source(cop,
-                   ['Parser::CurrentRuby = Parser::Ruby20'])
+                   'Parser::CurrentRuby = Parser::Ruby20')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/deprecated_hash_methods_spec.rb
+++ b/spec/rubocop/cop/style/deprecated_hash_methods_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Style::DeprecatedHashMethods do
 
   it 'registers an offense for has_key? with one arg' do
     inspect_source(cop,
-                   ['o.has_key?(o)'])
+                   'o.has_key?(o)')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['`Hash#has_key?` is deprecated in favor of `Hash#key?`.'])
@@ -15,13 +15,13 @@ describe RuboCop::Cop::Style::DeprecatedHashMethods do
 
   it 'accepts has_key? with no args' do
     inspect_source(cop,
-                   ['o.has_key?'])
+                   'o.has_key?')
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for has_value? with one arg' do
     inspect_source(cop,
-                   ['o.has_value?(o)'])
+                   'o.has_value?(o)')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['`Hash#has_value?` is deprecated in favor of `Hash#value?`.'])
@@ -29,7 +29,7 @@ describe RuboCop::Cop::Style::DeprecatedHashMethods do
 
   it 'accepts has_value? with no args' do
     inspect_source(cop,
-                   ['o.has_value?'])
+                   'o.has_value?')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/dot_position_spec.rb
+++ b/spec/rubocop/cop/style/dot_position_spec.rb
@@ -32,17 +32,18 @@ describe RuboCop::Cop::Style::DotPosition, :config do
     end
 
     it 'does not err on method call with no dots' do
-      inspect_source(cop, ['puts something'])
+      inspect_source(cop, 'puts something')
       expect(cop.offenses).to be_empty
     end
 
     it 'does not err on method call without a method name' do
-      inspect_source(cop, ['l.', '(1)'])
+      inspect_source(cop, ['l.',
+                           '(1)'])
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'does not err on method call on same line' do
-      inspect_source(cop, ['something.method_name'])
+      inspect_source(cop, 'something.method_name')
       expect(cop.offenses).to be_empty
     end
 
@@ -92,17 +93,18 @@ describe RuboCop::Cop::Style::DotPosition, :config do
     end
 
     it 'does not err on method call with no dots' do
-      inspect_source(cop, ['puts something'])
+      inspect_source(cop, 'puts something')
       expect(cop.offenses).to be_empty
     end
 
     it 'does not err on method call without a method name' do
-      inspect_source(cop, ['l', '.(1)'])
+      inspect_source(cop, ['l',
+                           '.(1)'])
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'does not err on method call on same line' do
-      inspect_source(cop, ['something.method_name'])
+      inspect_source(cop, 'something.method_name')
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -62,12 +62,12 @@ describe RuboCop::Cop::Style::EachWithObject do
   end
 
   it 'ignores inject and reduce passed in symbol' do
-    inspect_source(cop, ['[].inject(:+)', '[].reduce(:+)'])
+    inspect_source(cop, '[].inject(:+)', '[].reduce(:+)')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not blow up for reduce with no arguments' do
-    inspect_source(cop, ['[1, 2, 3].inject { |a, e| a + e }'])
+    inspect_source(cop, '[1, 2, 3].inject { |a, e| a + e }')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/else_alignment_spec.rb
+++ b/spec/rubocop/cop/style/else_alignment_spec.rb
@@ -12,8 +12,7 @@ describe RuboCop::Cop::Style::ElseAlignment do
   end
 
   it 'accepts a ternary if' do
-    inspect_source(cop,
-                   ['cond ? func1 : func2'])
+    inspect_source(cop, 'cond ? func1 : func2')
     expect(cop.offenses).to be_empty
   end
 
@@ -64,8 +63,7 @@ describe RuboCop::Cop::Style::ElseAlignment do
     end
 
     it 'accepts a one line if statement' do
-      inspect_source(cop,
-                     ['if cond then func1 else func2 end'])
+      inspect_source(cop, 'if cond then func1 else func2 end')
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/empty_lines_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Style::EmptyLines do
 
   it 'works when there are no tokens' do
     inspect_source(cop,
-                   ['#comment'])
+                   '#comment')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Style::EmptyLiteral do
   describe 'Empty Array' do
     it 'registers an offense for Array.new()' do
       inspect_source(cop,
-                     ['test = Array.new()'])
+                     'test = Array.new()')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Use array literal `[]` instead of `Array.new`.'])
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Style::EmptyLiteral do
 
     it 'registers an offense for Array.new' do
       inspect_source(cop,
-                     ['test = Array.new'])
+                     'test = Array.new')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Use array literal `[]` instead of `Array.new`.'])
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Style::EmptyLiteral do
 
     it 'does not register an offense for Array.new(3)' do
       inspect_source(cop,
-                     ['test = Array.new(3)'])
+                     'test = Array.new(3)')
       expect(cop.offenses).to be_empty
     end
 
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Style::EmptyLiteral do
   describe 'Empty Hash' do
     it 'registers an offense for Hash.new()' do
       inspect_source(cop,
-                     ['test = Hash.new()'])
+                     'test = Hash.new()')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Use hash literal `{}` instead of `Hash.new`.'])
@@ -45,7 +45,7 @@ describe RuboCop::Cop::Style::EmptyLiteral do
 
     it 'registers an offense for Hash.new' do
       inspect_source(cop,
-                     ['test = Hash.new'])
+                     'test = Hash.new')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Use hash literal `{}` instead of `Hash.new`.'])
@@ -53,13 +53,13 @@ describe RuboCop::Cop::Style::EmptyLiteral do
 
     it 'does not register an offense for Hash.new(3)' do
       inspect_source(cop,
-                     ['test = Hash.new(3)'])
+                     'test = Hash.new(3)')
       expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense for Hash.new { block }' do
       inspect_source(cop,
-                     ['test = Hash.new { block }'])
+                     'test = Hash.new { block }')
       expect(cop.offenses).to be_empty
     end
 
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Style::EmptyLiteral do
   describe 'Empty String' do
     it 'registers an offense for String.new()' do
       inspect_source(cop,
-                     ['test = String.new()'])
+                     'test = String.new()')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Use string literal `''` instead of `String.new`."])
@@ -80,7 +80,7 @@ describe RuboCop::Cop::Style::EmptyLiteral do
 
     it 'registers an offense for String.new' do
       inspect_source(cop,
-                     ['test = String.new'])
+                     'test = String.new')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Use string literal `''` instead of `String.new`."])
@@ -88,7 +88,7 @@ describe RuboCop::Cop::Style::EmptyLiteral do
 
     it 'does not register an offense for String.new("top")' do
       inspect_source(cop,
-                     ['test = String.new("top")'])
+                     'test = String.new("top")')
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -12,14 +12,14 @@ describe RuboCop::Cop::Style::Encoding, :config do
 
     it 'registers no offense when no encoding present but only ASCII ' \
        'characters' do
-      inspect_source(cop, ['def foo() end'])
+      inspect_source(cop, 'def foo() end')
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense when there is no encoding present but non ' \
        'ASCII characters' do
-      inspect_source(cop, ['def foo() \'ä\' end'])
+      inspect_source(cop, 'def foo() \'ä\' end')
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(
@@ -86,7 +86,7 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'registers an offense when no encoding present' do
-      inspect_source(cop, ['def foo() end'])
+      inspect_source(cop, 'def foo() end')
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(

--- a/spec/rubocop/cop/style/end_of_line_spec.rb
+++ b/spec/rubocop/cop/style/end_of_line_spec.rb
@@ -57,7 +57,7 @@ describe RuboCop::Cop::Style::EndOfLine do
 
   context 'when source is a string' do
     it 'registers an offense' do
-      inspect_source(cop, ["x=0\r"])
+      inspect_source(cop, "x=0\r")
 
       expect(cop.messages).to eq(['Carriage return character detected.'])
     end

--- a/spec/rubocop/cop/style/even_odd_spec.rb
+++ b/spec/rubocop/cop/style/even_odd_spec.rb
@@ -7,69 +7,69 @@ describe RuboCop::Cop::Style::EvenOdd do
 
   it 'registers an offense for x % 2 == 0' do
     inspect_source(cop,
-                   ['x % 2 == 0'])
+                   'x % 2 == 0')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Replace with `Fixnum#even?`.'])
   end
 
   it 'registers an offense for x % 2 != 0' do
     inspect_source(cop,
-                   ['x % 2 != 0'])
+                   'x % 2 != 0')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Replace with `Fixnum#odd?`.'])
   end
 
   it 'registers an offense for (x % 2) == 0' do
     inspect_source(cop,
-                   ['(x % 2) == 0'])
+                   '(x % 2) == 0')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Replace with `Fixnum#even?`.'])
   end
 
   it 'registers an offense for (x % 2) != 0' do
     inspect_source(cop,
-                   ['(x % 2) != 0'])
+                   '(x % 2) != 0')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Replace with `Fixnum#odd?`.'])
   end
 
   it 'registers an offense for x % 2 == 1' do
     inspect_source(cop,
-                   ['x % 2 == 1'])
+                   'x % 2 == 1')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Replace with `Fixnum#odd?`.'])
   end
 
   it 'registers an offense for x % 2 != 1' do
     inspect_source(cop,
-                   ['x % 2 != 1'])
+                   'x % 2 != 1')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Replace with `Fixnum#even?`.'])
   end
 
   it 'registers an offense for (x % 2) == 1' do
     inspect_source(cop,
-                   ['(x % 2) == 1'])
+                   '(x % 2) == 1')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Replace with `Fixnum#odd?`.'])
   end
 
   it 'registers an offense for (x % 2) != 1' do
     inspect_source(cop,
-                   ['(x % 2) != 1'])
+                   '(x % 2) != 1')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Replace with `Fixnum#even?`.'])
   end
 
   it 'accepts x % 3 == 0' do
     inspect_source(cop,
-                   ['x % 3 == 0'])
+                   'x % 3 == 0')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts x % 3 != 0' do
     inspect_source(cop,
-                   ['x % 3 != 0'])
+                   'x % 3 != 0')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/style/extra_spacing_spec.rb
@@ -6,17 +6,17 @@ describe RuboCop::Cop::Style::ExtraSpacing do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for double extra spacing on variable assignment' do
-    inspect_source(cop, ['m    = "hello"'])
+    inspect_source(cop, 'm    = "hello"')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'ignores whitespace at the beginning of the line' do
-    inspect_source(cop, ['  m = "hello"'])
+    inspect_source(cop, '  m = "hello"')
     expect(cop.offenses.size).to eq(0)
   end
 
   it 'ignores whitespace inside a string' do
-    inspect_source(cop, ['m = "hello   this"'])
+    inspect_source(cop, 'm = "hello   this"')
     expect(cop.offenses.size).to eq(0)
   end
 

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -45,12 +45,12 @@ describe RuboCop::Cop::Style::For, :config do
     end
 
     it 'accepts :for' do
-      inspect_source(cop, ['[:for, :ala, :bala]'])
+      inspect_source(cop, '[:for, :ala, :bala]')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts def for' do
-      inspect_source(cop, ['def for; end'])
+      inspect_source(cop, 'def for; end')
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Style::FormatString, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'sprintf' } }
     it 'registers an offense for a string followed by something' do
       inspect_source(cop,
-                     ['puts "%d" % 10'])
+                     'puts "%d" % 10')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Favor `sprintf` over `String#%`.'])
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Style::FormatString, :config do
 
     it 'registers an offense for something followed by an array' do
       inspect_source(cop,
-                     ['puts x % [10, 11]'])
+                     'puts x % [10, 11]')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Favor `sprintf` over `String#%`.'])
@@ -25,23 +25,23 @@ describe RuboCop::Cop::Style::FormatString, :config do
 
     it 'does not register an offense for numbers' do
       inspect_source(cop,
-                     ['puts 10 % 4'])
+                     'puts 10 % 4')
       expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense for ambiguous cases' do
       inspect_source(cop,
-                     ['puts x % 4'])
+                     'puts x % 4')
       expect(cop.offenses).to be_empty
 
       inspect_source(cop,
-                     ['puts x % Y'])
+                     'puts x % Y')
       expect(cop.offenses).to be_empty
     end
 
     it 'works if the first operand contains embedded expressions' do
       inspect_source(cop,
-                     ['puts "#{x * 5} %d #{@test}" % 10'])
+                     'puts "#{x * 5} %d #{@test}" % 10')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Favor `sprintf` over `String#%`.'])
@@ -49,7 +49,7 @@ describe RuboCop::Cop::Style::FormatString, :config do
 
     it 'registers an offense for format' do
       inspect_source(cop,
-                     ['format(something, a, b)'])
+                     'format(something, a, b)')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Favor `sprintf` over `format`.'])
@@ -61,7 +61,7 @@ describe RuboCop::Cop::Style::FormatString, :config do
 
     it 'registers an offense for a string followed by something' do
       inspect_source(cop,
-                     ['puts "%d" % 10'])
+                     'puts "%d" % 10')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Favor `format` over `String#%`.'])
@@ -69,7 +69,7 @@ describe RuboCop::Cop::Style::FormatString, :config do
 
     it 'registers an offense for something followed by an array' do
       inspect_source(cop,
-                     ['puts x % [10, 11]'])
+                     'puts x % [10, 11]')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Favor `format` over `String#%`.'])
@@ -77,23 +77,23 @@ describe RuboCop::Cop::Style::FormatString, :config do
 
     it 'does not register an offense for numbers' do
       inspect_source(cop,
-                     ['puts 10 % 4'])
+                     'puts 10 % 4')
       expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense for ambiguous cases' do
       inspect_source(cop,
-                     ['puts x % 4'])
+                     'puts x % 4')
       expect(cop.offenses).to be_empty
 
       inspect_source(cop,
-                     ['puts x % Y'])
+                     'puts x % Y')
       expect(cop.offenses).to be_empty
     end
 
     it 'works if the first operand contains embedded expressions' do
       inspect_source(cop,
-                     ['puts "#{x * 5} %d #{@test}" % 10'])
+                     'puts "#{x * 5} %d #{@test}" % 10')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Favor `format` over `String#%`.'])
@@ -101,7 +101,7 @@ describe RuboCop::Cop::Style::FormatString, :config do
 
     it 'registers an offense for sprintf' do
       inspect_source(cop,
-                     ['sprintf(something, a, b)'])
+                     'sprintf(something, a, b)')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Favor `format` over `sprintf`.'])
@@ -113,7 +113,7 @@ describe RuboCop::Cop::Style::FormatString, :config do
 
     it 'registers an offense for format' do
       inspect_source(cop,
-                     ['format(something, a, b)'])
+                     'format(something, a, b)')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Favor `String#%` over `format`.'])
@@ -121,7 +121,7 @@ describe RuboCop::Cop::Style::FormatString, :config do
 
     it 'registers an offense for sprintf' do
       inspect_source(cop,
-                     ['sprintf(something, a, b)'])
+                     'sprintf(something, a, b)')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Favor `String#%` over `sprintf`.'])
@@ -129,31 +129,31 @@ describe RuboCop::Cop::Style::FormatString, :config do
 
     it 'accepts format with 1 argument' do
       inspect_source(cop,
-                     ['format :xml'])
+                     'format :xml')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts sprintf with 1 argument' do
       inspect_source(cop,
-                     ['sprintf :xml'])
+                     'sprintf :xml')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts format without arguments' do
       inspect_source(cop,
-                     ['format'])
+                     'format')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts sprintf without arguments' do
       inspect_source(cop,
-                     ['sprintf'])
+                     'sprintf')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts String#%' do
       inspect_source(cop,
-                     ['puts "%d" % 10'])
+                     'puts "%d" % 10')
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/global_vars_spec.rb
+++ b/spec/rubocop/cop/style/global_vars_spec.rb
@@ -11,24 +11,24 @@ describe RuboCop::Cop::Style::GlobalVars, :config do
   let(:cop_config) { cop_config }
 
   it 'registers an offense for $custom' do
-    inspect_source(cop, ['puts $custom'])
+    inspect_source(cop, 'puts $custom')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'allows user whitelisted variables' do
-    inspect_source(cop, ['puts $allowed'])
+    inspect_source(cop, 'puts $allowed')
     expect(cop.offenses).to be_empty
   end
 
   described_class::BUILT_IN_VARS.each do |var|
     it "does not register an offense for built-in variable #{var}" do
-      inspect_source(cop, ["puts #{var}"])
+      inspect_source(cop, "puts #{var}")
       expect(cop.offenses).to be_empty
     end
   end
 
   it 'does not register an offense for backrefs like $1' do
-    inspect_source(cop, ['puts $1'])
+    inspect_source(cop, 'puts $1')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -17,55 +17,55 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'registers offense for hash rocket syntax when new is possible' do
-      inspect_source(cop, ['x = { :a => 0 }'])
+      inspect_source(cop, 'x = { :a => 0 }')
       expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
       expect(cop.config_to_allow_offenses)
         .to eq('EnforcedStyle' => 'hash_rockets')
     end
 
     it 'registers an offense for mixed syntax when new is possible' do
-      inspect_source(cop, ['x = { :a => 0, b: 1 }'])
+      inspect_source(cop, 'x = { :a => 0, b: 1 }')
       expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for hash rockets in method calls' do
-      inspect_source(cop, ['func(3, :a => 0)'])
+      inspect_source(cop, 'func(3, :a => 0)')
       expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
     end
 
     it 'accepts hash rockets when keys have different types' do
-      inspect_source(cop, ['x = { :a => 0, "b" => 1 }'])
+      inspect_source(cop, 'x = { :a => 0, "b" => 1 }')
       expect(cop.messages).to be_empty
     end
 
     it 'accepts hash rockets when keys have whitespaces in them' do
-      inspect_source(cop, ['x = { :"t o" => 0 }'])
+      inspect_source(cop, 'x = { :"t o" => 0 }')
       expect(cop.messages).to be_empty
     end
 
     it 'accepts hash rockets when keys have special symbols in them' do
-      inspect_source(cop, ['x = { :"\tab" => 1 }'])
+      inspect_source(cop, 'x = { :"\tab" => 1 }')
       expect(cop.messages).to be_empty
     end
 
     it 'accepts hash rockets when keys start with a digit' do
-      inspect_source(cop, ['x = { :"1" => 1 }'])
+      inspect_source(cop, 'x = { :"1" => 1 }')
       expect(cop.messages).to be_empty
     end
 
     it 'registers offense when keys start with an uppercase letter' do
-      inspect_source(cop, ['x = { :A => 0 }'])
+      inspect_source(cop, 'x = { :A => 0 }')
       expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
     end
 
     it 'accepts new syntax in a hash literal' do
-      inspect_source(cop, ['x = { a: 0, b: 1 }'])
+      inspect_source(cop, 'x = { a: 0, b: 1 }')
       expect(cop.messages).to be_empty
     end
 
     it 'accepts new syntax in method calls' do
-      inspect_source(cop, ['func(3, a: 0)'])
+      inspect_source(cop, 'func(3, a: 0)')
       expect(cop.messages).to be_empty
     end
 
@@ -103,29 +103,29 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'hash_rockets' } }
 
     it 'registers offense for Ruby 1.9 style' do
-      inspect_source(cop, ['x = { a: 0 }'])
+      inspect_source(cop, 'x = { a: 0 }')
       expect(cop.messages).to eq(['Always use hash rockets in hashes.'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'ruby19')
     end
 
     it 'registers an offense for mixed syntax' do
-      inspect_source(cop, ['x = { :a => 0, b: 1 }'])
+      inspect_source(cop, 'x = { :a => 0, b: 1 }')
       expect(cop.messages).to eq(['Always use hash rockets in hashes.'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for 1.9 style in method calls' do
-      inspect_source(cop, ['func(3, a: 0)'])
+      inspect_source(cop, 'func(3, a: 0)')
       expect(cop.messages).to eq(['Always use hash rockets in hashes.'])
     end
 
     it 'accepts hash rockets in a hash literal' do
-      inspect_source(cop, ['x = { :a => 0, :b => 1 }'])
+      inspect_source(cop, 'x = { :a => 0, :b => 1 }')
       expect(cop.messages).to be_empty
     end
 
     it 'accepts hash rockets in method calls' do
-      inspect_source(cop, ['func(3, :a => 0)'])
+      inspect_source(cop, 'func(3, :a => 0)')
       expect(cop.messages).to be_empty
     end
 

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -6,13 +6,13 @@ describe RuboCop::Cop::Style::IfWithSemicolon do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for one line if/;/end' do
-    inspect_source(cop, ['if cond; run else dont end'])
+    inspect_source(cop, 'if cond; run else dont end')
     expect(cop.messages).to eq(
       ['Do not use if x; Use the ternary operator instead.'])
   end
 
   it 'accepts one line if/then/end' do
-    inspect_source(cop, ['if cond then run else dont end'])
+    inspect_source(cop, 'if cond then run else dont end')
     expect(cop.messages).to be_empty
   end
 

--- a/spec/rubocop/cop/style/indent_array_spec.rb
+++ b/spec/rubocop/cop/style/indent_array_spec.rb
@@ -106,14 +106,12 @@ describe RuboCop::Cop::Style::IndentArray do
   end
 
   it 'accepts single line array' do
-    inspect_source(cop,
-                   ['a = [1, 2]'])
+    inspect_source(cop, 'a = [1, 2]')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts an empty array' do
-    inspect_source(cop,
-                   ['a = []'])
+    inspect_source(cop, 'a = []')
     expect(cop.offenses).to be_empty
   end
 
@@ -150,8 +148,7 @@ describe RuboCop::Cop::Style::IndentArray do
 
     context 'and arguments are not surrounded by parentheses' do
       it 'accepts single line array' do
-        inspect_source(cop,
-                       ['func x, [1, 2]'])
+        inspect_source(cop, 'func x, [1, 2]')
         expect(cop.offenses).to be_empty
       end
 

--- a/spec/rubocop/cop/style/indent_hash_spec.rb
+++ b/spec/rubocop/cop/style/indent_hash_spec.rb
@@ -202,13 +202,13 @@ describe RuboCop::Cop::Style::IndentHash do
 
     it 'accepts single line hash' do
       inspect_source(cop,
-                     ['a = { a: 1, b: 2 }'])
+                     'a = { a: 1, b: 2 }')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an empty hash' do
       inspect_source(cop,
-                     ['a = {}'])
+                     'a = {}')
       expect(cop.offenses).to be_empty
     end
   end
@@ -334,13 +334,13 @@ describe RuboCop::Cop::Style::IndentHash do
     context 'and argument are not surrounded by parentheses' do
       it 'accepts braceless hash' do
         inspect_source(cop,
-                       ['func a: 1, b: 2'])
+                       'func a: 1, b: 2')
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts single line hash with braces' do
         inspect_source(cop,
-                       ['func x, { a: 1, b: 2 }'])
+                       'func x, { a: 1, b: 2 }')
         expect(cop.offenses).to be_empty
       end
 

--- a/spec/rubocop/cop/style/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/style/indentation_consistency_spec.rb
@@ -60,8 +60,7 @@ describe RuboCop::Cop::Style::IndentationConsistency do
     end
 
     it 'accepts a one line if statement' do
-      inspect_source(cop,
-                     ['if cond then func1 else func2 end'])
+      inspect_source(cop, 'if cond then func1 else func2 end')
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -235,8 +235,7 @@ describe RuboCop::Cop::Style::IndentationWidth do
       end
 
       it 'accepts a one line if statement' do
-        inspect_source(cop,
-                       ['if cond then func1 else func2 end'])
+        inspect_source(cop, 'if cond then func1 else func2 end')
         expect(cop.offenses).to be_empty
       end
 

--- a/spec/rubocop/cop/style/infinite_loop_spec.rb
+++ b/spec/rubocop/cop/style/infinite_loop_spec.rb
@@ -29,7 +29,7 @@ describe RuboCop::Cop::Style::InfiniteLoop do
 
   it 'accepts Kernel#loop' do
     inspect_source(cop,
-                   ['loop { break if something }'])
+                   'loop { break if something }')
 
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::Style::LambdaCall, :config do
 
     it 'registers an offense for x.()' do
       inspect_source(cop,
-                     ['x.(a, b)'])
+                     'x.(a, b)')
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'braces')
     end
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Style::LambdaCall, :config do
     end
 
     it 'accepts x.call()' do
-      inspect_source(cop, ['x.call(a, b)'])
+      inspect_source(cop, 'x.call(a, b)')
       expect(cop.offenses).to be_empty
     end
 
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Style::LambdaCall, :config do
 
     it 'registers an offense for x.call()' do
       inspect_source(cop,
-                     ['x.call(a, b)'])
+                     'x.call(a, b)')
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'call')
     end
@@ -53,7 +53,7 @@ describe RuboCop::Cop::Style::LambdaCall, :config do
     end
 
     it 'accepts x.()' do
-      inspect_source(cop, ['x.(a, b)'])
+      inspect_source(cop, 'x.(a, b)')
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Style::Lambda do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for an old single-line lambda call' do
-    inspect_source(cop, ['f = lambda { |x| x }'])
+    inspect_source(cop, 'f = lambda { |x| x }')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['Use the new lambda literal syntax `->(params) {...}`.'])
@@ -35,7 +35,7 @@ describe RuboCop::Cop::Style::Lambda do
   end
 
   it 'accepts the lambda call outside of block' do
-    inspect_source(cop, ['l = lambda.test'])
+    inspect_source(cop, 'l = lambda.test')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/style/leading_comment_space_spec.rb
@@ -6,32 +6,27 @@ describe RuboCop::Cop::Style::LeadingCommentSpace do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for comment without leading space' do
-    inspect_source(cop,
-                   ['#missing space'])
+    inspect_source(cop, '#missing space')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'does not register an offense for # followed by no text' do
-    inspect_source(cop,
-                   ['#'])
+    inspect_source(cop, '#')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for more than one space' do
-    inspect_source(cop,
-                   ['#   heavily indented'])
+    inspect_source(cop, '#   heavily indented')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for more than one #' do
-    inspect_source(cop,
-                   ['###### heavily indented'])
+    inspect_source(cop, '###### heavily indented')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for only #s' do
-    inspect_source(cop,
-                   ['######'])
+    inspect_source(cop, '######')
     expect(cop.offenses).to be_empty
   end
 
@@ -43,8 +38,8 @@ describe RuboCop::Cop::Style::LeadingCommentSpace do
   end
 
   it 'registers an offense for #! after the first line' do
-    inspect_source(cop,
-                   ['test', '#!/usr/bin/ruby'])
+    inspect_source(cop, ['test',
+                         '#!/usr/bin/ruby'])
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -69,7 +69,7 @@ describe RuboCop::Cop::Style::LineEndConcatenation do
 
   it 'accepts string concat on the same line' do
     inspect_source(cop,
-                   ['top = "test" + "top"'])
+                   'top = "test" + "top"')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/method_call_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_parentheses_spec.rb
@@ -9,22 +9,22 @@ describe RuboCop::Cop::Style::MethodCallParentheses, :config do
   end
 
   it 'registers an offense for parens in method call without args' do
-    inspect_source(cop, ['top.test()'])
+    inspect_source(cop, 'top.test()')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts parentheses for methods starting with an upcase letter' do
-    inspect_source(cop, ['Test()'])
+    inspect_source(cop, 'Test()')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts no parens in method call without args' do
-    inspect_source(cop, ['top.test'])
+    inspect_source(cop, 'top.test')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts parens in method call with args' do
-    inspect_source(cop, ['top.test(a)'])
+    inspect_source(cop, 'top.test(a)')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/method_called_on_do_end_block_spec.rb
+++ b/spec/rubocop/cop/style/method_called_on_do_end_block_spec.rb
@@ -33,13 +33,13 @@ describe RuboCop::Cop::Style::MethodCalledOnDoEndBlock do
 
   context 'with a single-line do..end block' do
     it 'registers an offense for a chained call' do
-      inspect_source(cop, ['a do b end.c'])
+      inspect_source(cop, 'a do b end.c')
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['end.c'])
     end
 
     it 'accepts a single-line do..end block with a chained block' do
-      inspect_source(cop, ['a do b end.c do d end'])
+      inspect_source(cop, 'a do b end.c do d end')
       expect(cop.offenses).to be_empty
     end
   end
@@ -53,7 +53,7 @@ describe RuboCop::Cop::Style::MethodCalledOnDoEndBlock do
     end
 
     it 'accepts a single-line block with a chained call' do
-      inspect_source(cop, ['a { b }.c'])
+      inspect_source(cop, 'a { b }.c')
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/method_name_spec.rb
+++ b/spec/rubocop/cop/style/method_name_spec.rb
@@ -118,7 +118,7 @@ describe RuboCop::Cop::Style::MethodName, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'other' } }
 
     it 'fails' do
-      expect { inspect_source(cop, ['def a', 'end']) }
+      expect { inspect_source(cop, 'def a', 'end') }
         .to raise_error(RuntimeError)
     end
   end

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Style::MultilineTernaryOperator do
   end
 
   it 'accepts a single line ternary operator expression' do
-    inspect_source(cop, ['a = cond ? b : c'])
+    inspect_source(cop, 'a = cond ? b : c')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Style::NestedTernaryOperator do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for a nested ternary operator expression' do
-    inspect_source(cop, ['a ? (b ? b1 : b2) : a2'])
+    inspect_source(cop, 'a ? (b ? b1 : b2) : a2')
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -7,19 +7,19 @@ describe RuboCop::Cop::Style::NumericLiterals, :config do
   let(:cop_config) { { 'MinDigits' => 5 } }
 
   it 'registers an offense for a long undelimited integer' do
-    inspect_source(cop, ['a = 12345'])
+    inspect_source(cop, 'a = 12345')
     expect(cop.offenses.size).to eq(1)
     expect(cop.config_to_allow_offenses).to eq('MinDigits' => 6)
   end
 
   it 'registers an offense for a float with a long undelimited integer part' do
-    inspect_source(cop, ['a = 123456.789'])
+    inspect_source(cop, 'a = 123456.789')
     expect(cop.offenses.size).to eq(1)
     expect(cop.config_to_allow_offenses).to eq('MinDigits' => 7)
   end
 
   it 'registers an offense for an integer with misplaced underscore' do
-    inspect_source(cop, ['a = 123_456_78_90_00'])
+    inspect_source(cop, 'a = 123_456_78_90_00')
     expect(cop.offenses.size).to eq(1)
     expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
   end
@@ -31,12 +31,12 @@ describe RuboCop::Cop::Style::NumericLiterals, :config do
   end
 
   it 'accepts a short integer without underscore' do
-    inspect_source(cop, ['a = 123'])
+    inspect_source(cop, 'a = 123')
     expect(cop.messages).to be_empty
   end
 
   it 'does not count a leading minus sign as a digit' do
-    inspect_source(cop, ['a = -1230'])
+    inspect_source(cop, 'a = -1230')
     expect(cop.messages).to be_empty
   end
 

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Style::OneLineConditional do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for one line if/then/end' do
-    inspect_source(cop, ['if cond then run else dont end'])
+    inspect_source(cop, 'if cond then run else dont end')
     expect(cop.messages).to eq(['Favor the ternary operator (?:)' \
                                 ' over if/then/else/end constructs.'])
   end

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -88,7 +88,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
   end
 
   it 'is not confused by leading parenthesis in subexpression' do
-    inspect_source(cop, ['(a > b) && other ? one : two'])
+    inspect_source(cop, '(a > b) && other ? one : two')
     expect(cop.offenses).to be_empty
   end
 
@@ -107,7 +107,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
   end
 
   it 'does not blow up when the condition is a ternary op' do
-    inspect_source(cop, ['x if (a ? b : c)'])
+    inspect_source(cop, 'x if (a ? b : c)')
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -23,12 +23,12 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
   context '`%` interpolated string' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, ['%[string]'])
+      inspect_source(cop, '%[string]')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, ['%(string)'])
+      inspect_source(cop, '%(string)')
       expect(cop.messages).to eq([
         '`%`-literals should be delimited by `[` and `]`'
       ])
@@ -36,25 +36,25 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source(cop, ['%([string])'])
+      inspect_source(cop, '%([string])')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters ' \
        'when containing preferred delimiter characters in interpolation' do
-      inspect_source(cop, ['%(#{[1].first})'])
+      inspect_source(cop, '%(#{[1].first})')
       expect(cop.messages.size).to eq(1)
     end
   end
 
   context '`%q` string' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, ['%q[string]'])
+      inspect_source(cop, '%q[string]')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, ['%q(string)'])
+      inspect_source(cop, '%q(string)')
       expect(cop.messages).to eq([
         '`%q`-literals should be delimited by `[` and `]`'
       ])
@@ -62,19 +62,19 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source(cop, ['%q([string])'])
+      inspect_source(cop, '%q([string])')
       expect(cop.offenses).to be_empty
     end
   end
 
   context '`%Q` interpolated string' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, ['%Q[string]'])
+      inspect_source(cop, '%Q[string]')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, ['%Q(string)'])
+      inspect_source(cop, '%Q(string)')
       expect(cop.messages).to eq([
         '`%Q`-literals should be delimited by `[` and `]`'
       ])
@@ -82,25 +82,25 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source(cop, ['%Q([string])'])
+      inspect_source(cop, '%Q([string])')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters ' \
        'when containing preferred delimiter characters in interpolation' do
-      inspect_source(cop, ['%Q(#{[1].first})'])
+      inspect_source(cop, '%Q(#{[1].first})')
       expect(cop.messages.size).to eq(1)
     end
   end
 
   context '`%w` string array' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, ['%w[some words]'])
+      inspect_source(cop, '%w[some words]')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, ['%w(some words)'])
+      inspect_source(cop, '%w(some words)')
       expect(cop.messages).to eq([
         '`%w`-literals should be delimited by `[` and `]`'
       ])
@@ -108,19 +108,19 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source(cop, ['%w([some] [words])'])
+      inspect_source(cop, '%w([some] [words])')
       expect(cop.offenses).to be_empty
     end
   end
 
   context '`%W` interpolated string array' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, ['%W[some words]'])
+      inspect_source(cop, '%W[some words]')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, ['%W(some words)'])
+      inspect_source(cop, '%W(some words)')
       expect(cop.messages).to eq([
         '`%W`-literals should be delimited by `[` and `]`'
       ])
@@ -128,25 +128,25 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source(cop, ['%W([some] [words])'])
+      inspect_source(cop, '%W([some] [words])')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters ' \
        'when containing preferred delimiter characters in interpolation' do
-      inspect_source(cop, ['%W(#{[1].first})'])
+      inspect_source(cop, '%W(#{[1].first})')
       expect(cop.messages.size).to eq(1)
     end
   end
 
   context '`%r` interpolated regular expression' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, ['%r[regexp]'])
+      inspect_source(cop, '%r[regexp]')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, ['%r(regexp)'])
+      inspect_source(cop, '%r(regexp)')
       expect(cop.messages).to eq([
         '`%r`-literals should be delimited by `[` and `]`'
       ])
@@ -154,25 +154,25 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source(cop, ['%r([regexp])'])
+      inspect_source(cop, '%r([regexp])')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters ' \
        'when containing preferred delimiter characters in interpolation' do
-      inspect_source(cop, ['%r(#{[1].first})'])
+      inspect_source(cop, '%r(#{[1].first})')
       expect(cop.messages.size).to eq(1)
     end
   end
 
   context '`%i` symbol array', ruby: 2.0 do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, ['%i[some symbols]'])
+      inspect_source(cop, '%i[some symbols]')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, ['%i(some symbols)'])
+      inspect_source(cop, '%i(some symbols)')
       expect(cop.messages).to eq([
         '`%i`-literals should be delimited by `[` and `]`'
       ])
@@ -181,12 +181,12 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
   context '`%s` symbol' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, ['%s[symbol]'])
+      inspect_source(cop, '%s[symbol]')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, ['%s(symbol)'])
+      inspect_source(cop, '%s(symbol)')
       expect(cop.messages).to eq([
         '`%s`-literals should be delimited by `[` and `]`'
       ])
@@ -195,12 +195,12 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
   context '`%x` interpolated system call' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, ['%x[command]'])
+      inspect_source(cop, '%x[command]')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, ['%x(command)'])
+      inspect_source(cop, '%x(command)')
       expect(cop.messages).to eq([
         '`%x`-literals should be delimited by `[` and `]`'
       ])
@@ -208,13 +208,13 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source(cop, ['%x([command])'])
+      inspect_source(cop, '%x([command])')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters ' \
        'when containing preferred delimiter characters in interpolation' do
-      inspect_source(cop, ['%x(#{[1].first})'])
+      inspect_source(cop, '%x(#{[1].first})')
       expect(cop.messages.size).to eq(1)
     end
   end

--- a/spec/rubocop/cop/style/percent_q_literals_spec.rb
+++ b/spec/rubocop/cop/style/percent_q_literals_spec.rb
@@ -7,12 +7,12 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
 
   shared_examples 'accepts quote characters' do
     it 'accepts single quotes' do
-      inspect_source(cop, ["'hi'"])
+      inspect_source(cop, "'hi'")
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts double quotes' do
-      inspect_source(cop, ['"hi"'])
+      inspect_source(cop, '"hi"')
       expect(cop.offenses).to be_empty
     end
   end
@@ -20,12 +20,12 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
   shared_examples 'accepts any q string with backslash t' do
     context 'with special characters' do
       it 'accepts %q' do
-        inspect_source(cop, ['%q(\t)'])
+        inspect_source(cop, '%q(\t)')
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts %Q' do
-        inspect_source(cop, ['%Q(\t)'])
+        inspect_source(cop, '%Q(\t)')
         expect(cop.offenses).to be_empty
       end
     end
@@ -36,12 +36,12 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
 
     context 'without interpolation' do
       it 'accepts %q' do
-        inspect_source(cop, ['%q(hi)'])
+        inspect_source(cop, '%q(hi)')
         expect(cop.offenses).to be_empty
       end
 
       it 'registers offense for %Q' do
-        inspect_source(cop, ['%Q(hi)'])
+        inspect_source(cop, '%Q(hi)')
         expect(cop.messages)
           .to eq(['Do not use `%Q` unless interpolation is needed.  Use `%q`.'])
         expect(cop.highlights).to eq(['%Q('])
@@ -58,13 +58,13 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
 
     context 'with interpolation' do
       it 'accepts %Q' do
-        inspect_source(cop, ['%Q(#{1 + 2})'])
+        inspect_source(cop, '%Q(#{1 + 2})')
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts %q' do
         # This is most probably a mistake, but not this cop's responsibility.
-        inspect_source(cop, ['%q(#{1 + 2})'])
+        inspect_source(cop, '%q(#{1 + 2})')
         expect(cop.offenses).to be_empty
       end
 
@@ -77,13 +77,13 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
 
     context 'without interpolation' do
       it 'registers offense for %q' do
-        inspect_source(cop, ['%q(hi)'])
+        inspect_source(cop, '%q(hi)')
         expect(cop.messages).to eq(['Use `%Q` instead of `%q`.'])
         expect(cop.highlights).to eq(['%q('])
       end
 
       it 'accepts %Q' do
-        inspect_source(cop, ['%Q(hi)'])
+        inspect_source(cop, '%Q(hi)')
         expect(cop.offenses).to be_empty
       end
 
@@ -98,7 +98,7 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
 
     context 'with interpolation' do
       it 'accepts %Q' do
-        inspect_source(cop, ['%Q(#{1 + 2})'])
+        inspect_source(cop, '%Q(#{1 + 2})')
         expect(cop.offenses).to be_empty
       end
 
@@ -106,7 +106,7 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
         # It's strange if interpolation syntax appears inside a static string,
         # but we can't be sure if it's a mistake or not. Changing it to %Q
         # would alter semantics, so we leave it as it is.
-        inspect_source(cop, ['%q(#{1 + 2})'])
+        inspect_source(cop, '%q(#{1 + 2})')
         expect(cop.offenses).to be_empty
       end
 

--- a/spec/rubocop/cop/style/perl_backrefs_spec.rb
+++ b/spec/rubocop/cop/style/perl_backrefs_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Style::PerlBackrefs do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for $1' do
-    inspect_source(cop, ['puts $1'])
+    inspect_source(cop, 'puts $1')
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/style/proc_spec.rb
+++ b/spec/rubocop/cop/style/proc_spec.rb
@@ -6,17 +6,17 @@ describe RuboCop::Cop::Style::Proc do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for a Proc.new call' do
-    inspect_source(cop, ['f = Proc.new { |x| puts x }'])
+    inspect_source(cop, 'f = Proc.new { |x| puts x }')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts the proc method' do
-    inspect_source(cop, ['f = proc { |x| puts x }'])
+    inspect_source(cop, 'f = proc { |x| puts x }')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts the Proc.new call outside of block' do
-    inspect_source(cop, ['p = Proc.new'])
+    inspect_source(cop, 'p = Proc.new')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'compact' } }
 
     it 'reports an offense for a raise with 2 args' do
-      inspect_source(cop, ['raise RuntimeError, msg'])
+      inspect_source(cop, 'raise RuntimeError, msg')
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'exploded')
     end
@@ -27,17 +27,17 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
     end
 
     it 'reports an offense for a raise with 3 args' do
-      inspect_source(cop, ['raise RuntimeError, msg, caller'])
+      inspect_source(cop, 'raise RuntimeError, msg, caller')
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts a raise with msg argument' do
-      inspect_source(cop, ['raise msg'])
+      inspect_source(cop, 'raise msg')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a raise with an exception argument' do
-      inspect_source(cop, ['raise Ex.new(msg)'])
+      inspect_source(cop, 'raise Ex.new(msg)')
       expect(cop.offenses).to be_empty
     end
   end
@@ -46,7 +46,7 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'exploded' } }
 
     it 'reports an offense for a raise with exception object' do
-      inspect_source(cop, ['raise Ex.new(msg)'])
+      inspect_source(cop, 'raise Ex.new(msg)')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Provide an exception class and message ' \
@@ -65,22 +65,22 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
     end
 
     it 'accepts exception constructor with more than 1 argument' do
-      inspect_source(cop, ['raise RuntimeError.new(a1, a2, a3)'])
+      inspect_source(cop, 'raise RuntimeError.new(a1, a2, a3)')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a raise with 3 args' do
-      inspect_source(cop, ['raise RuntimeError, msg, caller'])
+      inspect_source(cop, 'raise RuntimeError, msg, caller')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a raise with 2 args' do
-      inspect_source(cop, ['raise RuntimeError, msg'])
+      inspect_source(cop, 'raise RuntimeError, msg')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a raise with msg argument' do
-      inspect_source(cop, ['raise msg'])
+      inspect_source(cop, 'raise msg')
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/redundant_exception_spec.rb
+++ b/spec/rubocop/cop/style/redundant_exception_spec.rb
@@ -6,22 +6,22 @@ describe RuboCop::Cop::Style::RedundantException do
   subject(:cop) { described_class.new }
 
   it 'reports an offense for a raise with RuntimeError' do
-    inspect_source(cop, ['raise RuntimeError, msg'])
+    inspect_source(cop, 'raise RuntimeError, msg')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'reports an offense for a fail with RuntimeError' do
-    inspect_source(cop, ['fail RuntimeError, msg'])
+    inspect_source(cop, 'fail RuntimeError, msg')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts a raise with RuntimeError if it does not have 2 args' do
-    inspect_source(cop, ['raise RuntimeError, msg, caller'])
+    inspect_source(cop, 'raise RuntimeError, msg, caller')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a fail with RuntimeError if it does not have 2 args' do
-    inspect_source(cop, ['fail RuntimeError, msg, caller'])
+    inspect_source(cop, 'fail RuntimeError, msg, caller')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
     let(:cop_config) { { 'MaxSlashes' => -1 } }
 
     it 'fails' do
-      expect { inspect_source(cop, ['x =~ /home/']) }
+      expect { inspect_source(cop, 'x =~ /home/') }
         .to raise_error(RuntimeError)
     end
   end
@@ -20,26 +20,26 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
     let(:cop_config) { { 'MaxSlashes' => 0 } }
 
     it 'registers an offense for one slash in // regexp' do
-      inspect_source(cop, ['x =~ /home\//'])
+      inspect_source(cop, 'x =~ /home\//')
       expect(cop.messages)
         .to eq(['Use %r for regular expressions matching more ' \
                 "than 0 '/' characters."])
     end
 
     it 'accepts zero slashes in // regexp' do
-      inspect_source(cop, ['z =~ /a/'])
+      inspect_source(cop, 'z =~ /a/')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for zero slashes in %r regexp' do
-      inspect_source(cop, ['y =~ %r(etc)'])
+      inspect_source(cop, 'y =~ %r(etc)')
       expect(cop.messages)
         .to eq(['Use %r only for regular expressions matching more ' \
                 "than 0 '/' characters."])
     end
 
     it 'accepts %r regexp with one slash' do
-      inspect_source(cop, ['x =~ %r(/home)'])
+      inspect_source(cop, 'x =~ %r(/home)')
       expect(cop.offenses).to be_empty
     end
 
@@ -47,17 +47,17 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       subject(:cop) { described_class.new(config, auto_gen_config: true) }
 
       it 'sets MaxSlashes: 1 for one slash in // regexp' do
-        inspect_source(cop, ['x =~ /home\//'])
+        inspect_source(cop, 'x =~ /home\//')
         expect(cop.config_to_allow_offenses).to eq('MaxSlashes' => 1)
       end
 
       it 'disables the cop for zero slashes in %r regexp' do
-        inspect_source(cop, ['y =~ %r(etc)'])
+        inspect_source(cop, 'y =~ %r(etc)')
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
 
       it 'generates nothing if there are no offenses' do
-        inspect_source(cop, ['x =~ %r(/home)'])
+        inspect_source(cop, 'x =~ %r(/home)')
         expect(cop.config_to_allow_offenses).to eq(nil)
       end
     end
@@ -100,7 +100,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
     end
 
     it 'ignores slashes do not belong // regexp' do
-      inspect_source(cop, ['x =~ /\s{#{x[/\s+/].length}}/'])
+      inspect_source(cop, 'x =~ /\s{#{x[/\s+/].length}}/')
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Style::RescueModifier do
 
   it 'registers an offense for modifier rescue' do
     inspect_source(cop,
-                   ['method rescue handle'])
+                   'method rescue handle')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['Avoid using `rescue` in its modifier form.'])
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Style::RescueModifier do
 
   it 'handles more complex expression with modifier rescue' do
     inspect_source(cop,
-                   ['method1 or method2 rescue handle'])
+                   'method1 or method2 rescue handle')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['Avoid using `rescue` in its modifier form.'])

--- a/spec/rubocop/cop/style/self_assignment_spec.rb
+++ b/spec/rubocop/cop/style/self_assignment_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Style::SelfAssignment do
   [:+, :-, :*, :**, :/, :|, :&].product(['x', '@x', '@@x']).each do |op, var|
     it "registers an offense for non-shorthand assignment #{op} and #{var}" do
       inspect_source(cop,
-                     ["#{var} = #{var} #{op} y"])
+                     "#{var} = #{var} #{op} y")
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Use self-assignment shorthand `#{op}=`."])
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Style::SelfAssignment do
 
     it "accepts shorthand assignment for #{op} and #{var}" do
       inspect_source(cop,
-                     ["#{var} = #{var} #{op} y"])
+                     "#{var} = #{var} #{op} y")
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Use self-assignment shorthand `#{op}=`."])
@@ -26,7 +26,7 @@ describe RuboCop::Cop::Style::SelfAssignment do
   ['||', '&&'].product(['x', '@x', '@@x']).each do |op, var|
     it "registers an offense for non-shorthand assignment #{op} and #{var}" do
       inspect_source(cop,
-                     ["#{var} = #{var} #{op} y"])
+                     "#{var} = #{var} #{op} y")
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Use self-assignment shorthand `#{op}=`."])
@@ -34,7 +34,7 @@ describe RuboCop::Cop::Style::SelfAssignment do
 
     it "accepts shorthand assignment for #{op} and #{var}" do
       inspect_source(cop,
-                     ["#{var} = #{var} #{op} y"])
+                     "#{var} = #{var} #{op} y")
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Use self-assignment shorthand `#{op}=`."])

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -8,31 +8,31 @@ describe RuboCop::Cop::Style::Semicolon, :config do
 
   it 'registers an offense for a single expression' do
     inspect_source(cop,
-                   ['puts "this is a test";'])
+                   'puts "this is a test";')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for several expressions' do
     inspect_source(cop,
-                   ['puts "this is a test"; puts "So is this"'])
+                   'puts "this is a test"; puts "So is this"')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for one line method with two statements' do
     inspect_source(cop,
-                   ['def foo(a) x(1); y(2); z(3); end'])
+                   'def foo(a) x(1); y(2); z(3); end')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts semicolon before end if so configured' do
     inspect_source(cop,
-                   ['def foo(a) z(3); end'])
+                   'def foo(a) z(3); end')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts semicolon after params if so configured' do
     inspect_source(cop,
-                   ['def foo(a); z(3) end'])
+                   'def foo(a); z(3) end')
     expect(cop.offenses).to be_empty
   end
 
@@ -65,13 +65,13 @@ describe RuboCop::Cop::Style::Semicolon, :config do
 
   it 'accepts one line empty module definitions' do
     inspect_source(cop,
-                   ['module Foo; end'])
+                   'module Foo; end')
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for semicolon at the end no matter what' do
     inspect_source(cop,
-                   ['module Foo; end;'])
+                   'module Foo; end;')
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -101,13 +101,13 @@ describe RuboCop::Cop::Style::Semicolon, :config do
 
     it 'accepts several expressions' do
       inspect_source(cop,
-                     ['puts "this is a test"; puts "So is this"'])
+                     'puts "this is a test"; puts "So is this"')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts one line method with two statements' do
       inspect_source(cop,
-                     ['def foo(a) x(1); y(2); z(3); end'])
+                     'def foo(a) x(1); y(2); z(3); end')
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/single_line_block_params_spec.rb
+++ b/spec/rubocop/cop/style/single_line_block_params_spec.rb
@@ -44,13 +44,13 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
 
   it 'allows an unused parameter to have a leading underscore' do
     inspect_source(cop,
-                   ['File.foreach(filename).reduce(0) { |a, _e| a + 1 }'])
+                   'File.foreach(filename).reduce(0) { |a, _e| a + 1 }')
     expect(cop.offenses).to be_empty
   end
 
   it 'finds incorrectly named parameters with leading underscores' do
     inspect_source(cop,
-                   ['File.foreach(filename).reduce(0) { |_x, _y| }'])
+                   'File.foreach(filename).reduce(0) { |_x, _y| }')
     expect(cop.messages).to eq(['Name `reduce` block params `|a, e|`.'])
   end
 

--- a/spec/rubocop/cop/style/single_space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/style/single_space_before_first_arg_spec.rb
@@ -56,7 +56,7 @@ describe RuboCop::Cop::Style::SingleSpaceBeforeFirstArg do
     end
 
     it 'accepts a method call with space after the left parenthesis' do
-      inspect_source(cop, ['something(  x  )'])
+      inspect_source(cop, 'something(  x  )')
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/space_after_colon_spec.rb
+++ b/spec/rubocop/cop/style/space_after_colon_spec.rb
@@ -8,23 +8,23 @@ describe RuboCop::Cop::Style::SpaceAfterColon do
   it 'registers an offense for colon without space after it' do
     # TODO: There is double reporting of the last colon (also from
     # SpaceAroundOperators).
-    inspect_source(cop, ['x = w ? {a:3}:4'])
+    inspect_source(cop, 'x = w ? {a:3}:4')
     expect(cop.messages).to eq(['Space missing after colon.'] * 2)
     expect(cop.highlights).to eq([':'] * 2)
   end
 
   it 'accepts colons in symbols' do
-    inspect_source(cop, ['x = :a'])
+    inspect_source(cop, 'x = :a')
     expect(cop.messages).to be_empty
   end
 
   it 'accepts colon in ternary followed by space' do
-    inspect_source(cop, ['x = w ? a : b'])
+    inspect_source(cop, 'x = w ? a : b')
     expect(cop.messages).to be_empty
   end
 
   it 'accepts hash rockets' do
-    inspect_source(cop, ['x = {"a"=>1}'])
+    inspect_source(cop, 'x = {"a"=>1}')
     expect(cop.messages).to be_empty
   end
 
@@ -44,7 +44,7 @@ describe RuboCop::Cop::Style::SpaceAfterColon do
   end
 
   it 'accepts colons in strings' do
-    inspect_source(cop, ["str << ':'"])
+    inspect_source(cop, "str << ':'")
     expect(cop.messages).to be_empty
   end
 

--- a/spec/rubocop/cop/style/space_after_comma_spec.rb
+++ b/spec/rubocop/cop/style/space_after_comma_spec.rb
@@ -6,19 +6,19 @@ describe RuboCop::Cop::Style::SpaceAfterComma do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for block argument commas without space' do
-    inspect_source(cop, ['each { |s,t| }'])
+    inspect_source(cop, 'each { |s,t| }')
     expect(cop.messages).to eq(
       ['Space missing after comma.'])
   end
 
   it 'registers an offense for array index commas without space' do
-    inspect_source(cop, ['formats[0,1]'])
+    inspect_source(cop, 'formats[0,1]')
     expect(cop.messages).to eq(
       ['Space missing after comma.'])
   end
 
   it 'registers an offense for method call arg commas without space' do
-    inspect_source(cop, ['a(1,2)'])
+    inspect_source(cop, 'a(1,2)')
     expect(cop.messages).to eq(
       ['Space missing after comma.'])
   end

--- a/spec/rubocop/cop/style/space_after_control_keyword_spec.rb
+++ b/spec/rubocop/cop/style/space_after_control_keyword_spec.rb
@@ -7,23 +7,23 @@ describe RuboCop::Cop::Style::SpaceAfterControlKeyword do
 
   it 'registers an offense for normal if' do
     inspect_source(cop,
-                   ['if(test) then result end'])
+                   'if(test) then result end')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for modifier unless' do
-    inspect_source(cop, ['action unless(test)'])
+    inspect_source(cop, 'action unless(test)')
 
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'does not get confused by keywords' do
-    inspect_source(cop, ['[:if, :unless].action'])
+    inspect_source(cop, '[:if, :unless].action')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not get confused by the ternary operator' do
-    inspect_source(cop, ['a ? b : c'])
+    inspect_source(cop, 'a ? b : c')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/space_after_not_spec.rb
+++ b/spec/rubocop/cop/style/space_after_not_spec.rb
@@ -6,12 +6,12 @@ describe RuboCop::Cop::Style::SpaceAfterNot do
   subject(:cop) { described_class.new }
 
   it 'reports an offense for space after !' do
-    inspect_source(cop, ['! something'])
+    inspect_source(cop, '! something')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts no space after !' do
-    inspect_source(cop, ['!something'])
+    inspect_source(cop, '!something')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/space_after_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/space_after_semicolon_spec.rb
@@ -6,13 +6,13 @@ describe RuboCop::Cop::Style::SpaceAfterSemicolon do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for semicolon without space after it' do
-    inspect_source(cop, ['x = 1;y = 2'])
+    inspect_source(cop, 'x = 1;y = 2')
     expect(cop.messages).to eq(
       ['Space missing after semicolon.'])
   end
 
   it 'does not crash if semicolon is the last character of the file' do
-    inspect_source(cop, ['x = 1;'])
+    inspect_source(cop, 'x = 1;')
     expect(cop.messages).to be_empty
   end
 

--- a/spec/rubocop/cop/style/space_around_equals_in_parameter_default_spec.rb
+++ b/spec/rubocop/cop/style/space_around_equals_in_parameter_default_spec.rb
@@ -9,7 +9,8 @@ describe RuboCop::Cop::Style::SpaceAroundEqualsInParameterDefault, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'space' } }
 
     it 'registers an offense for default value assignment without space' do
-      inspect_source(cop, ['def f(x, y=0, z= 1)', 'end'])
+      inspect_source(cop, ['def f(x, y=0, z= 1)',
+                           'end'])
       expect(cop.messages)
         .to eq(['Surrounding space missing in default value assignment.'] * 2)
       expect(cop.highlights).to eq(['=', '= '])
@@ -17,18 +18,21 @@ describe RuboCop::Cop::Style::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'registers an offense for assignment empty string without space' do
-      inspect_source(cop, ['def f(x, y="", z=1)', 'end'])
+      inspect_source(cop, ['def f(x, y="", z=1)',
+                           'end'])
       expect(cop.offenses.size).to eq(2)
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'no_space')
     end
 
     it 'registers an offense for assignment of empty list without space' do
-      inspect_source(cop, ['def f(x, y=[])', 'end'])
+      inspect_source(cop, ['def f(x, y=[])',
+                           'end'])
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts default value assignment with space' do
-      inspect_source(cop, ['def f(x, y = 0, z = {})', 'end'])
+      inspect_source(cop, ['def f(x, y = 0, z = {})',
+                           'end'])
       expect(cop.messages).to be_empty
     end
 
@@ -38,7 +42,8 @@ describe RuboCop::Cop::Style::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'accepts default value assignment with space' do
-      inspect_source(cop, ['def f(x, y = +1, z = {})', 'end'])
+      inspect_source(cop, ['def f(x, y = +1, z = {})',
+                           'end'])
       expect(cop.messages).to be_empty
     end
 
@@ -53,7 +58,8 @@ describe RuboCop::Cop::Style::SpaceAroundEqualsInParameterDefault, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 
     it 'registers an offense for default value assignment with space' do
-      inspect_source(cop, ['def f(x, y = 0, z =1, w= 2)', 'end'])
+      inspect_source(cop, ['def f(x, y = 0, z =1, w= 2)',
+                           'end'])
       expect(cop.messages)
         .to eq(['Surrounding space detected in default value assignment.'] * 3)
       expect(cop.highlights).to eq([' = ', ' =', '= '])
@@ -61,18 +67,21 @@ describe RuboCop::Cop::Style::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'registers an offense for assignment empty string with space' do
-      inspect_source(cop, ['def f(x, y = "", z = 1)', 'end'])
+      inspect_source(cop, ['def f(x, y = "", z = 1)',
+                           'end'])
       expect(cop.offenses.size).to eq(2)
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'space')
     end
 
     it 'registers an offense for assignment of empty list with space' do
-      inspect_source(cop, ['def f(x, y = [])', 'end'])
+      inspect_source(cop, ['def f(x, y = [])',
+                           'end'])
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts default value assignment without space' do
-      inspect_source(cop, ['def f(x, y=0, z={})', 'end'])
+      inspect_source(cop, ['def f(x, y=0, z={})',
+                           'end'])
       expect(cop.messages).to be_empty
     end
 

--- a/spec/rubocop/cop/style/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/style/space_around_operators_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'registers an offense for ternary operator without space' do
-    inspect_source(cop, ['x == 0?1:2'])
+    inspect_source(cop, 'x == 0?1:2')
     expect(cop.messages).to eq(
       ["Surrounding space missing for operator '?'.",
        "Surrounding space missing for operator ':'."])
@@ -73,7 +73,7 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'registers an offense for arguments to a method' do
-    inspect_source(cop, ['puts 1+2'])
+    inspect_source(cop, 'puts 1+2')
     expect(cop.messages).to eq(
       ["Surrounding space missing for operator '+'."])
   end
@@ -84,17 +84,17 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'accepts operator surrounded by tabs' do
-    inspect_source(cop, ["a\t+\tb"])
+    inspect_source(cop, "a\t+\tb")
     expect(cop.messages).to be_empty
   end
 
   it 'accepts operator symbols' do
-    inspect_source(cop, ['func(:-)'])
+    inspect_source(cop, 'func(:-)')
     expect(cop.messages).to be_empty
   end
 
   it 'accepts ranges' do
-    inspect_source(cop, ['a, b = (1..2), (1...3)'])
+    inspect_source(cop, 'a, b = (1..2), (1...3)')
     expect(cop.messages).to be_empty
   end
 
@@ -111,7 +111,7 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'accepts exclamation point negation' do
-    inspect_source(cop, ['x = !a&&!b'])
+    inspect_source(cop, 'x = !a&&!b')
     expect(cop.messages).to eq(
       ["Surrounding space missing for operator '&&'."])
   end
@@ -145,7 +145,7 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'accepts splat operator' do
-    inspect_source(cop, ['return *list if options'])
+    inspect_source(cop, 'return *list if options')
     expect(cop.messages).to be_empty
   end
 
@@ -163,12 +163,12 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'accepts an assignment with spaces' do
-    inspect_source(cop, ['x = 0'])
+    inspect_source(cop, 'x = 0')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts an operator called with method syntax' do
-    inspect_source(cop, ['Date.today.+(1).to_s'])
+    inspect_source(cop, 'Date.today.+(1).to_s')
     expect(cop.offenses).to be_empty
   end
 
@@ -218,7 +218,7 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'registers an offenses for exponent operator with spaces' do
-    inspect_source(cop, ['x = a * b ** 2'])
+    inspect_source(cop, 'x = a * b ** 2')
     expect(cop.messages).to eq(
       ['Space around operator ** detected.'])
   end
@@ -231,18 +231,18 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'accepts exponent operator without spaces' do
-    inspect_source(cop, ['x = a * b**2'])
+    inspect_source(cop, 'x = a * b**2')
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for a setter call without spaces' do
-    inspect_source(cop, ['x.y=2'])
+    inspect_source(cop, 'x.y=2')
     expect(cop.messages).to eq(
       ["Surrounding space missing for operator '='."])
   end
 
   it 'registers an offense for a hash rocket without spaces' do
-    inspect_source(cop, ['{ 1=>2, a: b }'])
+    inspect_source(cop, '{ 1=>2, a: b }')
     expect(cop.messages).to eq(
       ["Surrounding space missing for operator '=>'."])
   end
@@ -257,7 +257,7 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'accepts [] without space' do
-    inspect_source(cop, ['files[2]'])
+    inspect_source(cop, 'files[2]')
     expect(cop.messages).to eq([])
   end
 
@@ -277,7 +277,8 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'registers an offense for match operators without space' do
-    inspect_source(cop, ['x=~/abc/', 'y !~/abc/'])
+    inspect_source(cop, ['x=~/abc/',
+                         'y !~/abc/'])
     expect(cop.messages)
       .to eq(["Surrounding space missing for operator '=~'.",
               "Surrounding space missing for operator '!~'."])
@@ -307,7 +308,7 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'registers an offense for - without space with negative lhs operand' do
-    inspect_source(cop, ['-1-arg'])
+    inspect_source(cop, '-1-arg')
     expect(cop.messages)
       .to eq(["Surrounding space missing for operator '-'."])
   end

--- a/spec/rubocop/cop/style/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_before_block_braces_spec.rb
@@ -15,13 +15,13 @@ describe RuboCop::Cop::Style::SpaceBeforeBlockBraces do
 
   context 'when EnforcedStyle is space' do
     it 'accepts braces surrounded by spaces' do
-      inspect_source(cop, ['each { puts }'])
+      inspect_source(cop, 'each { puts }')
       expect(cop.messages).to be_empty
       expect(cop.highlights).to be_empty
     end
 
     it 'registers an offense for left brace without outer space' do
-      inspect_source(cop, ['each{ puts }'])
+      inspect_source(cop, 'each{ puts }')
       expect(cop.messages).to eq(['Space missing to the left of {.'])
       expect(cop.highlights).to eq(['{'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'no_space')
@@ -45,7 +45,7 @@ describe RuboCop::Cop::Style::SpaceBeforeBlockBraces do
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 
     it 'registers an offense for braces surrounded by spaces' do
-      inspect_source(cop, ['each { puts }'])
+      inspect_source(cop, 'each { puts }')
       expect(cop.messages).to eq(['Space detected to the left of {.'])
       expect(cop.highlights).to eq([' '])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'space')
@@ -65,7 +65,7 @@ describe RuboCop::Cop::Style::SpaceBeforeBlockBraces do
     end
 
     it 'accepts left brace without outer space' do
-      inspect_source(cop, ['each{ puts }'])
+      inspect_source(cop, 'each{ puts }')
       expect(cop.messages).to be_empty
       expect(cop.highlights).to be_empty
     end

--- a/spec/rubocop/cop/style/space_before_comma_spec.rb
+++ b/spec/rubocop/cop/style/space_before_comma_spec.rb
@@ -6,25 +6,25 @@ describe RuboCop::Cop::Style::SpaceBeforeComma do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for block argument with space before comma' do
-    inspect_source(cop, ['each { |s , t| }'])
+    inspect_source(cop, 'each { |s , t| }')
     expect(cop.messages).to eq(
       ['Space found before comma.'])
   end
 
   it 'registers an offense for array index with space before comma' do
-    inspect_source(cop, ['formats[0 , 1]'])
+    inspect_source(cop, 'formats[0 , 1]')
     expect(cop.messages).to eq(
       ['Space found before comma.'])
   end
 
   it 'registers an offense for method call arg with space before comma' do
-    inspect_source(cop, ['a(1 , 2)'])
+    inspect_source(cop, 'a(1 , 2)')
     expect(cop.messages).to eq(
       ['Space found before comma.'])
   end
 
   it 'does not register an offense for no spaces before comma' do
-    inspect_source(cop, ['a(1, 2)'])
+    inspect_source(cop, 'a(1, 2)')
     expect(cop.messages).to be_empty
   end
 

--- a/spec/rubocop/cop/style/space_before_comment_spec.rb
+++ b/spec/rubocop/cop/style/space_before_comment_spec.rb
@@ -6,17 +6,17 @@ describe RuboCop::Cop::Style::SpaceBeforeComment do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for missing space before an EOL comment' do
-    inspect_source(cop, ['a += 1# increment'])
+    inspect_source(cop, 'a += 1# increment')
     expect(cop.highlights).to eq(['# increment'])
   end
 
   it 'accepts an EOL comment with a preceding space' do
-    inspect_source(cop, ['a += 1 # increment'])
+    inspect_source(cop, 'a += 1 # increment')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a comment that begins a line' do
-    inspect_source(cop, ['# comment'])
+    inspect_source(cop, '# comment')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/space_before_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/space_before_semicolon_spec.rb
@@ -6,13 +6,13 @@ describe RuboCop::Cop::Style::SpaceBeforeSemicolon do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for space before semicolon' do
-    inspect_source(cop, ['x = 1 ; y = 2'])
+    inspect_source(cop, 'x = 1 ; y = 2')
     expect(cop.messages).to eq(
       ['Space found before semicolon.'])
   end
 
   it 'does not register an offense for no space before semicolons' do
-    inspect_source(cop, ['x = 1; y = 2'])
+    inspect_source(cop, 'x = 1; y = 2')
     expect(cop.messages).to be_empty
   end
 

--- a/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
     let(:cop_config) { { 'EnforcedStyleForEmptyBraces' => 'no_space' } }
 
     it 'accepts empty braces with no space inside' do
-      inspect_source(cop, ['each {}'])
+      inspect_source(cop, 'each {}')
       expect(cop.messages).to be_empty
     end
 
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
     end
 
     it 'registers an offense for empty braces with space inside' do
-      inspect_source(cop, ['each { }'])
+      inspect_source(cop, 'each { }')
       expect(cop.messages).to eq(['Space inside empty braces detected.'])
       expect(cop.highlights).to eq([' '])
     end
@@ -67,12 +67,12 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
     let(:cop_config) { { 'EnforcedStyleForEmptyBraces' => 'space' } }
 
     it 'accepts empty braces with space inside' do
-      inspect_source(cop, ['each { }'])
+      inspect_source(cop, 'each { }')
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for empty braces with no space inside' do
-      inspect_source(cop, ['each {}'])
+      inspect_source(cop, 'each {}')
       expect(cop.messages).to eq(['Space missing inside empty braces.'])
       expect(cop.highlights).to eq(['{}'])
     end
@@ -84,24 +84,24 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
   end
 
   it 'accepts braces surrounded by spaces' do
-    inspect_source(cop, ['each { puts }'])
+    inspect_source(cop, 'each { puts }')
     expect(cop.messages).to be_empty
     expect(cop.highlights).to be_empty
   end
 
   it 'accepts left brace without outer space' do
-    inspect_source(cop, ['each{ puts }'])
+    inspect_source(cop, 'each{ puts }')
     expect(cop.highlights).to be_empty
   end
 
   it 'registers an offense for left brace without inner space' do
-    inspect_source(cop, ['each {puts }'])
+    inspect_source(cop, 'each {puts }')
     expect(cop.messages).to eq(['Space missing inside {.'])
     expect(cop.highlights).to eq(['p'])
   end
 
   it 'registers an offense for right brace without inner space' do
-    inspect_source(cop, ['each { puts}'])
+    inspect_source(cop, 'each { puts}')
     expect(cop.messages).to eq(['Space missing inside }.'])
     expect(cop.highlights).to eq(['}'])
     expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
@@ -130,19 +130,19 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
 
   context 'with passed in parameters' do
     it 'accepts left brace with inner space' do
-      inspect_source(cop, ['each { |x| puts }'])
+      inspect_source(cop, 'each { |x| puts }')
       expect(cop.messages).to be_empty
       expect(cop.highlights).to be_empty
     end
 
     it 'registers an offense for left brace without inner space' do
-      inspect_source(cop, ['each {|x| puts }'])
+      inspect_source(cop, 'each {|x| puts }')
       expect(cop.messages).to eq(['Space between { and | missing.'])
       expect(cop.highlights).to eq(['{|'])
     end
 
     it 'accepts new lambda syntax' do
-      inspect_source(cop, ['->(x) { x }'])
+      inspect_source(cop, '->(x) { x }')
       expect(cop.messages).to be_empty
     end
 
@@ -183,13 +183,13 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
       end
 
       it 'registers an offense for left brace with inner space' do
-        inspect_source(cop, ['each { |x| puts }'])
+        inspect_source(cop, 'each { |x| puts }')
         expect(cop.messages).to eq(['Space between { and | detected.'])
         expect(cop.highlights).to eq([' '])
       end
 
       it 'accepts new lambda syntax' do
-        inspect_source(cop, ['->(x) { x }'])
+        inspect_source(cop, '->(x) { x }')
         expect(cop.messages).to be_empty
       end
 
@@ -199,7 +199,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
       end
 
       it 'accepts left brace without inner space' do
-        inspect_source(cop, ['each {|x| puts }'])
+        inspect_source(cop, 'each {|x| puts }')
         expect(cop.messages).to be_empty
         expect(cop.highlights).to be_empty
       end
@@ -216,26 +216,26 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
     end
 
     it 'accepts braces without spaces inside' do
-      inspect_source(cop, ['each {puts}'])
+      inspect_source(cop, 'each {puts}')
       expect(cop.messages).to be_empty
       expect(cop.highlights).to be_empty
     end
 
     it 'registers an offense for left brace with inner space' do
-      inspect_source(cop, ['each { puts}'])
+      inspect_source(cop, 'each { puts}')
       expect(cop.messages).to eq(['Space inside { detected.'])
       expect(cop.highlights).to eq([' '])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for right brace with inner space' do
-      inspect_source(cop, ['each {puts  }'])
+      inspect_source(cop, 'each {puts  }')
       expect(cop.messages).to eq(['Space inside } detected.'])
       expect(cop.highlights).to eq(['  '])
     end
 
     it 'registers offenses for both braces with inner space' do
-      inspect_source(cop, ['each { puts  }'])
+      inspect_source(cop, 'each { puts  }')
       expect(cop.messages).to eq(['Space inside { detected.',
                                   'Space inside } detected.'])
       expect(cop.highlights).to eq([' ', '  '])
@@ -244,7 +244,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
     end
 
     it 'accepts left brace without outer space' do
-      inspect_source(cop, ['each {puts}'])
+      inspect_source(cop, 'each {puts}')
       expect(cop.highlights).to be_empty
     end
 
@@ -256,19 +256,19 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
     context 'with passed in parameters' do
       context 'and space before block parameters allowed' do
         it 'accepts left brace with inner space' do
-          inspect_source(cop, ['each { |x| puts}'])
+          inspect_source(cop, 'each { |x| puts}')
           expect(cop.messages).to eq([])
           expect(cop.highlights).to eq([])
         end
 
         it 'registers an offense for left brace without inner space' do
-          inspect_source(cop, ['each {|x| puts}'])
+          inspect_source(cop, 'each {|x| puts}')
           expect(cop.messages).to eq(['Space between { and | missing.'])
           expect(cop.highlights).to eq(['{|'])
         end
 
         it 'accepts new lambda syntax' do
-          inspect_source(cop, ['->(x) {x}'])
+          inspect_source(cop, '->(x) {x}')
           expect(cop.messages).to be_empty
         end
 
@@ -288,13 +288,13 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
         end
 
         it 'registers an offense for left brace with inner space' do
-          inspect_source(cop, ['each { |x| puts}'])
+          inspect_source(cop, 'each { |x| puts}')
           expect(cop.messages).to eq(['Space between { and | detected.'])
           expect(cop.highlights).to eq([' '])
         end
 
         it 'accepts new lambda syntax' do
-          inspect_source(cop, ['->(x) {x}'])
+          inspect_source(cop, '->(x) {x}')
           expect(cop.messages).to be_empty
         end
 

--- a/spec/rubocop/cop/style/space_inside_brackets_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_brackets_spec.rb
@@ -56,12 +56,12 @@ describe RuboCop::Cop::Style::SpaceInsideBrackets do
   end
 
   it 'accepts square brackets called with method call syntax' do
-    inspect_source(cop, ['subject.[](0)'])
+    inspect_source(cop, 'subject.[](0)')
     expect(cop.messages).to be_empty
   end
 
   it 'only reports a single space once' do
-    inspect_source(cop, ['[ ]'])
+    inspect_source(cop, '[ ]')
     expect(cop.messages).to eq(
       ['Space inside square brackets detected.'])
   end

--- a/spec/rubocop/cop/style/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_hash_literal_braces_spec.rb
@@ -10,12 +10,12 @@ describe RuboCop::Cop::Style::SpaceInsideHashLiteralBraces, :config do
     let(:cop_config) { { 'EnforcedStyleForEmptyBraces' => 'no_space' } }
 
     it 'accepts empty braces with no space inside' do
-      inspect_source(cop, ['h = {}'])
+      inspect_source(cop, 'h = {}')
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for empty braces with space inside' do
-      inspect_source(cop, ['h = { }'])
+      inspect_source(cop, 'h = { }')
       expect(cop.messages)
         .to eq(['Space inside empty hash literal braces detected.'])
       expect(cop.highlights).to eq([' '])
@@ -31,12 +31,12 @@ describe RuboCop::Cop::Style::SpaceInsideHashLiteralBraces, :config do
     let(:cop_config) { { 'EnforcedStyleForEmptyBraces' => 'space' } }
 
     it 'accepts empty braces with space inside' do
-      inspect_source(cop, ['h = { }'])
+      inspect_source(cop, 'h = { }')
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for empty braces with no space inside' do
-      inspect_source(cop, ['h = {}'])
+      inspect_source(cop, 'h = {}')
       expect(cop.messages)
         .to eq(['Space inside empty hash literal braces missing.'])
       expect(cop.highlights).to eq(['{'])
@@ -62,7 +62,7 @@ describe RuboCop::Cop::Style::SpaceInsideHashLiteralBraces, :config do
 
   it 'registers an offense for correct + opposite' do
     inspect_source(cop,
-                   ['h = { a: 1}'])
+                   'h = { a: 1}')
     expect(cop.messages).to eq(['Space inside } missing.'])
     expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
   end
@@ -79,7 +79,7 @@ describe RuboCop::Cop::Style::SpaceInsideHashLiteralBraces, :config do
 
     it 'registers an offense for hashes with spaces' do
       inspect_source(cop,
-                     ['h = { a: 1, b: 2 }'])
+                     'h = { a: 1, b: 2 }')
       expect(cop.messages).to eq(['Space inside { detected.',
                                   'Space inside } detected.'])
       expect(cop.highlights).to eq([' ', ' '])
@@ -88,7 +88,7 @@ describe RuboCop::Cop::Style::SpaceInsideHashLiteralBraces, :config do
 
     it 'registers an offense for opposite + correct' do
       inspect_source(cop,
-                     ['h = {a: 1 }'])
+                     'h = {a: 1 }')
       expect(cop.messages).to eq(['Space inside } detected.'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -134,14 +134,14 @@ describe RuboCop::Cop::Style::SpaceInsideHashLiteralBraces, :config do
   end
 
   it 'accepts hash literals with no braces' do
-    inspect_source(cop, ['x(a: b.c)'])
+    inspect_source(cop, 'x(a: b.c)')
     expect(cop.offenses).to be_empty
   end
 
   it 'can handle interpolation in a braceless hash literal' do
     # A tricky special case where the closing brace of the
     # interpolation risks getting confused for a hash literal brace.
-    inspect_source(cop, ['f(get: "#{x}")'])
+    inspect_source(cop, 'f(get: "#{x}")')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/space_inside_parens_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_parens_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Style::SpaceInsideParens do
   end
 
   it 'accepts parentheses with no spaces' do
-    inspect_source(cop, ['split("\n")'])
+    inspect_source(cop, 'split("\n")')
     expect(cop.messages).to be_empty
   end
 

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -6,28 +6,28 @@ describe RuboCop::Cop::Style::SpecialGlobalVars do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for $:' do
-    inspect_source(cop, ['puts $:'])
+    inspect_source(cop, 'puts $:')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['Prefer `$LOAD_PATH` over `$:`.'])
   end
 
   it 'registers an offense for $"' do
-    inspect_source(cop, ['puts $"'])
+    inspect_source(cop, 'puts $"')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['Prefer `$LOADED_FEATURES` over `$"`.'])
   end
 
   it 'registers an offense for $0' do
-    inspect_source(cop, ['puts $0'])
+    inspect_source(cop, 'puts $0')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['Prefer `$PROGRAM_NAME` over `$0`.'])
   end
 
   it 'registers an offense for $$' do
-    inspect_source(cop, ['puts $$'])
+    inspect_source(cop, 'puts $$')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['Prefer `$PROCESS_ID` or `$PID` from the English ' \
@@ -35,13 +35,13 @@ describe RuboCop::Cop::Style::SpecialGlobalVars do
   end
 
   it 'is clear about variables from the English library vs those not' do
-    inspect_source(cop, ['puts $*'])
+    inspect_source(cop, 'puts $*')
     expect(cop.messages)
       .to eq(['Prefer `$ARGV` from the English library, or `ARGV` over `$*`.'])
   end
 
   it 'does not register an offense for backrefs like $1' do
-    inspect_source(cop, ['puts $1'])
+    inspect_source(cop, 'puts $1')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
@@ -92,7 +92,7 @@ describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'other' } }
 
     it 'fails' do
-      expect { inspect_source(cop, ['a = "#{"b"}"']) }
+      expect { inspect_source(cop, 'a = "#{"b"}"') }
         .to raise_error(RuntimeError)
     end
   end

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -35,22 +35,22 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'accepts single quotes' do
-      inspect_source(cop, ["a = 'x'"])
+      inspect_source(cop, "a = 'x'")
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts single quotes in interpolation' do
-      inspect_source(cop, [%q("hello#{hash['there']}")])
+      inspect_source(cop, %q("hello#{hash['there']}"))
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts %q and %Q quotes' do
-      inspect_source(cop, ['a = %q(x) + %Q[x]'])
+      inspect_source(cop, 'a = %q(x) + %Q[x]')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts % quotes' do
-      inspect_source(cop, ['a = %(x)'])
+      inspect_source(cop, 'a = %(x)')
       expect(cop.offenses).to be_empty
     end
 
@@ -77,7 +77,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'accepts double quotes at the start of regexp literals' do
-      inspect_source(cop, ['s = /"((?:[^\\"]|\\.)*)"/'])
+      inspect_source(cop, 's = /"((?:[^\\"]|\\.)*)"/')
       expect(cop.offenses).to be_empty
     end
 
@@ -91,12 +91,12 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'accepts " in a %w' do
-      inspect_source(cop, ['%w(")'])
+      inspect_source(cop, '%w(")')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts \\\\\n in a string' do # this would be: "\\\n"
-      inspect_source(cop, ['"foo \\\\\n bar"'])
+      inspect_source(cop, '"foo \\\\\n bar"')
       expect(cop.offenses).to be_empty
     end
 
@@ -137,7 +137,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
 
     it 'registers offense for single quotes when double quotes would ' \
       'be equivalent' do
-      inspect_source(cop, ["s = 'abc'"])
+      inspect_source(cop, "s = 'abc'")
       expect(cop.highlights).to eq(["'abc'"])
       expect(cop.messages)
         .to eq(['Prefer double-quoted strings unless you need ' \
@@ -158,22 +158,22 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'accepts double quotes' do
-      inspect_source(cop, ['a = "x"'])
+      inspect_source(cop, 'a = "x"')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts single quotes in interpolation' do
-      inspect_source(cop, [%q("hello#{hash['there']}")])
+      inspect_source(cop, %q("hello#{hash['there']}"))
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts %q and %Q quotes' do
-      inspect_source(cop, ['a = %q(x) + %Q[x]'])
+      inspect_source(cop, 'a = %q(x) + %Q[x]')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts % quotes' do
-      inspect_source(cop, ['a = %(x)'])
+      inspect_source(cop, 'a = %(x)')
       expect(cop.offenses).to be_empty
     end
 
@@ -194,12 +194,12 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'accepts single quotes at the start of regexp literals' do
-      inspect_source(cop, ["s = /'((?:[^\\']|\\.)*)'/"])
+      inspect_source(cop, "s = /'((?:[^\\']|\\.)*)'/")
       expect(cop.offenses).to be_empty
     end
 
     it "accepts ' in a %w" do
-      inspect_source(cop, ["%w(')"])
+      inspect_source(cop, "%w(')")
       expect(cop.offenses).to be_empty
     end
 
@@ -221,7 +221,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'other' } }
 
     it 'fails' do
-      expect { inspect_source(cop, ['a = "b"']) }
+      expect { inspect_source(cop, 'a = "b"') }
         .to raise_error(RuntimeError)
     end
   end

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -7,31 +7,31 @@ describe RuboCop::Cop::Style::SymbolArray do
 
   it 'registers an offense for arrays of symbols', ruby: 2.0 do
     inspect_source(cop,
-                   ['[:one, :two, :three]'])
+                   '[:one, :two, :three]')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'does not reg an offense for array with non-syms', ruby: 2.0 do
     inspect_source(cop,
-                   ['[:one, :two, "three"]'])
+                   '[:one, :two, "three"]')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not reg an offense for array starting with %i', ruby: 2.0 do
     inspect_source(cop,
-                   ['%i(one two three)'])
+                   '%i(one two three)')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not reg an offense for array with one element', ruby: 2.0 do
     inspect_source(cop,
-                   ['[:three]'])
+                   '[:three]')
     expect(cop.offenses).to be_empty
   end
 
   it 'does nothing on Ruby 1.9', ruby: 1.9 do
     inspect_source(cop,
-                   ['[:one, :two, :three]'])
+                   '[:one, :two, :three]')
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -16,68 +16,68 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
   end
 
   it 'registers an offense for a block when method in body is unary -/=' do
-    inspect_source(cop, ['something.map { |x| -x }'])
+    inspect_source(cop, 'something.map { |x| -x }')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['Pass `&:-@` as an argument to `map` instead of a block.'])
   end
 
   it 'accepts method receiving another argument beside the block' do
-    inspect_source(cop, ['File.open(file) { |f| f.readlines }'])
+    inspect_source(cop, 'File.open(file) { |f| f.readlines }')
 
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts block with more than 1 arguments' do
-    inspect_source(cop, ['something { |x, y| x.method }'])
+    inspect_source(cop, 'something { |x, y| x.method }')
 
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts lambda with 1 argument' do
-    inspect_source(cop, ['->(x) { x.method }'])
+    inspect_source(cop, '->(x) { x.method }')
 
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts proc with 1 argument' do
-    inspect_source(cop, ['proc { |x| x.method }'])
+    inspect_source(cop, 'proc { |x| x.method }')
 
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts Proc.new with 1 argument' do
-    inspect_source(cop, ['Proc.new { |x| x.method }'])
+    inspect_source(cop, 'Proc.new { |x| x.method }')
 
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts ignored method' do
-    inspect_source(cop, ['respond_to { |format| format.xml }'])
+    inspect_source(cop, 'respond_to { |format| format.xml }')
 
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts block with no arguments' do
-    inspect_source(cop, ['something { x.method }'])
+    inspect_source(cop, 'something { x.method }')
 
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts empty block body' do
-    inspect_source(cop, ['something { |x| }'])
+    inspect_source(cop, 'something { |x| }')
 
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts block with more than 1 expression in body' do
-    inspect_source(cop, ['something { |x| x.method; something_else }'])
+    inspect_source(cop, 'something { |x| x.method; something_else }')
 
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts block when method in body is not called on block arg' do
-    inspect_source(cop, ['something { |x| y.method }'])
+    inspect_source(cop, 'something { |x| y.method }')
 
     expect(cop.offenses).to be_empty
   end
@@ -94,7 +94,7 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
   end
 
   it 'does not crash with a bare method call' do
-    run = -> { inspect_source(cop, ['coll.map { |s| bare_method }']) }
+    run = -> { inspect_source(cop, 'coll.map { |s| bare_method }') }
     expect(&run).not_to raise_error
   end
 end

--- a/spec/rubocop/cop/style/tab_spec.rb
+++ b/spec/rubocop/cop/style/tab_spec.rb
@@ -6,22 +6,22 @@ describe RuboCop::Cop::Style::Tab do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for a line indented with tab' do
-    inspect_source(cop, ["\tx = 0"])
+    inspect_source(cop, "\tx = 0")
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for a line indented with multiple tabs' do
-    inspect_source(cop, ["\t\t\tx = 0"])
+    inspect_source(cop, "\t\t\tx = 0")
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for a line indented with mixed whitespace' do
-    inspect_source(cop, [" \tx = 0"])
+    inspect_source(cop, " \tx = 0")
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts a line with tab in a string' do
-    inspect_source(cop, ["(x = \"\t\")"])
+    inspect_source(cop, "(x = \"\t\")")
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/trailing_blank_lines_spec.rb
+++ b/spec/rubocop/cop/style/trailing_blank_lines_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Style::TrailingBlankLines, :config do
     end
 
     it 'registers an offense for no final newline' do
-      inspect_source(cop, ['x = 0'])
+      inspect_source(cop, 'x = 0')
       expect(cop.messages).to eq(['Final newline missing.'])
     end
 
@@ -56,7 +56,7 @@ describe RuboCop::Cop::Style::TrailingBlankLines, :config do
     end
 
     it 'registers an offense for no final newline' do
-      inspect_source(cop, ['x = 0'])
+      inspect_source(cop, 'x = 0')
       expect(cop.messages).to eq(['Final newline missing.'])
     end
 

--- a/spec/rubocop/cop/style/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/style/trailing_whitespace_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Style::TrailingWhitespace do
   end
 
   it 'registers an offense for a line ending with tab' do
-    inspect_source(cop, ["x = 0\t"])
+    inspect_source(cop, "x = 0\t")
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
@@ -6,26 +6,22 @@ describe RuboCop::Cop::Style::UnneededCapitalW do
   subject(:cop) { described_class.new }
 
   it 'registers no offense for normal arrays of strings' do
-    inspect_source(cop,
-                   ['["one", "two", "three"]'])
+    inspect_source(cop, '["one", "two", "three"]')
     expect(cop.offenses).to be_empty
   end
 
   it 'registers no offense for normal arrays of strings with interpolation' do
-    inspect_source(cop,
-                   ['["one", "two", "th#{ ?r }ee"]'])
+    inspect_source(cop, '["one", "two", "th#{ ?r }ee"]')
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for misused %W' do
-    inspect_source(cop,
-                   ['%W(cat dog)'])
+    inspect_source(cop, '%W(cat dog)')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers no offense for %W with interpolation' do
-    inspect_source(cop,
-                   ['%W(c#{ ?a }t dog)'])
+    inspect_source(cop, '%W(c#{ ?a }t dog)')
     expect(cop.offenses).to be_empty
   end
 
@@ -48,44 +44,37 @@ describe RuboCop::Cop::Style::UnneededCapitalW do
   end
 
   it 'registers no offense for %w without interpolation' do
-    inspect_source(cop,
-                   ['%w(cat dog)'])
+    inspect_source(cop, '%w(cat dog)')
     expect(cop.offenses).to be_empty
   end
 
   it 'registers no offense for %w with interpolation-like syntax' do
-    inspect_source(cop,
-                   ['%w(c#{ ?a }t dog)'])
+    inspect_source(cop, '%w(c#{ ?a }t dog)')
     expect(cop.offenses).to be_empty
   end
 
   it 'registers no offense for arrays with character constants' do
-    inspect_source(cop,
-                   ['["one", ?\n]'])
+    inspect_source(cop, '["one", ?\n]')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for array of non-words' do
-    inspect_source(cop,
-                   ['["one space", "two", "three"]'])
+    inspect_source(cop, '["one space", "two", "three"]')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for array containing non-string' do
-    inspect_source(cop,
-                   ['["one", "two", 3]'])
+    inspect_source(cop, '["one", "two", 3]')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for array with one element' do
-    inspect_source(cop,
-                   ['["three"]'])
+    inspect_source(cop, '["three"]')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for array with empty strings' do
-    inspect_source(cop,
-                   ['["", "two", "three"]'])
+    inspect_source(cop, '["", "two", "three"]')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/variable_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/variable_interpolation_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Style::VariableInterpolation do
 
   it 'registers an offense for interpolated global variables in string' do
     inspect_source(cop,
-                   ['puts "this is a #$test"'])
+                   'puts "this is a #$test"')
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['$test'])
     expect(cop.messages)
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Style::VariableInterpolation do
 
   it 'registers an offense for interpolated global variables in regexp' do
     inspect_source(cop,
-                   ['puts /this is a #$test/'])
+                   'puts /this is a #$test/')
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['$test'])
     expect(cop.messages)
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Style::VariableInterpolation do
 
   it 'registers an offense for interpolated global variables in regexp' do
     inspect_source(cop,
-                   ['puts `this is a #$test`'])
+                   'puts `this is a #$test`')
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['$test'])
     expect(cop.messages)
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Style::VariableInterpolation do
 
   it 'registers an offense for interpolated regexp back references' do
     inspect_source(cop,
-                   ['puts "this is a #$1"'])
+                   'puts "this is a #$1"')
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['$1'])
     expect(cop.messages)
@@ -46,7 +46,7 @@ describe RuboCop::Cop::Style::VariableInterpolation do
 
   it 'registers an offense for interpolated instance variables' do
     inspect_source(cop,
-                   ['puts "this is a #@test"'])
+                   'puts "this is a #@test"')
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['@test'])
     expect(cop.messages)
@@ -56,7 +56,7 @@ describe RuboCop::Cop::Style::VariableInterpolation do
 
   it 'registers an offense for interpolated class variables' do
     inspect_source(cop,
-                   ['puts "this is a #@@t"'])
+                   'puts "this is a #@@t"')
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['@@t'])
     expect(cop.messages)
@@ -65,7 +65,7 @@ describe RuboCop::Cop::Style::VariableInterpolation do
 
   it 'does not register an offense for variables in expressions' do
     inspect_source(cop,
-                   ['puts "this is a #{@test} #{@@t} #{$t} #{$1}"'])
+                   'puts "this is a #{@test} #{@@t} #{$t} #{$1}"')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/while_until_do_spec.rb
+++ b/spec/rubocop/cop/style/while_until_do_spec.rb
@@ -18,12 +18,12 @@ describe RuboCop::Cop::Style::WhileUntilDo do
   end
 
   it 'accepts do in single-line while' do
-    inspect_source(cop, ['while cond do something end'])
+    inspect_source(cop, 'while cond do something end')
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts do in single-line until' do
-    inspect_source(cop, ['until cond do something end'])
+    inspect_source(cop, 'until cond do something end')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -8,56 +8,56 @@ describe RuboCop::Cop::Style::WordArray, :config do
 
   it 'registers an offense for arrays of single quoted strings' do
     inspect_source(cop,
-                   ["['one', 'two', 'three']"])
+                   "['one', 'two', 'three']")
     expect(cop.offenses.size).to eq(1)
     expect(cop.config_to_allow_offenses).to eq('MinSize' => 3)
   end
 
   it 'registers an offense for arrays of double quoted strings' do
     inspect_source(cop,
-                   ['["one", "two", "three"]'])
+                   '["one", "two", "three"]')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for arrays of unicode word characters' do
     inspect_source(cop,
-                   ['["ВУЗ", "вуз", "中文网"]'])
+                   '["ВУЗ", "вуз", "中文网"]')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for arrays with character constants' do
     inspect_source(cop,
-                   ['["one", ?\n]'])
+                   '["one", ?\n]')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'does not register an offense for array of non-words' do
     inspect_source(cop,
-                   ['["one space", "two", "three"]'])
+                   '["one space", "two", "three"]')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for array containing non-string' do
     inspect_source(cop,
-                   ['["one", "two", 3]'])
+                   '["one", "two", 3]')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for array starting with %w' do
     inspect_source(cop,
-                   ['%w(one two three)'])
+                   '%w(one two three)')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for array with one element' do
     inspect_source(cop,
-                   ['["three"]'])
+                   '["three"]')
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for array with empty strings' do
     inspect_source(cop,
-                   ['["", "two", "three"]'])
+                   '["", "two", "three"]')
     expect(cop.offenses).to be_empty
   end
 
@@ -65,7 +65,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
     cop_config['MinSize'] = 3
 
     inspect_source(cop,
-                   ['["one", "two", "three"]'])
+                   '["one", "two", "three"]')
     expect(cop.offenses).to be_empty
   end
 
@@ -105,7 +105,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
     let(:cop_config) { { 'MinSize' => 0, 'WordRegex' => /\A[\w@.]+\z/ } }
 
     it 'registers an offense for arrays of email addresses' do
-      inspect_source(cop, ["['a@example.com', 'b@example.com']"])
+      inspect_source(cop, "['a@example.com', 'b@example.com']")
       expect(cop.offenses.size).to eq(1)
     end
 

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -30,7 +30,7 @@ end
 
 RSpec::Matchers.define :find_offenses_in do |code|
   match do |cop|
-    inspect_source(cop, [code])
+    inspect_source(cop, code)
     includes_highlight(cop) &&
       includes_message(cop) &&
       cop.offenses.any?


### PR DESCRIPTION
New contributors to the project make the mistake of always using arrays for the code given to `inspect_source`. It's not so strange given that there are so many places in the code today doing the same thing.

Not sure if I found all instances. Should be most of them anyway.
