### PR TITLE
[Fix #9957] Add `WholeWord` configuration to `Naming/InclusiveLanguage`'s `FlaggedTerms` config

### DIFF
--- a/changelog/fix_add_wholeword_configuration_to.md
+++ b/changelog/fix_add_wholeword_configuration_to.md
@@ -1,0 +1,1 @@
+* [#9957](https://github.com/rubocop/rubocop/issues/9957): Add `WholeWord` configuration to `Naming/InclusiveLanguage`'s `FlaggedTerms` config. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2557,6 +2557,7 @@ Naming/InclusiveLanguage:
         - denylist
         - block
     slave:
+      WholeWord: true
       Suggestions: ['replica', 'secondary', 'follower']
 
 Naming/MemoizedInstanceVariableName:

--- a/spec/rubocop/cop/naming/inclusive_language_spec.rb
+++ b/spec/rubocop/cop/naming/inclusive_language_spec.rb
@@ -71,6 +71,35 @@ RSpec.describe RuboCop::Cop::Naming::InclusiveLanguage, :config do
         RUBY
       end
     end
+
+    context 'WholeWord: true' do
+      let(:cop_config) do
+        { 'CheckStrings' => true, 'FlaggedTerms' => { 'slave' => { 'WholeWord' => true } } }
+      end
+
+      it 'only flags when the term is a whole word' do
+        expect_offense(<<~RUBY)
+          # infix allowed
+          TeslaVehicle
+          SLAVersion
+          :teslavehicle
+
+          # prefix allowed
+          DatabaseSlave
+
+          # suffix allowed
+          Slave1
+
+          # not allowed
+          Slave
+          ^^^^^ Consider replacing problematic term 'Slave'.
+          :database_slave
+                    ^^^^^ Consider replacing problematic term 'slave'.
+          'database@slave'
+                    ^^^^^ Consider replacing problematic term 'slave'.
+        RUBY
+      end
+    end
   end
 
   context 'allowed use' do


### PR DESCRIPTION
This is a *naive* fix for #9957.

Allows `FlaggedTerms` to be set up to only match against a whole word (and enables it for `slave`). This allows false positives like `SLAVersion` and `TeslaVehicle` to not be flagged by the cop.

However, we don't have an inflector for identifiers, and this cop is explicitly case insensitive, which means that enabling this will also stop flagging partial word matches like `DatabaseSlave`. This really only affects class names since `database_slave` will still be flagged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
