### PR TITLE
Fix an incorrect auto-correct for `Style/SingleLineMethods`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_single_line_methods.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_single_line_methods.md
@@ -1,0 +1,1 @@
+* [#9645](https://github.com/rubocop/rubocop/pull/9645): Fix an incorrect auto-correct for `Style/SingleLineMethods` when using single line class method definition. ([@koic][])

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -91,8 +91,9 @@ module RuboCop
         end
 
         def correct_to_endless(corrector, node)
+          self_receiver = node.self_receiver? ? 'self.' : ''
           arguments = node.arguments.any? ? node.arguments.source : '()'
-          replacement = "def #{node.method_name}#{arguments} = #{node.body.source}"
+          replacement = "def #{self_receiver}#{node.method_name}#{arguments} = #{node.body.source}"
           corrector.replace(node, replacement)
         end
 

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -168,6 +168,12 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
         RUBY
       end
 
+      it 'corrects to an endless class method definition' do
+        expect_correction(<<~RUBY.strip, source: 'def self.some_method; body end')
+          def self.some_method() = body
+        RUBY
+      end
+
       it 'retains comments' do
         source = 'def some_method; body end # comment'
         expect_correction(<<~RUBY.strip, source: source)


### PR DESCRIPTION
Fix the following incorrect auto-correct for `Style/SingleLineMethods` when using single line class method definition.

```console
% cat example.rb
def self.some_method; body end

% rubocop --only Style/SingleLineMethods -a
(snip)

Offenses:

example.rb:1:1: C: [Corrected] Style/SingleLineMethods: Avoid
single-line method definitions.
def self.some_method; body end
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

## Before

```console
% cat example.rb
def some_method() = body
```

`self` is lost due to auto-correction.

## After

```console
% cat example.rb
def self.some_method() = body
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
