### PR TITLE
Use `Cop::Base` API for `Style/HashSyntax`

### DIFF
--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -201,10 +201,10 @@ RSpec.describe RuboCop::Cop::Team do
       include_context 'mock console output'
 
       before do
-        allow_any_instance_of(RuboCop::Cop::Style::HashSyntax)
+        allow_any_instance_of(RuboCop::Cop::Style::RescueModifier)
           .to receive(:autocorrect).and_return(buggy_correction)
 
-        create_file(file_path, '{ :key => value }')
+        create_file(file_path, 'some_method rescue handle_error')
       end
 
       let(:buggy_correction) do
@@ -217,8 +217,8 @@ RSpec.describe RuboCop::Cop::Team do
       let(:cause) { StandardError.new('cause') }
 
       let(:error_message) do
-        'An error occurred while Style/HashSyntax cop was inspecting ' \
-        '/tmp/example.rb:1:0.'
+        'An error occurred while Style/RescueModifier cop was inspecting ' \
+        '/tmp/example.rb:1:12.'
       end
 
       it 'records Team#errors' do


### PR DESCRIPTION
Follow #7868.

This PR uses `Cop::Base` API for `Style/HashSyntax` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
