### PR TITLE
[Fix #9852] Fix empty line after guard clause with and and heredoc

### DIFF
--- a/changelog/fix_fix_empty_line_after_guard_clause_with.md
+++ b/changelog/fix_fix_empty_line_after_guard_clause_with.md
@@ -1,0 +1,1 @@
+* [#9876](https://github.com/rubocop/rubocop/pull/9876): Fix empty line after guard clause with `and return` and heredoc. ([@AndreiEres][])

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -523,4 +523,41 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
       end
     RUBY
   end
+
+  it 'registers no offenses using heredoc with `and return` before guard condition with empty line' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        puts(<<~MSG) and return if bar
+          A multiline
+          message
+        MSG
+
+        baz
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects using heredoc with `and return` before guard condition' do
+    expect_offense(<<~RUBY)
+      def foo
+        puts(<<~MSG) and return if bar
+          A multiline
+          message
+        MSG
+      ^^^^^ Add empty line after guard clause.
+        baz
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        puts(<<~MSG) and return if bar
+          A multiline
+          message
+        MSG
+
+        baz
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/9852

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
