### PR TITLE
[Fix #9767] Fix `Style/ClassAndModuleChildren` cop to preserve comments

### DIFF
--- a/changelog/fix_class_and_module_children_preserve_comment.md
+++ b/changelog/fix_class_and_module_children_preserve_comment.md
@@ -1,0 +1,1 @@
+* [#9767](https://github.com/rubocop/rubocop/issues/9767): Fix `Style/ClassAndModuleChildren` cop to preserve comments. ([@tejasbubane][])

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -87,9 +87,18 @@ module RuboCop
         end
 
         def compact_node(corrector, node)
-          replacement = "#{node.body.type} #{compact_identifier_name(node)}"
           range = range_between(node.loc.keyword.begin_pos, node.body.loc.name.end_pos)
-          corrector.replace(range, replacement)
+          corrector.replace(range, compact_replacement(node))
+        end
+
+        def compact_replacement(node)
+          replacement = "#{node.body.type} #{compact_identifier_name(node)}"
+
+          body_comments = processed_source.ast_with_comments[node.body]
+          unless body_comments.empty?
+            replacement = body_comments.map(&:text).push(replacement).join("\n")
+          end
+          replacement
         end
 
         def compact_identifier_name(node)

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -129,6 +129,23 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       RUBY
     end
 
+    it 'preserves comments' do
+      expect_offense(<<~RUBY)
+        # top comment
+        class Foo::Bar # describe Foo::Bar
+              ^^^^^^^^ Use nested module/class definitions instead of compact style.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # top comment
+        module Foo
+          class Bar # describe Foo::Bar
+          end
+        end
+      RUBY
+    end
+
     it 'accepts nested children' do
       expect_no_offenses(<<~RUBY)
         class FooClass
@@ -247,6 +264,29 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
         end
 
         module Foo::Bar::Baz
+        end
+      RUBY
+    end
+
+    it 'preserves comments between classes' do
+      expect_offense(<<~RUBY)
+        # describe Foo
+        # more Foo
+        class Foo
+              ^^^ Use compact module/class definition instead of nested style.
+          # describe Bar
+          # more Bar
+          class Bar
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # describe Foo
+        # more Foo
+        # describe Bar
+        # more Bar
+        class Foo::Bar
         end
       RUBY
     end


### PR DESCRIPTION
Closes #9767

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/