### PR TITLE
Revert "Merge pull request #9808" - fix MinGW CI

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -22,9 +22,8 @@ jobs:
         # [ ubuntu, macos, windows ]
         os: [ windows ]
         ruby: [ '2.5', '2.6', '2.7', '3.0', 'head' ]
-        # FIXME: Please uncomment when https://github.com/ruby/psych/issues/494 is resolved.
-        # include:
-        #   - { os: windows, ruby: mingw }
+        include:
+          - { os: windows, ruby: mingw }
         exclude:
           - { os: windows, ruby: head  }
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,8 +12,7 @@ pull_request_rules:
       - "status-success=windows 2.6"
       - "status-success=windows 2.7"
       - "status-success=windows 3.0"
-      # FIXME: Please uncomment when https://github.com/ruby/psych/issues/494 is resolved.
-      # - "status-success=windows mingw"
+      - "status-success=windows mingw"
       - "status-success=ci/circleci: cc-setup"
       - "status-success=ci/circleci: cc-upload-coverage"
       - "status-success=ci/circleci: documentation-checks"


### PR DESCRIPTION
MinGW master build problem addressed in PR #9808 is fixed.

This reverts commit ac00a838b6d537fd4f3b5e4ac1cd67df1bdd73ea, reversing
changes made to 5f6452403da77df245ac160804122c975a901ac0.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
