### PR TITLE
[Fix #9689] Treat parens around array items the same for children and deeper descendants

### DIFF
--- a/changelog/fix_treat_parens_around_array_items_the_same.md
+++ b/changelog/fix_treat_parens_around_array_items_the_same.md
@@ -1,0 +1,1 @@
+* [#9689](https://github.com/rubocop/rubocop/issues/9689): Treat parens around array items the same for children and deeper descendants. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -158,15 +158,11 @@ module RuboCop
           # { a: (1
           #      ), }
           # ```
-          (hash_element?(node) || array_element?(node)) && only_closing_paren_before_comma?(node)
+          hash_or_array_element?(node) && only_closing_paren_before_comma?(node)
         end
 
-        def hash_element?(node)
-          node.parent&.pair_type?
-        end
-
-        def array_element?(node)
-          node.parent&.array_type?
+        def hash_or_array_element?(node)
+          node.each_ancestor(:array, :hash).any?
         end
 
         def only_closing_paren_before_comma?(node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -162,6 +162,24 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
 
   it_behaves_like 'plausible', "[(1\n),]"
 
+  it_behaves_like 'plausible', <<~RUBY
+    [
+      (
+        1
+      ),
+      2
+    ]
+  RUBY
+
+  it_behaves_like 'plausible', <<~RUBY
+    [
+      x = (
+        1
+      ),
+      y = 2
+    ]
+  RUBY
+
   it 'registers an offense for parens around a literal hash value' do
     expect_offense(<<~RUBY)
       {a: (1)}


### PR DESCRIPTION
Previously there was a disparity between these two code blocks:

```ruby
[
 (
   1
 ),
 2
]
```

```ruby
[
 x = (
   1
 ),
 y = 2
]
```

The first was accepted as "plausible" but the second registered an offense (and was autocorrected to a syntax error because the comma in an array cannot be on its own line).

This change allows both to be treated the same by looking for any ancestor to be an array or hash rather than just the direct parent.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
