### PR TITLE
Fix an error for `InternalAffairs/NodeMatcherDirective`

### DIFF
--- a/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
+++ b/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
@@ -97,7 +97,7 @@ module RuboCop
 
         def insert_directive(corrector, node, actual_name)
           # If the pattern matcher uses arguments (`%1`, `%2`, etc.), include them in the directive
-          arguments = pattern_arguments(node.arguments[1].value)
+          arguments = pattern_arguments(node.arguments[1].source)
 
           range = range_with_surrounding_space(
             range: node.loc.expression,

--- a/spec/rubocop/cop/internal_affairs/node_matcher_directive_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/node_matcher_directive_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeMatcherDirective, :config do
       RUBY
     end
 
+    it 'registers an offense if the matcher does not have a directive and a method call is used for a pattern argument' do
+      expect_offense(<<~RUBY, method: method)
+        #{method} :foo?, format(PATTERN, type: 'const')
+        ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @!method foo?(node)
+        #{method} :foo?, format(PATTERN, type: 'const')
+      RUBY
+    end
+
     it 'registers an offense if the matcher does not have a directive but has preceeding comments' do
       expect_offense(<<~RUBY, method: method)
         # foo


### PR DESCRIPTION
This PR fixes the following error for `InternalAffairs/NodeMatcherDirective`.

```console
% cat example.rb
def_node_matcher :foo?, format(PATTERN, type: 'const')

% bundle exec rubocop --only InternalAffairs/NodeMatcherDirective -d
(snip)

Inspecting 1 file
Scanning
/Users/koic/src/github.com/koic/rubocop-issues/ia_cop/example.rb
An error occurred while InternalAffairs/NodeMatcherDirective cop was
inspecting
/Users/koic/src/github.com/koic/rubocop-issues/ia_cop/example.rb:1:0.
undefined method `value' for s(:send, nil, :format,
  s(:const, nil, :PATTERN),
  s(:hash,
    s(:pair,
      s(:sym, :type),
      s(:str, "const")))):RuboCop::AST::SendNode
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb:100:in
`insert_directive'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb:85:in
`block in register_offense'
(snip)

1 error occurred:
An error occurred while InternalAffairs/NodeMatcherDirective cop was
inspecting
/Users/koic/src/github.com/koic/rubocop-issues/ia_cop/example.rb:1:0.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop/rubocop/issues
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
