### PR TITLE
Allow braced numeric block calls in Style/MethodCallWithArgsParentheses

### DIFF
--- a/changelog/fix_allow_braced_numeric_blocks_in_style_Method_call_with_args_parentheses.md
+++ b/changelog/fix_allow_braced_numeric_blocks_in_style_Method_call_with_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#9854](https://github.com/rubocop/rubocop/pull/9854): Allow braced numeric blocks in `omit_parentheses` style of `Style/MethodCallWithArgsParentheses`. ([@gsamokovarov][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -116,7 +116,8 @@ module RuboCop
           end
 
           def call_with_braced_block?(node)
-            (node.send_type? || node.super_type?) && node.block_node && node.block_node.braces?
+            (node.send_type? || node.super_type?) &&
+              ((node.parent&.block_type? || node.parent&.numblock_type?) && node.parent&.braces?)
           end
 
           def call_as_argument_or_chain?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -404,6 +404,14 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       end
     end
 
+    context 'numbered parameters in 2.7', :ruby27 do
+      it 'accepts parens for braced numeric block calls' do
+        expect_no_offenses(<<~RUBY)
+          numblock.call(:arg) { _1 }
+        RUBY
+      end
+    end
+
     it 'register an offense for parens in method call without args' do
       trailing_whitespace = ' '
 


### PR DESCRIPTION
This is yet another fix for the `omit_parentheses` style of the
`Style/MethodCallWithArgsParentheses` cop. We're issuing offenses for
braced `numblock` calls:

```ruby
updated_ids = Set.new(items_to_update) { _1.remote_id.to_s }
                     ^^^^^^^^^^^^^^^^^ Omit parentheses for method calls with arguments.
```

Removing the parens leads to code that doesn't compile so this is not good.

Numeric block have their own AST node type:

```
-> ruby-parse -e "Set.new(items_to_update) { _1.remote_id }"
(numblock
  (send
    (const nil :Set) :new
    (send nil :items_to_update)) 1
  (send
    (lvar :_1) :remote_id))
```

vs

```
-> ruby-parse -e "Set.new(items_to_update) { |it| it.remote_id }"
(block
  (send
    (const nil :Set) :new
    (send nil :items_to_update))
  (args
    (procarg0
      (arg :it)))
  (send
    (lvar :it) :remote_id))
```

Send nodes can be queried for their block if given with `#block_node`,
however, the `numblock`s don't get recognized as such. Our check for braced
block calls used to rely on it:

https://github.com/rubocop/rubocop-ast/blob/master/lib/rubocop/ast/node/mixin/method_dispatch_node.rb#L35-L37
https://github.com/rubocop/rubocop-ast/blob/master/lib/rubocop/ast/node/mixin/method_dispatch_node.rb#L156-L158

I'm changing the implementation to work around this issue and recognize
`numblock` braced calls, but we may consider moving the fix to
`rubocop-ast` as well.