### PR TITLE
[Fix #9150] Escape curly brackets in docs

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2532,7 +2532,7 @@ Naming/HeredocDelimiterNaming:
   Enabled: true
   VersionAdded: '0.50'
   ForbiddenDelimiters:
-    - !ruby/regexp '/(^|\s)(EO[A-Z]{1}|END)(\s|$)/'
+    - !ruby/regexp '/(^|\s)(EO[A-Z]\{1\}|END)(\s|$)/'
 
 Naming/InclusiveLanguage:
   Description: 'Recommend the use of inclusive language instead of problematic terms.'
@@ -3210,7 +3210,7 @@ Style/Copyright:
   Description: 'Include a copyright notice in each file before any code.'
   Enabled: false
   VersionAdded: '0.30'
-  Notice: '^Copyright (\(c\) )?2[0-9]{3} .+'
+  Notice: '^Copyright (\(c\) )?2[0-9]\{3\} .+'
   AutocorrectNotice: ''
 
 Style/DateTime:
@@ -4931,7 +4931,7 @@ Style/WordArray:
   # whose element count is greater than or equal to `MinSize`.
   MinSize: 2
   # The regular expression `WordRegex` decides what is considered a word.
-  WordRegex: !ruby/regexp '/\A(?:\p{Word}|\p{Word}-\p{Word}|\n|\t)+\z/'
+  WordRegex: !ruby/regexp '/\A(?:\p\{Word\}|\p\{Word\}-\p\{Word\}|\n|\t)+\z/'
 
 Style/YodaCondition:
   Description: 'Forbid or enforce yoda conditions.'

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -72,8 +72,8 @@ module RuboCop
     #
     #   expect_no_corrections
     #
-    # If your code has variables of different lengths, you can use `%{foo}`,
-    # `^{foo}`, and `_{foo}` to format your template; you can also abbreviate
+    # If your code has variables of different lengths, you can use `%\{foo\}`,
+    # `^\{foo\}`, and `_\{foo\}` to format your template; you can also abbreviate
     # offense messages with `[...]`:
     #
     #   %w[raise fail].each do |keyword|


### PR DESCRIPTION
Escape curly brackets in docs as mentioned in https://github.com/rubocop/rubocop/issues/9150#issuecomment-873131561. 

ex. 
`{foo}` => `\{foo\}`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
