### PR TITLE
[Fix #9975] Parentheses are always required for `Style/MethodDefParentheses` when a forwarding argument (`...`) is used

### DIFF
--- a/changelog/fix_parentheses_are_always_required_when_a.md
+++ b/changelog/fix_parentheses_are_always_required_when_a.md
@@ -1,0 +1,1 @@
+* [#9975](https://github.com/rubocop/rubocop/issues/9975): Parentheses are always required for `Style/MethodDefParentheses` when a forwarding argument (`...`) is used. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -96,7 +96,7 @@ module RuboCop
         MSG_MISSING = 'Use def with parentheses when there are parameters.'
 
         def on_def(node)
-          return if node.endless?
+          return if forced_parentheses?(node)
 
           args = node.arguments
 
@@ -127,6 +127,15 @@ module RuboCop
           leading_space = range_between(args_with_space.begin_pos, arguments_range.begin_pos)
           corrector.replace(leading_space, '(')
           corrector.insert_after(arguments_range, ')')
+        end
+
+        def forced_parentheses?(node)
+          # Regardless of style, parentheses are necessary for:
+          # 1. Endless methods
+          # 2. Argument lists containing a `forward-arg` (`...`)
+          # Removing the parens would be a syntax error here.
+
+          node.endless? || node.arguments.any?(&:forward_arg_type?)
         end
 
         def require_parentheses?(args)

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -91,6 +91,14 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         def self.test param; end
       RUBY
     end
+
+    it 'requires parens for forwarding', :ruby27 do
+      expect_no_offenses(<<~RUBY)
+        def foo(...)
+          bar(...)
+        end
+      RUBY
+    end
   end
 
   shared_examples 'endless methods' do
@@ -110,6 +118,12 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
       it 'accepts parens for method calls inside an endless method' do
         expect_no_offenses(<<~RUBY)
           def foo(x) = bar(x)
+        RUBY
+      end
+
+      it 'accepts parens with `forward-arg`' do
+        expect_no_offenses(<<~RUBY)
+          def foo(...)= bar(...)
         RUBY
       end
     end


### PR DESCRIPTION
Ruby requires parens around an argument list when argument forwarding is used.

Fixes #9975.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
