### PR TITLE
Fix an incorrect auto-correct for `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_method_call_with_args_parentheses.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_method_call_with_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#9715](https://github.com/rubocop/rubocop/pull/9715): Fix an incorrect auto-correct for `EnforcedStyle: require_parentheses` of `Style/MethodCallWithArgsParentheses` with `Style/RescueModifier`. ([@koic][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -202,7 +202,7 @@ module RuboCop
         extend AutoCorrector
 
         def self.autocorrect_incompatible_with
-          [Style::NestedParenthesizedCalls]
+          [Style::NestedParenthesizedCalls, Style::RescueModifier]
         end
 
         def on_send(node)

--- a/lib/rubocop/cop/style/rescue_modifier.rb
+++ b/lib/rubocop/cop/style/rescue_modifier.rb
@@ -47,6 +47,10 @@ module RuboCop
 
         MSG = 'Avoid using `rescue` in its modifier form.'
 
+        def self.autocorrect_incompatible_with
+          [Style::MethodCallWithArgsParentheses]
+        end
+
         def on_resbody(node)
           return unless rescue_modifier?(node)
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -214,6 +214,28 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `EnforcedStyle: require_parentheses` of `Style/MethodCallWithArgsParentheses` with `Style/RescueModifier`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/MethodCallWithArgsParentheses:
+        EnforcedStyle: require_parentheses
+    YAML
+    source = <<~RUBY
+      do_something arg rescue nil
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--auto-correct-all',
+                     '--only', 'Style/MethodCallWithArgsParentheses,Style/RescueModifier'
+                   ])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      begin
+        do_something(arg)
+      rescue
+        nil
+      end
+    RUBY
+  end
+
   it 'corrects `EnforcedStyle: require_parentheses` of `Style/MethodCallWithArgsParentheses` with ' \
      '`EnforcedStyle: conditionals` of `Style/AndOr`' do
     create_file('.rubocop.yml', <<~YAML)


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Style/MethodCallWithArgsParentheses` with `Style/RescueModifier`.

```console
% cat example.rb
do_something arg rescue nil

% bundle exec rubocop -a --only
Style/MethodCallWithArgsParentheses,Style/RescueModifier
(snip)

Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Corrected] Style/MethodCallWithArgsParentheses: Use
parentheses for method calls with arguments.
do_something arg rescue nil
^^^^^^^^^^^^^^^^
example.rb:1:1: C: [Corrected] Style/RescueModifier: Avoid using rescue
in its modifier form.
do_something arg rescue nil
^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 2 offenses detected, 2 offenses corrected
```

## Before

Auto-corrected to invalid syntax.

```ruby
% cat example.rb
begin
  do_something(arg
rescue
  nil
end)

% ruby -c example.rb
example.rb:3: syntax error, unexpected `rescue', expecting ')'
rescue
example.rb:5: syntax error, unexpected ')', expecting end-of-input
```

## After

Auto-corrected to valid syntax.

```ruby
% cat example.rb
begin
  do_something(arg)
rescue
  nil
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
