### PR TITLE
Update `Style/NilLambda` to handle procs as well

### DIFF
--- a/changelog/change_update_stylenillambda_to_handle_procs_as.md
+++ b/changelog/change_update_stylenillambda_to_handle_procs_as.md
@@ -1,0 +1,1 @@
+* [#9776](https://github.com/rubocop/rubocop/pull/9776): Update `Style/NilLambda` to handle procs as well. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/nil_lambda_spec.rb
+++ b/spec/rubocop/cop/style/nil_lambda_spec.rb
@@ -171,4 +171,202 @@ RSpec.describe RuboCop::Cop::Style::NilLambda, :config do
       RUBY
     end
   end
+
+  context 'proc' do
+    it 'registers an offense when returning nil implicitly' do
+      expect_offense(<<~RUBY)
+        proc do
+        ^^^^^^^ Use an empty proc instead of always returning nil.
+          nil
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        proc do
+        end
+      RUBY
+    end
+
+    it 'registers an offense when returning nil with `return`' do
+      expect_offense(<<~RUBY)
+        proc do
+        ^^^^^^^ Use an empty proc instead of always returning nil.
+          return nil
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        proc do
+        end
+      RUBY
+    end
+
+    it 'registers an offense when returning nil with `break`' do
+      expect_offense(<<~RUBY)
+        proc do
+        ^^^^^^^ Use an empty proc instead of always returning nil.
+          break nil
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        proc do
+        end
+      RUBY
+    end
+
+    it 'registers an offense when returning nil with `next`' do
+      expect_offense(<<~RUBY)
+        proc do
+        ^^^^^^^ Use an empty proc instead of always returning nil.
+          next nil
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        proc do
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when not returning nil' do
+      expect_no_offenses(<<~RUBY)
+        proc do
+          6
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when doing more than returning nil' do
+      expect_no_offenses(<<~RUBY)
+        proc do |x|
+          x ? x.method : nil
+        end
+      RUBY
+    end
+
+    it 'does not remove block params or change spacing' do
+      expect_offense(<<~RUBY)
+        fn = proc do |x|
+             ^^^^^^^^^^^ Use an empty proc instead of always returning nil.
+               nil
+             end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        fn = proc do |x|
+             end
+      RUBY
+    end
+
+    it 'properly corrects single line' do
+      expect_offense(<<~RUBY)
+        proc { nil }
+        ^^^^^^^^^^^^ Use an empty proc instead of always returning nil.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        proc {}
+      RUBY
+    end
+  end
+
+  context 'Proc.new' do
+    it 'registers an offense when returning nil implicitly' do
+      expect_offense(<<~RUBY)
+        Proc.new do
+        ^^^^^^^^^^^ Use an empty proc instead of always returning nil.
+          nil
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Proc.new do
+        end
+      RUBY
+    end
+
+    it 'registers an offense when returning nil with `return`' do
+      expect_offense(<<~RUBY)
+        Proc.new do
+        ^^^^^^^^^^^ Use an empty proc instead of always returning nil.
+          return nil
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Proc.new do
+        end
+      RUBY
+    end
+
+    it 'registers an offense when returning nil with `break`' do
+      expect_offense(<<~RUBY)
+        Proc.new do
+        ^^^^^^^^^^^ Use an empty proc instead of always returning nil.
+          break nil
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Proc.new do
+        end
+      RUBY
+    end
+
+    it 'registers an offense when returning nil with `next`' do
+      expect_offense(<<~RUBY)
+        Proc.new do
+        ^^^^^^^^^^^ Use an empty proc instead of always returning nil.
+          next nil
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Proc.new do
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when not returning nil' do
+      expect_no_offenses(<<~RUBY)
+        Proc.new do
+          6
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when doing more than returning nil' do
+      expect_no_offenses(<<~RUBY)
+        Proc.new do |x|
+          x ? x.method : nil
+        end
+      RUBY
+    end
+
+    it 'does not remove block params or change spacing' do
+      expect_offense(<<~RUBY)
+        fn = Proc.new do |x|
+             ^^^^^^^^^^^^^^^ Use an empty proc instead of always returning nil.
+               nil
+             end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        fn = Proc.new do |x|
+             end
+      RUBY
+    end
+
+    it 'properly corrects single line' do
+      expect_offense(<<~RUBY)
+        Proc.new { nil }
+        ^^^^^^^^^^^^^^^^ Use an empty proc instead of always returning nil.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Proc.new {}
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Similarly to #9775, updates `Style/NilLambda` to handle procs as well.

Like I wrote in https://github.com/rubocop/rubocop/pull/9775#issuecomment-832989444, the naming is a bit off here, but I think it's better than the two alternatives -- create a separate `Style/NilProc` cop (duplication) or rename `Style/NilLambda` to `NilLambdaAndProc` or something (breaking change).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
