### PR TITLE
[Fix #9617] Disable suggested extensions when using the `--stdin` option

### DIFF
--- a/changelog/change_disable_suggested_extensions_when_using.md
+++ b/changelog/change_disable_suggested_extensions_when_using.md
@@ -1,0 +1,1 @@
+* [#9617](https://github.com/rubocop/rubocop/issues/9617): Disable suggested extensions when using the `--stdin` option. ([@dvandersluis][])

--- a/lib/rubocop/cli/command/suggest_extensions.rb
+++ b/lib/rubocop/cli/command/suggest_extensions.rb
@@ -43,7 +43,8 @@ module RuboCop
           # 2. When given RuboCop options that it doesn't make sense for
           # 3. For all formatters except specified in `INCLUDED_FORMATTERS'`
           ENV['CI'] ||
-            @options[:only] || @options[:debug] || @options[:list_target_files] || @options[:out] ||
+            @options[:only] || @options[:debug] || @options[:list_target_files] ||
+            @options[:out] || @options[:stdin] ||
             !INCLUDED_FORMATTERS.include?(current_formatter)
         end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2057,6 +2057,17 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     end
 
+    context 'when given --stdin' do
+      it 'does not show the suggestion' do
+        begin
+          $stdin = StringIO.new('p $/')
+          expect { cli.run(['--stdin', 'example.rb']) }.not_to suggest_extensions
+        ensure
+          $stdin = STDIN
+        end
+      end
+    end
+
     context 'when given a non-supported formatter' do
       it 'does not show the suggestion' do
         expect { cli.run(['example.rb', '--format', 'simple']) }.not_to suggest_extensions


### PR DESCRIPTION
Fixes #9617.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
