### PR TITLE
Replace CommentConfig#directive_parts with DirectiveComment instance

### DIFF
--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -6,6 +6,8 @@ module RuboCop
   # cops it contains.
   class DirectiveComment
     # @api private
+    REDUNDANT_COP = 'Lint/RedundantCopDisableDirective'
+    # @api private
     COP_NAME_PATTERN = '([A-Z]\w+/)*(?:[A-Z]\w+)'
     # @api private
     COP_NAMES_PATTERN = "(?:#{COP_NAME_PATTERN} , )*#{COP_NAME_PATTERN}"
@@ -47,10 +49,29 @@ module RuboCop
       @match_captures ||= comment.text.match(DIRECTIVE_COMMENT_REGEXP)&.captures
     end
 
+    # Checks if this directive disables cops
+    def disabled?
+      %w[disable todo].include?(mode)
+    end
+
+    # Checks if all cops specified in this directive
+    def all_cops?
+      cops == 'all'
+    end
+
+    # Returns array of specified in this directive cop names
+    def cop_names
+      @cop_names ||= all_cops? ? all_cop_names : parsed_cop_names
+    end
+
     private
 
     def parsed_cop_names
       (cops || '').split(/,\s*/)
+    end
+
+    def all_cop_names
+      Cop::Registry.global.names - [REDUNDANT_COP]
     end
   end
 end

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -21,18 +21,11 @@ module RuboCop
       line.split(DIRECTIVE_COMMENT_REGEXP).first
     end
 
-    attr_reader :comment
+    attr_reader :comment, :mode, :cops
 
     def initialize(comment)
       @comment = comment
-    end
-
-    # Return all the cops specified in the directive
-    def cops
-      return unless match_captures
-
-      cops_string = match_captures[1]
-      cops_string.split(/,\s*/).uniq.sort
+      @mode, @cops = match_captures
     end
 
     # Checks if this directive relates to single line
@@ -42,7 +35,7 @@ module RuboCop
 
     # Checks if this directive contains all the given cop names
     def match?(cop_names)
-      cops == cop_names.uniq.sort
+      parsed_cop_names.uniq.sort == cop_names.uniq.sort
     end
 
     def range
@@ -52,6 +45,12 @@ module RuboCop
     # Returns match captures to directive comment pattern
     def match_captures
       @match_captures ||= comment.text.match(DIRECTIVE_COMMENT_REGEXP)&.captures
+    end
+
+    private
+
+    def parsed_cop_names
+      (cops || '').split(/,\s*/)
     end
   end
 end

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -22,42 +22,6 @@ RSpec.describe RuboCop::DirectiveComment do
     end
   end
 
-  describe '#cops' do
-    subject(:cops) { directive_comment.cops }
-
-    context 'all' do
-      let(:comment_cop_names) { 'all' }
-
-      it 'returns [all]' do
-        expect(cops).to eq(%w[all])
-      end
-    end
-
-    context 'single cop' do
-      let(:comment_cop_names) { 'Metrics/AbcSize' }
-
-      it 'returns [Metrics/AbcSize]' do
-        expect(cops).to eq(%w[Metrics/AbcSize])
-      end
-    end
-
-    context 'single cop duplicated' do
-      let(:comment_cop_names) { 'Metrics/AbcSize,Metrics/AbcSize' }
-
-      it 'returns [Metrics/AbcSize]' do
-        expect(cops).to eq(%w[Metrics/AbcSize])
-      end
-    end
-
-    context 'multiple cops' do
-      let(:comment_cop_names) { 'Style/Not, Metrics/AbcSize' }
-
-      it 'returns the cops in alphabetical order' do
-        expect(cops).to eq(%w[Metrics/AbcSize Style/Not])
-      end
-    end
-  end
-
   describe '#match?' do
     subject(:match) { directive_comment.match?(cop_names) }
 
@@ -105,6 +69,15 @@ RSpec.describe RuboCop::DirectiveComment do
 
     context 'duplicate names' do
       let(:cop_names) { %w[Metrics/AbcSize Metrics/AbcSize Metrics/PerceivedComplexity Style/Not] }
+
+      it 'returns true' do
+        expect(match).to eq(true)
+      end
+    end
+
+    context 'all' do
+      let(:comment_cop_names) { 'all' }
+      let(:cop_names) { %w[all] }
 
       it 'returns true' do
         expect(match).to eq(true)

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -116,4 +116,59 @@ RSpec.describe RuboCop::DirectiveComment do
       end
     end
   end
+
+  describe '#disabled?' do
+    subject { directive_comment.disabled? }
+
+    [
+      ['when disable', '# rubocop:disable all', true],
+      ['when enable', '# rubocop:enable Foo/Bar', false],
+      ['when todo', '# rubocop:todo all', true]
+    ].each do |example|
+      context example[0] do
+        let(:text) { example[1] }
+
+        it { is_expected.to eq example[2] }
+      end
+    end
+  end
+
+  describe '#all_cops?' do
+    subject { directive_comment.all_cops? }
+
+    [
+      ['when mentioned all', '# rubocop:disable all', true],
+      ['when mentioned specific cops', '# rubocop:enable Foo/Bar', false]
+    ].each do |example|
+      context example[0] do
+        let(:text) { example[1] }
+
+        it { is_expected.to eq example[2] }
+      end
+    end
+  end
+
+  describe '#cop_names' do
+    subject(:cop_names) { directive_comment.cop_names }
+
+    context 'when all cops mentioned' do
+      let(:comment_cop_names) { 'all' }
+      let(:global) { instance_double(RuboCop::Cop::Registry, names: names) }
+      let(:names) { %w[all_names Lint/RedundantCopDisableDirective] }
+
+      before { allow(RuboCop::Cop::Registry).to receive(:global).and_return(global) }
+
+      it 'returns all cop names except redundant' do
+        expect(cop_names).to eq(%w[all_names])
+      end
+    end
+
+    context 'when cop specified' do
+      let(:comment_cop_names) { 'Foo/Bar' }
+
+      it 'returns parsed cop names' do
+        expect(cop_names).to eq(%w[Foo/Bar])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Part of https://github.com/rubocop/rubocop/issues/9563

- CommentConfig#directive_parts replaced  with DirectiveComment instance.
- Further we're going to continue moving part of responsibility to DirectiveComment

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
