### PR TITLE
Add `disabled_all?` to DirectiveComment

### DIFF
--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -64,6 +64,11 @@ module RuboCop
       !disabled? && all_cops?
     end
 
+    # Checks if this directive disables all cops
+    def disabled_all?
+      disabled? && all_cops?
+    end
+
     # Checks if all cops specified in this directive
     def all_cops?
       cops == 'all'

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -214,4 +214,32 @@ RSpec.describe RuboCop::DirectiveComment do
       end
     end
   end
+
+  describe '#disabled_all?' do
+    subject { directive_comment.disabled_all? }
+
+    context 'when enabled all cops' do
+      let(:text) { 'def foo # rubocop:enable all' }
+
+      it { is_expected.to eq false }
+    end
+
+    context 'when enabled specific cops' do
+      let(:text) { '# rubocop:enable Foo/Bar' }
+
+      it { is_expected.to eq false }
+    end
+
+    context 'when disabled all cops' do
+      let(:text) { '# rubocop:disable all' }
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when disabled specific cops' do
+      let(:text) { '# rubocop:disable Foo/Bar' }
+
+      it { is_expected.to eq false }
+    end
+  end
 end


### PR DESCRIPTION
Because we have `DirectiveComment#enabled_all?` I also have added `disabled_all?` checking and I'm going to use it in further PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
