### PR TITLE
Support Ruby 2.7's pattern matching for `Layout/IndentationWidth`

### DIFF
--- a/changelog/changelog/new_support_pattern_matching_for_layout_indentation_width.md
+++ b/changelog/changelog/new_support_pattern_matching_for_layout_indentation_width.md
@@ -1,0 +1,1 @@
+* [#9857](https://github.com/rubocop/rubocop/pull/9857): Support Ruby 2.7's pattern matching for `Layout/IndentationWidth` cop. ([@koic][])

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -138,6 +138,14 @@ module RuboCop
           check_indentation(case_node.when_branches.last.loc.keyword, case_node.else_branch)
         end
 
+        def on_case_match(case_match)
+          case_match.each_in_pattern do |in_pattern_node|
+            check_indentation(in_pattern_node.loc.keyword, in_pattern_node.body)
+          end
+
+          check_indentation(case_match.in_pattern_branches.last.loc.keyword, case_match.else_branch)
+        end
+
         def on_if(node, base = node)
           return if ignored_node?(node)
           return if node.ternary? || node.modifier_form?

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -866,6 +866,91 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
       end
     end
 
+    context 'with case match', :ruby27 do
+      it 'registers an offense for bad indentation in a case/in body' do
+        expect_offense(<<~RUBY)
+          case a
+          in b
+           c
+          ^ Use 2 (not 1) spaces for indentation.
+          end
+        RUBY
+      end
+
+      it 'registers an offense for bad indentation in a case/else body' do
+        expect_offense(<<~RUBY)
+          case a
+          in b
+            c
+          in d
+            e
+          else
+             f
+          ^^^ Use 2 (not 3) spaces for indentation.
+          end
+        RUBY
+      end
+
+      it 'accepts correctly indented case/in/else' do
+        expect_no_offenses(<<~RUBY)
+          case a
+          in b
+            c
+            c
+          in d
+          else
+            f
+          end
+        RUBY
+      end
+
+      it 'accepts aligned values in `in` clause' do
+        expect_no_offenses(<<~'RUBY')
+          case condition
+          in [42]
+            foo
+          in [43]
+            bar
+          end
+        RUBY
+      end
+
+      it 'accepts case/in/else laid out as a table' do
+        expect_no_offenses(<<~RUBY)
+          case sexp.loc.keyword.source
+          in 'if'     then cond, body, _else = *sexp
+          in 'unless' then cond, _else, body = *sexp
+          else             cond, body = *sexp
+          end
+        RUBY
+      end
+
+      it 'accepts case/in/else with then beginning a line' do
+        expect_no_offenses(<<~RUBY)
+          case sexp.loc.keyword.source
+          in 'if'
+          then cond, body, _else = *sexp
+          end
+        RUBY
+      end
+
+      it 'accepts indented in/else plus indented body' do
+        # "Indent `in` as deep as `case`" is the job of another cop.
+        expect_no_offenses(<<~RUBY)
+          case code_type
+            in 'ruby' | 'sql' | 'plain'
+              code_type
+            in 'erb'
+              'ruby; html-script: true'
+            in "html"
+              'xml'
+            else
+              'plain'
+          end
+        RUBY
+      end
+    end
+
     context 'with while/until' do
       it 'registers an offense for bad indentation of a while body' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR supports Ruby 2.7's pattern matching for `Layout/IndentationWidth`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
