### PR TITLE
[Fix #9955] Fix `Style/ExplicitBlockArgument` adding a second set of parentheses

### DIFF
--- a/changelog/fix_fix_styleexplicitblockargument_adding_a.md
+++ b/changelog/fix_fix_styleexplicitblockargument_adding_a.md
@@ -1,0 +1,1 @@
+* [#9955](https://github.com/rubocop/rubocop/issues/9955): Fix `Style/ExplicitBlockArgument` adding a second set of parentheses. ([@dvandersluis][])

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -46,8 +46,13 @@ module RuboCop
 
       def args_begin(node)
         loc = node.loc
-        selector =
-          node.super_type? || node.yield_type? ? loc.keyword : loc.selector
+        selector = if node.super_type? || node.yield_type?
+                     loc.keyword
+                   elsif node.def_type? || node.defs_type?
+                     loc.name
+                   else
+                     loc.selector
+                   end
         selector.end.resize(1)
       end
 

--- a/spec/rubocop/cop/style/explicit_block_argument_spec.rb
+++ b/spec/rubocop/cop/style/explicit_block_argument_spec.rb
@@ -191,4 +191,49 @@ RSpec.describe RuboCop::Cop::Style::ExplicitBlockArgument, :config do
       end
     RUBY
   end
+
+  it 'does not add extra parens when correcting' do
+    expect_offense(<<~RUBY)
+      def my_method()
+        foo() { yield }
+        ^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY, loop: false)
+      def my_method(&block)
+        foo(&block)
+      end
+    RUBY
+  end
+
+  it 'does not add extra parens to `super` when correcting' do
+    expect_offense(<<~RUBY)
+      def my_method
+        super() { yield }
+        ^^^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY, loop: false)
+      def my_method(&block)
+        super(&block)
+      end
+    RUBY
+  end
+
+  it 'adds to the existing arguments when correcting' do
+    expect_offense(<<~RUBY)
+      def my_method(x)
+        foo(x) { yield }
+        ^^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def my_method(x, &block)
+        foo(x, &block)
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
When `Style/ExplicitBlockArgument` adds the block argument to a `def` or `send` node, if the node already had empty parentheses after it, the corrector would add a second set, ie:

```ruby
def my_method()
  foo { yield }
end
```

would become 

```ruby
def my_method(&block)()
  foo(&block)
end
```

In the original issue, once all these corrections (plus from `Lint/UnusedMethodArgument` and `Style/DefWithParentheses`) were resolved, the method would end up without a block argument.

Fixes #9955.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
