### PR TITLE
[Fix #9749] Fix autocorrection for `Layout/LineLength` to not move the first argument of an unparenthesized `send` node to the next line

### DIFF
--- a/changelog/fix_fix_autocorrection_for_layoutlinelength.md
+++ b/changelog/fix_fix_autocorrection_for_layoutlinelength.md
@@ -1,0 +1,1 @@
+* [#9749](https://github.com/rubocop/rubocop/issues/9749): Fix autocorrection for `Layout/LineLength` to not move the first argument of an unparenthesized `send` node to the next line, which changes behaviour. ([@dvandersluis][])

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -70,9 +70,9 @@ module RuboCop
       def extract_first_element_over_column_limit(node, elements, max)
         line = node.first_line
 
-        # If the first argument is a hash pair but the method is not parenthesized,
-        # the argument cannot be moved to another line because it cause a syntax error.
-        elements.shift if node.send_type? && !node.parenthesized? && elements.first.pair_type?
+        # If a `send` node is not parenthesized, don't move the first element, because it
+        # can result in changed behavior or a syntax error.
+        elements = elements.drop(1) if node.send_type? && !node.parenthesized?
 
         i = 0
         i += 1 while within_column_limit?(elements[i], max, line)

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -605,6 +605,34 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
         end
       end
 
+      context 'when unparenthesized' do
+        context 'when there is one argument' do
+          it 'does not autocorrect' do
+            expect_offense(<<~RUBY)
+              method_call xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                                                      ^^ Line is too long. [42/40]
+            RUBY
+
+            expect_no_corrections
+          end
+        end
+
+        context 'when there are multiple arguments' do
+          it 'splits the line after the first element' do
+            args = 'x' * 28
+            expect_offense(<<~RUBY, args: args)
+              method_call #{args}, abc
+                          _{args}^^^^^ Line is too long. [45/40]
+            RUBY
+
+            expect_correction(<<~RUBY, loop: false)
+              method_call #{args},#{trailing_whitespace}
+              abc
+            RUBY
+          end
+        end
+      end
+
       context 'when call with hash on same line' do
         it 'adds an offense only to outer and autocorrects it' do
           expect_offense(<<~RUBY)


### PR DESCRIPTION
Previously in #9382, `Layout/LineLength` was fixed for unparenthesized `send` nodes with a hash, but now it is applied to all argument types, since the ruby parser will interpret it as a method call with no arguments.

Fixes #9749.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
