### PR TITLE
[Fix #9325] Make Exclude config parameters merge by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#9325](https://github.com/rubocop/rubocop/issues/9325): Make the `Exclude` configuration parameter merge by default. ([@jonas054][])
+
 ## 1.11.0 (2021-03-01)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,9 @@
 # Common configuration.
 
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
   RubyInterpreters:
     - ruby

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -89,10 +89,11 @@ Other types, such as `AllCops` / `Include` (an array), are overridden by the
 child setting.
 
 Arrays override because if they were merged, there would be no way to
-remove elements in child files.
+remove elements in child files. An exception to this rule is `Exclude`, which
+is an array but is still merged because that is more convenient for most users.
 
-However, advanced users can still merge arrays using the `inherit_mode` setting.
-See "Merging arrays using inherit_mode" below.
+Whether individual array parameters are overridden or merged is controlled
+through the `inherit_mode` setting. See "Merging arrays using inherit_mode" below.
 
 === Inheriting from another configuration file in the project
 
@@ -193,6 +194,26 @@ value.
 This applies to explicit inheritance using `inherit_from` as well as implicit
 inheritance from https://github.com/rubocop/rubocop/blob/master/config/default.yml[the default configuration].
 
+The setting for `inherit_mode` in the default configuration is:
+
+[source,yaml]
+----
+inherit_mode:
+  merge:
+    - Exclude
+----
+
+This makes `Exclude` a special case, being merged by default even though it is
+an array. If this behavior is not desired, user configuration should have the
+following setting:
+
+[source,yaml]
+----
+inherit_mode:
+  override:
+    - Exclude
+----
+
 Given the following config:
 
 [source,yaml]
@@ -203,40 +224,36 @@ inherit_from:
 
 inherit_mode:
   merge:
-    - Exclude
+    - Include
 
 AllCops:
-  Exclude:
-    - 'generated/**/*.rb'
+  Include:
+    - '**/*.special_ext'
 
 Style/For:
-  Exclude:
-    - bar.rb
+  Include:
+    - Somefile
 ----
 
 [source,yaml]
 ----
 # .shared.yml
 Style/For:
-  Exclude:
-    - foo.rb
+  Include:
+    - Otherfile
 ----
 
 The list of ``Exclude``s for the `Style/For` cop in this example will be
-`['foo.rb', 'bar.rb']`. Similarly, the `AllCops:Exclude` list will contain all
-the default patterns plus the `+generated/**/*.rb+` entry that was added locally.
+`['Somefile', 'Otherfile']`. Similarly, the `AllCops:Exclude` list will contain all
+the default patterns plus the `+**/*.special_ext+` entry that was added locally.
 
-The directive can also be used on individual cop configurations to override
-the global setting.
+The `inherit_mode` directive can also be used on individual cop configurations
+to override the global setting.
 
 [source,yaml]
 ----
 inherit_from:
   - shared.yml
-
-inherit_mode:
-  merge:
-    - Exclude
 
 Style/For:
   inherit_mode:

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -147,6 +147,8 @@ module RuboCop
       valid_cop_names.each do |name|
         validate_section_presence(name)
         each_invalid_parameter(name) do |param, supported_params|
+          next if name == 'inherit_mode' && param == 'override'
+
           warn Rainbow(<<~MESSAGE).yellow
             Warning: #{name} does not support #{param} parameter.
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'RuboCop Project', type: :feature do
     let(:configuration_keys) { config.keys }
 
     it 'has configuration for all cops' do
-      expect(configuration_keys).to match_all_cops
+      expect(configuration_keys - ['inherit_mode']).to match_all_cops
     end
 
     it 'has a nicely formatted description for all cops' do
@@ -79,8 +79,9 @@ RSpec.describe 'RuboCop Project', type: :feature do
     end
 
     it 'sorts configuration keys alphabetically' do
-      expected = configuration_keys.sort
-      configuration_keys.each_with_index do |key, idx|
+      cop_keys = configuration_keys - ['inherit_mode']
+      expected = cop_keys.sort
+      cop_keys.each_with_index do |key, idx|
         expect(key).to eq expected[idx]
       end
     end

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -119,15 +119,12 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
        '# Offense count: 2',
        'Test/Cop1:',
        '  Exclude:',
-       "    - 'Gemfile'",
        "    - 'test_a.rb'",
        "    - 'test_b.rb'",
        '',
        '# Offense count: 1',
        'Test/Cop2:',
        '  Exclude:',
-       "    - '**/*.blah'",
-       "    - !ruby/regexp /.*/bar/*/foo\.rb$/",
        "    - 'test_a.rb'",
        ''].join("\n")
     end


### PR DESCRIPTION
First of all, I'm not convinced that this is a good idea. Let's discuss.

It turned out to be trickier to implement than I had anticipated. There was code here and there that depended on the inherit mode being `override` for `Exclude`. The changes in pretty central parts of the logic makes me worry that we're opening up a can of worms. More issues will be reported down the line. That sort of thing.

And also, the complexities of configuration inheritance are getting worse with this change IMO. It's a bit weird that `Exclude`s are merged while `Include`s are overridden. I experimented with letting `Include`s be merged as well, but that's a much bigger change since default configuration uses `Include` to let specific cops only inspect one kind of file.

So that's the case against. :slightly_smiling_face: Here's the description:

Add the `inherit_mode` setting in default configuration to make `Exclude` parameters in user configuration merge with the same `Exclude` settings in inherited configuration. The result of `rubocop --auto-gen-config` is affected by this change, since we otherwise copy values from inherited `Exclude` settings into the generated file.