### PR TITLE
Fix a false positive for `Style/TrailingBodyOnMethodDefinition`

### DIFF
--- a/changelog/fix_false_positive_for_style_trailing_body_on_method_definition.md
+++ b/changelog/fix_false_positive_for_style_trailing_body_on_method_definition.md
@@ -1,0 +1,1 @@
+* [#9548](https://github.com/rubocop/rubocop/pull/9548): Fix a false positive for `Style/TrailingBodyOnMethodDefinition` when endless method definition body is after newline in opening parenthesis. ([@koic][])

--- a/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
+++ b/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
@@ -34,6 +34,7 @@ module RuboCop
 
         def on_def(node)
           return unless trailing_body?(node)
+          return if node.endless? && node.body.parenthesized_call?
 
           add_offense(first_part_of(node.body)) do |corrector|
             LineBreakCorrector.correct_trailing_body(

--- a/spec/rubocop/cop/style/trailing_body_on_method_definition_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_method_definition_spec.rb
@@ -91,6 +91,16 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnMethodDefinition, :config do
     RUBY
   end
 
+  context 'Ruby 3.0 or higher', :ruby30 do
+    it 'does not register offense when endless method definition body is after newline in opening parenthesis' do
+      expect_no_offenses(<<~RUBY)
+        def some_method = (
+          body
+        )
+      RUBY
+    end
+  end
+
   it 'auto-corrects with comment after body' do
     expect_offense(<<-RUBY.strip_margin('|'))
       |  def some_method; body # stuff


### PR DESCRIPTION
This PR fixes a false positive for `Style/TrailingBodyOnMethodDefinition` when endless method definition body is after newline in opening parenthesis.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
