### PR TITLE
Require support/coverage before the rubocop code

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 # encoding: utf-8
 
+# Coverage support needs to be required *before* the RuboCop code is required!
+require 'support/coverage'
+
 require 'rubocop'
 
 # Requires supporting files with custom matchers and macros, etc,


### PR DESCRIPTION
When #1492 got merged, coveralls.io reported test coverage dropping from 99% to around 80%. Requiring SimpleCov (via `spec/support/coverage.rb`) first [changes it back to 99%](https://coveralls.io/builds/1647186).

As http://www.rubydoc.info/gems/simplecov/frames#Getting_started says:

> Note: If SimpleCov starts after your application code is already loaded (via require), it won't be able to track your files and their coverage! The SimpleCov.start must be issued before any of your application code is required!

cc @jonas054 

Closes #1522
