### PR TITLE
Fix an incorrect auto-correct for `Style/AndOr`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_and_or.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_and_or.md
@@ -1,0 +1,1 @@
+* [#9646](https://github.com/rubocop/rubocop/pull/9646): Fix an incorrect auto-correct for `EnforcedStyle: require_parentheses` of `Style/MethodCallWithArgsParentheses` with `EnforcedStyle: conditionals` of `Style/AndOr`. ([@koic][])

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -94,7 +94,9 @@ module RuboCop
 
           return unless correctable_send?(node)
 
-          corrector.replace(whitespace_before_arg(node), '(')
+          whitespace_before_arg_range = whitespace_before_arg(node)
+          corrector.remove(whitespace_before_arg_range)
+          corrector.insert_before(whitespace_before_arg_range, '(')
           corrector.insert_after(node.last_argument, ')')
         end
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -215,6 +215,27 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `EnforcedStyle: require_parentheses` of `Style/MethodCallWithArgsParentheses` with ' \
+     '`EnforcedStyle: conditionals` of `Style/AndOr`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/MethodCallWithArgsParentheses:
+        EnforcedStyle: require_parentheses
+      Style/AndOr:
+        EnforcedStyle: conditionals
+    YAML
+    create_file('example.rb', <<~RUBY)
+      if foo and bar :arg
+      end
+    RUBY
+    expect(
+      cli.run(['--auto-correct', '--only', 'Style/MethodCallWithArgsParentheses,Style/AndOr'])
+    ).to eq(0)
+    expect(IO.read('example.rb')).to eq(<<~RUBY)
+      if foo && bar(:arg)
+      end
+    RUBY
+  end
+
   it 'corrects `Style/IfUnlessModifier` with `Style/SoleNestedConditional`' do
     source = <<~RUBY
       def foo


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `EnforcedStyle: require_parentheses` of `Style/MethodCallWithArgsParentheses` with `EnforcedStyle: conditionals` of `Style/AndOr`.

```console
% cat example.rb
if foo and bar :arg
end

% rubocop --only Style/AndOr,Style/MethodCallWithArgsParentheses -a
(snip)

Offenses:

example.rb:1:8: C: [Corrected] Style/AndOr: Use && instead of and.
if foo and bar :arg
       ^^^
example.rb:1:12: C: [Corrected] Style/MethodCallWithArgsParentheses: Use
parentheses for method calls with arguments.
if foo and bar :arg
           ^^^^^^^^

1 file inspected, 2 offenses detected, 2 offenses corrected
```

## Before

```console
% cat example.rb
if foo && bar(:arg))
end

% ruby -c example.rb
example.rb:1: syntax error, unexpected ')', expecting `then' or ';' or '\n'
if foo && bar(:arg))
```

## After

```console
% cat example.rb
if foo && bar(:arg)
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
