### PR TITLE
[Fix #9940] Fix an incorrect auto-correct for `Style/HashTransformValues`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_hash_transform_values.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_hash_transform_values.md
@@ -1,0 +1,1 @@
+* [#9940](https://github.com/rubocop/rubocop/issues/9940): Fix an incorrect auto-correct for `Style/HashTransformValues` when value is a hash literal for `_.to_h{...}`. ([@koic][])

--- a/lib/rubocop/cop/mixin/hash_transform_method.rb
+++ b/lib/rubocop/cop/mixin/hash_transform_method.rb
@@ -175,7 +175,12 @@ module RuboCop
         end
 
         def set_new_body_expression(transforming_body_expr, corrector)
-          corrector.replace(block_node.body, transforming_body_expr.loc.expression.source)
+          body_source = transforming_body_expr.loc.expression.source
+          if transforming_body_expr.hash_type? && !transforming_body_expr.braces?
+            body_source = "{ #{body_source} }"
+          end
+
+          corrector.replace(block_node.body, body_source)
         end
       end
     end

--- a/spec/rubocop/cop/style/hash_transform_values_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_values_spec.rb
@@ -211,6 +211,28 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
       RUBY
     end
 
+    it 'register and corrects an offense _.to_h{...} when value is a hash literal and is enclosed in braces' do
+      expect_offense(<<~RUBY)
+        {a: 1, b: 2}.to_h { |key, val| [key, { value: val }] }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        {a: 1, b: 2}.transform_values { |val| { value: val } }
+      RUBY
+    end
+
+    it 'register and corrects an offense _.to_h{...} when value is a hash literal and is not enclosed in braces' do
+      expect_offense(<<~RUBY)
+        {a: 1, b: 2}.to_h { |key, val| [key, value: val] }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        {a: 1, b: 2}.transform_values { |val| { value: val } }
+      RUBY
+    end
+
     it 'does not flag `_.to_h{...}` when both key & value are transformed' do
       expect_no_offenses(<<~RUBY)
         x.to_h { |k, v| [k.to_sym, foo(v)] }


### PR DESCRIPTION
Fixes #9940.

This PR fixes an incorrect auto-correct for `Style/HashTransformValues` when value is a hash literal for `_.to_h{...}`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
