### PR TITLE
Fix an incorrect auto-correct for `Style/HashConversion`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_hash_conversion.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_hash_conversion.md
@@ -1,0 +1,1 @@
+* [#9712](https://github.com/rubocop/rubocop/pull/9712): Fix an incorrect auto-correct for `Style/HashConversion` when `Hash[]` as a method argument without parentheses. ([@koic][])

--- a/lib/rubocop/cop/style/hash_conversion.rb
+++ b/lib/rubocop/cop/style/hash_conversion.rb
@@ -84,6 +84,9 @@ module RuboCop
         def register_offense_for_hash(node, hash_argument)
           add_offense(node, message: MSG_LITERAL_HASH_ARG) do |corrector|
             corrector.replace(node, "{#{hash_argument.source}}")
+
+            parent = node.parent
+            add_parentheses(parent, corrector) if parent&.send_type? && !parent.parenthesized?
           end
         end
 

--- a/spec/rubocop/cop/style/hash_conversion_spec.rb
+++ b/spec/rubocop/cop/style/hash_conversion_spec.rb
@@ -34,6 +34,28 @@ RSpec.describe RuboCop::Cop::Style::HashConversion, :config do
     RUBY
   end
 
+  it 'reports different offense for hash argument Hash[] as a method argument with parentheses' do
+    expect_offense(<<~RUBY)
+      do_something(Hash[a: b, c: d], 42)
+                   ^^^^^^^^^^^^^^^^ Prefer literal hash to Hash[key: value, ...].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something({a: b, c: d}, 42)
+    RUBY
+  end
+
+  it 'reports different offense for hash argument Hash[] as a method argument without parentheses' do
+    expect_offense(<<~RUBY)
+      do_something Hash[a: b, c: d], 42
+                   ^^^^^^^^^^^^^^^^ Prefer literal hash to Hash[key: value, ...].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something({a: b, c: d}, 42)
+    RUBY
+  end
+
   it 'reports different offense for empty Hash[]' do
     expect_offense(<<~RUBY)
       Hash[]


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Style/HashConversion` when `Hash[]` as a method argument without parentheses.

```console
% cat example.rb
do_something Hash[a: b, c: d], 42

% bundle exec rubocop --only Style/HashConversion -a
(snip)

Inspecting 1 file
C

Offenses:

example.rb:1:14: C: [Corrected] Style/HashConversion: Prefer literal
hash to Hash[key: value, ...].
do_something Hash[a: b, c: d], 42
             ^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

## Before

Auto-corrected to invalid syntax.

```ruby
% cat example.rb
do_something {a: b, c: d}, 42

% ruby -c example.rb
example.rb:1: syntax error, unexpected ':', expecting '}'
do_something {a: b, c: d}, 42
```

## After

Auto-corrected to valid syntax.

```ruby
% cat example.rb
do_something({a: b, c: d}, 42)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
