### PR TITLE
Remove double spaces after a period in documentation

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -96,7 +96,7 @@ AllCops:
   # cops in user configuration will be enabled even if they don't set the
   # Enabled parameter.
   # When `EnabledByDefault` is `true`, all cops, even those in disabled.yml,
-  # are enabled by default.  Cops can still be disabled in user configuration.
+  # are enabled by default. Cops can still be disabled in user configuration.
   # Note that it is invalid to set both EnabledByDefault and DisabledByDefault
   # to true in the same configuration.
   EnabledByDefault: false
@@ -132,11 +132,11 @@ AllCops:
   # use the oldest officially supported Ruby version (currently Ruby 2.2).
   TargetRubyVersion: ~
   # What version of Rails is the inspected code using?  If a value is specified
-  # for TargetRailsVersion then it is used.  Acceptable values are specificed
+  # for TargetRailsVersion then it is used. Acceptable values are specificed
   # as a float (i.e. 5.1); the patch version of Rails should not be included.
   # If TargetRailsVersion is not set, RuboCop will parse the Gemfile.lock or
   # gems.locked file to find the version of Rails that has been bound to the
-  # application.  If neither of those files exist, RuboCop will use Rails 5.0
+  # application. If neither of those files exist, RuboCop will use Rails 5.0
   # as the default.
   TargetRailsVersion: ~
 
@@ -1016,7 +1016,7 @@ Style/ConditionalAssignment:
 # You can override the default Notice in your .rubocop.yml file.
 #
 # In order to use autocorrect, you must supply a value for the
-# `AutocorrectNotice` key that matches the regexp Notice.  A blank
+# `AutocorrectNotice` key that matches the regexp Notice. A blank
 # `AutocorrectNotice` will cause an error during autocorrect.
 #
 # Autocorrect will add a copyright notice in a comment at the top
@@ -1530,7 +1530,7 @@ Style/WordArray:
     # bracket style: ['word1', 'word2']
     - brackets
   # The `MinSize` option causes the `WordArray` rule to be ignored for arrays
-  # smaller than a certain size.  The rule is only applied to arrays
+  # smaller than a certain size. The rule is only applied to arrays
   # whose element count is greater than or equal to `MinSize`.
   MinSize: 2
   # The regular expression `WordRegex` decides what is considered a word.

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -627,7 +627,7 @@ module RuboCop
         # "RUBY VERSION" line.
         in_ruby_section ||= line.match(/^\s*RUBY\s*VERSION\s*$/)
         next unless in_ruby_section
-        # We currently only allow this feature to work with MRI ruby.  If jruby
+        # We currently only allow this feature to work with MRI ruby. If jruby
         # (or something else) is used by the project, it's lock file will have a
         # line that looks like:
         #     RUBY VERSION

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -51,7 +51,7 @@ module RuboCop
 
     # Merges the given configuration with the default one. If
     # AllCops:DisabledByDefault is true, it changes the Enabled params so that
-    # only cops from user configuration are enabled.  If
+    # only cops from user configuration are enabled. If
     # AllCops::EnabledByDefault is true, it changes the Enabled params so that
     # only cops explicitly disabled in user configuration are disabled.
     def merge_with_default(config, config_file)

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -88,7 +88,7 @@ module RuboCop
             # brace plus space (rather than just inserting a space), then any
             # removal of the same brace will give us a clobbering error. This
             # in turn will make RuboCop fall back on cop-by-cop
-            # auto-correction.  Problem solved.
+            # auto-correction. Problem solved.
             case range.source
             when /\s/ then corrector.remove(range)
             when '{' then corrector.replace(range, '{ ')

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -4,8 +4,8 @@ module RuboCop
   module Cop
     module Lint
       # The safe navigation operator returns nil if the receiver is
-      # nil.  If you chain an ordinary method call after a safe
-      # navigation operator, it raises NoMethodError.  We should use a
+      # nil. If you chain an ordinary method call after a safe
+      # navigation operator, it raises NoMethodError. We should use a
       # safe navigation operator after a safe navigation operator.
       # This cop checks for the problem outlined above.
       #

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Rails
       # This cop is used to identify usages of http methods like `get`, `post`,
       # `put`, `patch` without the usage of keyword arguments in your tests and
-      # change them to use keyword args.  This cop only applies to Rails >= 5 .
+      # change them to use keyword args. This cop only applies to Rails >= 5.
       # If you are running Rails < 5 you should disable the
       # Rails/HttpPositionalArguments cop or set your TargetRailsVersion in your
       # .rubocop.yml file to 4.0, etc.

--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -6,12 +6,12 @@ module RuboCop
       # Check that a copyright notice was given in each source file.
       #
       # The default regexp for an acceptable copyright notice can be found in
-      # config/default.yml.  The default can be changed as follows:
+      # config/default.yml. The default can be changed as follows:
       #
       #     Style/Copyright:
       #       Notice: '^Copyright (\(c\) )?2\d{3} Acme Inc'
       #
-      # This regex string is treated as an unanchored regex.  For each file
+      # This regex string is treated as an unanchored regex. For each file
       # that RuboCop scans, a comment that matches this regex must be found or
       # an offense is reported.
       #

--- a/lib/rubocop/cop/style/percent_q_literals.rb
+++ b/lib/rubocop/cop/style/percent_q_literals.rb
@@ -30,7 +30,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         LOWER_CASE_Q_MSG = 'Do not use `%Q` unless interpolation is ' \
-                           'needed.  Use `%q`.'.freeze
+                           'needed. Use `%q`.'.freeze
         UPPER_CASE_Q_MSG = 'Use `%Q` instead of `%q`.'.freeze
 
         def on_str(node)

--- a/manual/caching.md
+++ b/manual/caching.md
@@ -32,7 +32,7 @@ overrides the setting.
 
 By default, the cache is stored in either
 `$XDG_CACHE_HOME/rubocop_cache` if `$XDG_CACHE_HOME` is set, or in
-`$HOME/.cache/rubocop_cache/` if it's not.  The configuration parameter
+`$HOME/.cache/rubocop_cache/` if it's not. The configuration parameter
 `AllCops: CacheRootDirectory` can be used to set the root to a
 different path. One reason to use this option could be that there's a
 network disk where users on different machines want to have a common

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -209,7 +209,7 @@ ones. If there is no `.rubocop.yml` file in the project or home directory,
 ### Including/Excluding files
 
 RuboCop does a recursive file search starting from the directory it is
-run in, or directories given as command line arguments.  Files that
+run in, or directories given as command line arguments. Files that
 match any pattern listed under `AllCops`/`Include` and extensionless
 files with a hash-bang (`#!`) declaration containing one of the known
 ruby interpreters listed under `AllCops`/`RubyInterpreters` are
@@ -301,7 +301,7 @@ valid for the directory tree starting where they are defined. They are not
 shadowed by the setting of `Include` and `Exclude` in other `.rubocop.yml`
 files in subdirectories. This is different from all other parameters, who
 follow RuboCop's general principle that configuration for an inspected file
-is taken from the nearest `.rubocop.yml`, searching upwards.  _This behavior
+is taken from the nearest `.rubocop.yml`, searching upwards. _This behavior
 will be overridden if you specify the `--ignore-parent-exclusion` command line
 argument_.
 
@@ -407,7 +407,7 @@ Metrics/LineLength:
     If lines are too short, text becomes hard to read because you must
     constantly jump from one line to the next while reading. If lines are too
     long, the line jumping becomes too hard because you "lose the line" while
-    going back to the start of the next line.  80 characters is a good
+    going back to the start of the next line. 80 characters is a good
     compromise.
 ```
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1660,8 +1660,8 @@ Enabled by default | Supports autocorrection
 Enabled | No
 
 The safe navigation operator returns nil if the receiver is
-nil.  If you chain an ordinary method call after a safe
-navigation operator, it raises NoMethodError.  We should use a
+nil. If you chain an ordinary method call after a safe
+navigation operator, it raises NoMethodError. We should use a
 safe navigation operator after a safe navigation operator.
 This cop checks for the problem outlined above.
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -804,7 +804,7 @@ Enabled | Yes
 
 This cop is used to identify usages of http methods like `get`, `post`,
 `put`, `patch` without the usage of keyword arguments in your tests and
-change them to use keyword args.  This cop only applies to Rails >= 5 .
+change them to use keyword args. This cop only applies to Rails >= 5.
 If you are running Rails < 5 you should disable the
 Rails/HttpPositionalArguments cop or set your TargetRailsVersion in your
 .rubocop.yml file to 4.0, etc.

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1097,12 +1097,12 @@ Disabled | Yes
 Check that a copyright notice was given in each source file.
 
 The default regexp for an acceptable copyright notice can be found in
-config/default.yml.  The default can be changed as follows:
+config/default.yml. The default can be changed as follows:
 
     Style/Copyright:
       Notice: '^Copyright (\(c\) )?2\d{3} Acme Inc'
 
-This regex string is treated as an unanchored regex.  For each file
+This regex string is treated as an unanchored regex. For each file
 that RuboCop scans, a comment that matches this regex must be found or
 an offense is reported.
 

--- a/manual/extensions.md
+++ b/manual/extensions.md
@@ -16,7 +16,7 @@ require:
 
 !!! Note
 
-    The paths are directly passed to `Kernel.require`.  If your
+    The paths are directly passed to `Kernel.require`. If your
     extension file is not in `$LOAD_PATH`, you need to specify the path as
     relative path prefixed with `./` explicitly, or absolute path. Paths
     starting with a `.` are resolved relative to `.rubocop.yml`.

--- a/manual/support.md
+++ b/manual/support.md
@@ -1,12 +1,12 @@
 RuboCop currently has several official & unofficial support channels.
 
-For questions, suggestions and support refer to one of them.  Please, don't
+For questions, suggestions and support refer to one of them. Please, don't
 use the support channels to report issues, as this makes them harder to track.
 
 ## Gitter
 
 Most internal discussions about the development of RuboCop happen on its
-[gitter channel](https://gitter.im/bbatsov/rubocop).  You can often find
+[gitter channel](https://gitter.im/bbatsov/rubocop). You can often find
 RuboCop's maintainers there and get some interesting news from the project's
 kitchen.
 

--- a/relnotes/v0.26.0.md
+++ b/relnotes/v0.26.0.md
@@ -1,4 +1,4 @@
-Nothing particularly exciting this time around.  The new release comes
+Nothing particularly exciting this time around. The new release comes
 with lots of bug fixes, more auto-corrections and several new cops.
 
 Note that the `Style/Encoding` cop is now disabled by default. See

--- a/spec/rubocop/cop/style/percent_q_literals_spec.rb
+++ b/spec/rubocop/cop/style/percent_q_literals_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::Style::PercentQLiterals, :config do
       it 'registers offense for %Q' do
         expect_offense(<<-RUBY.strip_indent)
           %Q(hi)
-          ^^^ Do not use `%Q` unless interpolation is needed.  Use `%q`.
+          ^^^ Do not use `%Q` unless interpolation is needed. Use `%q`.
         RUBY
       end
 


### PR DESCRIPTION
Documentation nitpick: harmonize the use of one space only after a period (`.`).

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
