### PR TITLE
[Fix #9613] Fix a false positive for `Style/RedundantSelf`

### DIFF
--- a/changelog/fix_false_positive_for_style_redundant_self_cop.md
+++ b/changelog/fix_false_positive_for_style_redundant_self_cop.md
@@ -1,0 +1,1 @@
+* [#9613](https://github.com/rubocop/rubocop/issues/9613): Fix a false positive for `Style/RedundantSelf` when a self receiver on an lvalue of mlhs arguments. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -144,8 +144,12 @@ module RuboCop
         end
 
         def on_argument(node)
-          name, = *node
-          @local_variables_scopes[node] << name
+          if node.mlhs_type?
+            on_args(node)
+          else
+            name, = *node
+            @local_variables_scopes[node] << name
+          end
         end
 
         def allow_self(node)

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -234,4 +234,13 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf, :config do
   it 'accepts a self receiver of methods also defined on `Kernel`' do
     expect_no_offenses('self.open')
   end
+
+  it 'accepts a self receiver on an lvalue of mlhs arguments' do
+    expect_no_offenses(<<~RUBY)
+      def do_something((a, b)) # This method expects Array that has 2 elements as argument.
+        self.a = a
+        self.b.some_method_call b
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #9613.

This PR fixes a false positive for `Style/RedundantSelf` when a self receiver on an lvalue of mlhs arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
