### PR TITLE
Change Style/Documentation to not require documentation for ClassMethods modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Change `Style/Documentation` to not require documentation for `ClassMethods` modules. ([@drenmi][])
+
 ## 1.11.0 (2021-03-01)
 
 ### New features

--- a/changelog/change_documentation_to_allow_class_methods.md
+++ b/changelog/change_documentation_to_allow_class_methods.md
@@ -1,0 +1,1 @@
+* Change `Style/Documentation` to not require documentation for `ClassMethods` modules. ([@drenmi][])

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -76,6 +76,11 @@ module RuboCop
           (send nil? {:public_constant :private_constant} ({sym str} _))
         PATTERN
 
+        # @!method class_methods?(node)
+        def_node_matcher :class_methods?, <<~PATTERN
+          (const nil? :ClassMethods)
+        PATTERN
+
         def on_class(node)
           return unless node.body
 
@@ -83,6 +88,8 @@ module RuboCop
         end
 
         def on_module(node)
+          return if class_methods?(node.identifier)
+
           check(node, node.body, :module)
         end
 

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -216,6 +216,16 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
       end
     end
 
+    it 'does not register an offense on a ClassMethods module' do
+      expect_no_offenses(<<~RUBY)
+        module ClassMethods
+          def foo
+            bar
+          end
+        end
+      RUBY
+    end
+
     context 'macro-only class' do
       it 'does not register offense with single macro' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
## Background

It is a common idiom in ruby to define a module named `ClassMethods` which is automatically extended when it's parent module is included, e.g.:

```ruby
module Foo
  module ClassMethods
    def bar
      # ...
    end
  end

  def self.included(klass)
    klass.extend(ClassMethods)
  end
end
```

This inner module does not need additional documentation beyond that of the parent module.

## What is this change?

This PR makes it so that `Style/Documentation` does not register offenses on modules named `ClassMethods`.

---

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
