### PR TITLE
[Fix #9586] Update `Naming/RescuedExceptionsVariableName` to not register on inner rescues when nested.

### DIFF
--- a/changelog/fix_update_naming_rescued_exceptions_variable_name.md
+++ b/changelog/fix_update_naming_rescued_exceptions_variable_name.md
@@ -1,0 +1,1 @@
+* [#9586](https://github.com/rubocop/rubocop/issues/9586): Update `Naming/RescuedExceptionsVariableName` to not register on inner rescues when nested. ([@dvandersluis][])

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -391,6 +391,59 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
         RUBY
       end
     end
+
+    context 'with multiple branches' do
+      it 'registers and corrects each offense' do
+        expect_offense(<<~RUBY)
+          begin
+            something
+          rescue MyException => exc
+                                ^^^ Use `e` instead of `exc`.
+            # do something
+          rescue OtherException => exc
+                                   ^^^ Use `e` instead of `exc`.
+            # do something else
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          begin
+            something
+          rescue MyException => e
+            # do something
+          rescue OtherException => e
+            # do something else
+          end
+        RUBY
+      end
+    end
+
+    context 'with nested rescues' do
+      it 'handles it' do
+        expect_offense(<<~RUBY)
+          begin
+          rescue StandardError => e1
+                                  ^^ Use `e` instead of `e1`.
+            begin
+              log(e1)
+            rescue StandardError => e2
+              log(e1, e2)
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          begin
+          rescue StandardError => e
+            begin
+              log(e)
+            rescue StandardError => e2
+              log(e, e2)
+            end
+          end
+        RUBY
+      end
+    end
   end
 
   context 'with the `PreferredName` setup' do


### PR DESCRIPTION
Fixes #9586.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
