### PR TITLE
[Fix #9434] Fix false positive in FirstArgumentIndentation

### DIFF
--- a/changelog/fix_first_argument_indentation_false_pos.md
+++ b/changelog/fix_first_argument_indentation_false_pos.md
@@ -1,0 +1,1 @@
+* [#9434](https://github.com/rubocop/rubocop/issues/9434): Fix false positive for setter calls in `Layout/FirstArgumentIndentation`. ([@jonas054][])

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -154,7 +154,7 @@ module RuboCop
 
         def on_send(node)
           return if style != :consistent && enforce_first_argument_with_fixed_indentation?
-          return if !node.arguments? || bare_operator?(node)
+          return if !node.arguments? || bare_operator?(node) || node.setter_method?
 
           indent = base_indentation(node) + configured_indentation_width
 

--- a/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
@@ -134,6 +134,15 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
         end
       end
 
+      context 'for a setter call' do
+        it 'accepts an unindented value' do
+          expect_no_offenses(<<~RUBY)
+            foo.baz =
+            bar
+          RUBY
+        end
+      end
+
       context 'for assignment' do
         it 'accepts a correctly indented first argument and does not care ' \
            'about the second argument' do


### PR DESCRIPTION
Setter calls are a kind of method invocation that `Layout/FirstArgumentIndentation` should just skip.