### PR TITLE
[Fix #9683] Fix an incorrect auto-correct for `Style/HashConversion`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_hash_conversion.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_hash_conversion.md
@@ -1,0 +1,1 @@
+* [#9683](https://github.com/rubocop/rubocop/issues/9683): Fix an incorrect auto-correct for `Style/HashConversion` when using `zip` method without argument in `Hash[]`. ([@koic][])

--- a/spec/rubocop/cop/style/hash_conversion_spec.rb
+++ b/spec/rubocop/cop/style/hash_conversion_spec.rb
@@ -76,6 +76,39 @@ RSpec.describe RuboCop::Cop::Style::HashConversion, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when using argumentless `zip` without parentheses in `Hash[]`' do
+    expect_offense(<<~RUBY)
+      Hash[array.zip]
+      ^^^^^^^^^^^^^^^ Prefer ary.to_h to Hash[ary].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array.zip([]).to_h
+    RUBY
+  end
+
+  it 'registers and corrects an offense when using argumentless `zip` with parentheses in `Hash[]`' do
+    expect_offense(<<~RUBY)
+      Hash[array.zip()]
+      ^^^^^^^^^^^^^^^^^ Prefer ary.to_h to Hash[ary].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array.zip([]).to_h
+    RUBY
+  end
+
+  it 'registers and corrects an offense when using `zip` with argument in `Hash[]`' do
+    expect_offense(<<~RUBY)
+      Hash[array.zip([1, 2, 3])]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer ary.to_h to Hash[ary].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array.zip([1, 2, 3]).to_h
+    RUBY
+  end
+
   context 'AllowSplatArgument: true' do
     let(:cop_config) { { 'AllowSplatArgument' => true } }
 


### PR DESCRIPTION
Fixes #9683.

This PR fixes an incorrect auto-correct for `Style/HashConversion` when using `zip` method in `Hash[]`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
