### PR TITLE
Add spec for CommentConfig#cop_disabled_line_ranges

### DIFF
--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -179,4 +179,26 @@ RSpec.describe RuboCop::CommentConfig do
         .to eq([7, 8, 9, 50])
     end
   end
+
+  describe '#cop_disabled_line_ranges' do
+    subject(:range) { comment_config.cop_disabled_line_ranges }
+
+    let(:source) do
+      <<~RUBY
+        # rubocop:disable Metrics/MethodLength with a comment why'
+        def some_method
+          puts 'foo'
+        end
+        # rubocop:enable Metrics/MethodLength
+
+        code = 'This is evil.'
+        eval(code) # rubocop:disable Security/Eval
+        puts 'This is not evil.'
+      RUBY
+    end
+
+    it 'collects line ranges by disabled cops' do
+      expect(range).to eq({ 'Metrics/MethodLength' => [1..5], 'Security/Eval' => [8..8] })
+    end
+  end
 end


### PR DESCRIPTION
Part of https://github.com/rubocop/rubocop/issues/9563

Added missing spec for CommentConfig#cop_disabled_line_ranges

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
