### PR TITLE
Configure Debugger cop to check for Capybara debug methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#1430](https://github.com/bbatsov/rubocop/issues/1430): Add `--except` option for disabling cops on the command line. ([@jonas054][])
 * [#1506](https://github.com/bbatsov/rubocop/pull/1506): Add auto-correct from `EvenOdd` cop. ([@blainesch][])
+* [#1507](https://github.com/bbatsov/rubocop/issues/1507): `Debugger` cop now checks for the Capybara debug methods `save_and_open_page` and `save_and_open_screenshot`. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -35,12 +35,24 @@ module RuboCop
         #   (send nil :binding) :pry_remote)
         PRY_REMOTE_NODE = s(:send, s(:send, nil, :binding), :pry_remote)
 
+        # save_and_open_page
+        #
+        # (send nil :save_and_open_page)
+        CAPYBARA_SAVE_PAGE = s(:send, nil, :save_and_open_page)
+
+        # save_and_open_screenshot
+        #
+        # (send nil :save_and_open_screenshot)
+        CAPYBARA_SAVE_SCREENSHOT = s(:send, nil, :save_and_open_screenshot)
+
         DEBUGGER_NODES = [
           DEBUGGER_NODE,
           BYEBUG_NODE,
           PRY_NODE,
           REMOTE_PRY_NODE,
-          PRY_REMOTE_NODE
+          PRY_REMOTE_NODE,
+          CAPYBARA_SAVE_PAGE,
+          CAPYBARA_SAVE_SCREENSHOT
         ]
 
         def on_send(node)

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -36,13 +36,25 @@ describe RuboCop::Cop::Lint::Debugger do
                                   'binding.pry_remote'])
   end
 
+  it 'reports an offense for capybara debug methods' do
+    src = %w(save_and_open_page save_and_open_screenshot)
+    inspect_source(cop, src)
+    expect(cop.offenses.size).to eq(2)
+    expect(cop.messages)
+      .to eq(['Remove debugger entry point `save_and_open_page`.',
+              'Remove debugger entry point `save_and_open_screenshot`.'])
+    expect(cop.highlights)
+      .to eq(%w(save_and_open_page save_and_open_screenshot))
+  end
+
   it 'does not report an offense for non-pry binding' do
     src = 'binding.pirate'
     inspect_source(cop, src)
     expect(cop.offenses).to be_empty
   end
 
-  %w(debugger byebug pry remote_pry pry_remote).each do |comment|
+  %w(debugger byebug pry remote_pry pry_remote
+     save_and_open_page save_and_open_screenshot).each do |comment|
     it "does not report an offense for #{comment} in comments" do
       src = "# #{comment}"
       inspect_source(cop, src)
@@ -50,7 +62,8 @@ describe RuboCop::Cop::Lint::Debugger do
     end
   end
 
-  %w(debugger byebug pry remote_pry pry_remote).each do |method_name|
+  %w(debugger byebug pry remote_pry pry_remote
+     save_and_open_page save_and_open_screenshot).each do |method_name|
     it "does not report an offense for a #{method_name} method" do
       src = "code.#{method_name}"
       inspect_source(cop, src)


### PR DESCRIPTION
This resolves #1507. Configure Debugger cop to check for `save_and_open_page` and `save_and_open_screenshot`.
