### PR TITLE
Use `Cop::Base` API for `EmptyParameter`

### DIFF
--- a/lib/rubocop/cop/mixin/empty_parameter.rb
+++ b/lib/rubocop/cop/mixin/empty_parameter.rb
@@ -16,7 +16,9 @@ module RuboCop
         empty_arguments?(node) do |args|
           return if args.empty_and_without_delimiters?
 
-          add_offense(args)
+          add_offense(args) do |corrector|
+            autocorrect(corrector, args)
+          end
         end
       end
     end

--- a/lib/rubocop/cop/style/empty_block_parameter.rb
+++ b/lib/rubocop/cop/style/empty_block_parameter.rb
@@ -21,9 +21,10 @@ module RuboCop
       #
       #   # good
       #   a { do_something }
-      class EmptyBlockParameter < Cop
+      class EmptyBlockParameter < Base
         include EmptyParameter
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Omit pipes for the empty block parameters.'
 
@@ -32,15 +33,13 @@ module RuboCop
           check(node) unless send_node.send_type? && send_node.lambda_literal?
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            block = node.parent
-            range = range_between(
-              block.loc.begin.end_pos,
-              node.loc.expression.end_pos
-            )
-            corrector.remove(range)
-          end
+        private
+
+        def autocorrect(corrector, node)
+          block = node.parent
+          range = range_between(block.loc.begin.end_pos, node.loc.expression.end_pos)
+
+          corrector.remove(range)
         end
       end
     end

--- a/lib/rubocop/cop/style/empty_lambda_parameter.rb
+++ b/lib/rubocop/cop/style/empty_lambda_parameter.rb
@@ -16,9 +16,10 @@ module RuboCop
       #
       #   # good
       #   -> (arg) { do_something(arg) }
-      class EmptyLambdaParameter < Cop
+      class EmptyLambdaParameter < Base
         include EmptyParameter
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Omit parentheses for the empty lambda parameters.'
 
@@ -29,15 +30,13 @@ module RuboCop
           check(node) if node.send_node.lambda_literal?
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            send_node = node.parent.send_node
-            range = range_between(
-              send_node.loc.expression.end_pos,
-              node.loc.expression.end_pos
-            )
-            corrector.remove(range)
-          end
+        private
+
+        def autocorrect(corrector, node)
+          send_node = node.parent.send_node
+          range = range_between(send_node.loc.expression.end_pos, node.loc.expression.end_pos)
+
+          corrector.remove(range)
         end
       end
     end


### PR DESCRIPTION
Follow #7868.

This PR uses `Cop::Base` API for cops mixing `EmptyParameter` module.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
