### PR TITLE
Fix `Style/RedundantBegin` removing comments on assignment statement correction

### DIFF
--- a/changelog/fix_style_redundant_being_removing_comments_on_assignment_statement_correction.md
+++ b/changelog/fix_style_redundant_being_removing_comments_on_assignment_statement_correction.md
@@ -1,0 +1,1 @@
+* [#9639](https://github.com/rubocop/rubocop/pull/9639): Fix `Style/RedundantBegin` removing comments on assignment statement correction. ([@marcotc][])

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -114,6 +114,17 @@ module RuboCop
 
           corrector.replace(offense_range, first_child.source)
           corrector.remove(range_between(offense_range.end_pos, first_child.source_range.end_pos))
+
+          restore_removed_comments(corrector, offense_range, node, first_child)
+        end
+
+        # Restore comments that occur between "begin" and "first_child".
+        # These comments will be moved to above the assignment line.
+        def restore_removed_comments(corrector, offense_range, node, first_child)
+          comments_range = range_between(offense_range.end_pos, first_child.source_range.begin_pos)
+          comments = comments_range.source
+
+          corrector.insert_before(node.parent, comments) unless comments.blank?
         end
 
         def empty_begin?(node)

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -197,14 +197,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
 
   it 'registers and corrects an offense when using `begin` with single statement for or assignment' do
     expect_offense(<<~RUBY)
-      var ||= begin
+      # outer comment
+      var ||= begin # inner comment 1
               ^^^^^ Redundant `begin` block detected.
+        # inner comment 2
         foo
+        # inner comment 3
       end
     RUBY
 
     expect_correction(<<~RUBY)
-      var ||= foo
+      # outer comment
+       # inner comment 1
+        # inner comment 2
+        var ||= foo
+        # inner comment 3
 
     RUBY
   end


### PR DESCRIPTION
`Style/RedundantBegin` cop currently removes comments that occur
before the first child node of the `begin` block. This happens
because comments are skipped when navigating the node tree.

Currently,
```ruby
var ||= begin
  # comment
  foo
end
```
will correct to
```ruby
var ||= foo
```

This PR changes that correction to
```ruby
# comment
var ||= foo
```

Other comments in the vicinity (before and after `begin/end` block,
and after first child node) are still preserved, as they
already were before this change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
