### PR TITLE
Support Ruby 2.7's pattern matching for `Style/ConditionalAssignment`

### DIFF
--- a/changelog/new_support_pattern_matching_for_style_conditional_assignment.md
+++ b/changelog/new_support_pattern_matching_for_style_conditional_assignment.md
@@ -1,0 +1,1 @@
+* [#9948](https://github.com/rubocop/rubocop/pull/9948): Support Ruby 2.7's pattern matching for `Style/ConditionalAssignment` cop. ([@koic][])

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -126,6 +126,33 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
       RUBY
     end
 
+    context '>= Ruby 2.7', :ruby27 do
+      it 'registers an offense for assigning any variable type to case in' do
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable} = case foo
+          ^{variable}^^^^^^^^^^^ Assign variables inside of conditionals
+                        in "a"
+                          1
+                        in "b"
+                          2
+                        else
+                          3
+                        end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          case foo
+          in "a"
+            #{variable} = 1
+          in "b"
+            #{variable} = 2
+          else
+            #{variable} = 3
+          end
+        RUBY
+      end
+    end
+
     it 'does not crash for rescue assignment' do
       expect_no_offenses(<<~RUBY)
         begin

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -271,6 +271,30 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config, :config, :co
             #{indent}end
           RUBY
         end
+
+        context '>= Ruby 2.7', :ruby27 do
+          it 'corrects comparison methods in case in' do
+            expect_offense(<<~RUBY)
+              case foo
+              ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
+              in bar
+                a #{method} b
+              else
+                a #{method} d
+              end
+            RUBY
+
+            indent = ' ' * "a #{method} ".length if indent_end
+            expect_correction(<<~RUBY)
+              a #{method} case foo
+              in bar
+                b
+              else
+                d
+              #{indent}end
+            RUBY
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This PR supports Ruby 2.7's pattern matching for `Style/ConditionalAssignment`.

This `Style/IdenticalConditionalBranches` cop is detecting for `if` and `case`.
Therefore, I think about detecting `case-match` with the cop instead of a new cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
