### PR TITLE
Fix layout false negatives around heredocs

### DIFF
--- a/changelog/fix_update_layoutspacebeforecomment_to.md
+++ b/changelog/fix_update_layoutspacebeforecomment_to.md
@@ -1,0 +1,1 @@
+* [#9984](https://github.com/rubocop/rubocop/pull/9984): Fix false negatives involving heredocs for `Layout/SpaceBeforeComma`, `Layout/SpaceBeforeComment`, `Layout/SpaceBeforeSemicolon` and `Layout/SpaceInsideParens`. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/space_before_comment.rb
+++ b/lib/rubocop/cop/layout/space_before_comment.rb
@@ -18,7 +18,7 @@ module RuboCop
         MSG = 'Put a space before an end-of-line comment.'
 
         def on_new_investigation
-          processed_source.tokens.each_cons(2) do |token1, token2|
+          processed_source.sorted_tokens.each_cons(2) do |token1, token2|
             next unless token2.comment?
             next unless token1.line == token2.line
             next unless token1.pos.end == token2.pos.begin

--- a/lib/rubocop/cop/layout/space_inside_parens.rb
+++ b/lib/rubocop/cop/layout/space_inside_parens.rb
@@ -43,12 +43,12 @@ module RuboCop
         MSG_SPACE = 'No space inside parentheses detected.'
 
         def on_new_investigation
-          @processed_source = processed_source
+          tokens = processed_source.sorted_tokens
 
           if style == :space
-            process_with_space_style(processed_source)
+            process_with_space_style(tokens)
           else
-            each_extraneous_space(processed_source.tokens) do |range|
+            each_extraneous_space(tokens) do |range|
               add_offense(range) do |corrector|
                 corrector.remove(range)
               end
@@ -58,8 +58,8 @@ module RuboCop
 
         private
 
-        def process_with_space_style(processed_source)
-          processed_source.tokens.each_cons(2) do |token1, token2|
+        def process_with_space_style(tokens)
+          tokens.each_cons(2) do |token1, token2|
             each_extraneous_space_in_empty_parens(token1, token2) do |range|
               add_offense(range) do |corrector|
                 corrector.remove(range)

--- a/lib/rubocop/cop/mixin/space_before_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_before_punctuation.rb
@@ -10,7 +10,7 @@ module RuboCop
       MSG = 'Space found before %<token>s.'
 
       def on_new_investigation
-        each_missing_space(processed_source.tokens) do |token, pos_before|
+        each_missing_space(processed_source.sorted_tokens) do |token, pos_before|
           add_offense(pos_before, message: format(MSG, token: kind(token))) do |corrector|
             PunctuationCorrector.remove_space(corrector, pos_before)
           end

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
   s.add_runtime_dependency('rexml')
-  s.add_runtime_dependency('rubocop-ast', '>= 1.8.0', '< 2.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 1.9.0', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 3.0')
 

--- a/spec/rubocop/cop/layout/space_before_comma_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_comma_spec.rb
@@ -50,4 +50,21 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeComma, :config do
       each { |s, t| a(1, formats[0, 1])}
     RUBY
   end
+
+  context 'heredocs' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        a(<<~STR , 2)
+                ^ Space found before comma.
+          text
+        STR
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a(<<~STR, 2)
+          text
+        STR
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/space_before_comment_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_comment_spec.rb
@@ -27,4 +27,19 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeComment, :config do
       =end
     RUBY
   end
+
+  it 'registers an offense and corrects after a heredoc' do
+    expect_offense(<<~RUBY)
+      <<~STR# my string
+            ^^^^^^^^^^^ Put a space before an end-of-line comment.
+        text
+      STR
+    RUBY
+
+    expect_correction(<<~RUBY)
+      <<~STR # my string
+        text
+      STR
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
@@ -64,4 +64,21 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeSemicolon, :config do
       end
     end
   end
+
+  context 'heredocs' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        <<~STR ; x = 1
+              ^ Space found before semicolon.
+          text
+        STR
+      RUBY
+
+      expect_correction(<<~RUBY)
+        <<~STR; x = 1
+          text
+        STR
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/space_inside_parens_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_parens_spec.rb
@@ -21,6 +21,22 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParens, :config do
       RUBY
     end
 
+    it 'registers an offense for space around heredoc start' do
+      expect_offense(<<~'RUBY')
+        f( <<~HEREDOC )
+                     ^ Space inside parentheses detected.
+          ^ Space inside parentheses detected.
+          This is my text
+        HEREDOC
+      RUBY
+
+      expect_correction(<<~RUBY)
+        f(<<~HEREDOC)
+          This is my text
+        HEREDOC
+      RUBY
+    end
+
     it 'accepts parentheses in block parameter list' do
       expect_no_offenses(<<~RUBY)
         list.inject(Tms.new) { |sum, (label, item)|
@@ -90,6 +106,22 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParens, :config do
       expect_correction(<<~RUBY)
         list.inject( Tms.new ) { |sum, ( label, item )|
         }
+      RUBY
+    end
+
+    it 'registers an offense for no space around heredoc start' do
+      expect_offense(<<~RUBY)
+        f(<<~HEREDOC)
+                    ^ No space inside parentheses detected.
+          ^ No space inside parentheses detected.
+          This is my text
+        HEREDOC
+      RUBY
+
+      expect_correction(<<~RUBY)
+        f( <<~HEREDOC )
+          This is my text
+        HEREDOC
       RUBY
     end
 


### PR DESCRIPTION
This fixes false negatives involving heredocs for `Layout/SpaceBeforeComma`, `Layout/SpaceBeforeComment`, `Layout/SpaceBeforeSemicolon` and `Layout/SpaceInsideParens`.

These cops rely on `processed_source.tokens` to determine layout, but heredocs mix up the order of tokens which causes layout issues after heredocs to be missed. This change uses `processed_source.sorted_tokens` to resolve this.

~Because that method is currently private, in this PR each cop has a new private method that calls `processed_source.send(:sorted_tokens)`. I have opened rubocop/rubocop-ast#195 to move that method to be public, after which I will replace all these methods.~

Requires `rubocop-ast` >= 1.9.0.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
