### PR TITLE
Fix an incorrect auto-correct for `Style/RedundantReturn`

### DIFF
--- a/changelog/fix_false_positive_for_style_redundant_return.md
+++ b/changelog/fix_false_positive_for_style_redundant_return.md
@@ -1,0 +1,1 @@
+* [#9631](https://github.com/rubocop/rubocop/issues/9631): Fix an incorrect auto-correct for `Style/RedundantReturn` when using `return` with splat argument. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -71,6 +71,10 @@ module RuboCop
           elsif hash_without_braces?(return_node.first_argument)
             add_braces(corrector, return_node.first_argument)
           end
+          if return_node.splat_argument?
+            first_argument = return_node.first_argument
+            corrector.replace(first_argument, first_argument.source.gsub(/\A\*/, ''))
+          end
 
           keyword = range_with_surrounding_space(range: return_node.loc.keyword,
                                                  side: :right)

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -54,6 +54,23 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
     RUBY
   end
 
+  it 'reports an offense for def ending with return with splat argument' do
+    expect_offense(<<~RUBY)
+      def func
+        some_preceding_statements
+        return *something
+        ^^^^^^ Redundant `return` detected.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def func
+        some_preceding_statements
+        something
+      end
+    RUBY
+  end
+
   it 'reports an offense for defs ending with return' do
     expect_offense(<<~RUBY)
       def self.func


### PR DESCRIPTION
Fixes https://github.com/testdouble/standard/issues/277.

This PR fixes the following false positive for `Style/RedundantReturn` when using `return` with splat argument.

```console
% cat example.rb
class MyClass
  def something
    data = [1, 2, 3]
    return *data
  end
end
```

## Before

Auto-corrected to invalid code.

```console
% rubocop --only Style/RedundantReturn -a
(snip)

% cat example.rb
class MyClass
  def something
    data = [1, 2, 3]
    *data
  end
end

% ruby -c example.rb
example.rb:4: syntax error, unexpected '\n', expecting '='
```

## After

Auto-corrected to valid code.

```console
% rubocop --only Style/RedundantReturn -a
(snip)

% cat example.rb
class MyClass
  def something
    data = [1, 2, 3]
    data
  end
end

% ruby -c example.rb
Syntax OK
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
