### PR TITLE
Fix a false positive for `Layout/ClosingParenthesisIndentation`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_closing_parenthesis_indentation.md
+++ b/changelog/fix_a_false_positive_for_layout_closing_parenthesis_indentation.md
@@ -1,0 +1,1 @@
+* [#9888](https://github.com/rubocop/rubocop/pull/9888): Fix a false positive for `Layout/ClosingParenthesisIndentation` when using keyword arguemnts. ([@koic][])

--- a/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
+++ b/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
@@ -155,7 +155,13 @@ module RuboCop
         end
 
         def all_elements_aligned?(elements)
-          elements.map { |e| e.loc.column }.uniq.count == 1
+          elements.flat_map do |e|
+            if e.hash_type?
+              e.each_pair.map { |pair| pair.loc.column }
+            else
+              e.loc.column
+            end
+          end.uniq.count == 1
         end
 
         def first_argument_line(elements)

--- a/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation, :config do
         RUBY
       end
 
+      it 'does not register an offense when using keyword arguments' do
+        expect_no_offenses(<<~RUBY)
+          some_method(x: 1,
+            y: 2,
+            z: 3
+          )
+        RUBY
+      end
+
       it 'accepts a correctly indented )' do
         expect_no_offenses(<<~RUBY)
           some_method(a,


### PR DESCRIPTION
This PR fixes a false positive for `Layout/ClosingParenthesisIndentation` when using keyword arguemnts.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
