### PR TITLE
Clarify that you can raise exceptions without arguments

### DIFF
--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -23,6 +23,7 @@ module RuboCop
       #   # good
       #   raise StandardError, 'message'
       #   fail 'message'
+      #   raise MyCustomError
       #   raise MyCustomError.new(arg1, arg2, arg3)
       #   raise MyKwArgError.new(key1: val1, key2: val2)
       #
@@ -37,6 +38,7 @@ module RuboCop
       #
       #   # good
       #   raise StandardError.new('message')
+      #   raise MyCustomError
       #   raise MyCustomError.new(arg1, arg2, arg3)
       #   fail 'message'
       class RaiseArgs < Base


### PR DESCRIPTION
Whilst `MyCustomError.new` violates this Rubocop rule, the documentation implies the only way of fixing it is to pass an argument representing the exception message, whereas actually if your custom exception has a default message, it's quite possible you just want to use the default message. This can be achieved without violating this Rubocop rule, by omitting the call to `.new`.

I spent an embarrassingly long time figuring that one out, so thought a change to the documentation might help future developers!

------

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
