### PR TITLE
[Fix rubocop#9328] Honour shareable_constant_value magic comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5812,3 +5812,4 @@
 [@AirWick219]: https://github.com/AirWick219
 [@markburns]: https://github.com/markburns
 [@gregfletch]: https://github.com/gregfletch
+[@thearjunmdas]: https://github.com/thearjunmdas

--- a/changelog/change_recognize_shareable_constant_value_magic.md
+++ b/changelog/change_recognize_shareable_constant_value_magic.md
@@ -1,0 +1,1 @@
+* [#9328](https://github.com/rubocop/rubocop/issues/9328): Recognize shareable_constant_value magic comment. ([@thearjunmdas][])

--- a/changelog/change_recognize_shareable_constant_value_magic.md
+++ b/changelog/change_recognize_shareable_constant_value_magic.md
@@ -1,1 +1,1 @@
-* [#9328](https://github.com/rubocop/rubocop/issues/9328): Recognize shareable_constant_value magic comment. ([@thearjunmdas][])
+* [#9328](https://github.com/rubocop/rubocop/issues/9328): Recognize shareable_constant_value magic comment. ([@thearjunmdas][], [@caalberts][])

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -14,6 +14,11 @@ module RuboCop
       # positives. Luckily, there is no harm in freezing an already
       # frozen object.
       #
+      # From Ruby 3.0, this cop honours the magic comment
+      # 'shareable_constant_value'. When this magic comment is set to any
+      # acceptable value other than none, it will suppress the offenses
+      # raised by this cop. It enforces frozen state.
+      #
       # NOTE: Regexp and Range literals are frozen objects since Ruby 3.0.
       #
       # @example EnforcedStyle: literals (default)

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -57,6 +57,21 @@ module RuboCop
       #       puts 1
       #     end
       #   end.freeze
+      #
+      # @example
+      #   # Magic comment - shareable_constant_value: literal
+      #
+      #   # bad
+      #   CONST = [1, 2, 3]
+      #
+      #   # good
+      #   # shareable_constant_value: literal
+      #   CONST = [1, 2, 3]
+      #
+      # NOTE: This special directive helps to create constants
+      # that hold only immutable objects, or Ractor-shareable
+      # constants. - ruby docs
+      #
       class MutableConstant < Base
         # Handles magic comment shareable_constant_value with O(n ^ 2) complexity
         # n - number of lines in the source

--- a/spec/rubocop/magic_comment_spec.rb
+++ b/spec/rubocop/magic_comment_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe RuboCop::MagicComment do
   shared_examples 'magic comment' do |comment, expectations = {}|
     encoding = expectations[:encoding]
     frozen_string = expectations[:frozen_string_literal]
+    shareable_constant_value = expectations[:shareable_constant_value]
 
     it "returns #{encoding.inspect} for encoding when comment is #{comment}" do
       expect(described_class.parse(comment).encoding).to eql(encoding)
@@ -11,6 +12,12 @@ RSpec.describe RuboCop::MagicComment do
 
     it "returns #{frozen_string.inspect} for frozen_string_literal when comment is #{comment}" do
       expect(described_class.parse(comment).frozen_string_literal).to eql(frozen_string)
+    end
+
+    it "returns #{shareable_constant_value.inspect} for shareable_constant_value " \
+       "when comment is #{comment}" do
+      expect(described_class.parse(comment)
+                            .shareable_constant_value).to eql(shareable_constant_value)
     end
   end
 
@@ -45,6 +52,34 @@ RSpec.describe RuboCop::MagicComment do
   include_examples 'magic comment', '# FROZEN-STRING-LITERAL: true', frozen_string_literal: true
 
   include_examples 'magic comment', '# fRoZeN-sTrInG_lItErAl: true', frozen_string_literal: true
+
+  include_examples 'magic comment', '# shareable_constant_value: literal', shareable_constant_value: 'literal'
+
+  include_examples 'magic comment', '# shareable_constant_value:literal', shareable_constant_value: 'literal'
+
+  include_examples 'magic comment', '# shareable-constant-value: literal', shareable_constant_value: 'literal'
+
+  include_examples 'magic comment', '# SHAREABLE-CONSTANT-VALUE: literal', shareable_constant_value: 'literal'
+
+  include_examples 'magic comment', '# sHaReaBLE-CoNstANT-ValUE: literal', shareable_constant_value: 'literal'
+
+  include_examples 'magic comment', '# shareable_constant_value: none', shareable_constant_value: 'none'
+
+  include_examples 'magic comment', '# xyz shareable_constant_value: literal'
+
+  include_examples 'magic comment', '# xyz shareable_constant_value: literal xyz'
+
+  include_examples(
+    'magic comment',
+    '# shareable_constant_value: experimental_everything',
+    shareable_constant_value: 'experimental_everything'
+  )
+
+  include_examples(
+    'magic comment',
+    '# shareable_constant_value: experimental_copy',
+    shareable_constant_value: 'experimental_copy'
+  )
 
   include_examples 'magic comment',
                    '# -*- frozen-string-literal: true -*-',


### PR DESCRIPTION
Ruby 3.0 supports [shareable_constant_value](https://docs.ruby-lang.org/en/3.0.0/doc/syntax/comments_rdoc.html#label-shareable_constant_value+Directive)  magic comment. This PR updates Style/MutableConstant to honour shareable_constant_value magic comment.

Fixes [#9328](https://github.com/rubocop/rubocop/issues/9328)

Took PR [9410](https://github.com/rubocop/rubocop/pull/9410) as reference. Tried to add @caalberts as co-author in changelog, but changelog spec fails.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
