### PR TITLE
[Fix #9959] Make `Style/IdenticalConditionalBranches` able to handle ternary `if`s

### DIFF
--- a/changelog/fix_make_styleidenticalconditionalbranches.md
+++ b/changelog/fix_make_styleidenticalconditionalbranches.md
@@ -1,0 +1,1 @@
+* [#9959](https://github.com/rubocop/rubocop/issues/9959): Make `Style/IdenticalConditionalBranches` able to handle ternary `if`s. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -134,11 +134,13 @@ module RuboCop
           expressions.size > 1 && expressions.uniq.one?
         end
 
-        def check_expressions(node, expressions, insert_position)
+        def check_expressions(node, expressions, insert_position) # rubocop:disable Metrics/MethodLength
           inserted_expression = false
 
           expressions.each do |expression|
             add_offense(expression) do |corrector|
+              next if node.if_type? && node.ternary?
+
               range = range_by_whole_lines(expression.source_range, include_final_newline: true)
               corrector.remove(range)
               next if inserted_expression

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -382,4 +382,16 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
       RUBY
     end
   end
+
+  context 'with a ternary' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        x ? y : y
+                ^ Move `y` out of the conditional.
+            ^ Move `y` out of the conditional.
+      RUBY
+
+      expect_no_corrections
+    end
+  end
 end


### PR DESCRIPTION
`Style/IdenticalConditionalBranches` was choking on ternaries, so this change allows it to register an offense without crashing. Ternaries are not corrected by this change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
