### PR TITLE
Workaround for CI build error when using Bundler 2.2.5 on Windows

### DIFF
--- a/spec/rubocop/lockfile_spec.rb
+++ b/spec/rubocop/lockfile_spec.rb
@@ -62,7 +62,9 @@ RSpec.describe RuboCop::Lockfile, :isolated_environment do
 
     it_behaves_like 'error states'
 
-    it 'returns all the dependencies' do
+    # FIXME: Remove `broken_on: windows` when `undefined method `add_dependency_names'
+    #        for nil:NilClass` error of Bundler 2.2.5 on Windows will be resolved.
+    it 'returns all the dependencies', broken_on: :windows do
       expect(names).to contain_exactly('dep', 'rake', 'rspec')
     end
 
@@ -80,7 +82,9 @@ RSpec.describe RuboCop::Lockfile, :isolated_environment do
 
     it_behaves_like 'error states'
 
-    it 'returns all the dependencies' do
+    # FIXME: Remove `broken_on: windows` when `undefined method `add_dependency_names'
+    #        for nil:NilClass` error of Bundler 2.2.5 on Windows will be resolved.
+    it 'returns all the dependencies', broken_on: :windows do
       expect(names).to contain_exactly('dep', 'dep2', 'dep3', 'rake', 'rspec')
     end
 
@@ -94,19 +98,25 @@ RSpec.describe RuboCop::Lockfile, :isolated_environment do
   describe '#includes_gem?' do
     subject { super().includes_gem?(name) }
 
-    context 'for an included dependency' do
+    # FIXME: Remove `broken_on: windows` when `undefined method `add_dependency_names'
+    #        for nil:NilClass` error of Bundler 2.2.5 on Windows will be resolved.
+    context 'for an included dependency', broken_on: :windows do
       let(:name) { 'rake' }
 
       it { is_expected.to eq(true) }
     end
 
-    context 'for an included gem' do
+    # FIXME: Remove `broken_on: windows` when `undefined method `add_dependency_names'
+    #        for nil:NilClass` error of Bundler 2.2.5 on Windows will be resolved.
+    context 'for an included gem', broken_on: :windows do
       let(:name) { 'dep2' }
 
       it { is_expected.to eq(true) }
     end
 
-    context 'for an excluded gem' do
+    # FIXME: Remove `broken_on: windows` when `undefined method `add_dependency_names'
+    #        for nil:NilClass` error of Bundler 2.2.5 on Windows will be resolved.
+    context 'for an excluded gem', broken_on: :windows do
       let(:name) { 'other' }
 
       it { is_expected.to eq(false) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,4 +77,6 @@ RSpec.configure do |config|
   if %w[jruby-9.2-ascii_spec jruby-9.2-spec].include? ENV['CIRCLE_STAGE']
     config.filter_run_excluding broken_on: :jruby
   end
+
+  config.filter_run_excluding(broken_on: :windows) if RuboCop::Platform.windows?
 end


### PR DESCRIPTION
This PR is a workaround for `undefined method 'add_dependency_names' for nil:NilClass` CI build error when using Bundler 2.2.25 on Windows.

```console
Failures:

  1) RuboCop::Lockfile#gems returns all the dependencies
     Failure/Error: @parser = lockfile ?
     Bundler::LockfileParser.new(lockfile) : nil

     NoMethodError:
       undefined method `add_dependency_names' for nil:NilClass
     # ./lib/rubocop/lockfile.rb:35:in `new'
     # ./lib/rubocop/lockfile.rb:35:in `parser'
     # ./lib/rubocop/lockfile.rb:17:in `gems'
     # ./spec/rubocop/lockfile_spec.rb:77:in `block (3 levels) in
       <top (required)>'
     # ./spec/rubocop/lockfile_spec.rb:79:in `block (3 levels) in
       <top (required)>'
  4) RuboCop::Lockfile#includes_gem? for an included dependency
     Failure/Error: @parser = lockfile ?
       Bundler::LockfileParser.new(lockfile) : nil

     NoMethodError:
       undefined method `add_dependency_names' for nil:NilClass
     # ./lib/rubocop/lockfile.rb:35:in `new'
     # ./lib/rubocop/lockfile.rb:35:in `parser'
     # ./lib/rubocop/lockfile.rb:17:in `gems'
     # ./lib/rubocop/lockfile.rb:25:in `includes_gem?'
     # ./spec/rubocop/lockfile_spec.rb:95:in `block (3 levels) in
       <top (required)>'
     # ./spec/rubocop/lockfile_spec.rb:100:in `block (4 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `block (4 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `block (3 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:7:in `block (2 levels) in
       <top (required)>'
     # tasks/spec_runner.rake:32:in `block in run_specs'
     # tasks/spec_runner.rake:44:in `with_encoding'
     # tasks/spec_runner.rake:28:in `run_specs'
     # tasks/spec_runner.rake:115:in `block in <top (required)>'

  5) RuboCop::Lockfile#dependencies returns all the dependencies
     Failure/Error: @parser = lockfile ?
     Bundler::LockfileParser.new(lockfile) : nil

     NoMethodError:
       undefined method `add_dependency_names' for nil:NilClass
     # ./lib/rubocop/lockfile.rb:35:in `new'
     # ./lib/rubocop/lockfile.rb:35:in `parser'
     # ./lib/rubocop/lockfile.rb:10:in `dependencies'
     # ./spec/rubocop/lockfile_spec.rb:59:in `block (3 levels) in
       <top (required)>'
     # ./spec/rubocop/lockfile_spec.rb:61:in `block (3 levels) in
       <top (required)>'
     # ./spec/rubocop/lockfile_spec.rb:66:in `block (3 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `block (4 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `block (3 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:7:in `block (2 levels) in
       <top (required)>'
     # tasks/spec_runner.rake:32:in `block in run_specs'
     # tasks/spec_runner.rake:44:in `with_encoding'
     # tasks/spec_runner.rake:28:in `run_specs'
     # tasks/spec_runner.rake:115:in `block in <top (required)>'

Finished in 4 minutes 9 seconds (files took 3.81 seconds to load)
16350 examples, 5 failures, 14 pending

Failed examples:

rspec ./spec/rubocop/lockfile_spec.rb:83 # RuboCop::Lockfile#gems
returns all the dependencies
rspec ./spec/rubocop/lockfile_spec.rb:112 #
RuboCop::Lockfile#includes_gem? for an excluded gem
rspec ./spec/rubocop/lockfile_spec.rb:106 #
RuboCop::Lockfile#includes_gem? for an included gem
rspec ./spec/rubocop/lockfile_spec.rb:100 #
RuboCop::Lockfile#includes_gem? for an included dependency
rspec ./spec/rubocop/lockfile_spec.rb:65 #
RuboCop::Lockfile#dependencies returns all the dependencies
```

https://github.com/rubocop/rubocop/runs/3211951622

It may be affected by the following Bundler's changes.

bundler/lib/bundler/lockfile_parser.rb:

```diff
        platform = platform ? Gem::Platform.new(platform) :
        Gem::Platform::RUBY
        @current_spec = LazySpecification.new(name, version, platform)
        @current_spec.source = @current_source
+       @current_source.add_dependency_names(name)

        @specs[@current_spec.identifier] = @current_spec
      elsif spaces.size == 6
```

https://github.com/rubygems/rubygems/pull/4782

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
