### PR TITLE
Fix RuboCop::MagicComment#valid_shareable_constant_value?

### DIFF
--- a/changelog/fix_fix_valid_shareable_constant_value.md
+++ b/changelog/fix_fix_valid_shareable_constant_value.md
@@ -1,0 +1,1 @@
+* [#9598](https://github.com/rubocop/rubocop/pull/9598): Fix RuboCop::MagicComment#valid_shareable_constant_value?. ([@kachick][])

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -47,7 +47,7 @@ module RuboCop
     end
 
     def valid_shareable_constant_value?
-      %w[none literal experimental_everything experimental_copy].include?(shareable_constant_values)
+      %w[none literal experimental_everything experimental_copy].include?(shareable_constant_value)
     end
 
     # Was a magic comment for the frozen string literal found?

--- a/spec/rubocop/magic_comment_spec.rb
+++ b/spec/rubocop/magic_comment_spec.rb
@@ -151,4 +151,44 @@ RSpec.describe RuboCop::MagicComment do
   include_examples 'magic comment',
                    '# vim:fileencoding=utf-8',
                    encoding: nil
+
+  describe '#valid_shareable_constant_value?' do
+    subject { described_class.parse(comment).valid_shareable_constant_value? }
+
+    context 'when given comment specified as `none`' do
+      let(:comment) { '# shareable_constant_value: none' }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when given comment specified as `literal`' do
+      let(:comment) { '# shareable_constant_value: literal' }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when given comment specified as `experimental_everything`' do
+      let(:comment) { '# shareable_constant_value: experimental_everything' }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when given comment specified as `experimental_copy`' do
+      let(:comment) { '# shareable_constant_value: experimental_copy' }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when given comment specified as unknown value' do
+      let(:comment) { '# shareable_constant_value: unknown' }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when given comment is not specified' do
+      let(:comment) { '' }
+
+      it { is_expected.to eq(false) }
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes a tiny bug infected since https://github.com/rubocop/rubocop/pull/9412.
But I guess It breaks to the surface yet, because RuboCop does not have `shareable_constant_value` related cop yet.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
