### PR TITLE
[Fix #9891] Fix --auto-gen-config bug for Style/HashSyntax

### DIFF
--- a/changelog/fix_autogenconfig_bug_for_HashSyntax.md
+++ b/changelog/fix_autogenconfig_bug_for_HashSyntax.md
@@ -1,0 +1,1 @@
+* [#9891](https://github.com/rubocop/rubocop/issues/9891): Fix `--auto-gen-config` bug for `Style/HashSyntax`. ([@jonas054][])

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -74,7 +74,7 @@ module RuboCop
             ruby19_no_mixed_keys_check(pairs)
           elsif style == :no_mixed_keys
             no_mixed_keys_check(pairs)
-          elsif node.source.include?('=>')
+          else
             ruby19_check(pairs)
           end
         end

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
   include_context 'cli spec behavior'
 
   describe '--auto-gen-config' do
-    before { RuboCop::Formatter::DisabledConfigFormatter.config_to_allow_offenses = {} }
+    before do
+      RuboCop::Formatter::DisabledConfigFormatter.config_to_allow_offenses = {}
+      RuboCop::Formatter::DisabledConfigFormatter.detected_styles = {}
+    end
 
     shared_examples 'LineLength handling' do |ctx, initial_dotfile, exp_dotfile|
       context ctx do
@@ -446,11 +449,10 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         todo_contents = File.read('.rubocop_todo.yml').lines[8..-1].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
-          # Configuration parameters: EnforcedStyle, IgnoredPatterns.
+          # Configuration parameters: IgnoredPatterns.
           # SupportedStyles: snake_case, camelCase
           Naming/MethodName:
-            Exclude:
-              - 'example1.rb'
+            EnforcedStyle: camelCase
 
           # Offense count: 1
           # Cop supports --auto-correct.


### PR DESCRIPTION
We must call `ruby19_check()` even if there are no hash rockets in the inspected node, to give it a chance to register that the correct style has been detected. The generation of `.rubocop_todo.yml` depends on it.