### PR TITLE
[Fix #9962] Update `Style/WordArray` to register an offense in `percent` style if any values contain spaces

### DIFF
--- a/changelog/change_update_stylewordarray_to_register_an.md
+++ b/changelog/change_update_stylewordarray_to_register_an.md
@@ -1,0 +1,1 @@
+* [#9962](https://github.com/rubocop/rubocop/issues/9962): Update `Style/WordArray` to register an offense in `percent` style if any values contain spaces. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4921,7 +4921,7 @@ Style/WordArray:
   StyleGuide: '#percent-w'
   Enabled: true
   VersionAdded: '0.9'
-  VersionChanged: '0.36'
+  VersionChanged: '<<next>>'
   EnforcedStyle: percent
   SupportedStyles:
     # percent style: %w(word1 word2)


### PR DESCRIPTION
Updates `Style/WordArray` to mark `%w()` arrays as offenses if they contain any values with spaces.

Fixes #9962.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
