### PR TITLE
Auto disable parallel when combined with --auto-correct, --auto-gen-config, or --fail-fast

### DIFF
--- a/changelog/change_auto_disable_parallel.md
+++ b/changelog/change_auto_disable_parallel.md
@@ -1,0 +1,1 @@
+* [#9647](https://github.com/rubocop/rubocop/pull/9647): The parallel flag will now be automatically ignored when combined with `--auto-correct`, `--auto-gen-config`, or `-F/--fail-fast`. Previously, an error was raised and execution stopped. ([@rrosenblum][])

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -343,21 +343,24 @@ module RuboCop
                                    'false is not allowed.'
       end
 
-      validate_parallel_with_combo_option
+      disable_parallel_when_invalid_combo
     end
 
-    def validate_parallel_with_combo_option
+    def disable_parallel_when_invalid_combo
       combos = {
-        auto_gen_config: '-P/--parallel uses caching to speed up execution, ' \
-                         'while --auto-gen-config needs a non-cached run, ' \
-                         'so they cannot be combined.',
-        fail_fast: '-P/--parallel cannot be combined with -F/--fail-fast.',
-        auto_correct: '-P/--parallel cannot be combined with --auto-correct.'
+        auto_gen_config: '--auto-gen-config',
+        fail_fast: '-F/--fail-fast.',
+        auto_correct: '--auto-correct.'
       }
 
-      combos.each do |key, msg|
-        raise OptionArgumentError, msg if @options.key?(key)
-      end
+      invalid_combos = combos.select { |key, _flag| @options.key?(key) }
+
+      return if invalid_combos.empty?
+
+      @options.delete(:parallel)
+
+      puts '-P/--parallel is being ignored because ' \
+           "it is not compatible with #{invalid_combos.values.join(', ')}"
     end
 
     def only_includes_redundant_disable?

--- a/lib/rubocop/rake_task.rb
+++ b/lib/rubocop/rake_task.rb
@@ -68,6 +68,9 @@ module RuboCop
           RakeFileUtils.verbose(verbose) do
             yield(*[self, task_args].slice(0, task_block.arity)) if task_block
             options = full_options.unshift('--auto-correct-all')
+            # `parallel` will automatically be removed from the options internally.
+            # This is a nice to have to supress the warning message
+            # about parallel and auto-corrent not being compatible.
             options.delete('--parallel')
             run_cli(verbose, options)
           end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -208,28 +208,38 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
 
       context 'combined with --auto-correct' do
-        it 'fails with an error message' do
-          msg = '-P/--parallel cannot be combined with --auto-correct.'
-          expect { options.parse %w[--parallel --auto-correct] }
-            .to raise_error(RuboCop::OptionArgumentError, msg)
+        it 'ignores parallel' do
+          msg = '-P/--parallel is being ignored because it is not compatible with --auto-correct'
+          options.parse %w[--parallel --auto-correct]
+          expect($stdout.string).to include(msg)
+          expect(options.instance_variable_get('@options').keys).not_to include(:parallel)
         end
       end
 
       context 'combined with --auto-gen-config' do
-        it 'fails with an error message' do
-          msg = '-P/--parallel uses caching to speed up execution, while ' \
-                '--auto-gen-config needs a non-cached run, so they cannot be ' \
-                'combined.'
-          expect { options.parse %w[--parallel --auto-gen-config] }
-            .to raise_error(RuboCop::OptionArgumentError, msg)
+        it 'ignore parallel' do
+          msg = '-P/--parallel is being ignored because it is not compatible with --auto-gen-config'
+          options.parse %w[--parallel --auto-gen-config]
+          expect($stdout.string).to include(msg)
+          expect(options.instance_variable_get('@options').keys).not_to include(:parallel)
         end
       end
 
       context 'combined with --fail-fast' do
-        it 'fails with an error message' do
-          msg = '-P/--parallel cannot be combined with -F/--fail-fast.'
-          expect { options.parse %w[--parallel --fail-fast] }
-            .to raise_error(RuboCop::OptionArgumentError, msg)
+        it 'ignores parallel' do
+          msg = '-P/--parallel is being ignored because it is not compatible with -F/--fail-fast'
+          options.parse %w[--parallel --fail-fast]
+          expect($stdout.string).to include(msg)
+          expect(options.instance_variable_get('@options').keys).not_to include(:parallel)
+        end
+      end
+
+      context 'combined with --auto-correct and --fail-fast' do
+        it 'ignores parallel' do
+          msg = '-P/--parallel is being ignored because it is not compatible with -F/--fail-fast'
+          options.parse %w[--parallel --fail-fast --auto-correct]
+          expect($stdout.string).to include(msg)
+          expect(options.instance_variable_get('@options').keys).not_to include(:parallel)
         end
       end
     end


### PR DESCRIPTION
This came up in a conversation in https://github.com/rubocop/rubocop/pull/9640. We probably should have made it work this way from the start instead of raising an exception.

It felt a big weird to handle this inside of a "validation". Please let me know if there is a better place for the code or if there is better error message.

I left in the code to delete the parallel flag from the rake task to avoid printing the warning about parallel being ignored.