### PR TITLE
Parenthesized forwarded args in `Style/MethodCallWithArgsParentheses` `omit_parentheses`

### DIFF
--- a/changelog/fix_parentheses_in_forwarded_args_for_style_method_call_with_args_parentheses.md
+++ b/changelog/fix_parentheses_in_forwarded_args_for_style_method_call_with_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#9637](https://github.com/rubocop/rubocop/issues/9637): Allow parentheses for forwarded args in `Style/MethodCallWithArgsParentheses`'s `omit_parentheses` style to avoid endless range ambiguity. ([@gsamokovarov][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -40,8 +40,12 @@ module RuboCop
       #     to `true` allows the presence of parentheses in such a method call
       #     even with arguments.
       #
-      # NOTE: Parens are required around a method with arguments when inside an
-      # endless method definition (>= Ruby 3.0).
+      # NOTE: Parentheses are still allowed in cases where omitting them
+      # results in ambiguous or syntactically incorrect code. For example,
+      # parentheses are required around a method with arguments when inside an
+      # endless method definition introduced in Ruby 3.0.  Parentheses are also
+      # allowed when forwarding arguments with the triple-dot syntax introduced
+      # in Ruby 2.7 as omitting them starts an endless range.
       #
       # @example EnforcedStyle: require_parentheses (default)
       #

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       class MethodCallWithArgsParentheses
         # Style omit_parentheses
-        # rubocop:disable Metrics/ModuleLength
+        # rubocop:disable Metrics/ModuleLength, Metrics/CyclomaticComplexity
         module OmitParentheses
           TRAILING_WHITESPACE_REGEX = /\s+\Z/.freeze
           OMIT_MSG = 'Omit parentheses for method calls with arguments.'
@@ -13,7 +13,6 @@ module RuboCop
 
           private
 
-          # rubocop:disable Metrics/CyclomaticComplexity
           def omit_parentheses(node)
             return unless node.parenthesized?
             return if inside_endless_method_def?(node)
@@ -27,7 +26,6 @@ module RuboCop
               auto_correct(corrector, node)
             end
           end
-          # rubocop:enable Metrics/CyclomaticComplexity
 
           def auto_correct(corrector, node)
             if parentheses_at_the_end_of_multiline_call?(node)
@@ -114,7 +112,7 @@ module RuboCop
               call_as_argument_or_chain?(node) ||
               hash_literal_in_arguments?(node) ||
               node.descendants.any? do |n|
-                ambigious_literal?(n) || logical_operator?(n) ||
+                n.forwarded_args_type? || ambigious_literal?(n) || logical_operator?(n) ||
                   call_with_braced_block?(n)
               end
           end
@@ -190,7 +188,7 @@ module RuboCop
             node.ancestors.drop_while { |a| !a.begin_type? }.any?(&:dstr_type?)
           end
         end
-        # rubocop:enable Metrics/ModuleLength
+        # rubocop:enable Metrics/ModuleLength, Metrics/CyclomaticComplexity
       end
     end
   end

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -361,6 +361,26 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
 
     it_behaves_like 'endless methods', omit: true
 
+    context 'forwarded arguments in 2.7', :ruby27 do
+      it 'accepts parens for forwarded arguments' do
+        expect_no_offenses(<<~RUBY)
+          def delegated_call(...)
+            @proxy.call(...)
+          end
+        RUBY
+      end
+    end
+
+    context 'forwarded arguments in 3.0', :ruby30 do
+      it 'accepts parens for forwarded arguments' do
+        expect_no_offenses(<<~RUBY)
+          def method_missing(name, ...)
+            @proxy.call(name, ...)
+          end
+        RUBY
+      end
+    end
+
     it 'register an offense for parens in method call without args' do
       trailing_whitespace = ' '
 


### PR DESCRIPTION
The new-style arguments delegation included in Ruby 2.7 and expanded in
Ruby 3.0 is required to be parenthesized, since the syntax is clashing with the
endless `start...` range, which can be started with `start ...` as well. Currently,
the most iffy cop of them all is issuing offenses for:

```ruby
def delegated_call(...)
  @proxy.call(...)
             ^^^^^ Omit parentheses for method calls with arguments.
end
```

Removing the parens will  start an endless range with the beginning being the
result of the method call without arguments. See the parse trees below for more
details:

```bash
-> ruby-parse -e "def foo(...); bar(...); end"
(def :foo
  (args
    (forward-arg))
  (send nil :bar
    (forwarded-args)))

-> ruby-parse -e "def foo(...); bar ...; end"
(def :foo
  (args
    (forward-arg))
  (erange
    (send nil :bar) nil))

-> ruby-parse -e "def foo(...); bar...; end"
(def :foo
  (args
    (forward-arg))
  (erange
    (send nil :bar) nil))
```

We don't want that, so allow the parentheses and leave this gotcha to
the poor developer that's gonna run onto it.