### PR TITLE
[Fix #9599] Fix an error for `Style/CaseLikeIf`

### DIFF
--- a/changelog/fix_error_for_style_case_like_if.md
+++ b/changelog/fix_error_for_style_case_like_if.md
@@ -1,0 +1,1 @@
+* [#9599](https://github.com/rubocop/rubocop/issues/9599): Fix an error for `Style/CaseLikeIf` when using `include?` without a receiver. ([@koic][])

--- a/spec/rubocop/cop/style/case_like_if_spec.rb
+++ b/spec/rubocop/cop/style/case_like_if_spec.rb
@@ -156,6 +156,24 @@ RSpec.describe RuboCop::Cop::Style::CaseLikeIf, :config do
     RUBY
   end
 
+  it 'does not register an offense when using `include?` without a receiver' do
+    expect_no_offenses(<<~RUBY)
+      if include?(Foo)
+      elsif include?(Bar)
+      else
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `cover?` without a receiver' do
+    expect_no_offenses(<<~RUBY)
+      if x == 1
+      elsif cover?(Bar)
+      else
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `=~`' do
     expect_offense(<<~RUBY)
       if /foo/ =~ x


### PR DESCRIPTION
Fixes #9599.

This PR fixes an error for `Style/CaseLikeIf` when using `include?` without a receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
