### PR TITLE
[Fix #9525] Add `AllowIfMethodWithArguments` option to `Style/SymbolProc`

### DIFF
--- a/changelog/new_add_allow_if_method_has_arguments_option_to_style_symbol_proc.md
+++ b/changelog/new_add_allow_if_method_has_arguments_option_to_style_symbol_proc.md
@@ -1,0 +1,1 @@
+* [#9525](https://github.com/rubocop-hq/rubocop/issues/9525): Add `AllowMethodsWithArguments` option to `Style/SymbolProc`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4588,6 +4588,7 @@ Style/SymbolProc:
   Safe: false
   VersionAdded: '0.26'
   VersionChanged: '1.5'
+  AllowMethodsWithArguments: false
   # A list of method names to be ignored by the check.
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
   IgnoredMethods:

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -142,16 +142,53 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
     expect(&run).not_to raise_error
   end
 
-  context 'when `super` has arguments' do
-    it 'registers an offense' do
-      expect_offense(<<~RUBY)
-        super(one, two) { |x| x.test }
-                        ^^^^^^^^^^^^^^ Pass `&:test` as an argument to `super` instead of a block.
-      RUBY
+  context 'when `AllowMethodsWithArguments: true`' do
+    let(:cop_config) { { 'AllowMethodsWithArguments' => true } }
 
-      expect_correction(<<~RUBY)
-        super(one, two, &:test)
-      RUBY
+    context 'when method has arguments' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          do_something(one, two) { |x| x.test }
+        RUBY
+      end
+    end
+
+    context 'when `super` has arguments' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          super(one, two) { |x| x.test }
+        RUBY
+      end
+    end
+  end
+
+  context 'when `AllowMethodsWithArguments: false`' do
+    let(:cop_config) { { 'AllowMethodsWithArguments' => false } }
+
+    context 'when method has arguments' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          do_something(one, two) { |x| x.test }
+                                 ^^^^^^^^^^^^^^ Pass `&:test` as an argument to `do_something` instead of a block.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          do_something(one, two, &:test)
+        RUBY
+      end
+    end
+
+    context 'when `super` has arguments' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          super(one, two) { |x| x.test }
+                          ^^^^^^^^^^^^^^ Pass `&:test` as an argument to `super` instead of a block.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          super(one, two, &:test)
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #9525.

This PR adds `AllowIfMethodWithArguments` option to `Style/SymbolProc`.

### `AllowIfMethodWithArguments: false` (default)

```ruby
# bad
something.do_something(foo) { |o| o.bar }

# good
something.do_something(foo, &:bar)
```

### `AllowIfMethodWithArguments: true`

```ruby
# good
something.do_something(foo) { |o| o.bar }
```

If user prefer a style that allows block for method with arguments, the user can set `true` to `AllowIfMethodWithArguments`.

## Other Information

It may be possible to consider defaulting to `AllowIfMethodWithArguments: true`, but at the time of this patch `Style/SymbolProc` cop respect keeping the existing behavior.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
