### PR TITLE
[Fix #9907] Fix an incorrect auto-correct for `Lint/UselessTimes`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_lint_useless_time.md
+++ b/changelog/fix_incorrect_autocorrect_for_lint_useless_time.md
@@ -1,0 +1,1 @@
+* [#9907](https://github.com/rubocop/rubocop/issues/9907): Fix an incorrect auto-correct for `Lint/UselessTimes` when using block argument for `1.times`. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_times.rb
+++ b/lib/rubocop/cop/lint/useless_times.rb
@@ -81,7 +81,7 @@ module RuboCop
           return if block_reassigns_arg?(node, block_arg)
 
           source = node.body.source
-          source.gsub!(/\b#{block_arg}\b/, '1') if block_arg
+          source.gsub!(/\b#{block_arg}\b/, '0') if block_arg
 
           corrector.replace(node, fix_indentation(source, node.loc.column...node.body.loc.column))
         end

--- a/spec/rubocop/cop/lint/useless_times_spec.rb
+++ b/spec/rubocop/cop/lint/useless_times_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessTimes, :config do
     RUBY
 
     expect_correction(<<~RUBY)
-      something(1)
+      something(0)
     RUBY
   end
 
@@ -163,8 +163,8 @@ RSpec.describe RuboCop::Cop::Lint::UselessTimes, :config do
       RUBY
 
       expect_correction(<<~RUBY)
-        do_something(1)
-        do_something_else(1)
+        do_something(0)
+        do_something_else(0)
       RUBY
     end
 
@@ -205,7 +205,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessTimes, :config do
       RUBY
 
       expect_correction(<<~RUBY)
-        do_something(1)
+        do_something(0)
         j = 1
         do_something_else(j)
       RUBY


### PR DESCRIPTION
Fixes #9907.

This PR fixes an incorrect auto-correct for `Lint/UselessTimes` when using block variable for `1.times`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
