### PR TITLE
[Fix #9563] Refactor CommentConfig

### DIFF
--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -54,6 +54,11 @@ module RuboCop
       %w[disable todo].include?(mode)
     end
 
+    # Checks if this directive enables all cops
+    def enabled_all?
+      !disabled? && all_cops?
+    end
+
     # Checks if all cops specified in this directive
     def all_cops?
       cops == 'all'
@@ -62,6 +67,11 @@ module RuboCop
     # Returns array of specified in this directive cop names
     def cop_names
       @cop_names ||= all_cops? ? all_cop_names : parsed_cop_names
+    end
+
+    # Returns line number for directive
+    def line_number
+      comment.loc.expression.line
     end
 
     private

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -171,4 +171,31 @@ RSpec.describe RuboCop::DirectiveComment do
       end
     end
   end
+
+  describe '#line_number' do
+    let(:comment) { instance_double(Parser::Source::Comment, text: text, loc: loc) }
+    let(:loc) { instance_double(Parser::Source::Map, expression: expression) }
+    let(:expression) { instance_double(Parser::Source::Range, line: 1) }
+
+    it 'returns line number for directive' do
+      expect(directive_comment.line_number).to be 1
+    end
+  end
+
+  describe '#enabled_all?' do
+    subject { directive_comment.enabled_all? }
+
+    [
+      ['when enabled all cops', 'def foo # rubocop:enable all', true],
+      ['when enabled specific cops', '# rubocop:enable Foo/Bar', false],
+      ['when disabled all cops', '# rubocop:disable all', false],
+      ['when disabled specific cops', '# rubocop:disable Foo/Bar', false]
+    ].each do |example|
+      context example[0] do
+        let(:text) { example[1] }
+
+        it { is_expected.to eq example[2] }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Last part of https://github.com/rubocop/rubocop/issues/9563

- Refactored CommentConfig
- Extra logic moved to DirectiveComment

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
