### PR TITLE
Add rescue nil config to suppressed exceptions

### DIFF
--- a/changelog/new_added_allow_rescue_nil_config_to_suppressed_exception.md
+++ b/changelog/new_added_allow_rescue_nil_config_to_suppressed_exception.md
@@ -1,0 +1,1 @@
+* Add `AllowNil` option for `Lint/SuppressedException` to allow/disallow `rescue nil`. ([@corroded][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2055,8 +2055,9 @@ Lint/SuppressedException:
   StyleGuide: '#dont-hide-exceptions'
   Enabled: true
   AllowComments: true
+  AllowNil: true
   VersionAdded: '0.9'
-  VersionChanged: '0.81'
+  VersionChanged: <<next>>
 
 Lint/SymbolConversion:
   Description: 'Checks for unnecessary symbol conversions.'

--- a/lib/rubocop/cop/lint/suppressed_exception.rb
+++ b/lib/rubocop/cop/lint/suppressed_exception.rb
@@ -64,12 +64,51 @@ module RuboCop
       #   rescue
       #     # do nothing
       #   end
+      #
+      # @example AllowNil: true (default)
+      #
+      #   # good
+      #   def some_method
+      #     do_something
+      #   rescue
+      #     nil
+      #   end
+      #
+      #   # good
+      #   begin
+      #     do_something
+      #   rescue
+      #     # do nothing
+      #   end
+      #
+      #   # good
+      #   do_something rescue nil
+      #
+      # @example AllowNil: false
+      #
+      #   # bad
+      #   def some_method
+      #     do_something
+      #   rescue
+      #     nil
+      #   end
+      #
+      #   # bad
+      #   begin
+      #     do_something
+      #   rescue
+      #     nil
+      #   end
+      #
+      #   # bad
+      #   do_something rescue nil
       class SuppressedException < Base
         MSG = 'Do not suppress exceptions.'
 
         def on_resbody(node)
-          return if node.body
+          return if node.body && !nil_body?(node)
           return if cop_config['AllowComments'] && comment_between_rescue_and_end?(node)
+          return if cop_config['AllowNil'] && nil_body?(node)
 
           add_offense(node)
         end
@@ -82,6 +121,10 @@ module RuboCop
 
           end_line = ancestor.loc.end.line
           processed_source[node.first_line...end_line].any? { |line| comment_line?(line) }
+        end
+
+        def nil_body?(node)
+          node.body&.nil_type?
         end
       end
     end

--- a/spec/rubocop/cop/lint/suppressed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/suppressed_exception_spec.rb
@@ -47,6 +47,48 @@ RSpec.describe RuboCop::Cop::Lint::SuppressedException, :config do
           end
         RUBY
       end
+
+      context 'with AllowNil set to true' do
+        let(:cop_config) { { 'AllowComments' => false, 'AllowNil' => true } }
+
+        it 'does not register an offense for rescue block with nil' do
+          expect_no_offenses(<<~RUBY)
+            begin
+              do_something
+            rescue
+              nil
+            end
+          RUBY
+        end
+
+        it 'does not register an offense for inline nil rescue' do
+          expect_no_offenses(<<~RUBY)
+            something rescue nil
+          RUBY
+        end
+      end
+
+      context 'with AllowNil set to false' do
+        let(:cop_config) { { 'AllowComments' => false, 'AllowNil' => false } }
+
+        it 'registers an offense for rescue block with nil' do
+          expect_offense(<<~RUBY)
+            begin
+              do_something
+            rescue
+            ^^^^^^ Do not suppress exceptions.
+              nil
+            end
+          RUBY
+        end
+
+        it 'registers an offense for inline nil rescue' do
+          expect_offense(<<~RUBY)
+            something rescue nil
+                      ^^^^^^^^^^ Do not suppress exceptions.
+          RUBY
+        end
+      end
     end
 
     context 'when empty rescue for defs' do


### PR DESCRIPTION
Based off: https://github.com/rubocop/rubocop/pull/7297

Also the comment by @bbatsov https://github.com/rubocop/rubocop/pull/7297#issuecomment-523501395

> If some people disagree we can extend the existing behaviour with some config option, but I definitely imagine cases where a return value of nil might be the reasonable thing to do.

I personally have been bitten by explicit `rescue nil`s and would prefer to flag it. I've set `AllowRescueNil` to default to `true` so as not to break existing configurations. Setting it to false renders `rescue nil` and 

```
begin
  do_something
rescue
  nil
end
```

as offences.
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
