### PR TITLE
[Fix #9989] Mark unsafe auto-correct for `Style/CommentedKeyword`

### DIFF
--- a/changelog/change_mark_unsafe_autocorrect_for_style_commented_keyword.md
+++ b/changelog/change_mark_unsafe_autocorrect_for_style_commented_keyword.md
@@ -1,0 +1,1 @@
+* [#9989](https://github.com/rubocop/rubocop/issues/9989): Mark `Style/CommentedKeyword` as unsafe auto-correction. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3156,8 +3156,9 @@ Style/CommentAnnotation:
 Style/CommentedKeyword:
   Description: 'Do not place comments on the same line as certain keywords.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.51'
-  VersionChanged: '1.7'
+  VersionChanged: '<<next>>'
 
 Style/ConditionalAssignment:
   Description: >-

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -12,6 +12,7 @@ module RuboCop
       #
       # Auto-correction removes comments from `end` keyword and keeps comments
       # for `class`, `module`, `def` and `begin` above the keyword.
+      # It is marked as unsafe auto-correction as it may remove meaningful comments.
       #
       # @example
       #   # bad


### PR DESCRIPTION
Fixes #9989

This PR mark unsafe auto-correct for `Style/CommentedKeyword` because it may remove meaningful comments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
