### PR TITLE
[Fix #9761] Fix `Style/ClassAndModuleChildren` false negative for `compact` style when a class/module is partially nested

### DIFF
--- a/changelog/fix_fix_styleclassandmodulechildren_false.md
+++ b/changelog/fix_fix_styleclassandmodulechildren_false.md
@@ -1,0 +1,1 @@
+* [#9761](https://github.com/rubocop/rubocop/issues/9761): Fix `Style/ClassAndModuleChildren` false negative for `compact` style when a class/module is partially nested. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -132,7 +132,7 @@ module RuboCop
         end
 
         def check_compact_style(node, body)
-          return unless one_child?(body) && !compact_node_name?(node)
+          return unless needs_compacting?(body)
 
           add_offense(node.loc.name, message: COMPACT_MSG) do |corrector|
             autocorrect(corrector, node)
@@ -145,12 +145,12 @@ module RuboCop
           nest_or_compact(corrector, node)
         end
 
-        def one_child?(body)
+        def needs_compacting?(body)
           body && %i[module class].include?(body.type)
         end
 
         def compact_node_name?(node)
-          /::/.match?(node.loc.name.source)
+          /::/.match?(node.identifier.source)
         end
       end
     end

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -91,6 +91,44 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       RUBY
     end
 
+    it 'registers an offense for partially nested classes' do
+      expect_offense(<<~RUBY)
+        class Foo::Bar
+              ^^^^^^^^ Use nested module/class definitions instead of compact style.
+          class Baz
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Foo
+          class Bar
+          class Baz
+          end
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense for partially nested modules' do
+      expect_offense(<<~RUBY)
+        module Foo::Bar
+               ^^^^^^^^ Use nested module/class definitions instead of compact style.
+          module Baz
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Foo
+          module Bar
+          module Baz
+          end
+          end
+        end
+      RUBY
+    end
+
     it 'accepts nested children' do
       expect_no_offenses(<<~RUBY)
         class FooClass
@@ -161,6 +199,54 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
 
       expect_correction(<<~RUBY)
         module FooModule::BarModule
+        end
+      RUBY
+    end
+
+    it 'registers an offense for classes with partially nested children' do
+      expect_offense(<<~RUBY)
+        class Foo::Bar
+              ^^^^^^^^ Use compact module/class definition instead of nested style.
+          class Baz
+          end
+        end
+
+        class Foo
+              ^^^ Use compact module/class definition instead of nested style.
+          class Bar::Baz
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo::Bar::Baz
+        end
+
+        class Foo::Bar::Baz
+        end
+      RUBY
+    end
+
+    it 'registers an offense for modules with partially nested children' do
+      expect_offense(<<~RUBY)
+        module Foo::Bar
+               ^^^^^^^^ Use compact module/class definition instead of nested style.
+          module Baz
+          end
+        end
+
+        module Foo
+               ^^^ Use compact module/class definition instead of nested style.
+          module Bar::Baz
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Foo::Bar::Baz
+        end
+
+        module Foo::Bar::Baz
         end
       RUBY
     end


### PR DESCRIPTION
This fix makes `Style/ClassAndModuleChildren` register an offense for the following type of code with the `compact` style:

```ruby
class Foo::Bar
  class Baz
  end
end
```

Fixes #9761.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
