### PR TITLE
Using refinements

### DIFF
--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'base/internals'
+
 module RuboCop
   module Cop
     # A scaffold for concrete cops.
@@ -38,6 +40,7 @@ module RuboCop
       include Util
       include IgnoredNode
       include AutocorrectLogic
+      using Internals
 
       attr_reader :config, :processed_source
 
@@ -246,86 +249,12 @@ module RuboCop
       end
 
       # @api private
-      # Called between investigations
-      def ready
-        return self if self.class.support_multiple_source?
-
-        self.class.new(@config, @options)
-      end
-
-      ### Reserved for Cop::Cop
-
-      # @deprecated Make potential errors with previous API more obvious
-      def offenses
-        raise 'The offenses are not directly available; ' \
-          'they are returned as the result of the investigation'
-      end
-
-      ### Reserved for Commissioner
-
-      # @api private
-      def callbacks_needed
-        self.class.callbacks_needed
-      end
-
-      # @api private
       def self.callbacks_needed
         @callbacks_needed ||= public_instance_methods.select do |m|
           m.match?(/^on_|^after_/) &&
             !Base.method_defined?(m) # exclude standard "callbacks" like 'on_begin_investigation'
         end
       end
-
-      private
-
-      ### Reserved for Cop::Cop
-
-      def callback_argument(range)
-        range
-      end
-
-      def apply_correction(corrector)
-        @current_corrector&.merge!(corrector) if corrector
-      end
-
-      def correction_strategy
-        return :unsupported unless correctable?
-        return :uncorrected unless autocorrect?
-
-        :attempt_correction
-      end
-
-      ### Reserved for Commissioner:
-
-      def current_offense_locations
-        @current_offense_locations ||= Set.new
-      end
-
-      def currently_disabled_lines
-        @currently_disabled_lines ||= Set.new
-      end
-
-      private_class_method def self.restrict_on_send
-        @restrict_on_send ||= self::RESTRICT_ON_SEND.to_a.freeze
-      end
-
-      # Called before any investigation
-      def begin_investigation(processed_source)
-        @current_offenses = []
-        @current_offense_locations = nil
-        @currently_disabled_lines = nil
-        @processed_source = processed_source
-        @current_corrector = Corrector.new(@processed_source) if @processed_source.valid_syntax?
-      end
-
-      # Called to complete an investigation
-      def complete_investigation
-        InvestigationReport.new(self, processed_source, @current_offenses, @current_corrector)
-      ensure
-        reset_investigation
-      end
-
-      ### Actually private methods
 
       def self.builtin?
         return false unless (m = instance_methods(false).first) # any custom method will do
@@ -335,110 +264,9 @@ module RuboCop
       end
       private_class_method :builtin?
 
-      def reset_investigation
-        @currently_disabled_lines = @current_offenses = @processed_source = @current_corrector = nil
-      end
 
-      # @return [Symbol, Corrector] offense status
-      def correct(range)
-        status = correction_strategy
-
-        if block_given?
-          corrector = Corrector.new(self)
-          yield corrector
-          if !corrector.empty? && !self.class.support_autocorrect?
-            raise "The Cop #{name} must `extend AutoCorrector` to be able to autocorrect"
-          end
-        end
-
-        status = attempt_correction(range, corrector) if status == :attempt_correction
-
-        [status, corrector]
-      end
-
-      # @return [Symbol] offense status
-      def attempt_correction(range, corrector)
-        if corrector && !corrector.empty?
-          status = :corrected
-        elsif disable_uncorrectable?
-          corrector = disable_uncorrectable(range)
-          status = :corrected_with_todo
-        else
-          return :uncorrected
-        end
-
-        apply_correction(corrector) if corrector
-        status
-      end
-
-      def disable_uncorrectable(range)
-        line = range.line
-        return unless currently_disabled_lines.add?(line)
-
-        disable_offense(range)
-      end
-
-      def range_from_node_or_range(node_or_range)
-        if node_or_range.respond_to?(:loc)
-          node_or_range.loc.expression
-        elsif node_or_range.is_a?(::Parser::Source::Range)
-          node_or_range
-        else
-          extra = ' (call `add_global_offense`)' if node_or_range.nil?
-          raise "Expected a Source::Range, got #{node_or_range.inspect}#{extra}"
-        end
-      end
-
-      def find_message(range, message)
-        annotate(message || message(range))
-      end
-
-      def annotate(message)
-        RuboCop::Cop::MessageAnnotator.new(
-          config, cop_name, cop_config, @options
-        ).annotate(message)
-      end
-
-      def file_name_matches_any?(file, parameter, default_result)
-        patterns = cop_config[parameter]
-        return default_result unless patterns
-
-        path = nil
-        patterns.any? do |pattern|
-          # Try to match the absolute path, as Exclude properties are absolute.
-          next true if match_path?(pattern, file)
-
-          # Try with relative path.
-          path ||= config.path_relative_to_config(file)
-          match_path?(pattern, path)
-        end
-      end
-
-      def enabled_line?(line_number)
-        return true if @options[:ignore_disable_comments] || !@processed_source
-
-        @processed_source.comment_config.cop_enabled_at_line?(self, line_number)
-      end
-
-      def find_severity(_range, severity)
-        custom_severity || severity || default_severity
-      end
-
-      def default_severity
-        self.class.lint? ? :warning : :convention
-      end
-
-      def custom_severity
-        severity = cop_config['Severity']
-        return unless severity
-
-        if Severity::NAMES.include?(severity.to_sym)
-          severity.to_sym
-        else
-          message = "Warning: Invalid severity '#{severity}'. " \
-            "Valid severities are #{Severity::NAMES.join(', ')}."
-          warn(Rainbow(message).red)
-        end
+      private_class_method def self.restrict_on_send
+        @restrict_on_send ||= self::RESTRICT_ON_SEND.to_a.freeze
       end
     end
   end

--- a/lib/rubocop/cop/base/internals.rb
+++ b/lib/rubocop/cop/base/internals.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    class Base
+      module Internals
+        refine Base do
+          # @api private
+          # Called between investigations
+          def ready
+            return self if self.class.support_multiple_source?
+
+            self.class.new(@config, @options)
+          end
+
+          ### Reserved for Cop::Cop
+
+          # @deprecated Make potential errors with previous API more obvious
+          def offenses
+            raise 'The offenses are not directly available; ' \
+              'they are returned as the result of the investigation'
+          end
+
+          ### Reserved for Commissioner
+
+          # @api private
+          def callbacks_needed
+            self.class.callbacks_needed
+          end
+
+          private
+
+          ### Reserved for Cop::Cop
+
+          def callback_argument(range)
+            range
+          end
+
+          def apply_correction(corrector)
+            @current_corrector&.merge!(corrector) if corrector
+          end
+
+          def correction_strategy
+            return :unsupported unless correctable?
+            return :uncorrected unless autocorrect?
+
+            :attempt_correction
+          end
+
+          ### Reserved for Commissioner:
+
+          def current_offense_locations
+            @current_offense_locations ||= Set.new
+          end
+
+          def currently_disabled_lines
+            @currently_disabled_lines ||= Set.new
+          end
+
+          # Called before any investigation
+          def begin_investigation(processed_source)
+            @current_offenses = []
+            @current_offense_locations = nil
+            @currently_disabled_lines = nil
+            @processed_source = processed_source
+            @current_corrector = Corrector.new(@processed_source) if @processed_source.valid_syntax?
+          end
+
+          # Called to complete an investigation
+          def complete_investigation
+            InvestigationReport.new(self, processed_source, @current_offenses, @current_corrector)
+          ensure
+            reset_investigation
+          end
+
+          ### Actually private methods
+
+          def reset_investigation
+            @currently_disabled_lines = @current_offenses = @processed_source = @current_corrector = nil
+          end
+
+          # @return [Symbol, Corrector] offense status
+          def correct(range)
+            status = correction_strategy
+
+            if block_given?
+              corrector = Corrector.new(self)
+              yield corrector
+              if !corrector.empty? && !self.class.support_autocorrect?
+                raise "The Cop #{name} must `extend AutoCorrector` to be able to autocorrect"
+              end
+            end
+
+            status = attempt_correction(range, corrector) if status == :attempt_correction
+
+            [status, corrector]
+          end
+
+          # @return [Symbol] offense status
+          def attempt_correction(range, corrector)
+            if corrector && !corrector.empty?
+              status = :corrected
+            elsif disable_uncorrectable?
+              corrector = disable_uncorrectable(range)
+              status = :corrected_with_todo
+            else
+              return :uncorrected
+            end
+
+            apply_correction(corrector) if corrector
+            status
+          end
+
+          def disable_uncorrectable(range)
+            line = range.line
+            return unless currently_disabled_lines.add?(line)
+
+            disable_offense(range)
+          end
+
+          def range_from_node_or_range(node_or_range)
+            if node_or_range.respond_to?(:loc)
+              node_or_range.loc.expression
+            elsif node_or_range.is_a?(::Parser::Source::Range)
+              node_or_range
+            else
+              extra = ' (call `add_global_offense`)' if node_or_range.nil?
+              raise "Expected a Source::Range, got #{node_or_range.inspect}#{extra}"
+            end
+          end
+
+          def find_message(range, message)
+            annotate(message || message(range))
+          end
+
+          def annotate(message)
+            RuboCop::Cop::MessageAnnotator.new(
+              config, cop_name, cop_config, @options
+            ).annotate(message)
+          end
+
+          def file_name_matches_any?(file, parameter, default_result)
+            patterns = cop_config[parameter]
+            return default_result unless patterns
+
+            path = nil
+            patterns.any? do |pattern|
+              # Try to match the absolute path, as Exclude properties are absolute.
+              next true if match_path?(pattern, file)
+
+              # Try with relative path.
+              path ||= config.path_relative_to_config(file)
+              match_path?(pattern, path)
+            end
+          end
+
+          def enabled_line?(line_number)
+            return true if @options[:ignore_disable_comments] || !@processed_source
+
+            @processed_source.comment_config.cop_enabled_at_line?(self, line_number)
+          end
+
+          def find_severity(_range, severity)
+            custom_severity || severity || default_severity
+          end
+
+          def default_severity
+            self.class.lint? ? :warning : :convention
+          end
+
+          def custom_severity
+            severity = cop_config['Severity']
+            return unless severity
+
+            if Severity::NAMES.include?(severity.to_sym)
+              severity.to_sym
+            else
+              message = "Warning: Invalid severity '#{severity}'. " \
+                "Valid severities are #{Severity::NAMES.join(', ')}."
+              warn(Rainbow(message).red)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -6,6 +6,7 @@ module RuboCop
     # work to the specified cops.
     class Commissioner
       include RuboCop::AST::Traversal
+      using Base::Internals
 
       RESTRICTED_CALLBACKS = %i[on_send on_csend after_send after_csend].freeze
       private_constant :RESTRICTED_CALLBACKS

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -9,6 +9,8 @@ module RuboCop
     # Legacy scaffold for Cops.
     # See https://docs.rubocop.org/rubocop/cop_api_v1_changelog.html
     class Cop < Base
+      using Internals
+
       attr_reader :offenses
 
       exclude_from_registry

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -10,6 +10,8 @@ module RuboCop
     # first the ones needed for autocorrection (if any), then the rest
     # (unless autocorrections happened).
     class Team
+      using Base::Internals
+
       attr_reader :errors, :warnings, :updated_source_file, :cops
 
       alias updated_source_file? updated_source_file

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using RuboCop::Cop::Base::Internals
+
 RSpec.describe RuboCop::Cop::Cop, :config do
   let(:source) { 'code = {some: :ruby}' }
   let(:location) { source_range(0...1) }

--- a/spec/rubocop/formatter/junit_formatter_spec.rb
+++ b/spec/rubocop/formatter/junit_formatter_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+using RuboCop::Cop::Base::Internals
 
 RSpec.describe RuboCop::Formatter::JUnitFormatter, :config do
   subject(:formatter) { described_class.new(output) }


### PR DESCRIPTION
There are many methods of `Cop::Base` that are not meant to be called by subclasses. Marking them `private` has no impact.

I was just made aware of [how refinements can be used to restrict access](https://bugs.ruby-lang.org/issues/17288#note-9). Using this we can completely hide these methods and insure that no cop is written using them (not realizing they are not meant to be called).

This is just a very rough POC for the time being, I'm not sure when I'll have time to really work on this.

There's an issue with stubs, I'm confident this can be resolved and be better.

A quick test revealed no performance hit.

Another place where it could be nice to use refinements is in the extensions (`ext/`), like my previous changes on `regexp_parser`'s Nodes.

I'm quite excited to realize that I've been wrongly neglecting refinements until now.

