### PR TITLE
[Fix #9752] Improve error message for top level department

### DIFF
--- a/changelog/fix_error_message_for_dept.md
+++ b/changelog/fix_error_message_for_dept.md
@@ -1,0 +1,1 @@
+* [#9752](https://github.com/rubocop/rubocop/issues/9752): Improve error message for top level department used in configuration. ([@jonas054][])

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1380,6 +1380,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         Layout/LyneLenth:
           Enabled: true
           Max: 100
+        Linth:
+          Enabled: false
         Lint/LiteralInCondition:
           Enabled: true
         Style/AlignHash:
@@ -1389,11 +1391,13 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect(cli.run(%w[--format simple example])).to eq(2)
       expect($stderr.string)
         .to eq(<<~OUTPUT)
-          Error: unrecognized cop Layout/LyneLenth found in example/.rubocop.yml
+          Error: unrecognized cop or department Layout/LyneLenth found in example/.rubocop.yml
           Did you mean `Layout/LineLength`?
-          unrecognized cop Lint/LiteralInCondition found in example/.rubocop.yml
+          unrecognized cop or department Linth found in example/.rubocop.yml
+          Did you mean `Lint`?
+          unrecognized cop or department Lint/LiteralInCondition found in example/.rubocop.yml
           Did you mean `Lint/LiteralAsCondition`?
-          unrecognized cop Style/AlignHash found in example/.rubocop.yml
+          unrecognized cop or department Style/AlignHash found in example/.rubocop.yml
           Did you mean `Style/Alias`, `Style/OptionHash`?
         OUTPUT
     end
@@ -1688,7 +1692,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         YAML
         expect(cli.run(['example1.rb'])).to eq(2)
         expect($stderr.string.strip).to eq(
-          'Error: unrecognized cop Syntax/Whatever found in .rubocop.yml'
+          'Error: unrecognized cop or department Syntax/Whatever found in .rubocop.yml'
         )
       end
     end

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe RuboCop::Config do
       it 'raises an validation error' do
         expect { configuration }.to raise_error(
           RuboCop::ValidationError,
-          'unrecognized cop LyneLenth found in .rubocop.yml'
+          'unrecognized cop or department LyneLenth found in .rubocop.yml'
         )
       end
     end


### PR DESCRIPTION
This is a smaller change that the one suggested in #9752. Instead of allowing to use top level departments in configuration, I just made a better error message. I think this change has a lower risk of causing new problems down the line.

When there are cop departments that seem to have a structure, like in the cookstyle gem where departments are named `Chef/Style`, `Chef/Correctness`, etc., it's easy to assume that there is a `Chef` department that can disable all departments under it. This is not the case, but the error message `Error: unrecognized cop Chef found in .cookstyle.yml` is not informative enough.

If an unrecognized cop or department is the first part of existing departments, we list the existing departments. This should help the user realize what needs to be changed. Example:
```
Error: unrecognized cop or department Chef found in .rubocop.yml
Chef is not a department. Use `Chef/Style`, `Chef/Deprecations`, `Chef/Sharing`, `Chef/Correctness`, `Chef/Modernize`, `Chef/Effortless`, `Chef/RedundantCode`.
```

Also, we change the wording of `unrecognized cop` to `unrecognized cop or department`, and extend the did-you-mean functionality to also look for similar department names.