### PR TITLE
Change RedundantLineBreak: InspectBlocks to false internally

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,7 +49,6 @@ Layout/ClassStructure:
 
 Layout/RedundantLineBreak:
   Enabled: true
-  InspectBlocks: true
 
 Layout/TrailingWhitespace:
   AllowInHeredoc: false


### PR DESCRIPTION
Following up on the discussion in #9678, this PR only removes one line of configuration for RuboCop itself.

Change the setting for internal inspections so that the `Layout/RedundantLineBreak` cop does not report multiline blocks. The opinion of the core team seems to lean towards allowing `do ... end` blocks when the author feels it's more readable than a single line block with braces.

This commit does not revert any previous changes. That should be done later on case-by-case basis if desired.