### PR TITLE
[Fix #9676] Fix an error for `Style/StringChars`

### DIFF
--- a/changelog/fix_an_error_for_style_string_chars.md
+++ b/changelog/fix_an_error_for_style_string_chars.md
@@ -1,0 +1,1 @@
+* [#9676](https://github.com/rubocop/rubocop/issues/9676): Fix an error for `Style/StringChars` when using `split` without parentheses. ([@koic][])

--- a/lib/rubocop/cop/style/string_chars.rb
+++ b/lib/rubocop/cop/style/string_chars.rb
@@ -17,6 +17,7 @@ module RuboCop
       #   string.chars
       #
       class StringChars < Base
+        include RangeHelp
         extend AutoCorrector
 
         MSG = 'Use `chars` instead of `%<current>s`.'
@@ -26,7 +27,7 @@ module RuboCop
         def on_send(node)
           return unless node.arguments.one? && BAD_ARGUMENTS.include?(node.first_argument.source)
 
-          range = node.loc.selector.begin.join(node.loc.end)
+          range = range_between(node.loc.selector.begin_pos, node.source_range.end_pos)
 
           add_offense(range, message: format(MSG, current: range.source)) do |corrector|
             corrector.replace(range, 'chars')

--- a/spec/rubocop/cop/style/string_chars_spec.rb
+++ b/spec/rubocop/cop/style/string_chars_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe RuboCop::Cop::Style::StringChars, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when using `split` without parentheses' do
+    expect_offense(<<~RUBY)
+      do_something { |foo| foo.split '' }
+                               ^^^^^^^^ Use `chars` instead of `split ''`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something { |foo| foo.chars }
+    RUBY
+  end
+
   it 'does not register an offense when using `chars`' do
     expect_no_offenses(<<~RUBY)
       string.chars


### PR DESCRIPTION
Fixes #9676.

This PR fixes an error for `Style/StringChars` when using `split` without parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
