### PR TITLE
[Fix #9519] Disable all cop department with directive comment 

### DIFF
--- a/changelog/new_disable_all_cop_department_with_directive_comment.md
+++ b/changelog/new_disable_all_cop_department_with_directive_comment.md
@@ -1,0 +1,1 @@
+* [#9626](https://github.com/rubocop/rubocop/pull/9626): Disable all cop department with directive comment. ([@AndreiEres][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -671,6 +671,15 @@ file by adding a comment such as
 # rubocop:enable Layout/LineLength, Style/StringLiterals
 ----
 
+You can also disable entire departments by giving a department name in the comment.
+
+[source,ruby]
+----
+# rubocop:disable Metrics, Layout/LineLength
+[...]
+# rubocop:enable Metrics, Layout/LineLength
+----
+
 You can also disable _all_ cops with
 
 [source,ruby]

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -114,6 +114,9 @@ module RuboCop
             next if ignore_offense?(line_range)
 
             comment = processed_source.comment_at_line(line_range.begin)
+
+            next if department_disabled?(cop, comment)
+
             redundant_cop = if all_disabled?(comment)
                               find_redundant_all(line_range, line_ranges[ix + 1])
                             else
@@ -173,6 +176,13 @@ module RuboCop
           disabled_ranges.any? do |range|
             range.cover?(line_range.min) && range.cover?(line_range.max)
           end
+        end
+
+        def department_disabled?(cop, comment)
+          DirectiveComment
+            .new(comment)
+            .department_names
+            .any? { |department| cop.start_with?(department) }
         end
 
         def directive_count(comment)

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -185,7 +185,8 @@ module RuboCop
         end
 
         def department_disabled?(cop, comment)
-          DirectiveComment.new(comment).in_directive_department?(cop)
+          directive = DirectiveComment.new(comment)
+          directive.in_directive_department?(cop) && !directive.overridden_by_department?(cop)
         end
 
         def directive_count(comment)

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -185,9 +185,7 @@ module RuboCop
         end
 
         def department_disabled?(cop, comment)
-          DirectiveComment.new(comment).department_names.any? do |department|
-            cop.start_with?(department)
-          end
+          DirectiveComment.new(comment).in_directive_department?(cop)
         end
 
         def directive_count(comment)

--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -54,6 +54,7 @@ module RuboCop
           directive = DirectiveComment.new(comment)
 
           cop_names.each do |name|
+            name = name.split('/').first if department?(directive, name)
             add_offense(
               range_of_offense(comment, name),
               message: format(MSG, cop: all_or_name(name))
@@ -118,6 +119,10 @@ module RuboCop
 
         def all_or_name(name)
           name == 'all' ? 'all cops' : name
+        end
+
+        def department?(directive, name)
+          directive.in_directive_department?(name) && !directive.overridden_by_department?(name)
         end
       end
     end

--- a/lib/rubocop/cop/migration/department_name.rb
+++ b/lib/rubocop/cop/migration/department_name.rb
@@ -61,7 +61,9 @@ module RuboCop
         end
 
         def valid_content_token?(content_token)
-          /\W+/.match?(content_token) || DISABLING_COPS_CONTENT_TOKEN.match?(content_token)
+          /\W+/.match?(content_token) ||
+            DISABLING_COPS_CONTENT_TOKEN.match?(content_token) ||
+            Registry.global.department?(content_token)
         end
 
         def contain_unexpected_character_for_department_name?(name)

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -91,6 +91,10 @@ module RuboCop
       splitted_cops_string.select { |cop| department?(cop) }
     end
 
+    def directive_count
+      splitted_cops_string.count
+    end
+
     # Returns line number for directive
     def line_number
       comment.loc.expression.line

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -91,6 +91,11 @@ module RuboCop
       splitted_cops_string.select { |cop| department?(cop) }
     end
 
+    # Checks if directive departments include cop
+    def in_directive_department?(cop)
+      department_names.any? { |department| cop.start_with?(department) }
+    end
+
     def directive_count
       splitted_cops_string.count
     end

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -70,6 +70,11 @@ module RuboCop
       !disabled? && all_cops?
     end
 
+    # Checks if this directive disables all cops
+    def disabled_all?
+      disabled? && all_cops?
+    end
+
     # Checks if all cops specified in this directive
     def all_cops?
       cops == 'all'

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -96,6 +96,11 @@ module RuboCop
       department_names.any? { |department| cop.start_with?(department) }
     end
 
+    # Checks if cop department has already used in directive comment
+    def overridden_by_department?(cop)
+      in_directive_department?(cop) && splitted_cops_string.include?(cop)
+    end
+
     def directive_count
       splitted_cops_string.count
     end

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -25,10 +25,11 @@ module RuboCop
       line.split(DIRECTIVE_COMMENT_REGEXP).first
     end
 
-    attr_reader :comment, :mode, :cops
+    attr_reader :comment, :cop_registry, :mode, :cops
 
-    def initialize(comment)
+    def initialize(comment, cop_registry = Cop::Registry.global)
       @comment = comment
+      @cop_registry = cop_registry
       @mode, @cops = match_captures
     end
 
@@ -123,15 +124,15 @@ module RuboCop
     end
 
     def department?(name)
-      Cop::Registry.global.department?(name)
+      cop_registry.department?(name)
     end
 
     def all_cop_names
-      exclude_redundant_directive_cop(Cop::Registry.global.names)
+      exclude_redundant_directive_cop(cop_registry.names)
     end
 
     def cop_names_for_department(department)
-      names = Cop::Registry.global.names_for_department(department)
+      names = cop_registry.names_for_department(department)
       has_redundant_directive_cop = department == REDUNDANT_DIRECTIVE_COP_DEPARTMENT
       has_redundant_directive_cop ? exclude_redundant_directive_cop(names) : names
     end

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -6,7 +6,9 @@ module RuboCop
   # cops it contains.
   class DirectiveComment
     # @api private
-    REDUNDANT_COP = 'Lint/RedundantCopDisableDirective'
+    REDUNDANT_DIRECTIVE_COP_DEPARTMENT = 'Lint'
+    # @api private
+    REDUNDANT_DIRECTIVE_COP = "#{REDUNDANT_DIRECTIVE_COP_DEPARTMENT}/RedundantCopDisableDirective"
     # @api private
     COP_NAME_PATTERN = '([A-Z]\w+/)*(?:[A-Z]\w+)'
     # @api private
@@ -86,11 +88,27 @@ module RuboCop
     private
 
     def parsed_cop_names
-      (cops || '').split(/,\s*/)
+      (cops || '').split(/,\s*/).map do |name|
+        department?(name) ? cop_names_for_department(name) : name
+      end.flatten
+    end
+
+    def department?(name)
+      Cop::Registry.global.department?(name)
     end
 
     def all_cop_names
-      Cop::Registry.global.names - [REDUNDANT_COP]
+      exclude_redundant_directive_cop(Cop::Registry.global.names)
+    end
+
+    def cop_names_for_department(department)
+      names = Cop::Registry.global.names_for_department(department)
+      has_redundant_directive_cop = department == REDUNDANT_DIRECTIVE_COP_DEPARTMENT
+      has_redundant_directive_cop ? exclude_redundant_directive_cop(names) : names
+    end
+
+    def exclude_redundant_directive_cop(cops)
+      cops - [REDUNDANT_DIRECTIVE_COP]
     end
   end
 end

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -85,6 +85,12 @@ module RuboCop
       @cop_names ||= all_cops? ? all_cop_names : parsed_cop_names
     end
 
+    # Returns array of specified in this directive department names
+    # when all department disabled
+    def department_names
+      splitted_cops_string.select { |cop| department?(cop) }
+    end
+
     # Returns line number for directive
     def line_number
       comment.loc.expression.line
@@ -92,8 +98,12 @@ module RuboCop
 
     private
 
+    def splitted_cops_string
+      (cops || '').split(/,\s*/)
+    end
+
     def parsed_cop_names
-      (cops || '').split(/,\s*/).map do |name|
+      splitted_cops_string.map do |name|
         department?(name) ? cop_names_for_department(name) : name
       end.flatten
     end

--- a/spec/rubocop/cop/lint/missing_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/missing_cop_enable_directive_spec.rb
@@ -21,6 +21,24 @@ RSpec.describe RuboCop::Cop::Lint::MissingCopEnableDirective, :config do
         # Some other code
       RUBY
     end
+
+    it 'registers an offense when a department is disabled and never re-enabled' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout
+        ^ Re-enable Layout department with `# rubocop:enable` after disabling it.
+        x =   0
+        # Some other code
+      RUBY
+    end
+
+    it 'does not register an offense when the disable department is re-enabled' do
+      expect_no_offenses(<<~RUBY)
+        # rubocop:disable Layout
+        x =   0
+        # rubocop:enable Layout
+        # Some other code
+      RUBY
+    end
   end
 
   context 'when the maximum range size is finite' do
@@ -52,6 +70,36 @@ RSpec.describe RuboCop::Cop::Lint::MissingCopEnableDirective, :config do
         x =   0
         y = 1
         # rubocop:enable Layout/SpaceAroundOperators
+        # Some other code
+      RUBY
+    end
+
+    it 'registers an offense when a department is disabled for too many lines' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout
+        ^ Re-enable Layout department within 2 lines after disabling it.
+        x =   0
+        y = 1
+        # Some other code
+        # rubocop:enable Layout
+      RUBY
+    end
+
+    it 'registers an offense when a department is disabled and never re-enabled' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout
+        ^ Re-enable Layout department within 2 lines after disabling it.
+        x =   0
+        # Some other code
+      RUBY
+    end
+
+    it 'does not register an offense when the disable department is re-enabled within the limit' do
+      expect_no_offenses(<<~RUBY)
+        # rubocop:disable Layout
+        x =   0
+        y = 1
+        # rubocop:enable Layout
         # Some other code
       RUBY
     end

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -547,6 +547,40 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
         RUBY
       end
 
+      it 'removes cop duplicated by department' do
+        expect_offense(<<~RUBY)
+          # rubocop:disable Metrics, Metrics/ClassLength
+                                     ^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/ClassLength`.
+          def bar
+            do_something
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # rubocop:disable Metrics
+          def bar
+            do_something
+          end
+        RUBY
+      end
+
+      it 'removes cop duplicated by department on previous line' do
+        expect_offense(<<~RUBY)
+          # rubocop:disable Metrics
+          def bar
+            do_something # rubocop:disable Metrics/ClassLength
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/ClassLength`.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # rubocop:disable Metrics
+          def bar
+            do_something
+          end
+        RUBY
+      end
+
       it 'does not remove correct department' do
         expect_no_offenses(<<~RUBY)
           # rubocop:disable Metrics

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -503,5 +503,16 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
         end
       end
     end
+
+    context 'with a disabled department' do
+      it 'does not remove correct department' do
+        expect_no_offenses(<<~RUBY)
+          # rubocop:disable Metrics
+          def bar
+            do_something
+          end
+        RUBY
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -505,6 +505,48 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
     end
 
     context 'with a disabled department' do
+      let(:offenses) do
+        [
+          RuboCop::Cop::Offense.new(:convention,
+                                    OpenStruct.new(line: 2, column: 0),
+                                    'Class has too many lines.',
+                                    'Metrics/ClassLength')
+        ]
+      end
+
+      it 'removes entire comment' do
+        expect_offense(<<~RUBY)
+          # rubocop:disable Style
+          ^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Style` department.
+          def bar
+            do_something
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def bar
+            do_something
+          end
+        RUBY
+      end
+
+      it 'removes redundant department' do
+        expect_offense(<<~RUBY)
+          # rubocop:disable Style, Metrics/ClassLength
+                            ^^^^^ Unnecessary disabling of `Style` department.
+          def bar
+            do_something
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # rubocop:disable Metrics/ClassLength
+          def bar
+            do_something
+          end
+        RUBY
+      end
+
       it 'does not remove correct department' do
         expect_no_offenses(<<~RUBY)
           # rubocop:disable Metrics

--- a/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
@@ -226,4 +226,104 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopEnableDirective, :config do
       end
     end
   end
+
+  context 'when all department enabled' do
+    it 'registers offense and corrects unnecessary enable' do
+      expect_offense(<<~RUBY)
+        foo
+        # rubocop:enable Layout
+                         ^^^^^^ Unnecessary enabling of Layout.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo
+      RUBY
+    end
+
+    it 'registers an offense and corrects when the first department is unnecessarily enabled' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLength
+        foo
+        # rubocop:enable Metrics, Layout/LineLength
+                         ^^^^^^^ Unnecessary enabling of Metrics.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # rubocop:disable Layout/LineLength
+        foo
+        # rubocop:enable Layout/LineLength
+      RUBY
+    end
+
+    it 'registers multiple offenses and corrects the same comment' do
+      expect_offense(<<~RUBY)
+        foo
+        # rubocop:enable Metrics, Layout
+                                  ^^^^^^ Unnecessary enabling of Layout.
+                         ^^^^^^^ Unnecessary enabling of Metrics.
+        bar
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo
+        bar
+      RUBY
+    end
+
+    it 'registers correct offense when combined with necessary enable' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLength
+        fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = barrrrrrrrrrrrrrrrrrrrrrrrrr
+        # rubocop:enable Metrics, Layout/LineLength
+                         ^^^^^^^ Unnecessary enabling of Metrics.
+        bar
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # rubocop:disable Layout/LineLength
+        fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = barrrrrrrrrrrrrrrrrrrrrrrrrr
+        # rubocop:enable Layout/LineLength
+        bar
+      RUBY
+    end
+
+    it 'registers offense and corrects redundant enabling of same department' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout
+        fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = barrrrrrrrrrrrrrrrrrrrrrrrrr
+        # rubocop:enable Layout
+
+        bar
+
+        # rubocop:enable Layout
+                         ^^^^^^ Unnecessary enabling of Layout.
+        bar
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # rubocop:disable Layout
+        fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = barrrrrrrrrrrrrrrrrrrrrrrrrr
+        # rubocop:enable Layout
+
+        bar
+
+        bar
+      RUBY
+    end
+
+    it 'registers offense and corrects redundant enabling of cop of same department' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout
+        fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = barrrrrrrrrrrrrrrrrrrrrrrrrr
+        # rubocop:enable Layout, Layout/LineLength
+                                 ^^^^^^^^^^^^^^^^^ Unnecessary enabling of Layout/LineLength.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # rubocop:disable Layout
+        fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = barrrrrrrrrrrrrrrrrrrrrrrrrr
+        # rubocop:enable Layout
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
@@ -325,5 +325,22 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopEnableDirective, :config do
         # rubocop:enable Layout
       RUBY
     end
+
+    it 'registers offense and corrects redundant enabling of department of same cop' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLength
+        fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = barrrrrrrrrrrrrrrrrrrrrrrrrr
+        # rubocop:enable Layout
+                         ^^^^^^ Unnecessary enabling of Layout.
+        some_code
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # rubocop:disable Layout/LineLength
+        fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = barrrrrrrrrrrrrrrrrrrrrrrrrr
+
+        some_code
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/migration/department_name_spec.rb
+++ b/spec/rubocop/cop/migration/department_name_spec.rb
@@ -108,4 +108,13 @@ RSpec.describe RuboCop::Cop::Migration::DepartmentName, :config do
       RUBY
     end
   end
+
+  context 'when only department name has given' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        # rubocop:disable Style
+        alias :ala :bala
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -261,4 +261,32 @@ RSpec.describe RuboCop::DirectiveComment do
       end
     end
   end
+
+  describe '#disabled_all?' do
+    subject { directive_comment.disabled_all? }
+
+    context 'when enabled all cops' do
+      let(:text) { 'def foo # rubocop:enable all' }
+
+      it { is_expected.to eq false }
+    end
+
+    context 'when enabled specific cops' do
+      let(:text) { '# rubocop:enable Foo/Bar' }
+
+      it { is_expected.to eq false }
+    end
+
+    context 'when disabled all cops' do
+      let(:text) { '# rubocop:disable all' }
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when disabled specific cops' do
+      let(:text) { '# rubocop:disable Foo/Bar' }
+
+      it { is_expected.to eq false }
+    end
+  end
 end

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -235,6 +235,51 @@ RSpec.describe RuboCop::DirectiveComment do
     end
   end
 
+  describe '#department_names' do
+    subject { directive_comment.department_names }
+
+    let(:department?) { false }
+    let(:global) { instance_double(RuboCop::Cop::Registry, department?: department?) }
+
+    before { allow(RuboCop::Cop::Registry).to receive(:global).and_return(global) }
+
+    context 'when only cop specified' do
+      let(:comment_cop_names) { 'Foo/Bar' }
+
+      it { is_expected.to eq [] }
+    end
+
+    context 'when all cops mentioned' do
+      let(:comment_cop_names) { 'all' }
+
+      it { is_expected.to eq [] }
+    end
+
+    context 'when only department specified' do
+      let(:comment_cop_names) { 'Foo' }
+      let(:department?) { true }
+
+      it { is_expected.to eq %w[Foo] }
+    end
+
+    context 'when couple departments specified' do
+      let(:comment_cop_names) { 'Foo, Baz' }
+      let(:department?) { true }
+
+      it { is_expected.to eq %w[Foo Baz] }
+    end
+
+    context 'when department and cops specified' do
+      let(:comment_cop_names) { 'Foo, Baz/Cop' }
+
+      before do
+        allow(global).to receive(:department?).with('Foo').and_return(true)
+      end
+
+      it { is_expected.to eq %w[Foo] }
+    end
+  end
+
   describe '#line_number' do
     let(:comment) { instance_double(Parser::Source::Comment, text: text, loc: loc) }
     let(:loc) { instance_double(Parser::Source::Map, expression: expression) }

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -356,4 +356,36 @@ RSpec.describe RuboCop::DirectiveComment do
       it { is_expected.to eq 4 }
     end
   end
+
+  describe '#in_directive_department?' do
+    subject { directive_comment.in_directive_department?(cop) }
+
+    let(:global) { instance_double(RuboCop::Cop::Registry, department?: department?) }
+
+    before { allow(RuboCop::Cop::Registry).to receive(:global).and_return(global) }
+
+    context 'when cop department disabled' do
+      let(:cop) { 'Foo/Bar' }
+      let(:text) { '# rubocop:enable Foo' }
+      let(:department?) { true }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when another department disabled' do
+      let(:cop) { 'Foo/Bar' }
+      let(:text) { '# rubocop:enable Bar' }
+      let(:department?) { true }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when cop disabled' do
+      let(:cop) { 'Foo/Bar' }
+      let(:text) { '# rubocop:enable Foo/Bar' }
+      let(:department?) { false }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -1,309 +1,330 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::DirectiveComment do
-  subject(:directive_comment) { described_class.new(comment) }
-
+  let(:directive_comment) { described_class.new(comment, cop_registry) }
   let(:comment) { instance_double(Parser::Source::Comment, text: text) }
-  let(:comment_cop_names) { 'all' }
-  let(:text) { "#rubocop:enable #{comment_cop_names}" }
+  let(:cop_registry) do
+    instance_double(RuboCop::Cop::Registry, names: all_cop_names, department?: department?)
+  end
+  let(:text) { '#rubocop:enable all' }
+  let(:all_cop_names) { %w[] }
+  let(:department?) { false }
 
   describe '.before_comment' do
     subject { described_class.before_comment(text) }
 
-    [
-      ['when line has code', 'def foo # rubocop:disable all', 'def foo '],
-      ['when line has NO code', '# rubocop:disable all', '']
-    ].each do |example|
-      context example[0] do
-        let(:text) { example[1] }
+    context 'when line has code' do
+      let(:text) { 'def foo # rubocop:disable all' }
 
-        it { is_expected.to eq example[2] }
-      end
+      it { is_expected.to eq('def foo ') }
+    end
+
+    context 'when line has NO code' do
+      let(:text) { '# rubocop:disable all' }
+
+      it { is_expected.to eq('') }
     end
   end
 
   describe '#match?' do
-    subject(:match) { directive_comment.match?(cop_names) }
+    subject { directive_comment.match?(cop_names) }
 
-    let(:comment_cop_names) { 'Metrics/AbcSize, Metrics/PerceivedComplexity, Style/Not' }
+    let(:text) { '#rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity, Style/Not' }
 
-    context 'no comment_cop_names' do
+    context 'when there are no cop names' do
       let(:cop_names) { [] }
 
-      it 'returns false' do
-        expect(match).to eq(false)
-      end
+      it { is_expected.to eq(false) }
     end
 
-    context 'same cop names as in the comment' do
+    context 'when cop names are same as in the comment' do
       let(:cop_names) { %w[Metrics/AbcSize Metrics/PerceivedComplexity Style/Not] }
 
-      it 'returns true' do
-        expect(match).to eq(true)
-      end
+      it { is_expected.to eq(true) }
     end
 
-    context 'same cop names as in the comment in a different order' do
+    context 'when cop names are same but in a different order' do
       let(:cop_names) { %w[Style/Not Metrics/AbcSize Metrics/PerceivedComplexity] }
 
-      it 'returns true' do
-        expect(match).to eq(true)
-      end
+      it { is_expected.to eq(true) }
     end
 
-    context 'subset of names' do
+    context 'when cop names are subset of names' do
       let(:cop_names) { %w[Metrics/AbcSize Style/Not] }
 
-      it 'returns false' do
-        expect(match).to eq(false)
-      end
+      it { is_expected.to eq(false) }
     end
 
-    context 'superset of names' do
+    context 'when cop names are superset of names' do
       let(:cop_names) { %w[Lint/Void Metrics/AbcSize Metrics/PerceivedComplexity Style/Not] }
 
-      it 'returns false' do
-        expect(match).to eq(false)
-      end
+      it { is_expected.to eq(false) }
     end
 
-    context 'duplicate names' do
+    context 'when cop names are same but have duplicated names' do
       let(:cop_names) { %w[Metrics/AbcSize Metrics/AbcSize Metrics/PerceivedComplexity Style/Not] }
 
-      it 'returns true' do
-        expect(match).to eq(true)
-      end
+      it { is_expected.to eq(true) }
     end
 
-    context 'all' do
-      let(:comment_cop_names) { 'all' }
+    context 'when disabled all cops' do
+      let(:text) { '#rubocop:enable all' }
       let(:cop_names) { %w[all] }
 
-      it 'returns true' do
-        expect(match).to eq(true)
-      end
+      it { is_expected.to eq(true) }
     end
   end
 
   describe '#match_captures' do
     subject { directive_comment.match_captures }
 
-    [
-      ['when disable', '# rubocop:disable all', ['disable', 'all', nil, nil]],
-      ['when enable', '# rubocop:enable Foo/Bar', ['enable', 'Foo/Bar', nil, 'Foo/']],
-      ['when todo', '# rubocop:todo all', ['todo', 'all', nil, nil]],
-      ['when typo', '# rudocop:todo Dig/ThisMine', nil]
-    ].each do |example|
-      context example[0] do
-        let(:text) { example[1] }
+    context 'when disable' do
+      let(:text) { '# rubocop:disable all' }
 
-        it { is_expected.to eq example[2] }
-      end
+      it { is_expected.to eq(['disable', 'all', nil, nil]) }
+    end
+
+    context 'when enable' do
+      let(:text) { '# rubocop:enable Foo/Bar' }
+
+      it { is_expected.to eq(['enable', 'Foo/Bar', nil, 'Foo/']) }
+    end
+
+    context 'when todo' do
+      let(:text) { '# rubocop:todo all' }
+
+      it { is_expected.to eq(['todo', 'all', nil, nil]) }
+    end
+
+    context 'when typo' do
+      let(:text) { '# rudocop:todo Dig/ThisMine' }
+
+      it { is_expected.to eq(nil) }
     end
   end
 
   describe '#single_line?' do
     subject { directive_comment.single_line? }
 
-    [
-      ['when relates to single line', 'def foo # rubocop:disable all', true],
-      ['when does NOT relate to single line', '# rubocop:disable all', false]
-    ].each do |example|
-      context example[0] do
-        let(:text) { example[1] }
+    context 'when relates to single line' do
+      let(:text) { 'def foo # rubocop:disable all' }
 
-        it { is_expected.to eq example[2] }
-      end
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when does NOT relate to single line' do
+      let(:text) { '# rubocop:disable all' }
+
+      it { is_expected.to eq(false) }
     end
   end
 
   describe '#disabled?' do
     subject { directive_comment.disabled? }
 
-    [
-      ['when disable', '# rubocop:disable all', true],
-      ['when enable', '# rubocop:enable Foo/Bar', false],
-      ['when todo', '# rubocop:todo all', true]
-    ].each do |example|
-      context example[0] do
-        let(:text) { example[1] }
+    context 'when disable' do
+      let(:text) { '# rubocop:disable all' }
 
-        it { is_expected.to eq example[2] }
-      end
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when enable' do
+      let(:text) { '# rubocop:enable Foo/Bar' }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when todo' do
+      let(:text) { '# rubocop:todo all' }
+
+      it { is_expected.to eq(true) }
     end
   end
 
   describe '#enabled?' do
     subject { directive_comment.enabled? }
 
-    [
-      ['when disable', '# rubocop:disable all', false],
-      ['when enable', '# rubocop:enable Foo/Bar', true],
-      ['when todo', '# rubocop:todo all', false]
-    ].each do |example|
-      context example[0] do
-        let(:text) { example[1] }
+    context 'when disable' do
+      let(:text) { '# rubocop:disable all' }
 
-        it { is_expected.to eq example[2] }
-      end
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when enable' do
+      let(:text) { '# rubocop:enable Foo/Bar' }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when todo' do
+      let(:text) { '# rubocop:todo all' }
+
+      it { is_expected.to eq(false) }
     end
   end
 
   describe '#all_cops?' do
     subject { directive_comment.all_cops? }
 
-    [
-      ['when mentioned all', '# rubocop:disable all', true],
-      ['when mentioned specific cops', '# rubocop:enable Foo/Bar', false]
-    ].each do |example|
-      context example[0] do
-        let(:text) { example[1] }
+    context 'when mentioned all' do
+      let(:text) { '# rubocop:disable all' }
 
-        it { is_expected.to eq example[2] }
-      end
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when mentioned specific cops' do
+      let(:text) { '# rubocop:enable Foo/Bar' }
+
+      it { is_expected.to eq(false) }
     end
   end
 
   describe '#cop_names' do
     subject { directive_comment.cop_names }
 
-    let(:all_cop_names) { %w[] }
-    let(:department?) { false }
-    let(:global) do
-      instance_double(RuboCop::Cop::Registry, names: all_cop_names, department?: department?)
-    end
-
-    before { allow(RuboCop::Cop::Registry).to receive(:global).and_return(global) }
-
     context 'when only cop specified' do
-      let(:comment_cop_names) { 'Foo/Bar' }
+      let(:text) { '#rubocop:enable Foo/Bar' }
 
-      it { is_expected.to eq %w[Foo/Bar] }
+      it { is_expected.to eq(%w[Foo/Bar]) }
     end
 
     context 'when all cops mentioned' do
-      let(:comment_cop_names) { 'all' }
+      let(:text) { '#rubocop:enable all' }
       let(:all_cop_names) { %w[all_names Lint/RedundantCopDisableDirective] }
 
-      it { is_expected.to eq %w[all_names] }
+      it { is_expected.to eq(%w[all_names]) }
     end
 
     context 'when only department specified' do
-      let(:comment_cop_names) { 'Foo' }
+      let(:text) { '#rubocop:enable Foo' }
       let(:department?) { true }
 
       before do
-        allow(global).to receive(:names_for_department).with('Foo').and_return(%w[Foo/Bar Foo/Baz])
+        allow(cop_registry).to receive(:names_for_department)
+          .with('Foo').and_return(%w[Foo/Bar Foo/Baz])
       end
 
-      it { is_expected.to eq %w[Foo/Bar Foo/Baz] }
+      it { is_expected.to eq(%w[Foo/Bar Foo/Baz]) }
     end
 
     context 'when couple departments specified' do
-      let(:comment_cop_names) { 'Foo, Baz' }
+      let(:text) { '#rubocop:enable Foo, Baz' }
       let(:department?) { true }
 
       before do
-        allow(global).to receive(:names_for_department).with('Foo').and_return(%w[Foo/Bar Foo/Baz])
-        allow(global).to receive(:names_for_department).with('Baz').and_return(%w[Baz/Bar])
+        allow(cop_registry).to receive(:names_for_department).with('Baz').and_return(%w[Baz/Bar])
+        allow(cop_registry).to receive(:names_for_department)
+          .with('Foo').and_return(%w[Foo/Bar Foo/Baz])
       end
 
-      it { is_expected.to eq %w[Foo/Bar Foo/Baz Baz/Bar] }
+      it { is_expected.to eq(%w[Foo/Bar Foo/Baz Baz/Bar]) }
     end
 
     context 'when department and cops specified' do
-      let(:comment_cop_names) { 'Foo, Baz/Cop' }
+      let(:text) { '#rubocop:enable Foo, Baz/Cop' }
 
       before do
-        allow(global).to receive(:department?).with('Foo').and_return(true)
-        allow(global).to receive(:names_for_department).with('Foo').and_return(%w[Foo/Bar Foo/Baz])
+        allow(cop_registry).to receive(:department?).with('Foo').and_return(true)
+        allow(cop_registry).to receive(:names_for_department)
+          .with('Foo').and_return(%w[Foo/Bar Foo/Baz])
       end
 
-      it { is_expected.to eq %w[Foo/Bar Foo/Baz Baz/Cop] }
+      it { is_expected.to eq(%w[Foo/Bar Foo/Baz Baz/Cop]) }
     end
 
     context 'when redundant directive cop department specified' do
-      let(:comment_cop_names) { 'Lint' }
+      let(:text) { '#rubocop:enable Lint' }
       let(:department?) { true }
 
       before do
-        allow(global).to receive(:names_for_department)
+        allow(cop_registry).to receive(:names_for_department)
           .with('Lint').and_return(%w[Lint/One Lint/Two Lint/RedundantCopDisableDirective])
       end
 
-      it { is_expected.to eq %w[Lint/One Lint/Two] }
+      it { is_expected.to eq(%w[Lint/One Lint/Two]) }
     end
   end
 
   describe '#department_names' do
     subject { directive_comment.department_names }
 
-    let(:department?) { false }
-    let(:global) { instance_double(RuboCop::Cop::Registry, department?: department?) }
-
-    before { allow(RuboCop::Cop::Registry).to receive(:global).and_return(global) }
-
     context 'when only cop specified' do
-      let(:comment_cop_names) { 'Foo/Bar' }
+      let(:text) { '#rubocop:enable Foo/Bar' }
 
-      it { is_expected.to eq [] }
+      it { is_expected.to eq([]) }
     end
 
     context 'when all cops mentioned' do
-      let(:comment_cop_names) { 'all' }
+      let(:text) { '#rubocop:enable all' }
 
-      it { is_expected.to eq [] }
+      it { is_expected.to eq([]) }
     end
 
     context 'when only department specified' do
-      let(:comment_cop_names) { 'Foo' }
+      let(:text) { '#rubocop:enable Foo' }
       let(:department?) { true }
 
-      it { is_expected.to eq %w[Foo] }
+      it { is_expected.to eq(%w[Foo]) }
     end
 
     context 'when couple departments specified' do
-      let(:comment_cop_names) { 'Foo, Baz' }
+      let(:text) { '#rubocop:enable Foo, Baz' }
       let(:department?) { true }
 
-      it { is_expected.to eq %w[Foo Baz] }
+      it { is_expected.to eq(%w[Foo Baz]) }
     end
 
     context 'when department and cops specified' do
-      let(:comment_cop_names) { 'Foo, Baz/Cop' }
+      let(:text) { '#rubocop:enable Foo, Baz/Cop' }
 
       before do
-        allow(global).to receive(:department?).with('Foo').and_return(true)
+        allow(cop_registry).to receive(:department?).with('Foo').and_return(true)
       end
 
-      it { is_expected.to eq %w[Foo] }
+      it { is_expected.to eq(%w[Foo]) }
     end
   end
 
   describe '#line_number' do
-    let(:comment) { instance_double(Parser::Source::Comment, text: text, loc: loc) }
-    let(:loc) { instance_double(Parser::Source::Map, expression: expression) }
-    let(:expression) { instance_double(Parser::Source::Range, line: 1) }
+    let(:loc) do
+      instance_double(
+        Parser::Source::Map,
+        expression: instance_double(Parser::Source::Range, line: 1)
+      )
+    end
+
+    before { allow(comment).to receive(:loc).and_return(loc) }
 
     it 'returns line number for directive' do
-      expect(directive_comment.line_number).to be 1
+      expect(directive_comment.line_number).to eq(1)
     end
   end
 
   describe '#enabled_all?' do
     subject { directive_comment.enabled_all? }
 
-    [
-      ['when enabled all cops', 'def foo # rubocop:enable all', true],
-      ['when enabled specific cops', '# rubocop:enable Foo/Bar', false],
-      ['when disabled all cops', '# rubocop:disable all', false],
-      ['when disabled specific cops', '# rubocop:disable Foo/Bar', false]
-    ].each do |example|
-      context example[0] do
-        let(:text) { example[1] }
+    context 'when enabled all cops' do
+      let(:text) { 'def foo # rubocop:enable all' }
 
-        it { is_expected.to eq example[2] }
-      end
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when enabled specific cops' do
+      let(:text) { '# rubocop:enable Foo/Bar' }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when disabled all cops' do
+      let(:text) { '# rubocop:disable all' }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when disabled specific cops' do
+      let(:text) { '# rubocop:disable Foo/Bar' }
+
+      it { is_expected.to eq(false) }
     end
   end
 
@@ -313,25 +334,25 @@ RSpec.describe RuboCop::DirectiveComment do
     context 'when enabled all cops' do
       let(:text) { 'def foo # rubocop:enable all' }
 
-      it { is_expected.to eq false }
+      it { is_expected.to eq(false) }
     end
 
     context 'when enabled specific cops' do
       let(:text) { '# rubocop:enable Foo/Bar' }
 
-      it { is_expected.to eq false }
+      it { is_expected.to eq(false) }
     end
 
     context 'when disabled all cops' do
       let(:text) { '# rubocop:disable all' }
 
-      it { is_expected.to eq true }
+      it { is_expected.to eq(true) }
     end
 
     context 'when disabled specific cops' do
       let(:text) { '# rubocop:disable Foo/Bar' }
 
-      it { is_expected.to eq false }
+      it { is_expected.to eq(false) }
     end
   end
 
@@ -341,90 +362,75 @@ RSpec.describe RuboCop::DirectiveComment do
     context 'when few cops used' do
       let(:text) { '# rubocop:enable Foo/Bar, Foo/Baz' }
 
-      it { is_expected.to eq 2 }
+      it { is_expected.to eq(2) }
     end
 
     context 'when few department used' do
       let(:text) { '# rubocop:enable Foo, Bar, Baz' }
 
-      it { is_expected.to eq 3 }
+      it { is_expected.to eq(3) }
     end
 
     context 'when cops and departments used' do
       let(:text) { '# rubocop:enable Foo/Bar, Foo/Baz, Bar, Baz' }
 
-      it { is_expected.to eq 4 }
+      it { is_expected.to eq(4) }
     end
   end
 
   describe '#in_directive_department?' do
-    subject { directive_comment.in_directive_department?(cop) }
-
-    let(:global) { instance_double(RuboCop::Cop::Registry, department?: department?) }
-
-    before { allow(RuboCop::Cop::Registry).to receive(:global).and_return(global) }
+    subject { directive_comment.in_directive_department?('Foo/Bar') }
 
     context 'when cop department disabled' do
-      let(:cop) { 'Foo/Bar' }
       let(:text) { '# rubocop:enable Foo' }
       let(:department?) { true }
 
-      it { is_expected.to be true }
+      it { is_expected.to eq(true) }
     end
 
     context 'when another department disabled' do
-      let(:cop) { 'Foo/Bar' }
       let(:text) { '# rubocop:enable Bar' }
       let(:department?) { true }
 
-      it { is_expected.to be false }
+      it { is_expected.to eq(false) }
     end
 
     context 'when cop disabled' do
-      let(:cop) { 'Foo/Bar' }
       let(:text) { '# rubocop:enable Foo/Bar' }
-      let(:department?) { false }
 
-      it { is_expected.to be false }
+      it { is_expected.to eq(false) }
     end
   end
 
   describe '#overridden_by_department?' do
-    subject { directive_comment.overridden_by_department?(cop) }
-
-    let(:global) { instance_double(RuboCop::Cop::Registry, department?: false) }
+    subject { directive_comment.overridden_by_department?('Foo/Bar') }
 
     before do
-      allow(RuboCop::Cop::Registry).to receive(:global).and_return(global)
-      allow(global).to receive(:department?).with('Foo').and_return(true)
+      allow(cop_registry).to receive(:department?).with('Foo').and_return(true)
     end
 
     context "when cop is overridden by it's department" do
-      let(:cop) { 'Foo/Bar' }
       let(:text) { '# rubocop:enable Foo, Foo/Bar' }
 
-      it { is_expected.to be true }
+      it { is_expected.to eq(true) }
     end
 
     context "when cop is not overridden by it's department" do
-      let(:cop) { 'Foo/Bar' }
       let(:text) { '# rubocop:enable Bar, Foo/Bar' }
 
-      it { is_expected.to be false }
+      it { is_expected.to eq(false) }
     end
 
     context 'when there are no departments' do
-      let(:cop) { 'Foo/Bar' }
       let(:text) { '# rubocop:enable Foo/Bar' }
 
-      it { is_expected.to be false }
+      it { is_expected.to eq(false) }
     end
 
     context 'when there are no cops' do
-      let(:cop) { 'Foo/Bar' }
       let(:text) { '# rubocop:enable Foo' }
 
-      it { is_expected.to be false }
+      it { is_expected.to eq(false) }
     end
   end
 end

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -388,4 +388,43 @@ RSpec.describe RuboCop::DirectiveComment do
       it { is_expected.to be false }
     end
   end
+
+  describe '#overridden_by_department?' do
+    subject { directive_comment.overridden_by_department?(cop) }
+
+    let(:global) { instance_double(RuboCop::Cop::Registry, department?: false) }
+
+    before do
+      allow(RuboCop::Cop::Registry).to receive(:global).and_return(global)
+      allow(global).to receive(:department?).with('Foo').and_return(true)
+    end
+
+    context "when cop is overridden by it's department" do
+      let(:cop) { 'Foo/Bar' }
+      let(:text) { '# rubocop:enable Foo, Foo/Bar' }
+
+      it { is_expected.to be true }
+    end
+
+    context "when cop is not overridden by it's department" do
+      let(:cop) { 'Foo/Bar' }
+      let(:text) { '# rubocop:enable Bar, Foo/Bar' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when there are no departments' do
+      let(:cop) { 'Foo/Bar' }
+      let(:text) { '# rubocop:enable Foo/Bar' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when there are no cops' do
+      let(:cop) { 'Foo/Bar' }
+      let(:text) { '# rubocop:enable Foo' }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -334,4 +334,26 @@ RSpec.describe RuboCop::DirectiveComment do
       it { is_expected.to eq false }
     end
   end
+
+  describe '#directive_count' do
+    subject { directive_comment.directive_count }
+
+    context 'when few cops used' do
+      let(:text) { '# rubocop:enable Foo/Bar, Foo/Baz' }
+
+      it { is_expected.to eq 2 }
+    end
+
+    context 'when few department used' do
+      let(:text) { '# rubocop:enable Foo, Bar, Baz' }
+
+      it { is_expected.to eq 3 }
+    end
+
+    context 'when cops and departments used' do
+      let(:text) { '# rubocop:enable Foo/Bar, Foo/Baz, Bar, Baz' }
+
+      it { is_expected.to eq 4 }
+    end
+  end
 end


### PR DESCRIPTION
New feature for request https://github.com/rubocop/rubocop/issues/9519

- Added checking for department only to directive comment.
- Added note about new feature to documentation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
