### PR TITLE
[Fix #9953] Fix a false auto-correction behavior for `Layout/EndAlignment`

### DIFF
--- a/changelog/fix_a_false_autocorrection_for_layout_end_alignment.md
+++ b/changelog/fix_a_false_autocorrection_for_layout_end_alignment.md
@@ -1,0 +1,1 @@
+* [#9953](https://github.com/rubocop/rubocop/issues/9953): Fix an infinite loop error and a false auto-correction behavior for `Layout/EndAlignment` when using a conditional statement in a method argument. ([@koic][])

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -165,7 +165,8 @@ module RuboCop
         end
 
         def alignment_node_for_variable_style(node)
-          return node.parent if node.case_type? && node.argument?
+          return node.parent if node.case_type? && node.argument? &&
+                                node.loc.line == node.parent.loc.line
 
           assignment = assignment_or_operator_method(node)
 

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -339,6 +339,31 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
         end
       RUBY
     end
+
+    it 'register an offense when using a conditional statement in a method argument and `end` is not aligned' do
+      expect_offense(<<~RUBY)
+        format(
+          case condition
+          when foo
+            bar
+          else
+            baz
+        end, qux
+        ^^^ `end` at 7, 0 is not aligned with `case` at 2, 2.
+        )
+      RUBY
+
+      expect_correction(<<~RUBY)
+        format(
+          case condition
+          when foo
+            bar
+          else
+            baz
+          end, qux
+        )
+      RUBY
+    end
   end
 
   context 'correct + opposite' do


### PR DESCRIPTION
Fixes #9953.

Fix an infinite loop error and a false auto-correction behavior for `Layout/EndAlignment` when using a conditional statement in a method argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
