### PR TITLE
Fix an error for `Style/MultilineMethodSignature`

### DIFF
--- a/changelog/fix_error_for_style_multiline_method_signature.md
+++ b/changelog/fix_error_for_style_multiline_method_signature.md
@@ -1,0 +1,1 @@
+* [#9644](https://github.com/rubocop/rubocop/pull/9644): Fix an error and an incorrect auto-correct for `Style/MultilineMethodSignature` when line break after opening parenthesis. ([@koic][])

--- a/spec/rubocop/cop/style/multiline_method_signature_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_signature_spec.rb
@@ -17,6 +17,25 @@ RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects when line break after opening parenthesis' do
+        expect_offense(<<~RUBY)
+          class Foo
+            def foo(
+            ^^^^^^^^ Avoid multi-line method signatures.
+              arg
+          )
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Foo
+            def foo(arg)
+            end
+          end
+        RUBY
+      end
+
       context 'when method signature is on a single line' do
         it 'does not register an offense for parameterized method' do
           expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR fixes the following error and the incorrect auto-correct for `Style/MultilineMethodSignature` when line break after opening parenthesis.

```ruby
% cat example.rb
class Foo
  def foo(
    arg
)
  end
end
```

## Before

```console
% rubocop -a --only Style/MultilineMethodSignature example.rb
(snip)

Inspecting 1 file
C

Offenses:

example.rb:2:3: C: [Corrected] Style/MultilineMethodSignature: Avoid
multi-line method signatures.
def foo( ...
^^^^^^^^

0 files inspected, 1 offense detected, 1 offense corrected
Infinite loop detected in /private/tmp/example.rb and caused by Style/MultilineMethodSignature
/Users/koic/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-1.12.0/lib/rubocop/runner.rb:304:in
`check_for_infinite_loop'
/Users/koic/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-1.12.0/lib/rubocop/runner.rb:287:in
`block in iterate_until_no_changes'
/Users/koic/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-1.12.0/lib/rubocop/runner.rb:286:in
`loop'
(snip)

% cat example.rb
class Foo
  def foo(
    arg)
  end
end
```

## After

```console
% rubocop -a --only Style/MultilineMethodSignature example.rb
(snip)

class Foo
  def foo(arg)
  end
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
