### PR TITLE
[Change #9744] Auto disable parallel when combined with cache false

### DIFF
--- a/changelog/change_disable_parallel_with_cache_false.md
+++ b/changelog/change_disable_parallel_with_cache_false.md
@@ -1,0 +1,1 @@
+* [#9744](https://github.com/rubocop/rubocop/pull/9744): The parallel flag will now be automatically ignored when combined with `--cache false`. Previously, an error was raised and execution stopped. ([@rrosenblum][])

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -199,11 +199,11 @@ RSpec.describe RuboCop::Options, :isolated_environment do
 
     describe '--parallel' do
       context 'combined with --cache false' do
-        it 'fails with an error message' do
-          msg = ['-P/--parallel uses caching to speed up execution, so ',
-                 'combining with --cache false is not allowed.'].join
-          expect { options.parse %w[--parallel --cache false] }
-            .to raise_error(RuboCop::OptionArgumentError, msg)
+        it 'ignores parallel' do
+          msg = '-P/--parallel is being ignored because it is not compatible with --cache false'
+          options.parse %w[--parallel --cache false]
+          expect($stdout.string).to include(msg)
+          expect(options.instance_variable_get('@options').keys).not_to include(:parallel)
         end
       end
 


### PR DESCRIPTION
This closes #9744. 

Modify the behavior of `--parallel` combined with `--cache false` to emit a warning and disable parallel. It previously would raise an error and halt execution. This is consistent with the changes in #9647  
