### PR TITLE
Fix an incorrect auto-correct for `Style/IfUnlessModifier`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_if_unless_modifier.md
+++ b/changelog/fix_incorrect_autocorrect_for_if_unless_modifier.md
@@ -1,0 +1,1 @@
+* [#9690](https://github.com/rubocop/rubocop/pull/9690): Fix an incorrect auto-correct for `Style/IfUnlessModifier` when using a method with heredoc argument. ([@koic][])

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -73,6 +73,25 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         end
       end
 
+      context 'when using a method with heredoc argument' do
+        it 'accepts' do
+          expect_offense(<<~RUBY)
+            fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(<<~EOS) if condition
+                                                                                 ^^ Modifier form of `if` makes the line too long.
+              string
+            EOS
+          RUBY
+
+          expect_correction(<<~RUBY)
+            if condition
+              fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(<<~EOS)
+                string
+              EOS
+            end
+          RUBY
+        end
+      end
+
       describe 'IgnoreCopDirectives' do
         let(:spaces) { ' ' * 57 }
         let(:comment) { '# rubocop:disable Style/For' }


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Style/IfUnlessModifier` when using a method with heredoc argument.

```console
% cat .rubocop.yml
Layout/LineLength:
  Max: 80

% cat example.rb
fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(<<~EOS) if condition
  string
EOS

% bundle exec rubocop --only Style/IfUnlessModifier -a
(snip)

Inspecting 1 file
C

Offenses:

example.rb:1:70: C: [Corrected] Style/IfUnlessModifier: Modifier form of
if makes the line too long.
fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(<<~EOS) if condition
                                                                     ^^

1 file inspected, 1 offense detected, 1 offense corrected
```

## Before

Auto-corrected to unexpected invalid syntax code.

```console
% cat example.rb
if condition
  fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(<<~EOS)
end
  string
EOS

% ruby -c example.rb
example.rb:2: syntax error, unexpected end-of-input, expecting `end'
```

## After

Auto-corrected to expected valid syntax code.

```console
% cat example.rb
if condition
  fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(<<~EOS)
    string
  EOS
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
