### PR TITLE
[Fix #9848] Handle EOL comments in ClassStructure auto-correct

### DIFF
--- a/changelog/fix_class_structure_eol_comment_bug.md
+++ b/changelog/fix_class_structure_eol_comment_bug.md
@@ -1,0 +1,1 @@
+* [#9848](https://github.com/rubocop/rubocop/issues/9848): Fix handling of comments in `Layout/ClassStructure` auto-correct. ([@jonas054][])

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -289,10 +289,14 @@ module RuboCop
           (node.first_line - 1).downto(1) do |annotation_line|
             break unless (comment = processed_source.comment_at_line(annotation_line))
 
-            first_comment = comment
+            first_comment = comment if whole_line_comment_at_line?(annotation_line)
           end
 
           start_line_position(first_comment || node)
+        end
+
+        def whole_line_comment_at_line?(line)
+          /\A\s*#/.match?(processed_source.lines[line - 1])
         end
 
         def start_line_position(node)

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -39,6 +39,25 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
     )
   end
 
+  context 'when the first line ends with a comment' do
+    it 'reports an offense and swaps the lines' do
+      expect_offense <<-RUBY
+        class GridTask
+          DESC = 'Grid Task' # grid task name OID, subclasses should set this
+          extend Helpers::MakeFromFile
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `module_inclusion` is supposed to appear before `constants`.
+        end
+      RUBY
+
+      expect_correction <<-RUBY
+        class GridTask
+          extend Helpers::MakeFromFile
+          DESC = 'Grid Task' # grid task name OID, subclasses should set this
+        end
+      RUBY
+    end
+  end
+
   context 'with a complete ordered example' do
     it 'does not create offense' do
       expect_no_offenses <<-RUBY


### PR DESCRIPTION
The algorithm for finding the start of a code segment to move must be aware of the fact that some comments are end-of-line comments. Those are not the comments we're looking for. It's only comments above the given code line that are interesting.