### PR TITLE
[Fix #5576] Treat relativity of Include parameters correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#7977](https://github.com/rubocop/rubocop/issues/7977): Add `Layout/RedundantLineBreak` cop. ([@jonas054][])
 * [#9691](https://github.com/rubocop/rubocop/issues/9691): Add configuration parameter `InspectBlocks` to `Layout/RedundantLineBreak`. ([@jonas054][])
 
+### Bug fixes
+
+* [#5576](https://github.com/rubocop/rubocop/issues/5576): Fix problem with inherited `Include` parameters. ([@jonas054][])
+
 ## 1.12.1 (2021-04-04)
 
 ### Bug fixes

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -37,7 +37,22 @@ module RuboCop
                       inherit_mode: determine_inherit_mode(hash, k))
           end
           hash[k] = v
+          fix_include_paths(base_config.loaded_path, hash, path, k, v) if v.key?('Include')
         end
+      end
+    end
+
+    # When one .rubocop.yml file inherits from another .rubocop.yml file, the Include paths in the
+    # base configuration are relative to the directory where the base configuration file is. For the
+    # derived configuration, we need to make those paths relative to where the derived configuration
+    # file is.
+    def fix_include_paths(base_config_path, hash, path, key, value)
+      return unless File.basename(base_config_path).start_with?('.rubocop')
+
+      base_dir = File.dirname(base_config_path)
+      derived_dir = File.dirname(path)
+      hash[key]['Include'] = value['Include'].map do |include_path|
+        PathUtil.relative_path(File.join(base_dir, include_path), derived_dir)
       end
     end
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -269,6 +269,9 @@ RSpec.describe RuboCop::ConfigLoader do
             Exclude:
               - vendor/**
               - !ruby/regexp /[A-Z]/
+          Style/StringLiterals:
+            Include:
+              - dir/**/*.rb
         YAML
 
         create_file(file_path, ['inherit_from: ../.rubocop.yml'])
@@ -277,6 +280,10 @@ RSpec.describe RuboCop::ConfigLoader do
       it 'gets an absolute AllCops/Exclude' do
         excludes = configuration_from_file['AllCops']['Exclude']
         expect(excludes).to eq([File.expand_path('vendor/**'), /[A-Z]/])
+      end
+
+      it 'gets an Include that is relative to the subdirectory' do
+        expect(configuration_from_file['Style/StringLiterals']['Include']).to eq(['**/*.rb'])
       end
 
       it 'ignores parent AllCops/Exclude if ignore_parent_exclusion is true' do
@@ -320,6 +327,9 @@ RSpec.describe RuboCop::ConfigLoader do
           AllCops:
             Exclude:
               - vendor/**
+          Style/StringLiterals:
+            Include:
+              - '**/*.rb'
         YAML
 
         create_file(file_path, ['inherit_from: ../src/.rubocop.yml'])
@@ -328,6 +338,10 @@ RSpec.describe RuboCop::ConfigLoader do
       it 'gets an absolute AllCops/Exclude' do
         excludes = configuration_from_file['AllCops']['Exclude']
         expect(excludes).to eq([File.expand_path('src/vendor/**')])
+      end
+
+      it 'gets an Include that is relative to the subdirectory' do
+        expect(configuration_from_file['Style/StringLiterals']['Include']).to eq(['../src/**/*.rb'])
       end
     end
 


### PR DESCRIPTION
For configuration files whose name begins with `.rubocop`, the paths in `Include` parameters are relative to the directory of the configuration file.

When another configuration file inherits from such a file, we cannot just copy the `Include` paths. We must modify them so they select the files that were originally intended.