### PR TITLE
Add autocorrect for `Style/UnlessLogicalOperators`

### DIFF
--- a/changelog/new_add_autocorrect_for_styleunlesslogicaloperators.md
+++ b/changelog/new_add_autocorrect_for_styleunlesslogicaloperators.md
@@ -1,0 +1,1 @@
+* Add autocorrect for `Style/UnlessLogicalOperators`. ([@SeekingMeaning][])

--- a/spec/rubocop/cop/style/unless_logical_operators_spec.rb
+++ b/spec/rubocop/cop/style/unless_logical_operators_spec.rb
@@ -12,9 +12,17 @@ RSpec.describe RuboCop::Cop::Style::UnlessLogicalOperators, :config do
         ^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use mixed logical operators in an `unless`.
       RUBY
 
+      expect_correction(<<~RUBY)
+        return if !(a && b) && !c
+      RUBY
+
       expect_offense(<<~RUBY)
         return unless a || b && c
         ^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use mixed logical operators in an `unless`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        return if !a && !(b && c)
       RUBY
     end
 
@@ -24,9 +32,17 @@ RSpec.describe RuboCop::Cop::Style::UnlessLogicalOperators, :config do
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use mixed logical operators in an `unless`.
       RUBY
 
+      expect_correction(<<~RUBY)
+        return if !(a && b) or !c
+      RUBY
+
       expect_offense(<<~RUBY)
         return unless a and b && c
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use mixed logical operators in an `unless`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        return if !a or !(b && c)
       RUBY
     end
 
@@ -36,9 +52,17 @@ RSpec.describe RuboCop::Cop::Style::UnlessLogicalOperators, :config do
         ^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use mixed logical operators in an `unless`.
       RUBY
 
+      expect_correction(<<~RUBY)
+        return if !(a && b) and !c
+      RUBY
+
       expect_offense(<<~RUBY)
         return unless a or b && c
         ^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use mixed logical operators in an `unless`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        return if !a and !(b && c)
       RUBY
     end
 
@@ -48,9 +72,17 @@ RSpec.describe RuboCop::Cop::Style::UnlessLogicalOperators, :config do
         ^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use mixed logical operators in an `unless`.
       RUBY
 
+      expect_correction(<<~RUBY)
+        return if !(a || b) and !c
+      RUBY
+
       expect_offense(<<~RUBY)
         return unless a or b || c
         ^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use mixed logical operators in an `unless`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        return if !a and !(b || c)
       RUBY
     end
 
@@ -60,9 +92,17 @@ RSpec.describe RuboCop::Cop::Style::UnlessLogicalOperators, :config do
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use mixed logical operators in an `unless`.
       RUBY
 
+      expect_correction(<<~RUBY)
+        return if !(a || b) or !c
+      RUBY
+
       expect_offense(<<~RUBY)
         return unless a and b || c
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use mixed logical operators in an `unless`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        return if !a or !(b || c)
       RUBY
     end
 
@@ -70,6 +110,10 @@ RSpec.describe RuboCop::Cop::Style::UnlessLogicalOperators, :config do
       expect_offense(<<~RUBY)
         return unless a || (b && c) || d
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use mixed logical operators in an `unless`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        return if !(a || (b && c)) && !d
       RUBY
     end
 
@@ -148,12 +192,20 @@ RSpec.describe RuboCop::Cop::Style::UnlessLogicalOperators, :config do
         return unless a && b
         ^^^^^^^^^^^^^^^^^^^^ Do not use any logical operator in an `unless`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        return if !a || !b
+      RUBY
     end
 
     it 'registers an offense when using only `||`' do
       expect_offense(<<~RUBY)
         return unless a || b
         ^^^^^^^^^^^^^^^^^^^^ Do not use any logical operator in an `unless`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        return if !a && !b
       RUBY
     end
 
@@ -162,6 +214,10 @@ RSpec.describe RuboCop::Cop::Style::UnlessLogicalOperators, :config do
         return unless a and b
         ^^^^^^^^^^^^^^^^^^^^^ Do not use any logical operator in an `unless`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        return if !a or !b
+      RUBY
     end
 
     it 'registers an offense when using only `or`' do
@@ -169,12 +225,20 @@ RSpec.describe RuboCop::Cop::Style::UnlessLogicalOperators, :config do
         return unless a or b
         ^^^^^^^^^^^^^^^^^^^^ Do not use any logical operator in an `unless`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        return if !a and !b
+      RUBY
     end
 
     it 'registers an offense when using `&&` followed by ||' do
       expect_offense(<<~RUBY)
         return unless a && b || c
         ^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use any logical operator in an `unless`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        return if !(a && b) && !c
       RUBY
     end
 


### PR DESCRIPTION
This PR adds autocorrect for `unless ... &&` and `unless ... ||`

For example:

```ruby
return unless a || b
```

is auto-corrected to:

```ruby
return if !a && !b
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
