### PR TITLE
[Fix #9698] Fix an error for `Style/StructInheritance`

### DIFF
--- a/changelog/fix_an_error_for_style_struct_inheritance.md
+++ b/changelog/fix_an_error_for_style_struct_inheritance.md
@@ -1,0 +1,1 @@
+* [#9698](https://github.com/rubocop/rubocop/issues/9698): Fix an error for `Style/StructInheritance` when extending instance of `Struct` without `do` ... `end` and class body is empty and single line definition. ([@koic][])

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -49,9 +49,17 @@ module RuboCop
           if parent.block_type?
             corrector.remove(range_with_surrounding_space(range: parent.loc.end, newlines: false))
           elsif (class_node = parent.parent).body.nil?
-            corrector.remove(range_by_whole_lines(class_node.loc.end, include_final_newline: true))
+            corrector.remove(range_for_empty_class_body(class_node, parent))
           else
             corrector.insert_after(parent.loc.expression, ' do')
+          end
+        end
+
+        def range_for_empty_class_body(class_node, struct_new)
+          if class_node.single_line?
+            range_between(struct_new.source_range.end_pos, class_node.source_range.end_pos)
+          else
+            range_by_whole_lines(class_node.loc.end, include_final_newline: true)
           end
         end
       end

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -56,6 +56,17 @@ RSpec.describe RuboCop::Cop::Style::StructInheritance, :config do
     RUBY
   end
 
+  it 'registers an offense when extending instance of Struct without `do` ... `end` and class body is empty and single line definition' do
+    expect_offense(<<~RUBY)
+      class Person < Struct.new(:first_name, :last_name); end
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't extend an instance initialized by `Struct.new`. Use a block to customize the struct.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Person = Struct.new(:first_name, :last_name)
+    RUBY
+  end
+
   it 'registers an offense when extending instance of ::Struct with do ... end' do
     expect_offense(<<~RUBY)
       class Person < ::Struct.new(:first_name, :last_name) do end


### PR DESCRIPTION
Fixes #9698.

This PR fixes an error for `Style/StructInheritance` when extending instance of `Struct` without `do` ... `end` and class body is empty and single line definition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
