### PR TITLE
configuration: * seems to bind before `; escape it

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -334,7 +334,7 @@ configuration file is. In configuration files that don't begin with `.rubocop`,
 e.g. `our_company_defaults.yml`, paths are relative to the directory where
 `rubocop` is run.
 
-This affects cops that have customisable paths: if the default is `db/migrate/*.rb`,
+This affects cops that have customisable paths: if the default is `db/migrate/\*.rb`,
 and the cop is enabled in `db/migrate/.rubocop.yml`, the path will need to be
 explicitly set as `*.rb`, as the default will look for `db/migrate/db/migrate/*.rb`.
 This is unlikely to be what you wanted.


### PR DESCRIPTION
Text rendered, before:

> This affects cops that have customisable paths: if the default is db/migrate/.rb, and the cop is enabled in db/migrate/.rubocop.yml, the path will need to be explicitly set as .rb, as the default will look for db/migrate/db/migrate/*.rb. This is unlikely to be what you wanted.

![image](https://user-images.githubusercontent.com/13077/121231446-6ca27800-c85e-11eb-9de0-67cac4fdeda7.png)

After:

> This affects cops that have customisable paths: if the default is db/migrate/*.rb, and the cop is enabled in db/migrate/.rubocop.yml, the path will need to be explicitly set as *.rb, as the default will look for db/migrate/db/migrate/*.rb. This is unlikely to be what you wanted.
