### PR TITLE
Fix an incorrect auto-correct for `Style/SingleLineMethods`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_single_line_methods.md
+++ b/changelog/fix_incorrect_autocorrect_for_single_line_methods.md
@@ -1,0 +1,1 @@
+* [#9740](https://github.com/rubocop/rubocop/pull/9740): Fix an incorrect auto-correct for `Style/SingleLineMethods` when defining setter method. ([@koic][])

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -68,6 +68,7 @@ module RuboCop
           return false unless endless_method_config['Enabled']
           return false if endless_method_config['EnforcedStyle'] == 'disallow'
           return false unless body_node
+          return false if body_node.parent.assignment_method?
 
           !(body_node.begin_type? || body_node.kwbegin_type?)
         end
@@ -115,14 +116,18 @@ module RuboCop
         end
 
         def method_body_source(method_body)
-          if !method_body.send_type? || method_body.arguments.empty? || method_body.parenthesized?
-            method_body.source
-          else
+          if require_parentheses?(method_body)
             arguments_source = method_body.arguments.map(&:source).join(', ')
             body_source = "#{method_body.method_name}(#{arguments_source})"
 
             method_body.receiver ? "#{method_body.receiver.source}.#{body_source}" : body_source
+          else
+            method_body.source
           end
+        end
+
+        def require_parentheses?(method_body)
+          method_body.send_type? && !method_body.arguments.empty? && !method_body.comparison_method?
         end
       end
     end

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -211,6 +211,23 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
         RUBY
       end
 
+      RuboCop::AST::Node::COMPARISON_OPERATORS.each do |op|
+        it "corrects to an endless class method definition when using #{op}" do
+          expect_correction(<<~RUBY.strip, source: "def #{op}(other) self #{op} other end")
+            def #{op}(other) = self #{op} other
+          RUBY
+        end
+      end
+
+      # NOTE: Setter method cannot be defined in the endless method definition.
+      it 'corrects to multiline method definition when defining setter method' do
+        expect_correction(<<~RUBY.chop, source: 'def foo=(foo) @foo = foo end')
+          def foo=(foo)#{trailing_whitespace}
+            @foo = foo#{trailing_whitespace}
+          end
+        RUBY
+      end
+
       it 'corrects to a normal method if the method body contains multiple statements' do
         expect_correction(<<~RUBY.strip, source: 'def some_method; foo; bar end')
           def some_method;#{trailing_whitespace}


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Style/SingleLineMethods` when defining setter method.

```console
% cat example.rb
def foo=(other) @foo == foo end

% bundle exec rubocop --only Style/SingleLineMethods -a
(snip)

Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Corrected] Style/SingleLineMethods: Avoid
single-line method definitions.
def foo=(other) @foo == foo end
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

### Before

Auto-corrected to invalid syntax because setter method cannot be defined in
an endless method definition.

```ruby
% cat example.rb
def foo=(other) = @foo == foo

% ruby -c example.rb
example.rb:1: setter method cannot be defined in an endless method definition
def foo=(other) = @foo == foo
```

### After

```ruby
% cat example.rb
def foo=(other)
  @foo == foo
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
