### PR TITLE
Fix Layout/ClassStructure public_class_methods ordering

### DIFF
--- a/changelog/fix_layout_class_structure_class_methods.md
+++ b/changelog/fix_layout_class_structure_class_methods.md
@@ -1,0 +1,1 @@
+* [#9118](https://github.com/rubocop-hq/rubocop/pull/9118): Fix Layout/ClassStructure public_class_methods ordering. ([@timlkelly][])

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -139,7 +139,7 @@ module RuboCop
 
         HUMANIZED_NODE_TYPE = {
           casgn: :constants,
-          defs: :class_methods,
+          defs: :public_class_methods,
           def: :public_methods,
           sclass: :class_singleton
         }.freeze

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -325,4 +325,16 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
       end
     RUBY
   end
+
+  context 'with initializer before public_class_methods' do
+    it 'creates an offense' do
+      expect_offense <<~RUBY
+        class Person
+          def initialize; end
+          def self.some_method; end
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ `public_class_methods` is supposed to appear before `initializer`.
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
The `Layout/ClassStructure` rule does not enforce the order of `public_class_methods`. Given the default ordering, I would expect public class methods to appear before the initializer. 

Expected:
```
# person.rb
class Person
  def self.some_method; end
  def initialize; end
end
```

However, when in the incorrect order, it does not raise any offenses:

```
# person.rb
class Person
  def initialize; end
  def self.some_method; end
end
```

```
❯ rubocop person.rb --only Layout/ClassStructure
warning: parser/current is loading parser/ruby27, which recognizes
warning: 2.7.2-compliant syntax, but you are running 2.7.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
```

```
❯ rubocop -V
warning: parser/current is loading parser/ruby27, which recognizes
warning: 2.7.2-compliant syntax, but you are running 2.7.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
1.4.2 (using Parser 2.7.2.0, rubocop-ast 1.2.0, running on ruby 2.7.1 x86_64-darwin19)
```

---

The problem is that `Rubocop::Cop::Layout::ClassStructure#walk_over_nested_class_definition` is ignoring class method nodes because `#classify` returns `class_methods` while the configuration's `ExpectedOrder` provides `public_class_methods`.

I thought it would be easier to update the value in `HUMANIZED_NODE_TYPE` instead of changing the configuration to match, as that would require users to update their `ExpectedOrder` configurations.

With that said, this now catches several `Layout/ClassStructure` offenses in the codebase. Here is the output from `bundle exec rake default`

```
Offenses:

lib/rubocop/config.rb:36:5: C: Layout/ClassStructure: public_class_methods is supposed to appear before initializer.
    def self.create(hash, path) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/base.rb:95:7: C: Layout/ClassStructure: public_class_methods is supposed to appear before initializer.
      def self.joining_forces; end
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/base.rb:330:7: C: Layout/ClassStructure: public_class_methods is supposed to appear before private_methods.
      def self.builtin? ...
      ^^^^^^^^^^^^^^^^^
lib/rubocop/cop/corrector.rb:71:7: C: Layout/ClassStructure: public_class_methods is supposed to appear before initializer.
      def self.source_buffer(source) ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/metrics/utils/abc_size_calculator.rb:32:11: C: Layout/ClassStructure: constants is supposed to appear before public_class_methods.
          ARGUMENT_TYPES = %i[arg optarg restarg kwarg kwoptarg kwrestarg blockarg].freeze
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/registry.rb:213:7: C: Layout/ClassStructure: public_class_methods is supposed to appear before initializer.
      def self.all ...
      ^^^^^^^^^^^^
lib/rubocop/cop/team.rb:28:7: C: Layout/ClassStructure: public_class_methods is supposed to appear before initializer.
      def self.new(cop_or_classes, config, options = {}) ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/target_ruby.rb:197:5: C: Layout/ClassStructure: constants is supposed to appear before public_class_methods.
    SOURCES = [RuboCopConfig, RubyVersionFile, BundlerLockFile, GemspecFile, Default].freeze
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tasks/changelog.rb:122:3: C: Layout/ClassStructure: public_class_methods is supposed to appear before initializer.
  def self.pending? ...
  ^^^^^^^^^^^^^^^^^

1205 files inspected, 9 offenses detected, 9 offenses auto-correctable
RuboCop failed!
```

Some of these are easy changes, like [tasks/changelog.rb:122:3](https://github.com/rubocop-hq/rubocop/blob/master/tasks/changelog.rb#L122)

While others seem a little more complex, for instance [lib/rubocop/cop/base.rb:330:7](https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/base.rb#L330-L336). This appears to be declaring a private class method, however, this node does not seem to know that it should be private. From my understanding, this rule does not provide guidance on where private class methods should be positioned in the class. So I did not want to make any further changes without a discussion of what the expected behavior should be.


Separately, I noticed that the `ExpectedOrder` in the `.rubocop.yml` file for this project lists `instance_methods`, which I don't think corresponds to anything and should be changed to `public_methods` to match the value in `HUMANIZED_NODE_TYPE`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
