### PR TITLE
Fix dedenting Style/ClassAndModuleChildren

### DIFF
--- a/changelog/fix_indentation_in_class_and_module_children.md
+++ b/changelog/fix_indentation_in_class_and_module_children.md
@@ -1,0 +1,1 @@
+* [#9886](https://github.com/rubocop/rubocop/pull/9886): Fix indentation in Style/ClassAndModuleChildren. ([@markburns][])

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -84,6 +84,7 @@ module RuboCop
         def compact_definition(corrector, node)
           compact_node(corrector, node)
           remove_end(corrector, node.body)
+          unindent(corrector, node)
         end
 
         def compact_node(corrector, node)
@@ -112,6 +113,19 @@ module RuboCop
             body.loc.end.end_pos + 1
           )
           corrector.remove(range)
+        end
+
+        def configured_indentation_width
+          config.for_badge(Layout::IndentationWidth.badge).fetch('Width', 2)
+        end
+
+        def unindent(corrector, node)
+          return if node.body.children.last.nil?
+
+          column_delta = configured_indentation_width - leading_spaces(node.body.children.last).size
+          return if column_delta.zero?
+
+          AlignmentCorrector.correct(corrector, processed_source, node, column_delta)
         end
 
         def leading_spaces(node)

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -210,12 +210,43 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
         module FooModule
                ^^^^^^^^^ Use compact module/class definition instead of nested style.
           module BarModule
+            def method_example
+            end
           end
         end
       RUBY
 
       expect_correction(<<~RUBY)
         module FooModule::BarModule
+          def method_example
+          end
+        end
+      RUBY
+    end
+
+    it 'correctly indents heavily nested children' do
+      expect_offense(<<~RUBY)
+        module FooModule
+               ^^^^^^^^^ Use compact module/class definition instead of nested style.
+          module BarModule
+            module BazModule
+              module QuxModule
+                CONST = 1
+
+                def method_example
+                end
+              end
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module FooModule::BarModule::BazModule::QuxModule
+          CONST = 1
+
+          def method_example
+          end
         end
       RUBY
     end


### PR DESCRIPTION
Fixes the auto-corrected indentation for Style/ClassAndModuleChildren with compact style .


~~This PR adds a failing spec for an issue with the Style/ClassAndModuleChildren cop not dedenting code correctly.~~

~~I noticed this as I was wishing to add a new style, and found that the compact style does not remove whitespace correctly.~~
~~I am curious if this is normal behaviour. I.e. do the indentation checks occur last, and so can be used for auto-correcting whitespace?~~

~~I am trying to familiarise myself with the codebase to work out exactly how to implement this functionality in an idiomatic way. But if you have any pointers that would be helpful. I'd be happy to have a go at fixing this.~~

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
