### PR TITLE
[Fix #9150] Escape special chars in docs

### DIFF
--- a/docs/modules/ROOT/pages/cops_naming.adoc
+++ b/docs/modules/ROOT/pages/cops_naming.adoc
@@ -501,7 +501,7 @@ EOS
 | Name | Default value | Configurable values
 
 | ForbiddenDelimiters
-| `(?-mix:(^|\s)(EO[A-Z]{1}|END)(\s|$))`
+| `(?-mix:(^|\s)(EO[A-Z]\{1\}|END)(\s|$))`
 | Array
 |===
 

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -2084,7 +2084,7 @@ an offense is reported.
 | Name | Default value | Configurable values
 
 | Notice
-| `^Copyright (\(c\) )?2[0-9]{3} .+`
+| `^Copyright (\(c\) )?2[0-9]\{3\} .+`
 | String
 
 | AutocorrectNotice
@@ -12474,8 +12474,8 @@ array of 2 or fewer elements.
 | Integer
 
 | WordRegex
-| `(?-mix:\A(?:\p{Word}|\p{Word}-\p{Word}|\n|\t)+\z)`
-| 
+| `(?-mix:\A(?:\p\{Word\}|\p\{Word\}-\p\{Word\}|\n|\t)+\z)`
+|
 |===
 
 === References

--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -271,8 +271,8 @@ describe RuboCop::Cop::Style::SimplifyNotEmptyWithAny, :config do
 end
 ----
 
-If your code has variables of different lengths, you can use `%{foo}`,
-`^{foo}`, and `_{foo}` to format your template; you can also abbreviate
+If your code has variables of different lengths, you can use `%\{foo\}`,
+`^\{foo\}`, and `_\{foo\}` to format your template; you can also abbreviate
 offense messages with `[...]`:
 
 [source,ruby]


### PR DESCRIPTION
This partially resolves https://github.com/rubocop/rubocop/issues/9150.  See similar PR at https://github.com/rubocop/rubocop-ast/pull/187.  This PR escapes the special characters `{` and `}` when they aren't  intended to be interpolated.  It does not fully resolve the issue, because older tags are still included when the docs are generated.  Those tags are configured at https://github.com/rubocop/docs.rubocop.org/blob/master/antora-playbook.yml.

```shell
# Let's generate HTML docs on master
# We will see the same warnings we see in docs.rubocop.org
rubocop-fork git:(master) $ git co master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
rubocop-fork git:(master) $ asciidoctor -a attribute-missing=warn docs/modules/ROOT/pages/cops_naming.adoc -o cops_naming-master.html
asciidoctor: WARNING: skipping reference to missing attribute: 1
rubocop-fork git:(master) $ asciidoctor -a attribute-missing=warn docs/modules/ROOT/pages/cops_style.adoc -o cops_style-master.html
asciidoctor: WARNING: skipping reference to missing attribute: 3
asciidoctor: WARNING: skipping reference to missing attribute: word
asciidoctor: WARNING: skipping reference to missing attribute: word
asciidoctor: WARNING: skipping reference to missing attribute: word
rubocop-fork git:(master) $ asciidoctor -a attribute-missing=warn docs/modules/ROOT/pages/development.adoc -o development-master.html
asciidoctor: WARNING: skipping reference to missing attribute: foo
asciidoctor: WARNING: skipping reference to missing attribute: foo
asciidoctor: WARNING: skipping reference to missing attribute: foo

# Now let's run on the feature branch
rubocop-fork git:(master) $ git co wm/escape_special_chars_in_docs
switched to branch 'wm/escape_special_chars_in_docs'
rubocop-fork git:(wm/escape_special_chars_in_docs) $ asciidoctor -a attribute-missing=warn docs/modules/ROOT/pages/cops_naming.adoc -o cops_naming-escaped.html
rubocop-fork git:(wm/escape_special_chars_in_docs) $ asciidoctor -a attribute-missing=warn docs/modules/ROOT/pages/cops_style.adoc -o cops_style-escaped.html
rubocop-fork git:(wm/escape_special_chars_in_docs) $ asciidoctor -a attribute-missing=warn docs/modules/ROOT/pages/development.adoc -o development-escaped.html

# Here we make sure that the generated files are the same, except for the timestamps
rubocop-fork git:(wm/escape_special_chars_in_docs) $ diff cops_naming-master.html cops_naming-escaped.html
2343c2343
< Last updated 2021-07-02 13:24:59 -0400
---
> Last updated 2021-07-02 13:27:01 -0400
rubocop-fork git:(wm/escape_special_chars_in_docs) $ diff cops_style-master.html cops_style-escaped.html
20675c20675
< Last updated 2021-07-02 13:24:59 -0400
---
> Last updated 2021-07-02 13:27:01 -0400
rubocop-fork git:(wm/escape_special_chars_in_docs) $ diff development-master.html development-escaped.html
991c991
< Last updated 2021-07-02 13:24:59 -0400
---
> Last updated 2021-07-02 13:27:01 -0400
```
-----------------
Note I'm marking `Added tests` and `Ran "bundle exec rake default".` as done, because these changes just impact docs and not the codebase. 
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
