### PR TITLE
[Fix #9558] Fix inconsistency when dealing with URIs that are wrapped in single quotes vs double quotes

### DIFF
--- a/changelog/fix_fix_inconsistency_when_dealing_with_uris.md
+++ b/changelog/fix_fix_inconsistency_when_dealing_with_uris.md
@@ -1,0 +1,1 @@
+* [#9558](https://github.com/rubocop/rubocop/issues/9558): Fix inconsistency when dealing with URIs that are wrapped in single quotes vs double quotes. ([@dvandersluis][])

--- a/lib/rubocop/cop/mixin/line_length_help.rb
+++ b/lib/rubocop/cop/mixin/line_length_help.rb
@@ -24,9 +24,7 @@ module RuboCop
       end
 
       def allowed_uri_position?(line, uri_range)
-        uri_range.begin < max_line_length &&
-          (uri_range.end == line_length(line) ||
-           uri_range.end == line_length(line) - 1)
+        uri_range.begin < max_line_length && uri_range.end == line_length(line)
       end
 
       def line_length(line)
@@ -40,6 +38,14 @@ module RuboCop
         begin_position, end_position = last_uri_match.offset(0).map do |pos|
           pos + indentation_difference(line)
         end
+
+        # Extend the end position until the start of the next word, if any.
+        # This allows for URIs that are wrapped in quotes or parens to be handled properly
+        # while not allowing additional words to be added after the URL.
+        if (match = line[end_position..line_length(line)]&.match(/^\S+(?=\s|$)/))
+          end_position += match.offset(0).last
+        end
+
         return nil if begin_position < max_line_length &&
                       end_position < max_line_length
 

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -124,6 +124,27 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       end
     end
 
+    context 'and the excessive characters include part of a URL in double quotes' do
+      it 'does not include the quote as part of the offense' do
+        expect_offense(<<-RUBY)
+          # See: "https://github.com/rubocop/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c" and
+                                                                                                     ^^^^ Line is too long. [105/80]
+          #   "http://google.com/"
+        RUBY
+      end
+    end
+
+    context 'and the excessive characters include part of a URL ' \
+            'and trailing whitespace' do
+      it 'registers an offense for the line' do
+        expect_offense(<<-RUBY)
+          # See: https://github.com/rubocop/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c#{trailing_whitespace}
+                                                                                                   ^ Line is too long. [100/80]
+          #   http://google.com/
+        RUBY
+      end
+    end
+
     context 'and an error other than URI::InvalidURIError is raised ' \
             'while validating a URI-ish string' do
       let(:cop_config) do
@@ -158,6 +179,26 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
             #{'x' * 40} = 'otherprotocol://a.very.long.line.which.violates.LineLength/sadf'
           RUBY
         end
+      end
+    end
+
+    context 'and the URI is assigned' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          #{'x' * 40} = 'https://a.very.long.line.which.violates.LineLength/sadf'
+          #{'x' * 40} = "https://a.very.long.line.which.violates.LineLength/sadf"
+        RUBY
+      end
+    end
+
+    context 'and the URI is an argument' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          #{'x' * 40}("https://a.very.long.line.which.violates.LineLength/sadf")
+          #{'x' * 40} "https://a.very.long.line.which.violates.LineLength/sadf"
+          #{'x' * 40}('https://a.very.long.line.which.violates.LineLength/sadf')
+          #{'x' * 40} 'https://a.very.long.line.which.violates.LineLength/sadf'
+        RUBY
       end
     end
   end


### PR DESCRIPTION
The `LineLength` cop uses `LineLengthHelp#allowed_uri_position?` to determine if the URI is in an allowed position. Previously it checked that the URL either ended the line, or ended one character before the end of the line:

https://github.com/rubocop/rubocop/blob/291aec7f04775dbe8aaff0c6a2d7328aaca0427b/lib/rubocop/cop/mixin/line_length_help.rb#L26-L30

It looks like this was added originally in #5361... also to handle disparity between single and double quotes. 🤔 

As it turns out, ruby's default URI parser (which we use to match parts of strings as a URL), accepts `'` as a valid character, but does not accept `"`. It also matches `)`. Therefore, the URL extracted from the string differs depending on the type of quote being used:

```ruby
regexp = URI::DEFAULT_PARSER.make_regexp(['http', 'https'])
regexp.match(%q[http://foo.com/')])
=> #<MatchData "http://foo.com/')" 1:"http" 2:nil 3:nil 4:"foo.com" 5:nil 6:nil 7:"/')" 8:nil 9:nil>
regexp.match(%q[http://foo.com/")])
=> #<MatchData "http://foo.com/" 1:"http" 2:nil 3:nil 4:"foo.com" 5:nil 6:nil 7:"/" 8:nil 9:nil>
```

This was leading to the failure in the issue, because for the single quoted string, the "URL" ends on the last character (despite the `')` not actually being a part of the URL!), but for the double quoted string, the parser actually ends at the "real" end of the URL, and then `allowed_uri_position?` fails.

This change updates the `uri_range` to also capture any trailing characters until the next whitespace, and then just checks that the `uri_range` ends at the end of the line. This fixes the issue while also continuing to register an offense for subsequent words.

Fixes #9558.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
