### PR TITLE
Fix an incorrect auto-correct for `Style/EvalWithLocation`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_eval_with_location.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_eval_with_location.md
@@ -1,0 +1,1 @@
+* [#9616](https://github.com/rubocop/rubocop/pull/9616): Fix an incorrect auto-correct for `Style/EvalWithLocation` when using `#instance_eval` with a string argument in parentheses. ([@koic][])

--- a/lib/rubocop/cop/style/eval_with_location.rb
+++ b/lib/rubocop/cop/style/eval_with_location.rb
@@ -224,7 +224,7 @@ module RuboCop
 
           register_offense(node) do |corrector|
             line_str = missing_line(node, code)
-            corrector.insert_after(node.loc.expression.end, ", __FILE__, #{line_str}")
+            corrector.insert_after(node.last_argument.source_range.end, ", __FILE__, #{line_str}")
           end
         end
 

--- a/spec/rubocop/cop/style/eval_with_location_spec.rb
+++ b/spec/rubocop/cop/style/eval_with_location_spec.rb
@@ -159,6 +159,17 @@ RSpec.describe RuboCop::Cop::Style::EvalWithLocation, :config do
     RUBY
   end
 
+  it 'registers an offense when using `#instance_eval` with a string argument in parentheses' do
+    expect_offense(<<~RUBY)
+      instance_eval('@foo = foo')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pass `__FILE__` and `__LINE__` to `instance_eval`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      instance_eval('@foo = foo', __FILE__, __LINE__)
+    RUBY
+  end
+
   it 'registers an offense when using `#class_eval` with an incorrect lineno' do
     expect_offense(<<~RUBY)
       C.class_eval <<-CODE, __FILE__, __LINE__


### PR DESCRIPTION
Fixes https://github.com/testdouble/standard/issues/275.

This PR fixes the following incorrect auto-correct for `Style/EvalWithLocation` when using `#instance_eval` with a string argument in parentheses.

```console
% cat example.rb
instance_eval('@foo = foo')

% rubocop -A --only Style/EvalWithLocation
(snip)

Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Corrected] Style/EvalWithLocation: Pass __FILE__ and
__LINE__ to instance_eval.
instance_eval('@foo = foo')
^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

## Before

```console
% cat example.rb
instance_eval('@foo = foo'), __FILE__, __LINE__

% ruby -c example.rb
example.rb:1: syntax error, unexpected ',', expecting end-of-input
instance_eval('@foo = foo'), __FILE__, __LINE__
```

## After

```console
% cat example.rb
instance_eval('@foo = foo', __FILE__, __LINE__)

% ruby -c example.rb
Syntax OK
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
