### PR TITLE
[Fix #9799] Fix invalid line splitting by `Layout/LineLength` for `send` nodes with heredoc arguments

### DIFF
--- a/changelog/fix_fix_invalid_line_splitting_by.md
+++ b/changelog/fix_fix_invalid_line_splitting_by.md
@@ -1,0 +1,1 @@
+* [#9799](https://github.com/rubocop/rubocop/issues/9799): Fix invalid line splitting by `Layout/LineLength` for `send` nodes with heredoc arguments. ([@dvandersluis][])

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -76,9 +76,25 @@ module RuboCop
 
         i = 0
         i += 1 while within_column_limit?(elements[i], max, line)
+        i = shift_elements_for_heredoc_arg(node, elements, i)
+
+        return if i.nil?
         return elements.first if i.zero?
 
         elements[i - 1]
+      end
+
+      # @api private
+      # If a send node contains a heredoc argument, splitting cannot happen
+      # after the heredoc or else it will cause a syntax error.
+      def shift_elements_for_heredoc_arg(node, elements, index)
+        return index unless node.send_type?
+
+        heredoc_index = elements.index { |arg| (arg.str_type? || arg.dstr_type?) && arg.heredoc? }
+        return index unless heredoc_index
+        return nil if heredoc_index.zero?
+
+        heredoc_index >= index ? index : heredoc_index + 1
       end
 
       # @api private


### PR DESCRIPTION
When a `send` node has heredoc arguments, the line cannot be split after the heredoc or it will be a syntax error.

Fixes #9799.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
