### PR TITLE
Fix a build error for Ruby 3.1.0-dev

### DIFF
--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1024,7 +1024,11 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
     shared_examples('prints config') do
       it 'prints the current configuration' do
         out = stdout.lines.to_a
-        printed_config = YAML.load(out.join) # rubocop:disable Security/YAMLLoad
+        printed_config = if Psych::VERSION >= '4.0.0' # RUBY_VERSION >= '3.1.0'
+                           YAML.unsafe_load(out.join)
+                         else
+                           YAML.load(out.join) # rubocop:disable Security/YAMLLoad
+                         end
         cop_names = (arguments[0] || '').split(',')
         cop_names.each do |cop_name|
           global_conf[cop_name].each do |key, value|


### PR DESCRIPTION
Follow https://github.com/ruby/psych/pull/487.

This PR fixes the following Ruby 3.1.0-dev build matrix error.

```console
% ruby -ryaml -ve 'p Psych::VERSION'
ruby 3.1.0dev (2021-05-17T10:51:51Z master ee611341c9) [x86_64-darwin19]
"4.0.0"

% bundle exec rspec ./spec/rubocop/cli/options_spec.rb
(snip)

Failures:

  1) RuboCop::CLI options --show-cops with no args prints the current
  configuration
     Failure/Error: printed_config = YAML.load(out.join) #
  rubocop:disable Security/YAMLLoad

     Psych::DisallowedClass:
       Tried to load unspecified class: Regexp
     Shared Example Group: "prints config" called from
       ./spec/rubocop/cli/options_spec.rb:1104
     # (eval):2:in `regexp'
     # ./spec/rubocop/cli/options_spec.rb:1027:in `block (4 levels) in
       <top (required)>'
     # ./spec/support/cli_spec_behavior.rb:26:in `block (2 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `block (4 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `block (3 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:7:in `block (2 levels) in
       <top (required)>'

Finished in 25.97 seconds (files took 1.02 seconds to load)
117 examples, 1 failure

Failed examples:

rspec ./spec/rubocop/cli/options_spec.rb[1:13:1:4] # RuboCop::CLI
options --show-cops with no args prints the current configuration
```

https://app.circleci.com/pipelines/github/rubocop/rubocop/4637/workflows/d6722067-28c1-4740-a1b8-abea06edab0d/jobs/185620

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
