### PR TITLE
Allow parentheses in safe navigation calls for `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#9612](https://github.com/rubocop/rubocop/pull/9612): Allow parentheses in safe navigation calls for `Style/MethodCallWithArgsParentheses` `EnforcedStyle: omit_parentheses`. ([@gsamokovarov][])
+
 ## 1.11.0 (2021-03-01)
 
 ### New features

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -98,7 +98,7 @@ module RuboCop
 
           def call_with_ambiguous_arguments?(node)
             call_with_braced_block?(node) ||
-              call_as_argument_or_chain?(node) ||
+              call_in_safe_navigation_argument_or_chain?(node) ||
               hash_literal_in_arguments?(node) ||
               node.descendants.any? do |n|
                 ambigious_literal?(n) || logical_operator?(n) ||
@@ -111,10 +111,10 @@ module RuboCop
               node.block_node && node.block_node.braces?
           end
 
-          def call_as_argument_or_chain?(node)
-            node.parent &&
+          def call_in_safe_navigation_argument_or_chain?(node)
+            node.csend_type? || node.parent &&
               (node.parent.send_type? && !assigned_before?(node.parent, node) ||
-              node.parent.csend_type? || node.parent.super_type?)
+               node.parent.csend_type? || node.parent.super_type?)
           end
 
           def hash_literal_in_arguments?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -753,6 +753,10 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('Something.find(criteria: given)&.field')
     end
 
+    it 'accepts parens in safe operator calls' do
+      expect_no_offenses('foo&.[](bar)')
+    end
+
     context 'allowing parenthesis in chaining' do
       let(:cop_config) do
         {


### PR DESCRIPTION
While calls like `foo&.[] bar` do compile, I won't blame people if they
want to leave the parentheses so they know what's going on, even if
they chose to use `EnforcedStyle: omit_parentheses`.

I'm proposing we legitimize the parens in `foo&.[](bar)` and any other
safe navigation calls. I don't think this deserves extra configuration
either.

What do you folks think?
