### PR TITLE
Fix an incorrect auto-correct for `Layout/LineLength`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_layout_line_length.md
+++ b/changelog/fix_incorrect_autocorrect_for_layout_line_length.md
@@ -1,0 +1,1 @@
+* [#9938](https://github.com/rubocop/rubocop/pull/9938): Fix an incorrect auto-correct for `Layout/LineLength` when a heredoc is used as the first element of an array. ([@koic][])

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -97,9 +97,9 @@ module RuboCop
       # If a send node contains a heredoc argument, splitting cannot happen
       # after the heredoc or else it will cause a syntax error.
       def shift_elements_for_heredoc_arg(node, elements, index)
-        return index unless node.send_type?
+        return index unless node.send_type? || node.array_type?
 
-        heredoc_index = elements.index { |arg| (arg.str_type? || arg.dstr_type?) && arg.heredoc? }
+        heredoc_index = elements.index { |arg| arg.respond_to?(:heredoc?) && arg.heredoc? }
         return index unless heredoc_index
         return nil if heredoc_index.zero?
 

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -779,6 +779,16 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           expect_no_corrections
         end
 
+        it 'does not break up the line when a heredoc is used as the first element of an array' do
+          expect_offense(<<~RUBY)
+            [<<~STRING, { key1: value1, key2: value2 }]
+                                                    ^^^ Line is too long. [43/40]
+            STRING
+          RUBY
+
+          expect_no_corrections
+        end
+
         context 'and other arguments before the heredoc' do
           it 'can break up the line before the heredoc argument' do
             args = 'x' * 20


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Layout/LineLength` when a heredoc is used as the first element of an array.

```console
% cat example.rb
[<<~STRING, { key1: value1, key2: value2 }]
STRING

% ruby -c example.rb
Syntax OK

% cat .rubocop.yml
Layout/LineLength:
  Max: 40

% bundle exec rubocop --only Layout/LineLength example.rb -a
(snip)

Inspecting 1 file
C

Offenses:

example.rb:1:41: C: [Corrected] Layout/LineLength: Line is too long. [43/40]
[<<~STRING, { key1: value1, key2: value2 }]
                                        ^^^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
[<<~STRING,
{ key1: value1, key2: value2 }]
STRING

% ruby -c example.rb
example.rb:1: syntax error, unexpected end-of-input, expecting ']'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
