### PR TITLE
[Fix #5953] Fix a false positive for `Style/AccessModifierDeclarations`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_access_modifier_declarations.md
+++ b/changelog/fix_a_false_positive_for_style_access_modifier_declarations.md
@@ -1,0 +1,1 @@
+* [#5953](https://github.com/rubocop/rubocop/issues/5953): Fix a false positive for `Style/AccessModifierDeclarations` when using `module_function` with symbol. ([@koic][])

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -79,7 +79,7 @@ module RuboCop
 
         # @!method access_modifier_with_symbol?(node)
         def_node_matcher :access_modifier_with_symbol?, <<~PATTERN
-          (send nil? {:private :protected :public} (sym _))
+          (send nil? {:private :protected :public :module_function} (sym _))
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
       }
     end
 
-    %w[private protected public].each do |access_modifier|
+    %w[private protected public module_function].each do |access_modifier|
       it "offends when #{access_modifier} is inlined with a method" do
         expect_offense(<<~RUBY, access_modifier: access_modifier)
           class Test
@@ -108,7 +108,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
       }
     end
 
-    %w[private protected public].each do |access_modifier|
+    %w[private protected public module_function].each do |access_modifier|
       it "offends when #{access_modifier} is not inlined" do
         expect_offense(<<~RUBY, access_modifier: access_modifier)
           class Test


### PR DESCRIPTION
Fixes #5953.

This PR fixes a false positive for `Style/AccessModifierDeclarations` when using `module_function` with symbol.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
