### PR TITLE
Fix an error for `Layout/LineLength`

### DIFF
--- a/changelog/fix_error_for_layout_line_length.md
+++ b/changelog/fix_error_for_layout_line_length.md
@@ -1,0 +1,1 @@
+* [#9638](https://github.com/rubocop/rubocop/pull/9638): Fix an error for `Layout/LineLength` when over limit at right hand side of multiple assignment. ([@koic][])

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -83,7 +83,7 @@ module RuboCop
 
       # @api private
       def within_column_limit?(element, max, line)
-        element && element.loc.column < max && element.loc.line == line
+        element && element.loc.column <= max && element.loc.line == line
       end
 
       # @api private

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -1060,5 +1060,22 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
         end
       end
     end
+
+    context 'multiple assignment' do
+      context 'when over limit at right hand side' do
+        it 'registers and corrects an offense' do
+          expect_offense(<<~RUBY)
+            a = fooooooooooooooooooooooooooooooooooooo, b
+                                                    ^^^^^ Line is too long. [45/40]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            a =#{trailing_whitespace}
+            fooooooooooooooooooooooooooooooooooooo,#{trailing_whitespace}
+            b
+          RUBY
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the following infinite loop error for `Layout/LineLength` when over limit at right hand side of multiple assignment.

```console
% cat .rubocop.yml
Layout/LineLength:
  Max: 40

% cat example.rb
a = fooooooooooooooooooooooooooooooooooooo, b

% bundle exec rubocop --only Layout/LineLength -a
(snip)

0 files inspected, 200 offenses detected, 200 offenses corrected
Infinite loop detected in /tmp/example.rb and caused by Layout/LineLength
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/runner.rb:290:in
`block in iterate_until_no_changes'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/runner.rb:286:in
`loop'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/runner.rb:286:in
`iterate_until_no_changes'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
