### PR TITLE
Use `Cop::Base` API for `Style/RescueModifier`

### DIFF
--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -201,10 +201,10 @@ RSpec.describe RuboCop::Cop::Style::RescueModifier, :config do
       expect_correction(<<~RUBY)
         begin
           begin
-            blah
-          rescue
-            1
-          end
+          blah
+        rescue
+          1
+        end
         rescue
           2
         end

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -201,11 +201,16 @@ RSpec.describe RuboCop::Cop::Team do
       include_context 'mock console output'
 
       before do
-        allow_any_instance_of(RuboCop::Cop::Style::RescueModifier)
+        allow_any_instance_of(RuboCop::Cop::Bundler::OrderedGems)
           .to receive(:autocorrect).and_return(buggy_correction)
 
-        create_file(file_path, 'some_method rescue handle_error')
+        create_file(file_path, <<~RUBY)
+          gem 'rubocop'
+          gem 'rspec'
+        RUBY
       end
+
+      let(:file_path) { '/tmp/Gemfile' }
 
       let(:buggy_correction) do
         lambda do |_corrector|
@@ -217,8 +222,8 @@ RSpec.describe RuboCop::Cop::Team do
       let(:cause) { StandardError.new('cause') }
 
       let(:error_message) do
-        'An error occurred while Style/RescueModifier cop was inspecting ' \
-        '/tmp/example.rb:1:12.'
+        'An error occurred while Bundler/OrderedGems cop was inspecting ' \
+        '/tmp/Gemfile.'
       end
 
       it 'records Team#errors' do


### PR DESCRIPTION
Follow https://github.com/rubocop/rubocop/pull/7868.

This PR uses `Cop::Base` API for `Style/RescueModifier`. It uses `corrector.remove`, `corrector.before_insert`, and `corrector.after_insert` instead of `corrector.replace` to prevent `Parser::ClobberingError` when auto-correction.
This change degenerates the code indentation that auto-corrected for `foo rescue bar rescue baz`, but I think nested `rescue` is an edge case and is not a critical path as it can be auto-corrected with `Layout/IndentationWidth` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
