### PR TITLE
Fix an incorrect auto-correct for `Style/RedundantBegin`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_begin.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_begin.md
@@ -1,0 +1,1 @@
+* [#9777](https://github.com/rubocop/rubocop/pull/9777): Fix an incorrect auto-correct for `Style/RedundantBegin` when using multi-line `if` in `begin` block. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -110,7 +110,7 @@ module RuboCop
           first_child = node.children.first
 
           source = first_child.source
-          source = "(#{source})" if first_child.if_type?
+          source = "(#{source})" if first_child.if_type? && first_child.modifier_form?
 
           corrector.replace(offense_range, source)
           corrector.remove(range_between(offense_range.end_pos, first_child.source_range.end_pos))

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -553,6 +553,25 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     expect(File.read('example.rb')).to eq(corrected)
   end
 
+  it 'corrects `Style/RedundantBegin` with `Style/MultilineMemoization`' do
+    source = <<~RUBY
+      @memo ||= begin
+                  if condition
+                    do_something
+                  end
+                end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run(['-a', '--only', 'Style/RedundantBegin,Style/MultilineMemoization'])).to eq(0)
+    corrected = <<~RUBY
+      @memo ||= if condition
+                    do_something
+                  end
+      #{trailing_whitespace * 10}
+    RUBY
+    expect(File.read('example.rb')).to eq(corrected)
+  end
+
   it 'corrects LineEndConcatenation offenses leaving the ' \
      'RedundantInterpolation offense unchanged' do
     # If we change string concatenation from plus to backslash, the string

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -248,6 +248,23 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when using multi-line `if` in `begin` block' do
+    expect_offense(<<~RUBY)
+      var ||= begin
+              ^^^^^ Redundant `begin` block detected.
+        if condition
+          foo
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      var ||= if condition
+          foo
+        end\n
+    RUBY
+  end
+
   it 'does not register an offense when using `begin` with multiple statement for or assignment' do
     expect_no_offenses(<<~RUBY)
       var ||= begin


### PR DESCRIPTION
This PR fixes an incorrect auto-correct for `Style/RedundantBegin` when using multi-line `if` in `begin` block.

And fixes https://github.com/testdouble/standard/issues/289 that is causing the following infinite loop error due to `Style/RedundantBegin` with `Style/MultilineMemoization`.

```ruby
% cat example.rb
@memo ||= begin
  if condition
    do_something
  end
end

% bundle exec rubocop -a --only Style/RedundantBegin,Style/MultilineMemoization
(snip)

Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Corrected] Style/MultilineMemoization: Wrap
multiline memoization blocks in begin and end.
@memo ||= (if condition ...
^^^^^^^^^^^^^^^^^^^^^^^
example.rb:1:11: C: [Corrected] Style/RedundantBegin: Redundant begin
block detected.
@memo ||= begin
          ^^^^^

0 files inspected, 2 offenses detected, 2 offenses corrected
Infinite loop detected in
/Users/koic/src/github.com/koic/rubocop-issues/289/example.rb and caused
by Style/MultilineMemoization
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/runner.rb:285:in
`block in iterate_until_no_changes'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/runner.rb:281:in
`loop'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/runner.rb:281:in `iterate_until_no_changes'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
