### PR TITLE
Refactor `Layout/EmptyLinesAroundAccessModifier` to use AST instread of regexp

### DIFF
--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -32,21 +32,21 @@ module RuboCop
         def on_class(node)
           _name, superclass, _body = *node
 
-          @class_or_module_def_line = if superclass
-                                        superclass.first_line
-                                      else
-                                        node.source_range.first_line
-                                      end
+          @class_or_module_def = superclass || node.source_range
         end
 
         def on_module(node)
-          @class_or_module_def_line = node.source_range.first_line
+          @class_or_module_def = node.source_range
         end
 
         def on_sclass(node)
           self_node, _body = *node
 
-          @class_or_module_def_line = self_node.source_range.first_line
+          @class_or_module_def = self_node.source_range
+        end
+
+        def on_block(node)
+          @block_line = node.source_range.first_line
         end
 
         def on_send(node)
@@ -59,15 +59,13 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            send_line = node.first_line
-            next_line = processed_source[send_line]
             line = range_by_whole_lines(node.source_range)
 
-            unless previous_line_empty?(send_line)
+            unless previous_line_empty?(node.first_line)
               corrector.insert_before(line, "\n")
             end
 
-            unless next_line_empty?(next_line)
+            unless next_line_empty?(node.last_line)
               corrector.insert_after(line, "\n")
             end
           end
@@ -85,42 +83,44 @@ module RuboCop
           previous_line = previous_line_ignoring_comments(processed_source,
                                                           send_line)
 
-          block_start?(previous_line) ||
+          block_start?(send_line) ||
             class_def?(send_line) ||
             previous_line.blank?
         end
 
-        def next_line_empty?(next_line)
-          body_end?(next_line) || next_line.blank?
+        def next_line_empty?(last_send_line)
+          next_line = processed_source[last_send_line]
+
+          body_end?(last_send_line) || next_line.blank?
         end
 
         def empty_lines_around?(node)
-          send_line = node.first_line
-
-          next_line = processed_source[send_line]
-
-          previous_line_empty?(send_line) && next_line_empty?(next_line)
+          previous_line_empty?(node.first_line) &&
+            next_line_empty?(node.last_line)
         end
 
         def class_def?(line)
-          return false unless @class_or_module_def_line
+          return false unless @class_or_module_def
 
-          line == @class_or_module_def_line + 1
+          line == @class_or_module_def.first_line + 1
         end
 
         def block_start?(line)
-          line.match(/ (do|{)( \|.*?\|)?\s?$/)
+          return false unless @block_line
+
+          line == @block_line + 1
         end
 
         def body_end?(line)
-          line =~ /^\s*end\b/
+          return false unless @class_or_module_def
+
+          line == @class_or_module_def.last_line - 1
         end
 
         def message(node)
           send_line = node.first_line
-          previous_line = processed_source[send_line - 2]
 
-          if block_start?(previous_line) ||
+          if block_start?(send_line) ||
              class_def?(send_line)
             format(MSG_AFTER, modifier: node.loc.selector.source)
           else


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/pull/6307#issuecomment-422870948.

This PR refactors `Layout/EmptyLinesAroundAccessModifier` to use AST instread of regexp.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
