### PR TITLE
Support `in` pattern syntax for `Layout/CaseIndentation`

### DIFF
--- a/changelog/new_support_in_pattern_syntax_for_layout_case_indentation.md
+++ b/changelog/new_support_in_pattern_syntax_for_layout_case_indentation.md
@@ -1,0 +1,1 @@
+* [#9818](https://github.com/rubocop/rubocop/pull/9818): Support Ruby 2.7's `in` pattern syntax for `Layout/CaseIndentation`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -377,10 +377,11 @@ Layout/BlockEndNewline:
   VersionAdded: '0.49'
 
 Layout/CaseIndentation:
-  Description: 'Indentation of when in a case/when/[else/]end.'
+  Description: 'Indentation of when in a case/(when|in)/[else/]end.'
   StyleGuide: '#indent-when-to-case'
   Enabled: true
   VersionAdded: '0.49'
+  VersionChanged: '<<next>>'
   EnforcedStyle: case
   SupportedStyles:
     - case


### PR DESCRIPTION
This PR supports Ruby 2.7's `in` pattern syntax for `Layout/CaseIndentation`. It is extending `Layout/CaseIndentation` cop because I think it's expected that the indentation layout will be the same for `case ... when` and `case ... in`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
