### PR TITLE
Fix an incorrect auto-correct for `Layout/HashAlignment`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_layout_hash_alignment.md
+++ b/changelog/fix_incorrect_autocorrect_for_layout_hash_alignment.md
@@ -1,0 +1,1 @@
+* [#9897](https://github.com/rubocop/rubocop/pull/9897): Fix an incorrect auto-correct for `Layout/HashAlignment` when setting `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and using misaligned keyword arguments. ([@koic][])

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -220,7 +220,7 @@ module RuboCop
         def autocorrect_incompatible_with_other_cops?(node)
           enforce_first_argument_with_fixed_indentation? &&
             node.pairs.any? &&
-            node.parent&.call_type? && node.parent.loc.line == node.pairs.first.loc.line
+            node.parent&.call_type? && node.parent.loc.selector.line == node.pairs.first.loc.line
         end
 
         def reset!

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1849,6 +1849,10 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       self&.update(foo: bar,
           baz: boo,
           pony: party)
+
+      foo
+       .do_something(foo: bar,
+                     baz: qux)
     RUBY
 
     create_file('.rubocop.yml', <<~YAML)
@@ -1868,6 +1872,10 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       self&.update(foo: bar,
         baz: boo,
         pony: party)
+
+      foo
+       .do_something(foo: bar,
+         baz: qux)
     RUBY
   end
 


### PR DESCRIPTION
Fixes https://github.com/testdouble/standard/issues/306.

This PR fixes an incorrect auto-correct for `Layout/HashAlignment` when setting `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and using misaligned keyword arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
