### PR TITLE
[Fix #9729] Fix an error for `Style/IfUnlessModifier`

### DIFF
--- a/changelog/fix_an_error_for_style_if_unless_modifier.md
+++ b/changelog/fix_an_error_for_style_if_unless_modifier.md
@@ -1,0 +1,1 @@
+* [#9729](https://github.com/rubocop/rubocop/issues/9729): Fix an error for `Style/IfUnlessModifier` when variable assignment is used in the branch body of if modifier. ([@koic][])

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -67,15 +67,14 @@ module RuboCop
 
         def autocorrect(corrector, node)
           replacement = if node.modifier_form?
-                          indentation = ' ' * node.source_range.column
-                          last_argument = node.if_branch.last_argument
+                          last_argument = node.if_branch.last_argument if node.if_branch.send_type?
 
                           if last_argument.respond_to?(:heredoc?) && last_argument.heredoc?
                             heredoc = extract_heredoc_from(last_argument)
                             remove_heredoc(corrector, heredoc)
-                            to_normal_form_with_heredoc(node, indentation, heredoc)
+                            to_normal_form_with_heredoc(node, indent(node), heredoc)
                           else
-                            to_normal_form(node, indentation)
+                            to_normal_form(node, indent(node))
                           end
                         else
                           to_modifier_form(node)

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -92,6 +92,21 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         end
       end
 
+      context 'when variable assignment is used in the branch body of if modifier' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            variable = foooooooooooooooooooooooooooooooooooooooooooooooooooooooo if condition
+                                                                                 ^^ Modifier form of `if` makes the line too long.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            if condition
+              variable = foooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+            end
+          RUBY
+        end
+      end
+
       describe 'IgnoreCopDirectives' do
         let(:spaces) { ' ' * 57 }
         let(:comment) { '# rubocop:disable Style/For' }


### PR DESCRIPTION
Fixes #9729.

This PR fixes an error for `Style/IfUnlessModifier` when variable assignment is used in the branch body of if modifier.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
