### PR TITLE
Avoid parser warning

### DIFF
--- a/changelog/fix_have_styleredundantargument_use_correct.md
+++ b/changelog/fix_have_styleredundantargument_use_correct.md
@@ -1,0 +1,1 @@
+* [#9700](https://github.com/rubocop/rubocop/issues/9700): Avoid warning about Ruby version mismatch. ([@marcandre][])

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -230,6 +230,11 @@ module RuboCop
         !relevant_file?(file)
       end
 
+      # There should be very limited reasons for a Cop to do it's own parsing
+      def parse(source, path = nil)
+        ProcessedSource.new(source, target_ruby_version, path)
+      end
+
       ### Persistence
 
       # Override if your cop should be called repeatedly for multiple investigations

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -93,12 +93,6 @@ module RuboCop
         Registry.qualified_cop_name(name, origin)
       end
 
-      # @deprecated
-      # Open issue if there's a valid use case to include this in Base
-      def parse(source, path = nil)
-        ProcessedSource.new(source, target_ruby_version, path)
-      end
-
       private
 
       def begin_investigation(processed_source)

--- a/lib/rubocop/cop/style/redundant_argument.rb
+++ b/lib/rubocop/cop/style/redundant_argument.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'parser/current'
-
 module RuboCop
   module Cop
     module Style
@@ -68,17 +66,10 @@ module RuboCop
         end
 
         def redundant_arg_for_method(method_name)
-          return nil unless cop_config['Methods'].key?(method_name)
+          arg = cop_config['Methods'].fetch(method_name) { return }
 
           @mem ||= {}
-          @mem[method_name] ||=
-            begin
-              arg = cop_config['Methods'].fetch(method_name)
-              buffer = Parser::Source::Buffer.new('(string)', 1)
-              buffer.source = arg.inspect
-              builder = RuboCop::AST::Builder.new
-              Parser::CurrentRuby.new(builder).parse(buffer)
-            end
+          @mem[method_name] ||= parse(arg.inspect).ast
         end
 
         def argument_range(node)


### PR DESCRIPTION
The culprit was actually a Cop that was doing a `require 'parser/current'` that was avoidable and not actually the best thing to do.