### PR TITLE
Fixup GitHub Actions formatter when run in non-default directory

### DIFF
--- a/changelog/fix_github_actions_in_non_default_directory.md
+++ b/changelog/fix_github_actions_in_non_default_directory.md
@@ -1,0 +1,1 @@
+* [#9933](https://github.com/rubocop/rubocop/pull/9933): Fix GitHub Actions formatter when running in non-default directory. ([@ojab][])

--- a/lib/rubocop/formatter/git_hub_actions_formatter.rb
+++ b/lib/rubocop/formatter/git_hub_actions_formatter.rb
@@ -33,7 +33,7 @@ module RuboCop
         output.printf(
           "\n::%<severity>s file=%<file>s,line=%<line>d,col=%<column>d::%<message>s\n",
           severity: github_severity(offense),
-          file: file,
+          file: PathUtil.smart_path(file),
           line: offense.line,
           column: offense.real_column,
           message: github_escape(offense.message)

--- a/spec/rubocop/formatter/git_hub_actions_formatter_spec.rb
+++ b/spec/rubocop/formatter/git_hub_actions_formatter_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe RuboCop::Formatter::GitHubActionsFormatter, :config do
       end
     end
 
+    context 'when file is relative to the current directory' do
+      let(:file) { "#{Dir.pwd}/path/to/file" }
+
+      it 'reports offenses as error with the relative path' do
+        expect(output.string)
+          .to include('::error file=path/to/file,line=1,col=1::This is a message.')
+      end
+    end
+
     context 'when no offenses are detected' do
       let(:offenses) { [] }
 


### PR DESCRIPTION
In some cases (specifically when running inside the container with
non-default `working-directory`) GitHub cannot link absolute paths
produced by formatter to the code, while relative [to the project root] 
paths works.

Output relative paths if they're inside current directory, so this
usecase is covered.

I can craft a public repo with reproducer, since I see this issue in private repo, but hopefully you believe me ._.
I doubt that we should care about usecases outside of GHA, so this PR could break reporting only if project is checked out into non-default directory and `rubocop` runs from some outer directory (i. e. not from the project root), but such cases should be trivially fixable by changing `working-directory`. 

In the case in question it's unfixable or non-trivially fixable because GHA message<->code matching rules are non-public.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* n/a Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
