### PR TITLE
[Fix #9603] Fix a false positive for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_false_positive_for_style_sole_nested_conditional.md
+++ b/changelog/fix_false_positive_for_style_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#9603](https://github.com/rubocop/rubocop/issues/9603): Fix a false positive for `Style/SoleNestedConditional` when using nested modifier on value assigned in condition. ([@koic][])

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -428,6 +428,22 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'does not register an offense when using nested modifier on value assigned in single condition' do
+    expect_no_offenses(<<~RUBY)
+      if var = foo
+        do_something if var
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using nested modifier on value assigned in multiple conditions' do
+    expect_no_offenses(<<~RUBY)
+      if cond && var = foo
+        do_something if var
+      end
+    RUBY
+  end
+
   context 'when the inner condition has a send node without parens' do
     context 'in guard style' do
       it 'registers an offense and corrects' do


### PR DESCRIPTION
Fixes #9603.

This PR fixes a false positive for `Style/SoleNestedConditional` when using nested modifier on value assigned in condition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
