### PR TITLE
[Fix #9636] Resolve symlinks when excluding directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5555,3 +5555,4 @@
 [@kachick]: https://github.com/kachick
 [@corroded]: https://github.com/corroded
 [@osyo-manga]: https://github.com/osyo-manga
+[@ob-stripe]: https://github.com/ob-stripe

--- a/changelog/fix_resolve_symlinks_when_excluding_directories.md
+++ b/changelog/fix_resolve_symlinks_when_excluding_directories.md
@@ -1,0 +1,1 @@
+* [#9636](https://github.com/rubocop/rubocop/issues/9636): Resolve symlinks when excluding directories. ([@ob-stripe][])

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -97,7 +97,11 @@ module RuboCop
       base_dir = base_dir.gsub('/{}/', '/\{}/')
       dirs = Dir.glob(File.join(base_dir.gsub('/**/', '/\**/'), '*/'), flags)
                 .reject do |dir|
-                  dir.end_with?('/./', '/../') || File.fnmatch?(exclude_pattern, dir, flags)
+                  next true if dir.end_with?('/./', '/../')
+                  next true if File.fnmatch?(exclude_pattern, dir, flags)
+
+                  File.symlink?(dir.chomp('/')) && File.fnmatch?(exclude_pattern,
+                                                                 "#{File.realpath(dir)}/", flags)
                 end
       dirs.flat_map { |dir| wanted_dir_patterns(dir, exclude_pattern, flags) }.unshift(base_dir)
     end

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -24,4 +24,13 @@ module FileHelper
   def create_empty_file(file_path)
     create_file(file_path, '')
   end
+
+  def create_link(link_path, target_path)
+    link_path = File.expand_path(link_path)
+
+    dir_path = File.dirname(link_path)
+    FileUtils.makedirs dir_path unless File.exist?(dir_path)
+
+    FileUtils.symlink(target_path, link_path)
+  end
 end


### PR DESCRIPTION
Resolve symlinks when excluding directories, i.e. if `foo/**/*` is present in the Exclude list and there is a `bar` symlink pointing to `foo`, files under `bar` will be properly excluded.

Fixes #9636.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
