### PR TITLE
Add `PreferHashRocketsForQuotedSymbols` to `Style/HashSyntax`

### DIFF
--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -54,6 +54,8 @@ module RuboCop
       #   # good
       #   {a: 1, b: 2}
       #   {:c => 3, 'd' => 4}
+      #
+      # TODO: Add to docs
       class HashSyntax < Base
         include ConfigurableEnforcedStyle
         include RangeHelp
@@ -144,6 +146,12 @@ module RuboCop
              # similarly for other non-alnum final characters (except quotes,
              # to prefer { "x y": 1 } over { :"x y" => 1 }).
              !/[\p{Alnum}"']\z/.match?(sym_name)
+            return false
+          end
+
+          if cop_config['PreferHashRocketsForQuotedSymbols'] &&
+              # Prefer { :"x y" => 1 } over { "x y": 1 }.
+              /\A['"]|['"]\z/.match?(sym_name)
             return false
           end
 


### PR DESCRIPTION
## TL;DR

This adds `PreferHashRocketsForQuotedSymbols` to `Style/HashSyntax`, allowing `{ "foo": 123 }` to be reported as an offence.

## Why?

Given the elegant syntax for symbol hash keys
```ruby
{
  foo: 123,
}
```
developers often try to use it in scenarios where they need a string key
```ruby
{
  'foo': 123,
}
```
not realizing the key remains a symbol, and that they needed to use
```ruby
{
  'foo' => 123,
}
```
instead.

While there are legitimate uses for quoting a symbol (if it includes special characters), in most cases this is not the intended use case.

Therefore, the `PreferHashRocketsForQuotedSymbols` option is added to `Style/HashSyntax`, to give the option to disallow the error-prone syntax.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
