### PR TITLE
[Fix #9621] Add `consistent` style to `Lint/SymbolConversion` to require all symbol keys in a hash to use the same convention

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2063,6 +2063,10 @@ Lint/SymbolConversion:
   Description: 'Checks for unnecessary symbol conversions.'
   Enabled: pending
   VersionAdded: '1.9'
+  EnforcedStyle: strict
+  SupportedStyles:
+    - strict
+    - consistent
 
 Lint/Syntax:
   Description: 'Checks for syntax errors.'


### PR DESCRIPTION
The `consistent` style works the same as the previous default style (now called `strict`), in that symbol conversions should be explicit. However, in the case of a hash with a mix of symbol keys requiring quoting and not, this style now enforces that all keys are quoted for consistency.

Fixes #9621.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
