### PR TITLE
[Fix #9803] Update Bundler/GemVersion to check commit references

### DIFF
--- a/changelog/fix_gem_version_not_respecting_tags.md
+++ b/changelog/fix_gem_version_not_respecting_tags.md
@@ -1,0 +1,1 @@
+* [#9803](https://github.com/rubocop/rubocop/pull/9803): Fix `Bundler/GemVersion` cop not respecting git tags. ([@tejasbubane][])

--- a/changelog/fix_gem_version_not_respecting_tags.md
+++ b/changelog/fix_gem_version_not_respecting_tags.md
@@ -1,1 +1,1 @@
-* [#9803](https://github.com/rubocop/rubocop/pull/9803): Fix `Bundler/GemVersion` cop not respecting git tags. ([@tejasbubane][])
+* [#9803](https://github.com/rubocop/rubocop/pull/9803): Fix `Bundler/GemVersion` cop not respecting git tags. ([@tejasbubane,@timlkelly][])

--- a/changelog/fix_gem_version_not_respecting_tags.md
+++ b/changelog/fix_gem_version_not_respecting_tags.md
@@ -1,1 +1,1 @@
-* [#9803](https://github.com/rubocop/rubocop/pull/9803): Fix `Bundler/GemVersion` cop not respecting git tags. ([@tejasbubane,@timlkelly][])
+* [#9803](https://github.com/rubocop/rubocop/pull/9803): Fix `Bundler/GemVersion` cop not respecting git tags. ([@tejasbubane][], [@timlkelly][])

--- a/spec/rubocop/cop/bundler/gem_version_spec.rb
+++ b/spec/rubocop/cop/bundler/gem_version_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe RuboCop::Cop::Bundler::GemVersion, :config do
         ^^^^^^^^^^^^^ Gem version specification is required.
         gem 'rubocop', require: false
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Gem version specification is required.
+        gem 'rubocop', tag: '1.2.0'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Gem version specification is required.
       RUBY
     end
 
@@ -24,6 +26,9 @@ RSpec.describe RuboCop::Cop::Bundler::GemVersion, :config do
         gem 'rubocop', '~> 1'
         gem 'rubocop', '~> 1.12', require: false
         gem 'rubocop', '>= 1.5.0', '< 1.10.0', git: 'https://github.com/rubocop/rubocop'
+        gem 'rubocop', github: 'rubocop/rubocop', tag: 'v1'
+        gem 'rubocop', git: 'https://github.com/rubocop/rubocop', ref: 'b3f37bc7f'
+        gem 'foobar', bitbucket: 'foo/bar', tag: 'v1'
       RUBY
     end
 
@@ -65,6 +70,14 @@ RSpec.describe RuboCop::Cop::Bundler::GemVersion, :config do
     it 'does not flag gems included in AllowedGems metadata' do
       expect_no_offenses(<<~RUBY)
         gem 'rspec', '~> 3.10'
+      RUBY
+    end
+
+    it 'does not flag gems using git source with tag or ref' do
+      expect_no_offenses(<<~RUBY)
+        gem 'rubocop', github: 'rubocop/rubocop', tag: 'v1'
+        gem 'rubocop', git: 'https://github.com/rubocop/rubocop', ref: 'b3f37bc7f'
+        gem 'foobar', bitbucket: 'foo/bar', tag: 'v1'
       RUBY
     end
   end

--- a/spec/rubocop/cop/bundler/gem_version_spec.rb
+++ b/spec/rubocop/cop/bundler/gem_version_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe RuboCop::Cop::Bundler::GemVersion, :config do
         ^^^^^^^^^^^^^ Gem version specification is required.
         gem 'rubocop', require: false
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Gem version specification is required.
-        gem 'rubocop', tag: '1.2.0'
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Gem version specification is required.
       RUBY
     end
 
@@ -26,9 +24,9 @@ RSpec.describe RuboCop::Cop::Bundler::GemVersion, :config do
         gem 'rubocop', '~> 1'
         gem 'rubocop', '~> 1.12', require: false
         gem 'rubocop', '>= 1.5.0', '< 1.10.0', git: 'https://github.com/rubocop/rubocop'
-        gem 'rubocop', github: 'rubocop/rubocop', tag: 'v1'
-        gem 'rubocop', git: 'https://github.com/rubocop/rubocop', ref: 'b3f37bc7f'
-        gem 'foobar', bitbucket: 'foo/bar', tag: 'v1'
+        gem 'rubocop', branch: 'feature-branch'
+        gem 'rubocop', ref: 'b3f37bc7f'
+        gem 'rubocop', tag: 'v1'
       RUBY
     end
 
@@ -57,6 +55,12 @@ RSpec.describe RuboCop::Cop::Bundler::GemVersion, :config do
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Gem version specification is forbidden.
         gem 'rubocop', '>= 1.5.0', '< 1.10.0', git: 'https://github.com/rubocop/rubocop'
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Gem version specification is forbidden.
+        gem 'rubocop', branch: 'feature-branch'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Gem version specification is forbidden.
+        gem 'rubocop', ref: 'b3f37bc7f'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Gem version specification is forbidden.
+        gem 'rubocop', tag: 'v1'
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Gem version specification is forbidden.
       RUBY
     end
 
@@ -70,14 +74,6 @@ RSpec.describe RuboCop::Cop::Bundler::GemVersion, :config do
     it 'does not flag gems included in AllowedGems metadata' do
       expect_no_offenses(<<~RUBY)
         gem 'rspec', '~> 3.10'
-      RUBY
-    end
-
-    it 'does not flag gems using git source with tag or ref' do
-      expect_no_offenses(<<~RUBY)
-        gem 'rubocop', github: 'rubocop/rubocop', tag: 'v1'
-        gem 'rubocop', git: 'https://github.com/rubocop/rubocop', ref: 'b3f37bc7f'
-        gem 'foobar', bitbucket: 'foo/bar', tag: 'v1'
       RUBY
     end
   end


### PR DESCRIPTION
https://github.com/rubocop/rubocop/pull/9807 seems to be stale. This pull request completes the work it set out to do and will close #9803 and #9807.

I originally wanted to create a pull request to merge into https://github.com/rubocop/rubocop/pull/9807, however, I was not able to figure that out. Probably due to my inexperience when working on git projects across multiple forks.

This differs slightly from https://github.com/rubocop/rubocop/pull/9807 given the conversation that has happened in that pull request:
- This proposal does not take the hosted git service into consideration
- This proposal also checks for `branch`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
