### PR TITLE
[Fix #8469] Add singleton class operator inspection

### DIFF
--- a/changelog/fix_space_around_singleton_class_operator.md
+++ b/changelog/fix_space_around_singleton_class_operator.md
@@ -1,0 +1,1 @@
+* [#8469](https://github.com/rubocop/rubocop/issues/8469): Add inspection of `class <<` to `Layout/SpaceAroundOperators`. ([@jonas054][])

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -63,6 +63,10 @@ module RuboCop
           [Style::SelfAssignment]
         end
 
+        def on_sclass(node)
+          check_operator(:sclass, node.loc.operator, node.source_range)
+        end
+
         def on_pair(node)
           return unless node.hash_rocket?
 

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -278,9 +278,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
     RUBY
   end
 
-  it 'accepts the construct class <<self with no space after <<' do
-    expect_no_offenses(<<~RUBY)
-      class <<self
+  it 'registers an offense and corrects singleton class operator`' do
+    expect_offense(<<~RUBY)
+      class<<self
+           ^^ Surrounding space missing for operator `<<`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class << self
       end
     RUBY
   end


### PR DESCRIPTION
We classify the `<<` operator used for the singleton class construct `class << self` as an operator like any other. This means that not inspecting it was a bug, and this change fixes it.