### PR TITLE
Add readability to CommentConfig spec source

### DIFF
--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -5,62 +5,63 @@ RSpec.describe RuboCop::CommentConfig do
 
   describe '#cop_enabled_at_line?' do
     let(:source) do
-      [
-        '# rubocop:disable Metrics/MethodLength with a comment why',
-        'def some_method',
-        "  puts 'foo'",                                      # 3
-        'end',
-        '# rubocop:enable Metrics/MethodLength',
-        '',
-        '# rubocop:disable all',
-        'some_method',                                       # 8
-        '# rubocop:enable all',
-        '',
-        "code = 'This is evil.'",
-        'eval(code) # rubocop:disable Security/Eval',
-        "puts 'This is not evil.'",                          # 12
-        '',
-        'def some_method',
-        "  puts 'Disabling indented single line' # rubocop:disable " \
-        'Layout/LineLength',
-        'end',
-        '',                                                  # 18
-        'string = <<END',
-        'This is a string not a real comment # rubocop:disable Style/Loop',
-        'END',
-        '',
-        'foo # rubocop:disable Style/MethodCallWithoutArgsParentheses', # 23
-        '',
-        '# rubocop:enable Lint/Void',
-        '',
-        '# rubocop:disable Style/For, Style/Not,Layout/IndentationStyle',
-        'foo',                                               # 28
-        '',
-        'class One',
-        '  # rubocop:disable Style/ClassVars',
-        '  @@class_var = 1',
-        'end',                                               # 33
-        '',
-        'class Two',
-        '  # rubocop:disable Style/ClassVars',
-        '  @@class_var = 2',
-        'end',                                               # 38
-        '# rubocop:enable Style/Not,Layout/IndentationStyle',
-        '# rubocop:disable Style/Send, Lint/RandOne some comment why',
-        '# rubocop:disable Layout/BlockAlignment some comment why',
-        '# rubocop:enable Style/Send, Layout/BlockAlignment but why?',
-        '# rubocop:enable Lint/RandOne foo bar!',            # 43
-        '# rubocop:disable Lint/EmptyInterpolation',
-        '"result is #{}"',
-        '# rubocop:enable Lint/EmptyInterpolation',
-        '# rubocop:disable RSpec/Example',
-        '# rubocop:disable Custom2/Number9',                 # 48
-        '',
-        '#=SomeDslDirective # rubocop:disable Layout/LeadingCommentSpace',
-        '# rubocop:disable RSpec/Rails/HttpStatus',
-        'it { is_expected.to have_http_status 200 }',        # 52
-        '# rubocop:enable RSpec/Rails/HttpStatus'
-      ].join("\n")
+      # rubocop:disable Lint/EmptyExpression, Lint/EmptyInterpolation
+      <<~RUBY
+        # rubocop:disable Metrics/MethodLength with a comment why
+        def some_method
+          puts 'foo'                                                        # 03
+        end
+        # rubocop:enable Metrics/MethodLength
+
+        # rubocop:disable all
+        some_method                                                         # 08
+        # rubocop:enable all
+
+        code = 'This is evil.'
+        eval(code) # rubocop:disable Security/Eval
+        puts 'This is not evil.'                                            # 12
+
+        def some_method
+          puts 'Disabling indented single line' # rubocop:disable Layout/LineLength
+        end
+                                                                            # 18
+        string = <<END
+        This is a string not a real comment # rubocop:disable Style/Loop
+        END
+
+        foo # rubocop:disable Style/MethodCallWithoutArgsParentheses        # 23
+
+        # rubocop:enable Lint/Void
+
+        # rubocop:disable Style/For, Style/Not,Layout/IndentationStyle
+        foo                                                                 # 28
+
+        class One
+          # rubocop:disable Style/ClassVars
+          @@class_var = 1
+        end                                                                 # 33
+
+        class Two
+          # rubocop:disable Style/ClassVars
+          @@class_var = 2
+        end                                                                 # 38
+        # rubocop:enable Style/Not,Layout/IndentationStyle
+        # rubocop:disable Style/Send, Lint/RandOne some comment why
+        # rubocop:disable Layout/BlockAlignment some comment why
+        # rubocop:enable Style/Send, Layout/BlockAlignment but why?
+        # rubocop:enable Lint/RandOne foo bar!                              # 43
+        # rubocop:disable Lint/EmptyInterpolation
+        "result is #{}"
+        # rubocop:enable Lint/EmptyInterpolation
+        # rubocop:disable RSpec/Example
+        # rubocop:disable Custom2/Number9                                   # 48
+
+        #=SomeDslDirective # rubocop:disable Layout/LeadingCommentSpace
+        # rubocop:disable RSpec/Rails/HttpStatus
+        it { is_expected.to have_http_status 200 }                          # 52
+        # rubocop:enable RSpec/Rails/HttpStatus
+      RUBY
+      # rubocop:enable Lint/EmptyExpression, Lint/EmptyInterpolation
     end
 
     def disabled_lines_of_cop(cop)


### PR DESCRIPTION
Part of https://github.com/rubocop/rubocop/issues/9563

Added readability to CommentConfig spec source by replacing string joining with heredoc.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
