### PR TITLE
[Fix #9716] Support deprecated Socket.gethostbyaddr and Socket.gethostbyname

### DIFF
--- a/changelog/fix_support_deprecated_socket.md
+++ b/changelog/fix_support_deprecated_socket.md
@@ -1,0 +1,1 @@
+* [#9732](https://github.com/rubocop/rubocop/pull/9732): Support deprecated Socket.gethostbyaddr and Socket.gethostbyname. ([@AndreiEres][])

--- a/lib/rubocop/cop/lint/deprecated_class_methods.rb
+++ b/lib/rubocop/cop/lint/deprecated_class_methods.rb
@@ -24,16 +24,15 @@ module RuboCop
         extend AutoCorrector
 
         # Inner class to DeprecatedClassMethods.
-        # This class exists to add abstraction and clean naming to the
-        # objects that are going to be operated on.
+        # This class exists to add abstraction and clean naming
+        # to the deprecated objects
         class DeprecatedClassMethod
           include RuboCop::AST::Sexp
 
-          attr_reader :class_constant, :deprecated_method, :replacement_method
+          attr_reader :method, :class_constant
 
-          def initialize(deprecated:, replacement:, class_constant: nil)
-            @deprecated_method = deprecated
-            @replacement_method = replacement
+          def initialize(method, class_constant: nil)
+            @method = method
             @class_constant = class_constant
           end
 
@@ -48,28 +47,62 @@ module RuboCop
                 [nil]
               end
           end
+
+          def to_s
+            [class_constant, method].compact.join(delimeter)
+          end
+
+          private
+
+          def delimeter
+            CLASS_METHOD_DELIMETER
+          end
+        end
+
+        # Inner class to DeprecatedClassMethods.
+        # This class exists to add abstraction and clean naming
+        # to the replacements for deprecated objects
+        class Replacement
+          attr_reader :method, :class_constant
+
+          def initialize(method, class_constant: nil)
+            @method = method
+            @class_constant = class_constant
+          end
+
+          def to_s
+            [class_constant, method].compact.join(delimeter)
+          end
+
+          private
+
+          def delimeter
+            CLASS_METHOD_DELIMETER
+          end
         end
 
         MSG = '`%<current>s` is deprecated in favor of `%<prefer>s`.'
-        DEPRECATED_METHODS_OBJECT = [
-          DeprecatedClassMethod.new(deprecated: :exists?,
-                                    replacement: :exist?,
-                                    class_constant: :File),
-          DeprecatedClassMethod.new(deprecated: :exists?,
-                                    replacement: :exist?,
-                                    class_constant: :Dir),
-          DeprecatedClassMethod.new(deprecated: :iterator?, replacement: :block_given?)
-        ].freeze
 
-        RESTRICT_ON_SEND = DEPRECATED_METHODS_OBJECT.map(&:deprecated_method).freeze
+        DEPRECATED_METHODS_OBJECT = {
+          DeprecatedClassMethod.new(:exists?, class_constant: :File) =>
+            Replacement.new(:exist?, class_constant: :File),
+
+          DeprecatedClassMethod.new(:exists?, class_constant: :Dir) =>
+            Replacement.new(:exist?, class_constant: :Dir),
+
+          DeprecatedClassMethod.new(:iterator?) => Replacement.new(:block_given?)
+        }.freeze
+
+        RESTRICT_ON_SEND = DEPRECATED_METHODS_OBJECT.keys.map(&:method).freeze
+
+        CLASS_METHOD_DELIMETER = '.'
 
         def on_send(node)
-          check(node) do |data|
-            message = format(MSG, current: deprecated_method(data),
-                                  prefer: replacement_method(data))
+          check(node) do |deprecated|
+            message = format(MSG, current: deprecated, prefer: replacement(deprecated))
 
             add_offense(node.loc.selector, message: message) do |corrector|
-              corrector.replace(node.loc.selector, data.replacement_method.to_s)
+              corrector.replace(node.loc.selector, replacement(deprecated).method)
             end
           end
         end
@@ -77,28 +110,16 @@ module RuboCop
         private
 
         def check(node)
-          DEPRECATED_METHODS_OBJECT.each do |data|
-            next unless data.class_nodes.include?(node.receiver)
-            next unless node.method?(data.deprecated_method)
+          DEPRECATED_METHODS_OBJECT.each_key do |deprecated|
+            next unless deprecated.class_nodes.include?(node.receiver)
+            next unless node.method?(deprecated.method)
 
-            yield data
+            yield deprecated
           end
         end
 
-        def deprecated_method(data)
-          method_call(data.class_constant, data.deprecated_method)
-        end
-
-        def replacement_method(data)
-          method_call(data.class_constant, data.replacement_method)
-        end
-
-        def method_call(class_constant, method)
-          if class_constant
-            format('%<constant>s.%<method>s', constant: class_constant, method: method)
-          else
-            format('%<method>s', method: method)
-          end
+        def replacement(deprecated)
+          DEPRECATED_METHODS_OBJECT[deprecated]
         end
       end
     end

--- a/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
@@ -81,4 +81,52 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedClassMethods, :config do
       expect_no_offenses('Foo.iterator?')
     end
   end
+
+  context 'prefer `Addrinfo#getnameinfo` over `Socket.gethostbyaddr`' do
+    it 'registers an offense for Socket.gethostbyaddr' do
+      expect_offense(<<~RUBY)
+        Socket.gethostbyaddr([221,186,184,68].pack("CCCC"))
+               ^^^^^^^^^^^^^ `Socket.gethostbyaddr` is deprecated in favor of `Addrinfo#getnameinfo`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense for ::Socket.gethostbyaddr' do
+      expect_offense(<<~RUBY)
+        ::Socket.gethostbyaddr([221,186,184,68].pack("CCCC"))
+                 ^^^^^^^^^^^^^ `Socket.gethostbyaddr` is deprecated in favor of `Addrinfo#getnameinfo`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'does not register an offense for method `gethostbyaddr` on other receivers' do
+      expect_no_offenses('Foo.gethostbyaddr')
+    end
+  end
+
+  context 'prefer `Addrinfo#getaddrinfo` over `Socket.gethostbyname`' do
+    it 'registers an offense for Socket.gethostbyname' do
+      expect_offense(<<~RUBY)
+        Socket.gethostbyname("hal")
+               ^^^^^^^^^^^^^ `Socket.gethostbyname` is deprecated in favor of `Addrinfo#getaddrinfo`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense for ::Socket.gethostbyname' do
+      expect_offense(<<~RUBY)
+        ::Socket.gethostbyname("hal")
+                 ^^^^^^^^^^^^^ `Socket.gethostbyname` is deprecated in favor of `Addrinfo#getaddrinfo`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'does not register an offense for method `gethostbyname` on other receivers' do
+      expect_no_offenses('Foo.gethostbyname')
+    end
+  end
 end


### PR DESCRIPTION
Fixed https://github.com/rubocop/rubocop/issues/9716

- Refactored original class to add functionality to not autocorrect and suggest replacing with instance method.
- Added Socket.gethostbyaddr and Socket.gethostbyname

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
