### PR TITLE
Support one-line pattern matching syntax

### DIFF
--- a/changelog/new_support_one_line_pattern_matching.md
+++ b/changelog/new_support_one_line_pattern_matching.md
@@ -1,0 +1,1 @@
+* [#9873](https://github.com/rubocop/rubocop/pull/9873): Support one-line pattern matching syntax for `Layout/SpaceAroundKeyword` and `Layout/SpaceAroundOperators`. ([@koic][])

--- a/lib/rubocop/cop/layout/space_around_keyword.rb
+++ b/lib/rubocop/cop/layout/space_around_keyword.rb
@@ -81,6 +81,18 @@ module RuboCop
           check(node, %i[begin end].freeze, nil)
         end
 
+        # Handle one-line pattern matching syntax (`in`) with `Parser::Ruby27`.
+        def on_match_pattern(node)
+          return if target_ruby_version >= 3.0
+
+          check(node, [:operator].freeze)
+        end
+
+        # Handle one-line pattern matching syntax (`in`) with `Parser::Ruby30`.
+        def on_match_pattern_p(node)
+          check(node, [:operator].freeze)
+        end
+
         def on_next(node)
           check(node, [:keyword].freeze)
         end

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -120,6 +120,12 @@ module RuboCop
           check_operator(:special_asgn, node.loc.operator, right.source_range)
         end
 
+        def on_match_pattern(node)
+          return if target_ruby_version < 3.0
+
+          check_operator(:match_pattern, node.loc.operator, node.source_range)
+        end
+
         alias on_or       on_binary
         alias on_and      on_binary
         alias on_lvasgn   on_assignment

--- a/spec/rubocop/cop/layout/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_keyword_spec.rb
@@ -133,6 +133,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
     #       The answer will determine whether to enable or discard the test in the future.
     # it_behaves_like 'missing before', 'in', 'case ""in a; end', 'case "" in a; end'
     it_behaves_like 'missing after', 'in', 'case a; in""; end', 'case a; in ""; end'
+
+    it_behaves_like 'missing before', 'in', '""in a', '"" in a'
+    it_behaves_like 'missing after', 'in', 'a in""', 'a in ""'
+  end
+
+  context '>= Ruby 3.0', :ruby30 do
+    it_behaves_like 'accept before', '=>', '""=> a'
+    it_behaves_like 'accept after', '=>', 'a =>""'
   end
 
   it_behaves_like 'missing before', 'while', '1while ""', '1 while ""'


### PR DESCRIPTION
This PR supports one-line pattern matching syntax for `Layout/SpaceAroundKeyword` and `Layout/SpaceAroundOperators`.

`match-pattern` node changes differently in Ruby 2.7 and Ruby 3.0.

## Ruby 2.7 (`Parser::Ruby27`)

```console
% ruby-parse -e '42 in foo'
(match-pattern
  (int 42)
  (match-var :foo))
```

## Ruby 3.0 (`Parser::Ruby30`)

```console
% ruby-parse -e '42 => foo'
(match-pattern
  (int 42)
  (match-var :foo))
```

And one-line `in` syntax that represents one-line pattern maching changes
from `match-pattern` node to `match-pattern-p` in Ruby 3.0.

```console
% ruby-parse -e '42 in foo'
(match-pattern-p
(int 42)
  (match-var :foo))
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
