### PR TITLE
Fix trivial typo in rake_task.rb

### DIFF
--- a/lib/rubocop/rake_task.rb
+++ b/lib/rubocop/rake_task.rb
@@ -70,7 +70,7 @@ module RuboCop
             options = full_options.unshift('--auto-correct-all')
             # `parallel` will automatically be removed from the options internally.
             # This is a nice to have to suppress the warning message
-            # about parallel and auto-corrent not being compatible.
+            # about parallel and auto-correct not being compatible.
             options.delete('--parallel')
             run_cli(verbose, options)
           end


### PR DESCRIPTION
This is quite pedantic, but while looking through the code in `rake_task` I noticed a typo in a comment&mdash;"correct" was, ironically enough, misspelled. My tiny little contribution to making rubocop even better. :)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists). (**n1zyy**: No existing issue)
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests. (**n1zyy**: Only altering a comment)
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details. (**n1zyy**: No user-observable changes)

[1]: https://chris.beams.io/posts/git-commit/
