### PR TITLE
Make the cop generator to insert require even if the department is unknown

### DIFF
--- a/lib/rubocop/cop/generator/require_file_injector.rb
+++ b/lib/rubocop/cop/generator/require_file_injector.rb
@@ -54,7 +54,7 @@ module RuboCop
               elsif in_the_same_department
                 break index
               end
-            end
+            end || require_entries.size
           end
         end
 

--- a/spec/rubocop/cop/generator/require_file_injector_spec.rb
+++ b/spec/rubocop/cop/generator/require_file_injector_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe RuboCop::Cop::Generator::RequireFileInjector do
   context 'when using an unknown department' do
     let(:source_path) { 'lib/rubocop/cop/unknown/fake_cop.rb' }
 
-    let(:source) { <<-RUBY }
+    let(:source) { <<~RUBY }
       # frozen_string_literal: true
 
       require 'parser'
@@ -215,11 +215,38 @@ RSpec.describe RuboCop::Cop::Generator::RequireFileInjector do
       File.write(root_file_path, source)
     end
 
-    it 'does not write to any file' do
+    it 'inserts a `require_relative` statement to the bottom of the file' do
+      generated_source = <<~RUBY
+        # frozen_string_literal: true
+
+        require 'parser'
+        require 'rainbow'
+
+        require 'English'
+        require 'set'
+        require 'forwardable'
+
+        require_relative 'rubocop/version'
+
+        require_relative 'rubocop/cop/lint/flip_flop'
+
+        require_relative 'rubocop/cop/style/end_block'
+        require_relative 'rubocop/cop/style/even_odd'
+        require_relative 'rubocop/cop/style/fake_cop'
+        require_relative 'rubocop/cop/style/file_name'
+
+        require_relative 'rubocop/cop/rails/action_filter'
+
+        require_relative 'rubocop/cop/team'
+        require_relative 'rubocop/cop/unknown/fake_cop'
+      RUBY
+
       injector.inject
 
-      expect(File.read(root_file_path)).to eq source
-      expect(stdout.string.empty?).to be(true)
+      expect(File.read(root_file_path)).to eq generated_source
+      expect(stdout.string).to eq(<<~MESSAGE)
+        [modify] lib/root.rb - `require_relative 'rubocop/cop/unknown/fake_cop'` was injected.
+      MESSAGE
     end
   end
 end


### PR DESCRIPTION
# Problem

The cop generator does not insert `require_relative` statements with `rake new_cop[Xxx/Yyy]`, if the department, which is Xxx in this case, is unknown.

I think it is confusing. I expect new_cop task to generate all necessary codes to start developing a new cop.

Actually I was confused by the behavior when I started developing a new custom cop gem.
I used [custom_cops_generator](https://github.com/pocke/custom_cops_generator) to generate plugin boilerplate, and it put the following code to `lib/rubocop/cop/xxx_cops.rb` with the following content.

```ruby
# frozen_string_literal: true
```

It is almost empty, so the generator did not insert `require_relative` statement to the file. But I expected it to insert the statement.

# Solution


If the department is unknown, insert `require_relative` to the bottom of the file.
I guess it may insert to an inappropriate location. Nevertheless, I think it is a better way because we can move the `require_relative` after insertion if it is in the wrong place.


----

The API is for RuboCop developer, so I did not add any entry to the changelog.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
