### PR TITLE
[Fix #9539] Fix an error for `Style/RedundantBegin`

### DIFF
--- a/changelog/fix_error_for_style_redundant_begin.md
+++ b/changelog/fix_error_for_style_redundant_begin.md
@@ -1,0 +1,1 @@
+* [#9539](https://github.com/rubocop-hq/rubocop/issues/9539): Fix an error for `Style/RedundantBegin` when using body of `begin` is empty. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -85,7 +85,9 @@ module RuboCop
         end
 
         def on_kwbegin(node)
-          return if contain_rescue_or_ensure?(node) || valid_context_using_only_begin?(node)
+          return if empty_begin?(node) ||
+                    contain_rescue_or_ensure?(node) ||
+                    valid_context_using_only_begin?(node)
 
           register_offense(node)
         end
@@ -97,6 +99,10 @@ module RuboCop
             corrector.remove(node.loc.begin)
             corrector.remove(node.loc.end)
           end
+        end
+
+        def empty_begin?(node)
+          node.children.empty?
         end
 
         def contain_rescue_or_ensure?(node)

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -222,6 +222,13 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     RUBY
   end
 
+  it 'does not register an offense when using body of `begin` is empty' do
+    expect_no_offenses(<<~RUBY)
+      begin
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using `begin` for or assignment and method call' do
     expect_no_offenses(<<~RUBY)
       var ||= begin


### PR DESCRIPTION
Fixes #9539.

This PR fixes an error for `Style/RedundantBegin` when using body of `begin` is empty.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
