### PR TITLE
[Fix #9836] Fix incorrect corrections for `Layout/HashAlignment` when a `kwsplat` node is on the same line as a `pair` node with table style

### DIFF
--- a/changelog/fix_fix_incorrect_corrections_for.md
+++ b/changelog/fix_fix_incorrect_corrections_for.md
@@ -1,0 +1,1 @@
+* [#9836](https://github.com/rubocop/rubocop/issues/9836): Fix incorrect corrections for `Layout/HashAlignment` when a `kwsplat` node is on the same line as a `pair` node with table style. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -772,7 +772,7 @@ Layout/HashAlignment:
   Enabled: true
   AllowMultipleStyles: true
   VersionAdded: '0.49'
-  VersionChanged: '0.77'
+  VersionChanged: '<<next>>'
   # Alignment of entries using hash rocket as separator. Valid values are:
   #
   # key - left alignment of keys

--- a/lib/rubocop/cop/mixin/hash_alignment_styles.rb
+++ b/lib/rubocop/cop/mixin/hash_alignment_styles.rb
@@ -43,7 +43,7 @@ module RuboCop
         end
 
         def value_delta(pair)
-          return 0 if pair.kwsplat_type? || pair.value_on_new_line?
+          return 0 if pair.value_on_new_line?
 
           correct_value_column = pair.loc.operator.end.column + 1
           actual_value_column = pair.value.loc.column
@@ -108,8 +108,6 @@ module RuboCop
         end
 
         def value_delta(first_pair, current_pair)
-          return 0 if current_pair.kwsplat_type?
-
           correct_value_column = first_pair.key.loc.column +
                                  current_pair.delimiter(true).length +
                                  max_key_width
@@ -137,6 +135,19 @@ module RuboCop
 
         def value_delta(first_pair, current_pair)
           first_pair.value_delta(current_pair)
+        end
+      end
+
+      # Handles calculation of deltas for `kwsplat` nodes.
+      # This is a special case that just ensures the kwsplat is aligned with the rest of the hash
+      # since a `kwsplat` does not have a key, separator or value.
+      class KeywordSplatAlignment
+        def deltas(first_pair, current_pair)
+          if Util.begins_its_line?(current_pair.source_range)
+            { key: first_pair.key_delta(current_pair) }
+          else
+            {}
+          end
         end
       end
     end

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -540,7 +540,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         Hash(foo: 'bar',
                **extra_params
-               ^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+               ^^^^^^^^^^^^^^ Align keyword splats with the rest of the hash if it spans more than one line.
         )
       RUBY
 
@@ -555,7 +555,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         {foo: 'bar',
                **extra_params
-               ^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+               ^^^^^^^^^^^^^^ Align keyword splats with the rest of the hash if it spans more than one line.
         }
       RUBY
 
@@ -1126,5 +1126,145 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
 
   it 'register no offense for yield without args' do
     expect_no_offenses('yield')
+  end
+
+  context 'with `EnforcedColonStyle`: `table`' do
+    let(:cop_config) do
+      {
+        'EnforcedColonStyle' => 'table'
+      }
+    end
+
+    context 'and misaligned keys' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          foo ab: 1,
+              c: 2
+              ^^^^ Align the keys and values of a hash literal if they span more than one line.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo ab: 1,
+              c:  2
+        RUBY
+      end
+    end
+
+    context 'when the only item is a kwsplat' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          foo({**rest})
+        RUBY
+      end
+    end
+
+    context 'and a double splat argument after a hash key' do
+      it 'registers an offense on the misaligned key and corrects' do
+        expect_offense(<<~RUBY)
+          foo ab: 1,
+              c: 2, **rest
+              ^^^^ Align the keys and values of a hash literal if they span more than one line.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo ab: 1,
+              c:  2, **rest
+        RUBY
+      end
+    end
+
+    context 'and aligned keys but a double splat argument after' do
+      it 'does not register an offense on the `kwsplat`' do
+        expect_no_offenses(<<~RUBY)
+          foo a: 1,
+              b: 2, **rest
+        RUBY
+      end
+    end
+
+    context 'and a misaligned double splat argument' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          foo a: 1,
+                **rest
+                ^^^^^^ Align keyword splats with the rest of the hash if it spans more than one line.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo a: 1,
+              **rest
+        RUBY
+      end
+    end
+  end
+
+  context 'with `EnforcedHashRocketStyle`: `table`' do
+    let(:cop_config) do
+      {
+        'EnforcedHashRocketStyle' => 'table'
+      }
+    end
+
+    context 'and misaligned keys' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          foo :ab => 1,
+              :c => 2
+              ^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo :ab => 1,
+              :c  => 2
+        RUBY
+      end
+    end
+
+    context 'when the only item is a kwsplat' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          foo({**rest})
+        RUBY
+      end
+    end
+
+    context 'and a double splat argument after a hash key' do
+      it 'registers an offense on the misaligned key and corrects' do
+        expect_offense(<<~RUBY)
+          foo :ab => 1,
+              :c => 2, **rest
+              ^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo :ab => 1,
+              :c  => 2, **rest
+        RUBY
+      end
+    end
+
+    context 'and aligned keys but a double splat argument after' do
+      it 'does not register an offense on the `kwsplat`' do
+        expect_no_offenses(<<~RUBY)
+          foo :a => 1,
+              :b => 2, **rest
+        RUBY
+      end
+    end
+
+    context 'and a misaligned double splat argument' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          foo :a => 1,
+                **rest
+                ^^^^^^ Align keyword splats with the rest of the hash if it spans more than one line.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo :a => 1,
+              **rest
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Keyword splats were previously treated as pairs using colon style, which some hacks in the Alignment classes to handle them (see #3919). However, this did not account for all possibilities and would cause previous pairs on the same line as the `kwsplat` to be removed by autocorrection.

Instead, now a special `KeywordSplatAlignment` type was added to handle `kwsplat`s. The previously behaviour about `kwsplat`s was retained (they will still be aligned with the beginning of the rest of the hash, regardless of enforced style), and the hacks in `KeyAlignment` and `TableAlignment` for `kwsplat`s were removed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
