### PR TITLE
[Fix #9954] Fix an infinite loop error for `Layout/HashAlignment`

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_layout_hash_alignment.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_hash_alignment.md
@@ -1,0 +1,1 @@
+* [#9954](https://github.com/rubocop/rubocop/issues/9954): Fix infinite loop error for `Layout/HashAlignment` when `EnforcedStyle: with_fixed_indentation` is specified for `Layout/ArgumentAlignment`. ([@koic][])

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -218,9 +218,13 @@ module RuboCop
         private
 
         def autocorrect_incompatible_with_other_cops?(node)
-          enforce_first_argument_with_fixed_indentation? &&
-            node.pairs.any? &&
-            node.parent&.call_type? && node.parent.loc.selector&.line == node.pairs.first.loc.line
+          return false unless enforce_first_argument_with_fixed_indentation? &&
+                              node.pairs.any? &&
+                              node.parent&.call_type?
+
+          parent_loc = node.parent.loc
+          selector = parent_loc.selector || parent_loc.expression
+          selector.line == node.pairs.first.loc.line
         end
 
         def reset!

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1875,6 +1875,9 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       foo
        .do_something(foo: bar,
                      baz: qux)
+
+      do_something.(foo: bar, baz: qux,
+                    quux: corge)
     RUBY
 
     create_file('.rubocop.yml', <<~YAML)
@@ -1898,6 +1901,9 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       foo
        .do_something(foo: bar,
          baz: qux)
+
+      do_something.(foo: bar, baz: qux,
+        quux: corge)
     RUBY
   end
 


### PR DESCRIPTION
Fixes #9954.

This PR fixes an infinite loop error for `Layout/HashAlignment` when `EnforcedStyle: with_fixed_indentation` is specified for `Layout/ArgumentAlignment`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
