### PR TITLE
Support Ruby 2.7's pattern matching syntax for `Layout/SpaceAroundKeyword`

### DIFF
--- a/lib/rubocop/cop/layout/space_around_keyword.rb
+++ b/lib/rubocop/cop/layout/space_around_keyword.rb
@@ -53,6 +53,10 @@ module RuboCop
           check(node, %i[keyword else].freeze)
         end
 
+        def on_case_match(node)
+          check(node, %i[keyword else].freeze)
+        end
+
         def on_ensure(node)
           check(node, [:keyword].freeze)
         end
@@ -63,6 +67,10 @@ module RuboCop
 
         def on_if(node)
           check(node, %i[keyword else begin end].freeze, 'then')
+        end
+
+        def on_in_pattern(node)
+          check(node, [:keyword].freeze)
         end
 
         def on_kwbegin(node)

--- a/new_support_pattern_matching_for_layout_space_around_keyword.md
+++ b/new_support_pattern_matching_for_layout_space_around_keyword.md
@@ -1,0 +1,1 @@
+* [#9838](https://github.com/rubocop/rubocop/pull/9838): Support Ruby 2.7's pattern matching syntax for `Layout/SpaceAroundKeyword`. ([@koic][])

--- a/spec/rubocop/cop/layout/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_keyword_spec.rb
@@ -51,6 +51,9 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   it_behaves_like 'missing after', 'break', 'break""', 'break ""'
   it_behaves_like 'accept after', '(', 'break(1)'
   it_behaves_like 'missing after', 'case', 'case"" when 1; end', 'case "" when 1; end'
+  context '>= Ruby 2.7', :ruby27 do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    it_behaves_like 'missing after', 'case', 'case""; in 1; end', 'case ""; in 1; end'
+  end
 
   it_behaves_like 'missing before', 'do', 'a "b"do end', 'a "b" do end'
   it_behaves_like 'missing after', 'do', 'a do|x| end', 'a do |x| end'
@@ -77,6 +80,11 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
                   'case a; when b; "" else end'
   it_behaves_like 'missing after', 'else', 'case a; when b; else"" end',
                   'case a; when b; else "" end'
+  context '>= Ruby 2.7', :ruby27 do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    it_behaves_like 'missing before', 'else', 'case a; in b; ""else end',
+                    'case a; in b; "" else end'
+    it_behaves_like 'missing after', 'else', 'case a; in b; else"" end', 'case a; in b; else "" end'
+  end
 
   it_behaves_like 'missing before', 'elsif', 'if a; ""elsif b; end', 'if a; "" elsif b; end'
   it_behaves_like 'missing after', 'elsif', 'if a; elsif""; end', 'if a; elsif ""; end'
@@ -110,6 +118,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   it_behaves_like 'missing after', 'until', '1 until""', '1 until ""'
   it_behaves_like 'missing before', 'when', 'case ""when a; end', 'case "" when a; end'
   it_behaves_like 'missing after', 'when', 'case a when""; end', 'case a when ""; end'
+  context '>= Ruby 2.7', :ruby27 do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    # TODO: `case ""in a; end` is syntax error in Ruby 3.0.1.
+    #       This syntax is confirmed: https://bugs.ruby-lang.org/issues/17925
+    #       The answer will determine whether to enable or discard the test in the future.
+    # it_behaves_like 'missing before', 'in', 'case ""in a; end', 'case "" in a; end'
+    it_behaves_like 'missing after', 'in', 'case a; in""; end', 'case a; in ""; end'
+  end
+
   it_behaves_like 'missing before', 'while', '1while ""', '1 while ""'
   it_behaves_like 'missing after', 'while', '1 while""', '1 while ""'
   it_behaves_like 'missing after', 'yield', 'yield""', 'yield ""'


### PR DESCRIPTION
This PR supports Ruby 2.7's pattern matching syntax for `Layout/SpaceAroundKeyword`.

The following is a technical note.

There are the following differences between `case ... when` and `case ... in`.
So there is a TODO test for this patch's test and I confirmed this syntax below:
https://bugs.ruby-lang.org/issues/17925

An answer will determine whether to enable or discard the commented out test in the future.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
