### PR TITLE
[Fix #9541] Fix `Style/HashConversion` when the correction needs to be wrapped in parens

### DIFF
--- a/changelog/fix_fix_stylehashconversion_when_the.md
+++ b/changelog/fix_fix_stylehashconversion_when_the.md
@@ -1,0 +1,1 @@
+* [#9541](https://github.com/rubocop/rubocop/issues/9541): Fix `Style/HashConversion` when the correction needs to be wrapped in parens. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/hash_conversion.rb
+++ b/lib/rubocop/cop/style/hash_conversion.rb
@@ -67,9 +67,15 @@ module RuboCop
             add_offense(node, message: MSG_SPLAT) unless allowed_splat_argument?
           else
             add_offense(node, message: MSG_TO_H) do |corrector|
-              corrector.replace(node, "#{first_argument.source}.to_h")
+              replacement = first_argument.source
+              replacement = "(#{replacement})" if requires_parens?(first_argument)
+              corrector.replace(node, "#{replacement}.to_h")
             end
           end
+        end
+
+        def requires_parens?(node)
+          node.call_type? && node.arguments.any? && !node.parenthesized?
         end
 
         def multi_argument(node)

--- a/spec/rubocop/cop/style/hash_conversion_spec.rb
+++ b/spec/rubocop/cop/style/hash_conversion_spec.rb
@@ -54,6 +54,17 @@ RSpec.describe RuboCop::Cop::Style::HashConversion, :config do
     expect_no_corrections
   end
 
+  it 'wraps complex statements in parens if needed' do
+    expect_offense(<<~RUBY)
+      Hash[a.foo :bar]
+      ^^^^^^^^^^^^^^^^ Prefer ary.to_h to Hash[ary].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (a.foo :bar).to_h
+    RUBY
+  end
+
   context 'AllowSplatArgument: true' do
     let(:cop_config) { { 'AllowSplatArgument' => true } }
 


### PR DESCRIPTION
When the argument to `Hash[]` is a send node without parens, the `to_h` would be added to the wrong thing.

Fixes #9541.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
