### PR TITLE
Make `Layout/LeadingCommentSpace` aware of `#:nodoc`

### DIFF
--- a/changelog/change_make_layout_leading_comment_space_aware_of_nodoc.md
+++ b/changelog/change_make_layout_leading_comment_space_aware_of_nodoc.md
@@ -1,0 +1,1 @@
+* [#9964](https://github.com/rubocop/rubocop/pull/9964): Make `Layout/LeadingCommentSpace` aware of `#:nodoc`. ([@koic][])

--- a/lib/rubocop/cop/layout/leading_comment_space.rb
+++ b/lib/rubocop/cop/layout/leading_comment_space.rb
@@ -57,7 +57,7 @@ module RuboCop
 
         def on_new_investigation
           processed_source.comments.each do |comment|
-            next unless /\A#+[^#\s=:+-]/.match?(comment.text)
+            next unless /\A#+[^#\s=+-]/.match?(comment.text)
             next if comment.loc.line == 1 && allowed_on_first_line?(comment)
             next if doxygen_comment_style?(comment)
             next if gemfile_ruby_comment?(comment)

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -135,12 +135,20 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
     end
   end
 
-  it 'accepts rdoc syntax' do
-    expect_no_offenses(<<~RUBY)
-      #++
-      #--
-      #:nodoc:
-    RUBY
+  describe 'RDoc syntax' do
+    it 'does not register an offense when using `#++` or `#--`' do
+      expect_no_offenses(<<~RUBY)
+        #++
+        #--
+      RUBY
+    end
+
+    it 'registers an offense when starting `:`' do
+      expect_offense(<<~RUBY)
+        #:nodoc:
+        ^^^^^^^^ Missing space after `#`.
+      RUBY
+    end
   end
 
   it 'accepts sprockets directives' do


### PR DESCRIPTION
This PR makes `Layout/LeadingCommentSpace` aware of `#:nodoc`.

The following mention is the trigger.
https://twitter.com/kamipo/status/1421031611588485121

It seems that there was no definitive comment on whether to allow `#:nodoc:`.

- https://github.com/rubocop/rubocop/issues/277
- https://github.com/rubocop/rubocop/commit/db79146

I've look RDoc doc's example of Ruby 3.0 and it looks to include leading comment space.

```ruby
module MyModule # :nodoc:
  class Input
  end
end

module OtherModule # :nodoc: all
  class Output
  end
end
```

https://docs.ruby-lang.org/en/3.0.0/RDoc/Markup.html#class-RDoc::Markup-label-Controlling+what+is+documented

I also considered making it an option for the presence or absence of leading comment space in `#:nodoc:`, but I think it would be better to consistent it that space is included when possible as the role of cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
