### PR TITLE
Configure rspec shared_context_metadata_behavior to :apply_to_host_groups (compatibility for rspec 4)

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,14 @@ require 'rubocop/rspec/support'
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
+  # This config option will be enabled by default on RSpec 4,
+  # but for reasons of backwards compatibility, you have to
+  # set it on RSpec 3.
+  #
+  # It causes the host group and examples to inherit metadata
+  # from the shared context.
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples


### PR DESCRIPTION
I stumbled upon this while looking into some info on rspec's `shared_context`. I don't fully follow the implications of the change. Reading the info from the commit, I was expecting to need to change some areas of context inclusion. 


https://relishapp.com/rspec/rspec-core/docs/example-groups/shared-context
https://github.com/rspec/rspec-core/commit/ed2d59c8a97d32f4a20e91d0abdad87f90d2b930