### PR TITLE
Add new `EnableNewCopsUpTo` option to enable all pending cops up to a specific Rubocop version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#8565](https://github.com/rubocop/rubocop/pull/8565): Add option to enable all new cops up to a given version of the plugin they came from. ([@zofrex][])
+
 ## 1.19.1 (2021-08-19)
 
 ### Bug fixes
@@ -5813,3 +5817,4 @@
 [@markburns]: https://github.com/markburns
 [@gregfletch]: https://github.com/gregfletch
 [@thearjunmdas]: https://github.com/thearjunmdas
+[@zofrex]: https://github.com/zofrex

--- a/config/default.yml
+++ b/config/default.yml
@@ -106,6 +106,8 @@ AllCops:
   # the `--enable-pending-cops` command-line option.
   # When `NewCops` is `disable`, pending cops are disabled in bulk. Can be overridden by
   # the `--disable-pending-cops` command-line option.
+  # You can also set this to a version number per-department, e.g. `NewCops: 1.1` will
+  # enable all cops that were added in version 1.1 and earlier of the relevant plugin.
   NewCops: pending
   # Enables the result cache if `true`. Can be overridden by the `--cache` command
   # line option.

--- a/docs/modules/ROOT/pages/versioning.adoc
+++ b/docs/modules/ROOT/pages/versioning.adoc
@@ -82,6 +82,21 @@ AllCops:
 
 NOTE: The command-line options takes precedence over `.rubocop.yml` file.
 
+=== Enabling/Disabling Pending Cops by Version
+
+It is possible to enable all pending cops up to a given version of the plugin
+they come from. This makes it easy to enable cops in bulk, without risking CI
+breaking when future updates bring in newer cops.
+
+[source,yaml]
+----
+Lint:
+  NewCops: 1.2
+----
+
+This would enable all cops from the Lint department that were added in Rubocop
+version 1.2 or earlier, but not cops added in later versions.
+
 === Enabling/Disabling Individual Pending Cops
 
 Finally, you can enable/disable individual pending cops by setting their `Enabled` configuration to either `true` or `false` in your `.rubocop.yml` file:

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -248,8 +248,22 @@ module RuboCop
         cop_metadata = self[qualified_cop_name]
         next unless cop_metadata['Enabled'] == 'pending'
 
+        next if pending_cop_enabled_by_version?(qualified_cop_name, cop_metadata)
+
         pending_cops << CopConfig.new(qualified_cop_name, cop_metadata)
       end
+    end
+
+    def version_le(version, compare_to)
+      !version.nil? && !compare_to.nil? \
+        && Gem::Version.correct?(version) && Gem::Version.correct?(compare_to) \
+        && Gem::Version.new(version) <= Gem::Version.new(compare_to)
+    end
+
+    def pending_cop_enabled_by_version?(cop_name, cop_cfg)
+      department = department_of(cop_name)
+      department && !department['NewCops'].nil? && version_le(cop_cfg['VersionAdded'],
+                                                              department['NewCops'])
     end
 
     private

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -156,7 +156,8 @@ module RuboCop
       def enabled?(cop, config, only_safe)
         cfg = config.for_cop(cop)
 
-        cop_enabled = cfg.fetch('Enabled') == true || enabled_pending_cop?(cfg, config)
+        cop_enabled = cfg.fetch('Enabled') == true ||
+                      enabled_pending_cop?(cfg, config, cop.cop_name)
 
         if only_safe
           cop_enabled && cfg.fetch('Safe', true)
@@ -165,11 +166,13 @@ module RuboCop
         end
       end
 
-      def enabled_pending_cop?(cop_cfg, config)
+      def enabled_pending_cop?(cop_cfg, config, cop_name)
         return false if @options[:disable_pending_cops]
 
-        cop_cfg.fetch('Enabled') == 'pending' &&
-          (@options[:enable_pending_cops] || config.enabled_new_cops?)
+        return false if cop_cfg.fetch('Enabled') != 'pending'
+
+        @options[:enable_pending_cops] || config.enabled_new_cops? \
+          || config.pending_cop_enabled_by_version?(cop_name, cop_cfg)
       end
 
       def names

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -771,6 +771,72 @@ RSpec.describe RuboCop::Config do
     end
   end
 
+  context 'whether the cop is pending' do
+    context 'when the cop is pending' do
+      let(:hash) do
+        {
+          'Layout/TrailingWhitespace' => { 'Enabled' => 'pending' }
+        }
+      end
+
+      it 'is in the list of pending cops' do
+        expect(configuration.pending_cops).to \
+          include(have_attributes(name: 'Layout/TrailingWhitespace'))
+      end
+
+      context 'NewCops for the department is a version number' do
+        let(:new_cops_value) { '' }
+
+        let(:hash) do
+          {
+            'Layout' => { 'NewCops' => new_cops_value },
+            'Layout/TrailingWhitespace' => { 'Enabled' => 'pending', 'VersionAdded' => '0.80' }
+          }
+        end
+
+        context 'NewCops > VersionAdded' do
+          let(:new_cops_value) { '0.81' }
+
+          it 'is not in the list of pending cops' do
+            expect(configuration.pending_cops).not_to \
+              include(have_attributes(name: 'Layout/TrailingWhitespace'))
+          end
+        end
+
+        context 'NewCops == VersionAdded' do
+          let(:new_cops_value) { '0.80' }
+
+          it 'is not in the list of pending cops' do
+            expect(configuration.pending_cops).not_to \
+              include(have_attributes(name: 'Layout/TrailingWhitespace'))
+          end
+        end
+
+        context 'NewCops < VersionAdded' do
+          let(:new_cops_value) { '0.79' }
+
+          it 'is in the list of pending cops' do
+            expect(configuration.pending_cops).to \
+              include(have_attributes(name: 'Layout/TrailingWhitespace'))
+          end
+        end
+      end
+    end
+
+    context 'when the cop is not pending' do
+      let(:hash) do
+        {
+          'Layout/TrailingWhitespace' => { 'Enabled' => true }
+        }
+      end
+
+      it 'is not in the list of pending cops' do
+        expect(configuration.pending_cops).not_to \
+          include(have_attributes(name: 'Layout/TrailingWhitespace'))
+      end
+    end
+  end
+
   describe '#for_department', :restore_registry do
     let(:hash) do
       {

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -304,6 +304,40 @@ RSpec.describe RuboCop::Cop::Registry do
           expect(result).to include(RuboCop::Cop::Lint::BooleanSymbol)
         end
       end
+
+      context 'when specifying a version for NewCops in .rubocop.yml' do
+        let(:cops) do
+          [
+            RuboCop::Cop::Lint::EmptyBlock,
+            RuboCop::Cop::Lint::NoReturnInBeginEndBlocks,
+            RuboCop::Cop::Lint::EmptyBlock
+          ]
+        end
+
+        let(:config) do
+          RuboCop::Config.new(
+            'Lint' => { 'NewCops' => '1.2' },
+            'Lint/EmptyBlock' => { 'Enabled' => 'pending', 'VersionAdded' => '1.1' },
+            'Lint/NoReturnInBeginEndBlocks' => { 'Enabled' => 'pending', 'VersionAdded' => '1.2' },
+            'Lint/EmptyClass' => { 'Enabled' => 'pending', 'VersionAdded' => '1.3' }
+          )
+        end
+
+        it 'includes cops added before the specified version' do
+          result = registry.enabled(config, [])
+          expect(result).to include(RuboCop::Cop::Lint::EmptyBlock)
+        end
+
+        it 'includes cops added in the specified version' do
+          result = registry.enabled(config, [])
+          expect(result).to include(RuboCop::Cop::Lint::NoReturnInBeginEndBlocks)
+        end
+
+        it 'does not include cops added after the specified version' do
+          result = registry.enabled(config, [])
+          expect(result).not_to include(RuboCop::Cop::Lint::EmptyClass)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
I would like to modestly propose a new feature for enabling pending cops in bulk:

I realised while creating my `.rubocop.yml` for a new project, that what I wanted to do with pending cops wasn't to enable all of them (and potentially fail CI in the future due to new cops) but nor did I want to ignore pending cops available _right now_ that I could ensure my code passes. I know I could add each one individually to `.rubocop.yml` but that's a bit tedious and my configuration is quite short and I'd rather keep it that way.

What occurred to me is that I'd like to enable all the cops that were available in the version of Rubocop I'm using, and not ones in newer versions. And thus this feature idea was born.

With this feature you can set the `EnableNewCopsUpTo` option in your `.rubocop.yml` file:

```
AllCops:
  EnableNewCopsUpTo: '0.89'
```

And all pending cops that were added in that version or earlier will be enabled, and any added in the future will give a warning just like they do presently.

When you see those warnings and have some time, you can try enabling them, fix any issues, and bump the version number in your config again.

I'm not married to any of the code here, but I'd rather bring a working demo along when proposing a feature. The version comparison code is maybe not great, it was just the fastest way to get a semver comparison to happen. I'm even less married to the option name which is quite clunky.

I added tests for the change in `registry.rb` but didn't really grok how to test the changes in `config.rb`.

I also added a first pass at documentation, but it could probably be clearer and will of course need to change if any of the names change.

I'm open to suggestions and feedback on any of the changes here! I thought this might be a neat way to deal with the problem and to have my cake and eat it, and based on reading some threads around here I have a feeling I'm not the only person who wants new cops but doesn't want a long list of enabled pending ones in their `.rubocop.yml`. Let me know what you think!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* ~~[ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~ (N/A)
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
