### PR TITLE
Fix an error for `Style/ClassMethodsDefinitions`

### DIFF
--- a/changelog/fix_an_error_for_style_class_methods_definitions.md
+++ b/changelog/fix_an_error_for_style_class_methods_definitions.md
@@ -1,0 +1,1 @@
+* [#9560](https://github.com/rubocop/rubocop/pull/9560): Fix an error for `Lint/ClassMethodsDefinitions` when defining class methods with `class << self` with comment only body. ([@koic][])

--- a/lib/rubocop/cop/mixin/comments_help.rb
+++ b/lib/rubocop/cop/mixin/comments_help.rb
@@ -23,7 +23,11 @@ module RuboCop
       def begin_pos_with_comment(node)
         first_comment = processed_source.ast_with_comments[node].first
 
-        start_line_position(first_comment || node)
+        if first_comment && (first_comment.loc.line < node.loc.line)
+          start_line_position(first_comment)
+        else
+          start_line_position(node)
+        end
       end
 
       def start_line_position(node)

--- a/spec/rubocop/cop/style/class_methods_definitions_spec.rb
+++ b/spec/rubocop/cop/style/class_methods_definitions_spec.rb
@@ -175,6 +175,46 @@ RSpec.describe RuboCop::Cop::Style::ClassMethodsDefinitions, :config do
       RUBY
     end
 
+    it 'registers and corrects an offense when defining class methods with `class << self` with comment only body' do
+      expect_offense(<<~RUBY)
+        class Foo
+          class << self
+          ^^^^^^^^^^^^^ Do not define public methods within class << self.
+            def do_something
+              # TODO
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          def self.do_something
+            # TODO
+          end
+        end
+      RUBY
+    end
+
+    it 'registers and corrects an offense when defining class methods with `class << self` with inline comment' do
+      expect_offense(<<~RUBY)
+        class Foo
+          class << self
+          ^^^^^^^^^^^^^ Do not define public methods within class << self.
+            def do_something # TODO
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          def self.do_something # TODO
+          end
+        end
+      RUBY
+    end
+
     it 'does not register an offense when `class << self` contains non public methods' do
       expect_no_offenses(<<~RUBY)
         class A


### PR DESCRIPTION
This PR fixes the following error for `Lint/ClassMethodsDefinitions` when defining class methods with `class << self` with comment only body.

```console
% cat /tmp/example.rb
class Foo
  class << self
    def do_something
      # TODO
    end
  end
end

% rubocop /tmp/example.rb --only Style/ClassMethodsDefinitions -d
For /private/tmp: Default configuration from
/Users/koic/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-1.11.0/config/default.yml
Inspecting 1 file
Scanning /private/tmp/example.rb
An error occurred while Style/ClassMethodsDefinitions cop was inspecting
/private/tmp/example.rb:2:2.
undefined method `gsub' for nil:NilClass
/Users/koic/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-1.11.0/lib/rubocop/cop/style/class_methods_definitions.rb:147:in `extract_def_from_sclass'
/Users/koic/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-1.11.0/lib/rubocop/cop/style/class_methods_definitions.rb:120:in `block in autocorrect_sclass'
/Users/koic/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-1.11.0/lib/rubocop/cop/style/class_methods_definitions.rb:117:in `each'
/Users/koic/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-1.11.0/lib/rubocop/cop/style/class_methods_definitions.rb:117:in `autocorrect_sclass'
/Users/koic/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-1.11.0/lib/rubocop/cop/style/class_methods_definitions.rb:77:in `block in on_sclass'
/Users/koic/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-1.11.0/lib/rubocop/cop/base.rb:340:in `correct'
/Users/koic/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-1.11.0/lib/rubocop/cop/base.rb:127:in `add_offense'
/Users/koic/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-1.11.0/lib/rubocop/cop/style/class_methods_definitions.rb:76:in `on_sclass'
(snip)

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Style/ClassMethodsDefinitions cop was inspecting
/private/tmp/example.rb:2:2.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop/rubocop/issues

Mention the following information in the issue report:
1.11.0 (using Parser 3.0.0.0, rubocop-ast 1.4.1, running on ruby 3.0.0 x86_64-darwin19)
Finished in 0.07133800000883639 seconds
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
