### PR TITLE
[Fix #9890] Make Colon After Comment Annotation Configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5722,3 +5722,4 @@
 [@timlkelly]: https://github.com/timlkelly
 [@AirWick219]: https://github.com/AirWick219
 [@markburns]: https://github.com/markburns
+[@gregfletch]: https://github.com/gregfletch

--- a/changelog/fix_make_comment_annotation_style_configurable.md
+++ b/changelog/fix_make_comment_annotation_style_configurable.md
@@ -1,0 +1,1 @@
+* [#9890](https://github.com/rubocop/rubocop/issues/9890): Make colon after comment annotation configurable. ([@gregfletch][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3150,10 +3150,7 @@ Style/CommentAnnotation:
     - HACK
     - REVIEW
     - NOTE
-  EnforcedStyle: colon
-  SupportedStyles:
-    - colon
-    - space
+  RequireColon: true
 
 Style/CommentedKeyword:
   Description: 'Do not place comments on the same line as certain keywords.'

--- a/config/default.yml
+++ b/config/default.yml
@@ -3150,6 +3150,10 @@ Style/CommentAnnotation:
     - HACK
     - REVIEW
     - NOTE
+  EnforcedStyle: colon
+  SupportedStyles:
+    - colon
+    - space
 
 Style/CommentedKeyword:
   Description: 'Do not place comments on the same line as certain keywords.'

--- a/lib/rubocop/cop/style/comment_annotation.rb
+++ b/lib/rubocop/cop/style/comment_annotation.rb
@@ -12,7 +12,7 @@ module RuboCop
       # incorrect registering of keywords (eg. `review`) inside a paragraph as an
       # annotation.
       #
-      # @example EnforcedStyle: colon (default)
+      # @example RequireColon: true (default)
       #   # bad
       #   # TODO make better
       #
@@ -37,7 +37,7 @@ module RuboCop
       #   # good
       #   # OPTIMIZE: does not work
       #
-      # @example EnforcedStyle: space
+      # @example RequireColon: false
       #   # bad
       #   # TODO: make better
       #
@@ -57,7 +57,6 @@ module RuboCop
       #   # OPTIMIZE does not work
       class CommentAnnotation < Base
         include AnnotationComment
-        include ConfigurableEnforcedStyle
         include RangeHelp
         extend AutoCorrector
 
@@ -86,11 +85,7 @@ module RuboCop
         private
 
         def register_offense(range, note, first_word)
-          message = if style == :colon
-                      MSG_COLON_STYLE
-                    else
-                      MSG_SPACE_STYLE
-                    end
+          message = requires_colon? ? MSG_COLON_STYLE : MSG_SPACE_STYLE
 
           add_offense(
             range,
@@ -121,7 +116,7 @@ module RuboCop
         end
 
         def correct_annotation?(first_word, colon, space, note)
-          return correct_colon_annotation?(first_word, colon, space, note) if style == :colon
+          return correct_colon_annotation?(first_word, colon, space, note) if requires_colon?
 
           correct_space_annotation?(first_word, colon, space, note)
         end
@@ -135,11 +130,13 @@ module RuboCop
         end
 
         def correct_offense(corrector, range, first_word)
-          if style == :colon
-            corrector.replace(range, "#{first_word.upcase}: ")
-          else
-            corrector.replace(range, "#{first_word.upcase} ")
-          end
+          return corrector.replace(range, "#{first_word.upcase}: ") if requires_colon?
+
+          corrector.replace(range, "#{first_word.upcase} ")
+        end
+
+        def requires_colon?
+          cop_config['RequireColon']
         end
       end
     end

--- a/lib/rubocop/cop/style/comment_annotation.rb
+++ b/lib/rubocop/cop/style/comment_annotation.rb
@@ -12,7 +12,7 @@ module RuboCop
       # incorrect registering of keywords (eg. `review`) inside a paragraph as an
       # annotation.
       #
-      # @example
+      # @example EnforcedStyle: colon (default)
       #   # bad
       #   # TODO make better
       #
@@ -36,14 +36,37 @@ module RuboCop
       #
       #   # good
       #   # OPTIMIZE: does not work
+      #
+      # @example EnforcedStyle: space
+      #   # bad
+      #   # TODO: make better
+      #
+      #   # good
+      #   # TODO make better
+      #
+      #   # bad
+      #   # fixme does not work
+      #
+      #   # good
+      #   # FIXME does not work
+      #
+      #   # bad
+      #   # Optimize does not work
+      #
+      #   # good
+      #   # OPTIMIZE does not work
       class CommentAnnotation < Base
         include AnnotationComment
+        include ConfigurableEnforcedStyle
         include RangeHelp
         extend AutoCorrector
 
-        MSG = 'Annotation keywords like `%<keyword>s` should be all ' \
-              'upper case, followed by a colon, and a space, ' \
-              'then a note describing the problem.'
+        MSG_COLON_STYLE = 'Annotation keywords like `%<keyword>s` should be all ' \
+                          'upper case, followed by a colon, and a space, ' \
+                          'then a note describing the problem.'
+        MSG_SPACE_STYLE = 'Annotation keywords like `%<keyword>s` should be all ' \
+                          'upper case, followed by a space, ' \
+                          'then a note describing the problem.'
         MISSING_NOTE = 'Annotation comment, with keyword `%<keyword>s`, is missing a note.'
 
         def on_new_investigation
@@ -63,13 +86,19 @@ module RuboCop
         private
 
         def register_offense(range, note, first_word)
+          message = if style == :colon
+                      MSG_COLON_STYLE
+                    else
+                      MSG_SPACE_STYLE
+                    end
+
           add_offense(
             range,
-            message: format(note ? MSG : MISSING_NOTE, keyword: first_word)
+            message: format(note ? message : MISSING_NOTE, keyword: first_word)
           ) do |corrector|
             next if note.nil?
 
-            corrector.replace(range, "#{first_word.upcase}: ")
+            correct_offense(corrector, range, first_word)
           end
         end
 
@@ -92,7 +121,25 @@ module RuboCop
         end
 
         def correct_annotation?(first_word, colon, space, note)
+          return correct_colon_annotation?(first_word, colon, space, note) if style == :colon
+
+          correct_space_annotation?(first_word, colon, space, note)
+        end
+
+        def correct_colon_annotation?(first_word, colon, space, note)
           keyword?(first_word) && (colon && space && note || !colon && !note)
+        end
+
+        def correct_space_annotation?(first_word, colon, space, note)
+          keyword?(first_word) && (!colon && space && note || !colon && !note)
+        end
+
+        def correct_offense(corrector, range, first_word)
+          if style == :colon
+            corrector.replace(range, "#{first_word.upcase}: ")
+          else
+            corrector.replace(range, "#{first_word.upcase} ")
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
-  context 'with default EnforcedStyle configuration (colon + space)' do
+  context 'with default RequireColon configuration (colon + space)' do
     let(:cop_config) { { 'Keywords' => %w[TODO FIXME OPTIMIZE HACK REVIEW] } }
 
     context 'missing colon' do
@@ -144,11 +144,11 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
     end
   end
 
-  context 'with space EnforcedStyle configuration' do
+  context 'with RequireColon configuration set to false' do
     let(:cop_config) do
       {
         'Keywords' => %w[TODO FIXME OPTIMIZE HACK REVIEW],
-        'EnforcedStyle' => 'space'
+        'RequireColon' => false
       }
     end
 
@@ -166,7 +166,7 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
     end
 
     context 'with configured keyword' do
-      let(:cop_config) { { 'Keywords' => %w[ISSUE], 'EnforcedStyle' => 'space' } }
+      let(:cop_config) { { 'Keywords' => %w[ISSUE], 'RequireColon' => false } }
 
       it 'registers an offense for containing a colon after the word' do
         expect_offense(<<~RUBY)
@@ -235,7 +235,7 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
       let(:cop_config) do
         {
           'Keywords' => %w[FIXME OPTIMIZE HACK REVIEW],
-          'EnforcedStyle' => 'space'
+          'RequireColon' => false
         }
       end
 

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -1,144 +1,273 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
-  let(:cop_config) { { 'Keywords' => %w[TODO FIXME OPTIMIZE HACK REVIEW] } }
+  context 'with default EnforcedStyle configuration (colon + space)' do
+    let(:cop_config) { { 'Keywords' => %w[TODO FIXME OPTIMIZE HACK REVIEW] } }
 
-  context 'missing colon' do
-    it 'registers an offense and adds colon' do
-      expect_offense(<<~RUBY)
-        # TODO make better
-          ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
-      RUBY
+    context 'missing colon' do
+      it 'registers an offense and adds colon' do
+        expect_offense(<<~RUBY)
+          # TODO make better
+            ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        # TODO: make better
+        expect_correction(<<~RUBY)
+          # TODO: make better
+        RUBY
+      end
+    end
+
+    context 'with configured keyword' do
+      let(:cop_config) { { 'Keywords' => %w[ISSUE] } }
+
+      it 'registers an offense for a missing colon after the word' do
+        expect_offense(<<~RUBY)
+          # ISSUE wrong order
+            ^^^^^^ Annotation keywords like `ISSUE` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # ISSUE: wrong order
+        RUBY
+      end
+    end
+
+    context 'missing space after colon' do
+      it 'registers an offense and adds space' do
+        expect_offense(<<~RUBY)
+          # TODO:make better
+            ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # TODO: make better
+        RUBY
+      end
+    end
+
+    context 'lower case keyword' do
+      it 'registers an offense and upcases' do
+        expect_offense(<<~RUBY)
+          # fixme: does not work
+            ^^^^^^^ Annotation keywords like `fixme` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # FIXME: does not work
+        RUBY
+      end
+    end
+
+    context 'capitalized keyword' do
+      it 'registers an offense and upcases' do
+        expect_offense(<<~RUBY)
+          # Optimize: does not work
+            ^^^^^^^^^^ Annotation keywords like `Optimize` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # OPTIMIZE: does not work
+        RUBY
+      end
+    end
+
+    context 'upper case keyword with colon by no note' do
+      it 'registers an offense without auto-correction' do
+        expect_offense(<<~RUBY)
+          # HACK:
+            ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.
+        RUBY
+
+        expect_no_corrections
+      end
+    end
+
+    it 'accepts upper case keyword with colon, space and note' do
+      expect_no_offenses('# REVIEW: not sure about this')
+    end
+
+    it 'accepts upper case keyword alone' do
+      expect_no_offenses('# OPTIMIZE')
+    end
+
+    it 'accepts a comment that is obviously a code example' do
+      expect_no_offenses('# Todo.destroy(1)')
+    end
+
+    it 'accepts a keyword that is just the beginning of a sentence' do
+      expect_no_offenses(<<~RUBY)
+        # Optimize if you want. I wouldn't recommend it.
+        # Hack is a fun game.
       RUBY
+    end
+
+    it 'accepts a keyword that is somewhere in a sentence' do
+      expect_no_offenses(<<~RUBY)
+        # Example: There are three reviews, with ranks 1, 2, and 3. A new
+        # review is saved with rank 2. The two reviews that originally had
+        # ranks 2 and 3 will have their ranks increased to 3 and 4.
+      RUBY
+    end
+
+    context 'when a keyword is not in the configuration' do
+      let(:cop_config) { { 'Keywords' => %w[FIXME OPTIMIZE HACK REVIEW] } }
+
+      it 'accepts the word without colon' do
+        expect_no_offenses('# TODO make better')
+      end
+    end
+
+    context 'offenses in consecutive inline comments' do
+      it 'registers each of them' do
+        expect_offense(<<~RUBY)
+          class ToBeDone
+            ITEMS = [
+              '', # TODO Item 1
+                    ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+              '', # TODO Item 2
+                    ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+            ].freeze
+          end
+        RUBY
+      end
+    end
+
+    context 'multiline comment' do
+      it 'only registers an offense on the first line' do
+        expect_offense(<<~RUBY)
+          # TODO line 1
+            ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+          # TODO line 2
+          # TODO line 3
+        RUBY
+      end
     end
   end
 
-  context 'with configured keyword' do
-    let(:cop_config) { { 'Keywords' => %w[ISSUE] } }
+  context 'with space EnforcedStyle configuration' do
+    let(:cop_config) do
+      {
+        'Keywords' => %w[TODO FIXME OPTIMIZE HACK REVIEW],
+        'EnforcedStyle' => 'space'
+      }
+    end
 
-    it 'registers an offense for a missing colon after the word' do
-      expect_offense(<<~RUBY)
-        # ISSUE wrong order
-          ^^^^^^ Annotation keywords like `ISSUE` should be all upper case, followed by a colon, and a space, then a note describing the problem.
-      RUBY
+    context 'with colon' do
+      it 'registers an offense and removes colon' do
+        expect_offense(<<~RUBY)
+          # TODO: make better
+            ^^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a space, then a note describing the problem.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        # ISSUE: wrong order
+        expect_correction(<<~RUBY)
+          # TODO make better
+        RUBY
+      end
+    end
+
+    context 'with configured keyword' do
+      let(:cop_config) { { 'Keywords' => %w[ISSUE], 'EnforcedStyle' => 'space' } }
+
+      it 'registers an offense for containing a colon after the word' do
+        expect_offense(<<~RUBY)
+          # ISSUE: wrong order
+            ^^^^^^^ Annotation keywords like `ISSUE` should be all upper case, followed by a space, then a note describing the problem.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # ISSUE wrong order
+        RUBY
+      end
+    end
+
+    context 'lower case keyword' do
+      it 'registers an offense and upcases' do
+        expect_offense(<<~RUBY)
+          # fixme does not work
+            ^^^^^^ Annotation keywords like `fixme` should be all upper case, followed by a space, then a note describing the problem.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # FIXME does not work
+        RUBY
+      end
+    end
+
+    context 'upper case keyword with colon by no note' do
+      it 'registers an offense without auto-correction' do
+        expect_offense(<<~RUBY)
+          # HACK:
+            ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.
+        RUBY
+
+        expect_no_corrections
+      end
+    end
+
+    it 'accepts upper case keyword with colon, space and note' do
+      expect_no_offenses('# REVIEW not sure about this')
+    end
+
+    it 'accepts upper case keyword alone' do
+      expect_no_offenses('# OPTIMIZE')
+    end
+
+    it 'accepts a comment that is obviously a code example' do
+      expect_no_offenses('# Todo.destroy(1)')
+    end
+
+    it 'accepts a keyword that is just the beginning of a sentence' do
+      expect_no_offenses(<<~RUBY)
+        # Optimize if you want. I wouldn't recommend it.
+        # Hack is a fun game.
       RUBY
     end
-  end
 
-  context 'missing space after colon' do
-    it 'registers an offense and adds space' do
-      expect_offense(<<~RUBY)
-        # TODO:make better
-          ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        # TODO: make better
+    it 'accepts a keyword that is somewhere in a sentence' do
+      expect_no_offenses(<<~RUBY)
+        # Example: There are three reviews, with ranks 1, 2, and 3. A new
+        # review is saved with rank 2. The two reviews that originally had
+        # ranks 2 and 3 will have their ranks increased to 3 and 4.
       RUBY
     end
-  end
 
-  context 'lower case keyword' do
-    it 'registers an offense and upcases' do
-      expect_offense(<<~RUBY)
-        # fixme: does not work
-          ^^^^^^^ Annotation keywords like `fixme` should be all upper case, followed by a colon, and a space, then a note describing the problem.
-      RUBY
+    context 'when a keyword is not in the configuration' do
+      let(:cop_config) do
+        {
+          'Keywords' => %w[FIXME OPTIMIZE HACK REVIEW],
+          'EnforcedStyle' => 'space'
+        }
+      end
 
-      expect_correction(<<~RUBY)
-        # FIXME: does not work
-      RUBY
+      it 'accepts the word with colon' do
+        expect_no_offenses('# TODO: make better')
+      end
     end
-  end
 
-  context 'capitalized keyword' do
-    it 'registers an offense and upcases' do
-      expect_offense(<<~RUBY)
-        # Optimize: does not work
-          ^^^^^^^^^^ Annotation keywords like `Optimize` should be all upper case, followed by a colon, and a space, then a note describing the problem.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        # OPTIMIZE: does not work
-      RUBY
+    context 'offenses in consecutive inline comments' do
+      it 'registers each of them' do
+        expect_offense(<<~RUBY)
+          class ToBeDone
+            ITEMS = [
+              '', # TODO: Item 1
+                    ^^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a space, then a note describing the problem.
+              '', # TODO: Item 2
+                    ^^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a space, then a note describing the problem.
+            ].freeze
+          end
+        RUBY
+      end
     end
-  end
 
-  context 'upper case keyword with colon by no note' do
-    it 'registers an offense without auto-correction' do
-      expect_offense(<<~RUBY)
-        # HACK:
-          ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.
-      RUBY
-
-      expect_no_corrections
-    end
-  end
-
-  it 'accepts upper case keyword with colon, space and note' do
-    expect_no_offenses('# REVIEW: not sure about this')
-  end
-
-  it 'accepts upper case keyword alone' do
-    expect_no_offenses('# OPTIMIZE')
-  end
-
-  it 'accepts a comment that is obviously a code example' do
-    expect_no_offenses('# Todo.destroy(1)')
-  end
-
-  it 'accepts a keyword that is just the beginning of a sentence' do
-    expect_no_offenses(<<~RUBY)
-      # Optimize if you want. I wouldn't recommend it.
-      # Hack is a fun game.
-    RUBY
-  end
-
-  it 'accepts a keyword that is somewhere in a sentence' do
-    expect_no_offenses(<<~RUBY)
-      # Example: There are three reviews, with ranks 1, 2, and 3. A new
-      # review is saved with rank 2. The two reviews that originally had
-      # ranks 2 and 3 will have their ranks increased to 3 and 4.
-    RUBY
-  end
-
-  context 'when a keyword is not in the configuration' do
-    let(:cop_config) { { 'Keywords' => %w[FIXME OPTIMIZE HACK REVIEW] } }
-
-    it 'accepts the word without colon' do
-      expect_no_offenses('# TODO make better')
-    end
-  end
-
-  context 'offenses in consecutive inline comments' do
-    it 'registers each of them' do
-      expect_offense(<<~RUBY)
-        class ToBeDone
-          ITEMS = [
-            '', # TODO Item 1
-                  ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
-            '', # TODO Item 2
-                  ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
-          ].freeze
-        end
-      RUBY
-    end
-  end
-
-  context 'multiline comment' do
-    it 'only registers an offense on the first line' do
-      expect_offense(<<~RUBY)
-        # TODO line 1
-          ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
-        # TODO line 2
-        # TODO line 3
-      RUBY
+    context 'multiline comment' do
+      it 'only registers an offense on the first line' do
+        expect_offense(<<~RUBY)
+          # TODO: line 1
+            ^^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a space, then a note describing the problem.
+          # TODO: line 2
+          # TODO: line 3
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
[Fix #9890]

Make the separator for the Style/CommentAnnotation cop configurable. By default, the enforced style will be the current behaviour of annotation keyword followed by a colon (`:`), and a space. A new supported style is added to only require a space following the annotation keyword.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
