### PR TITLE
[Fix #9770] Update `Lint/EmptyBlock` to handle procs the same way as lambdas

### DIFF
--- a/changelog/change_update_lintemptyblock_to_handle_procs.md
+++ b/changelog/change_update_lintemptyblock_to_handle_procs.md
@@ -1,0 +1,1 @@
+* [#9770](https://github.com/rubocop/rubocop/issues/9770): Update `Lint/EmptyBlock` to handle procs the same way as lambdas. ([@dvandersluis][])

--- a/spec/rubocop/cop/lint/empty_block_spec.rb
+++ b/spec/rubocop/cop/lint/empty_block_spec.rb
@@ -43,6 +43,32 @@ RSpec.describe RuboCop::Cop::Lint::EmptyBlock, :config do
     RUBY
   end
 
+  it 'does not register an offense on an empty proc' do
+    expect_no_offenses(<<~RUBY)
+      proc do
+      end
+    RUBY
+  end
+
+  it 'does not register an offense on an empty Proc.new' do
+    expect_no_offenses(<<~RUBY)
+      Proc.new {}
+    RUBY
+  end
+
+  it 'does not register an offense on an empty ::Proc.new' do
+    expect_no_offenses(<<~RUBY)
+      ::Proc.new {}
+    RUBY
+  end
+
+  it 'registers an offense for an empty block given to a non-Kernel `proc` method' do
+    expect_offense(<<~RUBY)
+      Foo.proc {}
+      ^^^^^^^^^^^ Empty block detected.
+    RUBY
+  end
+
   context 'when AllowComments is false' do
     let(:cop_config) { { 'AllowComments' => false } }
 
@@ -78,6 +104,28 @@ RSpec.describe RuboCop::Cop::Lint::EmptyBlock, :config do
       expect_offense(<<~RUBY)
         -> {}
         ^^^^^ Empty block detected.
+      RUBY
+    end
+
+    it 'registers an offense on an empty proc' do
+      expect_offense(<<~RUBY)
+        proc do
+        ^^^^^^^ Empty block detected.
+        end
+      RUBY
+    end
+
+    it 'registers an offense on an empty Proc.new' do
+      expect_offense(<<~RUBY)
+        Proc.new {}
+        ^^^^^^^^^^^ Empty block detected.
+      RUBY
+    end
+
+    it 'registers an offense on an empty ::Proc.new' do
+      expect_offense(<<~RUBY)
+        ::Proc.new {}
+        ^^^^^^^^^^^^^ Empty block detected.
       RUBY
     end
   end


### PR DESCRIPTION
`Lint/EmptyBlock` now treats procs the same way as lambdas (governed by the `AllowLambdas` configuration).

Fixes #9770.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
