### PR TITLE
Use `Cop::Base` API for `Layout/RedundantLineBreak`

### DIFF
--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -42,8 +42,9 @@ module RuboCop
       #   # good
       #   foo(a) { |x| puts x }
       #
-      class RedundantLineBreak < Cop
+      class RedundantLineBreak < Base
         include CheckAssignment
+        extend AutoCorrector
 
         MSG = 'Redundant line break detected.'
 
@@ -55,22 +56,23 @@ module RuboCop
 
           return unless offense?(node) && !part_of_ignored_node?(node)
 
-          add_offense(node)
-          ignore_node(node)
+          register_offense(node)
         end
+
+        private
 
         def check_assignment(node, _rhs)
           return unless offense?(node)
 
-          add_offense(node)
+          register_offense(node)
+        end
+
+        def register_offense(node)
+          add_offense(node) do |corrector|
+            corrector.replace(node.source_range, to_single_line(node.source).strip)
+          end
           ignore_node(node)
         end
-
-        def autocorrect(node)
-          ->(corrector) { corrector.replace(node.source_range, to_single_line(node.source).strip) }
-        end
-
-        private
 
         def offense?(node)
           return false if configured_to_not_be_inspected?(node)


### PR DESCRIPTION
Follow #7868.

This PR uses `Cop::Base` API for `Layout/RedundantLineBreak`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
