### PR TITLE
Fix an incorrect auto-correct for `Style/SingleLineMethods`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_single_line_methods.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_single_line_methods.md
@@ -1,0 +1,1 @@
+* [#9704](https://github.com/rubocop/rubocop/pull/9704): Fix an incorrect auto-correct for `Style/SingleLineMethods` when single line method call without parentheses. ([@koic][])

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -91,7 +91,9 @@ module RuboCop
         def correct_to_endless(corrector, node)
           self_receiver = node.self_receiver? ? 'self.' : ''
           arguments = node.arguments.any? ? node.arguments.source : '()'
-          replacement = "def #{self_receiver}#{node.method_name}#{arguments} = #{node.body.source}"
+          body_source = method_body_source(node.body)
+          replacement = "def #{self_receiver}#{node.method_name}#{arguments} = #{body_source}"
+
           corrector.replace(node, replacement)
         end
 
@@ -110,6 +112,17 @@ module RuboCop
             eol_comment: processed_source.comment_at_line(node.source_range.line),
             node: node, corrector: corrector
           )
+        end
+
+        def method_body_source(method_body)
+          if method_body.arguments.empty? || method_body.parenthesized?
+            method_body.source
+          else
+            arguments_source = method_body.arguments.map(&:source).join(', ')
+            body_source = "#{method_body.method_name}(#{arguments_source})"
+
+            method_body.receiver ? "#{method_body.receiver.source}.#{body_source}" : body_source
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -187,6 +187,18 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
         RUBY
       end
 
+      it 'corrects to an endless method definition when single line method call with parentheses' do
+        expect_correction(<<~RUBY.strip, source: 'def index() head(:ok) end')
+          def index() = head(:ok)
+        RUBY
+      end
+
+      it 'corrects to an endless method definition when single line method call without parentheses' do
+        expect_correction(<<~RUBY.strip, source: 'def index() head :ok end')
+          def index() = head(:ok)
+        RUBY
+      end
+
       it 'does not add parens if they are already present' do
         expect_correction(<<~RUBY.strip, source: 'def some_method() body end')
           def some_method() = body


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Style/SingleLineMethods` when single line method call without parentheses.

```console
% ruby -v
ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-darwin19]

% cat example.rb
def index() head :ok end

% bundle exec rubocop --only Style/SingleLineMethods -a
(snip)

Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Corrected] Style/SingleLineMethods: Avoid
single-line method definitions.
def index() head :ok end
^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

## Before

Auto-correctd to invalid endless method definition syntax.

```ruby
% cat example.rb
def index() = head :ok

% ruby -c example.rb
example.rb:1: syntax error, unexpected symbol literal, expecting `do' or
'{' or '('
def index() = head :ok
```

## After

Auto-correctd to valid endless method definition syntax.

```ruby
% cat example.rb
def index() = head(:ok)

% ruby -c example.rb
Syntax OK
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
