### PR TITLE
Add `InternalAffairs/InheritDeprecatedCopClass` cop

### DIFF
--- a/lib/rubocop/cop/bundler/ordered_gems.rb
+++ b/lib/rubocop/cop/bundler/ordered_gems.rb
@@ -24,7 +24,7 @@ module RuboCop
       #   gem 'rubocop'
       #   # For tests
       #   gem 'rspec'
-      class OrderedGems < Cop
+      class OrderedGems < Cop # rubocop:disable InternalAffairs/InheritDeprecatedCopClass
         include ConfigurableEnforcedStyle
         include OrderedGemNode
 

--- a/lib/rubocop/cop/gemspec/ordered_dependencies.rb
+++ b/lib/rubocop/cop/gemspec/ordered_dependencies.rb
@@ -50,7 +50,7 @@ module RuboCop
       #   spec.add_dependency 'rubocop'
       #   # For tests
       #   spec.add_dependency 'rspec'
-      class OrderedDependencies < Cop
+      class OrderedDependencies < Cop # rubocop:disable InternalAffairs/InheritDeprecatedCopClass
         include ConfigurableEnforcedStyle
         include OrderedGemNode
 

--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -2,6 +2,7 @@
 
 require_relative 'internal_affairs/empty_line_between_expect_offense_and_correction'
 require_relative 'internal_affairs/example_description'
+require_relative 'internal_affairs/inherit_deprecated_cop_class'
 require_relative 'internal_affairs/method_name_equal'
 require_relative 'internal_affairs/node_destructuring'
 require_relative 'internal_affairs/node_matcher_directive'

--- a/lib/rubocop/cop/internal_affairs/inherit_deprecated_cop_class.rb
+++ b/lib/rubocop/cop/internal_affairs/inherit_deprecated_cop_class.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # `RuboCop::Cop::Cop` is deprecated and will be removed in Rubocop 2.0.
+      # Your custom cop class should inherit from `RuboCop::Cop::Base` instead of
+      # `RuboCop::Cop::Cop`.
+      #
+      # See "v1 Upgrade Notes" for more details:
+      # https://docs.rubocop.org/rubocop/v1_upgrade_notes.html
+      #
+      # @example
+      #   # bad
+      #   class Foo < Cop
+      #   end
+      #
+      #   # good
+      #   class Foo < Base
+      #   end
+      #
+      class InheritDeprecatedCopClass < Base
+        MSG = 'Use `Base` instead of `Cop`.'
+
+        def on_class(node)
+          return unless (parent_class = node.parent_class)
+          return unless parent_class.children.last == :Cop
+
+          add_offense(parent_class)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/internal_affairs/inherit_deprecated_cop_class_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/inherit_deprecated_cop_class_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::InternalAffairs::InheritDeprecatedCopClass, :config do
+  it 'registers an offense when using `Cop`' do
+    expect_offense(<<~RUBY)
+      class Foo < Cop
+                  ^^^ Use `Base` instead of `Cop`.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `RuboCop::Cop::Cop`' do
+    expect_offense(<<~RUBY)
+      class Foo < RuboCop::Cop::Cop
+                  ^^^^^^^^^^^^^^^^^ Use `Base` instead of `Cop`.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `Base`' do
+    expect_no_offenses(<<~RUBY)
+      class Foo < Base
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when not inherited super class' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+      end
+    RUBY
+  end
+end

--- a/spec/support/cops/class_must_be_a_module_cop.rb
+++ b/spec/support/cops/class_must_be_a_module_cop.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Test
-      class ClassMustBeAModuleCop < RuboCop::Cop::Cop
+      class ClassMustBeAModuleCop < RuboCop::Cop::Cop # rubocop:disable InternalAffairs/InheritDeprecatedCopClass
         def on_class(node)
           add_offense(node, message: 'Class must be a Module')
         end

--- a/spec/support/cops/module_must_be_a_class_cop.rb
+++ b/spec/support/cops/module_must_be_a_class_cop.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Test
-      class ModuleMustBeAClassCop < RuboCop::Cop::Cop
+      class ModuleMustBeAClassCop < RuboCop::Cop::Cop # rubocop:disable InternalAffairs/InheritDeprecatedCopClass
         def on_module(node)
           add_offense(node, message: 'Module must be a Class')
         end


### PR DESCRIPTION
This PR adds `InternalAffairs/InheritDeprecatedCopClass` cop.

Here is a note of progress towards the V1 API. `Bundler/OrderedGems` and `Gemspec/OrderedDependencies` cops are not migrated to V1 API yet. All cops in rubocop org will be migrated when the two cops are migrated.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
