### PR TITLE
Fix a false positive for `Lint/NumberConversion`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_number_conversion.md
+++ b/changelog/fix_a_false_positive_for_lint_number_conversion.md
@@ -1,0 +1,1 @@
+* [#9757](https://github.com/rubocop/rubocop/pull/9757): Fix a false positive for `Lint/NumberConversion` when `:to_f` is one of multiple method arguments. ([@koic][])

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -97,7 +97,7 @@ module RuboCop
 
         def handle_as_symbol(node)
           to_method_symbol(node) do |receiver, sym_node, to_method|
-            next if receiver.nil?
+            next if receiver.nil? || !node.arguments.one?
 
             message = format(
               MSG,

--- a/spec/rubocop/cop/lint/number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/number_conversion_spec.rb
@@ -121,6 +121,12 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
         to_i
       RUBY
     end
+
+    it 'when `:to_f` is one of multiple method arguments' do
+      expect_no_offenses(<<~RUBY)
+        delegate :to_f, to: :description, allow_nil: true
+      RUBY
+    end
   end
 
   context 'to_method in symbol form' do


### PR DESCRIPTION
This PR fixes the following false positive and incorrect auto-correct for `Lint/NumberConversion` when `:to_f` is one of multiple method arguments.

```console
% cat example.rb
delegate :to_f, to: :description, allow_nil: true

% bundle exec rubocop --only Lint/NumberConversion -A example.rb
(snip)

Inspecting 1 file
W

Offenses:

example.rb:1:1: W: [Corrected] Lint/NumberConversion: Replace unsafe
number conversion with number class parsing, instead of using :to_f, use
stricter { |i| Float(i) }.
delegate :to_f, to: :description, allow_nil: true
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
delegate { |i| Float(i) }, to: :description, allow_nil: true

% ruby -c example.rb
example.rb:1: syntax error, unexpected ',', expecting end-of-input
delegate { |i| Float(i) }, to: :description, allow_nil:...
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
