### PR TITLE
Fix an incorrect auto-correct for `Style/SingleLineMethods`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_single_line_methods.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_single_line_methods.md
@@ -1,0 +1,1 @@
+* [#9909](https://github.com/rubocop/rubocop/pull/9909): This PR fixes an incorrect auto-correct for `Style/SingleLineMethods` when using `return`, `break`, or `next` for one line method body in Ruby 3.0. ([@koic][])

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -219,6 +219,30 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
         end
       end
 
+      it 'does not to an endless class method definition when using `return`' do
+        expect_correction(<<~RUBY.strip, source: 'def foo(argument) return bar(argument); end')
+          def foo(argument)#{trailing_whitespace}
+            return bar(argument);#{trailing_whitespace}
+          end
+        RUBY
+      end
+
+      it 'does not to an endless class method definition when using `break`' do
+        expect_correction(<<~RUBY.strip, source: 'def foo(argument) break bar(argument); end')
+          def foo(argument)#{trailing_whitespace}
+            break bar(argument);#{trailing_whitespace}
+          end
+        RUBY
+      end
+
+      it 'does not to an endless class method definition when using `next`' do
+        expect_correction(<<~RUBY.strip, source: 'def foo(argument) next bar(argument); end')
+          def foo(argument)#{trailing_whitespace}
+            next bar(argument);#{trailing_whitespace}
+          end
+        RUBY
+      end
+
       # NOTE: Setter method cannot be defined in the endless method definition.
       it 'corrects to multiline method definition when defining setter method' do
         expect_correction(<<~RUBY.chop, source: 'def foo=(foo) @foo = foo end')


### PR DESCRIPTION
This PR fixes an incorrect auto-correct for `Style/SingleLineMethods` when using `return`, `break`, or `next` for one line method body in Ruby 3.0.

These are not supported in the endless method definition.

```console
% ruby -v
ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-darwin19]

% cat example.rb
def foo(argument) break bar(argument); end
def foo(argument) next bar(argument); end
def foo(argument) return bar(argument); end

% ruby -c example.rb
Syntax OK

% bundle exec rubocop --only Style/SingleLineMethods -a
(snip)

Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Corrected] Style/SingleLineMethods: Avoid
single-line method definitions.
def foo(argument) break bar(argument); end
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
example.rb:2:1: C: [Corrected] Style/SingleLineMethods: Avoid
single-line method definitions.
def foo(argument) next bar(argument); end
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
example.rb:3:1: C: [Corrected] Style/SingleLineMethods: Avoid
single-line method definitions.
def foo(argument) return bar(argument); end
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 3 offenses detected, 3 offenses corrected

% cat example.rb
def foo(argument) = break bar(argument)
def foo(argument) = next bar(argument)
def foo(argument) = return bar(argument)

% ruby -ce 'def foo(argument) = break bar(argument)'
-e:1: syntax error, unexpected local variable or method, expecting
end-of-input
def foo(argument) = break bar(argument)

% ruby -ce 'def foo(argument) = next bar(argument)'
-e:1: syntax error, unexpected local variable or method, expecting
end-of-input
def foo(argument) = next bar(argument)

% ruby -ce 'def foo(argument) = return bar(argument)'
-e:1: syntax error, unexpected local variable or method, expecting
end-of-input
def foo(argument) = return bar(argument)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
