### PR TITLE
Workaround for mingw build error

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -22,8 +22,9 @@ jobs:
         # [ ubuntu, macos, windows ]
         os: [ windows ]
         ruby: [ '2.5', '2.6', '2.7', '3.0', 'head' ]
-        include:
-          - { os: windows, ruby: mingw }
+        # FIXME: Please uncomment when https://github.com/ruby/psych/issues/494 is resolved.
+        # include:
+        #   - { os: windows, ruby: mingw }
         exclude:
           - { os: windows, ruby: head  }
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,7 +12,8 @@ pull_request_rules:
       - "status-success=windows 2.6"
       - "status-success=windows 2.7"
       - "status-success=windows 3.0"
-      - "status-success=windows mingw"
+      # FIXME: Please uncomment when https://github.com/ruby/psych/issues/494 is resolved.
+      # - "status-success=windows mingw"
       - "status-success=ci/circleci: cc-setup"
       - "status-success=ci/circleci: cc-upload-coverage"
       - "status-success=ci/circleci: documentation-checks"


### PR DESCRIPTION
This PR skips mingw build matrix due to the following build error.

```console
D:/ruby-mingw/lib/ruby/3.1.0/yaml.rb:3: warning: It seems your ruby
installation is missing psych (for YAML output).
To eliminate this warning, please install libyaml and reinstall your
ruby.
LoadError: 126: The specified module could not be found.   -
D:/ruby-mingw/lib/ruby/3.1.0/x64-mingw32/psych.so
<internal:D:/ruby-mingw/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in
`require': 126: The specified module could not be found.   -
D:/ruby-mingw/lib/ruby/3.1.0/x64-mingw32/psych.so (LoadError)
    from
    <internal:D:/ruby-mingw/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
    from D:/ruby-mingw/lib/ruby/3.1.0/psych.rb:13:in `<top (required)>'
    from
    <internal:D:/ruby-mingw/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
    from
    <internal:D:/ruby-mingw/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
    from D:/ruby-mingw/lib/ruby/3.1.0/yaml.rb:4:in `<top (required)>'
    from
    <internal:D:/ruby-mingw/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
    from
    <internal:D:/ruby-mingw/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/psyched_yaml.rb:12:in `<top (required)>'
    from
    D:/ruby-mingw/lib/ruby/3.1.0/bundler/rubygems_integration.rb:114:in `require_relative'
    from
    D:/ruby-mingw/lib/ruby/3.1.0/bundler/rubygems_integration.rb:114:in `configuration'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/fetcher.rb:247:in `connection'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/fetcher.rb:89:in `initialize'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/source/rubygems.rb:273:in `new'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/source/rubygems.rb:273:in `block in fetchers'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/source/rubygems.rb:271:in `map'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/source/rubygems.rb:271:in `fetchers'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/source/rubygems.rb:407:in `block in remote_specs'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/index.rb:9:in `build'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/source/rubygems.rb:406:in `remote_specs'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/source/rubygems.rb:104:in `specs'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/definition.rb:296:in `block (2 levels) in index'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/definition.rb:294:in `each'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/definition.rb:294:in `block in index'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/index.rb:9:in `build'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/definition.rb:291:in `index'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/definition.rb:913:in `source_requirements'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/definition.rb:285:in `resolve'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/definition.rb:176:in `resolve_remotely!'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/installer.rb:291:in `resolve_if_needed'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/installer.rb:83:in `block in run'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/process_lock.rb:12:in `block in lock'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/process_lock.rb:9:in `open'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/process_lock.rb:9:in `lock'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/installer.rb:72:in `run'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/installer.rb:24:in `install'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/cli/install.rb:60:in `run'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/cli.rb:259:in `block in install'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/settings.rb:133:in `temporary'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/cli.rb:258:in `install'
    from
    D:/ruby-mingw/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
    from
    D:/ruby-mingw/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
    from
    D:/ruby-mingw/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/cli.rb:30:in `dispatch'
    from
    D:/ruby-mingw/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/cli.rb:24:in `start'
    from
    D:/ruby-mingw/lib/ruby/gems/3.1.0/gems/bundler-2.3.0.dev/libexec/bundle:49:in `block in <top (required)>'
    from D:/ruby-mingw/lib/ruby/3.1.0/bundler/friendly_errors.rb:130:in `with_friendly_errors'
    from
    D:/ruby-mingw/lib/ruby/gems/3.1.0/gems/bundler-2.3.0.dev/libexec/bundle:37:in
    `<top (required)>'
    from D:/ruby-mingw/bin/bundle:31:in `load'
    from D:/ruby-mingw/bin/bundle:31:in `<main>'
```

https://github.com/rubocop/rubocop/pull/9806/checks?check_run_id=2601617298

I reported the issue to https://github.com/ruby/psych/issues/494.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
