### PR TITLE
Move checking directive comments from CommentConfig to DirectiveComment 

### DIFF
--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -7,19 +7,6 @@ module RuboCop
     # @api private
     REDUNDANT_DISABLE = 'Lint/RedundantCopDisableDirective'
 
-    # @api private
-    COP_NAME_PATTERN = '([A-Z]\w+/)*(?:[A-Z]\w+)'
-    # @api private
-    COP_NAMES_PATTERN = "(?:#{COP_NAME_PATTERN} , )*#{COP_NAME_PATTERN}"
-    # @api private
-    COPS_PATTERN = "(all|#{COP_NAMES_PATTERN})"
-
-    # @api private
-    COMMENT_DIRECTIVE_REGEXP = Regexp.new(
-      "# rubocop : ((?:disable|enable|todo))\\b #{COPS_PATTERN}"
-        .gsub(' ', '\s*')
-    )
-
     CopAnalysis = Struct.new(:line_ranges, :start_line_number)
 
     attr_reader :processed_source

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -138,7 +138,7 @@ module RuboCop
     end
 
     def directive_on_comment_line?(comment)
-      comment.text[1..-1].match?(COMMENT_DIRECTIVE_REGEXP)
+      DirectiveComment.new(comment).single_line?
     end
 
     def each_directive

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -151,10 +151,10 @@ module RuboCop
     end
 
     def directive_parts(comment)
-      match = comment.text.match(COMMENT_DIRECTIVE_REGEXP)
-      return unless match
+      match_captures = DirectiveComment.new(comment).match_captures
+      return unless match_captures
 
-      switch, cops_string = match.captures
+      switch, cops_string = match_captures
 
       cop_names =
         cops_string == 'all' ? all_cop_names : cops_string.split(/,\s*/)
@@ -180,7 +180,7 @@ module RuboCop
     end
 
     def enable_all?(comment)
-      _, cops = comment.text.match(COMMENT_DIRECTIVE_REGEXP).captures
+      _, cops = DirectiveComment.new(comment).match_captures
       cops == 'all'
     end
 

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -174,8 +174,7 @@ module RuboCop
         end
 
         def directive_count(comment)
-          match = comment.text.match(CommentConfig::COMMENT_DIRECTIVE_REGEXP)
-          _, cops_string = match.captures
+          _, cops_string = DirectiveComment.new(comment).match_captures
           cops_string.split(/,\s*/).size
         end
 

--- a/lib/rubocop/cop/mixin/documentation_comment.rb
+++ b/lib/rubocop/cop/mixin/documentation_comment.rb
@@ -45,7 +45,7 @@ module RuboCop
       end
 
       def rubocop_directive_comment?(comment)
-        CommentConfig::COMMENT_DIRECTIVE_REGEXP.match?(comment.text)
+        !!DirectiveComment.new(comment).match_captures
       end
     end
   end

--- a/lib/rubocop/cop/mixin/line_length_help.rb
+++ b/lib/rubocop/cop/mixin/line_length_help.rb
@@ -79,8 +79,7 @@ module RuboCop
       end
 
       def line_length_without_directive(line)
-        before_comment, = line.split(CommentConfig::COMMENT_DIRECTIVE_REGEXP)
-        before_comment.rstrip.length
+        DirectiveComment.before_comment(line).rstrip.length
       end
     end
   end

--- a/lib/rubocop/cop/mixin/line_length_help.rb
+++ b/lib/rubocop/cop/mixin/line_length_help.rb
@@ -16,7 +16,7 @@ module RuboCop
 
         return false unless comment
 
-        comment.text.match?(CommentConfig::COMMENT_DIRECTIVE_REGEXP)
+        !!DirectiveComment.new(comment).match_captures
       end
 
       def allow_uri?

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -70,8 +70,8 @@ module RuboCop
         end
 
         def directive_cops(comment)
-          match = CommentConfig::COMMENT_DIRECTIVE_REGEXP.match(comment.text)
-          match && match[2] ? match[2].split(',').map(&:strip) : []
+          match_captures = DirectiveComment.new(comment).match_captures
+          match_captures && match_captures[1] ? match_captures[1].split(',').map(&:strip) : []
         end
 
         def allowed_cops

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -35,6 +35,11 @@ module RuboCop
       cops_string.split(/,\s*/).uniq.sort
     end
 
+    # Checks if this directive relates to single line
+    def single_line?
+      !self.class.before_comment(comment.text).empty?
+    end
+
     # Checks if this directive contains all the given cop names
     def match?(cop_names)
       cops == cop_names.uniq.sort

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -17,6 +17,10 @@ module RuboCop
         .gsub(' ', '\s*')
     )
 
+    def self.before_comment(line)
+      line.split(DIRECTIVE_COMMENT_REGEXP).first
+    end
+
     attr_reader :comment
 
     def initialize(comment)

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -96,4 +96,21 @@ RSpec.describe RuboCop::DirectiveComment do
       end
     end
   end
+
+  describe '#match_captures' do
+    subject { directive_comment.match_captures }
+
+    [
+      ['when disable', '# rubocop:disable all', ['disable', 'all', nil, nil]],
+      ['when enable', '# rubocop:enable Foo/Bar', ['enable', 'Foo/Bar', nil, 'Foo/']],
+      ['when todo', '# rubocop:todo all', ['todo', 'all', nil, nil]],
+      ['when typo', '# rudocop:todo Dig/ThisMine', nil]
+    ].each do |example|
+      context example[0] do
+        let(:text) { example[1] }
+
+        it { is_expected.to eq example[2] }
+      end
+    end
+  end
 end

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -7,6 +7,21 @@ RSpec.describe RuboCop::DirectiveComment do
   let(:comment_cop_names) { 'all' }
   let(:text) { "#rubocop:enable #{comment_cop_names}" }
 
+  describe '.before_comment' do
+    subject { described_class.before_comment(text) }
+
+    [
+      ['when line has code', 'def foo # rubocop:disable all', 'def foo '],
+      ['when line has NO code', '# rubocop:disable all', '']
+    ].each do |example|
+      context example[0] do
+        let(:text) { example[1] }
+
+        it { is_expected.to eq example[2] }
+      end
+    end
+  end
+
   describe '#cops' do
     subject(:cops) { directive_comment.cops }
 

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -128,4 +128,19 @@ RSpec.describe RuboCop::DirectiveComment do
       end
     end
   end
+
+  describe '#single_line?' do
+    subject { directive_comment.single_line? }
+
+    [
+      ['when relates to single line', 'def foo # rubocop:disable all', true],
+      ['when does NOT relate to single line', '# rubocop:disable all', false]
+    ].each do |example|
+      context example[0] do
+        let(:text) { example[1] }
+
+        it { is_expected.to eq example[2] }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Part of https://github.com/rubocop/rubocop/issues/9563

- Directive comment regexp and matching helper moved to DerectiveComment.
- Direct execution of private directive comment regexp replaced with matching helper from DerectiveComment.
- In other cases added `before_comment` and `single_line?` helpers to prevent direct execution of private directive comment regexp.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
