### PR TITLE
Add new `InternalAffairs/NodeMatcherDirective` cop.

### DIFF
--- a/lib/rubocop/cop/bundler/duplicated_gem.rb
+++ b/lib/rubocop/cop/bundler/duplicated_gem.rb
@@ -57,6 +57,7 @@ module RuboCop
 
         private
 
+        # @!method gem_declarations(node)
         def_node_search :gem_declarations, '(send nil? :gem str ...)'
 
         def duplicated_gem_nodes

--- a/lib/rubocop/cop/bundler/gem_comment.rb
+++ b/lib/rubocop/cop/bundler/gem_comment.rb
@@ -66,6 +66,7 @@ module RuboCop
         VERSION_SPECIFIERS_OPTION = 'version_specifiers'
         RESTRICT_ON_SEND = %i[gem].freeze
 
+        # @!method gem_declaration?(node)
         def_node_matcher :gem_declaration?, '(send nil? :gem str ...)'
 
         def on_send(node)

--- a/lib/rubocop/cop/bundler/insecure_protocol_source.rb
+++ b/lib/rubocop/cop/bundler/insecure_protocol_source.rb
@@ -36,6 +36,7 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[source].freeze
 
+        # @!method insecure_protocol_source?(node)
         def_node_matcher :insecure_protocol_source?, <<~PATTERN
           (send nil? :source
             $(sym ${:gemcutter :rubygems :rubyforge}))

--- a/lib/rubocop/cop/bundler/ordered_gems.rb
+++ b/lib/rubocop/cop/bundler/ordered_gems.rb
@@ -64,6 +64,7 @@ module RuboCop
           declarations.to_a[node_index - 1]
         end
 
+        # @!method gem_declarations(node)
         def_node_search :gem_declarations, <<~PATTERN
           (:send nil? :gem str ...)
         PATTERN

--- a/lib/rubocop/cop/gemspec/date_assignment.rb
+++ b/lib/rubocop/cop/gemspec/date_assignment.rb
@@ -25,6 +25,7 @@ module RuboCop
 
         MSG = 'Do not use `date =` in gemspec, it is set automatically when the gem is packaged.'
 
+        # @!method gem_specification(node)
         def_node_matcher :gem_specification, <<~PATTERN
           (block
             (send

--- a/lib/rubocop/cop/gemspec/duplicated_assignment.rb
+++ b/lib/rubocop/cop/gemspec/duplicated_assignment.rb
@@ -40,6 +40,7 @@ module RuboCop
         MSG = '`%<assignment>s` method calls already given on line '\
               '%<line_of_first_occurrence>d of the gemspec.'
 
+        # @!method gem_specification(node)
         def_node_search :gem_specification, <<~PATTERN
           (block
             (send
@@ -49,6 +50,7 @@ module RuboCop
               (arg $_)) ...)
         PATTERN
 
+        # @!method assignment_method_declarations(node)
         def_node_search :assignment_method_declarations, <<~PATTERN
           (send
             (lvar #match_block_variable_name?) #assignment_method? ...)

--- a/lib/rubocop/cop/gemspec/ordered_dependencies.rb
+++ b/lib/rubocop/cop/gemspec/ordered_dependencies.rb
@@ -95,6 +95,7 @@ module RuboCop
           node.method_name
         end
 
+        # @!method dependency_declarations(node)
         def_node_search :dependency_declarations, <<~PATTERN
           (send (lvar _) {:add_dependency :add_runtime_dependency :add_development_dependency} (str _) ...)
         PATTERN

--- a/lib/rubocop/cop/gemspec/required_ruby_version.rb
+++ b/lib/rubocop/cop/gemspec/required_ruby_version.rb
@@ -55,10 +55,12 @@ module RuboCop
                         '.rubocop.yml) should be equal.'
         MISSING_MSG = '`required_ruby_version` should be specified.'
 
+        # @!method required_ruby_version(node)
         def_node_search :required_ruby_version, <<~PATTERN
           (send _ :required_ruby_version= $_)
         PATTERN
 
+        # @!method defined_ruby_version(node)
         def_node_matcher :defined_ruby_version, <<~PATTERN
           {$(str _) $(array (str _) (str _))
             (send (const (const nil? :Gem) :Requirement) :new $(str _))}

--- a/lib/rubocop/cop/gemspec/ruby_version_globals_usage.rb
+++ b/lib/rubocop/cop/gemspec/ruby_version_globals_usage.rb
@@ -28,8 +28,10 @@ module RuboCop
       class RubyVersionGlobalsUsage < Base
         MSG = 'Do not use `RUBY_VERSION` in gemspec file.'
 
+        # @!method ruby_version?(node)
         def_node_matcher :ruby_version?, '(const {cbase nil?} :RUBY_VERSION)'
 
+        # @!method gem_specification?(node)
         def_node_search :gem_specification?, <<~PATTERN
           (block
             (send

--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -4,6 +4,7 @@ require_relative 'internal_affairs/empty_line_between_expect_offense_and_correct
 require_relative 'internal_affairs/example_description'
 require_relative 'internal_affairs/method_name_equal'
 require_relative 'internal_affairs/node_destructuring'
+require_relative 'internal_affairs/node_matcher_directive'
 require_relative 'internal_affairs/node_type_predicate'
 require_relative 'internal_affairs/offense_location_keyword'
 require_relative 'internal_affairs/redundant_described_class_as_subject'

--- a/lib/rubocop/cop/internal_affairs/example_description.rb
+++ b/lib/rubocop/cop/internal_affairs/example_description.rb
@@ -57,6 +57,7 @@ module RuboCop
           /\b(does not|doesn't) (auto[- ]?)?correct/
         ].freeze
 
+        # @!method offense_example?(node)
         def_node_matcher :offense_example?, <<~PATTERN
           (block
             (send _ {:it :specify} $_description)

--- a/lib/rubocop/cop/internal_affairs/method_name_equal.rb
+++ b/lib/rubocop/cop/internal_affairs/method_name_equal.rb
@@ -20,6 +20,7 @@ module RuboCop
               '`method_name == %<method_name>s`.'
         RESTRICT_ON_SEND = %i[==].freeze
 
+        # @!method method_name?(node)
         def_node_matcher :method_name?, <<~PATTERN
           (send
             $(send

--- a/lib/rubocop/cop/internal_affairs/node_destructuring.rb
+++ b/lib/rubocop/cop/internal_affairs/node_destructuring.rb
@@ -19,10 +19,12 @@ module RuboCop
         MSG = 'Use the methods provided with the node extensions instead ' \
               'of manually destructuring nodes.'
 
+        # @!method node_variable?(node)
         def_node_matcher :node_variable?, <<~PATTERN
           {(lvar [#node_suffix? _]) (send nil? [#node_suffix? _])}
         PATTERN
 
+        # @!method node_destructuring?(node)
         def_node_matcher :node_destructuring?, <<~PATTERN
           {(masgn (mlhs ...) {(send #node_variable? :children) (array (splat #node_variable?))})}
         PATTERN

--- a/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
+++ b/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # Checks that node matcher definitions are tagged with a YARD `@!method`
+      # directive so that editors are able to find the dynamically defined
+      # method.
+      #
+      # @example
+      #  # bad
+      #  def_node_matcher :foo?, <<~PATTERN
+      #    ...
+      #  PATTERN
+      #
+      #  # good
+      #  # @!method foo?(node)
+      #  def_node_matcher :foo?, <<~PATTERN
+      #    ...
+      #  PATTERN
+      #
+      class NodeMatcherDirective < Base
+        extend AutoCorrector
+        include RangeHelp
+
+        MSG = 'Preceed `%<method>s` with a `@!method` YARD directive.'
+        MSG_WRONG_NAME = '`@!method` YARD directive has invalid method name, ' \
+          'use `%<expected>s` instead of `%<actual>s`.'
+        MSG_TOO_MANY = 'Multiple `@!method` YARD directives found for this matcher.'
+
+        RESTRICT_ON_SEND = %i[def_node_matcher def_node_search].to_set.freeze
+        REGEXP = /^\s*#\s*@!method\s+(?<method_name>[a-z0-9_]+[?!]?)(?:\((?<args>.*)\))?/.freeze
+
+        # @!method pattern_matcher?(node)
+        def_node_matcher :pattern_matcher?, <<~PATTERN
+          (send _ %RESTRICT_ON_SEND {str sym} {str dstr})
+        PATTERN
+
+        def on_send(node)
+          return if node.arguments.none?
+          return unless valid_method_name?(node)
+
+          actual_name = node.arguments.first.value
+          directives = method_directives(node)
+          return too_many_directives(node) if directives.size > 1
+
+          directive = directives.first
+          return if directive_correct?(directive, actual_name)
+
+          register_offense(node, directive, actual_name)
+        end
+
+        private
+
+        def valid_method_name?(node)
+          node.arguments.first.str_type? || node.arguments.first.sym_type?
+        end
+
+        def method_directives(node)
+          comments = processed_source.ast_with_comments[node]
+
+          comments.map do |comment|
+            match = comment.text.match(REGEXP)
+            next unless match
+
+            { node: comment, method_name: match[:method_name], args: match[:args] }
+          end.compact
+        end
+
+        def too_many_directives(node)
+          add_offense(node, message: MSG_TOO_MANY)
+        end
+
+        def directive_correct?(directive, actual_name)
+          directive && directive[:method_name] == actual_name.to_s
+        end
+
+        def register_offense(node, directive, actual_name)
+          message = formatted_message(directive, actual_name, node.method_name)
+
+          add_offense(node, message: message) do |corrector|
+            if directive
+              correct_directive(corrector, directive, actual_name)
+            else
+              insert_directive(corrector, node, actual_name)
+            end
+          end
+        end
+
+        def formatted_message(directive, actual_name, method_name)
+          if directive
+            format(MSG_WRONG_NAME, expected: actual_name, actual: directive[:method_name])
+          else
+            format(MSG, method: method_name)
+          end
+        end
+
+        def insert_directive(corrector, node, actual_name)
+          # If the pattern matcher uses arguments (`%1`, `%2`, etc.), include them in the directive
+          arguments = pattern_arguments(node.arguments[1].value)
+
+          range = range_with_surrounding_space(
+            range: node.loc.expression,
+            side: :left,
+            newlines: false
+          )
+          indentation = range.source.match(/^\s*/)[0]
+          directive = "#{indentation}# @!method #{actual_name}(#{arguments.join(', ')})\n"
+          directive = "\n#{directive}" if add_newline?(node)
+
+          corrector.insert_before(range, directive)
+        end
+
+        def pattern_arguments(pattern)
+          arguments = %w[node]
+          max_pattern_var = pattern.scan(/(?<=%)\d+/).map(&:to_i).max
+          max_pattern_var&.times { |i| arguments << "arg#{i + 1}" }
+          arguments
+        end
+
+        def add_newline?(node)
+          # Determine if a blank line should be inserted before the new directive
+          # in order to spread out pattern matchers
+          return if node.sibling_index&.zero?
+          return unless node.parent
+
+          prev_sibling = node.parent.child_nodes[node.sibling_index - 1]
+          return unless prev_sibling && pattern_matcher?(prev_sibling)
+
+          node.loc.line == last_line(prev_sibling) + 1
+        end
+
+        def last_line(node)
+          if node.last_argument.heredoc?
+            node.last_argument.loc.heredoc_end.line
+          else
+            node.loc.last_line
+          end
+        end
+
+        def correct_directive(corrector, directive, actual_name)
+          correct = "@!method #{actual_name}"
+          regexp = /@!method\s+#{Regexp.escape(directive[:method_name])}/
+
+          replacement = directive[:node].text.gsub(regexp, correct)
+          corrector.replace(directive[:node], replacement)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/internal_affairs/node_type_predicate.rb
+++ b/lib/rubocop/cop/internal_affairs/node_type_predicate.rb
@@ -19,6 +19,7 @@ module RuboCop
         MSG = 'Use `#%<type>s_type?` to check node type.'
         RESTRICT_ON_SEND = %i[==].freeze
 
+        # @!method node_type_check(node)
         def_node_matcher :node_type_check, <<~PATTERN
           (send (send $_ :type) :== (sym $_))
         PATTERN

--- a/lib/rubocop/cop/internal_affairs/offense_location_keyword.rb
+++ b/lib/rubocop/cop/internal_affairs/offense_location_keyword.rb
@@ -34,10 +34,12 @@ module RuboCop
 
         private
 
+        # @!method node_type_check(node)
         def_node_matcher :node_type_check, <<~PATTERN
           (send nil? :add_offense $_node $hash)
         PATTERN
 
+        # @!method offending_location_argument(node)
         def_node_matcher :offending_location_argument, <<~PATTERN
           (pair (sym :location) $(send (send $_node :loc) $_keyword))
         PATTERN

--- a/lib/rubocop/cop/internal_affairs/redundant_described_class_as_subject.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_described_class_as_subject.rb
@@ -21,6 +21,7 @@ module RuboCop
 
         MSG = 'Remove the redundant `subject`%<additional_message>s.'
 
+        # @!method described_class_subject?(node)
         def_node_matcher :described_class_subject?, <<~PATTERN
           (block
             (send nil? :subject

--- a/lib/rubocop/cop/internal_affairs/redundant_let_rubocop_config_new.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_let_rubocop_config_new.rb
@@ -25,6 +25,7 @@ module RuboCop
 
         MSG = 'Remove `let` that is `RuboCop::Config.new` with no arguments%<additional_message>s.'
 
+        # @!method let_rubocop_config_new?(node)
         def_node_matcher :let_rubocop_config_new?, <<~PATTERN
           (block
             (send nil? :let

--- a/lib/rubocop/cop/internal_affairs/redundant_location_argument.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_location_argument.rb
@@ -23,6 +23,7 @@ module RuboCop
         MSG = 'Redundant location argument to `#add_offense`.'
         RESTRICT_ON_SEND = %i[add_offense].freeze
 
+        # @!method redundant_location_argument(node)
         def_node_matcher :redundant_location_argument, <<~PATTERN
           (send nil? :add_offense _
             (hash <$(pair (sym :location) (sym :expression)) ...>)

--- a/lib/rubocop/cop/internal_affairs/redundant_message_argument.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_message_argument.rb
@@ -26,16 +26,19 @@ module RuboCop
         MSG = 'Redundant message argument to `#add_offense`.'
         RESTRICT_ON_SEND = %i[add_offense].freeze
 
+        # @!method node_type_check(node)
         def_node_matcher :node_type_check, <<~PATTERN
           (send nil? :add_offense $_node $hash)
         PATTERN
 
+        # @!method redundant_message_argument(node)
         def_node_matcher :redundant_message_argument, <<~PATTERN
           (pair
             (sym :message)
             ${(const nil? :MSG) (send nil? :message) (send nil? :message _)})
         PATTERN
 
+        # @!method message_method_call(node)
         def_node_matcher :message_method_call, '(send nil? :message $_node)'
 
         def on_send(node)

--- a/lib/rubocop/cop/internal_affairs/style_detected_api_use.rb
+++ b/lib/rubocop/cop/internal_affairs/style_detected_api_use.rb
@@ -67,18 +67,22 @@ module RuboCop
           no_acceptable_style! style_detected
         ].freeze
 
+        # @!method correct_style_detected_check(node)
         def_node_matcher :correct_style_detected_check, <<~PATTERN
           (send nil? :correct_style_detected)
         PATTERN
 
+        # @!method negative_style_detected_method_check(node)
         def_node_matcher :negative_style_detected_method_check, <<~PATTERN
           (send nil? /(?:opposite|unexpected|ambiguous|unrecognized)_style_detected|conflicting_styles_detected/ ...)
         PATTERN
 
+        # @!method no_acceptable_style_check(node)
         def_node_matcher :no_acceptable_style_check, <<~PATTERN
           (send nil? :no_acceptable_style!)
         PATTERN
 
+        # @!method style_detected_check(node)
         def_node_matcher :style_detected_check, <<~PATTERN
           (send nil? :style_detected ...)
         PATTERN

--- a/lib/rubocop/cop/internal_affairs/useless_message_assertion.rb
+++ b/lib/rubocop/cop/internal_affairs/useless_message_assertion.rb
@@ -16,10 +16,12 @@ module RuboCop
       class UselessMessageAssertion < Base
         MSG = 'Do not specify cop behavior using `described_class::MSG`.'
 
+        # @!method described_class_msg(node)
         def_node_search :described_class_msg, <<~PATTERN
           (const (send nil? :described_class) :MSG)
         PATTERN
 
+        # @!method rspec_expectation_on_msg?(node)
         def_node_matcher :rspec_expectation_on_msg?, <<~PATTERN
           (send (send nil? :expect #contains_described_class_msg?) :to ...)
         PATTERN

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -68,6 +68,7 @@ module RuboCop
 
         MSG = '%<current>s is not aligned with %<prefer>s%<alt_prefer>s.'
 
+        # @!method block_end_align_target?(node, child)
         def_node_matcher :block_end_align_target?, <<~PATTERN
           {assignment?
            splat

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -147,6 +147,7 @@ module RuboCop
         MSG = '`%<category>s` is supposed to appear before ' \
               '`%<previous>s`.'
 
+        # @!method dynamic_constant?(node)
         def_node_matcher :dynamic_constant?, <<~PATTERN
           (casgn nil? _ (send ...))
         PATTERN

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -206,6 +206,7 @@ module RuboCop
           node.source_range.begin_pos > parent.source_range.begin_pos
         end
 
+        # @!method eligible_method_call?(node)
         def_node_matcher :eligible_method_call?, <<~PATTERN
           (send _ !:[]= ...)
         PATTERN

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -52,6 +52,7 @@ module RuboCop
         MSG = 'Use %<configured_indentation_width>d (not %<indentation>d) ' \
               'spaces for%<name>s indentation.'
 
+        # @!method access_modifier?(node)
         def_node_matcher :access_modifier?, <<~PATTERN
           [(send ...) access_modifier?]
         PATTERN

--- a/lib/rubocop/cop/lint/big_decimal_new.rb
+++ b/lib/rubocop/cop/lint/big_decimal_new.rb
@@ -21,6 +21,7 @@ module RuboCop
               'Use `%<double_colon>sBigDecimal()` instead.'
         RESTRICT_ON_SEND = %i[new].freeze
 
+        # @!method big_decimal_new(node)
         def_node_matcher :big_decimal_new, <<~PATTERN
           (send
             (const ${nil? cbase} :BigDecimal) :new ...)

--- a/lib/rubocop/cop/lint/boolean_symbol.rb
+++ b/lib/rubocop/cop/lint/boolean_symbol.rb
@@ -27,6 +27,7 @@ module RuboCop
         MSG = 'Symbol with a boolean name - ' \
               'you probably meant to use `%<boolean>s`.'
 
+        # @!method boolean_symbol?(node)
         def_node_matcher :boolean_symbol?, '(sym {:true :false})'
 
         def on_sym(node)

--- a/lib/rubocop/cop/lint/constant_definition_in_block.rb
+++ b/lib/rubocop/cop/lint/constant_definition_in_block.rb
@@ -66,10 +66,12 @@ module RuboCop
 
         MSG = 'Do not define constants this way within a block.'
 
+        # @!method constant_assigned_in_block?(node)
         def_node_matcher :constant_assigned_in_block?, <<~PATTERN
           ({^block_type? [^begin_type? ^^block_type?]} nil? ...)
         PATTERN
 
+        # @!method module_defined_in_block?(node)
         def_node_matcher :module_defined_in_block?, <<~PATTERN
           ({^block_type? [^begin_type? ^^block_type?]} ...)
         PATTERN

--- a/lib/rubocop/cop/lint/constant_resolution.rb
+++ b/lib/rubocop/cop/lint/constant_resolution.rb
@@ -58,6 +58,7 @@ module RuboCop
       class ConstantResolution < Base
         MSG = 'Fully qualify this constant to avoid possibly ambiguous resolution.'
 
+        # @!method unqualified_const?(node)
         def_node_matcher :unqualified_const?, <<~PATTERN
           (const nil? #const_name?)
         PATTERN

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -59,10 +59,12 @@ module RuboCop
 
         RESTRICT_ON_SEND = [].freeze
 
+        # @!method kernel?(node)
         def_node_matcher :kernel?, <<~PATTERN
           (const {nil? cbase} :Kernel)
         PATTERN
 
+        # @!method valid_receiver?(node, arg1)
         def_node_matcher :valid_receiver?, <<~PATTERN
           {
             (const {nil? cbase} %1)

--- a/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
+++ b/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
@@ -46,6 +46,7 @@ module RuboCop
 
         NO_ARG_ALGORITHM = %w[BF DES IDEA RC4].freeze
 
+        # @!method algorithm_const(node)
         def_node_matcher :algorithm_const, <<~PATTERN
           (send
             $(const

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -82,6 +82,7 @@ module RuboCop
           end
         end
 
+        # @!method method_alias?(node)
         def_node_matcher :method_alias?, <<~PATTERN
           (alias (sym $_name) sym)
         PATTERN
@@ -94,10 +95,12 @@ module RuboCop
           found_instance_method(node, name)
         end
 
+        # @!method alias_method?(node)
         def_node_matcher :alias_method?, <<~PATTERN
           (send nil? :alias_method (sym $_name) _)
         PATTERN
 
+        # @!method sym_name(node)
         def_node_matcher :sym_name, '(sym $_name)'
         def on_send(node)
           if (name = alias_method?(node))

--- a/lib/rubocop/cop/lint/duplicate_require.rb
+++ b/lib/rubocop/cop/lint/duplicate_require.rb
@@ -24,6 +24,7 @@ module RuboCop
         REQUIRE_METHODS = Set.new(%i[require require_relative]).freeze
         RESTRICT_ON_SEND = REQUIRE_METHODS
 
+        # @!method require_call?(node)
         def_node_matcher :require_call?, <<~PATTERN
           (send {nil? (const _ :Kernel)} %REQUIRE_METHODS _)
         PATTERN

--- a/lib/rubocop/cop/lint/each_with_object_argument.rb
+++ b/lib/rubocop/cop/lint/each_with_object_argument.rb
@@ -25,6 +25,7 @@ module RuboCop
         MSG = 'The argument to each_with_object cannot be immutable.'
         RESTRICT_ON_SEND = %i[each_with_object].freeze
 
+        # @!method each_with_object?(node)
         def_node_matcher :each_with_object?, <<~PATTERN
           ({send csend} _ :each_with_object $_)
         PATTERN

--- a/lib/rubocop/cop/lint/erb_new_arguments.rb
+++ b/lib/rubocop/cop/lint/erb_new_arguments.rb
@@ -80,6 +80,7 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[new].freeze
 
+        # @!method erb_new_with_non_keyword_arguments(node)
         def_node_matcher :erb_new_with_non_keyword_arguments, <<~PATTERN
           (send
             (const {nil? cbase} :ERB) :new $...)

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -92,6 +92,7 @@ module RuboCop
           end
         end
 
+        # @!method called_on_string?(node)
         def_node_matcher :called_on_string?, <<~PATTERN
           {(send {nil? const_type?} _ (str _) ...)
            (send (str ...) ...)}

--- a/lib/rubocop/cop/lint/hash_compare_by_identity.rb
+++ b/lib/rubocop/cop/lint/hash_compare_by_identity.rb
@@ -24,6 +24,7 @@ module RuboCop
 
         MSG = 'Use `Hash#compare_by_identity` instead of using `object_id` for keys.'
 
+        # @!method id_as_hash_key?(node)
         def_node_matcher :id_as_hash_key?, <<~PATTERN
           (send _ {:key? :has_key? :fetch :[] :[]=} (send _ :object_id) ...)
         PATTERN

--- a/lib/rubocop/cop/lint/ineffective_access_modifier.rb
+++ b/lib/rubocop/cop/lint/ineffective_access_modifier.rb
@@ -53,6 +53,7 @@ module RuboCop
         ALTERNATIVE_PROTECTED = '`protected` inside a `class << self` ' \
                                 'block'
 
+        # @!method private_class_methods(node)
         def_node_search :private_class_methods, <<~PATTERN
           (send nil? :private_class_method $...)
         PATTERN

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -58,6 +58,7 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[new].freeze
 
+        # @!method class_new_call?(node)
         def_node_matcher :class_new_call?, <<~PATTERN
           (send
             (const {cbase nil?} :Class) :new

--- a/lib/rubocop/cop/lint/multiple_comparison.rb
+++ b/lib/rubocop/cop/lint/multiple_comparison.rb
@@ -25,6 +25,7 @@ module RuboCop
         SET_OPERATION_OPERATORS = %i[& | ^].freeze
         RESTRICT_ON_SEND = COMPARISON_METHODS
 
+        # @!method multiple_compare?(node)
         def_node_matcher :multiple_compare?, <<~PATTERN
           (send (send _ {:< :> :<= :>=} $_) {:#{COMPARISON_METHODS.join(' :')}} _)
         PATTERN

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -81,14 +81,17 @@ module RuboCop
             class_or_module_or_struct_new_call?(child)
         end
 
+        # @!method eval_call?(node)
         def_node_matcher :eval_call?, <<~PATTERN
           (block (send _ {:instance_eval :class_eval :module_eval} ...) ...)
         PATTERN
 
+        # @!method exec_call?(node)
         def_node_matcher :exec_call?, <<~PATTERN
           (block (send _ {:instance_exec :class_exec :module_exec} ...) ...)
         PATTERN
 
+        # @!method class_or_module_or_struct_new_call?(node)
         def_node_matcher :class_or_module_or_struct_new_call?, <<~PATTERN
           (block (send (const {nil? cbase} {:Class :Module :Struct}) :new ...) ...)
         PATTERN

--- a/lib/rubocop/cop/lint/next_without_accumulator.rb
+++ b/lib/rubocop/cop/lint/next_without_accumulator.rb
@@ -25,6 +25,7 @@ module RuboCop
       class NextWithoutAccumulator < Base
         MSG = 'Use `next` with an accumulator argument in a `reduce`.'
 
+        # @!method on_body_of_reduce(node)
         def_node_matcher :on_body_of_reduce, <<~PATTERN
           (block (send _recv {:reduce :inject} !sym) _blockargs $(begin ...))
         PATTERN

--- a/lib/rubocop/cop/lint/non_deterministic_require_order.rb
+++ b/lib/rubocop/cop/lint/non_deterministic_require_order.rb
@@ -129,32 +129,39 @@ module RuboCop
           unsorted_dir_glob_pass?(node) || unsorted_dir_each_pass?(node)
         end
 
+        # @!method unsorted_dir_block?(node)
         def_node_matcher :unsorted_dir_block?, <<~PATTERN
           (send (const {nil? cbase} :Dir) :glob ...)
         PATTERN
 
+        # @!method unsorted_dir_each?(node)
         def_node_matcher :unsorted_dir_each?, <<~PATTERN
           (send (send (const {nil? cbase} :Dir) {:[] :glob} ...) :each)
         PATTERN
 
+        # @!method method_require?(node)
         def_node_matcher :method_require?, <<~PATTERN
           (block-pass (send nil? :method (sym :require)))
         PATTERN
 
+        # @!method unsorted_dir_glob_pass?(node)
         def_node_matcher :unsorted_dir_glob_pass?, <<~PATTERN
           (send (const {nil? cbase} :Dir) :glob ...
             (block-pass (send nil? :method (sym :require))))
         PATTERN
 
+        # @!method unsorted_dir_each_pass?(node)
         def_node_matcher :unsorted_dir_each_pass?, <<~PATTERN
           (send (send (const {nil? cbase} :Dir) {:[] :glob} ...) :each
             (block-pass (send nil? :method (sym :require))))
         PATTERN
 
+        # @!method loop_variable(node)
         def_node_matcher :loop_variable, <<~PATTERN
           (args (arg $_))
         PATTERN
 
+        # @!method var_is_required?(node, name)
         def_node_search :var_is_required?, <<~PATTERN
           (send nil? :require (lvar %1))
         PATTERN

--- a/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
+++ b/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
@@ -73,7 +73,10 @@ module RuboCop
           !return_node.children.empty?
         end
 
+        # @!method chained_send?(node)
         def_node_matcher :chained_send?, '(send !nil? ...)'
+
+        # @!method define_method?(node)
         def_node_matcher :define_method?, <<~PATTERN
           (send _ {:define_method :define_singleton_method} _)
         PATTERN

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -62,10 +62,12 @@ module RuboCop
               '%<corrected_method>s.'
         METHODS = CONVERSION_METHOD_CLASS_MAPPING.keys.map(&:inspect).join(' ')
 
+        # @!method to_method(node)
         def_node_matcher :to_method, <<~PATTERN
           (send $_ ${#{METHODS}})
         PATTERN
 
+        # @!method to_method_symbol(node)
         def_node_matcher :to_method_symbol, <<~PATTERN
           {(send _ $_ ${(sym ${#{METHODS}})} ...)
            (send _ $_ ${(block_pass (sym ${#{METHODS}}))} ...)}

--- a/lib/rubocop/cop/lint/raise_exception.rb
+++ b/lib/rubocop/cop/lint/raise_exception.rb
@@ -33,10 +33,12 @@ module RuboCop
         MSG = 'Use `StandardError` over `Exception`.'
         RESTRICT_ON_SEND = %i[raise fail].freeze
 
+        # @!method exception?(node)
         def_node_matcher :exception?, <<~PATTERN
           (send nil? {:raise :fail} $(const ${cbase nil?} :Exception) ... )
         PATTERN
 
+        # @!method exception_new_with_message?(node)
         def_node_matcher :exception_new_with_message?, <<~PATTERN
           (send nil? {:raise :fail}
             (send $(const ${cbase nil?} :Exception) :new ... ))

--- a/lib/rubocop/cop/lint/rand_one.rb
+++ b/lib/rubocop/cop/lint/rand_one.rb
@@ -25,6 +25,7 @@ module RuboCop
               'Perhaps you meant `rand(2)` or `rand`?'
         RESTRICT_ON_SEND = %i[rand].freeze
 
+        # @!method rand_one?(node)
         def_node_matcher :rand_one?, <<~PATTERN
           (send {(const {nil? cbase} :Kernel) nil?} :rand {(int {-1 1}) (float {-1.0 1.0})})
         PATTERN

--- a/lib/rubocop/cop/lint/redundant_require_statement.rb
+++ b/lib/rubocop/cop/lint/redundant_require_statement.rb
@@ -28,6 +28,7 @@ module RuboCop
         MSG = 'Remove unnecessary `require` statement.'
         RESTRICT_ON_SEND = %i[require].freeze
 
+        # @!method unnecessary_require_statement?(node)
         def_node_matcher :unnecessary_require_statement?, <<~PATTERN
           (send nil? :require
             (str {"enumerator" "rational" "complex" "thread"}))

--- a/lib/rubocop/cop/lint/redundant_safe_navigation.rb
+++ b/lib/rubocop/cop/lint/redundant_safe_navigation.rb
@@ -43,6 +43,7 @@ module RuboCop
 
         NIL_SPECIFIC_METHODS = (nil.methods - Object.new.methods).to_set.freeze
 
+        # @!method respond_to_nil_specific_method?(node)
         def_node_matcher :respond_to_nil_specific_method?, <<~PATTERN
           (csend _ :respond_to? (sym %NIL_SPECIFIC_METHODS))
         PATTERN

--- a/lib/rubocop/cop/lint/redundant_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/redundant_splat_expansion.rb
@@ -79,6 +79,7 @@ module RuboCop
         PERCENT_CAPITAL_I = '%I'
         ASSIGNMENT_TYPES = %i[lvasgn ivasgn cvasgn gvasgn].freeze
 
+        # @!method array_new?(node)
         def_node_matcher :array_new?, <<~PATTERN
           {
             $(send (const {nil? cbase} :Array) :new ...)
@@ -86,6 +87,7 @@ module RuboCop
           }
         PATTERN
 
+        # @!method literal_expansion(node)
         def_node_matcher :literal_expansion, <<~PATTERN
           (splat {$({str dstr int float array} ...) (block $#array_new? ...) $#array_new?} ...)
         PATTERN

--- a/lib/rubocop/cop/lint/redundant_string_coercion.rb
+++ b/lib/rubocop/cop/lint/redundant_string_coercion.rb
@@ -25,6 +25,7 @@ module RuboCop
         MSG_SELF = 'Use `self` instead of `Object#to_s` in ' \
                    'interpolation.'
 
+        # @!method to_s_without_args?(node)
         def_node_matcher :to_s_without_args?, '(send _ :to_s)'
 
         def on_interpolation(begin_node)

--- a/lib/rubocop/cop/lint/redundant_with_index.rb
+++ b/lib/rubocop/cop/lint/redundant_with_index.rb
@@ -33,6 +33,7 @@ module RuboCop
         MSG_EACH_WITH_INDEX = 'Use `each` instead of `each_with_index`.'
         MSG_WITH_INDEX = 'Remove redundant `with_index`.'
 
+        # @!method redundant_with_index?(node)
         def_node_matcher :redundant_with_index?, <<~PATTERN
           (block
             $(send

--- a/lib/rubocop/cop/lint/redundant_with_object.rb
+++ b/lib/rubocop/cop/lint/redundant_with_object.rb
@@ -34,6 +34,7 @@ module RuboCop
 
         MSG_WITH_OBJECT = 'Remove redundant `with_object`.'
 
+        # @!method redundant_with_object?(node)
         def_node_matcher :redundant_with_object?, <<~PATTERN
           (block
             $(send _ {:each_with_object :with_object}

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -29,6 +29,7 @@ module RuboCop
         MSG = 'Do not chain ordinary method call' \
               ' after safe navigation operator.'
 
+        # @!method bad_method?(node)
         def_node_matcher :bad_method?, <<~PATTERN
           {
             (send $(csend ...) $_ ...)

--- a/lib/rubocop/cop/lint/safe_navigation_with_empty.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_with_empty.rb
@@ -25,6 +25,7 @@ module RuboCop
         MSG = 'Avoid calling `empty?` with the safe navigation operator ' \
           'in conditionals.'
 
+        # @!method safe_navigation_empty_in_conditional?(node)
         def_node_matcher :safe_navigation_empty_in_conditional?, <<~PATTERN
           (if (csend (send ...) :empty?) ...)
         PATTERN

--- a/lib/rubocop/cop/lint/send_with_mixin_argument.rb
+++ b/lib/rubocop/cop/lint/send_with_mixin_argument.rb
@@ -43,6 +43,7 @@ module RuboCop
         SEND_METHODS = %i[send public_send __send__].freeze
         RESTRICT_ON_SEND = SEND_METHODS
 
+        # @!method send_with_mixin_argument?(node)
         def_node_matcher :send_with_mixin_argument?, <<~PATTERN
           (send
             (const _ _) {:#{SEND_METHODS.join(' :')}}

--- a/lib/rubocop/cop/lint/shadowed_argument.rb
+++ b/lib/rubocop/cop/lint/shadowed_argument.rb
@@ -67,6 +67,7 @@ module RuboCop
         MSG = 'Argument `%<argument>s` was shadowed by a local variable ' \
               'before it was used.'
 
+        # @!method uses_var?(node)
         def_node_search :uses_var?, '(lvar %)'
 
         def self.joining_forces

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -42,6 +42,7 @@ module RuboCop
       class ShadowingOuterLocalVariable < Base
         MSG = 'Shadowing outer local variable - `%<variable>s`.'
 
+        # @!method ractor_block?(node)
         def_node_matcher :ractor_block?, <<~PATTERN
           (block (send (const nil? :Ractor) :new ...) ...)
         PATTERN

--- a/lib/rubocop/cop/lint/struct_new_override.rb
+++ b/lib/rubocop/cop/lint/struct_new_override.rb
@@ -29,6 +29,7 @@ module RuboCop
         STRUCT_METHOD_NAMES = Struct.instance_methods
         STRUCT_MEMBER_NAME_TYPES = %i[sym str].freeze
 
+        # @!method struct_new(node)
         def_node_matcher :struct_new, <<~PATTERN
           (send
             (const ${nil? cbase} :Struct) :new ...)

--- a/lib/rubocop/cop/lint/to_enum_arguments.rb
+++ b/lib/rubocop/cop/lint/to_enum_arguments.rb
@@ -23,14 +23,17 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[to_enum enum_for].freeze
 
+        # @!method enum_conversion_call?(node)
         def_node_matcher :enum_conversion_call?, <<~PATTERN
           (send {nil? self} {:to_enum :enum_for} $_ $...)
         PATTERN
 
+        # @!method method_name?(node, name)
         def_node_matcher :method_name?, <<~PATTERN
           {(send nil? {:__method__ :__callee__}) (sym %1)}
         PATTERN
 
+        # @!method passing_keyword_arg?(node, name)
         def_node_matcher :passing_keyword_arg?, <<~PATTERN
           (pair (sym %1) (lvar %1))
         PATTERN

--- a/lib/rubocop/cop/lint/unified_integer.rb
+++ b/lib/rubocop/cop/lint/unified_integer.rb
@@ -22,6 +22,7 @@ module RuboCop
 
         MSG = 'Use `Integer` instead of `%<klass>s`.'
 
+        # @!method fixnum_or_bignum_const(node)
         def_node_matcher :fixnum_or_bignum_const, <<~PATTERN
           (:const {nil? (:cbase)} ${:Fixnum :Bignum})
         PATTERN

--- a/lib/rubocop/cop/lint/unmodified_reduce_accumulator.rb
+++ b/lib/rubocop/cop/lint/unmodified_reduce_accumulator.rb
@@ -66,6 +66,7 @@ module RuboCop
         MSG = 'Ensure the accumulator `%<accum>s` will be modified by `%<method>s`.'
         MSG_INDEX = 'Do not return an element of the accumulator in `%<method>s`.'
 
+        # @!method reduce_with_block?(node)
         def_node_matcher :reduce_with_block?, <<~PATTERN
           {
             (block (send _recv {:reduce :inject} ...) args ...)
@@ -73,10 +74,12 @@ module RuboCop
           }
         PATTERN
 
+        # @!method accumulator_index?(node, accumulator_name)
         def_node_matcher :accumulator_index?, <<~PATTERN
           (send (lvar %1) {:[] :[]=} ...)
         PATTERN
 
+        # @!method element_modified?(node, element_name)
         def_node_search :element_modified?, <<~PATTERN
           {
             (send _receiver !{:[] :[]=} <`(lvar %1) `_ ...>)               # method(el, ...)
@@ -86,6 +89,7 @@ module RuboCop
           }
         PATTERN
 
+        # @!method lvar_used?(node, name)
         def_node_matcher :lvar_used?, <<~PATTERN
           {
             (lvar %1)
@@ -96,6 +100,7 @@ module RuboCop
           }
         PATTERN
 
+        # @!method expression_values(node)
         def_node_search :expression_values, <<~PATTERN
           {
             (%RuboCop::AST::Node::VARIABLES $_)

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -51,6 +51,7 @@ module RuboCop
 
         private
 
+        # @!method flow_command?(node)
         def_node_matcher :flow_command?, <<~PATTERN
           {
             return next break retry redo

--- a/lib/rubocop/cop/lint/unreachable_loop.rb
+++ b/lib/rubocop/cop/lint/unreachable_loop.rb
@@ -131,6 +131,7 @@ module RuboCop
           end
         end
 
+        # @!method break_command?(node)
         def_node_matcher :break_command?, <<~PATTERN
           {
             return break

--- a/lib/rubocop/cop/lint/unused_method_argument.rb
+++ b/lib/rubocop/cop/lint/unused_method_argument.rb
@@ -62,6 +62,7 @@ module RuboCop
         include UnusedArgument
         extend AutoCorrector
 
+        # @!method not_implemented?(node)
         def_node_matcher :not_implemented?, <<~PATTERN
           {(send nil? :raise (const {nil? cbase} :NotImplementedError))
            (send nil? :fail ...)}

--- a/lib/rubocop/cop/lint/uri_escape_unescape.rb
+++ b/lib/rubocop/cop/lint/uri_escape_unescape.rb
@@ -47,6 +47,7 @@ module RuboCop
         METHOD_NAMES = %i[escape encode unescape decode].freeze
         RESTRICT_ON_SEND = METHOD_NAMES
 
+        # @!method uri_escape_unescape?(node)
         def_node_matcher :uri_escape_unescape?, <<~PATTERN
           (send
             (const ${nil? cbase} :URI) ${:#{METHOD_NAMES.join(' :')}}

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -150,18 +150,22 @@ module RuboCop
           corrector.remove(range)
         end
 
+        # @!method static_method_definition?(node)
         def_node_matcher :static_method_definition?, <<~PATTERN
           {def (send nil? {:attr :attr_reader :attr_writer :attr_accessor} ...)}
         PATTERN
 
+        # @!method dynamic_method_definition?(node)
         def_node_matcher :dynamic_method_definition?, <<~PATTERN
           {(send nil? :define_method ...) (block (send nil? :define_method ...) ...)}
         PATTERN
 
+        # @!method class_or_instance_eval?(node)
         def_node_matcher :class_or_instance_eval?, <<~PATTERN
           (block (send _ {:class_eval :instance_eval}) ...)
         PATTERN
 
+        # @!method class_or_module_or_struct_new_call?(node)
         def_node_matcher :class_or_module_or_struct_new_call?, <<~PATTERN
           (block (send (const {nil? cbase} {:Class :Module :Struct}) :new ...) ...)
         PATTERN

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -56,6 +56,7 @@ module RuboCop
 
         private
 
+        # @!method setter_call_to_local_variable?(node)
         def_node_matcher :setter_call_to_local_variable?, <<~PATTERN
           [(send (lvar _) ...) setter_method?]
         PATTERN

--- a/lib/rubocop/cop/lint/useless_times.rb
+++ b/lib/rubocop/cop/lint/useless_times.rb
@@ -27,14 +27,17 @@ module RuboCop
         MSG = 'Useless call to `%<count>i.times` detected.'
         RESTRICT_ON_SEND = %i[times].freeze
 
+        # @!method times_call?(node)
         def_node_matcher :times_call?, <<~PATTERN
           (send (int $_) :times (block-pass (sym $_))?)
         PATTERN
 
+        # @!method block_arg(node)
         def_node_matcher :block_arg, <<~PATTERN
           (block _ (args (arg $_)) ...)
         PATTERN
 
+        # @!method block_reassigns_arg?(node)
         def_node_search :block_reassigns_arg?, <<~PATTERN
           (lvasgn %)
         PATTERN

--- a/lib/rubocop/cop/metrics/module_length.rb
+++ b/lib/rubocop/cop/metrics/module_length.rb
@@ -44,6 +44,7 @@ module RuboCop
 
         private
 
+        # @!method module_definition?(node)
         def_node_matcher :module_definition?, <<~PATTERN
           (casgn nil? _ (block (send (const {nil? cbase} :Module) :new) ...))
         PATTERN

--- a/lib/rubocop/cop/metrics/parameter_lists.rb
+++ b/lib/rubocop/cop/metrics/parameter_lists.rb
@@ -90,6 +90,7 @@ module RuboCop
 
         private
 
+        # @!method argument_to_lambda_or_proc?(node)
         def_node_matcher :argument_to_lambda_or_proc?, <<~PATTERN
           ^lambda_or_proc?
         PATTERN

--- a/lib/rubocop/cop/metrics/utils/repeated_attribute_discount.rb
+++ b/lib/rubocop/cop/metrics/utils/repeated_attribute_discount.rb
@@ -60,6 +60,7 @@ module RuboCop
 
           private
 
+          # @!method attribute_call?(node)
           def_node_matcher :attribute_call?, <<~PATTERN
             ( {csend send} _receiver _method # and no parameters
             )
@@ -90,6 +91,7 @@ module RuboCop
             end
           end
 
+          # @!method root_node?(node)
           def_node_matcher :root_node?, <<~PATTERN
             { nil? | self               # e.g. receiver of `my_method` or `self.my_attr`
             | lvar | ivar | cvar | gvar # e.g. receiver of `var.my_method`

--- a/lib/rubocop/cop/mixin/def_node.rb
+++ b/lib/rubocop/cop/mixin/def_node.rb
@@ -25,6 +25,7 @@ module RuboCop
         processed_source[0..index].map(&:strip)
       end
 
+      # @!method non_public_modifier?(node)
       def_node_matcher :non_public_modifier?, <<~PATTERN
         (send nil? {:private :protected} ({def defs} ...))
       PATTERN

--- a/lib/rubocop/cop/mixin/empty_lines_around_body.rb
+++ b/lib/rubocop/cop/mixin/empty_lines_around_body.rb
@@ -18,7 +18,10 @@ module RuboCop
 
         private
 
+        # @!method constant_definition?(node)
         def_node_matcher :constant_definition?, '{class module}'
+
+        # @!method empty_line_required?(node)
         def_node_matcher :empty_line_required?,
                          '{def defs class module (send nil? {:private :protected :public})}'
 

--- a/lib/rubocop/cop/mixin/empty_parameter.rb
+++ b/lib/rubocop/cop/mixin/empty_parameter.rb
@@ -8,6 +8,7 @@ module RuboCop
 
       private
 
+      # @!method empty_arguments?(node)
       def_node_matcher :empty_arguments?, <<~PATTERN
         (block _ $(args) _)
       PATTERN

--- a/lib/rubocop/cop/mixin/enforce_superclass.rb
+++ b/lib/rubocop/cop/mixin/enforce_superclass.rb
@@ -13,10 +13,12 @@ module RuboCop
     # @api private
     module EnforceSuperclass
       def self.included(base)
+        # @!method class_definition(node)
         base.def_node_matcher :class_definition, <<~PATTERN
           (class (const _ !:#{base::SUPERCLASS}) #{base::BASE_PATTERN} ...)
         PATTERN
 
+        # @!method class_new_definition(node)
         base.def_node_matcher :class_new_definition, <<~PATTERN
           [!^(casgn {nil? cbase} :#{base::SUPERCLASS} ...)
            !^^(casgn {nil? cbase} :#{base::SUPERCLASS} (block ...))

--- a/lib/rubocop/cop/mixin/hash_transform_method.rb
+++ b/lib/rubocop/cop/mixin/hash_transform_method.rb
@@ -9,6 +9,7 @@ module RuboCop
 
       RESTRICT_ON_SEND = %i[[] to_h].freeze
 
+      # @!method array_receiver?(node)
       def_node_matcher :array_receiver?, <<~PATTERN
         {(array ...) (send _ :each_with_index) (send _ :with_index _ ?) (send _ :zip ...)}
       PATTERN

--- a/lib/rubocop/cop/mixin/method_complexity.rb
+++ b/lib/rubocop/cop/mixin/method_complexity.rb
@@ -36,6 +36,7 @@ module RuboCop
 
       private
 
+      # @!method define_method?(node)
       def_node_matcher :define_method?, <<~PATTERN
         (block
          (send nil? :define_method ({sym str} $_))

--- a/lib/rubocop/cop/mixin/negative_conditional.rb
+++ b/lib/rubocop/cop/mixin/negative_conditional.rb
@@ -12,7 +12,10 @@ module RuboCop
 
       private
 
+      # @!method single_negative?(node)
       def_node_matcher :single_negative?, '(send !(send _ :!) :!)'
+
+      # @!method empty_condition?(node)
       def_node_matcher :empty_condition?, '(begin)'
 
       def check_negative_conditional(node, message:, &block)

--- a/lib/rubocop/cop/mixin/rational_literal.rb
+++ b/lib/rubocop/cop/mixin/rational_literal.rb
@@ -8,6 +8,7 @@ module RuboCop
 
       private
 
+      # @!method rational_literal?(node)
       def_node_matcher :rational_literal?, <<~PATTERN
         (send
           (int _) :/

--- a/lib/rubocop/cop/mixin/safe_assignment.rb
+++ b/lib/rubocop/cop/mixin/safe_assignment.rb
@@ -10,8 +10,13 @@ module RuboCop
 
       private
 
+      # @!method empty_condition?(node)
       def_node_matcher :empty_condition?, '(begin)'
+
+      # @!method setter_method?(node)
       def_node_matcher :setter_method?, '[(send ...) setter_method?]'
+
+      # @!method safe_assignment?(node)
       def_node_matcher :safe_assignment?,
                        '(begin {equals_asgn? #setter_method?})'
 

--- a/lib/rubocop/cop/mixin/visibility_help.rb
+++ b/lib/rubocop/cop/mixin/visibility_help.rb
@@ -28,6 +28,7 @@ module RuboCop
         end || right.last
       end
 
+      # @!method visibility_block?(node)
       def_node_matcher :visibility_block?, <<~PATTERN
         (send nil? { :private :protected :public })
       PATTERN

--- a/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
+++ b/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
@@ -22,6 +22,7 @@ module RuboCop
         OP_LIKE_METHODS = %i[eql? equal?].freeze
         EXCLUDED = %i[+@ -@ [] []= << === ` =~].freeze
 
+        # @!method op_method_candidate?(node)
         def_node_matcher :op_method_candidate?, <<~PATTERN
           (def [#op_method? $_] (args $(arg [!:other !:_other])) _)
         PATTERN

--- a/lib/rubocop/cop/naming/constant_name.rb
+++ b/lib/rubocop/cop/naming/constant_name.rb
@@ -23,6 +23,7 @@ module RuboCop
         # than just standard ASCII characters
         SNAKE_CASE = /^[[:digit:][:upper:]_]+$/.freeze
 
+        # @!method class_or_struct_return_method?(node)
         def_node_matcher :class_or_struct_return_method?, <<~PATTERN
           (send
             (const _ {:Class :Struct}) :new
@@ -64,6 +65,7 @@ module RuboCop
             (node.receiver.nil? || !literal_receiver?(node))
         end
 
+        # @!method literal_receiver?(node)
         def_node_matcher :literal_receiver?, <<~PATTERN
           {(send literal? ...)
            (send (begin literal?) ...)}

--- a/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
+++ b/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
@@ -148,6 +148,7 @@ module RuboCop
           'with `_`. Use `@%<suggested_var>s` instead.'
         DYNAMIC_DEFINE_METHODS = %i[define_method define_singleton_method].to_set.freeze
 
+        # @!method method_definition?(node)
         def_node_matcher :method_definition?, <<~PATTERN
           ${
             (block (send _ %DYNAMIC_DEFINE_METHODS ({sym str} $_)) ...)
@@ -179,6 +180,7 @@ module RuboCop
         end
         # rubocop:enable Metrics/AbcSize
 
+        # @!method defined_memoized?(node, ivar)
         def_node_matcher :defined_memoized?, <<~PATTERN
           (begin
             (if (defined $(ivar %1)) (return $(ivar %1)) nil?)

--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -35,7 +35,10 @@ module RuboCop
 
         MSG = 'Use %<style>s for method names.'
 
+        # @!method sym_name(node)
         def_node_matcher :sym_name, '(sym $_name)'
+
+        # @!method str_name(node)
         def_node_matcher :str_name, '(str $_name)'
 
         def on_send(node)

--- a/lib/rubocop/cop/naming/predicate_name.rb
+++ b/lib/rubocop/cop/naming/predicate_name.rb
@@ -30,6 +30,7 @@ module RuboCop
       class PredicateName < Base
         include AllowedMethods
 
+        # @!method dynamic_method_define(node)
         def_node_matcher :dynamic_method_define, <<~PATTERN
           (send nil? #method_definition_macros
             (sym $_)

--- a/lib/rubocop/cop/security/eval.rb
+++ b/lib/rubocop/cop/security/eval.rb
@@ -15,6 +15,7 @@ module RuboCop
         MSG = 'The use of `eval` is a serious security risk.'
         RESTRICT_ON_SEND = %i[eval].freeze
 
+        # @!method eval?(node)
         def_node_matcher :eval?, <<~PATTERN
           (send {nil? (send nil? :binding)} :eval $!str ...)
         PATTERN

--- a/lib/rubocop/cop/security/json_load.rb
+++ b/lib/rubocop/cop/security/json_load.rb
@@ -28,6 +28,7 @@ module RuboCop
         MSG = 'Prefer `JSON.parse` over `JSON.%<method>s`.'
         RESTRICT_ON_SEND = %i[load restore].freeze
 
+        # @!method json_load(node)
         def_node_matcher :json_load, <<~PATTERN
           (send (const {nil? cbase} :JSON) ${:load :restore} ...)
         PATTERN

--- a/lib/rubocop/cop/security/marshal_load.rb
+++ b/lib/rubocop/cop/security/marshal_load.rb
@@ -22,6 +22,7 @@ module RuboCop
         MSG = 'Avoid using `Marshal.%<method>s`.'
         RESTRICT_ON_SEND = %i[load restore].freeze
 
+        # @!method marshal_load(node)
         def_node_matcher :marshal_load, <<~PATTERN
           (send (const {nil? cbase} :Marshal) ${:load :restore}
           !(send (const {nil? cbase} :Marshal) :dump ...))

--- a/lib/rubocop/cop/security/open.rb
+++ b/lib/rubocop/cop/security/open.rb
@@ -24,6 +24,7 @@ module RuboCop
         MSG = 'The use of `%<receiver>sopen` is a serious security risk.'
         RESTRICT_ON_SEND = %i[open].freeze
 
+        # @!method open?(node)
         def_node_matcher :open?, <<~PATTERN
           (send ${nil? (const {nil? cbase} :URI)} :open $!str ...)
         PATTERN

--- a/lib/rubocop/cop/security/yaml_load.rb
+++ b/lib/rubocop/cop/security/yaml_load.rb
@@ -21,6 +21,7 @@ module RuboCop
         MSG = 'Prefer using `YAML.safe_load` over `YAML.load`.'
         RESTRICT_ON_SEND = %i[load].freeze
 
+        # @!method yaml_load(node)
         def_node_matcher :yaml_load, <<~PATTERN
           (send (const {nil? cbase} :YAML) :load ...)
         PATTERN

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -77,6 +77,7 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[private protected public module_function].freeze
 
+        # @!method access_modifier_with_symbol?(node)
         def_node_matcher :access_modifier_with_symbol?, <<~PATTERN
           (send nil? {:private :protected :public} (sym _))
         PATTERN

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -145,6 +145,7 @@ module RuboCop
           corrector.replace(node.old_identifier, node.old_identifier.source[1..-1])
         end
 
+        # @!method identifier(node)
         def_node_matcher :identifier, <<~PATTERN
           (sym $_)
         PATTERN

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -47,14 +47,17 @@ module RuboCop
 
         MSG = 'Use arguments forwarding.'
 
+        # @!method use_rest_arguments?(node)
         def_node_matcher :use_rest_arguments?, <<~PATTERN
           (args (restarg $_) $...)
         PATTERN
 
+        # @!method only_rest_arguments?(node, name)
         def_node_matcher :only_rest_arguments?, <<~PATTERN
           (send _ _ (splat (lvar %1)))
         PATTERN
 
+        # @!method forwarding_method_arguments?(node, rest_name, block_name, kwargs_name)
         def_node_matcher :forwarding_method_arguments?, <<~PATTERN
           {
             (send _ _

--- a/lib/rubocop/cop/style/array_coercion.rb
+++ b/lib/rubocop/cop/style/array_coercion.rb
@@ -26,10 +26,12 @@ module RuboCop
         SPLAT_MSG = 'Use `Array(%<arg>s)` instead of `[*%<arg>s]`.'
         CHECK_MSG = 'Use `Array(%<arg>s)` instead of explicit `Array` check.'
 
+        # @!method array_splat?(node)
         def_node_matcher :array_splat?, <<~PATTERN
           (array (splat $_))
         PATTERN
 
+        # @!method unless_array?(node)
         def_node_matcher :unless_array?, <<~PATTERN
           (if
             (send

--- a/lib/rubocop/cop/style/array_join.rb
+++ b/lib/rubocop/cop/style/array_join.rb
@@ -23,6 +23,7 @@ module RuboCop
         MSG = 'Favor `Array#join` over `Array#*`.'
         RESTRICT_ON_SEND = %i[*].freeze
 
+        # @!method join_candidate?(node)
         def_node_matcher :join_candidate?, '(send $array :* $str)'
 
         def on_send(node)

--- a/lib/rubocop/cop/style/attr.rb
+++ b/lib/rubocop/cop/style/attr.rb
@@ -62,6 +62,7 @@ module RuboCop
           end
         end
 
+        # @!method class_eval?(node)
         def_node_matcher :class_eval?, <<~PATTERN
           (block (send _ {:class_eval :module_eval}) ...)
         PATTERN

--- a/lib/rubocop/cop/style/case_equality.rb
+++ b/lib/rubocop/cop/style/case_equality.rb
@@ -35,6 +35,7 @@ module RuboCop
         MSG = 'Avoid the use of the case equality operator `===`.'
         RESTRICT_ON_SEND = %i[===].freeze
 
+        # @!method case_equality?(node)
         def_node_matcher :case_equality?, '(send $#const? :=== $_)'
 
         def on_send(node)

--- a/lib/rubocop/cop/style/class_equality_comparison.rb
+++ b/lib/rubocop/cop/style/class_equality_comparison.rb
@@ -25,6 +25,7 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[== equal? eql?].freeze
 
+        # @!method class_comparison_candidate?(node)
         def_node_matcher :class_comparison_candidate?, <<~PATTERN
           (send
             {$(send _ :class) (send $(send _ :class) :name)}

--- a/lib/rubocop/cop/style/collection_compact.rb
+++ b/lib/rubocop/cop/style/collection_compact.rb
@@ -35,6 +35,7 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[reject reject! select select!].freeze
 
+        # @!method reject_method?(node)
         def_node_matcher :reject_method?, <<~PATTERN
           (block
             (send
@@ -44,6 +45,7 @@ module RuboCop
               $(lvar _) :nil?))
         PATTERN
 
+        # @!method select_method?(node)
         def_node_matcher :select_method?, <<~PATTERN
           (block
             (send

--- a/lib/rubocop/cop/style/colon_method_call.rb
+++ b/lib/rubocop/cop/style/colon_method_call.rb
@@ -22,6 +22,7 @@ module RuboCop
 
         MSG = 'Do not use `::` for method calls.'
 
+        # @!method java_type_node?(node)
         def_node_matcher :java_type_node?, <<~PATTERN
           (send
             (const nil? :Java) _)

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -231,6 +231,7 @@ module RuboCop
 
         # The shovel operator `<<` does not have its own type. It is a `send`
         # type.
+        # @!method assignment_type?(node)
         def_node_matcher :assignment_type?, <<~PATTERN
           {
             #{ASSIGNMENT_TYPES.join(' ')}
@@ -300,6 +301,7 @@ module RuboCop
           style == :assign_inside_condition && assignment_rhs_exist?(node)
         end
 
+        # @!method candidate_condition?(node)
         def_node_matcher :candidate_condition?, '[{if case} !#allowed_ternary?]'
 
         def allowed_ternary?(assignment)

--- a/lib/rubocop/cop/style/constant_visibility.rb
+++ b/lib/rubocop/cop/style/constant_visibility.rb
@@ -92,6 +92,7 @@ module RuboCop
           end
         end
 
+        # @!method visibility_declaration_for?(node, const_name)
         def_node_matcher :visibility_declaration_for?, <<~PATTERN
           (send nil? {:public_constant :private_constant} ({sym str} #match_name?(%1)))
         PATTERN

--- a/lib/rubocop/cop/style/date_time.rb
+++ b/lib/rubocop/cop/style/date_time.rb
@@ -47,14 +47,17 @@ module RuboCop
         CLASS_MSG = 'Prefer Time over DateTime.'
         COERCION_MSG = 'Do not use #to_datetime.'
 
+        # @!method date_time?(node)
         def_node_matcher :date_time?, <<~PATTERN
           (send (const {nil? (cbase)} :DateTime) ...)
         PATTERN
 
+        # @!method historic_date?(node)
         def_node_matcher :historic_date?, <<~PATTERN
           (send _ _ _ (const (const {nil? (cbase)} :Date) _))
         PATTERN
 
+        # @!method to_datetime?(node)
         def_node_matcher :to_datetime?, <<~PATTERN
           (send _ :to_datetime)
         PATTERN

--- a/lib/rubocop/cop/style/dir.rb
+++ b/lib/rubocop/cop/style/dir.rb
@@ -22,6 +22,7 @@ module RuboCop
         MSG = "Use `__dir__` to get an absolute path to the current file's directory."
         RESTRICT_ON_SEND = %i[expand_path dirname].freeze
 
+        # @!method dir_replacement?(node)
         def_node_matcher :dir_replacement?, <<~PATTERN
           {(send (const {nil? cbase} :File) :expand_path (send (const {nil? cbase} :File) :dirname  #file_keyword?))
            (send (const {nil? cbase} :File) :dirname     (send (const {nil? cbase} :File) :realpath #file_keyword?))}

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -65,8 +65,13 @@ module RuboCop
 
         MSG = 'Missing top-level %<type>s documentation comment.'
 
+        # @!method constant_definition?(node)
         def_node_matcher :constant_definition?, '{class module casgn}'
+
+        # @!method outer_module(node)
         def_node_search :outer_module, '(const (const nil? _) _)'
+
+        # @!method constant_visibility_declaration?(node)
         def_node_matcher :constant_visibility_declaration?, <<~PATTERN
           (send nil? {:public_constant :private_constant} ({sym str} _))
         PATTERN

--- a/lib/rubocop/cop/style/documentation_method.rb
+++ b/lib/rubocop/cop/style/documentation_method.rb
@@ -97,6 +97,7 @@ module RuboCop
 
         MSG = 'Missing method documentation comment.'
 
+        # @!method module_function_node?(node)
         def_node_matcher :module_function_node?, <<~PATTERN
           (send nil? :module_function ...)
         PATTERN

--- a/lib/rubocop/cop/style/double_negation.rb
+++ b/lib/rubocop/cop/style/double_negation.rb
@@ -39,6 +39,7 @@ module RuboCop
         MSG = 'Avoid the use of double negation (`!!`).'
         RESTRICT_ON_SEND = %i[!].freeze
 
+        # @!method double_negative?(node)
         def_node_matcher :double_negative?, '(send (send _ :!) :!)'
 
         def on_send(node)

--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -46,6 +46,7 @@ module RuboCop
 
         private
 
+        # @!method offending_each_range(node)
         def_node_matcher :offending_each_range, <<~PATTERN
           (block (send (begin (${irange erange} (int $_) (int $_))) :each) (args) ...)
         PATTERN

--- a/lib/rubocop/cop/style/each_with_object.rb
+++ b/lib/rubocop/cop/style/each_with_object.rb
@@ -23,6 +23,7 @@ module RuboCop
         MSG = 'Use `each_with_object` instead of `%<method>s`.'
         METHODS = %i[inject reduce].freeze
 
+        # @!method each_with_object_candidate?(node)
         def_node_matcher :each_with_object_candidate?, <<~PATTERN
           (block $(send _ {:inject :reduce} _) $_ $_)
         PATTERN

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -27,11 +27,20 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[new].freeze
 
+        # @!method array_node(node)
         def_node_matcher :array_node, '(send (const {nil? cbase} :Array) :new)'
+
+        # @!method hash_node(node)
         def_node_matcher :hash_node, '(send (const {nil? cbase} :Hash) :new)'
+
+        # @!method str_node(node)
         def_node_matcher :str_node, '(send (const {nil? cbase} :String) :new)'
+
+        # @!method array_with_block(node)
         def_node_matcher :array_with_block,
                          '(block (send (const {nil? cbase} :Array) :new) args _)'
+
+        # @!method hash_with_block(node)
         def_node_matcher :hash_with_block, <<~PATTERN
           {
             (block (send (const {nil? cbase} :Hash) :new) args _)

--- a/lib/rubocop/cop/style/eval_with_location.rb
+++ b/lib/rubocop/cop/style/eval_with_location.rb
@@ -65,10 +65,12 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[eval class_eval module_eval instance_eval].freeze
 
+        # @!method valid_eval_receiver?(node)
         def_node_matcher :valid_eval_receiver?, <<~PATTERN
           { nil? (const {nil? cbase} :Kernel) }
         PATTERN
 
+        # @!method line_with_offset?(node, sign, num)
         def_node_matcher :line_with_offset?, <<~PATTERN
           {
             (send #special_line_keyword? %1 (int %2))

--- a/lib/rubocop/cop/style/even_odd.rb
+++ b/lib/rubocop/cop/style/even_odd.rb
@@ -21,6 +21,7 @@ module RuboCop
         MSG = 'Replace with `Integer#%<method>s?`.'
         RESTRICT_ON_SEND = %i[== !=].freeze
 
+        # @!method even_odd_candidate?(node)
         def_node_matcher :even_odd_candidate?, <<~PATTERN
           (send
             {(send $_ :% (int 2))

--- a/lib/rubocop/cop/style/expand_path_arguments.rb
+++ b/lib/rubocop/cop/style/expand_path_arguments.rb
@@ -54,6 +54,7 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[expand_path].freeze
 
+        # @!method file_expand_path(node)
         def_node_matcher :file_expand_path, <<~PATTERN
           (send
             (const {nil? cbase} :File) :expand_path
@@ -61,6 +62,7 @@ module RuboCop
             $_)
         PATTERN
 
+        # @!method pathname_parent_expand_path(node)
         def_node_matcher :pathname_parent_expand_path, <<~PATTERN
           (send
             (send
@@ -68,6 +70,7 @@ module RuboCop
                 $_) :parent) :expand_path)
         PATTERN
 
+        # @!method pathname_new_parent_expand_path(node)
         def_node_matcher :pathname_new_parent_expand_path, <<~PATTERN
           (send
             (send

--- a/lib/rubocop/cop/style/explicit_block_argument.rb
+++ b/lib/rubocop/cop/style/explicit_block_argument.rb
@@ -45,6 +45,7 @@ module RuboCop
         MSG = 'Consider using explicit block argument in the '\
               "surrounding method's signature over `yield`."
 
+        # @!method yielding_block?(node)
         def_node_matcher :yielding_block?, <<~PATTERN
           (block $_ (args $...) (yield $...))
         PATTERN

--- a/lib/rubocop/cop/style/float_division.rb
+++ b/lib/rubocop/cop/style/float_division.rb
@@ -55,15 +55,19 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[/].freeze
 
+        # @!method right_coerce?(node)
         def_node_matcher :right_coerce?, <<~PATTERN
           (send _ :/ (send _ :to_f))
         PATTERN
+        # @!method left_coerce?(node)
         def_node_matcher :left_coerce?, <<~PATTERN
           (send (send _ :to_f) :/ _)
         PATTERN
+        # @!method both_coerce?(node)
         def_node_matcher :both_coerce?, <<~PATTERN
           (send (send _ :to_f) :/ (send _ :to_f))
         PATTERN
+        # @!method any_coerce?(node)
         def_node_matcher :any_coerce?, <<~PATTERN
           {(send _ :/ (send _ :to_f)) (send (send _ :to_f) :/ _)}
         PATTERN

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -42,6 +42,7 @@ module RuboCop
         MSG = 'Favor `%<prefer>s` over `%<current>s`.'
         RESTRICT_ON_SEND = %i[format sprintf %].freeze
 
+        # @!method formatter(node)
         def_node_matcher :formatter, <<~PATTERN
           {
             (send nil? ${:sprintf :format} _ _ ...)
@@ -50,6 +51,7 @@ module RuboCop
           }
         PATTERN
 
+        # @!method variable_argument?(node)
         def_node_matcher :variable_argument?, <<~PATTERN
           (send {str dstr} :% {send_type? lvar_type?})
         PATTERN

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -89,6 +89,7 @@ module RuboCop
 
         private
 
+        # @!method format_string_in_typical_context?(node)
         def_node_matcher :format_string_in_typical_context?, <<~PATTERN
           {
             ^(send _ {:format :sprintf :printf} %0 ...)

--- a/lib/rubocop/cop/style/global_std_stream.rb
+++ b/lib/rubocop/cop/style/global_std_stream.rb
@@ -34,6 +34,7 @@ module RuboCop
 
         STD_STREAMS = %i[STDIN STDOUT STDERR].to_set.freeze
 
+        # @!method const_to_gvar_assignment?(node, name)
         def_node_matcher :const_to_gvar_assignment?, <<~PATTERN
           (gvasgn %1 (const nil? _))
         PATTERN

--- a/lib/rubocop/cop/style/hash_conversion.rb
+++ b/lib/rubocop/cop/style/hash_conversion.rb
@@ -40,6 +40,7 @@ module RuboCop
         MSG_SPLAT = 'Prefer array_of_pairs.to_h to Hash[*array].'
         RESTRICT_ON_SEND = %i[[]].freeze
 
+        # @!method hash_from_array?(node)
         def_node_matcher :hash_from_array?, '(send (const {nil? cbase} :Hash) :[] ...)'
 
         def on_send(node)

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -23,6 +23,7 @@ module RuboCop
 
         MSG = 'Use `%<prefer>s` instead of `%<current>s`.'
 
+        # @!method kv_each(node)
         def_node_matcher :kv_each, <<~PATTERN
           (block $(send (send _ ${:keys :values}) :each) ...)
         PATTERN

--- a/lib/rubocop/cop/style/hash_except.rb
+++ b/lib/rubocop/cop/style/hash_except.rb
@@ -33,6 +33,7 @@ module RuboCop
         MSG = 'Use `%<prefer>s` instead.'
         RESTRICT_ON_SEND = %i[reject select filter].freeze
 
+        # @!method bad_method?(node)
         def_node_matcher :bad_method?, <<~PATTERN
           (block
             (send _ _)

--- a/lib/rubocop/cop/style/hash_like_case.rb
+++ b/lib/rubocop/cop/style/hash_like_case.rb
@@ -39,6 +39,7 @@ module RuboCop
       class HashLikeCase < Base
         MSG = 'Consider replacing `case-when` with a hash lookup.'
 
+        # @!method hash_like_case?(node)
         def_node_matcher :hash_like_case?, <<~PATTERN
           (case
             _

--- a/lib/rubocop/cop/style/hash_transform_keys.rb
+++ b/lib/rubocop/cop/style/hash_transform_keys.rb
@@ -32,6 +32,7 @@ module RuboCop
 
         minimum_target_ruby_version 2.5
 
+        # @!method on_bad_each_with_object(node)
         def_node_matcher :on_bad_each_with_object, <<~PATTERN
           (block
             ({send csend} !#array_receiver? :each_with_object (hash))
@@ -43,6 +44,7 @@ module RuboCop
             ({send csend} (lvar _memo) :[]= $!`_memo $(lvar _val)))
         PATTERN
 
+        # @!method on_bad_hash_brackets_map(node)
         def_node_matcher :on_bad_hash_brackets_map, <<~PATTERN
           (send
             (const _ :Hash)
@@ -55,6 +57,7 @@ module RuboCop
               (array $_ $(lvar _val))))
         PATTERN
 
+        # @!method on_bad_map_to_h(node)
         def_node_matcher :on_bad_map_to_h, <<~PATTERN
           ({send csend}
             (block
@@ -66,6 +69,7 @@ module RuboCop
             :to_h)
         PATTERN
 
+        # @!method on_bad_to_h(node)
         def_node_matcher :on_bad_to_h, <<~PATTERN
           (block
             ({send csend} !#array_receiver? :to_h)

--- a/lib/rubocop/cop/style/hash_transform_values.rb
+++ b/lib/rubocop/cop/style/hash_transform_values.rb
@@ -29,6 +29,7 @@ module RuboCop
         include HashTransformMethod
         extend AutoCorrector
 
+        # @!method on_bad_each_with_object(node)
         def_node_matcher :on_bad_each_with_object, <<~PATTERN
           (block
             ({send csend} !#array_receiver? :each_with_object (hash))
@@ -40,6 +41,7 @@ module RuboCop
             ({send csend} (lvar _memo) :[]= $(lvar _key) $!`_memo))
         PATTERN
 
+        # @!method on_bad_hash_brackets_map(node)
         def_node_matcher :on_bad_hash_brackets_map, <<~PATTERN
           (send
             (const _ :Hash)
@@ -52,6 +54,7 @@ module RuboCop
               (array $(lvar _key) $_)))
         PATTERN
 
+        # @!method on_bad_map_to_h(node)
         def_node_matcher :on_bad_map_to_h, <<~PATTERN
           ({send csend}
             (block
@@ -63,6 +66,7 @@ module RuboCop
             :to_h)
         PATTERN
 
+        # @!method on_bad_to_h(node)
         def_node_matcher :on_bad_to_h, <<~PATTERN
           (block
             ({send csend} !#array_receiver? :to_h)

--- a/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
+++ b/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
@@ -34,9 +34,11 @@ module RuboCop
         MSG = 'Remove redundant %<keyword>s with boolean literal branches.'
         MSG_FOR_ELSIF = 'Use `else` instead of redundant `elsif` with boolean literal branches.'
 
+        # @!method if_with_boolean_literal_branches?(node)
         def_node_matcher :if_with_boolean_literal_branches?, <<~PATTERN
           (if #return_boolean_value? {(true) (false) | (false) (true)})
         PATTERN
+        # @!method double_negative?(node)
         def_node_matcher :double_negative?, '(send (send _ :!) :!)'
 
         def on_if(node)

--- a/lib/rubocop/cop/style/implicit_runtime_error.rb
+++ b/lib/rubocop/cop/style/implicit_runtime_error.rb
@@ -19,6 +19,7 @@ module RuboCop
               ' rather than just a message.'
         RESTRICT_ON_SEND = %i[raise fail].freeze
 
+        # @!method implicit_runtime_error_raise_or_fail(node)
         def_node_matcher :implicit_runtime_error_raise_or_fail,
                          '(send nil? ${:raise :fail} {str dstr})'
 

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -48,6 +48,7 @@ module RuboCop
           [Style::Not, Style::SymbolProc]
         end
 
+        # @!method inverse_candidate?(node)
         def_node_matcher :inverse_candidate?, <<~PATTERN
           {
             (send $(send $(...) $_ $...) :!)
@@ -56,6 +57,7 @@ module RuboCop
           }
         PATTERN
 
+        # @!method inverse_block?(node)
         def_node_matcher :inverse_block?, <<~PATTERN
           (block $(send (...) $_) ... { $(send ... :!)
                                         $(send (...) {:!= :!~} ...)

--- a/lib/rubocop/cop/style/min_max.rb
+++ b/lib/rubocop/cop/style/min_max.rb
@@ -34,6 +34,7 @@ module RuboCop
 
         private
 
+        # @!method min_max_candidate(node)
         def_node_matcher :min_max_candidate, <<~PATTERN
           ({array return} (send [$_receiver !nil?] :min) (send [$_receiver !nil?] :max))
         PATTERN

--- a/lib/rubocop/cop/style/mixin_usage.rb
+++ b/lib/rubocop/cop/style/mixin_usage.rb
@@ -45,11 +45,13 @@ module RuboCop
               'or `module`.'
         RESTRICT_ON_SEND = %i[include extend prepend].freeze
 
+        # @!method include_statement(node)
         def_node_matcher :include_statement, <<~PATTERN
           (send nil? ${:include :extend :prepend}
             const)
         PATTERN
 
+        # @!method in_top_level_scope?(node)
         def_node_matcher :in_top_level_scope?, <<~PATTERN
           {
             root?                        # either at the top level

--- a/lib/rubocop/cop/style/module_function.rb
+++ b/lib/rubocop/cop/style/module_function.rb
@@ -82,8 +82,13 @@ module RuboCop
         FORBIDDEN_MSG =
           'Do not use `module_function` or `extend self`.'
 
+        # @!method module_function_node?(node)
         def_node_matcher :module_function_node?, '(send nil? :module_function)'
+
+        # @!method extend_self_node?(node)
         def_node_matcher :extend_self_node?, '(send nil? :extend self)'
+
+        # @!method private_directive?(node)
         def_node_matcher :private_directive?, '(send nil? :private ...)'
 
         def on_module(node)

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -71,10 +71,15 @@ module RuboCop
 
         private
 
+        # @!method simple_double_comparison?(node)
         def_node_matcher :simple_double_comparison?, '(send $lvar :== $lvar)'
+
+        # @!method simple_comparison_lhs?(node)
         def_node_matcher :simple_comparison_lhs?, <<~PATTERN
           (send $lvar :== $_)
         PATTERN
+
+        # @!method simple_comparison_rhs?(node)
         def_node_matcher :simple_comparison_rhs?, <<~PATTERN
           (send $_ :== $lvar)
         PATTERN

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -154,12 +154,14 @@ module RuboCop
           end
         end
 
+        # @!method splat_value(node)
         def_node_matcher :splat_value, <<~PATTERN
           (array (splat $_))
         PATTERN
 
         # Some of these patterns may not actually return an immutable object,
         # but we want to consider them immutable for this cop.
+        # @!method operation_produces_immutable_object?(node)
         def_node_matcher :operation_produces_immutable_object?, <<~PATTERN
           {
             (const _ _)
@@ -176,6 +178,7 @@ module RuboCop
           }
         PATTERN
 
+        # @!method range_enclosed_in_parentheses?(node)
         def_node_matcher :range_enclosed_in_parentheses?, <<~PATTERN
           (begin ({irange erange} _ _))
         PATTERN

--- a/lib/rubocop/cop/style/negated_if_else_condition.rb
+++ b/lib/rubocop/cop/style/negated_if_else_condition.rb
@@ -35,6 +35,7 @@ module RuboCop
 
         NEGATED_EQUALITY_METHODS = %i[!= !~].freeze
 
+        # @!method double_negation?(node)
         def_node_matcher :double_negation?, '(send (send _ :!) :!)'
 
         def self.autocorrect_incompatible_with

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -37,7 +37,10 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[== === nil?].freeze
 
+        # @!method nil_comparison?(node)
         def_node_matcher :nil_comparison?, '(send _ {:== :===} nil)'
+
+        # @!method nil_check?(node)
         def_node_matcher :nil_check?, '(send _ :nil?)'
 
         def on_send(node)

--- a/lib/rubocop/cop/style/nil_lambda.rb
+++ b/lib/rubocop/cop/style/nil_lambda.rb
@@ -28,6 +28,7 @@ module RuboCop
 
         MSG = 'Use an empty lambda instead of always returning nil.'
 
+        # @!method nil_return?(node)
         def_node_matcher :nil_return?, <<~PATTERN
           { ({return next break} nil) (nil) }
         PATTERN

--- a/lib/rubocop/cop/style/non_nil_check.rb
+++ b/lib/rubocop/cop/style/non_nil_check.rb
@@ -49,9 +49,16 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[!= nil? !].freeze
 
+        # @!method not_equal_to_nil?(node)
         def_node_matcher :not_equal_to_nil?, '(send _ :!= nil)'
+
+        # @!method unless_check?(node)
         def_node_matcher :unless_check?, '(if (send _ :nil?) ...)'
+
+        # @!method nil_check?(node)
         def_node_matcher :nil_check?, '(send _ :nil?)'
+
+        # @!method not_and_nil_check?(node)
         def_node_matcher :not_and_nil_check?, '(send (send _ :nil?) :!)'
 
         def on_send(node)

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -115,14 +115,17 @@ module RuboCop
           end
         end
 
+        # @!method predicate(node)
         def_node_matcher :predicate, <<~PATTERN
           (send $(...) ${:zero? :positive? :negative?})
         PATTERN
 
+        # @!method comparison(node)
         def_node_matcher :comparison, <<~PATTERN
           (send [$(...) !gvar_type?] ${:== :> :<} (int 0))
         PATTERN
 
+        # @!method inverted_comparison(node)
         def_node_matcher :inverted_comparison, <<~PATTERN
           (send (int 0) ${:== :> :<} [$(...) !gvar_type?])
         PATTERN

--- a/lib/rubocop/cop/style/option_hash.rb
+++ b/lib/rubocop/cop/style/option_hash.rb
@@ -22,6 +22,7 @@ module RuboCop
       class OptionHash < Base
         MSG = 'Prefer keyword arguments to options hashes.'
 
+        # @!method option_hash(node)
         def_node_matcher :option_hash, <<~PATTERN
           (args ... $(optarg [#suspicious_name? _] (hash)))
         PATTERN

--- a/lib/rubocop/cop/style/or_assignment.rb
+++ b/lib/rubocop/cop/style/or_assignment.rb
@@ -31,6 +31,7 @@ module RuboCop
 
         MSG = 'Use the double pipe equals operator `||=` instead.'
 
+        # @!method ternary_assignment?(node)
         def_node_matcher :ternary_assignment?, <<~PATTERN
           ({lvasgn ivasgn cvasgn gvasgn} _var
             (if
@@ -39,6 +40,7 @@ module RuboCop
               $_))
         PATTERN
 
+        # @!method unless_assignment?(node)
         def_node_matcher :unless_assignment?, <<~PATTERN
           (if
             ({lvar ivar cvar gvar} _var) nil?

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -115,6 +115,7 @@ module RuboCop
           end
         end
 
+        # @!method implicit_self_getter?(node)
         def_node_matcher :implicit_self_getter?, '(send nil? $_)'
 
         # Helper class necessitated by silly design of TSort prior to Ruby 2.1
@@ -123,8 +124,13 @@ module RuboCop
           include TSort
           extend RuboCop::NodePattern::Macros
 
+          # @!method var_name(node)
           def_node_matcher :var_name, '{(casgn _ $_) (_ $_)}'
+
+          # @!method uses_var?(node)
           def_node_search :uses_var?, '{({lvar ivar cvar gvar} %) (const _ %)}'
+
+          # @!method matching_calls(node, receiver, method_name)
           def_node_search :matching_calls, '(send %1 %2 $...)'
 
           def initialize(assignments)

--- a/lib/rubocop/cop/style/parentheses_around_condition.rb
+++ b/lib/rubocop/cop/style/parentheses_around_condition.rb
@@ -71,6 +71,7 @@ module RuboCop
 
         private
 
+        # @!method control_op_condition(node)
         def_node_matcher :control_op_condition, <<~PATTERN
           (begin $_ ...)
         PATTERN

--- a/lib/rubocop/cop/style/proc.rb
+++ b/lib/rubocop/cop/style/proc.rb
@@ -18,6 +18,7 @@ module RuboCop
 
         MSG = 'Use `proc` instead of `Proc.new`.'
 
+        # @!method proc_new?(node)
         def_node_matcher :proc_new?,
                          '(block $(send (const {nil? cbase} :Proc) :new) ...)'
 

--- a/lib/rubocop/cop/style/random_with_offset.rb
+++ b/lib/rubocop/cop/style/random_with_offset.rb
@@ -30,6 +30,7 @@ module RuboCop
           'integers with offsets.'
         RESTRICT_ON_SEND = %i[+ - succ pred next].freeze
 
+        # @!method integer_op_rand?(node)
         def_node_matcher :integer_op_rand?, <<~PATTERN
           (send
             int {:+ :-}
@@ -39,6 +40,7 @@ module RuboCop
               {int (irange int int) (erange int int)}))
         PATTERN
 
+        # @!method rand_op_integer?(node)
         def_node_matcher :rand_op_integer?, <<~PATTERN
           (send
             (send
@@ -49,6 +51,7 @@ module RuboCop
             int)
         PATTERN
 
+        # @!method rand_modified?(node)
         def_node_matcher :rand_modified?, <<~PATTERN
           (send
             (send
@@ -71,6 +74,7 @@ module RuboCop
 
         private
 
+        # @!method random_call(node)
         def_node_matcher :random_call, <<~PATTERN
           {(send (send $_ _ $_) ...)
            (send _ _ (send $_ _ $_))}
@@ -144,6 +148,7 @@ module RuboCop
           end
         end
 
+        # @!method to_int(node)
         def_node_matcher :to_int, <<~PATTERN
           (int $_)
         PATTERN

--- a/lib/rubocop/cop/style/redundant_assignment.rb
+++ b/lib/rubocop/cop/style/redundant_assignment.rb
@@ -42,6 +42,7 @@ module RuboCop
 
         MSG = 'Redundant assignment before returning detected.'
 
+        # @!method redundant_assignment?(node)
         def_node_matcher :redundant_assignment?, <<~PATTERN
           (... $(lvasgn _name _expression) (lvar _name))
         PATTERN

--- a/lib/rubocop/cop/style/redundant_conditional.rb
+++ b/lib/rubocop/cop/style/redundant_conditional.rb
@@ -53,10 +53,12 @@ module RuboCop
           format(MSG, msg: msg)
         end
 
+        # @!method redundant_condition?(node)
         def_node_matcher :redundant_condition?, <<~RUBY
           (if (send _ #{COMPARISON_OPERATOR_MATCHER} _) true false)
         RUBY
 
+        # @!method redundant_condition_inverted?(node)
         def_node_matcher :redundant_condition_inverted?, <<~RUBY
           (if (send _ #{COMPARISON_OPERATOR_MATCHER} _) false true)
         RUBY

--- a/lib/rubocop/cop/style/redundant_exception.rb
+++ b/lib/rubocop/cop/style/redundant_exception.rb
@@ -53,10 +53,12 @@ module RuboCop
           end
         end
 
+        # @!method exploded?(node)
         def_node_matcher :exploded?, <<~PATTERN
           (send nil? ${:raise :fail} (const {nil? cbase} :RuntimeError) $_)
         PATTERN
 
+        # @!method compact?(node)
         def_node_matcher :compact?, <<~PATTERN
           (send nil? {:raise :fail} $(send (const {nil? cbase} :RuntimeError) :new $_))
         PATTERN

--- a/lib/rubocop/cop/style/redundant_fetch_block.rb
+++ b/lib/rubocop/cop/style/redundant_fetch_block.rb
@@ -38,6 +38,7 @@ module RuboCop
 
         MSG = 'Use `%<good>s` instead of `%<bad>s`.'
 
+        # @!method redundant_fetch_block_candidate?(node)
         def_node_matcher :redundant_fetch_block_candidate?, <<~PATTERN
           (block
             $(send _ :fetch _)
@@ -78,6 +79,7 @@ module RuboCop
             rails_cache?(send.receiver)
         end
 
+        # @!method rails_cache?(node)
         def_node_matcher :rails_cache?, <<~PATTERN
           (send (const _ :Rails) :cache)
         PATTERN

--- a/lib/rubocop/cop/style/redundant_file_extension_in_require.rb
+++ b/lib/rubocop/cop/style/redundant_file_extension_in_require.rb
@@ -30,6 +30,7 @@ module RuboCop
         MSG = 'Redundant `.rb` file extension detected.'
         RESTRICT_ON_SEND = %i[require require_relative].freeze
 
+        # @!method require_call?(node)
         def_node_matcher :require_call?, <<~PATTERN
           (send nil? {:require :require_relative} $str_type?)
         PATTERN

--- a/lib/rubocop/cop/style/redundant_freeze.rb
+++ b/lib/rubocop/cop/style/redundant_freeze.rb
@@ -53,6 +53,7 @@ module RuboCop
           end
         end
 
+        # @!method operation_produces_immutable_object?(node)
         def_node_matcher :operation_produces_immutable_object?, <<~PATTERN
           {
             (begin (send {float int} {:+ :- :* :** :/ :% :<<} _))

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -17,11 +17,20 @@ module RuboCop
         include Parentheses
         extend AutoCorrector
 
+        # @!method square_brackets?(node)
         def_node_matcher :square_brackets?,
                          '(send {(send _recv _msg) str array hash} :[] ...)'
+
+        # @!method range_end?(node)
         def_node_matcher :range_end?, '^^{irange erange}'
+
+        # @!method method_node_and_args(node)
         def_node_matcher :method_node_and_args, '$(call _recv _msg $...)'
+
+        # @!method rescue?(node)
         def_node_matcher :rescue?, '{^resbody ^^resbody}'
+
+        # @!method arg_in_call_with_block?(node)
         def_node_matcher :arg_in_call_with_block?,
                          '^^(block (send _ _ equal?(%0) ...) ...)'
 
@@ -109,6 +118,7 @@ module RuboCop
           check_send(begin_node, node) if node.call_type?
         end
 
+        # @!method interpolation?(node)
         def_node_matcher :interpolation?, '[^begin ^^dstr]'
 
         def check_send(begin_node, node)
@@ -220,14 +230,17 @@ module RuboCop
             first_yield_argument?(node)
         end
 
+        # @!method first_send_argument?(node)
         def_node_matcher :first_send_argument?, <<~PATTERN
           ^(send _ _ equal?(%0) ...)
         PATTERN
 
+        # @!method first_super_argument?(node)
         def_node_matcher :first_super_argument?, <<~PATTERN
           ^(super equal?(%0) ...)
         PATTERN
 
+        # @!method first_yield_argument?(node)
         def_node_matcher :first_yield_argument?, <<~PATTERN
           ^(yield equal?(%0) ...)
         PATTERN

--- a/lib/rubocop/cop/style/redundant_self_assignment.rb
+++ b/lib/rubocop/cop/style/redundant_self_assignment.rb
@@ -82,6 +82,7 @@ module RuboCop
           METHODS_RETURNING_SELF.include?(method_name)
         end
 
+        # @!method redundant_self_assignment?(node, method_name)
         def_node_matcher :redundant_self_assignment?, <<~PATTERN
           (send
             (self) _
@@ -91,6 +92,7 @@ module RuboCop
               ...))
         PATTERN
 
+        # @!method redundant_nonself_assignment?(node, receiver, method_name)
         def_node_matcher :redundant_nonself_assignment?, <<~PATTERN
           (send
             %1 _

--- a/lib/rubocop/cop/style/redundant_sort.rb
+++ b/lib/rubocop/cop/style/redundant_sort.rb
@@ -58,6 +58,7 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[sort sort_by].freeze
 
+        # @!method redundant_sort?(node)
         def_node_matcher :redundant_sort?, <<~MATCHER
           {
             (send $(send _ $:sort ...) ${:last :first})

--- a/lib/rubocop/cop/style/redundant_sort_by.rb
+++ b/lib/rubocop/cop/style/redundant_sort_by.rb
@@ -21,6 +21,7 @@ module RuboCop
 
         MSG = 'Use `sort` instead of `sort_by { |%<var>s| %<var>s }`.'
 
+        # @!method redundant_sort_by(node)
         def_node_matcher :redundant_sort_by, <<~PATTERN
           (block $(send _ :sort_by) (args (arg $_x)) (lvar _x))
         PATTERN

--- a/lib/rubocop/cop/style/rescue_standard_error.rb
+++ b/lib/rubocop/cop/style/rescue_standard_error.rb
@@ -81,10 +81,12 @@ module RuboCop
         MSG_EXPLICIT = 'Avoid rescuing without specifying ' \
           'an error class.'
 
+        # @!method rescue_without_error_class?(node)
         def_node_matcher :rescue_without_error_class?, <<~PATTERN
           (resbody nil? _ _)
         PATTERN
 
+        # @!method rescue_standard_error?(node)
         def_node_matcher :rescue_standard_error?, <<~PATTERN
           (resbody $(array (const {nil? cbase} :StandardError)) _ _)
         PATTERN

--- a/lib/rubocop/cop/style/return_nil.rb
+++ b/lib/rubocop/cop/style/return_nil.rb
@@ -35,7 +35,10 @@ module RuboCop
         RETURN_MSG = 'Use `return` instead of `return nil`.'
         RETURN_NIL_MSG = 'Use `return nil` instead of `return`.'
 
+        # @!method return_node?(node)
         def_node_matcher :return_node?, '(return)'
+
+        # @!method return_nil_node?(node)
         def_node_matcher :return_nil_node?, '(return nil)'
 
         def on_return(node)
@@ -79,7 +82,10 @@ module RuboCop
           node.def_type? || node.defs_type? || node.lambda?
         end
 
+        # @!method chained_send?(node)
         def_node_matcher :chained_send?, '(send !nil? ...)'
+
+        # @!method define_method?(node)
         def_node_matcher :define_method?, <<~PATTERN
           (send _ {:define_method :define_singleton_method} _)
         PATTERN

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -74,6 +74,7 @@ module RuboCop
 
         # if format: (if checked_variable body nil)
         # unless format: (if checked_variable nil body)
+        # @!method modifier_if_safe_navigation_candidate(node)
         def_node_matcher :modifier_if_safe_navigation_candidate, <<~PATTERN
           {
             (if {
@@ -88,6 +89,7 @@ module RuboCop
           }
         PATTERN
 
+        # @!method not_nil_check?(node)
         def_node_matcher :not_nil_check?, '(send (send $_ :nil?) :!)'
 
         def on_if(node)

--- a/lib/rubocop/cop/style/sample.rb
+++ b/lib/rubocop/cop/style/sample.rb
@@ -33,6 +33,7 @@ module RuboCop
         MSG = 'Use `%<correct>s` instead of `%<incorrect>s`.'
         RESTRICT_ON_SEND = %i[first last [] at slice].freeze
 
+        # @!method sample_candidate?(node)
         def_node_matcher :sample_candidate?, <<~PATTERN
           (send $(send _ :shuffle $...) ${:#{RESTRICT_ON_SEND.join(' :')}} $...)
         PATTERN

--- a/lib/rubocop/cop/style/signal_exception.rb
+++ b/lib/rubocop/cop/style/signal_exception.rb
@@ -114,7 +114,10 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[raise fail].freeze
 
+        # @!method kernel_call?(node, name)
         def_node_matcher :kernel_call?, '(send (const {nil? cbase} :Kernel) %1 ...)'
+
+        # @!method custom_fail_methods(node)
         def_node_search :custom_fail_methods,
                         '{(def :fail ...) (defs _ :fail ...)}'
 

--- a/lib/rubocop/cop/style/single_argument_dig.rb
+++ b/lib/rubocop/cop/style/single_argument_dig.rb
@@ -29,6 +29,7 @@ module RuboCop
         MSG = 'Use `%<receiver>s[%<argument>s]` instead of `%<original>s`.'
         RESTRICT_ON_SEND = %i[dig].freeze
 
+        # @!method single_argument_dig?(node)
         def_node_matcher :single_argument_dig?, <<~PATTERN
           (send _ :dig $!splat)
         PATTERN

--- a/lib/rubocop/cop/style/slicing_with_range.rb
+++ b/lib/rubocop/cop/style/slicing_with_range.rb
@@ -21,6 +21,7 @@ module RuboCop
         MSG = 'Prefer ary[n..] over ary[n..-1].'
         RESTRICT_ON_SEND = %i[[]].freeze
 
+        # @!method range_till_minus_one?(node)
         def_node_matcher :range_till_minus_one?, '(irange !nil? (int -1))'
 
         def on_send(node)

--- a/lib/rubocop/cop/style/stderr_puts.rb
+++ b/lib/rubocop/cop/style/stderr_puts.rb
@@ -22,6 +22,7 @@ module RuboCop
           'Use `warn` instead of `%<bad>s` to allow such output to be disabled.'
         RESTRICT_ON_SEND = %i[puts].freeze
 
+        # @!method stderr_puts?(node)
         def_node_matcher :stderr_puts?, <<~PATTERN
           (send
             {(gvar #stderr_gvar?) (const {nil? cbase} :STDERR)}

--- a/lib/rubocop/cop/style/string_concatenation.rb
+++ b/lib/rubocop/cop/style/string_concatenation.rb
@@ -34,6 +34,7 @@ module RuboCop
         MSG = 'Prefer string interpolation to string concatenation.'
         RESTRICT_ON_SEND = %i[+].freeze
 
+        # @!method string_concatenation?(node)
         def_node_matcher :string_concatenation?, <<~PATTERN
           {
             (send str_type? :+ _)

--- a/lib/rubocop/cop/style/string_hash_keys.rb
+++ b/lib/rubocop/cop/style/string_hash_keys.rb
@@ -17,10 +17,12 @@ module RuboCop
 
         MSG = 'Prefer symbols instead of strings as hash keys.'
 
+        # @!method string_hash_key?(node)
         def_node_matcher :string_hash_key?, <<~PATTERN
           (pair (str _) _)
         PATTERN
 
+        # @!method receive_environments_method?(node)
         def_node_matcher :receive_environments_method?, <<~PATTERN
           {
             ^^(send (const {nil? cbase} :IO) :popen ...)

--- a/lib/rubocop/cop/style/strip.rb
+++ b/lib/rubocop/cop/style/strip.rb
@@ -20,6 +20,7 @@ module RuboCop
         MSG = 'Use `strip` instead of `%<methods>s`.'
         RESTRICT_ON_SEND = %i[lstrip rstrip].freeze
 
+        # @!method lstrip_rstrip(node)
         def_node_matcher :lstrip_rstrip, <<~PATTERN
           {(send $(send _ $:rstrip) $:lstrip)
            (send $(send _ $:lstrip) $:rstrip)}

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -37,6 +37,7 @@ module RuboCop
           end
         end
 
+        # @!method struct_constructor?(node)
         def_node_matcher :struct_constructor?, <<~PATTERN
           {(send (const {nil? cbase} :Struct) :new ...)
            (block (send (const {nil? cbase} :Struct) :new ...) ...)}

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -35,8 +35,13 @@ module RuboCop
               'instead of a block.'
         SUPER_TYPES = %i[super zsuper].freeze
 
+        # @!method proc_node?(node)
         def_node_matcher :proc_node?, '(send (const {nil? cbase} :Proc) :new)'
+
+        # @!method symbol_proc_receiver?(node)
         def_node_matcher :symbol_proc_receiver?, '{(send ...) (super ...) zsuper}'
+
+        # @!method symbol_proc?(node)
         def_node_matcher :symbol_proc?, <<~PATTERN
           {
             (block $#symbol_proc_receiver? $(args (arg _var)) (send (lvar _var) $_))

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -191,6 +191,7 @@ module RuboCop
             (child.send_type? && child.prefix_not?)
         end
 
+        # @!method method_name(node)
         def_node_matcher :method_name, <<~PATTERN
           {($:defined? _ ...)
            (send {_ nil?} $_ _ ...)}

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -120,6 +120,7 @@ module RuboCop
             !allowed_method_name?(node) && !allowed_writer?(node.method_name)
         end
 
+        # @!method looks_like_trivial_writer?(node)
         def_node_matcher :looks_like_trivial_writer?, <<~PATTERN
           {(def    _ (args (arg ...)) (ivasgn _ (lvar _)))
            (defs _ _ (args (arg ...)) (ivasgn _ (lvar _)))}

--- a/lib/rubocop/cop/style/unless_logical_operators.rb
+++ b/lib/rubocop/cop/style/unless_logical_operators.rb
@@ -52,12 +52,17 @@ module RuboCop
         FORBID_MIXED_LOGICAL_OPERATORS = 'Do not use mixed logical operators in an `unless`.'
         FORBID_LOGICAL_OPERATORS = 'Do not use any logical operator in an `unless`.'
 
+        # @!method or_with_and?(node)
         def_node_matcher :or_with_and?, <<~PATTERN
           (if (or <`and ...> ) ...)
         PATTERN
+
+        # @!method and_with_or?(node)
         def_node_matcher :and_with_or?, <<~PATTERN
           (if (and <`or ...> ) ...)
         PATTERN
+
+        # @!method logical_operator?(node)
         def_node_matcher :logical_operator?, <<~PATTERN
           (if ({and or} ... ) ...)
         PATTERN

--- a/lib/rubocop/cop/style/unpack_first.rb
+++ b/lib/rubocop/cop/style/unpack_first.rb
@@ -24,6 +24,7 @@ module RuboCop
           '`%<receiver>s.unpack(%<format>s)%<method>s`.'
         RESTRICT_ON_SEND = %i[first [] slice at].freeze
 
+        # @!method unpack_and_first_element?(node)
         def_node_matcher :unpack_and_first_element?, <<~PATTERN
           {
             (send $(send (...) :unpack $(...)) :first)

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -72,6 +72,7 @@ module RuboCop
 
         PROGRAM_NAMES = %i[$0 $PROGRAM_NAME].freeze
 
+        # @!method file_constant_equal_program_name?(node)
         def_node_matcher :file_constant_equal_program_name?, <<~PATTERN
           (send #source_file_path_constant? {:== :!=} (gvar #program_name?))
         PATTERN

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -71,6 +71,7 @@ module RuboCop
           end
         end
 
+        # @!method zero_length_predicate(node)
         def_node_matcher :zero_length_predicate, <<~PATTERN
           {(send (send (...) ${:length :size}) $:== (int $0))
            (send (int $0) $:== (send (...) ${:length :size}))
@@ -78,6 +79,7 @@ module RuboCop
            (send (int $1) $:> (send (...) ${:length :size}))}
         PATTERN
 
+        # @!method nonzero_length_predicate(node)
         def_node_matcher :nonzero_length_predicate, <<~PATTERN
           {(send (send (...) ${:length :size}) ${:> :!=} (int $0))
            (send (int $0) ${:< :!=} (send (...) ${:length :size}))}
@@ -90,6 +92,7 @@ module RuboCop
           "!#{other_receiver(node).source}.empty?"
         end
 
+        # @!method zero_length_receiver(node)
         def_node_matcher :zero_length_receiver, <<~PATTERN
           {(send (send $_ _) :== (int 0))
            (send (int 0) :== (send $_ _))
@@ -97,6 +100,7 @@ module RuboCop
            (send (int 1) :> (send $_ _))}
         PATTERN
 
+        # @!method other_receiver(node)
         def_node_matcher :other_receiver, <<~PATTERN
           {(send (send $_ _) _ _)
            (send _ _ (send $_ _))}
@@ -105,6 +109,7 @@ module RuboCop
         # Some collection like objects in the Ruby standard library
         # implement `#size`, but not `#empty`. We ignore those to
         # reduce false positives.
+        # @!method non_polymorphic_collection?(node)
         def_node_matcher :non_polymorphic_collection?, <<~PATTERN
           {(send (send (send (const {nil? cbase} :File) :stat _) ...) ...)
            (send (send (send (const {nil? cbase} {:Tempfile :StringIO}) {:new :open} ...) ...) ...)}

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -147,10 +147,12 @@ module RuboCop
 
       GEMSPEC_EXTENSION = '.gemspec'
 
+      # @!method required_ruby_version(node)
       def_node_search :required_ruby_version, <<~PATTERN
         (send _ :required_ruby_version= $_)
       PATTERN
 
+      # @!method gem_requirement?(node)
       def_node_matcher :gem_requirement?, <<~PATTERN
         (send (const(const _ :Gem):Requirement) :new $str)
       PATTERN

--- a/spec/rubocop/cop/internal_affairs/node_matcher_directive_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/node_matcher_directive_spec.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::InternalAffairs::NodeMatcherDirective, :config do
+  %i[def_node_matcher def_node_search].each do |method|
+    it 'does not register an offense if the node matcher already has a directive' do
+      expect_no_offenses(<<~RUBY)
+        # @!method foo?(node)
+        #{method} :foo?, '(str)'
+      RUBY
+    end
+
+    it 'does not register an offense if the directive is in a comment block' do
+      expect_no_offenses(<<~RUBY)
+        # @!method foo?(node)
+        # foo? matcher
+        #{method} :foo?, '(str)'
+      RUBY
+    end
+
+    it 'registers an offense if the matcher does not have a directive' do
+      expect_offense(<<~RUBY, method: method)
+        #{method} :foo?, '(str)'
+        ^{method}^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @!method foo?(node)
+        #{method} :foo?, '(str)'
+      RUBY
+    end
+
+    it 'registers an offense if the matcher does not have a directive but has preceeding comments' do
+      expect_offense(<<~RUBY, method: method)
+        # foo
+        #{method} :foo?, '(str)'
+        ^{method}^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+
+        # foo bar baz
+        # foo bar baz
+        # foo bar baz
+        #{method} :bar?, '(sym)'
+        ^{method}^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # foo
+        # @!method foo?(node)
+        #{method} :foo?, '(str)'
+
+        # foo bar baz
+        # foo bar baz
+        # foo bar baz
+        # @!method bar?(node)
+        #{method} :bar?, '(sym)'
+      RUBY
+    end
+
+    it 'registers an offense if the directive name does not match the actual name' do
+      expect_offense(<<~RUBY, method: method)
+        # @!method bar?(node)
+        #{method} :foo?, '(str)'
+        ^{method}^^^^^^^^^^^^^^^ `@!method` YARD directive has invalid method name, use `foo?` instead of `bar?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @!method foo?(node)
+        #{method} :foo?, '(str)'
+      RUBY
+    end
+
+    it 'registers an offense if the matcher has multiple directives' do
+      expect_offense(<<~RUBY, method: method)
+        # @!method foo?(node)
+        # @!method foo?(node)
+        #{method} :foo?, '(str)'
+        ^{method}^^^^^^^^^^^^^^^ Multiple `@!method` YARD directives found for this matcher.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'autocorrects with the right arguments if the pattern includes arguments' do
+      expect_offense(<<~RUBY, method: method)
+        #{method} :foo?, '(str %1)'
+        ^{method}^^^^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @!method foo?(node, arg1)
+        #{method} :foo?, '(str %1)'
+      RUBY
+    end
+
+    it 'autocorrects with the right arguments if the pattern references a non-contiguous argument' do
+      expect_offense(<<~RUBY, method: method)
+        #{method} :foo?, '(str %4)'
+        ^{method}^^^^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @!method foo?(node, arg1, arg2, arg3, arg4)
+        #{method} :foo?, '(str %4)'
+      RUBY
+    end
+
+    it 'does not register an offense if called with a dynamic method name' do
+      expect_no_offenses(<<~'RUBY')
+        #{method} matcher_name, '(str)'
+        #{method} "#{matcher_name}", '(str)'
+      RUBY
+    end
+
+    it 'retains indentation properly when inserting' do
+      expect_offense(<<~RUBY, method: method)
+        class MyCop
+          #{method} :foo?, '(str)'
+          ^{method}^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class MyCop
+          # @!method foo?(node)
+          #{method} :foo?, '(str)'
+        end
+      RUBY
+    end
+
+    it 'retains indentation properly when correcting' do
+      expect_offense(<<~RUBY, method: method)
+        class MyCop
+          # @!method bar?(node)
+          #{method} :foo?, '(str)'
+          ^{method}^^^^^^^^^^^^^^^ `@!method` YARD directive has invalid method name, use `foo?` instead of `bar?`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class MyCop
+          # @!method foo?(node)
+          #{method} :foo?, '(str)'
+        end
+      RUBY
+    end
+
+    it 'inserts a blank line between multiple pattern matchers' do
+      expect_offense(<<~RUBY, method: method)
+        #{method} :foo?, '(str)'
+        ^{method}^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+        #{method} :bar?, '(str)'
+        ^{method}^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @!method foo?(node)
+        #{method} :foo?, '(str)'
+
+        # @!method bar?(node)
+        #{method} :bar?, '(str)'
+      RUBY
+    end
+
+    it 'inserts a blank line between multiple multi-line pattern matchers' do
+      expect_offense(<<~RUBY, method: method)
+        #{method} :foo?, <<~PATTERN
+        ^{method}^^^^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+          (str)
+        PATTERN
+        #{method} :bar?, <<~PATTERN
+        ^{method}^^^^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+          (str)
+        PATTERN
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @!method foo?(node)
+        #{method} :foo?, <<~PATTERN
+          (str)
+        PATTERN
+
+        # @!method bar?(node)
+        #{method} :bar?, <<~PATTERN
+          (str)
+        PATTERN
+      RUBY
+    end
+
+    it 'does not insert a blank line if one already exists' do
+      expect_offense(<<~RUBY, method: method)
+        #{method} :foo?, <<~PATTERN
+        ^{method}^^^^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+          (str)
+        PATTERN
+
+        #{method} :bar?, <<~PATTERN
+        ^{method}^^^^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+          (str)
+        PATTERN
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @!method foo?(node)
+        #{method} :foo?, <<~PATTERN
+          (str)
+        PATTERN
+
+        # @!method bar?(node)
+        #{method} :bar?, <<~PATTERN
+          (str)
+        PATTERN
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
As discussed on discord, this cop looks for node matchers that do not have an appropriate `@!method` directive.

This is really useful for code editors which support YARD directives, as it allows them to be able to jump to the pattern matcher definition from the usage, as well as introspect what arguments are necessary. Even without one of these editors, it makes arguments explicit in the definition (so it's not a guess what `%1`, etc. mean in the pattern).

I am going to create PRs for the other gems (especially `rubocop-ast`) next.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
