### PR TITLE
Fix an incorrect auto-correct for `Lint/NumberConversion`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_lint_number_conversion.md
+++ b/changelog/fix_incorrect_autocorrect_for_lint_number_conversion.md
@@ -1,0 +1,1 @@
+* [#9633](https://github.com/rubocop/rubocop/pull/9633): Fix an incorrect auto-correct for `Lint/NumberConversion` when `to_i` method in symbol form. ([@koic][])

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -105,6 +105,8 @@ module RuboCop
               corrected_method: correct_sym_method(to_method)
             )
             add_offense(node, message: message) do |corrector|
+              remove_parentheses(corrector, node) if node.parenthesized?
+
               corrector.replace(sym_node, correct_sym_method(to_method))
             end
           end
@@ -118,6 +120,11 @@ module RuboCop
         def correct_sym_method(to_method)
           body = format(CONVERSION_METHOD_CLASS_MAPPING[to_method], number_object: 'i')
           "{ |i| #{body} }"
+        end
+
+        def remove_parentheses(corrector, node)
+          corrector.replace(node.loc.begin, ' ')
+          corrector.remove(node.loc.end)
         end
 
         def ignore_receiver?(receiver)

--- a/spec/rubocop/cop/lint/number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/number_conversion_spec.rb
@@ -131,7 +131,18 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
       RUBY
 
       expect_correction(<<~RUBY)
-        "1,2,3,foo,5,6,7,8".split(',').map({ |i| Integer(i, 10) })
+        "1,2,3,foo,5,6,7,8".split(',').map { |i| Integer(i, 10) }
+      RUBY
+    end
+
+    it 'registers offense and autocorrects without parentheses' do
+      expect_offense(<<~RUBY)
+        "1,2,3,foo,5,6,7,8".split(',').map &:to_i
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using &:to_i, use stricter { |i| Integer(i, 10) }.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        "1,2,3,foo,5,6,7,8".split(',').map { |i| Integer(i, 10) }
       RUBY
     end
 
@@ -142,7 +153,7 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
       RUBY
 
       expect_correction(<<~RUBY)
-        "foo".try({ |i| Float(i) })
+        "foo".try { |i| Float(i) }
       RUBY
     end
 
@@ -153,7 +164,7 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
       RUBY
 
       expect_correction(<<~RUBY)
-        "foo".send({ |i| Complex(i) })
+        "foo".send { |i| Complex(i) }
       RUBY
     end
   end


### PR DESCRIPTION
For example, the following auto-correction test code is invalid syntax:

```ruby
"1,2,3,foo,5,6,7,8".split(',').map({ |i| Integer(i, 10) })
```

This PR removes invalid parentheses and auto-corrects it to valid syntax:

```ruby
"1,2,3,foo,5,6,7,8".split(',').map { |i| Integer(i, 10) }
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
