### PR TITLE
Update default.yml for changes to `Lint/EmptyBlock` and `Style/NilLambda`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1612,7 +1612,7 @@ Lint/EmptyBlock:
   Description: 'This cop checks for blocks without a body.'
   Enabled: pending
   VersionAdded: '1.1'
-  VersionChanged: '1.3'
+  VersionChanged: '<<next>>'
   AllowComments: true
   AllowEmptyLambdas: true
 
@@ -3998,6 +3998,7 @@ Style/NilLambda:
   Description: 'Prefer `-> {}` to `-> { nil }`.'
   Enabled: pending
   VersionAdded: '1.3'
+  VersionChanged: '<<next>>'
 
 Style/NonNilCheck:
   Description: 'Checks for redundant nil checks.'


### PR DESCRIPTION
I forgot to update default.yml in #9775  and #9776.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
