### PR TITLE
[Fix #9591] Add `AllowMethodDefinitionArgument` option to `Layout/FirstArgumentIndentation`

### DIFF
--- a/changelog/new_add_allow_method_definition_argument_to_first_argument_indentation.md
+++ b/changelog/new_add_allow_method_definition_argument_to_first_argument_indentation.md
@@ -1,0 +1,1 @@
+* [#9591](https://github.com/rubocop/rubocop/issues/9591): Add `AllowMethodDefinitionArgument` option to `Layout/FirstArgumentIndentation`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -654,6 +654,7 @@ Layout/FirstArgumentIndentation:
   # By default, the indentation width from `Layout/IndentationWidth` is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
+  AllowMethodDefinitionArgument: false
 
 Layout/FirstArrayElementIndentation:
   Description: >-


### PR DESCRIPTION
Fixes #9591.

This PR adds `AllowMethodDefinitionArgument` option to `Layout/FirstArgumentIndentation`. The new option is intended to support the following style:
https://thepugautomatic.com/2015/01/backslashy-ruby/

It specifies `false` as the default value for the new option to keep the existing behavior.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
