### PR TITLE
[Fix #9894] Handle multiline strings in LineEndStringConcatenationIndentation

### DIFF
--- a/changelog/fix_LineEndStringConcatenationIndentation.md
+++ b/changelog/fix_LineEndStringConcatenationIndentation.md
@@ -1,0 +1,1 @@
+* [#9894](https://github.com/rubocop/rubocop/issues/9894): Handle multiline string literals in `Layout/LineEndStringConcatenationIndentation`. ([@jonas054][])

--- a/lib/rubocop/cop/layout/line_end_string_concatenation_indentation.rb
+++ b/lib/rubocop/cop/layout/line_end_string_concatenation_indentation.rb
@@ -86,8 +86,13 @@ module RuboCop
 
         def strings_concatenated_with_backslash?(dstr_node)
           !dstr_node.heredoc? &&
+            !single_string_literal?(dstr_node) &&
             dstr_node.children.length > 1 &&
             dstr_node.children.all? { |c| c.str_type? || c.dstr_type? }
+        end
+
+        def single_string_literal?(dstr_node)
+          dstr_node.loc.respond_to?(:begin) && dstr_node.loc.begin
         end
 
         def always_indented?(dstr_node)

--- a/spec/rubocop/cop/layout/line_end_string_concatenation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/line_end_string_concatenation_indentation_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe RuboCop::Cop::Layout::LineEndStringConcatenationIndentation, :con
   let(:cop_indent) { nil } # use indentation width from Layout/IndentationWidth
 
   shared_examples 'common' do
+    it 'accepts a multiline string literal' do
+      expect_no_offenses(<<~'RUBY')
+        puts %(
+          foo
+          bar
+        )
+      RUBY
+    end
+
     it 'accepts indented strings in implicit return statement of a block' do
       expect_no_offenses(<<~'RUBY')
         some_method do


### PR DESCRIPTION
A multiline string literal such as

```ruby
%(
  foo
  bar
)
```

is parsed as a `dstr`, and should just be skipped by this cop, as opposed to strings made up of several literals concatenated with backslash.