### PR TITLE
[Fix #9622] Fixed `Style/BisectedAttrAccessor` autocorrection to handle multiple bisected attrs in the same macro

### DIFF
--- a/changelog/fix_fixed_stylebisectedattraccessor.md
+++ b/changelog/fix_fixed_stylebisectedattraccessor.md
@@ -1,0 +1,1 @@
+* [#9622](https://github.com/rubocop/rubocop/issues/9622): Fixed `Style/BisectedAttrAccessor` autocorrection to handle multiple bisected attrs in the same macro. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/bisected_attr_accessor/macro.rb
+++ b/lib/rubocop/cop/style/bisected_attr_accessor/macro.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Style
+      class BisectedAttrAccessor
+        # Representation of an `attr_reader`, `attr_writer` or `attr` macro
+        # for use by `Style/BisectedAttrAccessor`.
+        # @api private
+        class Macro
+          include VisibilityHelp
+
+          attr_reader :node, :attrs, :bisection
+
+          def self.macro?(node)
+            node.method?(:attr_reader) || node.method?(:attr_writer) || node.method?(:attr)
+          end
+
+          def initialize(node)
+            @node = node
+            @attrs = node.arguments.map do |attr|
+              [attr.source, attr]
+            end.to_h
+            @bisection = []
+          end
+
+          def bisect(*names)
+            @bisection = attrs.slice(*names).values
+          end
+
+          def attr_names
+            @attr_names ||= attrs.keys
+          end
+
+          def bisected_names
+            bisection.map(&:source)
+          end
+
+          def visibility
+            @visibility ||= node_visibility(node)
+          end
+
+          def reader?
+            node.method?(:attr_reader) || node.method?(:attr)
+          end
+
+          def writer?
+            node.method?(:attr_writer)
+          end
+
+          def all_bisected?
+            rest.none?
+          end
+
+          def rest
+            @rest ||= attr_names - bisected_names
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This ended up being a pretty heavy refactor of the `Style/BisectedAttrAccessor` cop.

Previously we were doing multiple passes at determining what macros are relevant for the cop, and which names within them. Despite that, if a macro had multiple names and was rewritten, we'd lose context of what other names there were and only the first one would survive the autocorrection.

Instead, I have now extracted a `Macro` value object that encapsulates all the data for the macro, including visibility (since macros of different visibilities are not combined), bisected and non-bisected attribute names, etc. When investigating a class, any macros found have objects created, and they are retained to be used to correct the class as a whole after wards (but we still register offenses on individual macro attributes as before).

I have also added some more edge case tests that I encountered as I was working on this.

Fixes #9622.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
