### PR TITLE
[Fix #9922] Replace extra disable directives with comma

### DIFF
--- a/changelog/fix_autocorrect_in_Style_DoubleCopDisableDirective.md
+++ b/changelog/fix_autocorrect_in_Style_DoubleCopDisableDirective.md
@@ -1,0 +1,1 @@
+* [#9922](https://github.com/rubocop/rubocop/issues/9922): Make better auto-corrections in `Style/DoubleCopDisableDirective`. ([@jonas054][])

--- a/lib/rubocop/cop/style/double_cop_disable_directive.rb
+++ b/lib/rubocop/cop/style/double_cop_disable_directive.rb
@@ -36,13 +36,7 @@ module RuboCop
             next unless comment.text.scan(/# rubocop:(?:disable|todo)/).size > 1
 
             add_offense(comment) do |corrector|
-              prefix = if comment.text.start_with?('# rubocop:disable')
-                         '# rubocop:disable'
-                       else
-                         '# rubocop:todo'
-                       end
-
-              corrector.replace(comment, comment.text[/#{prefix} \S+/])
+              corrector.replace(comment, comment.text.gsub(%r{ # rubocop:(disable|todo)}, ','))
             end
           end
         end

--- a/spec/rubocop/cli/disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/disable_uncorrectable_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
             class Chess
               # rubocop:todo Metrics/MethodLength
               # rubocop:todo Metrics/AbcSize
-              def choose_move(who_to_move) # rubocop:todo Metrics/CyclomaticComplexity
+              def choose_move(who_to_move) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength
                 legal_moves = all_legal_moves_that_dont_put_me_in_check(who_to_move)
 
                 return nil if legal_moves.empty?

--- a/spec/rubocop/cop/style/double_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/style/double_cop_disable_directive_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RuboCop::Cop::Style::DoubleCopDisableDirective, :config do
     RUBY
 
     expect_correction(<<~RUBY)
-      def choose_move(who_to_move) # rubocop:disable Metrics/CyclomaticComplexity
+      def choose_move(who_to_move) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength
       end
     RUBY
   end
@@ -22,7 +22,7 @@ RSpec.describe RuboCop::Cop::Style::DoubleCopDisableDirective, :config do
     RUBY
 
     expect_correction(<<~RUBY)
-      def choose_move(who_to_move) # rubocop:todo Metrics/CyclomaticComplexity
+      def choose_move(who_to_move) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength
       end
     RUBY
   end


### PR DESCRIPTION
Just removing cop names from disable directives is not a good solution. It's bound to cause infinite loop errors when those cops try to add the disable directives back. The natural solution is to put in commas instead.