### PR TITLE
Bug: Layout/FirstArgumentIndentation false negative when method name is one special character

### DIFF
--- a/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
@@ -34,6 +34,57 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects an over-indented first argument on an alphanumeric method name' do
+        expect_offense(<<~RUBY)
+          self.run(
+              :foo,
+              ^^^^ Indent the first argument one step more than the start of the previous line.
+              bar: 3
+          )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          self.run(
+            :foo,
+              bar: 3
+          )
+        RUBY
+      end
+
+      it 'registers an offense and corrects an over-indented first argument on a pipe method name' do
+        expect_offense(<<~RUBY)
+          self.|(
+              :foo,
+              ^^^^ Indent the first argument one step more than the start of the previous line.
+              bar: 3
+          )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          self.|(
+            :foo,
+              bar: 3
+          )
+        RUBY
+      end
+
+      it 'registers an offense and corrects an over-indented first argument on a plus sign method name' do
+        expect_offense(<<~RUBY)
+          self.+(
+              :foo,
+              ^^^^ Indent the first argument one step more than the start of the previous line.
+              bar: 3
+          )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          self.+(
+            :foo,
+              bar: 3
+          )
+        RUBY
+      end
+
       it 'registers an offense and corrects an under-indented first argument' do
         expect_offense(<<~RUBY)
           run(


### PR DESCRIPTION
It is uncommon but completely valid to have methods names like `|`, `+`, `~`, `&`, etc. Some prominent libraries make use of this. For example, Sequel ORM has `Sequel.|` method which can be used to build a SQL `OR` clause, along with `Sequel.&`, `Sequel.~`, etc.

Example:

```
3.0.0 :005 > def |(a, b) = a + b
 => :|
3.0.0 :006 > self.|(1, 2)
 => 3
3.0.0 :007 > def +(a, b) = a + b
 => :+
3.0.0 :008 > self.+(1, 2)
 => 3
```

The Layout/FirstArgumentIndentation cop does not seem to register an offense when these special method names are invoked, as reproduced in the added specs in this branch.

I took a look thru some of the relevant source code of FirstArgumentIndentation, but as a cop author novice it's not obvious to me exactly what needs to change. 

---

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
