### PR TITLE
Fix typo in Style::RedundantSelf documentation

### DIFF
--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -9001,7 +9001,7 @@ The usage of `self` is only needed when:
   presence of a method name clash with an argument or a local
   variable.
 
-* Calling an attribute writer to prevent an local variable assignment.
+* Calling an attribute writer to prevent a local variable assignment.
 
 Note, with using explicit self you can only send messages with public or
 protected scope, you cannot send private messages this way.

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -11,7 +11,7 @@ module RuboCop
       #   presence of a method name clash with an argument or a local
       #   variable.
       #
-      # * Calling an attribute writer to prevent an local variable assignment.
+      # * Calling an attribute writer to prevent a local variable assignment.
       #
       # Note, with using explicit self you can only send messages with public or
       # protected scope, you cannot send private messages this way.


### PR DESCRIPTION
Fixes grammatical mistake in Style::RedundantSelf documentation by updating `an` to `a`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
