### PR TITLE
[Fix #8158] Fix `Style/MultilineWhenThen` to better handle multiline body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#8527](https://github.com/rubocop-hq/rubocop/pull/8527): Prevent an incorrect auto-correction for `Style/CaseEquality` cop when comparing with `===` against a regular expression receiver. ([@koic][])
 * [#8524](https://github.com/rubocop-hq/rubocop/issues/8524): Fix `Layout/EmptyLinesAroundClassBody`  and `Layout/EmptyLinesAroundModuleBody` to correctly handle an access modifier as a first child. ([@dsavochkin][])
 * [#8518](https://github.com/rubocop-hq/rubocop/issues/8518): Fix `Lint/ConstantResolution` cop reporting offense for `module` and `class` definitions. ([@tejasbubane][])
+* [#8158](https://github.com/rubocop-hq/rubocop/issues/8158): Fix `Style/MultilineWhenThen` cop to correctly handle cases with multiline body. ([@dsavochkin][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/multiline_when_then.rb
+++ b/lib/rubocop/cop/style/multiline_when_then.rb
@@ -44,7 +44,7 @@ module RuboCop
           # Requires `then` for write `when` and its body on the same line.
           return if require_then?(node)
 
-          # With more than one statements after then, there's not offense
+          # For arrays and hashes there's no offense
           return if accept_node_type?(node.body)
 
           range = node.loc.begin
@@ -64,7 +64,7 @@ module RuboCop
         end
 
         def accept_node_type?(node)
-          node&.begin_type? || node&.array_type? || node&.hash_type?
+          node&.array_type? || node&.hash_type?
         end
       end
     end

--- a/spec/rubocop/cop/style/multiline_when_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_when_then_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineWhenThen do
     RUBY
   end
 
-  it 'registers an offense for multiline when statement with then' do
+  it 'registers an offense for multiline (one line in a body) when statement with then' do
     expect_offense(<<~RUBY)
       case foo
       when bar then
@@ -31,6 +31,25 @@ RSpec.describe RuboCop::Cop::Style::MultilineWhenThen do
       case foo
       when bar
       do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense for multiline (two lines in a body) when statement with then' do
+    expect_offense(<<~RUBY)
+      case foo
+      when bar then
+               ^^^^ Do not use `then` for multiline `when` statement.
+      do_something1
+      do_something2
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case foo
+      when bar
+      do_something1
+      do_something2
       end
     RUBY
   end


### PR DESCRIPTION
Fixes #8158.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
