### PR TITLE
[Fix #9839] Add `AllowedReceivers` option for `Style/HashEachMethods`

### DIFF
--- a/changelog/new_add_allowed_receivers_option_for_style_hash_each_methods.md
+++ b/changelog/new_add_allowed_receivers_option_for_style_hash_each_methods.md
@@ -1,0 +1,1 @@
+* [#9840](https://github.com/rubocop/rubocop/issues/9840): Adds `AllowedReceivers` option for `Style/HashEachMethods`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3497,8 +3497,10 @@ Style/HashEachMethods:
   Description: 'Use Hash#each_key and Hash#each_value.'
   StyleGuide: '#hash-each'
   Enabled: true
-  VersionAdded: '0.80'
   Safe: false
+  VersionAdded: '0.80'
+  VersionChanged: <<next>>
+  AllowedReceivers: []
 
 Style/HashExcept:
   Description: >-

--- a/spec/rubocop/cop/style/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/style/hash_each_methods_spec.rb
@@ -87,5 +87,29 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         expect_no_offenses('each_value { |v| p v }')
       end
     end
+
+    context "when `AllowedReceivers: ['execute']`" do
+      let(:cop_config) { { 'AllowedReceivers' => ['execute'] } }
+
+      it 'does not register an offense when receiver is `execute` method' do
+        expect_no_offenses(<<~RUBY)
+          execute(sql).values.each { |v| p v }
+        RUBY
+      end
+
+      it 'does not register an offense when receiver is `execute` variable' do
+        expect_no_offenses(<<~RUBY)
+          execute = do_something(argument)
+          execute.values.each { |v| p v }
+        RUBY
+      end
+
+      it 'registers an offense when receiver is not allowed name' do
+        expect_offense(<<~RUBY)
+          do_something(arg).values.each { |v| p v }
+                            ^^^^^^^^^^^ Use `each_value` instead of `values.each`.
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #9839.

This PR adds `AllowedReceivers` option for `Style/HashEachMethods`.

`Style/HashEachMethods` cop is already marked as unsafe. This PR can use allow list to rule out false positives.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
