### PR TITLE
Add doc and test for about pattern matching for `Style/MissingElse`

### DIFF
--- a/lib/rubocop/cop/style/missing_else.rb
+++ b/lib/rubocop/cop/style/missing_else.rb
@@ -5,6 +5,9 @@ module RuboCop
     module Style
       # Checks for `if` expressions that do not have an `else` branch.
       #
+      # NOTE: Pattern matching is allowed to have no `else` branch because unlike `if` and `case`,
+      # it raises `NoMatchingPatternError` if the pattern doesn't match and without having `else`.
+      #
       # Supported styles are: if, case, both.
       #
       # @example EnforcedStyle: if
@@ -112,6 +115,10 @@ module RuboCop
           return if if_style?
 
           check(node)
+        end
+
+        def on_case_match(node)
+          # do nothing.
         end
 
         private

--- a/spec/rubocop/cop/style/missing_else_spec.rb
+++ b/spec/rubocop/cop/style/missing_else_spec.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
+  shared_examples 'pattern matching' do
+    context '>= Ruby 2.7', :ruby27 do
+      it 'does not register an offense' do
+        # Pattern matching is allowed to have no `else` branch because unlike `if` and `case`,
+        # it raises `NoMatchingPatternError` if the pattern doesn't match and without having `else`.
+        expect_no_offenses('case pattern; in a; foo; end')
+      end
+    end
+  end
+
   context 'UnlessElse enabled' do
     let(:config) do
       RuboCop::Config.new('Style/MissingElse' => {
@@ -94,6 +104,8 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
         end
       end
     end
+
+    include_examples 'pattern matching'
   end
 
   context 'UnlessElse disabled' do
@@ -192,6 +204,8 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
         end
       end
     end
+
+    include_examples 'pattern matching'
   end
 
   context 'EmptyElse enabled and set to warn on empty' do
@@ -296,6 +310,8 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
         end
       end
     end
+
+    include_examples 'pattern matching'
   end
 
   context 'EmptyElse enabled and set to warn on nil' do
@@ -400,6 +416,8 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
         end
       end
     end
+
+    include_examples 'pattern matching'
   end
 
   context 'configured to warn only on empty if' do
@@ -501,6 +519,8 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
         end
       end
     end
+
+    include_examples 'pattern matching'
   end
 
   context 'configured to warn only on empty case' do
@@ -599,5 +619,7 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
         end
       end
     end
+
+    include_examples 'pattern matching'
   end
 end


### PR DESCRIPTION
This PR adds doc and test for about pattern matching for `Style/MissingElse`.

Pattern matching is allowed to have no `else` branch because unlike already existing `if` and `case`,
it raises `NoMatchingPatternError` if the pattern does not match and without having `else`.

```ruby
case 'a'
in 'b'
end
# => `NoMatchingPatternError`
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
