### PR TITLE
Fix an error for `Style/SingleLineMethods`

### DIFF
--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -115,7 +115,7 @@ module RuboCop
         end
 
         def method_body_source(method_body)
-          if method_body.arguments.empty? || method_body.parenthesized?
+          if !method_body.send_type? || method_body.arguments.empty? || method_body.parenthesized?
             method_body.source
           else
             arguments_source = method_body.arguments.map(&:source).join(', ')

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -187,6 +187,12 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
         RUBY
       end
 
+      it 'corrects to an endless method definition when method body is a literal' do
+        expect_correction(<<~RUBY.strip, source: 'def some_method; 42 end')
+          def some_method() = 42
+        RUBY
+      end
+
       it 'corrects to an endless method definition when single line method call with parentheses' do
         expect_correction(<<~RUBY.strip, source: 'def index() head(:ok) end')
           def index() = head(:ok)


### PR DESCRIPTION
This PR fixes the following error for `Style/SingleLineMethods`.

```console
% cat  example.rb
def some_method; 42 end

% bundle exec rubocop --only Style/SingleLineMethods -d

(snip)

undefined method `arguments' for s(:int, 42):RuboCop::AST::IntNode
Did you mean?  argument?
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/single_line_methods.rb:118:in `method_body_source'
```

This is a regression of #9704.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
