### PR TITLE
Fix when highlights contain multibyte characters

### DIFF
--- a/changelog/fix_when_highlights_contain_multibyte_characters.md
+++ b/changelog/fix_when_highlights_contain_multibyte_characters.md
@@ -1,0 +1,1 @@
+* [#9649](https://github.com/rubocop/rubocop/pull/9649): Fix when highlights contain multibyte characters. ([@osyo-manga][])

--- a/lib/rubocop/formatter/clang_style_formatter.rb
+++ b/lib/rubocop/formatter/clang_style_formatter.rb
@@ -49,8 +49,10 @@ module RuboCop
       end
 
       def report_highlighted_area(highlighted_area)
-        output.puts("#{' ' * highlighted_area.begin_pos}" \
-                    "#{'^' * highlighted_area.size}")
+        space_area  = highlighted_area.source_buffer.slice(0...highlighted_area.begin_pos)
+        source_area = highlighted_area.source
+        output.puts("#{' ' * Unicode::DisplayWidth.of(space_area)}" \
+                    "#{'^' * Unicode::DisplayWidth.of(source_area)}")
       end
     end
   end

--- a/lib/rubocop/formatter/tap_formatter.rb
+++ b/lib/rubocop/formatter/tap_formatter.rb
@@ -37,8 +37,10 @@ module RuboCop
       end
 
       def report_highlighted_area(highlighted_area)
-        output.puts("# #{' ' * highlighted_area.begin_pos}" \
-                    "#{'^' * highlighted_area.size}")
+        space_area  = highlighted_area.source_buffer.slice(0...highlighted_area.begin_pos)
+        source_area = highlighted_area.source
+        output.puts("# #{' ' * Unicode::DisplayWidth.of(space_area)}" \
+                    "#{'^' * Unicode::DisplayWidth.of(source_area)}")
       end
 
       def report_offense(file, offense)

--- a/spec/rubocop/formatter/clang_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/clang_style_formatter_spec.rb
@@ -123,5 +123,27 @@ RSpec.describe RuboCop::Formatter::ClangStyleFormatter, :config do
           .to include(': [Corrected] This is a message.')
       end
     end
+
+    context 'when the source contains multibyte characters' do
+      let(:source) do
+        <<~RUBY
+          do_something("あああ", ["いいい"])
+        RUBY
+      end
+
+      it 'displays text containing the offending source line' do
+        location = source_range(source.index('[')..source.index(']'))
+
+        cop.add_offense(nil, location: location, message: 'message 1')
+        formatter.report_file('test', cop.offenses)
+
+        expect(output.string)
+          .to eq <<~OUTPUT
+            test:1:21: C: message 1
+            do_something("あああ", ["いいい"])
+                                   ^^^^^^^^^^
+        OUTPUT
+      end
+    end
   end
 end

--- a/spec/rubocop/formatter/tap_formatter_spec.rb
+++ b/spec/rubocop/formatter/tap_formatter_spec.rb
@@ -143,4 +143,33 @@ RSpec.describe RuboCop::Formatter::TapFormatter do
       end
     end
   end
+
+  describe '#report_file', :config do
+    let(:cop_class) { RuboCop::Cop::Cop }
+    let(:output) { StringIO.new }
+
+    before { cop.send(:begin_investigation, processed_source) }
+
+    context 'when the source contains multibyte characters' do
+      let(:source) do
+        <<~RUBY
+          do_something("あああ", ["いいい"])
+        RUBY
+      end
+
+      it 'displays text containing the offending source line' do
+        location = source_range(source.index('[')..source.index(']'))
+
+        cop.add_offense(nil, location: location, message: 'message 1')
+        formatter.report_file('test', cop.offenses)
+
+        expect(output.string)
+          .to eq <<~OUTPUT
+            # test:1:21: C: message 1
+            # do_something("あああ", ["いいい"])
+            #                        ^^^^^^^^^^
+        OUTPUT
+      end
+    end
+  end
 end


### PR DESCRIPTION

## Summary

When multibyte characters were included in the output results, they were not highlighted in the correct position.


## Expected behavior

* I'd like to see multibyte characters highlighted by their position

```
hash.rb:4:3: C: [Correctable] Layout/HashAlignment: Align the keys of a hash literal if they span more than one line.
  'あああああ'=>1,
  ^^^^^^^^^^^^^^^
hash.rb:4:10: C: [Correctable] Layout/SpaceAroundOperators: Surrounding space missing for operator =>.
  'あああああ'=>1,
              ^^
hash.rb:5:14: C: [Correctable] Layout/SpaceAfterComma: Space missing after comma.
  'いいいい' => 2,"うううう" =>3,
                 ^
hash.rb:5:15: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  'いいいい' => 2,"うううう" =>3,
                  ^^^^^^^^^^
hash.rb:5:22: C: [Correctable] Layout/SpaceAroundOperators: Surrounding space missing for operator =>.
  'いいいい' => 2,"うううう" =>3,
                             ^^
hash.rb:5:25: C: [Correctable] Style/TrailingCommaInHashLiteral: Avoid comma after the last item of a hash.
  'いいいい' => 2,"うううう" =>3,
                                ^
```


## Actual behavior

* However, the highlight is not positioned correctly

```
hash.rb:4:3: C: [Correctable] Layout/HashAlignment: Align the keys of a hash literal if they span more than one line.
  'あああああ'=>1,
  ^^^^^^^^^^
hash.rb:4:10: C: [Correctable] Layout/SpaceAroundOperators: Surrounding space missing for operator =>.
  'あああああ'=>1,
         ^^
hash.rb:5:14: C: [Correctable] Layout/SpaceAfterComma: Space missing after comma.
  'いいいい' => 2,"うううう" =>3,
             ^
hash.rb:5:15: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  'いいいい' => 2,"うううう" =>3,
              ^^^^^^
hash.rb:5:22: C: [Correctable] Layout/SpaceAroundOperators: Surrounding space missing for operator =>.
  'いいいい' => 2,"うううう" =>3,
                     ^^
hash.rb:5:25: C: [Correctable] Style/TrailingCommaInHashLiteral: Avoid comma after the last item of a hash.
  'いいいい' => 2,"うううう" =>3,
                        ^
```



## Steps to reproduce the problem

```shell
$ cat hash.rb
# frozen_string_literal: true

{
  'あああああ'=>1,
  'いいいい' => 2,"うううう" =>3,
}

$ rubocop hash.rb
Inspecting 1 file
C

Offenses:

hash.rb:4:3: C: [Correctable] Layout/HashAlignment: Align the keys of a hash literal if they span more than one line.
  'あああああ'=>1,
  ^^^^^^^^^^
hash.rb:4:10: C: [Correctable] Layout/SpaceAroundOperators: Surrounding space missing for operator =>.
  'あああああ'=>1,
         ^^
hash.rb:5:14: C: [Correctable] Layout/SpaceAfterComma: Space missing after comma.
  'いいいい' => 2,"うううう" =>3,
             ^
hash.rb:5:15: C: [Correctable] Style/StringLiterals: Prefer sFix when highlights contain multibyte charactersingle-quoted strings when you don't need string interpolation or special symbols.
  'いいいい' => 2,"うううう" =>3,
              ^^^^^^
hash.rb:5:22: C: [Correctable] Layout/SpaceAroundOperators: Surrounding space missing for operator =>.
  'いいいい' => 2,"うううう" =>3,
                     ^^
hash.rb:5:25: C: [Correctable] Style/TrailingCommaInHashLiteral: Avoid comma after the last item of a hash.
  'いいいい' => 2,"うううう" =>3,
                        ^

1 file inspected, 6 offenses detected, 6 offenses auto-correctable
$
```


Ref: https://github.com/rubocop/rubocop-jp/issues/43



-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
