### PR TITLE
Remove disallowed array syntax in specs

### DIFF
--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -57,7 +57,7 @@ describe RuboCop::Cop::Style::FormatString, :config do
 
     it 'registers an offense for format with 2 arguments' do
       inspect_source(cop,
-                     ['format("%X", 123)'])
+                     'format("%X", 123)')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Favor `sprintf` over `format`.'])


### PR DESCRIPTION
Recently merged pull request #1517 used the spec syntax that was disallowed in #1516, causing the master build to fail.
