### PR TITLE
Support Ruby 2.7's pattern matching for `Layout/SpaceAroundKeyword`

### DIFF
--- a/changelog/new_support_guard_if_unless_of_pattern_matching_for_layout_space_around_keyword.md
+++ b/changelog/new_support_guard_if_unless_of_pattern_matching_for_layout_space_around_keyword.md
@@ -1,0 +1,1 @@
+* [#9841](https://github.com/rubocop/rubocop/pull/9841): Support guard `if` and `unless` syntax keywords of Ruby 2.7's pattern matching for `Layout/SpaceAroundKeyword`. ([@koic][])

--- a/lib/rubocop/cop/layout/space_around_keyword.rb
+++ b/lib/rubocop/cop/layout/space_around_keyword.rb
@@ -69,6 +69,10 @@ module RuboCop
           check(node, %i[keyword else begin end].freeze, 'then')
         end
 
+        def on_if_guard(node)
+          check(node, [:keyword].freeze)
+        end
+
         def on_in_pattern(node)
           check(node, [:keyword].freeze)
         end
@@ -114,6 +118,10 @@ module RuboCop
         end
 
         def on_zsuper(node)
+          check(node, [:keyword].freeze)
+        end
+
+        def on_unless_guard(node)
           check(node, [:keyword].freeze)
         end
 

--- a/spec/rubocop/cop/layout/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_keyword_spec.rb
@@ -84,6 +84,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
     it_behaves_like 'missing before', 'else', 'case a; in b; ""else end',
                     'case a; in b; "" else end'
     it_behaves_like 'missing after', 'else', 'case a; in b; else"" end', 'case a; in b; else "" end'
+
+    it_behaves_like 'missing before', 'if', 'case a; in "pattern"if "condition"; else "" end',
+                    'case a; in "pattern" if "condition"; else "" end'
+    it_behaves_like 'missing after', 'if', 'case a; in "pattern" if"condition"; else "" end',
+                    'case a; in "pattern" if "condition"; else "" end'
+    it_behaves_like 'missing before', 'unless', 'case a; in "pattern"unless "condition"; else "" end',
+                    'case a; in "pattern" unless "condition"; else "" end'
+    it_behaves_like 'missing after', 'unless', 'case a; in "pattern" unless"condition"; else "" end',
+                    'case a; in "pattern" unless "condition"; else "" end'
   end
 
   it_behaves_like 'missing before', 'elsif', 'if a; ""elsif b; end', 'if a; "" elsif b; end'


### PR DESCRIPTION
This PR supports guard `if` and `unless` syntax keywords of Ruby 2.7's pattern matching for `Layout/SpaceAroundKeyword`.

```ruby
case 42
in 42 if true
  puts 'hello'
end
```

These nodes are called `if-guard` and `unless-guard` when using guard `if` and `unless` in pattern matching.

```ruby
% ruby-parse example.rb
(case-match
  (int 42)
  (in-pattern
    (int 42)
    (if-guard
      (true))
    (send nil :puts
      (str "hello"))) nil)
```

See below for this guard semantics:
https://github.com/whitequark/parser/pull/574#issuecomment-498365609

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
