### PR TITLE
[Fix #9928] Fix a false auto-correct for `Layout/EndAlignment`

### DIFF
--- a/changelog/fix_false_autocorrection_for_layout_end_alignment.md
+++ b/changelog/fix_false_autocorrection_for_layout_end_alignment.md
@@ -1,0 +1,1 @@
+* [#9928](https://github.com/rubocop/rubocop/issues/9928): Fix an infinite loop error and a false auto-correction behavior for `Layout/EndAlignment` when using operator methods and `EnforcedStyleAlignWith: variable`. ([@koic][])

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -167,7 +167,8 @@ module RuboCop
         def alignment_node_for_variable_style(node)
           return node.parent if node.case_type? && node.argument?
 
-          assignment = node.ancestors.find(&:assignment_or_similar?)
+          assignment = assignment_or_operator_method(node)
+
           if assignment && !line_break_before_keyword?(assignment.source_range, node)
             assignment
           else
@@ -175,6 +176,12 @@ module RuboCop
             # assignment, or if it is but there's a line break between LHS and
             # RHS.
             node
+          end
+        end
+
+        def assignment_or_operator_method(node)
+          node.ancestors.find do |ancestor|
+            ancestor.assignment_or_similar? || ancestor.send_type? && ancestor.operator_method?
           end
         end
       end

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -301,6 +301,44 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
     include_examples 'aligned', 'puts 1; while',  'Test',     '        end'
     include_examples 'aligned', 'puts 1; until',  'Test',     '        end'
     include_examples 'aligned', 'puts 1; case',   'a when b', '        end'
+
+    it 'register an offense when using `+` operator method and `end` is not aligned' do
+      expect_offense(<<~RUBY)
+        variable + if condition
+                     foo
+                   else
+                     bar
+                   end
+                   ^^^ `end` at 5, 11 is not aligned with `variable + if` at 1, 0.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        variable + if condition
+                     foo
+                   else
+                     bar
+        end
+      RUBY
+    end
+
+    it 'register an offense when using `-` operator method and `end` is not aligned' do
+      expect_offense(<<~RUBY)
+        variable - if condition
+                     foo
+                   else
+                     bar
+                   end
+                   ^^^ `end` at 5, 11 is not aligned with `variable - if` at 1, 0.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        variable - if condition
+                     foo
+                   else
+                     bar
+        end
+      RUBY
+    end
   end
 
   context 'correct + opposite' do


### PR DESCRIPTION
Fixes #9928.

This PR fixes an infinite loop error and a false auto-correction behavior for `Layout/EndAlignment` when using operator methods and `EnforcedStyleAlignWith: variable`.
This infinite loop error is due to an offense being registered but not auto-corrected.

`EnforcedStyleAlignWith: variable` enforces alignment to variable, it should be auto-corrected to be aligned to variable even when operator method is used.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
