### PR TITLE
Don't register an offense when sort method has arguments

### DIFF
--- a/changelog/fix_redundant_sort_false_positive.md
+++ b/changelog/fix_redundant_sort_false_positive.md
@@ -1,0 +1,1 @@
+* [#9970](https://github.com/rubocop/rubocop/pull/9970): Don't register an offense when sort method has arguments for `Style/RedundantSort` cop. ([@mtsmfm][])

--- a/lib/rubocop/cop/style/redundant_sort.rb
+++ b/lib/rubocop/cop/style/redundant_sort.rb
@@ -60,8 +60,8 @@ module RuboCop
         # @!method redundant_sort?(node)
         def_node_matcher :redundant_sort?, <<~MATCHER
           {
-            (send $(send _ $:sort ...) ${:last :first})
-            (send $(send _ $:sort ...) ${:[] :at :slice} {(int 0) (int -1)})
+            (send $(send _ $:sort) ${:last :first})
+            (send $(send _ $:sort) ${:[] :at :slice} {(int 0) (int -1)})
 
             (send $(send _ $:sort_by _) ${:last :first})
             (send $(send _ $:sort_by _) ${:[] :at :slice} {(int 0) (int -1)})

--- a/spec/rubocop/cop/style/redundant_sort_spec.rb
+++ b/spec/rubocop/cop/style/redundant_sort_spec.rb
@@ -206,6 +206,11 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort, :config do
     expect_no_offenses('[1, 2, 3].sort.first(1)')
   end
 
+  # Some gems like mongo provides sort method with an argument
+  it 'does not register an offense when sort has an argument' do
+    expect_no_offenses('mongo_client["users"].find.sort(_id: 1).first')
+  end
+
   it 'does not register an offense for sort!.first' do
     expect_no_offenses('[1, 2, 3].sort!.first')
   end
@@ -239,6 +244,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort, :config do
 
     it 'does not register an offense when at(-2) is called on sort_by' do
       expect_no_offenses('[1, 2, 3].sort_by(&:foo).at(-2)')
+    end
+
+    it 'does not register an offense when [-1] is called on sort with an argument' do
+      expect_no_offenses('mongo_client["users"].find.sort(_id: 1)[-1]')
     end
   end
 


### PR DESCRIPTION
Currently, `Style/RedundantSort` doesn't allow `sort(_id: 1).first` and suggests `min(_id: 1)` but it's not equivalent.

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'mongo'
end

mongo_client = Mongo::Client.new('mongodb://mongo/test')
mongo_client['users'].find.sort(_id: 1).first
# => nil

mongo_client['users'].find.min(_id: 1)
# TypeError: no implicit conversion of Hash into Integer
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
~~* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
