### PR TITLE
[Fix #9593] Fix an error when processing a directory is named `{}`

### DIFF
--- a/changelog/fix_an_error_when_processing_dir_is_named_empty_braces.md
+++ b/changelog/fix_an_error_when_processing_dir_is_named_empty_braces.md
@@ -1,0 +1,1 @@
+* [#9593](https://github.com/rubocop/rubocop/issues/9593): Fix an error when processing a directory is named `{}`. ([@koic][])

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -96,6 +96,7 @@ module RuboCop
     end
 
     def wanted_dir_patterns(base_dir, exclude_pattern, flags)
+      base_dir = base_dir.gsub('/{}/', '/\{}/')
       dirs = Dir.glob(File.join(base_dir.gsub('/**/', '/\**/'), '*/'), flags)
                 .reject do |dir|
                   dir.end_with?('/./', '/../') || File.fnmatch?(exclude_pattern, dir, flags)

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -441,6 +441,19 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       expect(found_basenames).to include('ruby4.rb')
     end
 
+    it 'works also if a folder is named "{}"' do
+      create_empty_file('{}/ruby4.rb')
+
+      config = instance_double(RuboCop::Config)
+      exclude_property = { 'Exclude' => [File.expand_path('dir1/**/*')] }
+      allow(config).to receive(:for_all_cops).and_return(exclude_property)
+      allow(config_store).to receive(:for).and_return(config)
+
+      expect(found_basenames).not_to include('ruby1.rb')
+      expect(found_basenames).to include('ruby3.rb')
+      expect(found_basenames).to include('ruby4.rb')
+    end
+
     # Cannot create a directory with containing `*` character on Windows.
     # https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
     unless RuboCop::Platform.windows?


### PR DESCRIPTION
Fixes #9593.

This PR fixes the following error when processing a directory is named `{}`.

```console
% mkdir {}
% rubocop
(snip)

File name too long - /tmp//////////////////////////////////////////////...
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
