### PR TITLE
[Fix #9811] Fix an error for `Layout/ArgumentAlignment`

### DIFF
--- a/changelog/fix_an_error_for_layout_argument_alignment.md
+++ b/changelog/fix_an_error_for_layout_argument_alignment.md
@@ -1,0 +1,1 @@
+* [#9811](https://github.com/rubocop/rubocop/issues/9811): Fix an error for `Layout/ArgumentAlignment` with `Layout/FirstHashElementIndentation` when setting `EnforcedStyle: with_fixed_indentation`. ([@koic][])

--- a/lib/rubocop/cop/layout/argument_alignment.rb
+++ b/lib/rubocop/cop/layout/argument_alignment.rb
@@ -56,8 +56,9 @@ module RuboCop
           first_arg = node.first_argument
           return if !multiple_arguments?(node, first_arg) || node.send_type? && node.method?(:[]=)
 
-          if first_arg.hash_type?
-            check_alignment(first_arg.pairs, base_column(node, first_arg.pairs.first))
+          if first_arg.hash_type? && !first_arg.braces?
+            pairs = first_arg.pairs
+            check_alignment(pairs, base_column(node, pairs.first))
           else
             check_alignment(node.arguments, base_column(node, first_arg))
           end

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -215,7 +215,7 @@ module RuboCop
         private
 
         def autocorrect_incompatible_with_other_cops?(node)
-          enforce_first_argument_with_fixed_indentation? && node.parent&.call_type?
+          enforce_first_argument_with_fixed_indentation? && !node.braces? && node.parent&.call_type?
         end
 
         def reset!

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1871,6 +1871,52 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and ' \
+     '`Layout/HashAlignment` and `Layout/FirstHashElementIndentation`' do
+    create_file('example.rb', <<~RUBY)
+      do_something(
+        {
+            foo: 'bar',
+            baz: 'qux'
+        }
+      )
+
+      do_something(
+            foo: 'bar',
+            baz: 'qux'
+      )
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/ArgumentAlignment:
+        EnforcedStyle: with_fixed_indentation
+    YAML
+
+    expect(
+      cli.run(
+        [
+          '--auto-correct',
+          '--only',
+          'Layout/ArgumentAlignment,Layout/HashAlignment,Layout/FirstHashElementIndentation'
+        ]
+      )
+    ).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      do_something(
+        {
+          foo: 'bar',
+          baz: 'qux'
+        }
+      )
+
+      do_something(
+        foo: 'bar',
+        baz: 'qux'
+      )
+    RUBY
+  end
+
   it 'does not crash Lint/SafeNavigationWithEmpty and offenses and accepts Style/SafeNavigation ' \
      'when checking `foo&.empty?` in a conditional' do
     create_file('example.rb', <<~RUBY)

--- a/spec/rubocop/cop/layout/argument_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/argument_alignment_spec.rb
@@ -594,5 +594,16 @@ RSpec.describe RuboCop::Cop::Layout::ArgumentAlignment, :config do
         end
       end
     end
+
+    it 'does not register an offense when using aligned braced hash as a argument' do
+      expect_no_offenses(<<~RUBY)
+        do_something(
+          {
+            foo: 'bar',
+            baz: 'qux'
+          }
+        )
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fixes #9811.

This PR fixes an error for `Layout/ArgumentAlignment` with `Layout/FirstHashElementIndentation` when setting
`EnforcedStyle: with_fixed_indentation`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
