### PR TITLE
Fix an incorrect auto-correct for `Layout/LineLength`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_layout_line_length.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_layout_line_length.md
@@ -1,0 +1,1 @@
+* [#9882](https://github.com/rubocop/rubocop/pull/9882): Fix an incorrect auto-correct for `Layout/LineLength` when using heredoc as the first method argument and omitting parentheses. ([@koic][])

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -72,7 +72,9 @@ module RuboCop
 
         # If a `send` node is not parenthesized, don't move the first element, because it
         # can result in changed behavior or a syntax error.
-        elements = elements.drop(1) if node.send_type? && !node.parenthesized?
+        if node.send_type? && !node.parenthesized? && !first_argument_is_heredoc?(node)
+          elements = elements.drop(1)
+        end
 
         i = 0
         i += 1 while within_column_limit?(elements[i], max, line)
@@ -82,6 +84,13 @@ module RuboCop
         return elements.first if i.zero?
 
         elements[i - 1]
+      end
+
+      # @api private
+      def first_argument_is_heredoc?(node)
+        first_argument = node.first_argument
+
+        first_argument.respond_to?(:heredoc?) && first_argument.heredoc?
       end
 
       # @api private

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -768,6 +768,17 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           expect_no_corrections
         end
 
+        it 'does not break up the line when parentheses are omitted' do
+          args = 'x' * 25
+          expect_offense(<<~RUBY, args: args)
+            foo <<~STRING, #{args}xxx
+                           _{args}^^^ Line is too long. [43/40]
+            STRING
+          RUBY
+
+          expect_no_corrections
+        end
+
         context 'and other arguments before the heredoc' do
           it 'can break up the line before the heredoc argument' do
             args = 'x' * 20


### PR DESCRIPTION
This PR fixes an incorrect auto-correct for `Layout/LineLength` when using heredoc as the first method argument and omitting parentheses.

```console
% cat example.rb
foo <<~RUBY, arg
RUBY

% bundle exec rubocop --only Layout/LineLength -a
(snip)

Inspecting 1 file
C

Offenses:

example.rb:1:16: C: [Corrected] Layout/LineLength: Line is too long. [16/15]
foo <<~RUBY, arg
               ^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
foo <<~RUBY,
arg
RUBY

% ruby -c example.rb
example.rb:1: syntax error, unexpected end-of-input
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
