### PR TITLE
[Fix #9977] Update `Layout/EmptyLineAfterGuardClause` to not register an offense if there is another expression following the guard clause on the same line

### DIFF
--- a/changelog/fix_skip_autocorrection_for.md
+++ b/changelog/fix_skip_autocorrection_for.md
@@ -1,0 +1,1 @@
+* [#9977](https://github.com/rubocop/rubocop/issues/9977): Update `Layout/EmptyLineAfterGuardClause` to not register an offense if there is another expression following the guard clause on the same line. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
@@ -38,12 +38,14 @@ module RuboCop
       class EmptyLineAfterGuardClause < Base
         include RangeHelp
         extend AutoCorrector
+        extend Util
 
         MSG = 'Add empty line after guard clause.'
         END_OF_HEREDOC_LINE = 1
 
         def on_if(node)
           return if correct_style?(node)
+          return if multiple_statements_on_line?(node)
 
           if node.modifier_form? && (heredoc_node = last_heredoc_argument(node))
             return if next_line_empty_or_enable_directive_comment?(heredoc_line(node, heredoc_node))
@@ -165,6 +167,13 @@ module RuboCop
           else
             node
           end
+        end
+
+        def multiple_statements_on_line?(node)
+          parent = node.parent
+          return false unless parent
+
+          parent.begin_type? && parent.single_line?
         end
       end
     end

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -362,7 +362,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  it 'accpets a guard clause when the next line is `ensure`' do
+  it 'accepts a guard clause when the next line is `ensure`' do
     expect_no_offenses(<<~RUBY)
       def foo
         begin
@@ -374,7 +374,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  it 'accpets a guard clause when the next line is `rescue`-`else`' do
+  it 'accepts a guard clause when the next line is `rescue`-`else`' do
     expect_no_offenses(<<~RUBY)
       def foo
         begin
@@ -400,7 +400,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  it 'accpets a guard clause when the next line is `elsif`' do
+  it 'accepts a guard clause when the next line is `elsif`' do
     expect_no_offenses(<<~RUBY)
       def foo
         if cond
@@ -438,7 +438,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  it 'accpets a guard clause that is after a multiline heredoc with chained calls' do
+  it 'accepts a guard clause that is after a multiline heredoc with chained calls' do
     expect_no_offenses(<<~RUBY)
       def foo
         raise ArgumentError, <<~END.squish.it.good unless guard
@@ -451,7 +451,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  it 'accpets a guard clause that is after a multiline heredoc nested argument call' do
+  it 'accepts a guard clause that is after a multiline heredoc nested argument call' do
     expect_no_offenses(<<~RUBY)
       def foo
         raise ArgumentError, call(<<~END.squish) unless guard

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
+  it 'does not register an offense when the clause is not followed by other code' do
+    expect_no_offenses(<<~RUBY)
+      return unless item.positive?
+    RUBY
+  end
+
   it 'registers an offense and corrects a guard clause not followed by empty line' do
     expect_offense(<<~RUBY)
       def foo
@@ -557,6 +563,42 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
         MSG
 
         baz
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when there are multiple clauses on the same line' do
+    expect_no_offenses(<<~RUBY)
+      def foo(item)
+        return unless item.positive?; item * 2
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the clause ends with a semicolon but the next clause is on the next line' do
+    expect_offense(<<~RUBY)
+      def foo(item)
+        return unless item.positive?;
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+        item * 2
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo(item)
+        return unless item.positive?;
+
+        item * 2
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when the clause ends with a semicolon but is followed by a newline' do
+    expect_no_offenses(<<~RUBY)
+      def foo(item)
+        return unless item.positive?;
+
+        item * 2
       end
     RUBY
   end


### PR DESCRIPTION
`Layout/EmptyLineAfterGuardClause` corrects by adding a blank line after the clause, assuming that it is on its own line (or followed by a comment). However, if there is another statement on the same line, it's not taken into account.

This change does not attempt to correct if the clause is not the last node on the line. It'll leave autocorrection to `Style/Semicolon` (which currently doesn't do this autocorrection either).

Fixes #9977.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
