### PR TITLE
Update `Style/Semicolon` to add autocorrection

### DIFF
--- a/changelog/change_enable_basic_autocorrection_for.md
+++ b/changelog/change_enable_basic_autocorrection_for.md
@@ -1,0 +1,1 @@
+* [#9979](https://github.com/rubocop/rubocop/pull/9979): Enable basic autocorrection for `Style/Semicolon`. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
   it 'registers an offense for one line method with two statements' do
     expect_offense(<<~RUBY)
       def foo(a) x(1); y(2); z(3); end
+                                 ^ Do not use semicolons to terminate expressions.
+                           ^ Do not use semicolons to terminate expressions.
                      ^ Do not use semicolons to terminate expressions.
     RUBY
 

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -20,7 +20,10 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
                            ^ Do not use semicolons to terminate expressions.
     RUBY
 
-    expect_no_corrections
+    expect_correction(<<~RUBY)
+      puts "this is a test"
+       puts "So is this"
+    RUBY
   end
 
   it 'registers an offense for one line method with two statements' do
@@ -31,7 +34,12 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
                      ^ Do not use semicolons to terminate expressions.
     RUBY
 
-    expect_no_corrections
+    expect_correction(<<~RUBY)
+      def foo(a) x(1)
+       y(2)
+       z(3)
+       end
+    RUBY
   end
 
   it 'accepts semicolon before end if so configured' do


### PR DESCRIPTION
I noticed that `Style/Semicolon` doesn't do autocorrection, so this adds basic auto-correction (replaces semicolons between statements with a new line, indentation will be fixed by other cops).

A small autocorrection conflict between this and `Style/SingleLineMethods` is prevented by adding that to `autocorrect_incompatible_with` (which we need to document somewhere because I can never remember what it's called 😬).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
