### PR TITLE
CI against latest stable version of JRuby (9.2.16.0)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,10 +187,7 @@ jobs:
   # JRuby 9.2
   jruby-9.2-spec:
     docker:
-      # FIXME: Workaround for JRuby 9.2.15.0.
-      # Please specify `circleci/jruby:9.2` when the following issue will be resolved.
-      # https://github.com/jruby/jruby/issues/6581
-      - image: circleci/jruby:9.2.14
+      - image: circleci/jruby:9.2
     environment:
       <<: *common_env
       <<: *jruby_env
@@ -198,10 +195,7 @@ jobs:
       *spec_steps
   jruby-9.2-ascii_spec:
     docker:
-      # FIXME: Workaround for JRuby 9.2.15.0.
-      # Please specify `circleci/jruby:9.2` when the following issue will be resolved.
-      # https://github.com/jruby/jruby/issues/6581
-      - image: circleci/jruby:9.2.14
+      - image: circleci/jruby:9.2
     environment:
       <<: *common_env
       <<: *jruby_env
@@ -209,10 +203,7 @@ jobs:
       *ascii_spec_steps
   jruby-9.2-rubocop:
     docker:
-      # FIXME: Workaround for JRuby 9.2.15.0.
-      # Please specify `circleci/jruby:9.2` when the following issue will be resolved.
-      # https://github.com/jruby/jruby/issues/6581
-      - image: circleci/jruby:9.2.14
+      - image: circleci/jruby:9.2
     environment:
       <<: *common_env
       <<: *jruby_env

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1183,11 +1183,6 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
       it 'prints all cops in their right department listing' do
         lines = stdout.lines
-        # FIXME: Remove the following workaround condition for JRuby.
-        # https://github.com/jruby/jruby/issues/6528
-        if RUBY_ENGINE == 'jruby' && Encoding.default_external == Encoding::ASCII
-          lines = lines.select(&:valid_encoding?)
-        end
         lines.slice_before(/Department /).each do |slice|
           departments = registry.departments.map(&:to_s)
           current =


### PR DESCRIPTION
This PR reverts workaround #9545 and https://github.com/rubocop/rubocop/pull/9347/commits/d0c8ae60c608ffcb6b73b31bf32411033c56e5ae.

@headius Thanks for solving these issue and releasing JRuby 9.2.16.0!
