### PR TITLE
[Fix #9927] Indent hash values in LineEndStringConcatenationIndentation

### DIFF
--- a/changelog/fix_indent_hash_values_in.md
+++ b/changelog/fix_indent_hash_values_in.md
@@ -1,0 +1,1 @@
+* [#9927](https://github.com/rubocop/rubocop/issues/9927): Indent hash values in `Layout/LineEndStringConcatenationIndentation`. ([@jonas054][])

--- a/spec/rubocop/cop/layout/line_end_string_concatenation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/line_end_string_concatenation_indentation_spec.rb
@@ -48,29 +48,6 @@ RSpec.describe RuboCop::Cop::Layout::LineEndStringConcatenationIndentation, :con
       RUBY
     end
 
-    it 'registers an offense for unaligned strings in hash literal values' do
-      expect_offense(<<~'RUBY')
-        MESSAGES = { KeyAlignment => 'Align the keys of a hash literal if ' \
-          'they span more than one line.',
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Align parts of a string concatenated with backslash.
-                     SeparatorAlignment => 'Align the separators of a hash ' \
-                       'literal if they span more than one line.',
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Align parts of a string concatenated with backslash.
-                     TableAlignment => 'Align the keys and values of a hash ' \
-                       'literal if they span more than one line.' }.freeze
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Align parts of a string concatenated with backslash.
-      RUBY
-
-      expect_correction(<<~'RUBY')
-        MESSAGES = { KeyAlignment => 'Align the keys of a hash literal if ' \
-                                     'they span more than one line.',
-                     SeparatorAlignment => 'Align the separators of a hash ' \
-                                           'literal if they span more than one line.',
-                     TableAlignment => 'Align the keys and values of a hash ' \
-                                       'literal if they span more than one line.' }.freeze
-      RUBY
-    end
-
     it 'accepts indented strings in implicit return statement of a method definition' do
       expect_no_offenses(<<~'RUBY')
         def some_method
@@ -216,6 +193,29 @@ RSpec.describe RuboCop::Cop::Layout::LineEndStringConcatenationIndentation, :con
       end
     end
 
+    it 'registers an offense for unaligned strings in hash literal values' do
+      expect_offense(<<~'RUBY')
+        MESSAGES = { KeyAlignment => 'Align the keys of a hash literal if ' \
+          'they span more than one line.',
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Align parts of a string concatenated with backslash.
+                     SeparatorAlignment => 'Align the separators of a hash ' \
+                       'literal if they span more than one line.',
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Align parts of a string concatenated with backslash.
+                     TableAlignment => 'Align the keys and values of a hash ' \
+                       'literal if they span more than one line.' }.freeze
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Align parts of a string concatenated with backslash.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        MESSAGES = { KeyAlignment => 'Align the keys of a hash literal if ' \
+                                     'they span more than one line.',
+                     SeparatorAlignment => 'Align the separators of a hash ' \
+                                           'literal if they span more than one line.',
+                     TableAlignment => 'Align the keys and values of a hash ' \
+                                       'literal if they span more than one line.' }.freeze
+      RUBY
+    end
+
     it 'registers an offense for indented string' do
       expect_offense(<<~'RUBY')
         puts 'a' \
@@ -284,6 +284,29 @@ RSpec.describe RuboCop::Cop::Layout::LineEndStringConcatenationIndentation, :con
           expect_correction(indented_strings)
         end
       end
+    end
+
+    it 'registers an offense for aligned strings in hash literal values' do
+      expect_offense(<<~'RUBY')
+        MESSAGES = { KeyAlignment => 'Align the keys of a hash literal if ' \
+                                     'they span more than one line.',
+                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Indent the first part of a string concatenated with backslash.
+                     SeparatorAlignment => 'Align the separators of a hash ' \
+                                           'literal if they span more than one line.',
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Indent the first part of a string concatenated with backslash.
+                     TableAlignment => 'Align the keys and values of a hash ' \
+                                       'literal if they span more than one line.' }.freeze
+                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Indent the first part of a string concatenated with backslash.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        MESSAGES = { KeyAlignment => 'Align the keys of a hash literal if ' \
+                       'they span more than one line.',
+                     SeparatorAlignment => 'Align the separators of a hash ' \
+                       'literal if they span more than one line.',
+                     TableAlignment => 'Align the keys and values of a hash ' \
+                       'literal if they span more than one line.' }.freeze
+      RUBY
     end
 
     it 'registers an offense for aligned string' do


### PR DESCRIPTION
Make `Layout/LineEndStringConcatenationIndentation` work like `Layout/MultilineOperationIndentation` when `EnforcedStyle` is `indented`. This means that concatenated strings in hash literals shall be indented, just like other concatenated strings.