### PR TITLE
Don't wrap .run arguments in two arrays

### DIFF
--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -56,7 +56,7 @@ describe RuboCop::CLI, :isolated_environment do
                   '  fail',
                   'end']
         create_file('example.rb', source)
-        expect(cli.run([%w(--only IndentationWidth --auto-correct)])).to eq(0)
+        expect(cli.run(%w(--only IndentationWidth --auto-correct))).to eq(0)
         corrected = ['foo = if bar',
                      '        something',
                      'elsif baz',


### PR DESCRIPTION
The spec only passes because `Options#convert_deprecated_options` will eventually call call `flatten!` on the array.
