### PR TITLE
Try fix CI errors on Windows

### DIFF
--- a/spec/rubocop/lockfile_spec.rb
+++ b/spec/rubocop/lockfile_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Lockfile, :isolated_environment do
   let(:lockfile) do
     create_file('Gemfile.lock', <<~LOCKFILE)
       GEM
-        gems:
+        specs:
           rake (13.0.1)
           rspec (3.9.0)
           dep (1.0.0)
@@ -62,9 +62,7 @@ RSpec.describe RuboCop::Lockfile, :isolated_environment do
 
     it_behaves_like 'error states'
 
-    # FIXME: Remove `broken_on: windows` when `undefined method `add_dependency_names'
-    #        for nil:NilClass` error of Bundler 2.2.5 on Windows will be resolved.
-    it 'returns all the dependencies', broken_on: :windows do
+    it 'returns all the dependencies' do
       expect(names).to contain_exactly('dep', 'rake', 'rspec')
     end
 
@@ -82,9 +80,7 @@ RSpec.describe RuboCop::Lockfile, :isolated_environment do
 
     it_behaves_like 'error states'
 
-    # FIXME: Remove `broken_on: windows` when `undefined method `add_dependency_names'
-    #        for nil:NilClass` error of Bundler 2.2.5 on Windows will be resolved.
-    it 'returns all the dependencies', broken_on: :windows do
+    it 'returns all the dependencies' do
       expect(names).to contain_exactly('dep', 'dep2', 'dep3', 'rake', 'rspec')
     end
 
@@ -98,25 +94,19 @@ RSpec.describe RuboCop::Lockfile, :isolated_environment do
   describe '#includes_gem?' do
     subject { super().includes_gem?(name) }
 
-    # FIXME: Remove `broken_on: windows` when `undefined method `add_dependency_names'
-    #        for nil:NilClass` error of Bundler 2.2.5 on Windows will be resolved.
-    context 'for an included dependency', broken_on: :windows do
+    context 'for an included dependency' do
       let(:name) { 'rake' }
 
       it { is_expected.to eq(true) }
     end
 
-    # FIXME: Remove `broken_on: windows` when `undefined method `add_dependency_names'
-    #        for nil:NilClass` error of Bundler 2.2.5 on Windows will be resolved.
-    context 'for an included gem', broken_on: :windows do
+    context 'for an included gem' do
       let(:name) { 'dep2' }
 
       it { is_expected.to eq(true) }
     end
 
-    # FIXME: Remove `broken_on: windows` when `undefined method `add_dependency_names'
-    #        for nil:NilClass` error of Bundler 2.2.5 on Windows will be resolved.
-    context 'for an excluded gem', broken_on: :windows do
+    context 'for an excluded gem' do
       let(:name) { 'other' }
 
       it { is_expected.to eq(false) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,6 +77,4 @@ RSpec.configure do |config|
   if %w[jruby-9.2-ascii_spec jruby-9.2-spec].include? ENV['CIRCLE_STAGE']
     config.filter_run_excluding broken_on: :jruby
   end
-
-  config.filter_run_excluding(broken_on: :windows) if RuboCop::Platform.windows?
 end


### PR DESCRIPTION
Not sure why the failure was specific to Windows, but I think the reason is that these specs were parsing an invalid lockfile. Since the `specs:` section didn't exist, bundler was failing to parse the lockfile source,and then trying to use it while parsing specs, resulting in a method being called on `nil`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
