### PR TITLE
[Fix #6263] Fix an error for `Layout/EmptyLineAfterGuardClause`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#6256](https://github.com/rubocop-hq/rubocop/pull/6256): Fix false positive for `Naming/FileName` when investigating dotfiles. ([@sinsoku][])
 * [#6242](https://github.com/rubocop-hq/rubocop/pull/6242): Fix `Style/EmptyCaseCondition` auto-correction removes comment between `case` and first `when`. ([@koic][])
 * [#6261](https://github.com/rubocop-hq/rubocop/pull/6261): Fix undefined method error for `Style/RedundantBegin` when calling `super` with a block. ([@eitoball][])
+* [#6263](https://github.com/rubocop-hq/rubocop/issues/6263): Fix an error `Layout/EmptyLineAfterGuardClause` when guard clause is after heredoc including string interpolation. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
@@ -47,7 +47,10 @@ module RuboCop
           if last_argument_is_heredoc?(node)
             heredoc_node = last_argument(node)
 
-            num_of_heredoc_lines = heredoc_node.children.size
+            heredoc_body = heredoc_node.loc.heredoc_body
+            num_of_heredoc_lines =
+              heredoc_body.last_line - heredoc_body.first_line
+
             line = node.last_line + num_of_heredoc_lines + END_OF_HEREDOC_LINE
 
             return if next_line_empty?(line)

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -51,6 +51,17 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
   end
 
   it 'registers an offense for next guard clause not followed by empty line ' \
+     'when guard clause is after heredoc including string interpolation' do
+    expect_offense(<<-'RUBY'.strip_indent)
+      raise(<<-FAIL) unless true
+        #{1 + 1}
+      FAIL
+      ^^^^ Add empty line after guard clause.
+      1
+    RUBY
+  end
+
+  it 'registers an offense for next guard clause not followed by empty line ' \
      'when guard clause is after condition without method invocation' do
     expect_no_offenses(<<-'RUBY'.strip_indent)
       def foo


### PR DESCRIPTION
Fixes #6263.

This PR fixes an error `Layout/EmptyLineAfterGuardClause` when guard clause is after heredoc including string interpolation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
