### PR TITLE
Fix `inherit_mode` for arrays in extension default

### DIFF
--- a/changelog/fix_inherit_mode-for-extensions.md
+++ b/changelog/fix_inherit_mode-for-extensions.md
@@ -1,0 +1,1 @@
+* [#9952](https://github.com/rubocop/rubocop/pull/9952) [rubocop-rspec#1126](https://github.com/rubocop/rubocop-rspec/issues/1126): Fix `inherit_mode` for deeply nested configuration defined in extensions' default configuration. ([@pirj][])


### PR DESCRIPTION
See https://github.com/rubocop/rubocop-rspec/issues/1126

`config/default.yml`:
```yaml
RSpec:
  Language:
    Examples:
      inherit_mode:
        merge:
          - Regular
      Regular:
        - it
        - specify
        - example
        - scenario
        - its
```

`.rubocop.yml`:
```yaml
require:
  - rubocop-rspec

RSpec:
  Language:
    Examples:
      Regular:
        - mycustomexamplealias
```

Previously, locally-set `inherit_mode` in extension default configuration was not respected.


I'd love a preliminary review. If you're fine with the approach, I'll add a proper test coverage.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/