### PR TITLE
Make `InternalAffairs/ExampleDescription` aware of several words

### DIFF
--- a/lib/rubocop/cop/internal_affairs/example_description.rb
+++ b/lib/rubocop/cop/internal_affairs/example_description.rb
@@ -41,7 +41,7 @@ module RuboCop
 
         EXPECT_NO_OFFENSES_INCORRECT_DESCRIPTIONS = [
           /^(adds|registers|reports|finds) (an? )?offense/,
-          /^flags\b/
+          /^(flags|handles|works)\b/
         ].freeze
 
         EXPECT_OFFENSE_INCORRECT_DESCRIPTIONS = [

--- a/spec/rubocop/cop/layout/condition_position_spec.rb
+++ b/spec/rubocop/cop/layout/condition_position_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::Layout::ConditionPosition, :config do
     RUBY
   end
 
-  it 'handles ternary ops' do
+  it 'accepts ternary ops' do
     expect_no_offenses('x ? a : b')
   end
 end

--- a/spec/rubocop/cop/layout/empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLines, :config do
     RUBY
   end
 
-  it 'works when there are no tokens' do
+  it 'does not register an offense when there are no tokens' do
     expect_no_offenses('#comment')
   end
 
-  it 'handles comments' do
+  it 'does not register an offense for comments' do
     expect_no_offenses(<<~RUBY)
       test
 

--- a/spec/rubocop/cop/lint/else_layout_spec.rb
+++ b/spec/rubocop/cop/lint/else_layout_spec.rb
@@ -99,15 +99,15 @@ RSpec.describe RuboCop::Cop::Lint::ElseLayout, :config do
     RUBY
   end
 
-  it 'handles ternary ops' do
+  it 'accepts ternary ops' do
     expect_no_offenses('x ? a : b')
   end
 
-  it 'handles modifier forms' do
+  it 'accepts modifier forms' do
     expect_no_offenses('x if something')
   end
 
-  it 'handles empty braces' do
+  it 'accepts empty braces' do
     expect_no_offenses(<<~RUBY)
       if something
         ()

--- a/spec/rubocop/cop/lint/out_of_range_regexp_ref_spec.rb
+++ b/spec/rubocop/cop/lint/out_of_range_regexp_ref_spec.rb
@@ -108,13 +108,13 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef, :config do
     RUBY
   end
 
-  it 'handles `match` with no arguments' do
+  it 'ignores `match` with no arguments' do
     expect_no_offenses(<<~RUBY)
       foo.match
     RUBY
   end
 
-  it 'handles `match` with no receiver' do
+  it 'ignores `match` with no receiver' do
     expect_no_offenses(<<~RUBY)
       match(bar)
     RUBY

--- a/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
+++ b/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
@@ -552,7 +552,7 @@ RSpec.describe RuboCop::Cop::Lint::UnmodifiedReduceAccumulator, :config do
         RUBY
       end
 
-      it 'handles break with no value' do
+      it 'allows break with no value' do
         expect_no_offenses(<<~RUBY)
           foo.#{method}([]) do |acc, el|
             break if something?

--- a/spec/rubocop/cop/lint/useless_setter_call_spec.rb
+++ b/spec/rubocop/cop/lint/useless_setter_call_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessSetterCall, :config do
     RUBY
   end
 
-  it 'handles exception assignments without exploding' do
+  it 'accepts exception assignments without exploding' do
     expect_no_offenses(<<~RUBY)
       def foo(bar)
         begin

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     RUBY
   end
 
-  it 'handles empty block' do
+  it 'accepts empty block' do
     expect_no_offenses(<<~RUBY)
       array.each { |_item| }
     RUBY

--- a/spec/rubocop/cop/naming/method_name_spec.rb
+++ b/spec/rubocop/cop/naming/method_name_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
     include_examples 'multiple attr methods', 'camelCase'
   end
 
-  it 'works for non-ascii characters' do
+  it 'accepts for non-ascii characters' do
     expect_no_offenses(<<~RUBY)
       def última_vista; end
     RUBY

--- a/spec/rubocop/cop/naming/variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/variable_name_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
       RUBY
     end
 
-    it 'works with non-ascii characters' do
+    it 'accepts with non-ascii characters' do
       expect_no_offenses('léo = 1')
     end
 

--- a/spec/rubocop/cop/style/document_dynamic_eval_definition_spec.rb
+++ b/spec/rubocop/cop/style/document_dynamic_eval_definition_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentDynamicEvalDefinition, :config do
       RUBY
     end
 
-    it 'handles inline comments' do
+    it 'does not register an offense when using inline comments' do
       expect_no_offenses(<<~RUBY)
         class_eval <<-EOT, __FILE__, __LINE__ + 1
           # def capitalize(*params, &block)
@@ -88,7 +88,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentDynamicEvalDefinition, :config do
       RUBY
     end
 
-    it 'handles other text' do
+    it 'does not register an offense when using other text' do
       expect_no_offenses(<<~RUBY)
         class_eval <<-EOT, __FILE__, __LINE__ + 1
           # EXAMPLE: def capitalize(*params, &block)
@@ -102,7 +102,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentDynamicEvalDefinition, :config do
       RUBY
     end
 
-    it 'handles multiple methods' do
+    it 'does not register an offense when using multiple methods' do
       expect_no_offenses(<<~RUBY)
         class_eval <<-EOT, __FILE__, __LINE__ + 1
           # def capitalize(*params, &block)
@@ -126,7 +126,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentDynamicEvalDefinition, :config do
       RUBY
     end
 
-    it 'handles multiple methods with split comments' do
+    it 'does not register an offense when using multiple methods with split comments' do
       expect_no_offenses(<<~RUBY)
         class_eval <<-EOT, __FILE__, __LINE__ + 1
           # def capitalize(*params, &block)
@@ -196,7 +196,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentDynamicEvalDefinition, :config do
       RUBY
     end
 
-    it 'handles inline comments' do
+    it 'does not register an offense when using inline comments' do
       expect_no_offenses(<<~RUBY)
         class_eval(
           # def capitalize(*params, &block)
@@ -212,7 +212,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentDynamicEvalDefinition, :config do
       RUBY
     end
 
-    it 'handles other text' do
+    it 'does not register an offense when using other text' do
       expect_no_offenses(<<~RUBY)
         class_eval(
           # EXAMPLE: def capitalize(*params, &block)
@@ -245,7 +245,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentDynamicEvalDefinition, :config do
       RUBY
     end
 
-    it 'handles multiple methods' do
+    it 'does not register an offense when using multiple methods' do
       expect_no_offenses(<<~RUBY)
         class_eval(
           # def capitalize(*params, &block)

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
     expect_no_corrections
   end
 
-  it 'handles __FILE__' do
+  it 'ignores __FILE__' do
     expect_no_offenses('__FILE__')
   end
 


### PR DESCRIPTION
Follow https://github.com/rubocop/rubocop/pull/9796#discussion_r631650841.

This PR makes `InternalAffairs/ExampleDescription` aware of descriptions starting with `handles` and `works` when using `expect_no_offenses`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
