### PR TITLE
[Fix #9601] Make `Style/RedundantBegin` aware of `begin` blocks around memoization

### DIFF
--- a/changelog/change_make_style_redundant_begin_aware_of_memoization.md
+++ b/changelog/change_make_style_redundant_begin_aware_of_memoization.md
@@ -1,0 +1,1 @@
+* [#9601](https://github.com/rubocop/rubocop/issues/9601): Make `Style/RedundantBegin` aware of redundant `begin`/`end` blocks around memoization. ([@koic][])

--- a/lib/rubocop/cop/mixin/uncommunicative_name.rb
+++ b/lib/rubocop/cop/mixin/uncommunicative_name.rb
@@ -53,12 +53,10 @@ module RuboCop
       end
 
       def name_type(node)
-        @name_type ||= begin
-          case node.type
-          when :block then 'block parameter'
-          when :def, :defs then 'method parameter'
-          end
-        end
+        @name_type ||= case node.type
+                       when :block then 'block parameter'
+                       when :def, :defs then 'method parameter'
+                       end
       end
 
       def num_offense(node, range)

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -63,6 +63,7 @@ module RuboCop
       #     end
       #   end
       class RedundantBegin < Base
+        include RangeHelp
         extend AutoCorrector
 
         MSG = 'Redundant `begin` block detected.'
@@ -95,10 +96,24 @@ module RuboCop
         private
 
         def register_offense(node)
-          add_offense(node.loc.begin) do |corrector|
-            corrector.remove(node.loc.begin)
+          offense_range = node.loc.begin
+
+          add_offense(offense_range) do |corrector|
+            if any_ancestor_assignment_node?(node)
+              replace_begin_with_statement(corrector, offense_range, node)
+            else
+              corrector.remove(offense_range)
+            end
+
             corrector.remove(node.loc.end)
           end
+        end
+
+        def replace_begin_with_statement(corrector, offense_range, node)
+          first_child = node.children.first
+
+          corrector.replace(offense_range, first_child.source)
+          corrector.remove(range_between(offense_range.end_pos, first_child.source_range.end_pos))
         end
 
         def empty_begin?(node)
@@ -114,8 +129,16 @@ module RuboCop
         def valid_context_using_only_begin?(node)
           parent = node.parent
 
-          node.each_ancestor.any?(&:assignment?) || parent&.post_condition_loop? ||
+          valid_begin_assignment?(node) || parent&.post_condition_loop? ||
             parent&.send_type? || parent&.operator_keyword?
+        end
+
+        def valid_begin_assignment?(node)
+          any_ancestor_assignment_node?(node) && !node.children.one?
+        end
+
+        def any_ancestor_assignment_node?(node)
+          node.each_ancestor.any?(&:assignment?)
         end
       end
     end

--- a/lib/rubocop/ext/regexp_parser.rb
+++ b/lib/rubocop/ext/regexp_parser.rb
@@ -39,9 +39,8 @@ module RuboCop
 
             # Shortcut to `loc.expression`
             def expression
-              @expression ||= begin
-                origin.adjust(begin_pos: start_index, end_pos: start_index + full_length)
-              end
+              end_pos = start_index + full_length
+              @expression ||= origin.adjust(begin_pos: start_index, end_pos: end_pos)
             end
           end
 
@@ -60,9 +59,7 @@ module RuboCop
           #
           # Please open issue if you need other locations
           def loc
-            @loc ||= begin
-              Map.new(expression, **build_location)
-            end
+            @loc ||= Map.new(expression, **build_location)
           end
 
           private

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -195,11 +195,50 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     RUBY
   end
 
-  it 'does not register an offense when using `begin` for or assignment' do
+  it 'registers and corrects an offense when using `begin` with single statement for or assignment' do
+    expect_offense(<<~RUBY)
+      var ||= begin
+              ^^^^^ Redundant `begin` block detected.
+        foo
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      var ||= foo
+
+    RUBY
+  end
+
+  it 'registers and corrects an offense when using `begin` with single statement that called a block for or assignment' do
+    expect_offense(<<~RUBY)
+      var ||= begin
+              ^^^^^ Redundant `begin` block detected.
+        foo do |arg|
+          bar
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      var ||= foo do |arg|
+          bar
+        end
+
+    RUBY
+  end
+
+  it 'does not register an offense when using `begin` with multiple statement for or assignment' do
     expect_no_offenses(<<~RUBY)
       var ||= begin
         foo
         bar
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `begin` with no statements for or assignment' do
+    expect_no_offenses(<<~RUBY)
+      var ||= begin
       end
     RUBY
   end


### PR DESCRIPTION
Fixes #9601.

This PR makes `Style/RedundantBegin` aware of redundant `begin`/`end` blocks around memoization.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
