### PR TITLE
[Fix #9672] Fix an incorrect auto-correct for `Style/HashConversion`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_hash_conversion.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_hash_conversion.md
@@ -1,0 +1,1 @@
+* [#9672](https://github.com/rubocop/rubocop/issues/9672): Fix an incorrect auto-correct for `Style/HashConversion` when using  multi-argument `Hash[]` as a method argument. ([@koic][])

--- a/lib/rubocop/cop/style/hash_conversion.rb
+++ b/lib/rubocop/cop/style/hash_conversion.rb
@@ -85,6 +85,9 @@ module RuboCop
           else
             add_offense(node, message: MSG_LITERAL_MULTI_ARG) do |corrector|
               corrector.replace(node, args_to_hash(node.arguments))
+
+              parent = node.parent
+              add_parentheses(parent, corrector) if parent&.send_type? && !parent.parenthesized?
             end
           end
         end

--- a/spec/rubocop/cop/style/hash_conversion_spec.rb
+++ b/spec/rubocop/cop/style/hash_conversion_spec.rb
@@ -45,6 +45,17 @@ RSpec.describe RuboCop::Cop::Style::HashConversion, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when using  multi-argument `Hash[]` as a method argument' do
+    expect_offense(<<~RUBY)
+      do_something Hash[a, b, c, d], arg
+                   ^^^^^^^^^^^^^^^^ Prefer literal hash to Hash[arg1, arg2, ...].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something({a => b, c => d}, arg)
+    RUBY
+  end
+
   it 'does not try to correct multi-argument Hash with odd number of arguments' do
     expect_offense(<<~RUBY)
       Hash[a, b, c]


### PR DESCRIPTION
Fixes #9672.

This PR fixes an incorrect auto-correct for `Style/HashConversion` when using  multi-argument `Hash[]` as a method argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
