### PR TITLE
Fix infinite loop between `Layout/IndentationWidth` and `Layout/RescueEnsureAlignment` autocorrection

### DIFF
--- a/changelog/fix_fix_infinite_loop_between.md
+++ b/changelog/fix_fix_infinite_loop_between.md
@@ -1,0 +1,1 @@
+* [#9619](https://github.com/rubocop/rubocop/pull/9619): Fix infinite loop between `Layout/IndentationWidth` and `Layout/RescueEnsureAlignment` autocorrection. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -310,12 +310,20 @@ module RuboCop
         def indentation_to_check?(base_loc, body_node)
           return false if skip_check?(base_loc, body_node)
 
-          if %i[rescue ensure].include?(body_node.type)
+          if body_node.rescue_type?
+            check_rescue?(body_node)
+          elsif body_node.ensure_type?
             block_body, = *body_node
             return unless block_body
-          end
 
-          true
+            check_rescue?(block_body) if block_body.rescue_type?
+          else
+            true
+          end
+        end
+
+        def check_rescue?(rescue_node)
+          rescue_node.body
         end
 
         def skip_check?(base_loc, body_node)

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -213,6 +213,46 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         RUBY
       end
 
+      it 'accepts `rescue`/`ensure` after an empty body' do
+        expect_no_offenses(<<~RUBY)
+          begin
+          rescue
+            handle_error
+          ensure
+            something
+          end
+        RUBY
+      end
+
+      it 'accepts `rescue` after an empty def' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+          rescue
+            handle_error
+          end
+        RUBY
+      end
+
+      it 'accepts `ensure` after an empty def' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+          ensure
+            something
+          end
+        RUBY
+      end
+
+      it 'accepts `rescue`/`ensure` after an empty def' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+          rescue
+            handle_error
+          ensure
+            something
+          end
+        RUBY
+      end
+
       it 'does not raise any error with empty braces' do
         expect_no_offenses(<<~RUBY)
           if cond
@@ -1294,16 +1334,16 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
             puts 'do something error prone'
             ^{} Use 2 (not 0) spaces for indentation.
             rescue SomeException, SomeOther => e
-             puts 'wrongly intended error handling'
+             puts 'wrongly indented error handling'
             ^ Use 2 (not 1) spaces for indentation.
             rescue
-             puts 'wrongly intended error handling'
+             puts 'wrongly indented error handling'
             ^ Use 2 (not 1) spaces for indentation.
             else
-               puts 'wrongly intended normal case handling'
+               puts 'wrongly indented normal case handling'
             ^^^ Use 2 (not 3) spaces for indentation.
             ensure
-                puts 'wrongly intended common handling'
+                puts 'wrongly indented common handling'
             ^^^^ Use 2 (not 4) spaces for indentation.
             end
           end
@@ -1317,11 +1357,21 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           def my_func
             puts 'do something error prone'
           rescue SomeException
-           puts 'wrongly intended error handling'
+           puts 'wrongly indented error handling'
           ^ Use 2 (not 1) spaces for indentation.
           rescue
-           puts 'wrongly intended error handling'
+           puts 'wrongly indented error handling'
           ^ Use 2 (not 1) spaces for indentation.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_func
+            puts 'do something error prone'
+          rescue SomeException
+            puts 'wrongly indented error handling'
+          rescue
+            puts 'wrongly indented error handling'
           end
         RUBY
       end
@@ -1331,10 +1381,10 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           foo def self.my_func
             puts 'do something error prone'
           rescue SomeException
-           puts 'wrongly intended error handling'
+           puts 'wrongly indented error handling'
           ^ Use 2 (not 1) spaces for indentation.
           rescue
-           puts 'wrongly intended error handling'
+           puts 'wrongly indented error handling'
           ^ Use 2 (not 1) spaces for indentation.
           end
         RUBY

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -408,6 +408,29 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
     RUBY
   end
 
+  it 'accepts correctly aligned rescue/ensure with def' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        something
+      rescue StandardError
+        handle_error
+      ensure
+        error
+      end
+    RUBY
+  end
+
+  it 'accepts correctly aligned rescue/ensure with def with no body' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+      rescue StandardError
+        handle_error
+      ensure
+        error
+      end
+    RUBY
+  end
+
   it 'accepts correctly aligned rescue in assigned begin-end block' do
     expect_no_offenses(<<-RUBY)
       foo = begin


### PR DESCRIPTION
There was an autocorrect infinite loop between `Layout/IndentationWidth` and `Layout/RescueEnsureAlignment`, as well as a false positive, for actually correct cases such as

```ruby
def a
rescue StandardError
ensure
  a
end
```

due to `Layout/IndentationWidth` getting confused by there being no body before the rescue. It will now only check indentation of a rescue node if it has a body.

I also added a test to make sure the two cops autocorrect properly when used in unison.

Fixes testdouble/standard#112.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
