### PR TITLE
Allow excluding some constants from Style/Documentation

### DIFF
--- a/changelog/new_allow_excluding_some_constants_from.md
+++ b/changelog/new_allow_excluding_some_constants_from.md
@@ -1,0 +1,1 @@
+* [#9219](https://github.com/rubocop-hq/rubocop/pull/9219): Allow excluding some constants from Style/Documentation. ([@fsateler][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3174,6 +3174,7 @@ Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
   Enabled: true
   VersionAdded: '0.9'
+  AllowedConstants: []
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -60,6 +60,15 @@ module RuboCop
       #       extend Foo
       #     end
       #
+      # @example AllowedConstants: ['ClassMethods']
+      #
+      #    # good
+      #    module A
+      #      module ClassMethods
+      #        # ...
+      #      end
+      #     end
+      #
       class Documentation < Base
         include DocumentationComment
 
@@ -85,12 +94,17 @@ module RuboCop
 
         def check(node, body, type)
           return if namespace?(body)
-          return if documentation_comment?(node) || nodoc_comment?(node)
-          return if compact_namespace?(node) &&
-                    nodoc_comment?(outer_module(node).first)
+          return if documentation_comment?(node)
+          return if constant_allowed?(node)
+          return if nodoc_self_or_outer_module?(node)
           return if macro_only?(body)
 
           add_offense(node.loc.keyword, message: format(MSG, type: type))
+        end
+
+        def nodoc_self_or_outer_module?(node)
+          nodoc_comment?(node) ||
+            compact_namespace?(node) && nodoc_comment?(outer_module(node).first)
         end
 
         def macro_only?(body)
@@ -110,6 +124,10 @@ module RuboCop
 
         def constant_declaration?(node)
           constant_definition?(node) || constant_visibility_declaration?(node)
+        end
+
+        def constant_allowed?(node)
+          allowed_constants.include?(node.identifier.short_name)
         end
 
         def compact_namespace?(node)
@@ -137,6 +155,10 @@ module RuboCop
 
         def nodoc(node)
           processed_source.ast_with_comments[node.children.first].first
+        end
+
+        def allowed_constants
+          @allowed_constants ||= cop_config.fetch('AllowedConstants', []).map(&:intern)
         end
       end
     end

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -698,6 +698,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example1.rb'",
          '',
          '# Offense count: 1',
+         '# Configuration parameters: AllowedConstants.',
          'Style/Documentation:',
          '  Exclude:',
          "    - 'spec/**/*'", # Copied from default configuration
@@ -1067,6 +1068,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '  Exclude:',
          "    - 'example1.rb'",
          '',
+         '# Configuration parameters: AllowedConstants.',
          'Style/Documentation:',
          '  Exclude:',
          "    - 'spec/**/*'", # Copied from default configuration

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -411,6 +411,21 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
           RUBY
         end
       end
+
+      describe 'when AllowedConstants is configured' do
+        before { config['Style/Documentation'] = { 'AllowedConstants' => ['ClassMethods'] } }
+
+        it 'ignores the constants in the config' do
+          expect_no_offenses(<<~RUBY)
+            module A
+              module ClassMethods
+                def do_something
+                end
+              end
+            end
+          RUBY
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
For example, a very common idiom is to define a ClassMethods module that
contains the class methods created by the parent module. In such cases,
it might be desired to document the parent module, but not the
ClassMethods module.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
