### PR TITLE
[Fix #9762] Update `VariableForce` to be able to handle `case-match` nodes

### DIFF
--- a/changelog/fix_update_variableforce_to_be_able_to.md
+++ b/changelog/fix_update_variableforce_to_be_able_to.md
@@ -1,0 +1,1 @@
+* [#9762](https://github.com/rubocop/rubocop/issues/9762): Update `VariableForce` to be able to handle `case-match` nodes. ([@dvandersluis][])

--- a/lib/rubocop/cop/variable_force/branch.rb
+++ b/lib/rubocop/cop/variable_force/branch.rb
@@ -226,6 +226,21 @@ module RuboCop
           end
         end
 
+        # case target
+        # in pattern # in_pattern
+        # else
+        #   else_body
+        # end
+        class CaseMatch < Base
+          define_predicate :target?,     child_index: 0
+          define_predicate :in_pattern?, child_index: 1..-2
+          define_predicate :else_body?,  child_index: -1
+
+          def always_run?
+            target?
+          end
+        end
+
         # for element in collection
         #   loop_body
         # end

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1416,4 +1416,19 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
       end
     end
   end
+
+  context 'inside a `case-match` node', :ruby27 do
+    it 'does not register an offense when the variable is used' do
+      expect_no_offenses(<<~RUBY)
+        case '0'
+        in String
+          res = 1
+        else
+          res = 2
+        end
+
+        do_something(res)
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
`VariableForce::Branch` was not aware of `case-match` nodes and thus did not properly mark all assignments in the following code as used, which caused rubocop to register a false positive `Lint/UselessAssignment`.

 ```ruby
def f
  case '0'
  in String
    res = 1 # would not be registered, causing an offense
  else
    res = 2 # would be registered
  end
  res
end
```

Fixes #9762.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
