### PR TITLE
Treat begin-end like do-end in Layout/BlockAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#7262](https://github.com/rubocop-hq/rubocop/issues/7262): `Lint/FormatParameterMismatch` did not recognize named format sequences like `%.2<name>f` where the name appears after some modifiers. ([@buehmann][])
 * [#7253](https://github.com/rubocop-hq/rubocop/issues/7253): Fix an error for `Lint/NumberConversion` when `#to_i` called without a receiver. ([@koic][])
 * [#7271](https://github.com/rubocop-hq/rubocop/issues/7271), [#6498](https://github.com/rubocop-hq/rubocop/issues/6498): Fix an interference between `Style/TrailingCommaIn*Literal` and `Layout/Multiline*BraceLayout` for arrays and hashes. ([@buehmann][])
+* [#7286](https://github.com/rubocop-hq/rubocop/pull/7286): Treat `begin`-`end` blocks like `do`-`end` blocks in `Layout/BlockAlignment`. ([@fphilipe][])
 
 ### Changes
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -109,9 +109,9 @@ module RuboCop
 
       def default_configuration
         @default_configuration ||= begin
-                                     print 'Default ' if debug?
-                                     load_file(DEFAULT_FILE)
-                                   end
+          print 'Default ' if debug?
+          load_file(DEFAULT_FILE)
+        end
       end
 
       # Merges the given configuration with the default one. If

--- a/lib/rubocop/config_store.rb
+++ b/lib/rubocop/config_store.rb
@@ -40,9 +40,9 @@ module RuboCop
       @path_cache[dir] ||= ConfigLoader.configuration_file_for(dir)
       path = @path_cache[dir]
       @object_cache[path] ||= begin
-                                print "For #{dir}: " if ConfigLoader.debug?
-                                ConfigLoader.configuration_from_file(path)
-                              end
+        print "For #{dir}: " if ConfigLoader.debug?
+        ConfigLoader.configuration_from_file(path)
+      end
     end
   end
 end

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -26,10 +26,18 @@ module RuboCop
       #        baz
       #          end
       #
+      #   begin
+      #     baz
+      #     end
+      #
       #   # good
       #
       #   variable = lambda do |i|
       #     i
+      #   end
+      #
+      #   variable = begin
+      #     baz
       #   end
       #
       # @example EnforcedStyleAlignWith: start_of_block
@@ -40,10 +48,20 @@ module RuboCop
       #        baz
       #          end
       #
+      #   x =
+      #     begin
+      #       baz
+      #   end
+      #
       #   # good
       #
       #   foo.bar
       #     .each do
+      #       baz
+      #     end
+      #
+      #   x =
+      #     begin
       #       baz
       #     end
       #
@@ -55,11 +73,19 @@ module RuboCop
       #        baz
       #          end
       #
+      #   x = begin
+      #         baz
+      #       end
+      #
       #   # good
       #
       #   foo.bar
       #     .each do
       #        baz
+      #   end
+      #
+      #   x = begin
+      #     baz
       #   end
       class BlockAlignment < Cop
         include ConfigurableEnforcedStyle
@@ -79,6 +105,7 @@ module RuboCop
         def on_block(node)
           check_block_alignment(start_for_block_node(node), node)
         end
+        alias on_kwbegin on_block
 
         def style_parameter_name
           'EnforcedStyleAlignWith'

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -476,10 +476,18 @@ foo.bar
      baz
        end
 
+begin
+  baz
+  end
+
 # good
 
 variable = lambda do |i|
   i
+end
+
+variable = begin
+  baz
 end
 ```
 #### EnforcedStyleAlignWith: start_of_block
@@ -492,10 +500,20 @@ foo.bar
      baz
        end
 
+x =
+  begin
+    baz
+end
+
 # good
 
 foo.bar
   .each do
+    baz
+  end
+
+x =
+  begin
     baz
   end
 ```
@@ -509,11 +527,19 @@ foo.bar
      baz
        end
 
+x = begin
+      baz
+    end
+
 # good
 
 foo.bar
   .each do
      baz
+end
+
+x = begin
+  baz
 end
 ```
 

--- a/spec/rubocop/cop/layout/block_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/block_alignment_spec.rb
@@ -7,6 +7,21 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
     { 'EnforcedStyleAlignWith' => 'either' }
   end
 
+  context 'with begin-end block' do
+    it 'registers an offense for mismatched block end' do
+      expect_offense(<<~RUBY)
+        begin
+          end
+          ^^^ `end` at 2, 2 is not aligned with `begin` at 1, 0.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+        end
+      RUBY
+    end
+  end
+
   context 'when the block has no arguments' do
     it 'registers an offense for mismatched block end' do
       expect_offense(<<~RUBY)
@@ -636,6 +651,14 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
       RUBY
     end
 
+    it 'allows when start_of_line aligned for begin-end block' do
+      expect_no_offenses(<<~RUBY)
+        x = begin
+          baz
+        end
+      RUBY
+    end
+
     it 'errors when do aligned' do
       expect_offense(<<~RUBY)
         foo.bar
@@ -649,6 +672,21 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         foo.bar
           .each do
             baz
+        end
+      RUBY
+    end
+
+    it 'errors when begin aligned for begin-end block' do
+      expect_offense(<<~RUBY)
+        x = begin
+              baz
+            end
+            ^^^ `end` at 3, 4 is not aligned with `x = begin` at 1, 0.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x = begin
+              baz
         end
       RUBY
     end
@@ -668,6 +706,14 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
       RUBY
     end
 
+    it 'allows when do aligned for begin-end block' do
+      expect_no_offenses(<<~RUBY)
+        begin
+          baz
+        end
+      RUBY
+    end
+
     it 'errors when start_of_line aligned' do
       expect_offense(<<~RUBY)
         foo.bar
@@ -680,6 +726,23 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
       expect_correction(<<~RUBY)
         foo.bar
           .each do
+            baz
+          end
+      RUBY
+    end
+
+    it 'errors when start_of_line aligned for begin-end block' do
+      expect_offense(<<~RUBY)
+        x =
+          begin
+            baz
+        end
+        ^^^ `end` at 4, 0 is not aligned with `begin` at 2, 2.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x =
+          begin
             baz
           end
       RUBY


### PR DESCRIPTION
`begin`-`end` blocks were not being treated like `do`-`end` blocks.

The following two very similar snippets (only the first line differs) were not causing the same number of offenses and, thus, were not being autocorrected the same way.

```ruby
foo do
  compute
  rescue
  123
  ensure
  log
  end
```

```ruby
begin
  compute
  rescue
  123
  ensure
  log
  end
```

The output of `rubocop --only Layout file.rb` for the respective snippets were:

```
Inspecting 1 file
C

Offenses:

do.rb:2:3: C: Layout/IndentationWidth: Use 2 (not 0) spaces for indentation.
  compute

do.rb:3:3: C: Layout/RescueEnsureAlignment: rescue at 3, 2 is not aligned with foo do at 1, 0.
  rescue
  ^^^^^^
do.rb:4:3: C: Layout/IndentationWidth: Use 2 (not 0) spaces for indentation.
  123

do.rb:5:3: C: Layout/RescueEnsureAlignment: ensure at 5, 2 is not aligned with foo do at 1, 0.
  ensure
  ^^^^^^
do.rb:6:3: C: Layout/IndentationWidth: Use 2 (not 0) spaces for indentation.
  log

do.rb:7:3: C: Layout/BlockAlignment: end at 7, 2 is not aligned with foo do at 1, 0.
  end
  ^^^

1 file inspected, 6 offenses detected
```

```
Inspecting 1 file
C

Offenses:

begin.rb:2:3: C: Layout/IndentationWidth: Use 2 (not 0) spaces for indentation.
  compute

begin.rb:3:3: C: Layout/RescueEnsureAlignment: rescue at 3, 2 is not aligned with begin at 1, 0.
  rescue
  ^^^^^^
begin.rb:4:3: C: Layout/IndentationWidth: Use 2 (not 0) spaces for indentation.
  123

begin.rb:5:3: C: Layout/RescueEnsureAlignment: ensure at 5, 2 is not aligned with begin at 1, 0.
  ensure
  ^^^^^^
begin.rb:6:3: C: Layout/IndentationWidth: Use 2 (not 0) spaces for indentation.
  log

1 file inspected, 5 offenses detected
```

Notice how the last `Layout/BlockAlignment` offense for the `do`-`end` snippet is not present for the `begin`-`end` block.

The snippets were being autocorrected as follows:

```ruby
foo do
  compute
rescue
  123
ensure
  log
end
```

```ruby
begin
    compute
rescue
  123
ensure
  log
  end
```

Notice how the `begin`-`end` block is being autocorrected in a way that makes no sense.

The fix is to run the same logic for `begin`-`end` blocks as for `do`-`end` blocks in `Layout/BlockAlignment`.

The autocorrected code now looks as follows:

```ruby
foo do
  compute
rescue
  123
ensure
  log
end
```

```ruby
begin
  compute
rescue
  123
ensure
  log
end
```

This revealed two new offenses of misaligned `begin`-`end` blocks in the codebase, which were fixed as well.

-----------------

## Discussion

I'd like to have a conversation about the state of these "blocks". I'm not sure the fix in this PR goes in the right direction for a couple of reasons.

First, the rule is called `Lint/BlockAlignment`. I'm not exactly sure if `begin`-`end` blocks are even called *blocks*.

Second, in my personal opinion, there shouldn't be a special treatment of `do`-`end` blocks in general. I believe that anything that starts a "block", i.e. something that is terminated by and `end`, should have the same indentation logic, namely:

- Everything within this "block" should be indented one level deeper than the terminating `end`.
- The terminating `end` could be aligned at the start of the line or at the start of the "block" in case the start is not at the start of the line (e.g. in a variable assignment).
- Some keywords within this "block" should be outdented (e.g. `when` in `case`-`end`).

Otherwise, I see no reason for them to be treated differently. Thus, my doubt about whether this PR even goes in the right direction can be summarized with one question: can't we treat all of these "blocks" the same way?

Here's a list of all these "blocks" that I could think of and the legit ways of indentation (`start_of_line` and `start_of_block`):

```ruby
# block

var = foo do |x|
        123 + x
      end

var = foo do |x|
  123 + x
end

var =
  foo do |x|
    123 + x
  end

# def

private def foo
  123
end

private def foo
          123
        end

# if/unless

var = if condition
        123
      elsif other_condition
        456
      else
        789
      end

var = if condition
  123
elsif other_condition
  456
else
  789
end

var =
  if condition
    123
  elsif other_condition
    456
  else
    789
  end

# case

var = case condition
      when 123
        'hello'
      else
        'world'
      end

var = case condition
when 123
  'hello'
else
  'world'
end

var =
  case condition
  when 123
    'hello'
  else
    'world'
  end

# begin

var = begin
        123
      rescue
        456
      ensure
        puts 'done'
      end

var = begin
  123
rescue
  456
ensure
  puts 'done'
end

var =
  begin
    123
  rescue
    456
  ensure
    puts 'done'
  end

# class/module

var = class Foo
        attr_reader :bar
      end

var = class Foo
  attr_reader :bar
end

var =
  class Foo
    attr_reader :bar
  end

# while/until

var = while condition
        123
      end

var = while condition
  123
end

var =
  while condition
    123
  end
```

I'd be curious to hear the opinion of others around these "blocks" 😊 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
