### PR TITLE
Fix an incorrect auto-correct for `Style/SingleLineMethods`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_single_line_methods.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_single_line_methods.md
@@ -1,0 +1,1 @@
+* [#9926](https://github.com/rubocop/rubocop/pull/9926): Fix an incorrect auto-correct for `Style/SingleLineMethods` when method body is enclosed in parentheses. ([@koic][])

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
     RUBY
   end
 
+  it 'registers an offense for a single-line method and method body is enclosed in parentheses' do
+    expect_offense(<<~RUBY)
+      def foo() (do_something) end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo()#{trailing_whitespace}
+        (do_something)#{trailing_whitespace}
+      end
+    RUBY
+  end
+
   context 'when AllowIfMethodIsEmpty is disabled' do
     let(:cop_config) { { 'AllowIfMethodIsEmpty' => false } }
 


### PR DESCRIPTION
Fixes https://github.com/testdouble/standard/issues/309.

This PR fixes an incorrect auto-correct for `Style/SingleLineMethods` when method body is enclosed in parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
