### PR TITLE
Fix a false negative for `Layout/HashAlignment`

### DIFF
--- a/changelog/fix_false_negative_for_layout_hash_alignment.md
+++ b/changelog/fix_false_negative_for_layout_hash_alignment.md
@@ -1,0 +1,1 @@
+* [#9805](https://github.com/rubocop/rubocop/pull/9805): Fix a false negative for `Layout/HashAlignment` when set `EnforcedStyle: with_fixed_indentation` of `ArgumentAlignment`. ([@koic][])

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -201,7 +201,7 @@ module RuboCop
         alias on_yield on_send
 
         def on_hash(node)
-          return if enforce_first_argument_with_fixed_indentation? || ignored_node?(node) ||
+          return if autocorrect_incompatible_with_other_cops?(node) || ignored_node?(node) ||
                     node.pairs.empty? || node.single_line?
 
           proc = ->(a) { a.checkable_layout?(node) }
@@ -213,6 +213,10 @@ module RuboCop
         attr_accessor :offences_by, :column_deltas
 
         private
+
+        def autocorrect_incompatible_with_other_cops?(node)
+          enforce_first_argument_with_fixed_indentation? && node.parent&.call_type?
+        end
 
         def reset!
           self.offences_by = {}

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1839,6 +1839,38 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and ' \
+     '`Layout/HashAlignment`' do
+    create_file('example.rb', <<~RUBY)
+      update(foo: bar,
+          baz: boo,
+          pony: party)
+
+      self&.update(foo: bar,
+          baz: boo,
+          pony: party)
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/ArgumentAlignment:
+        EnforcedStyle: with_fixed_indentation
+    YAML
+
+    expect(
+      cli.run(['--auto-correct', '--only', 'Layout/ArgumentAlignment,Layout/HashAlignment'])
+    ).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      update(foo: bar,
+        baz: boo,
+        pony: party)
+
+      self&.update(foo: bar,
+        baz: boo,
+        pony: party)
+    RUBY
+  end
+
   it 'does not crash Lint/SafeNavigationWithEmpty and offenses and accepts Style/SafeNavigation ' \
      'when checking `foo&.empty?` in a conditional' do
     create_file('example.rb', <<~RUBY)

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
-  let(:cop_config) { { 'EnforcedHashRocketStyle' => 'key', 'EnforcedColonStyle' => 'key' } }
+  let(:config) do
+    RuboCop::Config.new(
+      'Layout/HashAlignment' => default_cop_config.merge(cop_config),
+      'Layout/ArgumentAlignment' => argument_alignment_config
+    )
+  end
+
+  let(:default_cop_config) { { 'EnforcedHashRocketStyle' => 'key', 'EnforcedColonStyle' => 'key' } }
+  let(:argument_alignment_config) { { 'EnforcedStyle' => 'with_first_argument' } }
 
   shared_examples 'not on separate lines' do
     it 'accepts single line hash' do
@@ -108,6 +116,27 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_correction(<<~RUBY)
         yield({a: 0,
                b: 1})
+      RUBY
+    end
+  end
+
+  context 'when `EnforcedStyle: with_fixed_indentation` of `ArgumentAlignment`' do
+    let(:argument_alignment_config) { { 'EnforcedStyle' => 'with_fixed_indentation' } }
+
+    it 'register and corrects an offense' do
+      expect_offense(<<~RUBY)
+        THINGS = {
+          oh: :io,
+            hi: 'neat'
+            ^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+            }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        THINGS = {
+          oh: :io,
+          hi: 'neat'
+            }
       RUBY
     end
   end


### PR DESCRIPTION
This PR fixes a false negative for `Layout/HashAlignment` when set `EnforcedStyle: with_fixed_indentation` of `ArgumentAlignment`. It is a regression of #9798.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
