### PR TITLE
Workaround for random build error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,9 @@ gem 'bump', require: false
 gem 'memory_profiler', platform: :mri
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
-gem 'rubocop-performance', '~> 1.11.0'
+# RuboCop Performance upgrade to 1.11 is postponed until
+# https://github.com/rubocop/rubocop/pull/9721 will be resolved.
+gem 'rubocop-performance', '~> 1.10.0'
 gem 'rubocop-rspec', '~> 2.2.0'
 # Workaround for cc-test-reporter with SimpleCov 0.18.
 # Stop upgrading SimpleCov until the following issue will be resolved.


### PR DESCRIPTION
This PR reverts https://github.com/rubocop/rubocop/commit/b15e034.

The following tests will fail depending on the run tests sequence when using RuboCop Performance to 1.11.0.

```console
% bundle exec rspec --seed 33314 ./spec/rubocop/config_obsoletion_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 33314
....F....

Failures:

  1) RuboCop::ConfigObsoletion#validate when the configuration includes
  any extracted cops when the extensions are not loaded prints a warning
  message
     Failure/Error: expect(expected_message).to eq(e.message)

       expected: "`Rails` cops have been extracted to the
       `rubocop-rails` gem.\n(obsolete configuration found in
       example/.rubocop.yml, please update it)"
            got: "`Performance` cops have been extracted to the
       `rubocop-performance` gem.\n(obsolete configuration fo... the
       `rubocop-rails` gem.\n(obsolete configuration found in
       example/.rubocop.yml, please update it)"

       (compared using ==)

       Diff:
       @@ -1,2 +1,4 @@
       +`Performance` cops have been extracted to the
       `rubocop-performance` gem.
       +(obsolete configuration found in example/.rubocop.yml, please
       update it)
        `Rails` cops have been extracted to the `rubocop-rails` gem.
        (obsolete configuration found in example/.rubocop.yml, please
       update it)

     # ./spec/rubocop/config_obsoletion_spec.rb:269:in `rescue in
       block (5 levels) in <top (required)>'
     # ./spec/rubocop/config_obsoletion_spec.rb:266:in `block (5 levels)
       in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `block (4 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `block (3 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:7:in `block (2 levels) in
       <top (required)>'
     # ------------------
     # --- Caused by: ---
     # RuboCop::ValidationError:
     #   `Rails` cops have been extracted to the `rubocop-rails` gem.
     #   (obsolete configuration found in example/.rubocop.yml, please
       update it)
     #   ./lib/rubocop/config_obsoletion.rb:43:in `reject_obsolete!'

Finished in 0.16954 seconds (files took 0.94235 seconds to load)
9 examples, 1 failure

Failed examples:

rspec ./spec/rubocop/config_obsoletion_spec.rb:265 #
RuboCop::ConfigObsoletion#validate when the configuration includes any
extracted cops when the extensions are not loaded prints a warning
message

Randomized with seed 33314
```

RuboCop Performance upgrade to 1.11 is postponed until this test will be stable in this repository.
https://github.com/rubocop/rubocop-performance/pull/235 is RuboCop Performance change related to the build error.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
