### PR TITLE
Make `Layout/ArgumentAlignment` aware of kwargs

### DIFF
--- a/changelog/new_make_layout_argument_alignment_aware_of_kwargs.md
+++ b/changelog/new_make_layout_argument_alignment_aware_of_kwargs.md
@@ -1,0 +1,1 @@
+* [#9798](https://github.com/rubocop/rubocop/pull/9798): Make `Layout/ArgumentAlignment` aware of kwargs. ([@koic][])

--- a/lib/rubocop/cop/layout/first_hash_element_indentation.rb
+++ b/lib/rubocop/cop/layout/first_hash_element_indentation.rb
@@ -91,6 +91,8 @@ module RuboCop
         end
 
         def on_send(node)
+          return if enforce_first_argument_with_fixed_indentation?
+
           each_argument_node(node, :hash) do |hash_node, left_parenthesis|
             check(hash_node, left_parenthesis)
           end
@@ -181,6 +183,16 @@ module RuboCop
             'Indent the right brace the same as the start of the line ' \
             'where the left brace is.'
           end
+        end
+
+        def enforce_first_argument_with_fixed_indentation?
+          return false unless argument_alignment_config['Enabled']
+
+          argument_alignment_config['EnforcedStyle'] == 'with_fixed_indentation'
+        end
+
+        def argument_alignment_config
+          config.for_cop('Layout/ArgumentAlignment')
         end
       end
     end

--- a/spec/rubocop/cop/layout/argument_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/argument_alignment_spec.rb
@@ -88,6 +88,31 @@ RSpec.describe RuboCop::Cop::Layout::ArgumentAlignment, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when missed indendation kwargs' do
+      expect_offense(<<~RUBY)
+        func1(foo: 'foo',
+          bar: 'bar',
+          ^^^^^^^^^^ Align the arguments of a method call if they span more than one line.
+          baz: 'baz')
+          ^^^^^^^^^^ Align the arguments of a method call if they span more than one line.
+        func2(do_something,
+          foo: 'foo',
+          ^^^^^^^^^^^ Align the arguments of a method call if they span more than one line.
+          bar: 'bar',
+          baz: 'baz')
+      RUBY
+
+      expect_correction(<<~RUBY)
+        func1(foo: 'foo',
+              bar: 'bar',
+              baz: 'baz')
+        func2(do_something,
+              foo: 'foo',
+              bar: 'bar',
+              baz: 'baz')
+      RUBY
+    end
+
     it 'registers an offense and corrects splat operator' do
       expect_offense(<<~RUBY)
         func1(*a,
@@ -383,6 +408,31 @@ RSpec.describe RuboCop::Cop::Layout::ArgumentAlignment, :config do
           account:     account,
           open_price:  1.29,
           close_price: 1.30
+      RUBY
+    end
+
+    it 'registers an offense and corrects when missed indendation kwargs' do
+      expect_offense(<<~RUBY)
+        func1(foo: 'foo',
+              bar: 'bar',
+              ^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
+              baz: 'baz')
+              ^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
+        func2(do_something,
+              foo: 'foo',
+              ^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
+              bar: 'bar',
+              baz: 'baz')
+      RUBY
+
+      expect_correction(<<~RUBY)
+        func1(foo: 'foo',
+          bar: 'bar',
+          baz: 'baz')
+        func2(do_something,
+          foo: 'foo',
+          bar: 'bar',
+          baz: 'baz')
       RUBY
     end
 


### PR DESCRIPTION
This PR makes `Layout/ArgumentAlignment` aware of kwargs and fixes https://github.com/testdouble/standard/issues/216.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
