### PR TITLE
Use `Cop::Base` API for `TrailingComma`

### DIFF
--- a/lib/rubocop/cop/correctors/punctuation_corrector.rb
+++ b/lib/rubocop/cop/correctors/punctuation_corrector.rb
@@ -13,14 +13,12 @@ module RuboCop
           ->(corrector) { corrector.replace(token.pos, "#{token.pos.source} ") }
         end
 
-        def swap_comma(range)
+        def swap_comma(corrector, range)
           return unless range
 
-          lambda do |corrector|
-            case range.source
-            when ',' then corrector.remove(range)
-            else          corrector.insert_after(range, ',')
-            end
+          case range.source
+          when ',' then corrector.remove(range)
+          else          corrector.insert_after(range, ',')
           end
         end
       end

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -140,7 +140,9 @@ module RuboCop
           unit: format(kind, article: article) + extra_info.to_s
         )
 
-        add_offense(range, location: range, message: msg)
+        add_offense(range, message: msg) do |corrector|
+          PunctuationCorrector.swap_comma(corrector, range)
+        end
       end
 
       def put_comma(items, kind)
@@ -148,13 +150,11 @@ module RuboCop
         return if last_item.block_pass_type?
 
         range = autocorrect_range(last_item)
-        msg = format(
-          MSG,
-          command: 'Put a',
-          unit: format(kind, article: 'a multiline')
-        )
+        msg = format(MSG, command: 'Put a', unit: format(kind, article: 'a multiline'))
 
-        add_offense(range, location: range, message: msg)
+        add_offense(range, message: msg) do |corrector|
+          PunctuationCorrector.swap_comma(corrector, range)
+        end
       end
 
       def autocorrect_range(item)

--- a/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
@@ -84,8 +84,9 @@ module RuboCop
       #     1,
       #     2
       #   )
-      class TrailingCommaInArguments < Cop
+      class TrailingCommaInArguments < Base
         include TrailingComma
+        extend AutoCorrector
 
         def on_send(node)
           return unless node.arguments? && node.parenthesized?
@@ -95,10 +96,6 @@ module RuboCop
                 node.source_range.end_pos)
         end
         alias on_csend on_send
-
-        def autocorrect(range)
-          PunctuationCorrector.swap_comma(range)
-        end
 
         def self.autocorrect_incompatible_with
           [Layout::HeredocArgumentClosingParenthesis]

--- a/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb
@@ -81,17 +81,14 @@ module RuboCop
       #     1,
       #     2
       #   ]
-      class TrailingCommaInArrayLiteral < Cop
+      class TrailingCommaInArrayLiteral < Base
         include TrailingComma
+        extend AutoCorrector
 
         def on_array(node)
           return unless node.square_brackets?
 
           check_literal(node, 'item of %<article>s array')
-        end
-
-        def autocorrect(range)
-          PunctuationCorrector.swap_comma(range)
         end
       end
     end

--- a/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb
@@ -84,15 +84,12 @@ module RuboCop
       #     foo: 1,
       #     bar: 2
       #   }
-      class TrailingCommaInHashLiteral < Cop
+      class TrailingCommaInHashLiteral < Base
         include TrailingComma
+        extend AutoCorrector
 
         def on_hash(node)
           check_literal(node, 'item of %<article>s hash')
-        end
-
-        def autocorrect(range)
-          PunctuationCorrector.swap_comma(range)
         end
       end
     end


### PR DESCRIPTION
Follow #7868.

This PR uses `Cop::Base` API for cops mixing `TrailingComma` module.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
