### PR TITLE
Add example for style trailing body on method definition

### DIFF
--- a/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
+++ b/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
@@ -38,7 +38,7 @@ module RuboCop
 
         def on_def(node)
           return unless trailing_body?(node)
-          return if node.endless? && node.body.parenthesized_call?
+          return if node.endless?
 
           add_offense(first_part_of(node.body)) do |corrector|
             LineBreakCorrector.correct_trailing_body(

--- a/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
+++ b/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
@@ -5,6 +5,8 @@ module RuboCop
     module Style
       # This cop checks for trailing code after the method definition.
       #
+      # NOTE: It always accepts endless method definitions that are basically on the same line.
+      #
       # @example
       #   # bad
       #   def some_method; do_stuff
@@ -23,6 +25,8 @@ module RuboCop
       #     b = foo
       #     b[c: x]
       #   end
+      #
+      #   def endless_method = do_stuff
       #
       class TrailingBodyOnMethodDefinition < Base
         include Alignment


### PR DESCRIPTION
Follow https://github.com/rubocop/rubocop/pull/9548#issuecomment-787423830.

This PR adds example for `Style/TrailingBodyOnMethodDefinition` cop and removes a redundant condition from the cop. I noticed the redundant condition when writing the example description.
