### PR TITLE
[Fix #1512] Fix false negative for typical string formatting examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#1484](https://github.com/bbatsov/rubocop/issues/1484): Fix `EmptyLinesAroundAccessModifier` incorrectly finding a violation inside method calls with names identical to an access modifier. ([@dblock][])
 * Fix bug concerning `Exclude` properties inherited from a higher directory level. ([@jonas054][])
 * [#1500](https://github.com/bbatsov/rubocop/issues/1500): Fix crashing `--auto-correct --only IndentationWidth`. ([@jonas054][])
+* [#1512](https://github.com/bbatsov/rubocop/issues/1512): Fix false negative for typical string formatting examples. ([@kakutani][], [@jonas054][])
 
 ## 0.28.0 (10/12/2014)
 
@@ -1206,3 +1207,4 @@
 [@blainesch]: https://github.com/blainesch
 [@marxarelli]: https://github.com/marxarelli
 [@katieschilling]: https://github.com/katieschilling
+[@kakutani]: https://github.com/kakutani

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -31,13 +31,13 @@ module RuboCop
         end
 
         def format_method?(name, node)
-          receiver, method_name, args = *node
+          receiver, method_name, *args = *node
 
           # commands have no explicit receiver
           return false unless !receiver && method_name == name
 
           # we do an argument count check to reduce false positives
-          args && args.children.size >= 2
+          args.size >= 2
         end
 
         def format?(node)

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -54,6 +54,14 @@ describe RuboCop::Cop::Style::FormatString, :config do
       expect(cop.messages)
         .to eq(['Favor `sprintf` over `format`.'])
     end
+
+    it 'registers an offense for format with 2 arguments' do
+      inspect_source(cop,
+                     ['format("%X", 123)'])
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages)
+        .to eq(['Favor `sprintf` over `format`.'])
+    end
   end
 
   context 'when enforced style is format' do
@@ -106,6 +114,14 @@ describe RuboCop::Cop::Style::FormatString, :config do
       expect(cop.messages)
         .to eq(['Favor `format` over `sprintf`.'])
     end
+
+    it 'registers an offense for sprintf with 2 arguments' do
+      inspect_source(cop,
+                     "sprintf('%020d', 123)")
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages)
+        .to eq(['Favor `format` over `sprintf`.'])
+    end
   end
 
   context 'when enforced style is percent' do
@@ -125,6 +141,14 @@ describe RuboCop::Cop::Style::FormatString, :config do
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Favor `String#%` over `sprintf`.'])
+    end
+
+    it 'registers an offense for sprintf with 3 arguments' do
+      inspect_source(cop,
+                     'format("%d %04x", 123, 123)')
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages)
+        .to eq(['Favor `String#%` over `format`.'])
     end
 
     it 'accepts format with 1 argument' do


### PR DESCRIPTION
Using `args` instead of `*args` in unpacking the `:send` node was a bug that meant we counted the child nodes of the first argument to determine number of arguments for `format`/`sprintf`.

Thanks @kakutani for the implementation. I've just fixed up some whitespace issues and created a pull request.
