### PR TITLE
[Fix #9707] Fix false positive for `Style/MethodCallWithArgsParentheses` with `omit_parentheses` style on an endless `defs` node

### DIFF
--- a/changelog/fix_fix_false_positive_for.md
+++ b/changelog/fix_fix_false_positive_for.md
@@ -1,0 +1,1 @@
+* [#9707](https://github.com/rubocop/rubocop/issues/9707): Fix false positive for `Style/MethodCallWithArgsParentheses` with `omit_parentheses` style on an endless `defs` node. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -42,7 +42,7 @@ module RuboCop
 
           def inside_endless_method_def?(node)
             # parens are required around arguments inside an endless method
-            node.each_ancestor(:def).any?(&:endless?) && node.arguments.any?
+            node.each_ancestor(:def, :defs).any?(&:endless?) && node.arguments.any?
           end
 
           def syntax_like_method_call?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -23,10 +23,27 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
               def x() = foo#{trailing_whitespace}
             RUBY
           end
+
+          it 'registers an offense for `defs` when there are parens' do
+            expect_offense(<<~RUBY)
+              def self.x() = foo()
+                                ^^ Omit parentheses for method calls with arguments.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              def self.x() = foo#{trailing_whitespace}
+            RUBY
+          end
         else
           it 'does not register an offense when there are parens' do
             expect_no_offenses(<<~RUBY)
               def x() = foo()
+            RUBY
+          end
+
+          it 'does not register an offense for `defs` when there are parens' do
+            expect_no_offenses(<<~RUBY)
+              def self.x() = foo()
             RUBY
           end
         end
@@ -34,6 +51,18 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         it 'does not register an offense when there are no parens' do
           expect_no_offenses(<<~RUBY)
             def x() = foo
+          RUBY
+        end
+
+        it 'does not register an offense when there are arguments' do
+          expect_no_offenses(<<~RUBY)
+            def x() = foo(y)
+          RUBY
+        end
+
+        it 'does not register an offense for `defs` when there are arguments' do
+          expect_no_offenses(<<~RUBY)
+            def self.x() = foo(y)
           RUBY
         end
       end


### PR DESCRIPTION
Fixes #9707.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
