### PR TITLE
Workaround for JRuby 9.2.15.0 regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,10 @@ jobs:
   # JRuby 9.2
   jruby-9.2-spec:
     docker:
-      - image: circleci/jruby:9.2
+      # FIXME: Workaround for JRuby 9.2.15.0.
+      # Please specify `circleci/jruby:9.2` when the following issue will be resolved.
+      # https://github.com/jruby/jruby/issues/6581
+      - image: circleci/jruby:9.2.14
     environment:
       <<: *common_env
       <<: *jruby_env
@@ -195,7 +198,10 @@ jobs:
       *spec_steps
   jruby-9.2-ascii_spec:
     docker:
-      - image: circleci/jruby:9.2
+      # FIXME: Workaround for JRuby 9.2.15.0.
+      # Please specify `circleci/jruby:9.2` when the following issue will be resolved.
+      # https://github.com/jruby/jruby/issues/6581
+      - image: circleci/jruby:9.2.14
     environment:
       <<: *common_env
       <<: *jruby_env
@@ -203,7 +209,10 @@ jobs:
       *ascii_spec_steps
   jruby-9.2-rubocop:
     docker:
-      - image: circleci/jruby:9.2
+      # FIXME: Workaround for JRuby 9.2.15.0.
+      # Please specify `circleci/jruby:9.2` when the following issue will be resolved.
+      # https://github.com/jruby/jruby/issues/6581
+      - image: circleci/jruby:9.2.14
     environment:
       <<: *common_env
       <<: *jruby_env


### PR DESCRIPTION
This PR pins the JRuby CI image to 9.2.14 to avoid the following error in JRuby 9.2.15.0:

```console
#!/bin/bash -eo pipefail
bundle exec rake internal_investigation
rake aborted!
LoadError: no such file to load -- racc/info
/usr/local/bundle/gems/parser-3.0.0.0/lib/parser.rb:12:in `<main>'
/usr/local/bundle/gems/rubocop-ast-1.4.1/lib/rubocop/ast.rb:3:in
`<main>'
/usr/local/bundle/gems/rubocop-ast-1.4.1/lib/rubocop-ast.rb:3:in
`<main>'
/home/circleci/project/lib/rubocop.rb:14:in `<main>'
tasks/cops_documentation.rake:4:in `<main>'
/home/circleci/project/Rakefile:21:in `block in <main>'
/home/circleci/project/Rakefile:21:in `<main>'
/opt/jruby/bin/bundle:23:in `<main>'
(See full trace by running task with --trace)

Exited with code exit status 1
CircleCI received exit code 1
```

https://app.circleci.com/pipelines/github/rubocop/rubocop/4118/workflows/a4451248-05e0-4361-963d-2297357e7885/jobs/174452

This is an error when JRuby 9.2.15.0 CI image is executed locally.

```console
% docker run --rm -it circleci/jruby:9.2.15.0 /bin/sh -c 'gem i parser; ruby -rparser'
Unable to find image 'circleci/jruby:9.2.15.0' locally
9.2.15.0: Pulling from circleci/jruby
(snip)

Digest:
sha256:a7705120e8a76ee0f3b0d524e28f6be81534c04fd3c8ab6d9126559ca2cb2dc6
Status: Downloaded newer image for circleci/jruby:9.2.15.0
Fetching ast-2.4.2.gem
Fetching parser-3.0.0.0.gem
Successfully installed ast-2.4.2
Successfully installed parser-3.0.0.0
2 gems installed
LoadError: no such file to load -- racc/info
  require at org/jruby/RubyKernel.java:974
  require at
  /opt/jruby/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:54
   <main> at /opt/jruby/lib/ruby/stdlib/racc/parser.rb:13
  require at org/jruby/RubyKernel.java:974
  require at
  /opt/jruby/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:54
   <main> at /usr/local/bundle/gems/parser-3.0.0.0/lib/parser.rb:12
  require at org/jruby/RubyKernel.java:974
  require at /opt/jruby/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:130
```

JRuby CI image could be changed back to `circleci/jruby:9.2` when https://github.com/jruby/jruby/issues/6581 will be resolved.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
