### PR TITLE
Support Ruby 2.7's pattern matching for `Lint/DuplicateBranch`

### DIFF
--- a/changelog/new_add_pattern_matching_doc_and_test_for_lint_duplicate_branch.md
+++ b/changelog/new_add_pattern_matching_doc_and_test_for_lint_duplicate_branch.md
@@ -1,0 +1,1 @@
+* [#9930](https://github.com/rubocop/rubocop/pull/9930): Support Ruby 2.7's pattern matching for `Lint/DuplicateBranch` cop. ([@koic][])

--- a/lib/rubocop/cop/lint/duplicate_branch.rb
+++ b/lib/rubocop/cop/lint/duplicate_branch.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Lint
       # This cop checks that there are no repeated bodies
-      # within `if/unless`, `case-when` and `rescue` constructs.
+      # within `if/unless`, `case-when`, `case-in` and `rescue` constructs.
       #
       # With `IgnoreLiteralBranches: true`, branches are not registered
       # as offenses if they return a basic literal value (string, symbol,
@@ -97,6 +97,7 @@ module RuboCop
         end
         alias on_if on_branching_statement
         alias on_case on_branching_statement
+        alias on_case_match on_branching_statement
         alias on_rescue on_branching_statement
 
         private

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
   s.add_runtime_dependency('rexml')
-  s.add_runtime_dependency('rubocop-ast', '>= 1.7.0', '< 2.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 1.8.0', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 3.0')
 


### PR DESCRIPTION
This PR supports Ruby 2.7's pattern matching for `Lint/DuplicateBranch`.

~~When https://github.com/rubocop/rubocop-ast/pull/192 is merged, please remove the `Lint::DuplicateBranch#case_match_branches(node)` private method and use `AST::CaseMatchNode#branches` instead.~~

And this PR uses rubocop/rubocop-ast#192 feature, so it requires RuboCop AST 1.8.0 or higher.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
