### PR TITLE
[Fix #9641] Fix `Layout/MultilineMethodCallIndentation` triggering on method calls that look like operators

### DIFF
--- a/changelog/fix_fix_layoutmultilinemethodcallindentation.md
+++ b/changelog/fix_fix_layoutmultilinemethodcallindentation.md
@@ -1,0 +1,1 @@
+* [#9641](https://github.com/rubocop/rubocop/issues/9641): Fix `Layout/MultilineMethodCallIndentation` triggering on method calls that look like operators. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -72,6 +72,18 @@ module RuboCop
           send_node.loc.dot # Only check method calls with dot operator
         end
 
+        def right_hand_side(send_node)
+          dot = send_node.loc.dot
+          selector = send_node.loc.selector
+          if send_node.dot? && selector && dot.line == selector.line
+            dot.join(selector)
+          elsif selector
+            selector
+          elsif send_node.implicit_call?
+            dot.join(send_node.loc.begin)
+          end
+        end
+
         def offending_range(node, lhs, rhs, given_style)
           return false unless begins_its_line?(rhs)
           return false if not_for_this_cop?(node)

--- a/lib/rubocop/cop/layout/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_operation_indentation.rb
@@ -118,6 +118,10 @@ module RuboCop
               "spaces for indenting #{what} spanning multiple lines."
           end
         end
+
+        def right_hand_side(send_node)
+          send_node.first_argument.source_range
+        end
       end
     end
   end

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -35,26 +35,6 @@ module RuboCop
         lhs
       end
 
-      def right_hand_side(send_node)
-        if send_node.operator_method? && send_node.arguments?
-          send_node.first_argument.source_range # not used for method calls
-        else
-          regular_method_right_hand_side(send_node)
-        end
-      end
-
-      def regular_method_right_hand_side(send_node)
-        dot = send_node.loc.dot
-        selector = send_node.loc.selector
-        if send_node.dot? && selector && dot.line == selector.line
-          dot.join(selector)
-        elsif selector
-          selector
-        elsif send_node.implicit_call?
-          dot.join(send_node.loc.begin)
-        end
-      end
-
       # The correct indentation of `node` is usually `IndentationWidth`, with
       # one exception: prefix keywords.
       #

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -95,6 +95,15 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           .my_method
       RUBY
     end
+
+    it 'accepts alignment of method with assignment and operator-like method' do
+      expect_no_offenses(<<~RUBY)
+        query = x.|(
+          foo,
+          bar
+        )
+      RUBY
+    end
   end
 
   shared_examples 'common for aligned and indented' do

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -81,6 +81,11 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation, :config do
         .a
           .b(c)
 
+        Foo.&(
+            foo,
+            bar
+        )
+
         expect { Foo.new }.
           to change { Bar.count }.
               from(1).to(2)


### PR DESCRIPTION
`MultilineExpressionIndentation#right_hand_side`, which is used by both `Layout/MultilineMethodCallIndentation` and `Layout/MultilineOperationIndentation` was not correctly calculating the RHS when the send node looks like an operator but has a receiver (ie. `foo.&`). This was leading to an autocorrection loop with `Layout/ArgumentAlignment`, `Layout/ClosingParenthesisIndentation` and `Layout/FirstArgumentIndentation`.

I split out the `right_hand_side` method to be defined in each of the two cops so that the right behaviour can be in place for each cop.

Fixes #9641.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
