### PR TITLE
[Fix #9861] Fix error in `Layout/HashAlignment` with an empty hash literal

### DIFF
--- a/changelog/fix_fix_error_in_layouthashalignment_with_an.md
+++ b/changelog/fix_fix_error_in_layouthashalignment_with_an.md
@@ -1,0 +1,1 @@
+* [#9861](https://github.com/rubocop/rubocop/issues/9861): Fix error in `Layout/HashAlignment` with an empty hash literal. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -218,6 +218,7 @@ module RuboCop
 
         def autocorrect_incompatible_with_other_cops?(node)
           enforce_first_argument_with_fixed_indentation? &&
+            node.pairs.any? &&
             node.parent&.call_type? && node.parent.loc.line == node.pairs.first.loc.line
         end
 

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -171,6 +171,12 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
         }
       RUBY
     end
+
+    it 'does not register an offense for an empty hash literal' do
+      expect_no_offenses(<<~RUBY)
+        foo({})
+      RUBY
+    end
   end
 
   context 'always ignore last argument hash' do


### PR DESCRIPTION
Fixes #9861.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
