### PR TITLE
Allow parentheses in yield arguments for `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/changelog/fix_allow_parentheses_in_yield_arguments_with_style_method_call_with_args_parentheses.md
+++ b/changelog/fix_allow_parentheses_in_yield_arguments_with_style_method_call_with_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#9625](https://github.com/rubocop/rubocop/pull/9625): Allow parentheses in yield arguments with `Style/MethodCallWithArgsParentheses` `EnforcedStyle: omit_parentheses` to fix invalid Ruby auto-correction. ([@gsamokovarov][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -114,7 +114,7 @@ module RuboCop
           def call_as_argument_or_chain?(node)
             node.parent &&
               (node.parent.send_type? && !assigned_before?(node.parent, node) ||
-              node.parent.csend_type? || node.parent.super_type?)
+              node.parent.csend_type? || node.parent.super_type? || node.parent.yield_type?)
           end
 
           def hash_literal_in_arguments?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -658,6 +658,11 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('foo &block')
     end
 
+    it 'accepts parens in yield argument method calls' do
+      expect_no_offenses('yield File.basepath(path)')
+      expect_no_offenses('yield path, File.basepath(path)')
+    end
+
     it 'accepts parens in super without args' do
       expect_no_offenses('super()')
     end


### PR DESCRIPTION
When using the `omit_parentheses` style, we don't recognize `yield`
argument calls and require parentheses omission. If we yield multiple
values, we cannot omit the parentheses in method calls as this won't be
valid Ruby. We currently register offenses for:

```ruby
# Example 1
yield File.basename(path)
      ^^^^^^^^^^^^^^^^^^^ Omit parentheses for method calls with arguments.

# Correction...
yield File.basename path # 👈 This compiles.

# Example 2
yield path, File.basename(path)
            ^^^^^^^^^^^^^^^^^^^ Omit parentheses for method calls with arguments.

# Correction...
yield path, File.basename path  # 👈 This DOES NOT!!!
```

If we treat yield arguments as any other method call arguments, we'll
allow the parentheses and let people write valid Ruby in the cases
above.