### PR TITLE
[Fix #9773] Fix `Style/EmptyLiteral` to not register offenses for `String.new` when `Style/FrozenStringLiteral` is enabled

### DIFF
--- a/changelog/fix_fix_styleemptyliteral_to_not_register.md
+++ b/changelog/fix_fix_styleemptyliteral_to_not_register.md
@@ -1,0 +1,1 @@
+* [#9773](https://github.com/rubocop/rubocop/issues/9773): Fix `Style/EmptyLiteral` to not register offenses for `String.new` when `Style/FrozenStringLiteral` is enabled. ([@dvandersluis][])

--- a/lib/rubocop/cop/mixin/frozen_string_literal.rb
+++ b/lib/rubocop/cop/mixin/frozen_string_literal.rb
@@ -35,6 +35,12 @@ module RuboCop
         leading_comment_lines.any? { |line| MagicComment.parse(line).frozen_string_literal? }
       end
 
+      def frozen_string_literals_disabled?
+        leading_comment_lines.any? do |line|
+          MagicComment.parse(line).frozen_string_literal == false
+        end
+      end
+
       def frozen_string_literal_specified?
         leading_comment_lines.any? do |line|
           MagicComment.parse(line).frozen_string_literal_specified?

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -62,7 +62,7 @@ module RuboCop
             ARR_MSG
           elsif offense_hash_node?(node)
             HASH_MSG
-          elsif str_node(node) && !frozen_string_literals_enabled?
+          elsif str_node(node) && !frozen_strings?
             format(STR_MSG, prefer: preferred_string_literal)
           end
         end
@@ -124,6 +124,13 @@ module RuboCop
               '{}'
             end
           end
+        end
+
+        def frozen_strings?
+          return true if frozen_string_literals_enabled?
+
+          frozen_string_cop_enabled = config.for_cop('Style/FrozenStringLiteral')['Enabled']
+          frozen_string_cop_enabled && !frozen_string_literals_disabled?
         end
       end
     end


### PR DESCRIPTION
`Style/EmptyLiteral` replaces `String.new` with `''`, unless the file has a `frozen-string-literal: true` magic comment. However, if `Style/FrozenStringLiteral` is also enabled, this will cause broken code, because the magic comment will be added afterwards.

This change makes string behaviour the same if `Style/FrozenStringLiteral` is enabled as if the magic comment is found. However, if `Style/FrozenStringLiteral` is enabled but there is a `frozen-string-literal: false` magic comment, `Style/EmptyLiteral` will continue to replace the literal.

Fixes #9773.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
