### PR TITLE
[Fix #9771] Fix a false positive for `Style/TrivialAccessors`

### DIFF
--- a/changelog/fix_false_positive_for_style_trivial_accessors.md
+++ b/changelog/fix_false_positive_for_style_trivial_accessors.md
@@ -1,0 +1,1 @@
+* [#9771](https://github.com/rubocop/rubocop/issues/9771): Change `AllowDSLWriters` to true by default for `Style/TrivialAccessors`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4745,7 +4745,7 @@ Style/TrivialAccessors:
   StyleGuide: '#attr_family'
   Enabled: true
   VersionAdded: '0.9'
-  VersionChanged: '0.77'
+  VersionChanged: '<<next>>'
   # When set to `false` the cop will suggest the use of accessor methods
   # in situations like:
   #
@@ -4764,7 +4764,7 @@ Style/TrivialAccessors:
   # on_exception :restart
   #
   # Commonly used in DSLs
-  AllowDSLWriters: false
+  AllowDSLWriters: true
   IgnoreClassMethods: false
   AllowedMethods:
     - to_ary

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -27,6 +27,71 @@ module RuboCop
       #   class << self
       #     attr_reader :baz
       #   end
+      #
+      # @example ExactNameMatch: true (default)
+      #   # good
+      #   def name
+      #     @other_name
+      #   end
+      #
+      # @example ExactNameMatch: false
+      #   # bad
+      #   def name
+      #     @other_name
+      #   end
+      #
+      # @example AllowPredicates: true (default)
+      #   # good
+      #   def foo?
+      #     @foo
+      #   end
+      #
+      # @example AllowPredicates: false
+      #   # bad
+      #   def foo?
+      #     @foo
+      #   end
+      #
+      #   # good
+      #   attr_reader :foo
+      #
+      # @example AllowDSLWriters: true (default)
+      #   # good
+      #   def on_exception(action)
+      #     @on_exception=action
+      #   end
+      #
+      # @example AllowDSLWriters: false
+      #   # bad
+      #   def on_exception(action)
+      #     @on_exception=action
+      #   end
+      #
+      #   # good
+      #   attr_writer :on_exception
+      #
+      # @example IgnoreClassMethods: false (default)
+      #   # bad
+      #   def self.foo
+      #     @foo
+      #   end
+      #
+      #   # good
+      #   class << self
+      #     attr_reader :foo
+      #   end
+      #
+      # @example IgnoreClassMethods: true
+      #   # good
+      #   def self.foo
+      #     @foo
+      #   end
+      #
+      # @exampole AllowedMethods: ['allowed_method']
+      #   # good
+      #   def allowed_method
+      #     @foo
+      #   end
       class TrivialAccessors < Base
         include AllowedMethods
         extend AutoCorrector


### PR DESCRIPTION
Fixes #9771.

This PR fixes a false positive for `Style/TrivialAccessors` when defining a method that is not a writer.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
