### PR TITLE
[Fix #9608] Fix a false positive for `Layout/EmptyLineAfterGuardClause`

### DIFF
--- a/changelog/fix_false_positive_for_layout_empty_line_after_guard_clause.md
+++ b/changelog/fix_false_positive_for_layout_empty_line_after_guard_clause.md
@@ -1,0 +1,1 @@
+* [#9608](https://github.com/rubocop/rubocop/issues/9608): Fix a false positive for `Layout/EmptyLineAfterGuardClause` when using guard clause is after `rubocop:enable` comment. ([@koic][])

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -54,6 +54,11 @@ module RuboCop
       %w[disable todo].include?(mode)
     end
 
+    # Checks if this directive enables cops
+    def enabled?
+      mode == 'enable'
+    end
+
     # Checks if this directive enables all cops
     def enabled_all?
       !disabled? && all_cops?

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -199,6 +199,50 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
+  it 'registers and corrects when using guard clause is after `rubocop:disable` comment' do
+    expect_offense(<<~RUBY)
+      def foo
+        return if condition
+        ^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+        # rubocop:disable Department/Cop
+        bar
+        # rubocop:enable Department/Cop
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        return if condition
+
+        # rubocop:disable Department/Cop
+        bar
+        # rubocop:enable Department/Cop
+      end
+    RUBY
+  end
+
+  it 'registers and corrects when using guard clause is after `rubocop:enable` comment' do
+    expect_offense(<<~RUBY)
+      def foo
+        # rubocop:disable Department/Cop
+        return if condition
+        ^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+        # rubocop:enable Department/Cop
+        bar
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        # rubocop:disable Department/Cop
+        return if condition
+        # rubocop:enable Department/Cop
+
+        bar
+      end
+    RUBY
+  end
+
   it 'accepts modifier if' do
     expect_no_offenses(<<~RUBY)
       def foo
@@ -266,6 +310,18 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
         raise ArgumentError, 'HTTP redirect too deep' if limit.zero?
 
         foobar
+      end
+    RUBY
+  end
+
+  it 'accepts using guard clause is after `rubocop:enable` comment' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        # rubocop:disable Department/Cop
+        return if condition
+        # rubocop:enable Department/Cop
+
+        bar
       end
     RUBY
   end

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -133,6 +133,22 @@ RSpec.describe RuboCop::DirectiveComment do
     end
   end
 
+  describe '#enabled?' do
+    subject { directive_comment.enabled? }
+
+    [
+      ['when disable', '# rubocop:disable all', false],
+      ['when enable', '# rubocop:enable Foo/Bar', true],
+      ['when todo', '# rubocop:todo all', false]
+    ].each do |example|
+      context example[0] do
+        let(:text) { example[1] }
+
+        it { is_expected.to eq example[2] }
+      end
+    end
+  end
+
   describe '#all_cops?' do
     subject { directive_comment.all_cops? }
 


### PR DESCRIPTION
Fixes #9608.

This PR fixes a false positive for `Layout/EmptyLineAfterGuardClause` when using guard clause is after `rubocop:enable` comment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
