### PR TITLE
Remove deprecated flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Changes
 
 * [#1492](https://github.com/bbatsov/rubocop/pull/1492): Abort when auto-correct causes an infinite loop. ([@dblock][])
-* Options `-e`/`--emacs` are no longer recognized. Using them will now raise an error. ([@bquorning][])
+* Options `-e`/`--emacs` and `-s`/`--silent` are no longer recognized. Using them will now raise an error. ([@bquorning][])
 
 ### Bugs fixed
 

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -63,8 +63,6 @@ module RuboCop
     end
 
     def parse(args)
-      ignore_dropped_options(args)
-
       define_options(args).parse!(args)
 
       validate_compatibility
@@ -179,16 +177,6 @@ module RuboCop
     def long_opt_symbol(args)
       long_opt = args.find { |arg| arg.start_with?('--') }
       long_opt[2..-1].sub(/ .*/, '').gsub(/-/, '_').to_sym
-    end
-
-    def ignore_dropped_options(args)
-      # Currently we don't make -s/--silent option raise error
-      # since those are mostly used by external tools.
-      rejected = args.reject! { |a| %w(-s --silent).include?(a) }
-      return unless rejected
-
-      warn '-s/--silent options is dropped. ' \
-           '`emacs` and `files` formatters no longer display summary.'
     end
 
     def validate_auto_gen_config_option(args)

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -154,15 +154,4 @@ Usage: rubocop [options] [file1, file2, ...]
       end
     end
   end
-
-  unless RuboCop::Version::STRING.start_with?('0')
-    describe '-s/--silent option' do
-      it 'raises error in RuboCop 1.0.0' do
-        # This spec can be removed
-        # once Options#ignore_dropped_options is removed.
-        expect { options.parse(['--silent']) }
-          .to raise_error(OptionParser::InvalidOption)
-      end
-    end
-  end
 end


### PR DESCRIPTION
@bbatsov commented on https://github.com/bquorning/rubocop/commit/526dc81eb1608284f4cb735574b2df3d167ba65f that “They have been deprecated for about an year now and 1.0 is definitely not in sight.”

Not only have I removed the `--emacs` and `--silent` options completely, I also removed the “infrastructure” for deprecated options (`#ignore_dropped_options`, `#convert_deprecated_options` and `#deprecate` methods).

The build will pass once #1537 is merged and I have rebased.
