### PR TITLE
[Fix #9895] Disable `Naming/InclusiveLanguage` by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,19 +100,6 @@ Metrics/ModuleLength:
 Naming/InclusiveLanguage:
   Exclude:
     - lib/rubocop/cop/naming/inclusive_language.rb
-    - spec/rubocop/cop/naming/inclusive_language_spec.rb
-  FlaggedTerms:
-    whitelist:
-      Suggestions:
-        - allowlist
-    blacklist:
-      Suggestions:
-        - denylist
-    master:
-      AllowedRegex:
-        - 'blob/master/'
-        - 'master \(unreleased\)'
-        - !ruby/regexp "/ENV\\['RUBOCOP_VERSION'\\] == 'master'/"
 
 RSpec/FilePath:
   Exclude:

--- a/changelog/change_set_check_strings_false_and_remove_master_for_naming_inclusive_language.md
+++ b/changelog/change_set_check_strings_false_and_remove_master_for_naming_inclusive_language.md
@@ -1,0 +1,1 @@
+* [#9895](https://github.com/rubocop/rubocop/issues/9895): Set `CheckStrings: false` and Remove `master` from `FlaggedTerms` for `Naming/InclusiveLanguage`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2541,7 +2541,7 @@ Naming/InclusiveLanguage:
   CheckIdentifiers: true
   CheckConstants: true
   CheckVariables: true
-  CheckStrings: true
+  CheckStrings: false
   CheckSymbols: true
   CheckComments: true
   CheckFilepaths: true
@@ -2556,12 +2556,6 @@ Naming/InclusiveLanguage:
       Suggestions:
         - denylist
         - block
-    master:
-      Suggestions: ['main', 'primary', 'leader']
-      AllowedRegex:
-        - 'Master of None'
-        - 'Master Boot Record'
-        - 'Mastercard'        
     slave:
       Suggestions: ['replica', 'secondary', 'follower']
 

--- a/spec/rubocop/cop/naming/inclusive_language_spec.rb
+++ b/spec/rubocop/cop/naming/inclusive_language_spec.rb
@@ -136,9 +136,12 @@ RSpec.describe RuboCop::Cop::Naming::InclusiveLanguage, :config do
 
     context 'flagged term with three or more suggestions' do
       let(:cop_config) do
-        { 'FlaggedTerms' => {
-          'master' => { 'Suggestions' => %w[main primary leader] }
-        } }
+        {
+          'CheckStrings' => true,
+          'FlaggedTerms' => {
+            'master' => { 'Suggestions' => %w[main primary leader] }
+          }
+        }
       end
 
       it 'includes all suggestions in the message' do

--- a/tasks/cut_release.rake
+++ b/tasks/cut_release.rake
@@ -40,7 +40,7 @@ namespace :cut_release do
   def update_docs(old_version, new_version)
     update_file('docs/antora.yml') do |antora_metadata|
       antora_metadata.sub(
-        "version: 'master'", # rubocop:disable Naming/InclusiveLanguage
+        "version: 'master'",
         "version: '#{version_sans_patch(new_version)}'"
       )
     end


### PR DESCRIPTION
Fixes #9895 and follow up https://github.com/rubocop/rubocop/pull/9893#issuecomment-870343243.

This PR disables `Naming/InclusiveLanguage` by default because it has an unexpectedly impact for many users who give feedback.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
