### PR TITLE
[Fix #9429] Fix `Style/NegatedIfElseCondition` autocorrect to keep comments in correct branch

### DIFF
--- a/changelog/fix_comments_negated_if_else_condition_cop.md
+++ b/changelog/fix_comments_negated_if_else_condition_cop.md
@@ -1,0 +1,1 @@
+* [#9429](https://github.com/rubocop-hq/rubocop/issues/9429): Fix `Style/NegatedIfElseCondition` autocorrect to keep comments in correct branch. ([@tejasbubane][])

--- a/spec/rubocop/cop/style/negated_if_else_condition_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_else_condition_spec.rb
@@ -129,6 +129,64 @@ RSpec.describe RuboCop::Cop::Style::NegatedIfElseCondition, :config do
     RUBY
   end
 
+  it 'moves comments to correct branches during autocorrect' do
+    expect_offense(<<~RUBY)
+      if !condition.nil?
+      ^^^^^^^^^^^^^^^^^^ Invert the negated condition and swap the if-else branches.
+        # part B
+        # and foo is 39
+        foo = 39
+      else
+        # part A
+        # and foo is 42
+        foo = 42
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if condition.nil?
+        # part A
+        # and foo is 42
+        foo = 42
+      else
+        # part B
+        # and foo is 39
+        foo = 39
+      end
+    RUBY
+  end
+
+  it 'works with comments and multiple statements' do
+    expect_offense(<<~RUBY)
+      if !condition.nil?
+      ^^^^^^^^^^^^^^^^^^ Invert the negated condition and swap the if-else branches.
+        # part A
+        # and foo is 1 and bar is 2
+        foo = 1
+        bar = 2
+      else
+        # part B
+        # and foo is 3 and bar is 4
+        foo = 3
+        bar = 4
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if condition.nil?
+        # part B
+        # and foo is 3 and bar is 4
+        foo = 3
+        bar = 4
+      else
+        # part A
+        # and foo is 1 and bar is 2
+        foo = 1
+        bar = 2
+      end
+    RUBY
+  end
+
   it 'does not register an offense when negating condition for `if-elsif`' do
     expect_no_offenses(<<~RUBY)
       if !x


### PR DESCRIPTION
Closes #9429

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/