### PR TITLE
[Fix #9850] Fix missing option for `Lint/EmptyInPattern`

### DIFF
--- a/changelog/fix_missing_option_for_lint_empty_in_pattern.md
+++ b/changelog/fix_missing_option_for_lint_empty_in_pattern.md
@@ -1,0 +1,1 @@
+* [#9850](https://github.com/rubocop/rubocop/issues/9850): Fix missing `AllowComments` option for `Lint/EmptyInPattern`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1649,6 +1649,7 @@ Lint/EmptyFile:
 Lint/EmptyInPattern:
   Description: 'Checks for the presence of `in` pattern branches without a body.'
   Enabled: pending
+  AllowComments: true
   VersionAdded: '1.16'
 
 Lint/EmptyInterpolation:


### PR DESCRIPTION
Fixes #9850.

This PR fixes missing `AllowComments` option for `Lint/EmptyInPattern`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
