### PR TITLE
Prevent infinite loops during symlink traversal

### DIFF
--- a/changelog/fix_prevent_infinite_loops_during_symlink.md
+++ b/changelog/fix_prevent_infinite_loops_during_symlink.md
@@ -1,0 +1,1 @@
+* [#9748](https://github.com/rubocop/rubocop/pull/9748): Prevent infinite loops during symlink traversal. ([@Tonkpils][])

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -100,10 +100,17 @@ module RuboCop
                   next true if dir.end_with?('/./', '/../')
                   next true if File.fnmatch?(exclude_pattern, dir, flags)
 
-                  File.symlink?(dir.chomp('/')) && File.fnmatch?(exclude_pattern,
-                                                                 "#{File.realpath(dir)}/", flags)
+                  symlink_excluded_or_infinite_loop?(base_dir, dir, exclude_pattern, flags)
                 end
       dirs.flat_map { |dir| wanted_dir_patterns(dir, exclude_pattern, flags) }.unshift(base_dir)
+    end
+
+    def symlink_excluded_or_infinite_loop?(base_dir, current_dir, exclude_pattern, flags)
+      dir_realpath = File.realpath(current_dir)
+      File.symlink?(current_dir.chomp('/')) && (
+        File.fnmatch?(exclude_pattern, "#{dir_realpath}/", flags) ||
+        File.realpath(base_dir).start_with?(dir_realpath)
+      )
     end
 
     def combined_exclude_glob_patterns(base_dir)

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -448,6 +448,12 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       end
     end
 
+    it 'prevents infinite loops when traversing symlinks' do
+      create_link('dir1/link/', File.expand_path('dir1'))
+
+      expect(found_basenames).to include('ruby1.rb').once
+    end
+
     it 'resolves symlinks when looking for excluded directories' do
       create_link('link', 'dir1')
 


### PR DESCRIPTION
https://github.com/rubocop/rubocop/pull/8815 introduced a traversal strategy that used recursion.
https://github.com/rubocop/rubocop/pull/9703 then fixed an issue with this traversal which accounted for directories and symlinks.

When a symlink points to a parent directory that contains that symlink it'll cause this to go into a loop until the filename is too long for glob to handle.

We prevent this by checking for the inclusion of a symlink's real path in the base directory's realpath. If the base directory's path starts with the symlink's destination then we are in a loop and should skip processing the directory


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
