### PR TITLE
[Fix #9980] Fix a false positive for `Style/IdenticalConditionalBranches`

### DIFF
--- a/changelog/fix_false_positive_for_style_identical_conditional_branches.md
+++ b/changelog/fix_false_positive_for_style_identical_conditional_branches.md
@@ -1,0 +1,1 @@
+* [#9980](https://github.com/rubocop/rubocop/issues/9980): Fix a false positive for `Style/IdenticalConditionalBranches` when assigning to a variable used in a condition. ([@koic][])

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -96,6 +96,21 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
     end
   end
 
+  context 'on if..else with identical bodies and assigning to a variable used in `if` condition' do
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        x = 0
+        if x == 0
+          x += 1
+          foo
+        else
+          x += 1
+          bar
+        end
+      RUBY
+    end
+  end
+
   context 'on case with identical bodies' do
     it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)
@@ -233,6 +248,22 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
     end
   end
 
+  context 'on case..when with identical bodies and assigning to a variable used in `case` condition' do
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        x = 0
+        case x
+        when 1
+          x += 1
+          foo
+        when 42
+          x += 1
+          bar
+        end
+      RUBY
+    end
+  end
+
   context 'when using pattern matching', :ruby27 do
     context 'on case-match with identical bodies' do
       it 'registers an offense and corrects' do
@@ -258,6 +289,22 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
           end
           do_x
         RUBY
+      end
+
+      context 'on case..in with identical bodies and assigning to a variable used in `case` condition' do
+        it "doesn't register an offense" do
+          expect_no_offenses(<<~RUBY)
+            x = 0
+            case x
+            in 1
+              x += 1
+              foo
+            in 42
+              x += 1
+              bar
+            end
+          RUBY
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #9980.

This PR fixes a false positive for `Style/IdenticalConditionalBranches` when assigning to a variable used in a condition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
