### PR TITLE
[Fix #9713] Skip autocorrection for block_local_variables in `Lint/UnusedBlockArgument`

### DIFF
--- a/changelog/fix_autocorrect_for_lint_unused_block_argument.md
+++ b/changelog/fix_autocorrect_for_lint_unused_block_argument.md
@@ -1,0 +1,1 @@
+* [#9713](https://github.com/rubocop/rubocop/issues/9713): Fix autocorrection for block local variables in `Lint/UnusedBlockArgument`. ([@tejasbubane][])

--- a/lib/rubocop/cop/lint/unused_block_argument.rb
+++ b/lib/rubocop/cop/lint/unused_block_argument.rb
@@ -67,9 +67,15 @@ module RuboCop
         end
 
         def check_argument(variable)
-          return if allowed_block?(variable) || allowed_keyword_argument?(variable)
+          return if allowed_block?(variable) ||
+                    allowed_keyword_argument?(variable) ||
+                    used_block_local?(variable)
 
           super
+        end
+
+        def used_block_local?(variable)
+          variable.explicit_block_local_variable? && !variable.assignments.empty?
         end
 
         def allowed_block?(variable)

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -214,6 +214,17 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
           RUBY
         end
       end
+
+      context 'and the variable is used' do
+        it 'does not register offense' do
+          expect_no_offenses(<<~RUBY)
+            1.times do |index; x|
+              x = 10
+              puts index
+            end
+          RUBY
+        end
+      end
     end
 
     context 'when a lambda block takes arguments' do


### PR DESCRIPTION
Not sure if there is a better solution. But I think this cop should restrict itself to arguments and not make corrections within block body as suggested in the issue.

Closes #9713

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
