### PR TITLE
Fix `Layout/FirstArgumentIndentation` for operator methods not called as operators.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5468,3 +5468,4 @@
 [@cteece]: https://github.com/ceteece
 [@taichi-ishitani]: https://github.com/taichi-ishitani
 [@cteece]: https://github.com/cteece
+[@TSMMark]: https://github.com/TSMMark

--- a/changelog/fix_fix_layoutfirstargumentindentation_for.md
+++ b/changelog/fix_fix_layoutfirstargumentindentation_for.md
@@ -1,0 +1,1 @@
+* [#9542](https://github.com/rubocop/rubocop/pull/9542): Fix `Layout/FirstArgumentIndentation` for operator methods not called as operators. ([@dvandersluis][], [@TSMMark][])

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -153,7 +153,7 @@ module RuboCop
 
         def on_send(node)
           return if style != :consistent && enforce_first_argument_with_fixed_indentation?
-          return if !node.arguments? || node.operator_method?
+          return if !node.arguments? || bare_operator?(node)
 
           indent = base_indentation(node) + configured_indentation_width
 
@@ -166,6 +166,10 @@ module RuboCop
         end
 
         private
+
+        def bare_operator?(node)
+          node.operator_method? && !node.dot?
+        end
 
         def message(arg_node)
           return 'Bad indentation of the first argument.' unless arg_node

--- a/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
@@ -34,6 +34,57 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects an over-indented first argument on an alphanumeric method name' do
+        expect_offense(<<~RUBY)
+          self.run(
+              :foo,
+              ^^^^ Indent the first argument one step more than the start of the previous line.
+              bar: 3
+          )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          self.run(
+            :foo,
+              bar: 3
+          )
+        RUBY
+      end
+
+      it 'registers an offense and corrects an over-indented first argument on a pipe method name' do
+        expect_offense(<<~RUBY)
+          self.|(
+              :foo,
+              ^^^^ Indent the first argument one step more than the start of the previous line.
+              bar: 3
+          )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          self.|(
+            :foo,
+              bar: 3
+          )
+        RUBY
+      end
+
+      it 'registers an offense and corrects an over-indented first argument on a plus sign method name' do
+        expect_offense(<<~RUBY)
+          self.+(
+              :foo,
+              ^^^^ Indent the first argument one step more than the start of the previous line.
+              bar: 3
+          )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          self.+(
+            :foo,
+              bar: 3
+          )
+        RUBY
+      end
+
       it 'registers an offense and corrects an under-indented first argument' do
         expect_offense(<<~RUBY)
           run(


### PR DESCRIPTION
Continuation of #9538.

Operators were explicitly allowed by `Layout/FirstArgumentIndentation`, however when an operator method is called as a method (ie. not as a bare operator), the cop should still apply.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
