### PR TITLE
[Fix #9945] Fix heredoc indentation in trailing space corrections

### DIFF
--- a/changelog/fix_heredoc_trailing_spaces.md
+++ b/changelog/fix_heredoc_trailing_spaces.md
@@ -1,0 +1,1 @@
+* [#9945](https://github.com/rubocop/rubocop/issues/9945): Fix auto-correction of lines in heredocs with only spaces in `Layout/TrailingWhitespace`. ([@jonas054][])

--- a/lib/rubocop/cop/layout/heredoc_indentation.rb
+++ b/lib/rubocop/cop/layout/heredoc_indentation.rb
@@ -143,13 +143,6 @@ module RuboCop
           indent_level(base_line)
         end
 
-        def indent_level(str)
-          indentations = str.lines
-                            .map { |line| line[/^\s*/] }
-                            .reject { |line| line.end_with?("\n") }
-          indentations.empty? ? 0 : indentations.min_by(&:size).size
-        end
-
         # Returns '~', '-' or nil
         def heredoc_indent_type(node)
           node.source[/^<<([~-])/, 1]

--- a/lib/rubocop/cop/layout/trailing_whitespace.rb
+++ b/lib/rubocop/cop/layout/trailing_whitespace.rb
@@ -41,6 +41,7 @@ module RuboCop
       #
       class TrailingWhitespace < Base
         include RangeHelp
+        include Heredoc
         extend AutoCorrector
 
         MSG = 'Trailing whitespace detected.'
@@ -54,6 +55,8 @@ module RuboCop
           end
         end
 
+        def on_heredoc(_node); end
+
         private
 
         def process_line(line, lineno)
@@ -63,11 +66,31 @@ module RuboCop
           range = offense_range(lineno, line)
           add_offense(range) do |corrector|
             if heredoc
-              corrector.wrap(range, "\#{'", "'}") unless static?(heredoc)
+              process_line_in_heredoc(corrector, range, heredoc)
             else
               corrector.remove(range)
             end
           end
+        end
+
+        def process_line_in_heredoc(corrector, range, heredoc)
+          indent_level = indent_level(find_heredoc(range.line).loc.heredoc_body.source)
+          whitespace_only = whitespace_only?(range)
+          if whitespace_only && whitespace_is_indentation?(range, indent_level)
+            corrector.remove(range)
+          elsif !static?(heredoc)
+            range = range_between(range.begin_pos + indent_level, range.end_pos) if whitespace_only
+            corrector.wrap(range, "\#{'", "'}")
+          end
+        end
+
+        def whitespace_is_indentation?(range, level)
+          range.source[/ +/].length <= level
+        end
+
+        def whitespace_only?(range)
+          source = range_with_surrounding_space(range: range).source
+          source.start_with?("\n") && source.end_with?("\n")
         end
 
         def static?(heredoc)

--- a/lib/rubocop/cop/mixin/heredoc.rb
+++ b/lib/rubocop/cop/mixin/heredoc.rb
@@ -20,6 +20,13 @@ module RuboCop
 
       private
 
+      def indent_level(str)
+        indentations = str.lines
+                          .map { |line| line[/^\s*/] }
+                          .reject { |line| line.end_with?("\n") }
+        indentations.empty? ? 0 : indentations.min_by(&:size).size
+      end
+
       def delimiter_string(node)
         node.source.match(OPENING_DELIMITER).captures[1]
       end

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -144,6 +144,49 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
       RUBY
     end
 
+    it 'corrects by removing trailing whitespace used for indentation in a heredoc string' do
+      expect_offense(<<~RUBY)
+        x = <<~EXAMPLE
+          no trailing
+         #{trailing_whitespace}
+        ^^ Trailing whitespace detected.
+          no trailing
+        #{trailing_whitespace}
+        ^ Trailing whitespace detected.
+          no trailing
+        EXAMPLE
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x = <<~EXAMPLE
+          no trailing
+
+          no trailing
+
+          no trailing
+        EXAMPLE
+      RUBY
+    end
+
+    it 'corrects a whitespace line in a heredoc string that is longer than the indentation' do
+      expect_offense(<<~RUBY)
+        x = <<~EXAMPLE
+          no trailing
+          #{trailing_whitespace}
+        ^^^ Trailing whitespace detected.
+          no trailing
+        EXAMPLE
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x = <<~EXAMPLE
+          no trailing
+          \#{' '}
+          no trailing
+        EXAMPLE
+      RUBY
+    end
+
     it 'does not correct trailing whitespace in a static heredoc string' do
       expect_offense(<<~RUBY)
         x = <<~'EXAMPLE'


### PR DESCRIPTION
Whitespace-only lines within heredocs that are shorter than the indentation level, or equal to it, should be removed when correcting trailing whitespace. Inserting string interpolation tokens on these lines changes the indentation level for squiggly heredocs.

Although I mentioned in #9945 that `Layout/HeredocIndentation` does some unnecessary changes to empty lines within heredocs, I've chosen to only fix the actual bug here, which is in `Layout/TrailingWhitespace`. If both these cops are enabled, `Layout/TrailingWhitespace` will clean up after `Layout/HeredocIndentation` to make the code both readable and correct.