### PR TITLE
[Fix #9144] Add `aggressive` and `conservative` enforced styles for `Style/StringConcatenation` cop

### DIFF
--- a/changelog/change_string_concatenation_enforced_styles.md
+++ b/changelog/change_string_concatenation_enforced_styles.md
@@ -1,0 +1,1 @@
+* [#9144](https://github.com/rubocop/rubocop/issues/9144): Add `aggressive` and `conservative` modes of operation for `Style/StringConcatenation` cop. ([@tejasbubane][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4620,7 +4620,8 @@ Style/StringConcatenation:
   Enabled: true
   Safe: false
   VersionAdded: '0.89'
-  VersionChanged: '1.6'
+  VersionChanged: <<next>>
+  Mode: aggressive
 
 Style/StringHashKeys:
   Description: 'Prefer symbols instead of strings as hash keys.'

--- a/spec/rubocop/cop/style/string_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/string_concatenation_spec.rb
@@ -203,4 +203,36 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation, :config do
       RUBY
     end
   end
+
+  context 'Mode = conservative' do
+    let(:cop_config) { { 'Mode' => 'conservative' } }
+
+    context 'when first operand is not string literal' do
+      it 'does not register offense' do
+        expect_no_offenses(<<~RUBY)
+          user.name + "!!"
+          user.name + "<"
+        RUBY
+      end
+    end
+
+    context 'when first operand is string literal' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          "Hello " + user.name
+          ^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+          "Hello " + user.name + "!!"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+          user.name + "<" + "user.email" + ">"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          "Hello \#{user.name}"
+          "Hello \#{user.name}!!"
+          "\#{user.name}<user.email>"
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #9144

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/