### PR TITLE
[Fix #9958] Prevent an infinite loop when a detected method has fewer arguments than expected

### DIFF
--- a/changelog/fix_prevent_an_infinite_loop_when_a_detected.md
+++ b/changelog/fix_prevent_an_infinite_loop_when_a_detected.md
@@ -1,0 +1,1 @@
+* [#9958](https://github.com/rubocop/rubocop/issues/9958): Prevent an infinite loop when a detected method has fewer arguments than expected. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/single_line_block_params.rb
+++ b/lib/rubocop/cop/style/single_line_block_params.rb
@@ -109,7 +109,9 @@ module RuboCop
           # we remove any leading underscores before comparing.
           actual_args_no_underscores = actual_args.map { |arg| arg.to_s.sub(/^_+/, '') }
 
-          actual_args_no_underscores == target_args(method_name)
+          # Allow the arguments if the names match but not all are given
+          expected_args = target_args(method_name).first(actual_args_no_underscores.size)
+          actual_args_no_underscores == expected_args
         end
       end
     end

--- a/spec/rubocop/cop/style/single_line_block_params_spec.rb
+++ b/spec/rubocop/cop/style/single_line_block_params_spec.rb
@@ -98,4 +98,43 @@ RSpec.describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
       end
     RUBY
   end
+
+  it 'reports an offense if the names are partially correct' do
+    expect_offense(<<~RUBY)
+      test.reduce(x) { |a, b| foo(a, b) }
+                       ^^^^^^ Name `reduce` block params `|a, e|`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      test.reduce(x) { |a, e| foo(a, e) }
+    RUBY
+  end
+
+  it 'reports an offense if the names are in reverse order' do
+    expect_offense(<<~RUBY)
+      test.reduce(x) { |e, a| foo(e, a) }
+                       ^^^^^^ Name `reduce` block params `|a, e|`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      test.reduce(x) { |a, e| foo(a, e) }
+    RUBY
+  end
+
+  it 'does not report if the right names are used but not all arguments are given' do
+    expect_no_offenses(<<~RUBY)
+      test.reduce(x) { |a| foo(a) }
+    RUBY
+  end
+
+  it 'reports an offense if the arguments names are wrong and not all arguments are given' do
+    expect_offense(<<~RUBY)
+      test.reduce(x) { |b| foo(b) }
+                       ^^^ Name `reduce` block params `|a|`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      test.reduce(x) { |a| foo(a) }
+    RUBY
+  end
 end


### PR DESCRIPTION
When a method has fewer block arguments than expected (via the cop's configuration) but the names are correct, an offense is registered but autocorrection doesn't change anything, which leads to an infinite loop.

This change allows blocks with fewer than expected arguments as long as the names are correct.

Fixes #9958.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
