### PR TITLE
Set false to `SafeMultiline` for `Performance/StartWith` and `Performance/EndWith`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -120,6 +120,12 @@ Performance/CollectionLiteralInLoop:
     - 'Rakefile'
     - 'spec/**/*.rb'
 
+Performance/EndWith:
+  SafeMultiline: false
+
+Performance/StartWith:
+  SafeMultiline: false
+
 RSpec/StubbedMock:
   Enabled: false
 

--- a/lib/rubocop/cop/layout/end_of_line.rb
+++ b/lib/rubocop/cop/layout/end_of_line.rb
@@ -65,7 +65,7 @@ module RuboCop
 
         # If there is no LF on the last line, we don't care if there's no CR.
         def unimportant_missing_cr?(index, last_line, line)
-          style == :crlf && index == last_line - 1 && !/\n$/.match?(line)
+          style == :crlf && index == last_line - 1 && !line.end_with?("\n")
         end
 
         def offense_message(line)

--- a/lib/rubocop/cop/metrics/utils/abc_size_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/abc_size_calculator.rb
@@ -121,7 +121,8 @@ module RuboCop
           end
 
           def capturing_variable?(name)
-            name && !/^_/.match?(name)
+            # TODO: Remove `Symbol#to_s` after supporting only Ruby >= 2.7.
+            name && !name.to_s.start_with?('_')
           end
 
           def branch?(node)

--- a/lib/rubocop/cop/style/combinable_loops.rb
+++ b/lib/rubocop/cop/style/combinable_loops.rb
@@ -75,8 +75,9 @@ module RuboCop
         private
 
         def collection_looping_method?(node)
-          method_name = node.send_node.method_name
-          method_name.match?(/^each/) || method_name.match?(/_each$/)
+          # TODO: Remove `Symbol#to_s` after supporting only Ruby >= 2.7.
+          method_name = node.send_node.method_name.to_s
+          method_name.start_with?('each') || method_name.end_with?('_each')
         end
 
         def same_collection_looping?(node, sibling)

--- a/lib/rubocop/cop/style/redundant_self_assignment.rb
+++ b/lib/rubocop/cop/style/redundant_self_assignment.rb
@@ -66,8 +66,8 @@ module RuboCop
         alias on_gvasgn on_lvasgn
 
         def on_send(node)
-          # TODO: replace with #end_with? after supporting only ruby >= 2.7
-          return unless node.method_name.match?(/=$/)
+          # TODO: Remove `Symbol#to_s` after supporting only Ruby >= 2.7.
+          return unless node.method_name.to_s.end_with?('=')
           return unless redundant_assignment?(node)
 
           message = format(MSG, method_name: node.first_argument.method_name)


### PR DESCRIPTION
This PR sets false for `SafeMultiline` for `Performance/StartWith` and `Performance/EndWith` to .rubocop.yml in this rubocop/rubocop repository.
It is because multiline regular expression matching that corresponds to `start_with?` and `end_with?` are not used in the repository.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
