### PR TITLE
[Fix #9780] Support summary report for `JUnitFormatter`

### DIFF
--- a/changelog/new_support_summary_report_for_junit_formatter.md
+++ b/changelog/new_support_summary_report_for_junit_formatter.md
@@ -1,0 +1,1 @@
+* [#9780](https://github.com/rubocop/rubocop/issues/9780): Support summary report for `JUnitFormatter`. ([@koic][])

--- a/docs/modules/ROOT/pages/formatters.adoc
+++ b/docs/modules/ROOT/pages/formatters.adoc
@@ -260,7 +260,7 @@ This formatter is based on the https://github.com/mikian/rubocop-junit-formatter
 $ rubocop --format junit
 <?xml version='1.0'?>
 <testsuites>
-  <testsuite name='rubocop'>
+  <testsuite name='rubocop' tests='2' failures='2'>
     <testcase classname='example' name='Style/FrozenStringLiteralComment'>
       <failure type='Style/FrozenStringLiteralComment' message='Style/FrozenStringLiteralComment: Missing frozen string literal comment.'>
         /tmp/src/example.rb:1:1

--- a/lib/rubocop/formatter/junit_formatter.rb
+++ b/lib/rubocop/formatter/junit_formatter.rb
@@ -22,9 +22,13 @@ module RuboCop
         testsuites = REXML::Element.new('testsuites', @document)
         testsuite = REXML::Element.new('testsuite', testsuites)
         @testsuite = testsuite.tap { |element| element.add_attributes('name' => 'rubocop') }
+
+        reset_count
       end
 
       def file_finished(file, offenses)
+        @inspected_file_count += 1
+
         # TODO: Returns all cops with the same behavior as
         # the original rubocop-junit-formatter.
         # https://github.com/mikian/rubocop-junit-formatter/blob/v0.1.4/lib/rubocop/formatter/junit_formatter.rb#L9
@@ -32,15 +36,11 @@ module RuboCop
         # In the future, it would be preferable to return only enabled cops.
         Cop::Registry.all.each do |cop|
           target_offenses = offenses_for_cop(offenses, cop)
+          @offense_count += target_offenses.count
 
           next unless relevant_for_output?(options, target_offenses)
 
-          REXML::Element.new('testcase', @testsuite).tap do |testcase|
-            testcase.attributes['classname'] = classname_attribute_value(file)
-            testcase.attributes['name'] = cop.cop_name
-
-            add_failure_to(testcase, target_offenses, cop.cop_name)
-          end
+          add_testcase_element_to_testsuite_element(file, target_offenses, cop)
         end
       end
 
@@ -52,15 +52,30 @@ module RuboCop
         all_offenses.select { |offense| offense.cop_name == cop.cop_name }
       end
 
+      def add_testcase_element_to_testsuite_element(file, target_offenses, cop)
+        REXML::Element.new('testcase', @testsuite).tap do |testcase|
+          testcase.attributes['classname'] = classname_attribute_value(file)
+          testcase.attributes['name'] = cop.cop_name
+
+          add_failure_to(testcase, target_offenses, cop.cop_name)
+        end
+      end
+
       def classname_attribute_value(file)
         file.gsub(/\.rb\Z/, '').gsub("#{Dir.pwd}/", '').tr('/', '.')
       end
 
       def finished(_inspected_files)
+        @testsuite.add_attributes('tests' => @inspected_file_count, 'failures' => @offense_count)
         @document.write(output, 2)
       end
 
       private
+
+      def reset_count
+        @inspected_file_count = 0
+        @offense_count = 0
+      end
 
       def add_failure_to(testcase, offenses, cop_name)
         # One failure per offense. Zero failures is a passing test case,

--- a/spec/rubocop/formatter/junit_formatter_spec.rb
+++ b/spec/rubocop/formatter/junit_formatter_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RuboCop::Formatter::JUnitFormatter, :config do
       expect(output.string).to start_with(<<~XML)
         <?xml version='1.0'?>
         <testsuites>
-          <testsuite name='rubocop'>
+          <testsuite name='rubocop' tests='2' failures='4'>
       XML
     end
 


### PR DESCRIPTION
Fixes #9780.

This PR supports summary report for `JUnitFormatter`.

It adds the following attributes to the `<testsuite>` element.

- `tests` attribute ... Inspected file count.
- `failures` attribute ... Total offense count.

This is a JUnit format example:

```xml
% rubocop -f junit --display-only-failed lib/rubocop/formatter/junit_formatter.rb
<?xml version='1.0'?>
<testsuites>
  <testsuite name='rubocop' tests='1' failures='2'>
    <testcase classname='lib.rubocop.formatter.junit_formatter' name='Layout/LineLength'>
      <failure type='Layout/LineLength' message='Layout/LineLength: Line is too long. [110/100]'>
        /Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/formatter/junit_formatter.rb:65:101
      </failure>
    </testcase>
    <testcase classname='lib.rubocop.formatter.junit_formatter' name='Metrics/AbcSize'>
      <failure type='Metrics/AbcSize' message='Metrics/AbcSize:
Assignment Branch Condition size for file_finished is too high. [&lt;8, 16, 2&gt; 18/17]'>
        /Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/formatter/junit_formatter.rb:29:7
      </failure>
    </testcase>
  </testsuite>
</testsuites>
```

These mean the values of `1 file inspected` and `2 offenses detected` below.

```console
% rubocop lib/rubocop/formatter/junit_formatter.rb
Inspecting 1 file
(snip)

1 file inspected, 2 offenses detected, 2 offenses auto-correctable
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
