### PR TITLE
Fix a false negative for `Layout/IndentationWidth`

### DIFF
--- a/changelog/fix_false_negative_for_layout_indentation_width.md
+++ b/changelog/fix_false_negative_for_layout_indentation_width.md
@@ -1,0 +1,1 @@
+* [#9791](https://github.com/rubocop/rubocop/pull/9791): Fix a false negative for `Layout/IndentationWidth` when using `ensure` in `do` ... `end` block. ([@koic][])

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -313,9 +313,12 @@ module RuboCop
             check_rescue?(body_node)
           elsif body_node.ensure_type?
             block_body, = *body_node
-            return unless block_body
 
-            check_rescue?(block_body) if block_body.rescue_type?
+            if block_body&.rescue_type?
+              check_rescue?(block_body)
+            else
+              !block_body.nil?
+            end
           else
             true
           end

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1437,6 +1437,27 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         RUBY
       end
 
+      it 'does not register an offense for good indentation of `do` ... `ensure` ... `end` block' do
+        expect_no_offenses(<<~RUBY)
+          do_something do
+            foo
+          ensure
+            handle_error
+          end
+        RUBY
+      end
+
+      it 'registers an offense for bad indentation of `do` ... `ensure` ... `end` block' do
+        expect_offense(<<~RUBY)
+          do_something do
+              foo
+          ^^^^ Use 2 (not 4) spaces for indentation.
+          ensure
+            handle_error
+          end
+        RUBY
+      end
+
       context 'when using safe navigation operator' do
         it 'registers an offense for bad indentation of a {} body' do
           expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR fixes a false negative for `Layout/IndentationWidth` when using `ensure` in `do` ... `end` block

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
