### PR TITLE
Add spec for CommentConfig#comment_only_line?

### DIFF
--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::CommentConfig do
           puts 'Disabling indented single line' # rubocop:disable Layout/LineLength
         end
                                                                             # 18
-        string = <<END
+        string = <<~END
         This is a string not a real comment # rubocop:disable Style/Loop
         END
 
@@ -224,6 +224,53 @@ RSpec.describe RuboCop::CommentConfig do
 
     it 'has values as arrays of extra enabled cops' do
       expect(extra.values.first).to eq ['Metrics/MethodLength', 'Security/Eval']
+    end
+  end
+
+  describe 'comment_only_line?' do
+    let(:source) do
+      <<~RUBY
+        # rubocop:disable Metrics/MethodLength                                01
+        def some_method
+          puts 'foo'
+        end
+        # rubocop:enable Metrics/MethodLength                                 05
+
+        code = 'This is evil.'
+        eval(code) # rubocop:disable Security/Eval
+      RUBY
+    end
+
+    context 'when line contains only comment' do
+      [1, 5].each do |line_number|
+        it 'returns true' do
+          expect(comment_config.comment_only_line?(line_number)).to be true
+        end
+      end
+    end
+
+    context 'when line is empty' do
+      [6].each do |line_number|
+        it 'returns true' do
+          expect(comment_config.comment_only_line?(line_number)).to be true
+        end
+      end
+    end
+
+    context 'when line contains only code' do
+      [2, 3, 4, 7].each do |line_number|
+        it 'returns false' do
+          expect(comment_config.comment_only_line?(line_number)).to be false
+        end
+      end
+    end
+
+    context 'when line contains code and comment' do
+      [8].each do |line_number|
+        it 'returns false' do
+          expect(comment_config.comment_only_line?(line_number)).to be false
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Part of https://github.com/rubocop/rubocop/issues/9563

- Added spec for CommentConfig#comment_only_line?
- Also fixed typo in another spec
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
