### PR TITLE
[Fix #5022] Fix false negative for `Lint/DuplicateMethods` inside `class << self`

### DIFF
--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -135,11 +135,14 @@ module RuboCop
         def found_instance_method(node, name)
           return unless (scope = node.parent_module_name)
 
-          if scope =~ /\A#<Class:(.*)>\Z/
-            found_method(node, "#{Regexp.last_match(1)}.#{name}")
-          else
-            found_method(node, "#{scope}##{name}")
-          end
+          # Humanize the scope
+          scope = scope.sub(
+            /(?:(?<name>.*)::)#<Class:\k<name>>|#<Class:(?<name>.*)>(?:::)?/,
+            '\k<name>.'
+          )
+          scope << '#' unless scope.end_with?('.')
+
+          found_method(node, "#{scope}#{name}")
         end
 
         def found_method(node, method_name)

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
   s.add_runtime_dependency('rexml')
-  s.add_runtime_dependency('rubocop-ast', '>= 1.9.0', '< 2.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 1.9.1', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 3.0')
 

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
       RUBY
     end
 
-    xit 'understands class << self' do
+    it 'understands class << self' do
       expect_offense(<<~RUBY, 'test.rb')
         #{opening_line}
           class << self
@@ -424,8 +424,8 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
       RUBY
     end
 
-    xit 'registers an offense for duplicate class methods with `<<` and named ' \
-        "receiver in #{type}" do
+    it 'registers an offense for duplicate class methods with `<<` and named ' \
+       "receiver in #{type}" do
       expect_offense(<<~RUBY, 'test.rb')
         #{type} A
           class << self
@@ -505,6 +505,41 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
       end
       b = Class.new do
         def foo
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register for the same method in different scopes within `class << self`' do
+    expect_no_offenses(<<~RUBY, 'test.rb')
+      class A
+        class << self
+          def foo
+          end
+
+          class B
+            def foo
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'properly registers and offense when deeply nested' do
+    expect_offense(<<~RUBY, 'test.rb')
+      module A
+        module B
+          class C
+            class << self
+              def foo
+              end
+
+              def foo
+              ^^^^^^^ Method `A::B::C.foo` is defined at both test.rb:5 and test.rb:8.
+              end
+            end
+          end
         end
       end
     RUBY


### PR DESCRIPTION
Requires rubocop/rubocop-ast#197 in order to fix `Node#parent_module_name`.

Properly handles the updated format of `parent_module_name` and adds tests to ensure the case from #5022 works.

Also reverts the pending tests in #9995.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
