### PR TITLE
[Fix #9606] Fix an error for `Layout/IndentationConsistency`

### DIFF
--- a/changelog/fix_error_for_layout_indentation_consistency.md
+++ b/changelog/fix_error_for_layout_indentation_consistency.md
@@ -1,0 +1,1 @@
+* [#9606](https://github.com/rubocop/rubocop/issues/9606): Fix an error for `Layout/IndentationConsistency` when using access modifier at the top level. ([@koic][])

--- a/lib/rubocop/cop/layout/indentation_consistency.rb
+++ b/lib/rubocop/cop/layout/indentation_consistency.rb
@@ -162,8 +162,10 @@ module RuboCop
           # to the level of the module (see `AccessModifierIndentation` cop) we
           # return nil so that `check_alignment` will derive the correct
           # indentation from the first child that is not an access modifier.
-          module_indent = display_column(node.parent.source_range)
           access_modifier_indent = display_column(first_child.source_range)
+          return access_modifier_indent unless node.parent
+
+          module_indent = display_column(node.parent.source_range)
           access_modifier_indent if access_modifier_indent > module_indent
         end
 

--- a/spec/rubocop/cop/layout/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_consistency_spec.rb
@@ -9,6 +9,33 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
         "#{}"
       RUBY
     end
+
+    it 'accepts when using access modifier at the top level' do
+      expect_no_offenses(<<~'RUBY')
+        public
+
+        def foo
+        end
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using access modifier and dedented method definition ' \
+       'at the top level' do
+      expect_offense(<<~'RUBY')
+        public
+
+          def foo
+          ^^^^^^^ Inconsistent indentation detected.
+          end
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        public
+
+        def foo
+        end
+      RUBY
+    end
   end
 
   context 'with if statement' do


### PR DESCRIPTION
Fixes #9606.

This PR fixes the following error for `Layout/IndentationConsistency` when using access modifier at the top level.

```console
% cat example.rb
public

def foo
end

% bundle exec rubocop --only Layout/IndentationConsistency example.rb -d
(snip)

Scanning /Users/koic/src/github.com/koic/rubocop-issues/9606/example.rb
An error occurred while Layout/IndentationConsistency cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/9606/example.rb:1:0.
undefined method `source_range' for nil:NilClass
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/layout/indentation_consistency.rb:165:in
`base_column_for_normal_style'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/layout/indentation_consistency.rb:181:in
`check_normal_style'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/layout/indentation_consistency.rb:174:in
`check'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/layout/indentation_consistency.rb:129:in
`on_begin'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
