### PR TITLE
Support Ruby 2.7's `in` pattern syntax for `Lint/LiteralAsCondition`

### DIFF
--- a/changelog/new_support_pattern_matching_for_lint_literal_as_condition.md
+++ b/changelog/new_support_pattern_matching_for_lint_literal_as_condition.md
@@ -1,0 +1,1 @@
+* [#9877](https://github.com/rubocop/rubocop/pull/9877): Support Ruby 2.7's `in` pattern syntax for `Lint/LiteralAsCondition`. ([@koic][])

--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Lint
       # This cop checks for literals used as the conditions or as
       # operands in and/or expressions serving as the conditions of
-      # if/while/until.
+      # if/while/until/case-when/case-in.
       #
       # @example
       #
@@ -63,6 +63,18 @@ module RuboCop
               message = message(range)
 
               add_offense(range, message: message)
+            end
+          end
+        end
+
+        def on_case_match(case_match_node)
+          if case_match_node.condition
+            check_case(case_match_node)
+          else
+            case_match_node.each_in_pattern do |in_pattern_node|
+              next unless in_pattern_node.condition.literal?
+
+              add_offense(in_pattern_node)
             end
           end
         end

--- a/spec/rubocop/cop/lint/literal_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_as_condition_spec.rb
@@ -74,6 +74,25 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
       RUBY
     end
 
+    context '>= Ruby 2.7', :ruby27 do
+      it "registers an offense for literal #{lit} in case match" do
+        expect_offense(<<~RUBY, lit: lit)
+          case %{lit}
+               ^{lit} Literal `#{lit}` appeared as a condition.
+          in x then top
+          end
+        RUBY
+      end
+
+      it "accepts literal #{lit} in a when of a case match" do
+        expect_no_offenses(<<~RUBY)
+          case x
+          in #{lit} then top
+          end
+        RUBY
+      end
+    end
+
     it "registers an offense for literal #{lit} in &&" do
       expect_offense(<<~RUBY, lit: lit)
         if x && %{lit}
@@ -172,6 +191,41 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
       when [1, 2, 5] then top
       end
     RUBY
+  end
+
+  context '>= Ruby 2.7', :ruby27 do
+    it 'accepts array literal in case match, if it has non-literal elements' do
+      expect_no_offenses(<<~RUBY)
+        case [1, 2, x]
+        in [1, 2, 5] then top
+        end
+      RUBY
+    end
+
+    it 'accepts array literal in case match, if it has nested non-literal element' do
+      expect_no_offenses(<<~RUBY)
+        case [1, 2, [x, 1]]
+        in [1, 2, 5] then top
+        end
+      RUBY
+    end
+
+    it 'registers an offense for case match with a primitive array condition' do
+      expect_offense(<<~RUBY)
+        case [1, 2, [3, 4]]
+             ^^^^^^^^^^^^^^ Literal `[1, 2, [3, 4]]` appeared as a condition.
+        in [1, 2, 5] then top
+        end
+      RUBY
+    end
+
+    it 'accepts dstr literal in case match' do
+      expect_no_offenses(<<~'RUBY')
+        case "#{x}"
+        in [1, 2, 5] then top
+        end
+      RUBY
+    end
   end
 
   it 'accepts `true` literal in `while`' do


### PR DESCRIPTION
This PR supports Ruby 2.7's `in` pattern syntax for `Lint/LiteralAsCondition`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
