### PR TITLE
Refine offense message for `Style/WhenThen`

### DIFF
--- a/lib/rubocop/cop/style/when_then.rb
+++ b/lib/rubocop/cop/style/when_then.rb
@@ -20,12 +20,16 @@ module RuboCop
       class WhenThen < Base
         extend AutoCorrector
 
-        MSG = 'Do not use `when x;`. Use `when x then` instead.'
+        MSG = 'Do not use `when %<expression>s;`. Use `when %<expression>s then` instead.'
 
         def on_when(node)
           return if node.multiline? || node.then? || !node.body
 
-          add_offense(node.loc.begin) { |corrector| corrector.replace(node.loc.begin, ' then') }
+          message = format(MSG, expression: node.conditions.map(&:source).join(', '))
+
+          add_offense(node.loc.begin, message: message) do |corrector|
+            corrector.replace(node.loc.begin, ' then')
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/when_then_spec.rb
+++ b/spec/rubocop/cop/style/when_then_spec.rb
@@ -1,17 +1,32 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::WhenThen, :config do
-  it 'registers an offense for when x;' do
+  it 'registers an offense for when b;' do
     expect_offense(<<~RUBY)
       case a
       when b; c
-            ^ Do not use `when x;`. Use `when x then` instead.
+            ^ Do not use `when b;`. Use `when b then` instead.
       end
     RUBY
 
     expect_correction(<<~RUBY)
       case a
       when b then c
+      end
+    RUBY
+  end
+
+  it 'registers an offense for when b, c;' do
+    expect_offense(<<~RUBY)
+      case a
+      when b, c; d
+               ^ Do not use `when b, c;`. Use `when b, c then` instead.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case a
+      when b, c then d
       end
     RUBY
   end


### PR DESCRIPTION
This PR refines offense message for `Style/WhenThen`. It uses actual value of `when` for offense message.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
