### PR TITLE
[Fix #9843] Fix `Style/RedundantSelf` to allow conditional nodes to use `self` in the condition when a variable named is shadowed inside

### DIFF
--- a/changelog/fix_fix_styleredundantself_to_allow.md
+++ b/changelog/fix_fix_styleredundantself_to_allow.md
@@ -1,0 +1,1 @@
+* [#9843](https://github.com/rubocop/rubocop/issues/9843): Fix `Style/RedundantSelf` to allow conditional nodes to use `self` in the condition when a variable named is shadowed inside. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -24,6 +24,56 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf, :config do
     expect_no_offenses('a, b = self.a')
   end
 
+  it 'does not report an offense when lvasgn name is used in `if`' do
+    expect_no_offenses('a = self.a if self.a')
+  end
+
+  it 'does not report an offense when masgn name is used in `if`' do
+    expect_no_offenses('a, b = self.a if self.a')
+  end
+
+  it 'does not report an offense when lvasgn name is used in `unless`' do
+    expect_no_offenses('a = self.a unless self.a')
+  end
+
+  it 'does not report an offense when masgn name is used in `unless`' do
+    expect_no_offenses('a, b = self.a unless self.a')
+  end
+
+  it 'does not report an offense when lvasgn name is used in `while`' do
+    expect_no_offenses('a = self.a while self.a')
+  end
+
+  it 'does not report an offense when masgn name is used in `while`' do
+    expect_no_offenses('a, b = self.a while self.a')
+  end
+
+  it 'does not report an offense when lvasgn name is used in `until`' do
+    expect_no_offenses('a = self.a until self.a')
+  end
+
+  it 'does not report an offense when masgn name is used in `until`' do
+    expect_no_offenses('a, b = self.a until self.a')
+  end
+
+  it 'does not report an offense when lvasgn name is nested below `if`' do
+    expect_no_offenses('a = self.a if foo(self.a)')
+  end
+
+  it 'reports an offense when a different lvasgn name is used in `if`' do
+    expect_offense(<<~RUBY)
+      a = x if self.b
+               ^^^^ Redundant `self` detected.
+    RUBY
+  end
+
+  it 'reports an offense when a different masgn name is used in `if`' do
+    expect_offense(<<~RUBY)
+      a, b, c = x if self.d
+                     ^^^^ Redundant `self` detected.
+    RUBY
+  end
+
   it 'does not report an offense when self receiver in a method argument and ' \
      'lvalue have the same name' do
     expect_no_offenses('a = do_something(self.a)')


### PR DESCRIPTION
Previously, `Style/RedundantSelf` registered false positives when a condition used `self` to avoid shadowing a local variable:

```ruby
a = self.a if self.a
```

This was because the condition was not correlated to the lvar assign because they happen at different times. This is now fixed so `if`, `unless`, `while` and `until` nodes are covered.

Fixes #9843.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
