### PR TITLE
Docs: fix escaping of pipes in regexes that appear in table cells

### DIFF
--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -5479,7 +5479,7 @@ exactly(2).times { raise StandardError }
 | Name | Default value | Configurable values
 
 | IgnoredPatterns
-| `(?-mix:(exactly|at_least|at_most)\(\d+\)\.times)`
+| `(?-mix:(exactly\|at_least\|at_most)\(\d+\)\.times)`
 | Array
 |===
 

--- a/docs/modules/ROOT/pages/cops_naming.adoc
+++ b/docs/modules/ROOT/pages/cops_naming.adoc
@@ -501,7 +501,7 @@ EOS
 | Name | Default value | Configurable values
 
 | ForbiddenDelimiters
-| `(?-mix:(^|\s)(EO[A-Z]{1}|END)(\s|$))`
+| `(?-mix:(^|\s)(EO[A-Z]{1}\|END)(\s|$))`
 | Array
 |===
 

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -12112,8 +12112,8 @@ array of 2 or fewer elements.
 | Integer
 
 | WordRegex
-| `(?-mix:\A(?:\p{Word}|\p{Word}-\p{Word}|\n|\t)+\z)`
-| 
+| `(?-mix:\A(?:\p{Word}\|\p{Word}-\p{Word}\|\n\|\t)+\z)`
+|
 |===
 
 === References


### PR DESCRIPTION
Adds escaping to regular expressions that broke Asciidoc parsing of several cop documents.

Current documentation at https://docs.rubocop.org/rubocop/cops_style.html#configurable-attributes-97 looks like this:

![image](https://user-images.githubusercontent.com/692853/116235013-ac2a6e80-a7a0-11eb-9896-e9d4127e9f75.png)

The same document, in IntelliJ's Asciidoc previewer, after this PR:

![image](https://user-images.githubusercontent.com/692853/116235112-cd8b5a80-a7a0-11eb-9667-db680041098a.png)

-----------------

Unticked items are not applicable.

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
