### PR TITLE
[Fix #8127] Use expect_correction in remaining specs

### DIFF
--- a/spec/rubocop/cop/layout/multiline_array_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_array_brace_layout_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe RuboCop::Cop::Layout::MultilineArrayBraceLayout, :config do
   it_behaves_like 'multiline literal brace layout trailing comma' do
     let(:open) { '[' }
     let(:close) { ']' }
+
+    let(:same_line_message) do
+      'The closing array brace must be on the same line as the last array ' \
+        'element when the opening [...]'
+    end
+    let(:always_same_line_message) do
+      'The closing array brace must be on the same line as the last array ' \
+        'element.'
+    end
   end
 
   context 'when comment present before closing brace' do

--- a/spec/rubocop/cop/layout/multiline_hash_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_hash_brace_layout_spec.rb
@@ -45,5 +45,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineHashBraceLayout, :config do
     let(:close) { '}' }
     let(:a) { 'a: 1' }
     let(:b) { 'b: 2' }
+
+    let(:same_line_message) do
+      'Closing hash brace must be on the same line as the last hash element ' \
+        'when opening [...]'
+    end
+    let(:always_same_line_message) do
+      'Closing hash brace must be on the same line as the last hash element.'
+    end
   end
 end

--- a/spec/rubocop/cop/layout/multiline_method_call_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_brace_layout_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallBraceLayout, :config do
   it_behaves_like 'multiline literal brace layout trailing comma' do
     let(:open) { 'foo(' }
     let(:close) { ')' }
+
+    let(:same_line_message) do
+      'Closing method call brace must be on the same line as the last ' \
+        'argument when opening [...]'
+    end
+    let(:always_same_line_message) do
+      'Closing method call brace must be on the same line as the last argument.'
+    end
   end
 
   context 'when EnforcedStyle is new_line' do

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
         it 'accepts an assignment containing a heredoc' do
           expect_no_offenses(<<~RUBY)
             correct = lambda do
-              autocorrect_source(<<~EOT1)
+              expect_no_offenses(<<~EOT1)
                 <<-EOT2
                 foo
                 EOT2

--- a/spec/support/alignment_examples.rb
+++ b/spec/support/alignment_examples.rb
@@ -13,19 +13,18 @@ shared_examples_for 'misaligned' do |annotated_source, used_style|
     source = chunk.lines.reject { |line| /^ *\^/.match?(line) }.join
     name = source.gsub(/\n(?=[a-z ])/, ' <newline> ').gsub(/\s+/, ' ')
 
-    it "registers an offense for mismatched #{name}" do
+    it "registers an offense for mismatched #{name} and autocorrects" do
       expect_offense(chunk)
       expect(cop.config_to_allow_offenses).to eq(config_to_allow_offenses)
-    end
 
-    it "auto-corrects mismatched #{name}" do
       raise if chunk !~ /\^\^\^ `end` at (\d), \d is not aligned with `.*` at \d, (\d)./
 
       line_index = Integer(Regexp.last_match(1)) - 1
       correct_indentation = ' ' * Integer(Regexp.last_match(2))
-      expect(autocorrect_source(source))
-        .to eq(source.lines[0...line_index].join +
-               "#{correct_indentation}#{source.lines[line_index].strip}\n")
+      expect_correction(
+        source.lines[0...line_index].join +
+        "#{correct_indentation}#{source.lines[line_index].strip}\n"
+      )
     end
   end
 end

--- a/spec/support/multiline_literal_brace_layout_trailing_comma_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_trailing_comma_examples.rb
@@ -8,20 +8,36 @@ shared_examples_for 'multiline literal brace layout trailing comma' do
   let(:a) { 'a' } # The first element.
   let(:b) { 'b' } # The second element.
 
+  # same line message for symmetrical style (use [...] to abbreviate).
+  let(:same_line_message) do
+    'Closing brace must be on the same line as the last element when ' \
+    'opening [...]'
+  end
+
+  # same line message for same_line style
+  let(:always_same_line_message) do
+    'Closing brace must be on the same line as the last element.'
+  end
+
   context 'symmetrical style' do
     let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
     context 'opening brace on same line as first element' do
       context 'last element has a trailing comma' do
         it 'autocorrects closing brace on different line from last element' do
-          new_source = autocorrect_source(<<~RUBY.chomp)
+          expect_offense(<<~RUBY.chomp)
             #{prefix}#{open}#{a}, # a
             #{b}, # b
             #{close}
+            ^ #{same_line_message}
             #{suffix}
           RUBY
 
-          expect(new_source).to eq("#{prefix}#{open}#{a}, # a\n#{b},#{close} # b\n#{suffix}")
+          expect_correction(<<~RUBY.chomp)
+            #{prefix}#{open}#{a}, # a
+            #{b},#{close} # b
+            #{suffix}
+          RUBY
         end
       end
     end
@@ -33,14 +49,19 @@ shared_examples_for 'multiline literal brace layout trailing comma' do
     context 'opening brace on same line as first element' do
       context 'last element has a trailing comma' do
         it 'autocorrects closing brace on different line as last element' do
-          new_source = autocorrect_source(<<~RUBY.chomp)
+          expect_offense(<<~RUBY.chomp)
             #{prefix}#{open}#{a}, # a
             #{b}, # b
             #{close}
+            ^ #{always_same_line_message}
             #{suffix}
           RUBY
 
-          expect(new_source).to eq("#{prefix}#{open}#{a}, # a\n#{b},#{close} # b\n#{suffix}")
+          expect_correction(<<~RUBY.chomp)
+            #{prefix}#{open}#{a}, # a
+            #{b},#{close} # b
+            #{suffix}
+          RUBY
         end
       end
     end


### PR DESCRIPTION
[Fix #8127]

Replace `autocorrect_source` with newer `expect_correction` in remaining
specs:
* 'multiline literal brace layout trailing comma'
* 'misaligned'

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/