### PR TITLE
[Fix #9914] Fix an error for `Layout/HashAlignment`

### DIFF
--- a/changelog/fix_an_error_for_layout_hash_alignment.md
+++ b/changelog/fix_an_error_for_layout_hash_alignment.md
@@ -1,0 +1,1 @@
+* [#9914](https://github.com/rubocop/rubocop/issues/9914): Fix an error for `Layout/HashAlignment` when using aligned hash argument for `proc.()`. ([@koic][])

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -220,7 +220,7 @@ module RuboCop
         def autocorrect_incompatible_with_other_cops?(node)
           enforce_first_argument_with_fixed_indentation? &&
             node.pairs.any? &&
-            node.parent&.call_type? && node.parent.loc.selector.line == node.pairs.first.loc.line
+            node.parent&.call_type? && node.parent.loc.selector&.line == node.pairs.first.loc.line
         end
 
         def reset!

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -177,6 +177,12 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
         foo({})
       RUBY
     end
+
+    it 'does not register an offense using aligned hash argument for `proc.()`' do
+      expect_no_offenses(<<~RUBY)
+        proc.(key: value)
+      RUBY
+    end
   end
 
   context 'always ignore last argument hash' do


### PR DESCRIPTION
Fixes #9914.

This PR fixes an error for `Layout/HashAlignment` when using aligned hash argument for `proc.()`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
