### PR TITLE
[Fix #9533] Fix calc of multiline hash arg length for metrics length cops

### DIFF
--- a/changelog/fix_make_metrics_length_cops_aware_of_multi_line_kwargs.md
+++ b/changelog/fix_make_metrics_length_cops_aware_of_multi_line_kwargs.md
@@ -1,0 +1,1 @@
+* [#9533](https://github.com/rubocop/rubocop/issues/9533): Make metrics length cops aware of multi-line kwargs. ([@koic][])

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -26,10 +26,12 @@ module RuboCop
             return length if @foldable_types.empty?
 
             each_top_level_descendant(@node, @foldable_types) do |descendant|
-              if foldable_node?(descendant)
-                descendant_length = code_length(descendant)
-                length = length - descendant_length + 1
-              end
+              next unless foldable_node?(descendant)
+
+              descendant_length = code_length(descendant)
+              length = length - descendant_length + 1
+              # Subtract 2 length of opening and closing brace if method argument omits hash braces.
+              length -= 2 if descendant.hash_type? && !descendant.braces?
             end
 
             length

--- a/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
@@ -82,6 +82,36 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::CodeLengthCalculator do
         expect(length).to eq(2)
       end
 
+      it 'folds hashes as method args if asked' do
+        source = parse_source(<<~RUBY)
+          def test
+            a = 1
+            foo({
+              foo: :bar,
+              baz: :quux
+            })
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, foldable_types: %i[hash]).calculate
+        expect(length).to eq(2)
+      end
+
+      it 'folds hashes as method kwargs if asked' do
+        source = parse_source(<<~RUBY)
+          def test
+            a = 1
+            foo(
+              foo: :bar,
+              baz: :quux
+            )
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, foldable_types: %i[hash]).calculate
+        expect(length).to eq(2)
+      end
+
       it 'folds heredocs if asked' do
         source = parse_source(<<~RUBY)
           def test


### PR DESCRIPTION
Fixes #9533.

This PR makes calculation of length of multiline hash argument with and without brace the same.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
