### PR TITLE
[Fix #9874] Fix a false positive for `Style/RegexpLiteral`

### DIFF
--- a/changelog/fix_false_positive_for_style_regexp_literal.md
+++ b/changelog/fix_false_positive_for_style_regexp_literal.md
@@ -1,0 +1,1 @@
+* [#9874](https://github.com/rubocop/rubocop/issues/9874): Fix a false positive for `Style/RegexpLiteral` when using `%r` regexp literal with `EnforcedStyle: omit_parentheses` of `Style/MethodCallWithArgsParentheses`. ([@koic][])

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -117,7 +117,7 @@ module RuboCop
         def allowed_percent_r_literal?(node)
           style == :slashes && contains_disallowed_slash?(node) ||
             style == :percent_r ||
-            allowed_mixed_percent_r?(node)
+            allowed_mixed_percent_r?(node) || omit_parentheses_style?(node)
         end
 
         def allowed_mixed_percent_r?(node)
@@ -147,6 +147,14 @@ module RuboCop
 
         def preferred_delimiters
           config.for_cop('Style/PercentLiteralDelimiters') ['PreferredDelimiters']['%r'].chars
+        end
+
+        def omit_parentheses_style?(node)
+          return false unless node.parent&.call_type?
+
+          enforced_style = config.for_cop('Style/MethodCallWithArgsParentheses')['EnforcedStyle']
+
+          enforced_style == 'omit_parentheses'
         end
 
         def correct_delimiters(node, corrector)

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -5,10 +5,13 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
     supported_styles = { 'SupportedStyles' => %w[slashes percent_r mixed] }
     RuboCop::Config.new('Style/PercentLiteralDelimiters' =>
                           percent_literal_delimiters_config,
+                        'Style/MethodCallWithArgsParentheses' =>
+                          method_call_with_args_parentheses_config,
                         'Style/RegexpLiteral' =>
                           cop_config.merge(supported_styles))
   end
   let(:percent_literal_delimiters_config) { { 'PreferredDelimiters' => { '%r' => '{}' } } }
+  let(:method_call_with_args_parentheses_config) { { 'EnforcedStyle' => 'require_parentheses' } }
 
   describe 'when regex contains slashes in interpolation' do
     let(:cop_config) { { 'EnforcedStyle' => 'slashes' } }
@@ -484,6 +487,110 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
             https?://
             example\.com
           }x
+        RUBY
+      end
+    end
+  end
+
+  context 'when `EnforcedStyle: require_parentheses` of `Style/MethodCallWithArgsParentheses` cop' do
+    let(:method_call_with_args_parentheses_config) { { 'EnforcedStyle' => 'require_parentheses' } }
+
+    context 'when using `%r` regexp with `EnforcedStyle: slashes`' do
+      let(:cop_config) { { 'EnforcedStyle' => 'slashes' } }
+
+      it 'registers an offense when used as a method argument' do
+        expect_offense(<<~RUBY)
+          do_something %r/regexp/
+                       ^^^^^^^^^^ Use `//` around regular expression.
+        RUBY
+      end
+
+      it 'registers an offense when used as a safe navigation method argument' do
+        expect_offense(<<~RUBY)
+          foo&.do_something %r/regexp/
+                            ^^^^^^^^^^ Use `//` around regular expression.
+        RUBY
+      end
+
+      it 'registers an offense when not used as a method argument' do
+        expect_offense(<<~RUBY)
+          %r/regexp/
+          ^^^^^^^^^^ Use `//` around regular expression.
+        RUBY
+      end
+    end
+
+    context 'when using `%r` regexp with `EnforcedStyle: mixed`' do
+      let(:cop_config) { { 'EnforcedStyle' => 'mixed' } }
+
+      it 'registers an offense when used as a method argument' do
+        expect_offense(<<~RUBY)
+          do_something %r/regexp/
+                       ^^^^^^^^^^ Use `//` around regular expression.
+        RUBY
+      end
+
+      it 'registers an offense when used as a safe navigation method argument' do
+        expect_offense(<<~RUBY)
+          foo&.do_something %r/regexp/
+                            ^^^^^^^^^^ Use `//` around regular expression.
+        RUBY
+      end
+
+      it 'registers an offense when not used as a method argument' do
+        expect_offense(<<~RUBY)
+          %r/regexp/
+          ^^^^^^^^^^ Use `//` around regular expression.
+        RUBY
+      end
+    end
+  end
+
+  context 'when `EnforcedStyle: omit_parentheses` of `Style/MethodCallWithArgsParentheses` cop' do
+    let(:method_call_with_args_parentheses_config) { { 'EnforcedStyle' => 'omit_parentheses' } }
+
+    context 'when using `%r` regexp with `EnforcedStyle: slashes`' do
+      let(:cop_config) { { 'EnforcedStyle' => 'slashes' } }
+
+      it 'does not register an offense when used as a method argument' do
+        expect_no_offenses(<<~RUBY)
+          do_something %r/regexp/
+        RUBY
+      end
+
+      it 'does not register an offense when used as a safe navigation method argument' do
+        expect_no_offenses(<<~RUBY)
+          foo&.do_something %r/regexp/
+        RUBY
+      end
+
+      it 'registers an offense when not used as a method argument' do
+        expect_offense(<<~RUBY)
+          %r/regexp/
+          ^^^^^^^^^^ Use `//` around regular expression.
+        RUBY
+      end
+    end
+
+    context 'when using `%r` regexp with `EnforcedStyle: mixed`' do
+      let(:cop_config) { { 'EnforcedStyle' => 'mixed' } }
+
+      it 'does not register an offense when used as a method argument' do
+        expect_no_offenses(<<~RUBY)
+          do_something %r/regexp/
+        RUBY
+      end
+
+      it 'does not register an offense when used as a safe navigation method argument' do
+        expect_no_offenses(<<~RUBY)
+          foo&.do_something %r/regexp/
+        RUBY
+      end
+
+      it 'registers an offense when not used as a method argument' do
+        expect_offense(<<~RUBY)
+          %r/regexp/
+          ^^^^^^^^^^ Use `//` around regular expression.
         RUBY
       end
     end


### PR DESCRIPTION
Fixes #9874.

This PR fixes a false positive for `Style/RegexpLiteral` when using `%r` regexp literal with `EnforcedStyle: omit_parentheses` of `Style/MethodCallWithArgsParentheses`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
