### PR TITLE
[Fix #9684] Support `IgnoredMethods` option for `Lint/AmbiguousBlockAssociation`

### DIFF
--- a/changelog/new_ignored_methods_options_for_lint_ambiguous_block_association.md
+++ b/changelog/new_ignored_methods_options_for_lint_ambiguous_block_association.md
@@ -1,0 +1,1 @@
+* [#9684](https://github.com/rubocop/rubocop/issues/9684): Support `IgnoredMethods` option for `Lint/AmbguousBlockAssociation`. ([@gprado][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1387,6 +1387,8 @@ Lint/AmbiguousBlockAssociation:
   StyleGuide: '#syntax'
   Enabled: true
   VersionAdded: '0.48'
+  VersionChanged: '1.13'
+  IgnoredMethods: []
 
 Lint/AmbiguousOperator:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -40,7 +40,7 @@ x != y # or x = !y
 | Yes
 | No
 | 0.48
-| -
+| 1.13
 |===
 
 This cop checks for ambiguous block association with method
@@ -70,6 +70,16 @@ foo == bar { |b| b.baz }
 # Lambda arguments require no disambiguation
 foo = ->(bar) { bar.baz }
 ----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| IgnoredMethods
+| `[]`
+| Array
+|===
 
 === References
 

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -6,6 +6,8 @@ module RuboCop
       # This cop checks for ambiguous block association with method
       # when param passed without parentheses.
       #
+      # This cop can customize ignored methods with `IgnoredMethods`.
+      #
       # @example
       #
       #   # bad
@@ -26,7 +28,14 @@ module RuboCop
       #   # good
       #   # Lambda arguments require no disambiguation
       #   foo = ->(bar) { bar.baz }
+      #
+      # @example IgnoredMethods: [change]
+      #
+      #   # good
+      #   expect { do_something }.to change { object.attribute }
       class AmbiguousBlockAssociation < Base
+        include IgnoredMethods
+
         MSG = 'Parenthesize the param `%<param>s` to make sure that the ' \
               'block will be associated with the `%<method>s` method ' \
               'call.'
@@ -50,7 +59,8 @@ module RuboCop
         end
 
         def allowed_method?(node)
-          node.assignment? || node.operator_method? || node.method?(:[])
+          node.assignment? || node.operator_method? || node.method?(:[]) ||
+            ignored_method?(node.last_argument.send_node.source)
         end
 
         def message(send_node)

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -83,4 +83,21 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
       end
     end
   end
+
+  context 'IgnoredMethods' do
+    let(:cop_config) { { 'IgnoredMethods' => %w[change] } }
+
+    it 'does not register an offense for an ignored method' do
+      expect_no_offenses(<<~RUBY)
+        expect { order.expire }.to change { order.events }
+      RUBY
+    end
+
+    it 'registers an offense for other methods' do
+      expect_offense(<<~RUBY)
+        expect { order.expire }.to update { order.events }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `update { order.events }` to make sure that the block will be associated with the `update` method call.
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This PR adds support for `IgnoredMethods` parameter in `Lint/AmbiguousBlockAssociation` cop to allow better DSL support.
It fixes #9684 and is also related with #7486.

