### PR TITLE
[Fix #9627] Fix an incorrect auto-correct for `Style/StructInheritance`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_struct_inheritance.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_struct_inheritance.md
@@ -1,0 +1,1 @@
+* [#9627](https://github.com/rubocop/rubocop/issues/9627): Fix an incorrect auto-correct for `Style/StructInheritance` when extending instance of Struct without `do` ... `end` and class body is empty. ([@koic][])

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -48,6 +48,8 @@ module RuboCop
         def correct_parent(parent, corrector)
           if parent.block_type?
             corrector.remove(range_with_surrounding_space(range: parent.loc.end, newlines: false))
+          elsif (class_node = parent.parent).body.nil?
+            corrector.remove(range_by_whole_lines(class_node.loc.end, include_final_newline: true))
           else
             corrector.insert_after(parent.loc.expression, ' do')
           end

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe RuboCop::Cop::Style::StructInheritance, :config do
     RUBY
   end
 
+  it 'registers an offense when extending instance of Struct without `do` ... `end` and class body is empty' do
+    expect_offense(<<~RUBY)
+      class Person < Struct.new(:first_name, :last_name)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't extend an instance initialized by `Struct.new`. Use a block to customize the struct.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Person = Struct.new(:first_name, :last_name)
+    RUBY
+  end
+
   it 'registers an offense when extending instance of ::Struct with ' \
      'do ... end' do
     expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #9627.

This PR fixes an incorrect auto-correct for `Style/StructInheritance` when extending instance of Struct without `do` ... `end` and class body is empty.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
