### PR TITLE
Calls with braces in interpolation for `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/changelog/new_add_allow_parentheses_in_string_interpolation_config_to_style_method_call_with_args_parentheses.md
+++ b/changelog/new_add_allow_parentheses_in_string_interpolation_config_to_style_method_call_with_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#9629](https://github.com/rubocop/rubocop/issues/9629): Add `AllowParenthesesInStringInterpolation` configuration to `Style/MethodCallWithArgsParentheses` to allow parenthesized calls in string interpolation. ([@gsamokovarov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3675,6 +3675,7 @@ Style/MethodCallWithArgsParentheses:
   AllowParenthesesInMultilineCall: false
   AllowParenthesesInChaining: false
   AllowParenthesesInCamelCaseMethod: false
+  AllowParenthesesInStringInterpolation: false
   EnforcedStyle: require_parentheses
   SupportedStyles:
     - require_parentheses

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -146,6 +146,22 @@ module RuboCop
       #
       #   # good
       #   Array 1
+      #
+      # @example AllowParenthesesInStringInterpolation: false (default)
+      #
+      #   # bad
+      #   "#{t('this.is.bad')}"
+      #
+      #   # good
+      #   "#{t 'this.is.better'}"
+      #
+      # @example AllowParenthesesInStringInterpolation: true
+      #
+      #   # good
+      #   "#{t('this.is.good')}"
+      #
+      #   # good
+      #   "#{t 'this.is.also.good'}"
       class MethodCallWithArgsParentheses < Base
         require_relative 'method_call_with_args_parentheses/omit_parentheses'
         require_relative 'method_call_with_args_parentheses/require_parentheses'

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -467,6 +467,17 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    it 'register an offense for parens in string interpolation' do
+      expect_offense(<<~'RUBY')
+        "#{t('no.parens')}"
+            ^^^^^^^^^^^^^ Omit parentheses for method calls with arguments.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "#{t 'no.parens'}"
+      RUBY
+    end
+
     it 'register an offense in complex conditionals' do
       expect_offense(<<~RUBY)
         def foo
@@ -828,6 +839,22 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       it 'accepts parens for camel-case method names' do
         expect_no_offenses('Array(nil)')
       end
+    end
+  end
+
+  context 'allowing parens in string interpolation' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'omit_parentheses',
+        'AllowParenthesesInStringInterpolation' => true
+      }
+    end
+
+    it 'accepts parens for camel-case method names' do
+      expect_no_offenses(<<~'RUBY')
+        "#{t('this.is.good')}"
+        "#{t 'this.is.also.good'}"
+      RUBY
     end
   end
 


### PR DESCRIPTION
If we are calling methods in string interpolation with the `omit_parentheses`
style for the `Style/MethodCallWithArgsParentheses` cop, they are
currently forced to be without parentheses:

```ruby
"#{part 1}, #{part 2}, #{part 3}"
```

My coworkers at Dext want to be able to put spaces while calling methods
in interpolation, and I don't blame them. Having spaces reduces the
noise of following a method call in a string, especially if the string
happens to have multiple interpolations in it.

I want to add the `AllowParenthesesInStringInterpolation` cop configuration
that allows the use of parentheses in string interpolation calls.

```ruby
"#{part(1)}, #{part(2)}, #{part(3)}"
```