### PR TITLE
Mark `Style/IdenticalConditionalBranches` as unsafe auto-correction

### DIFF
--- a/changelog/change_mark_unsafe_autocorrect_for_style_identical_conditional_branches.mdb
+++ b/changelog/change_mark_unsafe_autocorrect_for_style_identical_conditional_branches.mdb
@@ -1,0 +1,1 @@
+* [#9985](https://github.com/rubocop/rubocop/pull/9985): Mark `Style/IdenticalConditionalBranches` as unsafe auto-correction. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3604,8 +3604,9 @@ Style/IdenticalConditionalBranches:
                  line at the end of each branch, which can validly be moved
                  out of the conditional.
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.36'
-  VersionChanged: '1.16'
+  VersionChanged: '<<next>>'
 
 Style/IfInsideElse:
   Description: 'Finds if nodes inside else, which can be converted to elsif.'

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -7,6 +7,22 @@ module RuboCop
       # each branch of a conditional expression. Such expressions should normally
       # be placed outside the conditional expression - before or after it.
       #
+      # This cop is marked unsafe auto-correction as the order of method invocations
+      # must be guaranteed in the following case:
+      #
+      # [source,ruby]
+      # ----
+      # if method_that_modifies_global_state # 1
+      #   method_that_relies_on_global_state # 2
+      #   foo                                # 3
+      # else
+      #   method_that_relies_on_global_state # 2
+      #   bar                                # 3
+      # end
+      # ----
+      #
+      # In such a case, auto-correction may change the invocation order.
+      #
       # NOTE: The cop is poorly named and some people might think that it actually
       # checks for duplicated conditional branches. The name will probably be changed
       # in a future major RuboCop release.


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/pull/9982#issuecomment-893950972

This PR marks `Style/IdenticalConditionalBranches` as unsafe auto-correction.

`Style/IdenticalConditionalBranches` cop is marked unsafe auto-correction as the order of method calls must be guaranteed in the following case:

```ruby
if method_that_modifies_global_state # 1
  method_that_relies_on_global_state # 2
  foo                                # 3
else
  method_that_relies_on_global_state # 2
  bar                                # 3
end
```

In such a case, auto-correction may change the invocation order.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
