### PR TITLE
[Fix #9822] Fix a false range for `Lint/RedundantCopDisableDirective`

### DIFF
--- a/changelog/fix_false_range_for_lint_redundant_cop_disable_directive.md
+++ b/changelog/fix_false_range_for_lint_redundant_cop_disable_directive.md
@@ -1,0 +1,1 @@
+* [#9822](https://github.com/rubocop/rubocop/issues/9822): Fix a false directive comment range for `Lint/RedundantCopDisableDirective`. ([@koic][])

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -41,7 +41,11 @@ module RuboCop
     end
 
     def range
-      comment.location.expression
+      match = comment.text.match(DIRECTIVE_COMMENT_REGEXP)
+      begin_pos = comment.loc.expression.begin_pos
+      Parser::Source::Range.new(
+        comment.loc.expression.source_buffer, begin_pos + match.begin(0), begin_pos + match.end(0)
+      )
     end
 
     # Returns match captures to directive comment pattern

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -42,6 +42,19 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
             end
           end
 
+          context 'when using a directive comment after a non-directive comment' do
+            it 'returns an offense' do
+              expect_offense(<<~RUBY)
+                # not very long comment # rubocop:disable Layout/LineLength
+                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Layout/LineLength`.
+              RUBY
+
+              expect_correction(<<~RUBY)
+                # not very long comment
+              RUBY
+            end
+          end
+
           context 'itself and another cop' do
             context 'disabled on the same range' do
               it 'returns no offense' do


### PR DESCRIPTION
Fixes #9822.

This PR fixes a false directive comment range for `Lint/RedundantCopDisableDirective`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
