### PR TITLE
Fix string literal autocorrect

### DIFF
--- a/changelog/fix_autocorrect_when_doublequotes_are.md
+++ b/changelog/fix_autocorrect_when_doublequotes_are.md
@@ -1,0 +1,1 @@
+* [#9751](https://github.com/rubocop/rubocop/pull/9751): `Style/StringLiteral` autocorrects `'\\'` into `"\\"`. ([@etiennebarrie][])

--- a/changelog/fix_dont_autocorrect_global_variable.md
+++ b/changelog/fix_dont_autocorrect_global_variable.md
@@ -1,0 +1,1 @@
+* [#9751](https://github.com/rubocop/rubocop/pull/9751): `Style/StringLiteral` doesn't autocorrect global variable interpolation. ([@etiennebarrie][])

--- a/lib/rubocop/cop/mixin/string_literals_help.rb
+++ b/lib/rubocop/cop/mixin/string_literals_help.rb
@@ -15,7 +15,7 @@ module RuboCop
         if style == :single_quotes
           !double_quotes_required?(src)
         else
-          !/" | \\[^'] | \#(@|\{)/x.match?(src)
+          !/" | \\[^'\\] | \#(@|\{)/x.match?(src)
         end
       end
     end

--- a/lib/rubocop/cop/mixin/string_literals_help.rb
+++ b/lib/rubocop/cop/mixin/string_literals_help.rb
@@ -15,7 +15,7 @@ module RuboCop
         if style == :single_quotes
           !double_quotes_required?(src)
         else
-          !/" | \\[^'\\] | \#(@|\{)/x.match?(src)
+          !/" | \\[^'\\] | \#[@{$]/x.match?(src)
         end
       end
     end

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -206,10 +206,13 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
       expect_offense(<<~'RUBY')
         '\''
         ^^^^ Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
+        '\\'
+        ^^^^ Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
       RUBY
 
       expect_correction(<<~'RUBY')
         "'"
+        "\\"
       RUBY
     end
 

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -264,10 +264,12 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
         a = '\n'
         b = '"'
         c = '#{x}'
+        d = '#@x'
+        e = '#$x'
       RUBY
     end
 
-    it 'flags single quotes with plain # (not #@var or #{interpolation}' do
+    it 'flags single quotes with plain # (not #@var or #{interpolation} or #$global' do
       expect_offense(<<~RUBY)
         a = 'blah #'
             ^^^^^^^^ Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.


### PR DESCRIPTION
With this config:

```
Style/StringLiterals:
  EnforcedStyle: double_quotes
```

`'\\'` is not autocorrected to `"\\"` which it could

and

`'#$foo'` is autocorrected to `"\#$foo"` which it shouldn't, because it adds an escape.

Sorry I did those two in the same PR, but that would have added conflicts otherwise, since they change the same line.
Let me know if you'd really rather have 2 PRs.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
