### PR TITLE
[Fix #9819] Fix a false negative for `Style/TopLevelMethodDefinition`

### DIFF
--- a/changelog/fix_false_negative_for_style_top_level_method_definition.md
+++ b/changelog/fix_false_negative_for_style_top_level_method_definition.md
@@ -1,0 +1,1 @@
+* [#9819](https://github.com/rubocop/rubocop/issues/9819): Fix a false negative for `Style/TopLevelMethodDefinition` when defining a top-level method after a class definition. ([@koic][])

--- a/lib/rubocop/cop/style/top_level_method_definition.rb
+++ b/lib/rubocop/cop/style/top_level_method_definition.rb
@@ -50,7 +50,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[define_method].freeze
 
         def on_def(node)
-          return unless node.root?
+          return unless top_level_method_definition?(node)
 
           add_offense(node)
         end
@@ -58,12 +58,20 @@ module RuboCop
         alias on_send on_def
 
         def on_block(node)
-          return unless define_method_block?(node) && node.root?
+          return unless define_method_block?(node) && top_level_method_definition?(node)
 
           add_offense(node)
         end
 
         private
+
+        def top_level_method_definition?(node)
+          if node.parent&.begin_type?
+            node.parent.root?
+          else
+            node.root?
+          end
+        end
 
         # @!method define_method_block?(node)
         def_node_matcher :define_method_block?, <<~PATTERN

--- a/spec/rubocop/cop/style/top_level_method_definition_spec.rb
+++ b/spec/rubocop/cop/style/top_level_method_definition_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe RuboCop::Cop::Style::TopLevelMethodDefinition, :config do
     end
   end
 
+  it 'registers an offense when defining a top-level method after a class definition' do
+    expect_offense(<<~RUBY)
+      class Foo
+      end
+
+      def foo; end
+      ^^^^^^^^^^^^ Do not define methods at the top-level.
+    RUBY
+  end
+
   it 'does not register an offense when using module' do
     expect_no_offenses(<<~RUBY)
       module Foo


### PR DESCRIPTION
Fixes #9819.

This PR fixes a false negative for `Style/TopLevelMethodDefinition` when defining a top-level method after a class definition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
