### PR TITLE
[Fix #9373]Fix  indentation style tabs infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5366,3 +5366,4 @@
 [@ohbarye]: https://github.com/ohbarye
 [@magneland]: https://github.com/magneland
 [@k-karen]: https://github.com/k-karen
+[@joeyparis]: https://github.com/joeyparis

--- a/changelog/fix_indentation_style_tabs_infinite_loop.md
+++ b/changelog/fix_indentation_style_tabs_infinite_loop.md
@@ -1,0 +1,1 @@
+* [#9373](https://github.com/rubocop-hq/rubocop/issues/9373): Fix Identation/Style infinite loop when its IdentationWidth attribute is set to anything but 1. ([@joeyparis][])

--- a/lib/rubocop/cop/layout/indentation_style.rb
+++ b/lib/rubocop/cop/layout/indentation_style.rb
@@ -6,6 +6,11 @@ module RuboCop
       # This cop checks that the indentation method is consistent.
       # Either tabs only or spaces only are used for indentation.
       #
+      # The `IndentationWidth` attribute is ignored when `EnforcedStyle` is `tabs`.
+      #
+      # When `EnforcedStyle` is set to `tabs` it is recommended to also set
+      # `Layout/IndentationWidth`'s `Width` attribute to `1`.
+      #
       # @example EnforcedStyle: spaces (default)
       #   # bad
       #   # This example uses a tab to indent bar.
@@ -82,7 +87,7 @@ module RuboCop
         def autocorrect_lambda_for_spaces(range)
           lambda do |corrector|
             corrector.replace(range, range.source.gsub(/\A\s+/) do |match|
-              "\t" * (match.size / configured_indentation_width)
+              "\t" * match.size
             end)
           end
         end


### PR DESCRIPTION
This fixes the bug described in #9373.

However, the testing for this cop breaks as it designed to replace every 2 spaces, with 1 tab but the fix replaces every 1 space with 1 tab. I would say this is a problem with the fix, but replacing 2 spaces only works in the vacuum of the test and leads to an infinite loop when used along with other cops.

When combined with `Layout/IndentationWidth` replacing every 1 space with a tab still leads to proper indentation by the time all the cops are done. But I'm assuming this is not ideal behavior for one to have to rely on another like that.

I'm not sure what the proper steps are to finalize this. Do I update the tests to just replace every 1 space with 1 tab? Or should we dive deeper into what else is contributing to the infinite loop?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
