### PR TITLE
[Fix #9551] Fix a false positive for `Style/UnlessLogicalOperators`

### DIFF
--- a/changelog/fix_false_positive_for_style_unless_logical_operators.md
+++ b/changelog/fix_false_positive_for_style_unless_logical_operators.md
@@ -1,0 +1,1 @@
+* [#9551](https://github.com/rubocop/rubocop/issues/9551): Fix a false positive for `Style/UnlessLogicalOperators` when using `||` operator and invoked method name includes "or" in the conditional branch. ([@koic][])

--- a/lib/rubocop/cop/style/unless_logical_operators.rb
+++ b/lib/rubocop/cop/style/unless_logical_operators.rb
@@ -87,11 +87,17 @@ module RuboCop
         end
 
         def mixed_precedence_and?(node)
-          node.source.include?('&&') && node.source.include?('and')
+          and_sources = node.condition.each_descendant(:and).map(&:operator)
+          and_sources << node.condition.operator if node.condition.and_type?
+
+          !(and_sources.all? { |s| s == '&&' } || and_sources.all? { |s| s == 'and' })
         end
 
         def mixed_precedence_or?(node)
-          node.source.include?('||') && node.source.include?('or')
+          or_sources = node.condition.each_descendant(:or).map(&:operator)
+          or_sources << node.condition.operator if node.condition.or_type?
+
+          !(or_sources.all? { |s| s == '||' } || or_sources.all? { |s| s == 'or' })
         end
       end
     end

--- a/spec/rubocop/cop/style/unless_logical_operators_spec.rb
+++ b/spec/rubocop/cop/style/unless_logical_operators_spec.rb
@@ -116,6 +116,26 @@ RSpec.describe RuboCop::Cop::Style::UnlessLogicalOperators, :config do
         return unless a?
       RUBY
     end
+
+    it 'does not register an offense when using `||` operator and invoked method name includes "or" in the conditional branch' do
+      expect_no_offenses(<<~RUBY)
+        unless condition
+          includes_or_in_the_name
+
+          foo || bar
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using `&&` operator and invoked method name includes "and" in the conditional branch' do
+      expect_no_offenses(<<~RUBY)
+        unless condition
+          includes_and_in_the_name
+
+          foo && bar
+        end
+      RUBY
+    end
   end
 
   context 'EnforcedStyle is `forbid_logical_operators`' do


### PR DESCRIPTION
Fixes #9551.

This PR fixes a false positive for `Style/UnlessLogicalOperators` when using `||` operator and invoked method name includes "or" in the conditional branch.

This is an issue due to string matching of source code instead of AST.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
