### PR TITLE
Add spec for CommentConfig#extra_enabled_comments

### DIFF
--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe RuboCop::CommentConfig do
 
     let(:source) do
       <<~RUBY
-        # rubocop:disable Metrics/MethodLength with a comment why'
+        # rubocop:disable Metrics/MethodLength with a comment why
         def some_method
           puts 'foo'
         end
@@ -200,6 +200,30 @@ RSpec.describe RuboCop::CommentConfig do
 
     it 'collects line ranges by disabled cops' do
       expect(range).to eq({ 'Metrics/MethodLength' => [1..5], 'Security/Eval' => [8..8] })
+    end
+  end
+
+  describe '#extra_enabled_comments' do
+    subject(:extra) { comment_config.extra_enabled_comments }
+
+    let(:source) do
+      <<~RUBY
+        # rubocop:enable Metrics/MethodLength, Security/Eval
+        def some_method
+          puts 'foo'
+        end
+      RUBY
+    end
+
+    it 'has keys as instances of Parser::Source::Comment for extra enabled comments' do
+      key = extra.keys.first
+
+      expect(key.is_a?(Parser::Source::Comment)).to be true
+      expect(key.text).to eq '# rubocop:enable Metrics/MethodLength, Security/Eval'
+    end
+
+    it 'has values as arrays of extra enabled cops' do
+      expect(extra.values.first).to eq ['Metrics/MethodLength', 'Security/Eval']
     end
   end
 end


### PR DESCRIPTION
Part of https://github.com/rubocop/rubocop/issues/9563

- Added missing spec for CommentConfig#extra_enabled_comments
- Also fixed typo in another spec

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
