### PR TITLE
[Fix #9827] Add basic auth support to download raw yml config from private repo

### DIFF
--- a/changelog/new_support_basic_auth_to_download_shared_config.md
+++ b/changelog/new_support_basic_auth_to_download_shared_config.md
@@ -1,0 +1,1 @@
+* [#9827](https://github.com/rubocop/rubocop/issues/9827): Add basic auth support to download raw yml config from private repo. ([@AirWick219][])

--- a/changelog/new_support_token_auth_to_download_shared_config.md
+++ b/changelog/new_support_token_auth_to_download_shared_config.md
@@ -1,0 +1,1 @@
+* [#9827](https://github.com/rubocop/rubocop/issues/9827): Add Token auth support to download raw yml config from private repo. ([@AirWick219][])

--- a/changelog/new_support_token_auth_to_download_shared_config.md
+++ b/changelog/new_support_token_auth_to_download_shared_config.md
@@ -1,1 +1,0 @@
-* [#9827](https://github.com/rubocop/rubocop/issues/9827): Add Token auth support to download raw yml config from private repo. ([@AirWick219][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -138,9 +138,16 @@ inherit_from:
   - ../.rubocop.yml
 ----
 
-You can inherit from a repo with a
-link:https://docs.github.com/en/developers/apps/about-apps#personal-access-token[GitHub personal access token]
-that is authorized to access the repo.
+You can inherit from a repo with basic auth that is authorized to access the repo as follow:
+
+[source,yaml]
+----
+inherit_from:
+  - http://<user_name>:<password>@raw.github.com/example/rubocop.yml
+----
+
+A link:https://docs.github.com/en/developers/apps/about-apps#personal-access-token[GitHub personal access token]
+can also be configured as follow:
 
 [source,yaml]
 ----

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -138,6 +138,16 @@ inherit_from:
   - ../.rubocop.yml
 ----
 
+You can inherit from a repo with a
+link:https://docs.github.com/en/developers/apps/about-apps#personal-access-token[GitHub personal access token]
+that is authorized to access the repo.
+
+[source,yaml]
+----
+inherit_from:
+  - http://<personal_access_token>@raw.github.com/example/rubocop.yml
+----
+
 === Inheriting configuration from a dependency gem
 
 The optional `inherit_gem` directive is used to include configuration from

--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -55,6 +55,7 @@ module RuboCop
     def generate_request(uri)
       request = Net::HTTP::Get.new(uri.request_uri)
 
+      request['Authorization'] = "token #{uri.user}" if uri.user
       request['If-Modified-Since'] = File.stat(cache_path).mtime.rfc2822 if cache_path_exists?
 
       yield request
@@ -70,7 +71,7 @@ module RuboCop
         begin
           response.error!
         rescue StandardError => e
-          message = "#{e.message} while downloading remote config file #{uri}"
+          message = "#{e.message} while downloading remote config file #{cloned_url}"
           raise e, message
         end
       end
@@ -94,9 +95,15 @@ module RuboCop
     end
 
     def cache_name_from_uri
-      uri = @uri.clone
+      uri = cloned_url
       uri.query = nil
       uri.to_s.gsub!(/[^0-9A-Za-z]/, '-')
+    end
+
+    def cloned_url
+      uri = @uri.clone
+      uri.user = nil if uri.user
+      uri
     end
   end
 end

--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -55,7 +55,7 @@ module RuboCop
     def generate_request(uri)
       request = Net::HTTP::Get.new(uri.request_uri)
 
-      request['Authorization'] = "token #{uri.user}" if uri.user
+      request.basic_auth(uri.user, uri.password) if uri.user
       request['If-Modified-Since'] = File.stat(cache_path).mtime.rfc2822 if cache_path_exists?
 
       yield request
@@ -103,6 +103,7 @@ module RuboCop
     def cloned_url
       uri = @uri.clone
       uri.user = nil if uri.user
+      uri.password = nil if uri.password
       uri
     end
   end

--- a/spec/rubocop/remote_config_spec.rb
+++ b/spec/rubocop/remote_config_spec.rb
@@ -39,6 +39,62 @@ RSpec.describe RuboCop::RemoteConfig do
       assert_requested :get, remote_config_url
     end
 
+    context 'when remote URL is configured with token auth' do
+      let(:token) { 'personal_access_token' }
+      let(:remote_config_url) { "http://#{token}@example.com/rubocop.yml" }
+      let(:stripped_remote_config_url) { 'http://example.com/rubocop.yml' }
+
+      before do
+        stub_request(:get, stripped_remote_config_url)
+          .to_return(headers: { 'Authorization' => "token #{token}" })
+        stub_request(:get, stripped_remote_config_url)
+          .to_return(status: 200, body: "Style/Encoding:\n    Enabled: true")
+      end
+
+      it 'downloads the file if the file does not exist' do
+        expect(remote_config).to eq(cached_file_path)
+        expect(File.exist?(cached_file_path)).to be_truthy
+      end
+
+      it 'does not download the file if cache lifetime has not been reached' do
+        FileUtils.touch cached_file_path, mtime: Time.now - ((60 * 60) * 20)
+
+        expect(remote_config).to eq(cached_file_path)
+        assert_not_requested :get, remote_config_url
+      end
+
+      it 'downloads the file if cache lifetime has been reached' do
+        FileUtils.touch cached_file_path, mtime: Time.now - ((60 * 60) * 30)
+
+        expect(remote_config).to eq(cached_file_path)
+        assert_requested :get, stripped_remote_config_url
+      end
+
+      context 'when the remote URL responds with 404' do
+        before do
+          stub_request(:get, stripped_remote_config_url).to_return(status: 404)
+        end
+
+        it 'raises error' do
+          expect do
+            remote_config
+          end.to raise_error(Net::HTTPServerException,
+                             '404 "" while downloading remote config file http://example.com/rubocop.yml')
+        end
+      end
+
+      context 'when the remote URL responds with 500' do
+        before { stub_request(:get, stripped_remote_config_url).to_return(status: 500) }
+
+        it 'raises error' do
+          expect do
+            remote_config
+          end.to raise_error(Net::HTTPFatalError,
+                             '500 "" while downloading remote config file http://example.com/rubocop.yml')
+        end
+      end
+    end
+
     context 'when the remote URL responds with redirect' do
       let(:new_location) { 'http://cdn.example.com/rubocop.yml' }
 

--- a/spec/rubocop/remote_config_spec.rb
+++ b/spec/rubocop/remote_config_spec.rb
@@ -46,8 +46,52 @@ RSpec.describe RuboCop::RemoteConfig do
 
       before do
         stub_request(:get, stripped_remote_config_url)
-          .to_return(headers: { 'Authorization' => "token #{token}" })
+          .with(basic_auth: [token])
+          .to_return(status: 200, body: "Style/Encoding:\n    Enabled: true")
+      end
+
+      it 'downloads the file if the file does not exist' do
+        expect(remote_config).to eq(cached_file_path)
+        expect(File.exist?(cached_file_path)).to be_truthy
+      end
+
+      it 'does not download the file if cache lifetime has not been reached' do
+        FileUtils.touch cached_file_path, mtime: Time.now - ((60 * 60) * 20)
+
+        expect(remote_config).to eq(cached_file_path)
+        assert_not_requested :get, remote_config_url
+      end
+
+      it 'downloads the file if cache lifetime has been reached' do
+        FileUtils.touch cached_file_path, mtime: Time.now - ((60 * 60) * 30)
+
+        expect(remote_config).to eq(cached_file_path)
+        assert_requested :get, stripped_remote_config_url
+      end
+
+      context 'when the remote URL responds with 404' do
+        before do
+          stub_request(:get, stripped_remote_config_url).to_return(status: 404)
+        end
+
+        it 'raises error' do
+          expect do
+            remote_config
+          end.to raise_error(Net::HTTPServerException,
+                             '404 "" while downloading remote config file http://example.com/rubocop.yml')
+        end
+      end
+    end
+
+    context 'when remote URL is configured with basic auth' do
+      let(:username) { 'username' }
+      let(:password) { 'password' }
+      let(:remote_config_url) { "http://#{username}:#{password}@example.com/rubocop.yml" }
+      let(:stripped_remote_config_url) { 'http://example.com/rubocop.yml' }
+
+      before do
         stub_request(:get, stripped_remote_config_url)
+          .with(basic_auth: [username, password])
           .to_return(status: 200, body: "Style/Encoding:\n    Enabled: true")
       end
 


### PR DESCRIPTION
This PR adds Token auth support so that users can inherit shared config from the internal private repo.  

This addresses https://github.com/rubocop/rubocop/issues/9827


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
