### PR TITLE
[Fix #9505] Disable cops on next line with directive comment

### DIFF
--- a/changelog/new_disable_cops_on_next_line_with_directive_comment.md
+++ b/changelog/new_disable_cops_on_next_line_with_directive_comment.md
@@ -1,0 +1,1 @@
+* [#9559](https://github.com/rubocop/rubocop/pull/9559): Disable cops on next line with directive comment. ([@AndreiEres][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -682,6 +682,14 @@ comment.
 for x in (0..19) # rubocop:disable Style/For
 ----
 
+Also cops can be disabled on a single next line with a comment.
+
+[source,ruby]
+----
+# rubocop:disable-next-line Style/For
+for x in (0..19)
+----
+
 If you want to disable a cop that inspects comments, you can do so by
 adding an "inner comment" on the comment line.
 

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -153,6 +153,8 @@ module RuboCop
     # so that `Lint/RedundantCopEnableDirective` can register offenses correctly.
     def handle_switch(directive, names, extras)
       directive.cop_names.each do |name|
+        next if directive.disabled_next_line?
+
         if directive.disabled?
           names[name] += 1
         elsif (names[name]).positive?

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -68,6 +68,8 @@ module RuboCop
       # Disabling cops after comments like `#=SomeDslDirective` does not related to single line
       if !comment_only_line?(directive.line_number) || directive.single_line?
         analyze_single_line(analysis, directive)
+      elsif directive.disabled_next_line?
+        analyze_next_line(analysis, directive)
       elsif directive.disabled?
         analyze_disabled(analysis, directive)
       else
@@ -79,6 +81,13 @@ module RuboCop
       return analysis unless directive.disabled?
 
       line = directive.line_number
+      start_line = analysis.start_line_number
+
+      CopAnalysis.new(analysis.line_ranges + [(line..line)], start_line)
+    end
+
+    def analyze_next_line(analysis, directive)
+      line = directive.line_number + 1
       start_line = analysis.start_line_number
 
       CopAnalysis.new(analysis.line_ranges + [(line..line)], start_line)

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -105,10 +105,9 @@ module RuboCop
           end
         end
 
-        def each_line_range(line_ranges, disabled_ranges, offenses,
-                            cop)
+        def each_line_range(line_ranges, disabled_ranges, offenses, cop)
           line_ranges.each_with_index do |line_range, ix|
-            comment = processed_source.comment_at_line(line_range.begin)
+            comment = comment_for_line(line_range.begin)
             next if ignore_offense?(disabled_ranges, line_range)
 
             redundant_cop = find_redundant(comment, offenses, cop, line_range, line_ranges[ix + 1])
@@ -125,7 +124,7 @@ module RuboCop
             # the end of the previous range, it means that the cop was
             # already disabled by an earlier comment. So it's redundant
             # whether there are offenses or not.
-            comment = processed_source.comment_at_line(range.begin)
+            comment = comment_for_line(range.begin)
 
             # Comments disabling all cops don't count since it's reasonable
             # to disable a few select cops first and then all cops further
@@ -251,6 +250,11 @@ module RuboCop
         def ends_its_line?(range)
           line = range.source_buffer.source_line(range.last_line)
           (line =~ /\s*\z/) == range.last_column
+        end
+
+        def comment_for_line(line)
+          # For case when `disable-next-line` is used
+          processed_source.comment_at_line(line) || processed_source.comment_at_line(line - 1)
         end
       end
     end

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -14,7 +14,7 @@ module RuboCop
     # @api private
     COPS_PATTERN = "(all|#{COP_NAMES_PATTERN})"
     # @api private
-    DIRECTIVE_COMMENT_MODES = '(?:disable|disable-next-line|enable|todo)'
+    DIRECTIVE_COMMENT_MODES = '(?:disable|disable-next-line|enable|todo|todo-next-line)'
     # @api private
     DIRECTIVE_COMMENT_REGEXP = Regexp.new(
       "# rubocop : (#{DIRECTIVE_COMMENT_MODES})\\b #{COPS_PATTERN}".gsub(' ', '\s*')
@@ -57,7 +57,7 @@ module RuboCop
 
     # Checks if this directive disables cops only on next line
     def disabled_next_line?
-      %w[disable-next-line].include?(mode)
+      %w[disable-next-line todo-next-line].include?(mode)
     end
 
     # Checks if this directive enables cops

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -14,9 +14,10 @@ module RuboCop
     # @api private
     COPS_PATTERN = "(all|#{COP_NAMES_PATTERN})"
     # @api private
+    DIRECTIVE_COMMENT_MODES = '(?:disable|disable-next-line|enable|todo)'
+    # @api private
     DIRECTIVE_COMMENT_REGEXP = Regexp.new(
-      "# rubocop : ((?:disable|enable|todo))\\b #{COPS_PATTERN}"
-        .gsub(' ', '\s*')
+      "# rubocop : (#{DIRECTIVE_COMMENT_MODES})\\b #{COPS_PATTERN}".gsub(' ', '\s*')
     )
 
     def self.before_comment(line)
@@ -52,6 +53,11 @@ module RuboCop
     # Checks if this directive disables cops
     def disabled?
       %w[disable todo].include?(mode)
+    end
+
+    # Checks if this directive disables cops only on next line
+    def disabled_next_line?
+      %w[disable-next-line].include?(mode)
     end
 
     # Checks if this directive enables cops

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -179,8 +179,7 @@ RSpec.describe RuboCop::CommentConfig do
     end
 
     it 'supports disabling cops on next line' do
-      expect(disabled_lines_of_cop('Style/EmptyMethod'))
-        .to eq([7, 8, 9, 56])
+      expect(disabled_lines_of_cop('Style/EmptyMethod')).to eq([7, 8, 9, 56])
     end
   end
 

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -60,6 +60,10 @@ RSpec.describe RuboCop::CommentConfig do
         # rubocop:disable RSpec/Rails/HttpStatus
         it { is_expected.to have_http_status 200 }                          # 52
         # rubocop:enable RSpec/Rails/HttpStatus
+
+        # rubocop:disable-next-line Style/EmptyMethod
+        def foo                                                             # 56
+        end
       RUBY
       # rubocop:enable Lint/EmptyExpression, Lint/EmptyInterpolation
     end
@@ -172,6 +176,11 @@ RSpec.describe RuboCop::CommentConfig do
 
     it 'supports disabling cops on a comment line with an EOL comment' do
       expect(disabled_lines_of_cop('Layout/LeadingCommentSpace')).to eq([7, 8, 9, 50])
+    end
+
+    it 'supports disabling cops on next line' do
+      expect(disabled_lines_of_cop('Style/EmptyMethod'))
+        .to eq([7, 8, 9, 56])
     end
   end
 

--- a/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
@@ -226,4 +226,20 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopEnableDirective, :config do
       end
     end
   end
+
+  context 'when cop disabled with `disable-next-line` and enabled again' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable-next-line Layout/LineLength
+        foo
+        # rubocop:enable Layout/LineLength
+                         ^^^^^^^^^^^^^^^^^ Unnecessary enabling of Layout/LineLength.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # rubocop:disable-next-line Layout/LineLength
+        foo
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -218,16 +218,21 @@ RSpec.describe RuboCop::DirectiveComment do
   describe '#disabled_next_line?' do
     subject { directive_comment.disabled_next_line? }
 
-    [
-      ['when disabled next line', '# rubocop:disable-next-line all', true],
-      ['when disabled current line', 'def foo # rubocop:disable all', false],
-      ['when disabled few lines', '# rubocop:disable Foo/Bar', false]
-    ].each do |example|
-      context example[0] do
-        let(:text) { example[1] }
+    shared_examples 'checks disabled_next_line?' do |explanation, comment, result|
+      context explanation do
+        let(:text) { comment }
 
-        it { is_expected.to eq example[2] }
+        it { is_expected.to eq result }
       end
     end
+
+    include_examples 'checks disabled_next_line?',
+                     'when disabled next line', '# rubocop:disable-next-line all', true
+    include_examples 'checks disabled_next_line?',
+                     'when "todoed" next line', '# rubocop:todo-next-line all', true
+    include_examples 'checks disabled_next_line?',
+                     'when disabled current line', 'def foo # rubocop:disable all', false
+    include_examples 'checks disabled_next_line?',
+                     'when disabled few lines', '# rubocop:disable Foo/Bar', false
   end
 end

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -214,4 +214,20 @@ RSpec.describe RuboCop::DirectiveComment do
       end
     end
   end
+
+  describe '#disabled_next_line?' do
+    subject { directive_comment.disabled_next_line? }
+
+    [
+      ['when disabled next line', '# rubocop:disable-next-line all', true],
+      ['when disabled current line', 'def foo # rubocop:disable all', false],
+      ['when disabled few lines', '# rubocop:disable Foo/Bar', false]
+    ].each do |example|
+      context example[0] do
+        let(:text) { example[1] }
+
+        it { is_expected.to eq example[2] }
+      end
+    end
+  end
 end


### PR DESCRIPTION
For https://github.com/rubocop/rubocop/issues/9505

- Added checking for `disable-next-line` to DirectiveComment
- Added ability to disable cops on next line with directive comment to CommentConfig
- Added notes about feature to docs

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
