### PR TITLE
[Fix #9792] Fix false positive for `Lint/Void` cop

### DIFF
--- a/changelog/fix_lint_void_false_positive.md
+++ b/changelog/fix_lint_void_false_positive.md
@@ -1,0 +1,1 @@
+* [#9792](https://github.com/rubocop/rubocop/issues/9792): Fix false positive for `Lint/Void` cop with ranges. ([@tejasbubane][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -104,7 +104,7 @@ module RuboCop
         end
 
         def check_literal(node)
-          return if !node.literal? || node.xstr_type?
+          return if !node.literal? || node.xstr_type? || node.range_type?
 
           add_offense(node, message: format(LIT_MSG, lit: node.source))
         end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -254,4 +254,22 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       nil
     RUBY
   end
+
+  it 'accepts method with irange block' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        1..100.times.each { puts 1 }
+        do_something
+      end
+    RUBY
+  end
+
+  it 'accepts method with erange block' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        1...100.times.each { puts 1 }
+        do_something
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Closes #9792

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/