### PR TITLE
Add link to index.adoc

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -22,7 +22,8 @@ linter:
 * Ability to disable certain cops only for specific files or parts of files
 * Extremely flexible configuration that allows you to adapt RuboCop to pretty much every style and preference
 * It's easy to extend RuboCop with custom cops and formatters
-* A vast number of ready-made extensions (e.g. `rubocop-rails`, `rubocop-rspec`, `rubocop-performance` and `rubocop-minitest`)
+* A vast number of ready-made xref:extensions.adoc[extensions] (e.g. `rubocop-rails`, `rubocop-rspec`, `rubocop-performance` and `rubocop-minitest`)
+
 * Wide editor/IDE support
 * Many online services use RuboCop internally (e.g. HoundCI, Sider and CodeClimate)
 * Best logo/stickers ever


### PR DESCRIPTION
・The "Extension" link is attached in the "Next Step" text.
・I suggested adding a link in "extensions" in the "Overview" text.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
