### PR TITLE
Fix a false negative for `Layout/HashAlignment`

### DIFF
--- a/changelog/fix_a_false_negative_for_layout_hash_alignment.md
+++ b/changelog/fix_a_false_negative_for_layout_hash_alignment.md
@@ -1,0 +1,1 @@
+* [#9849](https://github.com/rubocop/rubocop/pull/9849): Fix a false negative for `Layout/HashAlignment` when setting `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and using misaligned keyword arguments. ([@koic][])

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -217,7 +217,8 @@ module RuboCop
         private
 
         def autocorrect_incompatible_with_other_cops?(node)
-          enforce_first_argument_with_fixed_indentation? && !node.braces? && node.parent&.call_type?
+          enforce_first_argument_with_fixed_indentation? &&
+            node.parent&.call_type? && node.parent.loc.line == node.pairs.first.loc.line
         end
 
         def reset!

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -139,6 +139,38 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
             }
       RUBY
     end
+
+    it 'registers and corrects an offense when using misaligned keyword arguments' do
+      expect_offense(<<~RUBY)
+        config.fog_credentials_as_kwargs(
+          provider:              'AWS',
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+          aws_access_key_id:     ENV['S3_ACCESS_KEY'],
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+          aws_secret_access_key: ENV['S3_SECRET'],
+          region:                ENV['S3_REGION'],
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+        )
+      RUBY
+
+      expect_correction(<<~RUBY)
+        config.fog_credentials_as_kwargs(
+          provider: 'AWS',
+          aws_access_key_id: ENV['S3_ACCESS_KEY'],
+          aws_secret_access_key: ENV['S3_SECRET'],
+          region: ENV['S3_REGION'],
+        )
+      RUBY
+    end
+
+    it 'does not register an offense using aligned hash literal' do
+      expect_no_offenses(<<~RUBY)
+        {
+          oh: :io,
+          hi: 'neat'
+        }
+      RUBY
+    end
   end
 
   context 'always ignore last argument hash' do


### PR DESCRIPTION
Resolves https://github.com/testdouble/standard/pull/300

This PR fixes a false negative for `Layout/HashAlignment` when setting `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and using misaligned keyword arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
