### PR TITLE
--no-parallel (-P/--parallel can not be combined with --auto-correct)

### DIFF
--- a/changelog/change_add_no_parallel_option.md
+++ b/changelog/change_add_no_parallel_option.md
@@ -1,0 +1,1 @@
+* [#7544](https://github.com/rubocop/rubocop/pull/7544): Add --no-parallel (-P/--parallel can not be combined with --auto-correct). ([@kwerle][])

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -348,9 +348,11 @@ module RuboCop
 
     def disable_parallel_when_invalid_combo
       combos = {
-        auto_gen_config: '--auto-gen-config',
-        fail_fast: '-F/--fail-fast.',
-        auto_correct: '--auto-correct.'
+        auto_gen_config: '-P/--parallel uses caching to speed up execution, ' \
+                         'while --auto-gen-config needs a non-cached run, ' \
+                         'so they cannot be combined.',
+        fail_fast: '-P/--parallel cannot be combined with -F/--fail-fast.',
+        auto_correct: '-P/--parallel cannot be combined with --auto-correct.'
       }
 
       invalid_combos = combos.select { |key, _flag| @options.key?(key) }

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -499,7 +499,6 @@ module RuboCop
       verbose_version:                  'Display verbose version.',
       parallel:                         ['Use available CPUs to execute inspection in',
                                          'parallel. Default is false.'],
-      no_parallel:                      ['Disable parallel if it is set in the configuration.'],
       stdin:                            ['Pipe source from STDIN, using FILE in offense',
                                          'reports. This is useful for editor integration.'],
       init:                             'Generate a .rubocop.yml file in the current directory.'

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -348,11 +348,9 @@ module RuboCop
 
     def disable_parallel_when_invalid_combo
       combos = {
-        auto_gen_config: '-P/--parallel uses caching to speed up execution, ' \
-                         'while --auto-gen-config needs a non-cached run, ' \
-                         'so they cannot be combined.',
-        fail_fast: '-P/--parallel cannot be combined with -F/--fail-fast.',
-        auto_correct: '-P/--parallel cannot be combined with --auto-correct.'
+        auto_gen_config: '--auto-gen-config',
+        fail_fast: '-F/--fail-fast.',
+        auto_correct: '--auto-correct.'
       }
 
       invalid_combos = combos.select { |key, _flag| @options.key?(key) }

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -498,7 +498,8 @@ module RuboCop
       version:                          'Display version.',
       verbose_version:                  'Display verbose version.',
       parallel:                         ['Use available CPUs to execute inspection in',
-                                         'parallel.'],
+                                         'parallel. Default is false.'],
+      no_parallel:                      ['Disable parallel if it is set in the configuration.'],
       stdin:                            ['Pipe source from STDIN, using FILE in offense',
                                          'reports. This is useful for editor integration.'],
       init:                             'Generate a .rubocop.yml file in the current directory.'

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -186,7 +186,7 @@ module RuboCop
 
       option(opts, '-v', '--version')
       option(opts, '-V', '--verbose-version')
-      option(opts, '-P', '--parallel')
+      option(opts, '-P', '--[no-]parallel')
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -137,8 +137,8 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                   --[no-]color                 Force color output on or off.
               -v, --version                    Display version.
               -V, --verbose-version            Display verbose version.
-              -P, --parallel                   Use available CPUs to execute inspection in
-                                               parallel.
+              -P, --[no-]parallel              Use available CPUs to execute inspection in
+                                               parallel. Default is false.
               -l, --lint                       Run only lint cops.
               -x, --fix-layout                 Run only layout cops, with auto-correct on.
               -s, --stdin FILE                 Pipe source from STDIN, using FILE in offense
@@ -226,24 +226,20 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
 
       context 'combined with --fail-fast' do
-        it 'ignores parallel' do
-          msg = '-P/--parallel is being ignored because it is not compatible with -F/--fail-fast'
-          options.parse %w[--parallel --fail-fast]
-          expect($stdout.string).to include(msg)
-          expect(options.instance_variable_get('@options').keys).not_to include(:parallel)
-        end
-      end
-
-      context 'combined with --auto-correct and --fail-fast' do
-        it 'ignores parallel' do
-          msg = '-P/--parallel is being ignored because it is not compatible with -F/--fail-fast'
-          options.parse %w[--parallel --fail-fast --auto-correct]
-          expect($stdout.string).to include(msg)
-          expect(options.instance_variable_get('@options').keys).not_to include(:parallel)
+        it 'fails with an error message' do
+          msg = '-P/--parallel cannot be combined with -F/--fail-fast.'
+          expect { options.parse %w[--parallel --fail-fast] }
+            .to raise_error(RuboCop::OptionArgumentError, msg)
         end
       end
     end
 
+    describe '--no-parallel' do
+      it 'disables parallel from file' do
+        results = options.parse %w[--no-parallel]
+        expect(results).to eq([{:parallel=>false}, []])
+      end
+    end
     describe '--display-only-failed' do
       it 'fails if given without --format junit' do
         expect { options.parse %w[--display-only-failed] }

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -226,14 +226,23 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
 
       context 'combined with --fail-fast' do
-        it 'fails with an error message' do
-          msg = '-P/--parallel cannot be combined with -F/--fail-fast.'
-          expect { options.parse %w[--parallel --fail-fast] }
-            .to raise_error(RuboCop::OptionArgumentError, msg)
+        it 'ignores parallel' do
+          msg = '-P/--parallel is being ignored because it is not compatible with -F/--fail-fast'
+          options.parse %w[--parallel --fail-fast]
+          expect($stdout.string).to include(msg)
+          expect(options.instance_variable_get('@options').keys).not_to include(:parallel)
         end
       end
     end
 
+      context 'combined with --auto-correct and --fail-fast' do
+        it 'ignores parallel' do
+          msg = '-P/--parallel is being ignored because it is not compatible with -F/--fail-fast'
+          options.parse %w[--parallel --fail-fast --auto-correct]
+          expect($stdout.string).to include(msg)
+          expect(options.instance_variable_get('@options').keys).not_to include(:parallel)
+        end
+      end
     describe '--no-parallel' do
       it 'disables parallel from file' do
         results = options.parse %w[--no-parallel]

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -235,20 +235,22 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
     end
 
-      context 'combined with --auto-correct and --fail-fast' do
-        it 'ignores parallel' do
-          msg = '-P/--parallel is being ignored because it is not compatible with -F/--fail-fast'
-          options.parse %w[--parallel --fail-fast --auto-correct]
-          expect($stdout.string).to include(msg)
-          expect(options.instance_variable_get('@options').keys).not_to include(:parallel)
-        end
+    context 'combined with --auto-correct and --fail-fast' do
+      it 'ignores parallel' do
+        msg = '-P/--parallel is being ignored because it is not compatible with -F/--fail-fast'
+        options.parse %w[--parallel --fail-fast --auto-correct]
+        expect($stdout.string).to include(msg)
+        expect(options.instance_variable_get('@options').keys).not_to include(:parallel)
       end
+    end
+
     describe '--no-parallel' do
       it 'disables parallel from file' do
         results = options.parse %w[--no-parallel]
-        expect(results).to eq([{:parallel=>false}, []])
+        expect(results).to eq([{ parallel: false }, []])
       end
     end
+
     describe '--display-only-failed' do
       it 'fails if given without --format junit' do
         expect { options.parse %w[--display-only-failed] }


### PR DESCRIPTION
Fix #7544

We just discovered --parallel and added it to our .rubocop file. Turns out you can't use it with -a.

We would like to leave --parallel in our .rubocop file but would occasionally like to use -a. So we would like a --no-parallel flag to override our default - so we can do
rubocop --no-parallel -a

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

Note that master failed `bundle exec rake default`