### PR TITLE
[Fix #1527] Fix autocorrect bracesaroundhashparameters leaves extra space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#1504](https://github.com/bbatsov/rubocop/issues/1504): Fail with a meaningful error if the configuration file is malformed. ([@bquorning][])
 * Fix bug where `auto_correct` Rake tasks does not take in the options specified in its parent task. ([@rrosenblum][])
 * [#1054](https://github.com/bbatsov/rubocop/issues/1054): Handle comments within concatenated strings in `LineEndConcatenation`. ([@yujinakayama][], [@jonas054][])
+* [#1527](https://github.com/bbatsov/rubocop/issues/1527): Make autocorrect `BracesAroundHashParameter` leave the correct number of spaces. ([@mattjmcnaughton][])
 
 ## 0.28.0 (10/12/2014)
 
@@ -1213,3 +1214,4 @@
 [@katieschilling]: https://github.com/katieschilling
 [@kakutani]: https://github.com/kakutani
 [@rrosenblum]: https://github.com/rrosenblum
+[@mattjmcnaughton]: https://github.com/mattjmcnaughton

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -50,8 +50,10 @@ module RuboCop
         def autocorrect(node)
           @corrections << lambda do |corrector|
             if braces?(node)
-              corrector.remove(node.loc.begin)
-              corrector.remove(node.loc.end)
+              right_range = range_with_surrounding_space(node.loc.begin, :right)
+              corrector.remove(right_range)
+              left_range = range_with_surrounding_space(node.loc.end, :left)
+              corrector.remove(left_range)
             else
               corrector.insert_before(node.loc.expression, '{')
               corrector.insert_after(node.loc.expression, '}')

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -143,11 +143,17 @@ module RuboCop
 
       def range_with_surrounding_space(range, side = :both)
         src = @processed_source.buffer.source
-        go_left = side == :left || side == :both
-        go_right = side == :right || side == :both
-        begin_pos = range.begin_pos
+
+        if side == :both
+          go_left, go_right = true, true
+        else
+          go_left = side == :left
+          go_right = side == :right
+        end
+
+        begin_pos, end_pos = range.begin_pos, range.end_pos
         begin_pos -= 1 while go_left && src[begin_pos - 1] =~ /[ \t]/
-        end_pos = range.end_pos
+        begin_pos -= 1 if go_left && src[begin_pos - 1] == "\n"
         end_pos += 1 while go_right && src[end_pos] =~ /[ \t]/
         end_pos += 1 if go_right && src[end_pos] == "\n"
         Parser::Source::Range.new(@processed_source.buffer, begin_pos, end_pos)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -117,13 +117,11 @@ describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(['-D', '--auto-correct'])).to eq(0)
         corrected =
           ['# encoding: utf-8',
-           'expect(subject[:address]).to eq(',
-           "  street1:     '1 Market',",
-           "  street2:     '#200',",
-           "  city:        'Some Town',",
-           "  state:       'CA',",
-           "  postal_code: '99999-1111'",
-           ')']
+           "expect(subject[:address]).to eq(street1:     '1 Market',",
+           "                                street2:     '#200',",
+           "                                city:        'Some Town',",
+           "                                state:       'CA',",
+           "                                postal_code: '99999-1111')"]
         expect(IO.read('example.rb')).to eq(corrected.join("\n") + "\n")
       end
 

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -92,51 +92,56 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
     it 'corrects one non-hash parameter followed by a hash parameter with ' \
        'braces' do
       corrected = autocorrect_source(cop, ['where(1, { y: 2 })'])
-      expect(corrected).to eq('where(1,  y: 2 )')
+      expect(corrected).to eq('where(1, y: 2)')
     end
 
     it 'corrects one object method hash parameter with braces' do
       corrected = autocorrect_source(cop, ['x.func({ y: "z" })'])
-      expect(corrected).to eq('x.func( y: "z" )')
+      expect(corrected).to eq('x.func(y: "z")')
     end
 
     it 'corrects one hash parameter with braces' do
       corrected = autocorrect_source(cop, ['where({ x: 1 })'])
-      expect(corrected).to eq('where( x: 1 )')
+      expect(corrected).to eq('where(x: 1)')
     end
 
     it 'corrects one hash parameter with braces and whitespace' do
       corrected = autocorrect_source(cop, ['where(  ',
                                            ' { x: 1 }   )'])
       expect(corrected).to eq(['where(  ',
-                               '  x: 1    )'].join("\n"))
+                               ' x: 1   )'].join("\n"))
     end
 
     it 'corrects one hash parameter with braces and multiple keys' do
       corrected = autocorrect_source(cop, ['where({ x: 1, foo: "bar" })'])
-      expect(corrected).to eq('where( x: 1, foo: "bar" )')
+      expect(corrected).to eq('where(x: 1, foo: "bar")')
     end
 
     it 'corrects one hash parameter with braces and extra leading whitespace' do
       corrected = autocorrect_source(cop, ['where({   x: 1, y: 2 })'])
-      expect(corrected).to eq('where(   x: 1, y: 2 )')
+      expect(corrected).to eq('where(x: 1, y: 2)')
     end
 
     it 'corrects one hash parameter with braces and extra trailing ' \
        'whitespace' do
       corrected = autocorrect_source(cop, ['where({ x: 1, y: 2   })'])
-      expect(corrected).to eq('where( x: 1, y: 2   )')
+      expect(corrected).to eq('where(x: 1, y: 2)')
     end
 
     it 'corrects one hash parameter with braces and a trailing comma' do
       corrected = autocorrect_source(cop, ['where({ x: 1, y: 2, })'])
-      expect(corrected).to eq('where( x: 1, y: 2, )')
+      expect(corrected).to eq('where(x: 1, y: 2,)')
     end
 
     it 'corrects one hash parameter with braces and trailing comma and ' \
        'whitespace' do
       corrected = autocorrect_source(cop, ['where({ x: 1, y: 2,   })'])
-      expect(corrected).to eq('where( x: 1, y: 2,   )')
+      expect(corrected).to eq('where(x: 1, y: 2,)')
+    end
+
+    it 'corrects one hash parameter with braces without adding extra space' do
+      corrected = autocorrect_source(cop, 'get :i, { q: { x: 1 } }')
+      expect(corrected).to eq('get :i, q: { x: 1 }')
     end
   end
 
@@ -167,12 +172,12 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
 
       it 'corrects one hash parameter with braces' do
         corrected = autocorrect_source(cop, ['where(1, { x: 1 })'])
-        expect(corrected).to eq('where(1,  x: 1 )')
+        expect(corrected).to eq('where(1, x: 1)')
       end
 
       it 'corrects two hash parameters with braces' do
         corrected = autocorrect_source(cop, ['where(1, { x: 1 }, { y: 2 })'])
-        expect(corrected).to eq('where(1, { x: 1 },  y: 2 )')
+        expect(corrected).to eq('where(1, { x: 1 }, y: 2)')
       end
     end
   end
@@ -212,7 +217,7 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
 
       it 'corrects one hash parameter with braces' do
         corrected = autocorrect_source(cop, ['where(1, { x: 1 })'])
-        expect(corrected).to eq('where(1,  x: 1 )')
+        expect(corrected).to eq('where(1, x: 1)')
       end
     end
   end


### PR DESCRIPTION
Fixes #1527 

This pull request fixes the above mentioned issue. It also takes the added step of removing any extra white space when doing autocorrect for the `BracesAroundHashParameters` cop, as can be seen in `braces_around_hash_parameters_spec`. I also had to make a slight change to `Util.range_with_surrounding_space` to make the way it handled white space uniform for both the left and right directives. Finally, this required updating a test in `cli_spec`. 

Final note. I know in the Contributing guidelines it says to squash commits. Can someone give me some tips on how to do this? I'm mostly just confused because I pulled from the upstream master to make sure I was staying up to date, but I'm not sure how to factor those upstream commits into the rebase. Thanks!
