### PR TITLE
Add restrictive_version_specifiers to Bundler/GemComment

### DIFF
--- a/changelog/new_bundler_gem_comment_limiting_version_specifications.md
+++ b/changelog/new_bundler_gem_comment_limiting_version_specifications.md
@@ -1,0 +1,1 @@
+* [#9358](https://github.com/rubocop-hq/rubocop/pull/9358): Support `limiting_version_specifications` option in `Bundler/GemComment` cop. ([@RobinDaugherty][])

--- a/changelog/new_bundler_gem_comment_limiting_version_specifications.md
+++ b/changelog/new_bundler_gem_comment_limiting_version_specifications.md
@@ -1,1 +1,1 @@
-* [#9358](https://github.com/rubocop-hq/rubocop/pull/9358): Support `restrictive_version_specificiers` option in `Bundler/GemComment` cop. ([@RobinDaugherty][])
+* [#9358](https://github.com/rubocop/rubocop/pull/9358): Support `restrictive_version_specificiers` option in `Bundler/GemComment` cop. ([@RobinDaugherty][])

--- a/changelog/new_bundler_gem_comment_limiting_version_specifications.md
+++ b/changelog/new_bundler_gem_comment_limiting_version_specifications.md
@@ -1,1 +1,1 @@
-* [#9358](https://github.com/rubocop-hq/rubocop/pull/9358): Support `limiting_version_specifications` option in `Bundler/GemComment` cop. ([@RobinDaugherty][])
+* [#9358](https://github.com/rubocop-hq/rubocop/pull/9358): Support `restrictive_version_specificiers` option in `Bundler/GemComment` cop. ([@RobinDaugherty][])

--- a/lib/rubocop/cop/bundler/gem_comment.rb
+++ b/lib/rubocop/cop/bundler/gem_comment.rb
@@ -3,15 +3,24 @@
 module RuboCop
   module Cop
     module Bundler
-      # Add a comment describing each gem in your Gemfile.
+      # Each gem in the Gemfile should have a comment explaining
+      # its purpose in the project, or the reason for its version
+      # or source.
       #
-      # Optionally, the "OnlyFor" configuration
+      # The optional "OnlyFor" configuration array
       # can be used to only register offenses when the gems
       # use certain options or have version specifiers.
-      # Add "version_specifiers" and/or the gem option names
-      # you want to check.
       #
-      # A useful use-case is to enforce a comment when using
+      # When "version_specifiers" is included, a comment
+      # will be enforced if the gem has any version specifier.
+      #
+      # When "restrictive_version_specifiers" is included, a comment
+      # will be enforced if the gem has a version specifier that
+      # holds back the version of the gem.
+      #
+      # For any other value in the array, a comment will be enforced for
+      # a gem if an option by the same name is present.
+      # A useful use case is to enforce a comment when using
       # options that change the source of a gem:
       #
       # - `bitbucket`
@@ -21,7 +30,8 @@ module RuboCop
       # - `source`
       #
       # For a full list of options supported by bundler,
-      # you can check the https://bundler.io/man/gemfile.5.html[official documentation].
+      # see https://bundler.io/man/gemfile.5.html
+      # .
       #
       # @example OnlyFor: [] (default)
       #   # bad

--- a/lib/rubocop/cop/bundler/gem_comment.rb
+++ b/lib/rubocop/cop/bundler/gem_comment.rb
@@ -43,7 +43,7 @@ module RuboCop
       #   # Version 2.1 introduces breaking change baz
       #   gem 'foo', '< 2.1'
       #
-      # @example OnlyFor: ['limiting_version_specifiers']
+      # @example OnlyFor: ['restrictive_version_specifiers']
       #   # bad
       #
       #   gem 'foo', '< 2.1'
@@ -76,8 +76,8 @@ module RuboCop
         MSG = 'Missing gem description comment.'
         CHECKED_OPTIONS_CONFIG = 'OnlyFor'
         VERSION_SPECIFIERS_OPTION = 'version_specifiers'
-        LIMITING_VERSION_SPECIFIERS_OPTION = 'limiting_version_specifiers'
-        LIMITING_VERSION_PATTERN = /<|~>/.freeze
+        RESTRICTIVE_VERSION_SPECIFIERS_OPTION = 'restrictive_version_specifiers'
+        RESTRICTIVE_VERSION_PATTERN = /<|~>/.freeze
         RESTRICT_ON_SEND = %i[gem].freeze
 
         # @!method gem_declaration?(node)
@@ -127,8 +127,8 @@ module RuboCop
         def checked_options_present?(node)
           (cop_config[CHECKED_OPTIONS_CONFIG].include?(VERSION_SPECIFIERS_OPTION) &&
             version_specified_gem?(node)) ||
-            (cop_config[CHECKED_OPTIONS_CONFIG].include?(LIMITING_VERSION_SPECIFIERS_OPTION) &&
-              limiting_version_specified_gem?(node)) ||
+            (cop_config[CHECKED_OPTIONS_CONFIG].include?(RESTRICTIVE_VERSION_SPECIFIERS_OPTION) &&
+              restrictive_version_specified_gem?(node)) ||
             contains_checked_options?(node)
         end
 
@@ -139,13 +139,13 @@ module RuboCop
           node.arguments[1]&.str_type?
         end
 
-        # Version specifications that limit all updates going forward. This excludes versions
-        # like ">= 1.0" or "!= "
-        # as long as it has one we know there's at least one version specifier.
-        def limiting_version_specified_gem?(node)
+        # Version specifications that restrict all updates going forward. This excludes versions
+        # like ">= 1.0" or "!= 2.0.3".
+        def restrictive_version_specified_gem?(node)
           return unless version_specified_gem?(node)
 
-          node.arguments.any? { |arg| arg&.str_type? && LIMITING_VERSION_PATTERN.match?(arg.to_s) }
+          node.arguments
+              .any? { |arg| arg&.str_type? && RESTRICTIVE_VERSION_PATTERN.match?(arg.to_s) }
         end
 
         def contains_checked_options?(node)

--- a/spec/rubocop/cop/bundler/gem_comment_spec.rb
+++ b/spec/rubocop/cop/bundler/gem_comment_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
     context 'when the "OnlyFor" option is set' do
       before { cop_config['OnlyFor'] = checked_options }
 
-      context 'when the version specifiers are checked' do
+      context 'including "version_specifiers"' do
         let(:checked_options) { ['version_specifiers'] }
 
         context 'when a gem is commented' do
@@ -86,7 +86,7 @@ RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
           end
         end
 
-        context 'when a gem is uncommented and has no extra options' do
+        context 'when a gem is uncommented and has no version specified' do
           it 'does not register an offense' do
             expect_no_offenses(<<-GEM, 'Gemfile')
             gem 'rubocop'
@@ -120,7 +120,7 @@ RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
           end
         end
 
-        context 'when a gem is uncommented and has a version specifier along with unrelated options' do
+        context 'when a gem is uncommented and has a version specifier along with other options' do
           it 'registers an offense' do
             expect_offense(<<-GEM, 'Gemfile')
               gem 'rubocop', '~> 12.0', required: true
@@ -130,10 +130,74 @@ RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
         end
       end
 
-      context 'and some other options are checked' do
+      context 'including "limiting_version_specifiers"' do
+        let(:checked_options) { ['limiting_version_specifiers'] }
+
+        context 'when a gem is commented' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY, 'Gemfile')
+              # Style-guide enforcer.
+              gem 'rubocop'
+            RUBY
+          end
+        end
+
+        context 'when a gem is uncommented and has no version specified' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<-GEM, 'Gemfile')
+            gem 'rubocop'
+            GEM
+          end
+        end
+
+        context 'when a gem is uncommented and has options but no version specifiers' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<-GEM, 'Gemfile')
+              gem 'rubocop', group: development
+            GEM
+          end
+        end
+
+        context 'when a gem is uncommented and has only a minimum version specifier' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<-GEM, 'Gemfile')
+              gem 'rubocop', '>= 12.0'
+            GEM
+          end
+        end
+
+        context 'when a gem is uncommented and has a version specifier' do
+          it 'registers an offense' do
+            expect_offense(<<-GEM, 'Gemfile')
+                gem 'rubocop', '~> 12.0'
+                ^^^^^^^^^^^^^^^^^^^^^^^^ Missing gem description comment.
+            GEM
+          end
+        end
+
+        context 'when a gem is uncommented and has both minimum and non-minimum version specifier' do
+          it 'registers an offense' do
+            expect_offense(<<-GEM, 'Gemfile')
+                gem 'rubocop', '~> 12.0', '>= 11.0'
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing gem description comment.
+            GEM
+          end
+        end
+
+        context 'when a gem is uncommented and has a version specifier along with other options' do
+          it 'registers an offense' do
+            expect_offense(<<-GEM, 'Gemfile')
+              gem 'rubocop', '~> 12.0', required: true
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing gem description comment.
+            GEM
+          end
+        end
+      end
+
+      context 'including one or more option names but not "version_specifiers"' do
         let(:checked_options) { %w[github required] }
 
-        context 'when a gem is uncommented and has one of the checked options' do
+        context 'when a gem is uncommented and has one of the specified options' do
           it 'registers an offense' do
             expect_offense(<<-GEM, 'Gemfile')
               gem 'rubocop', github: 'some_user/some_fork'
@@ -142,7 +206,7 @@ RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
           end
         end
 
-        context 'when a gem is uncommented and has a version specifier but no other options' do
+        context 'when a gem is uncommented and has a version specifier but none of the specified options' do
           it 'does not register an offense' do
             expect_no_offenses(<<-GEM, 'Gemfile')
               gem 'rubocop', '~> 12.0'
@@ -150,7 +214,7 @@ RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
           end
         end
 
-        context 'when a gem is uncommented and only unchecked options' do
+        context 'when a gem is uncommented and containts only options not specified' do
           it 'does not register an offense' do
             expect_no_offenses(<<-GEM, 'Gemfile')
               gem 'rubocop', group: development

--- a/spec/rubocop/cop/bundler/gem_comment_spec.rb
+++ b/spec/rubocop/cop/bundler/gem_comment_spec.rb
@@ -130,8 +130,8 @@ RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
         end
       end
 
-      context 'including "limiting_version_specifiers"' do
-        let(:checked_options) { ['limiting_version_specifiers'] }
+      context 'including "restrictive_version_specifiers"' do
+        let(:checked_options) { ['restrictive_version_specifiers'] }
 
         context 'when a gem is commented' do
           it 'does not register an offense' do


### PR DESCRIPTION
The problem I'm trying to solve:

There are multiple reasons one might lock the version of a gem in the Gemfile:

1. When a minimum version of the gem is needed to support the project. (Like `">= 2.0"`.)
2. When a specific version of the gem has a known bug. (Should be done like `"!= 2.4.0"`.)
3. When a major version of the gem is incompatible with the project. (Usually looks like `"< 3.0"`.)
4. For no reason. Some gems even provide instructions like "add `gem 'mygem', '~> 2.3'` to your Gemfile".

The last two reasons lead to a project's dependencies falling behind because the `bundle update` process will not update to 3.0 without manual intervention. This would cause dependencies to continue to fall behind and in some cases even limit other non-locked dependencies because of cross-dependencies.

To combat this, good practice would include a periodic cleanup of Gemfile version specifications that limit updating of gems.

Another good practice is a rule that when a gem has a limiting version specifier like items 3 and 4 above, there's a comment in the Gemfile explaining the reason. This allows the periodic cleanup process to be more effective, since one can determine whether a bug is fixed, or know what kind of breakage or test failure to look for when updating the gem past the version specification.

Currently, the `version_specifiers` option for this cop checks a gem specification for any version specifier, requiring a gem comment if one exists. This means that a non-limiting version specification like ">= 1.0" without a justification would warrant a complaint.

This new option, `limiting_version_specifiers`, requires a gem comment only for version specifications that are limiting in nature, but not for other version specifications.

So the following version specifications are permitted without comment:
```rb
gem "rubocop", ">= 1.0"
gem "rubocop", "!= 2.3.4"
```

while the following require an accompanying gem comment:

```rb
gem "rubocop", "< 3.0"
gem "rubocop", ">= 1.0", "< 3.0"
gem "rubocop", "~> 2.0"
gem "rubocop", "= 2.3.5"
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
