### PR TITLE
Fix an incorrect auto-correct for `Layout/DotPosition`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_layout_dot_position.md
+++ b/changelog/fix_incorrect_autocorrect_for_layout_dot_position.md
@@ -1,0 +1,1 @@
+* [#9867](https://github.com/rubocop/rubocop/pull/9867): Fix an incorrect auto-correct for `Layout/DotPosition` when using only dot line. ([@koic][])

--- a/lib/rubocop/cop/layout/dot_position.rb
+++ b/lib/rubocop/cop/layout/dot_position.rb
@@ -24,6 +24,7 @@ module RuboCop
       #     method
       class DotPosition < Base
         include ConfigurableEnforcedStyle
+        include RangeHelp
         extend AutoCorrector
 
         def on_send(node)
@@ -42,7 +43,12 @@ module RuboCop
         private
 
         def autocorrect(corrector, dot, node)
-          corrector.remove(dot)
+          dot_range = if processed_source[dot.line - 1].strip == '.'
+                        range_by_whole_lines(dot, include_final_newline: true)
+                      else
+                        dot
+                      end
+          corrector.remove(dot_range)
           case style
           when :leading
             corrector.insert_before(selector_range(node), dot.source)

--- a/spec/rubocop/cop/layout/dot_position_spec.rb
+++ b/spec/rubocop/cop/layout/dot_position_spec.rb
@@ -34,6 +34,22 @@ RSpec.describe RuboCop::Cop::Layout::DotPosition, :config do
       RUBY
     end
 
+    it 'registers an offense for only dot line' do
+      expect_offense(<<~RUBY)
+        foo
+          .bar
+          .
+          ^ Place the . on the next line, together with the method name.
+          baz
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo
+          .bar
+          .baz
+      RUBY
+    end
+
     it 'accepts leading do in multi-line method call' do
       expect_no_offenses(<<~RUBY)
         something


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Layout/DotPosition` when using only dot line.

```console
% cat example.rb
foo
  .bar
  .
  baz

% rubocop --only Layout/DotPosition -a
(snip)

Inspecting 1 file
C

Offenses:

example.rb:3:3: C: [Corrected] Layout/DotPosition: Place the . on the
next line, together with the method name.
  .
  ^

1 file inspected, 1 offense detected, 1 offense corrected
```

## Before

```consle
% cat example.rb
foo
  .bar

  .baz

% ruby -c example.rb
example.rb:4: syntax error, unexpected '.', expecting end-of-input
  .baz
```

## After

```console
% cat example.rb
foo
  .bar
  .baz

% ruby -c example.rb
Syntax OK
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
