### PR TITLE
Style/RegexpLiteral: New EnforcedStyle `mixed_preserve`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -4329,10 +4329,13 @@ Style/RegexpLiteral:
   # slashes: Always use slashes.
   # percent_r: Always use `%r`.
   # mixed: Use slashes on single-line regexes, and `%r` on multi-line regexes.
+  # mixed_preserve: Preserve current style and only use `%r` if AllowInnerSlashes=true
+  #   and regexp string contains one or more slashes.
   SupportedStyles:
     - slashes
     - percent_r
     - mixed
+    - mixed_preserve
   # If `false`, the cop will always recommend using `%r` if one or more slashes
   # are found in the regexp string.
   AllowInnerSlashes: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -4329,7 +4329,7 @@ Style/RegexpLiteral:
   # slashes: Always use slashes.
   # percent_r: Always use `%r`.
   # mixed: Use slashes on single-line regexes, and `%r` on multi-line regexes.
-  # mixed_preserve: Preserve current style and only use `%r` if AllowInnerSlashes=true
+  # mixed_preserve: Preserve current style and only use `%r` if AllowInnerSlashes=false
   #   and regexp string contains one or more slashes.
   SupportedStyles:
     - slashes

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -68,6 +68,30 @@ module RuboCop
       #     (baz)
       #   }x
       #
+      # @example EnforcedStyle: mixed_preserve and AllowInnerSlashes: false
+      #   # bad
+      #   x =~ /home\//
+      #
+      #   # good
+      #   x =~ %r{home/}
+      #
+      #   # good
+      #   regex = /
+      #     foo
+      #     (bar)
+      #     (baz)
+      #   /x
+      #
+      #   # good
+      #   snake_case = /^[\dA-Z_]+$/
+      #
+      #   # good
+      #   regex = %r{
+      #     foo
+      #     (bar)
+      #     (baz)
+      #   }x
+      #
       # @example AllowInnerSlashes: false (default)
       #   # If `false`, the cop will always recommend using `%r` if one or more
       #   # slashes are found in the regexp string.
@@ -107,7 +131,9 @@ module RuboCop
         private
 
         def allowed_slash_literal?(node)
-          style == :slashes && !contains_disallowed_slash?(node) || allowed_mixed_slash?(node)
+          style == :slashes && !contains_disallowed_slash?(node) ||
+            allowed_mixed_slash?(node) ||
+            allowed_mixed_preserve?(node)
         end
 
         def allowed_mixed_slash?(node)
@@ -117,11 +143,16 @@ module RuboCop
         def allowed_percent_r_literal?(node)
           style == :slashes && contains_disallowed_slash?(node) ||
             style == :percent_r ||
-            allowed_mixed_percent_r?(node)
+            allowed_mixed_percent_r?(node) ||
+            allowed_mixed_preserve?(node)
         end
 
         def allowed_mixed_percent_r?(node)
           style == :mixed && node.multiline? || contains_disallowed_slash?(node)
+        end
+
+        def allowed_mixed_preserve?(node)
+          style == :mixed_preserve && !contains_disallowed_slash?(node)
         end
 
         def contains_disallowed_slash?(node)

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -944,7 +944,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '# Offense count: 1',
          '# Cop supports --auto-correct.',
          '# Configuration parameters: EnforcedStyle, AllowInnerSlashes.',
-         '# SupportedStyles: slashes, percent_r, mixed',
+         '# SupportedStyles: slashes, percent_r, mixed, mixed_preserve',
          'Style/RegexpLiteral:',
          '  Exclude:',
          "    - 'example.rb'"]

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
   let(:config) do
-    supported_styles = { 'SupportedStyles' => %w[slashes percent_r mixed] }
+    supported_styles = { 'SupportedStyles' => %w[slashes percent_r mixed mixed_preserve] }
     RuboCop::Config.new('Style/PercentLiteralDelimiters' =>
                           percent_literal_delimiters_config,
                         'Style/RegexpLiteral' =>
@@ -461,6 +461,113 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
           expect_correction(<<~'RUBY')
             foo = /home\//
+          RUBY
+        end
+      end
+    end
+
+    describe 'a multi-line %r regex without slashes' do
+      it 'is accepted' do
+        expect_no_offenses(<<~RUBY)
+          foo = %r{
+            foo
+            bar
+          }x
+        RUBY
+      end
+    end
+
+    describe 'a multi-line %r regex with slashes' do
+      it 'is accepted' do
+        expect_no_offenses(<<~RUBY)
+          foo = %r{
+            https?://
+            example\.com
+          }x
+        RUBY
+      end
+    end
+  end
+
+  context 'when EnforcedStyle is set to mixed_preserve' do
+    let(:cop_config) { { 'EnforcedStyle' => 'mixed_preserve' } }
+
+    describe 'a single-line `//` regex without slashes' do
+      it 'is accepted' do
+        expect_no_offenses('foo = /a/')
+      end
+    end
+
+    describe 'a single-line `//` regex with slashes' do
+      it 'registers an offense' do
+        expect_offense(<<~'RUBY')
+          foo = /home\//
+                ^^^^^^^^ Use `%r` around regular expression.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          foo = %r{home/}
+        RUBY
+      end
+
+      describe 'when configured to allow inner slashes' do
+        before { cop_config['AllowInnerSlashes'] = true }
+
+        it 'is accepted' do
+          expect_no_offenses('foo = /home\\//')
+        end
+      end
+    end
+
+    describe 'a multi-line `//` regex without slashes' do
+      it 'is accepted' do
+        expect_no_offenses(<<~'RUBY')
+          foo = /
+            foo
+            bar
+          /x
+        RUBY
+      end
+    end
+
+    describe 'a multi-line `//` regex with slashes' do
+      it 'registers an offense' do
+        expect_offense(<<~'RUBY')
+          foo = /
+                ^ Use `%r` around regular expression.
+            https?:\/\/
+            example\.com
+          /x
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          foo = %r{
+            https?://
+            example\.com
+          }x
+        RUBY
+      end
+    end
+
+    describe 'a single-line %r regex without slashes' do
+      it 'is accepted' do
+        expect_no_offenses(<<~RUBY)
+          foo = %r{a}
+        RUBY
+      end
+    end
+
+    describe 'a single-line %r regex with slashes' do
+      it 'is accepted' do
+        expect_no_offenses('foo = %r{home/}')
+      end
+
+      describe 'when configured to allow inner slashes' do
+        before { cop_config['AllowInnerSlashes'] = true }
+
+        it 'is accepted' do
+          expect_no_offenses(<<~RUBY)
+            foo = %r{home/}
           RUBY
         end
       end


### PR DESCRIPTION
This PR adds a new `EnforcedStyle` option `mixed_preserve` to preserve current regexp style as much as possible (e.g. allows multi-line `/.../` and single-line `%r{...}`).

## Motivation

The main reason for this option is to value consistency in cases where `%r{...}` is used as a key in a hash definition.

For example:

```ruby
      CATEGORIES = {   
        %r{\A(ee/)?config/feature_flags/} => :feature_flag,
        %r{\A(ee/)?(changelogs/unreleased)(-ee)?/} => :changelog,
        %r{\Adoc/.*(\.(md|png|gif|jpg))\z} => :docs,
        %r{\A(CONTRIBUTING|LICENSE|MAINTENANCE|PHILOSOPHY|PROCESS|README)(\.md)?\z} => :docs,
        # ^^^^ Cop complains
```

Since this regexp does not contain a slash `/` the cop suggests to use `/.../` instead.

The :new: `EnforcedStyle` option `mixed_preserve` (combined with `AllowInnerSlashes=false`) would preserve the current regexp style as much as possible unless it sees inner slashes.

See also https://gitlab.com/gitlab-org/gitlab/-/merge_requests/57921/diffs#note_542055521

## Caveats

This new `EnforcedStyle` option `mixed_preserve` is useless/noop when `AllowInnerSlashes=true`.

## Open questions

* Does the option name mirror the behaviour well or can we find a better name?
* Should we raise or warn if `EnforcedStyle=mixed_preserve` and `AllowInnerSlashes=true`?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
