### PR TITLE
Fix an incorrect auto-correct for `Lint/AmbiguousOperator`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_ambiguous_operator.md
+++ b/changelog/fix_incorrect_autocorrect_for_ambiguous_operator.md
@@ -1,0 +1,1 @@
+* [#9671](https://github.com/rubocop/rubocop/pull/9671): Fix an incorrect auto-correct for `Lint/AmbiguousOperator` with `Style/MethodCallWithArgsParentheses`. ([@koic][])

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -38,7 +38,10 @@ module RuboCop
         elsif node.arguments.empty?
           corrector.insert_after(node, '()')
         else
-          corrector.replace(args_begin(node), '(')
+          args_begin = args_begin(node)
+
+          corrector.remove(args_begin)
+          corrector.insert_before(args_begin, '(')
           corrector.insert_after(args_end(node), ')')
         end
       end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -236,6 +236,29 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `EnforcedStyle: require_parentheses` of `Style/MethodCallWithArgsParentheses` with ' \
+     '`Lint/AmbiguousOperator`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/MethodCallWithArgsParentheses:
+        EnforcedStyle: require_parentheses
+    YAML
+    create_file('example.rb', <<~RUBY)
+      def foo(&block)
+        do_something &block
+      end
+    RUBY
+    expect(
+      cli.run(
+        ['--auto-correct', '--only', 'Style/MethodCallWithArgsParentheses,Lint/AmbiguousOperator']
+      )
+    ).to eq(0)
+    expect(IO.read('example.rb')).to eq(<<~RUBY)
+      def foo(&block)
+        do_something(&block)
+      end
+    RUBY
+  end
+
   it 'corrects `Style/IfUnlessModifier` with `Style/SoleNestedConditional`' do
     source = <<~RUBY
       def foo


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Style/MethodCallWithArgsParentheses` with `Lint/AmbiguousOperator`.

```console
% cat example.rb
def foo(&block)
  do_something &block
end

% rubocop --only Style/MethodCallWithArgsParentheses,Lint/AmbiguousOperator -a
Inspecting 4 files
..WC

Offenses:

example.rb:2:3: C: [Corrected] Style/MethodCallWithArgsParentheses: Use
parentheses for method calls with arguments.
  do_something &block
  ^^^^^^^^^^^^^^^^^^^
example.rb:2:16: W: [Corrected] Lint/AmbiguousOperator: Ambiguous block
operator. Parenthesize the method arguments if it's surely a block
operator, or add a whitespace to the right of the & if it should be a
binary AND.
  do_something &block
               ^
ripper/example.rb:6:5: C: [Corrected]
Style/MethodCallWithArgsParentheses: Use parentheses for method calls
with arguments.
    raise message
    ^^^^^^^^^^^^^

4 files inspected, 3 offenses detected, 3 offenses corrected
```

## Before

Syntax error with redundant closing parentheses.

```console
% cat example.rb
def foo(&block)
  do_something(&block))
end

% ruby -c example.rb
example.rb:2: syntax error, unexpected ')', expecting end
  do_something(&block))
```

## After

Valid syntax.

```console
% cat example.rb
def foo(&block)
  do_something(&block)
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
