### PR TITLE
[Fix #9869] Print correct file in override warning

### DIFF
--- a/changelog/fix_override_warning.md
+++ b/changelog/fix_override_warning.md
@@ -1,0 +1,1 @@
+* [#9869](https://github.com/rubocop/rubocop/issues/9869): Fix reference to file in configuration override warning. ([@jonas054][])

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -23,7 +23,7 @@ module RuboCop
     def resolve_inheritance(path, hash, file, debug) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       inherited_files = Array(hash['inherit_from'])
       base_configs(path, inherited_files, file)
-        .reverse.each_with_index do |base_config, index|
+        .each_with_index.reverse_each do |base_config, index|
         override_department_setting_for_cops(base_config, hash)
         override_enabled_for_disabled_departments(base_config, hash)
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -349,23 +349,30 @@ RSpec.describe RuboCop::ConfigLoader do
       let(:file_path) { '.rubocop.yml' }
       let(:message) do
         '.rubocop.yml: Style/For:Exclude overrides the same parameter in ' \
-          '.rubocop_todo.yml'
+          '.rubocop_2.yml'
       end
 
       before do
         create_file(file_path, <<~YAML)
-          inherit_from: .rubocop_todo.yml
+          inherit_from:
+            - .rubocop_1.yml
+            - .rubocop_2.yml
 
           Style/For:
             Exclude:
               - spec/requests/group_invite_spec.rb
         YAML
 
-        create_file('.rubocop_todo.yml', <<~YAML)
+        create_file('.rubocop_1.yml', <<~YAML)
+          Style/StringLiterals:
+            Exclude:
+              - 'spec/models/group_spec.rb'
+        YAML
+
+        create_file('.rubocop_2.yml', <<~YAML)
           Style/For:
             Exclude:
               - 'spec/models/expense_spec.rb'
-              - 'spec/models/group_spec.rb'
         YAML
       end
 
@@ -796,9 +803,9 @@ RSpec.describe RuboCop::ConfigLoader do
           expect(configuration_from_file['Metrics/MethodLength']
                    .to_set.superset?(expected.to_set)).to be(true)
         end.to output(Regexp.new(<<~OUTPUT)).to_stdout
-          .rubocop.yml: Metrics/MethodLength:Enabled overrides the same parameter in normal.yml
           .rubocop.yml: Metrics/MethodLength:Enabled overrides the same parameter in special.yml
-          .rubocop.yml: Metrics/MethodLength:Max overrides the same parameter in special.yml
+          .rubocop.yml: Metrics/MethodLength:Enabled overrides the same parameter in normal.yml
+          .rubocop.yml: Metrics/MethodLength:Max overrides the same parameter in normal.yml
         OUTPUT
       end
     end


### PR DESCRIPTION
The list of files from `inherit_from` is iterated over in reverse order. If we first reverse and then iterate with indices, the indices will start at 0 for the item that was originally last in the list. This is not what we want.