### PR TITLE
Fix/hash as last array item

### DIFF
--- a/lib/rubocop/cop/style/hash_as_last_array_item.rb
+++ b/lib/rubocop/cop/style/hash_as_last_array_item.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'byebug'
 
 module RuboCop
   module Cop
@@ -76,8 +75,8 @@ module RuboCop
           return if node.children.empty? # Empty hash cannot be "unbraced"
 
           add_offense(node, message: 'Omit the braces around the hash.') do |corrector|
+            remove_last_element_trailing_comma(corrector, node.parent)
             corrector.remove(node.loc.begin)
-            remove_last_element_trailing_comma(corrector, node)
             corrector.remove(node.loc.end)
           end
         end

--- a/lib/rubocop/cop/style/hash_as_last_array_item.rb
+++ b/lib/rubocop/cop/style/hash_as_last_array_item.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'byebug'
 
 module RuboCop
   module Cop
@@ -29,6 +30,7 @@ module RuboCop
       #   # good
       #   [{ one: 1 }, { two: 2 }]
       class HashAsLastArrayItem < Base
+        include RangeHelp
         include ConfigurableEnforcedStyle
         extend AutoCorrector
 
@@ -75,12 +77,22 @@ module RuboCop
 
           add_offense(node, message: 'Omit the braces around the hash.') do |corrector|
             corrector.remove(node.loc.begin)
+            remove_last_element_trailing_comma(corrector, node)
             corrector.remove(node.loc.end)
           end
         end
 
         def braces_style?
           style == :braces
+        end
+
+        def remove_last_element_trailing_comma(corrector, node)
+          range = range_with_surrounding_space(
+            range: node.children.last.source_range,
+            side: :right
+          ).end.resize(1)
+          
+          corrector.remove(range) if range.source == ','
         end
       end
     end

--- a/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
+++ b/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
@@ -54,6 +54,40 @@ RSpec.describe RuboCop::Cop::Style::HashAsLastArrayItem, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when hash with braces and trailing comma' do
+      expect_offense(<<~RUBY)
+        [1, 2, { one: 1, two: 2, },]
+               ^^^^^^^^^^^^^^^^^^^ Omit the braces around the hash.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2,  one: 1, two: 2 ,]
+      RUBY
+    end
+
+    it 'registers an offense and corrects when hash with braces and trailing comma and new line' do
+      expect_offense(<<~RUBY)
+        [
+          1,
+          2,
+          {
+          ^ Omit the braces around the hash.
+            one: 1,
+            two: 2,
+          },
+        ]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [
+          1,
+          2,
+          one: 1,
+          two: 2,
+        ]
+      RUBY
+    end
+
     it 'does not register an offense when hash without braces' do
       expect_no_offenses(<<~RUBY)
         [1, 2, one: 1, two: 2]

--- a/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
+++ b/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::Cop::Style::HashAsLastArrayItem, :config do
       RUBY
 
       expect_correction(<<~RUBY)
-        [1, 2,  one: 1, two: 2 ,]
+        [1, 2,  one: 1, two: 2, ]
       RUBY
     end
 
@@ -82,8 +82,10 @@ RSpec.describe RuboCop::Cop::Style::HashAsLastArrayItem, :config do
         [
           1,
           2,
-          one: 1,
-          two: 2,
+          
+            one: 1,
+            two: 2,
+          
         ]
       RUBY
     end


### PR DESCRIPTION
**Fix autocorrect bug with HashAsLastArrayItem**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
