### PR TITLE
[Fix #9766] Fix a clobbering error for `Style/ClassAndModuleChildren` with `compact` style

### DIFF
--- a/changelog/fix_clobbering_error_in_class_and_module_children_cop.md
+++ b/changelog/fix_clobbering_error_in_class_and_module_children_cop.md
@@ -1,0 +1,1 @@
+* [#9766](https://github.com/rubocop/rubocop/pull/9766): Fix a clobbering error for `Style/ClassAndModuleChildren` cop with compact style. ([@tejasbubane][])

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -132,6 +132,9 @@ module RuboCop
         end
 
         def check_compact_style(node, body)
+          parent = node.parent
+          return if parent&.class_type? || parent&.module_type?
+
           return unless needs_compacting?(body)
 
           add_offense(node.loc.name, message: COMPACT_MSG) do |corrector|

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -227,6 +227,23 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       RUBY
     end
 
+    it 'registers and offense for deeply nested children' do
+      expect_offense(<<~RUBY)
+        class Foo
+              ^^^ Use compact module/class definition instead of nested style.
+          class Bar
+            class Baz
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo::Bar::Baz
+        end
+      RUBY
+    end
+
     it 'registers an offense for modules with partially nested children' do
       expect_offense(<<~RUBY)
         module Foo::Bar


### PR DESCRIPTION
Closes #9766

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/