### PR TITLE
Rework line end concatenation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#1512](https://github.com/bbatsov/rubocop/issues/1512): Fix false negative for typical string formatting examples. ([@kakutani][], [@jonas054][])
 * [#1504](https://github.com/bbatsov/rubocop/issues/1504): Fail with a meaningful error if the configuration file is malformed. ([@bquorning][])
 * Fix bug where `auto_correct` Rake tasks does not take in the options specified in its parent task. ([@rrosenblum][])
+* [#1054](https://github.com/bbatsov/rubocop/issues/1054): Handle comments within concatenated strings in `LineEndConcatenation`. ([@yujinakayama][], [@jonas054][])
 
 ## 0.28.0 (10/12/2014)
 

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -24,11 +24,13 @@ module RuboCop
         CONCAT_TOKEN_TYPES = [:tPLUS, :tLSHFT].freeze
         SIMPLE_STRING_TOKEN_TYPE = :tSTRING
         COMPLEX_STRING_EDGE_TOKEN_TYPES = [:tSTRING_BEG, :tSTRING_END].freeze
+        HIGH_PRECEDENCE_OP_TOKEN_TYPES = [:tSTAR2, :tPERCENT, :tDOT,
+                                          :tLBRACK2].freeze
         QUOTE_DELIMITERS = %w(' ").freeze
 
         def investigate(processed_source)
-          processed_source.tokens.each_cons(3) do |tokens|
-            check_token_set(*tokens)
+          processed_source.tokens.each_index do |index|
+            check_token_set(index)
           end
         end
 
@@ -40,12 +42,35 @@ module RuboCop
 
         private
 
-        def check_token_set(predecessor, operator, successor)
+        def check_token_set(index)
+          predecessor, operator, successor = processed_source.tokens[index, 3]
+          return unless successor
           return unless CONCAT_TOKEN_TYPES.include?(operator.type)
           return unless standard_string_literal?(predecessor)
           return unless standard_string_literal?(successor)
           return if operator.pos.line == successor.pos.line
+
+          next_successor = token_after_last_string(successor, index)
+          return if next_successor &&
+                    HIGH_PRECEDENCE_OP_TOKEN_TYPES.include?(next_successor.type)
+
           add_offense(operator.pos, operator.pos)
+        end
+
+        def token_after_last_string(successor, base_index)
+          index = base_index + 3
+          begin_token, end_token = COMPLEX_STRING_EDGE_TOKEN_TYPES
+          if successor.type == begin_token
+            ends_to_find = 1
+            while ends_to_find > 0
+              case processed_source.tokens[index].type
+              when begin_token then ends_to_find += 1
+              when end_token then ends_to_find -= 1
+              end
+              index += 1
+            end
+          end
+          processed_source.tokens[index]
         end
 
         def standard_string_literal?(token)

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -75,6 +75,36 @@ describe RuboCop::Cop::Style::LineEndConcatenation do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts string concat with a return value of method on a string' do
+    inspect_source(cop,
+                   [
+                     # What we want here is 'content   ', not '
+                     # content content content '.
+                     'content_and_three_spaces = "content" +',
+                     '  " " * 3',
+                     # Method call with dot on a string literal.
+                     "a_thing = 'a ' +",
+                     "  'gniht'.reverse",
+                     # Formatting operator.
+                     "output = 'value: ' +",
+                     "  '%d' % value",
+                     # Index operator.
+                     "'letter: ' +",
+                     "  'abcdefghij'[ix]"
+                   ])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts string concat with a return value of method on an interpolated ' \
+     'string' do
+    source = <<-END
+      x3a = 'x' +
+        "\#{'a' + "\#{3}"}".reverse
+    END
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
   it 'accepts string concat at line end when followed by comment' do
     inspect_source(cop,
                    ['top = "test" + # something',


### PR DESCRIPTION
Trying to close an old issue, #1054. This is based on @yujinakayama's solution with added handling of operators on the second argument according to @bbatsov's suggestion. Then there were a couple more operators to take care of, and also interpolated strings (possibly on multiple levels) in that context.
