### PR TITLE
[Fix #9731] Fix two autocorrection issues for `Style/NegatedIfElseCondition`

### DIFF
--- a/changelog/fix_fix_two_autocorrection_issues_for.md
+++ b/changelog/fix_fix_two_autocorrection_issues_for.md
@@ -1,0 +1,1 @@
+* [#9731](https://github.com/rubocop/rubocop/issues/9731): Fix two autocorrection issues for `Style/NegatedIfElseCondition`. ([@dvandersluis][])


### PR DESCRIPTION
Previously, when swapping the `if` and `else` branches, if one of the branches only had a single statement, the branch would end up not being spaced out properly.

Additionally, when there is a node with a comment inside the `if` that has an identical node with a comment *before* the `if` statement, `CommentsHelp.begin_pos_with_comment` returns an incorrect range, which was causing a clobbering error. I fixed this by creating ranges of the entire body of the if and else branches, so that they can just be swapped without relying on `ProcessedSource#ast_with_comments`. See rubocop/rubocop-ast#179.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
