### PR TITLE
[Fix #9588] Fix causing a variable to be shadowed from outside the rescue block

### DIFF
--- a/changelog/fix_causing_a_variable_to_be_shadowed.md
+++ b/changelog/fix_causing_a_variable_to_be_shadowed.md
@@ -1,0 +1,1 @@
+* [#9588](https://github.com/rubocop/rubocop/issues/9588): Fix causing a variable to be shadowed from outside the rescue block in the logic of Naming/RescuedExceptionsVariableName. ([@lilisako][])

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -75,6 +75,9 @@ module RuboCop
           preferred_name = preferred_name(offending_name)
           return if preferred_name.to_sym == offending_name
 
+          # check variable shadowing for exception variable
+          return if shadowed_variable_name?(node)
+
           range = offense_range(node)
           message = message(node)
 
@@ -149,6 +152,10 @@ module RuboCop
           offending_name = variable_name(node)
           preferred_name = preferred_name(offending_name)
           format(MSG, preferred: preferred_name, bad: offending_name)
+        end
+
+        def shadowed_variable_name?(node)
+          node.each_descendant(:lvar).any? { |n| n.children.first.to_s == preferred_name(n) }
         end
       end
     end

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -130,6 +130,19 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
         end
       end
 
+      context 'shadowing an external variable' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            e = 'error message'
+            begin
+              something
+            rescue StandardError => e1
+              log(e, e1)
+            end
+          RUBY
+        end
+      end
+
       context 'with lower letters class name' do
         it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #9588
Fix causing a variable to be shadowed from outside the rescue block. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
