### PR TITLE
Fix a false positive for `Style/RegexpLiteral`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_regexp_literal.md
+++ b/changelog/fix_a_false_positive_for_style_regexp_literal.md
@@ -1,0 +1,1 @@
+* [#9880](https://github.com/rubocop/rubocop/pull/9880): Fix a false positive for `Style/RegexpLiteral` when using a regexp starts with a blank as a method argument. ([@koic][])

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -117,7 +117,7 @@ module RuboCop
         def allowed_percent_r_literal?(node)
           style == :slashes && contains_disallowed_slash?(node) ||
             style == :percent_r ||
-            allowed_mixed_percent_r?(node) || omit_parentheses_style?(node)
+            allowed_mixed_percent_r?(node) || allowed_omit_parentheses_with_percent_r_literal?(node)
         end
 
         def allowed_mixed_percent_r?(node)
@@ -149,8 +149,9 @@ module RuboCop
           config.for_cop('Style/PercentLiteralDelimiters') ['PreferredDelimiters']['%r'].chars
         end
 
-        def omit_parentheses_style?(node)
+        def allowed_omit_parentheses_with_percent_r_literal?(node)
           return false unless node.parent&.call_type?
+          return true if node.content.start_with?(' ')
 
           enforced_style = config.for_cop('Style/MethodCallWithArgsParentheses')['EnforcedStyle']
 

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -518,6 +518,25 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
           ^^^^^^^^^^ Use `//` around regular expression.
         RUBY
       end
+
+      it 'does not register an offense when using a regexp starts with a blank as a method argument' do
+        expect_no_offenses(<<~RUBY)
+          do_something %r/ regexp/
+        RUBY
+      end
+
+      it 'does not register an offense when using a regexp starts with a blank as a safe navigation method argument' do
+        expect_no_offenses(<<~RUBY)
+          foo&.do_something %r/ regexp/
+        RUBY
+      end
+
+      it 'registers an offense when using a regexp starts with a blank' do
+        expect_offense(<<~RUBY)
+          %r/ regexp/
+          ^^^^^^^^^^^ Use `//` around regular expression.
+        RUBY
+      end
     end
 
     context 'when using `%r` regexp with `EnforcedStyle: mixed`' do
@@ -541,6 +560,25 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
         expect_offense(<<~RUBY)
           %r/regexp/
           ^^^^^^^^^^ Use `//` around regular expression.
+        RUBY
+      end
+
+      it 'does not register an offense when using a regexp starts with a blank as a method argument' do
+        expect_no_offenses(<<~RUBY)
+          do_something %r/ regexp/
+        RUBY
+      end
+
+      it 'does not register an offense when using a regexp starts with a blank as a safe navigation method argument' do
+        expect_no_offenses(<<~RUBY)
+          foo&.do_something %r/ regexp/
+        RUBY
+      end
+
+      it 'registers an offense when using a regexp starts with a blank' do
+        expect_offense(<<~RUBY)
+          %r/ regexp/
+          ^^^^^^^^^^^ Use `//` around regular expression.
         RUBY
       end
     end


### PR DESCRIPTION
This PR fixes the following false positive for `Style/RegexpLiteral` when using a regexp starts with a blank as a method argument.

```console
% cat example.rb
do_something %r| regexp|

% bundle exec rubocop --only Style/RegexpLiteral -a
(snip)

Offenses:

example.rb:1:14: C: [Corrected] Style/RegexpLiteral: Use // around regular expression.
do_something %r| regexp|
             ^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
do_something / regexp/

% ruby -c example.rb
example.rb:1: syntax error, unexpected end-of-input
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
