### PR TITLE
[Fix #9681] Fix an incorrect auto-correct for `Style/RedundantBegin`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_redundant_begin.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_redundant_begin.md
@@ -1,0 +1,1 @@
+* [#9681](https://github.com/rubocop/rubocop/issues/9681): Fix an incorrect auto-correct for `Style/RedundantBegin` when using modifier `if` single statement in `begin` block. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -109,7 +109,10 @@ module RuboCop
         def replace_begin_with_statement(corrector, offense_range, node)
           first_child = node.children.first
 
-          corrector.replace(offense_range, first_child.source)
+          source = first_child.source
+          source = "(#{source})" if first_child.if_type?
+
+          corrector.replace(offense_range, source)
           corrector.remove(range_between(offense_range.end_pos, first_child.source_range.end_pos))
 
           restore_removed_comments(corrector, offense_range, node, first_child)

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -234,6 +234,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when using modifier `if` single statement in `begin` block' do
+    expect_offense(<<~RUBY)
+      var ||= begin
+              ^^^^^ Redundant `begin` block detected.
+        foo if condition
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      var ||= (foo if condition)
+
+    RUBY
+  end
+
   it 'does not register an offense when using `begin` with multiple statement for or assignment' do
     expect_no_offenses(<<~RUBY)
       var ||= begin


### PR DESCRIPTION
Fixes #9681.

This PR fixes an incorrect auto-correct for `Style/RedundantBegin` when using modifier `if` single statement in `begin`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
