### PR TITLE
Remove duplicate code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changes
 
 * [#1492](https://github.com/bbatsov/rubocop/pull/1492): Abort when auto-correct causes an infinite loop. ([@dblock][])
+* Remove duplicate code. ([@rrosenblum][])
 
 ### Bugs fixed
 

--- a/lib/rubocop/cop/style/string_literals_in_interpolation.rb
+++ b/lib/rubocop/cop/style/string_literals_in_interpolation.rb
@@ -24,14 +24,6 @@ module RuboCop
 
           wrong_quotes?(node, style)
         end
-
-        def autocorrect(node)
-          @corrections << lambda do |corrector|
-            replacement = node.loc.begin.is?('"') ? "'" : '"'
-            corrector.replace(node.loc.begin, replacement)
-            corrector.replace(node.loc.end, replacement)
-          end
-        end
       end
     end
   end

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -97,21 +97,6 @@ module RuboCop
         message = offense.corrected? ? green('[Corrected] ') : ''
         message << annotate_message(offense.message)
       end
-
-      def pluralize(number, thing, options = {})
-        text = ''
-
-        if number == 0 && options[:no_for_zero]
-          text = 'no'
-        else
-          text << number.to_s
-        end
-
-        text << " #{thing}"
-        text << 's' unless number == 1
-
-        text
-      end
     end
   end
 end


### PR DESCRIPTION
I found some code duplication listed on https://codeclimate.com/github/bbatsov/rubocop/issues/categories/duplication that was easy to fix. 

This should also fix the code coverage in [text_util.rb](https://coveralls.io/files/401400345). It is being hidden by the duplicate method in `simple_text_formatter.rb`
