### PR TITLE
Bump RuboCop Performance to 1.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ else
 end
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
-gem 'rubocop-performance', '~> 1.9.0'
+gem 'rubocop-performance', '~> 1.10.0'
 gem 'rubocop-rspec', '~> 2.2.0'
 # Workaround for cc-test-reporter with SimpleCov 0.18.
 # Stop upgrading SimpleCov until the following issue will be resolved.

--- a/lib/rubocop/cop/mixin/preferred_delimiters.rb
+++ b/lib/rubocop/cop/mixin/preferred_delimiters.rb
@@ -15,7 +15,7 @@ module RuboCop
       end
 
       def delimiters
-        preferred_delimiters[type].split(//)
+        preferred_delimiters[type].split('')
       end
 
       private

--- a/lib/rubocop/cop/style/command_literal.rb
+++ b/lib/rubocop/cop/style/command_literal.rb
@@ -165,7 +165,7 @@ module RuboCop
         end
 
         def preferred_delimiter
-          (command_delimiter || default_delimiter).split(//)
+          (command_delimiter || default_delimiter).split('')
         end
 
         def command_delimiter

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -150,7 +150,7 @@ module RuboCop
 
         def preferred_delimiters
           config.for_cop('Style/PercentLiteralDelimiters') \
-            ['PreferredDelimiters']['%r'].split(//)
+            ['PreferredDelimiters']['%r'].split('')
         end
 
         def correct_delimiters(node, corrector)

--- a/spec/support/alignment_examples.rb
+++ b/spec/support/alignment_examples.rb
@@ -8,7 +8,7 @@ shared_examples_for 'misaligned' do |annotated_source, used_style|
                              else
                                { 'Enabled' => false }
                              end
-  annotated_source.split(/\n\n/).each do |chunk|
+  annotated_source.split("\n\n").each do |chunk|
     chunk << "\n" unless chunk.end_with?("\n")
     source = chunk.lines.reject { |line| /^ *\^/.match?(line) }.join
     name = source.gsub(/\n(?=[a-z ])/, ' <newline> ').gsub(/\s+/, ' ')


### PR DESCRIPTION
This PR bumps RuboCop Performance to 1.10 and suppresses the new `Performance/RedundantSplitRegexpArgument` cop's offenses.

```console
% bundle exec rubocop
(snip)

Offenses:

lib/rubocop/cop/mixin/preferred_delimiters.rb:18:42: C: [Corrected]
Performance/RedundantSplitRegexpArgument: Use string as argument instead
of regexp.
        preferred_delimiters[type].split(//)
                                         ^^
lib/rubocop/cop/mixin/preferred_delimiters.rb:18:42: C: [Corrected]
Style/StringLiterals: Prefer single-quoted strings when you don't need
string interpolation or special symbols.
        preferred_delimiters[type].split("")
                                         ^^
lib/rubocop/cop/style/command_literal.rb:168:58: C: [Corrected]
Performance/RedundantSplitRegexpArgument: Use string as argument instead
of regexp.
          (command_delimiter || default_delimiter).split(//)
                                                         ^^
lib/rubocop/cop/style/command_literal.rb:168:58: C: [Corrected]
Style/StringLiterals: Prefer single-quoted strings when you don't need
string interpolation or special symbols.
          (command_delimiter || default_delimiter).split("")
                                                         ^^
lib/rubocop/cop/style/regexp_literal.rb:153:49: C: [Corrected]
Performance/RedundantSplitRegexpArgument: Use string as argument instead
of regexp.
            ['PreferredDelimiters']['%r'].split(//)
                                                ^^
lib/rubocop/cop/style/regexp_literal.rb:153:49: C: [Corrected]
Style/StringLiterals: Prefer single-quoted strings when you don't need
string interpolation or special symbols.
            ['PreferredDelimiters']['%r'].split("")
                                                ^^
spec/support/alignment_examples.rb:11:26: C: [Corrected]
Performance/RedundantSplitRegexpArgument: Use string as argument instead
of regexp.
  annotated_source.split(/\n\n/).each do |chunk|
                         ^^^^^^

1265 files inspected, 7 offenses detected, 7 offenses corrected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
