### PR TITLE
Parallel static analysis by default

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,12 +22,7 @@ require 'rubocop/rake_task'
 Dir['tasks/**/*.rake'].each { |t| load t }
 
 desc 'Run RuboCop over itself'
-RuboCop::RakeTask.new(:internal_investigation).tap do |task|
-  if RUBY_ENGINE == 'ruby' &&
-     !/mswin|msys|mingw|cygwin|bccwin|wince|emc/.match?(RbConfig::CONFIG['host_os'])
-    task.options = %w[--parallel]
-  end
-end
+RuboCop::RakeTask.new(:internal_investigation)
 
 task default: %i[documentation_syntax_check spec ascii_spec internal_investigation]
 

--- a/changelog/new_parallel_static_analysis_by_default.md
+++ b/changelog/new_parallel_static_analysis_by_default.md
@@ -1,0 +1,1 @@
+* [#10000](https://github.com/rubocop/rubocop/pull/10000): Parallel static analysis by default. ([@koic][])

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -492,7 +492,7 @@ module RuboCop
       version:                          'Display version.',
       verbose_version:                  'Display verbose version.',
       parallel:                         ['Use available CPUs to execute inspection in',
-                                         'parallel. Default is false.'],
+                                         'parallel. Default is true.'],
       stdin:                            ['Pipe source from STDIN, using FILE in offense',
                                          'reports. This is useful for editor integration.'],
       init:                             'Generate a .rubocop.yml file in the current directory.'

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
               -v, --version                    Display version.
               -V, --verbose-version            Display verbose version.
               -P, --[no-]parallel              Use available CPUs to execute inspection in
-                                               parallel. Default is false.
+                                               parallel. Default is true.
               -l, --lint                       Run only lint cops.
               -x, --fix-layout                 Run only layout cops, with auto-correct on.
               -s, --stdin FILE                 Pipe source from STDIN, using FILE in offense


### PR DESCRIPTION
Modern PCs have multi-core. RuboCop has `--parallel` option, but it is not used by default. This means that there is extra core resources for static analysis because multi-core is not being used effectively.

This PR will be parallel processing by default, so RuboCop will run faster in proportion to number of cores. Options that can be parallel processing, such as `--only`, `--except`, and others have the
same default behavior.
However, there are options that cannot be parallel processing, such as auto-correction and others, so they are serial processing as before.

`--parallel` can be a hidden option for some users. This change is expected to reduce user's wait time for running RuboCop.

Below is an example on my development PC.

Before:

```console
% cd path/to/rubocop
./exe/rubocop --display-time
(snip)

1293 files inspected, no offenses detected
Finished in 61.09493000002112 seconds
```

After:

```console
% cd path/to/rubocop
./exe/rubocop --display-time
(snip)

1293 files inspected, no offenses detected
Finished in 10.13813699997263 seconds
```

If user's PC has a lot of cores, memory and RuboCop targets a lot of files to inspect, it will be effective.

One concern is that parallel processing uses more memory. For example, Ruby's MJIT is off by default as an example of concerning about memory consumption in a low memory production runtime (e.g. Heroku's minimum Dyno).
However, RuboCop is a development tool, I assume that it will be fine in most cases.

If user want to use it in a low memory production runtime, user can specify `--no-parallel`.

Note: JRuby and Windows are not supported based on #4537.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
