### PR TITLE
[Fix #9582] Fix incorrect auto-correct for `Style/ClassEqualityComparison`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_class_equality_comparison.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_class_equality_comparison.md
@@ -1,0 +1,1 @@
+* [#9582](https://github.com/rubocop/rubocop/issues/9582): Fix incorrect auto-correct for `Style/ClassEqualityComparison` when comparing `Module#name` for equality. ([@koic][])

--- a/lib/rubocop/cop/style/class_equality_comparison.rb
+++ b/lib/rubocop/cop/style/class_equality_comparison.rb
@@ -50,6 +50,8 @@ module RuboCop
 
         def class_name(class_node, node)
           if node.children.first.method?(:name)
+            return class_node.receiver.source if class_node.receiver
+
             class_node.source.delete('"').delete("'")
           else
             class_node.source

--- a/spec/rubocop/cop/style/class_equality_comparison_spec.rb
+++ b/spec/rubocop/cop/style/class_equality_comparison_spec.rb
@@ -49,6 +49,17 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when comparing `Module#name` for equality' do
+    expect_offense(<<~RUBY)
+      var.class.name == Date.name
+          ^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      var.instance_of?(Date)
+    RUBY
+  end
+
   it 'registers an offense and corrects when comparing double quoted class name for equality' do
     expect_offense(<<~RUBY)
       var.class.name == "Date"


### PR DESCRIPTION
Fixes #9582.

This PR fixes incorrect auto-correct for `Style/ClassEqualityComparison` when comparing `Module#name` for equality.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
