### PR TITLE
[Fix #9845] Fix `Style/QuotedSymbols` for hash-rocket hashes

### DIFF
--- a/changelog/fix_fix_stylequotedsymbols_for_hashrocket.md
+++ b/changelog/fix_fix_stylequotedsymbols_for_hashrocket.md
@@ -1,0 +1,1 @@
+* [#9845](https://github.com/rubocop/rubocop/issues/9845): Fix `Style/QuotedSymbols` for hash-rocket hashes. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/quoted_symbols.rb
+++ b/lib/rubocop/cop/style/quoted_symbols.rb
@@ -58,7 +58,7 @@ module RuboCop
         private
 
         def autocorrect(corrector, node)
-          str = if hash_key?(node)
+          str = if hash_colon_key?(node)
                   # strip quotes
                   correct_quotes(node.source[1..-2])
                 else
@@ -67,6 +67,11 @@ module RuboCop
                 end
 
           corrector.replace(node, str)
+        end
+
+        def hash_colon_key?(node)
+          # Is the node a hash key with the colon style?
+          hash_key?(node) && node.parent.colon?
         end
 
         def correct_quotes(str)

--- a/spec/rubocop/cop/style/quoted_symbols_spec.rb
+++ b/spec/rubocop/cop/style/quoted_symbols_spec.rb
@@ -112,6 +112,25 @@ RSpec.describe RuboCop::Cop::Style::QuotedSymbols, :config do
         { 'a': value }
       RUBY
     end
+
+    context 'hash with hashrocket style' do
+      it 'accepts properly quoted symbols' do
+        expect_no_offenses(<<~RUBY)
+          { :'a' => value }
+        RUBY
+      end
+
+      it 'corrects wrong quotes' do
+        expect_offense(<<~RUBY)
+          { :"a" => value }
+            ^^^^ Prefer single-quoted symbols when you don't need string interpolation or special symbols.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          { :'a' => value }
+        RUBY
+      end
+    end
   end
 
   shared_examples_for 'enforce double quotes' do
@@ -192,6 +211,25 @@ RSpec.describe RuboCop::Cop::Style::QuotedSymbols, :config do
       expect_correction(<<~RUBY)
         :"a"
       RUBY
+    end
+
+    context 'hash with hashrocket style' do
+      it 'accepts properly quoted symbols' do
+        expect_no_offenses(<<~RUBY)
+          { :"a" => value }
+        RUBY
+      end
+
+      it 'corrects wrong quotes' do
+        expect_offense(<<~RUBY)
+          { :'a' => value }
+            ^^^^ Prefer double-quoted symbols unless you need single quotes to avoid extra backslashes for escaping.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          { :"a" => value }
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
`Style/QuotedSymbols` was not correcting symbols in hash-rocket hashes correctly.

Fixes #9845.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
