### PR TITLE
[Fix #7422] Treat `casgn` nodes like other assignment nodes in `Layout/SpaceAroundOperators`

### DIFF
--- a/changelog/fix_treat_casgn_nodes_like_other_assignment.md
+++ b/changelog/fix_treat_casgn_nodes_like_other_assignment.md
@@ -1,0 +1,1 @@
+* [#7422](https://github.com/rubocop/rubocop/issues/7422): Treat constant assignment like other assignment in `Layout/SpaceAroundOperators`. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -108,6 +108,14 @@ module RuboCop
           check_operator(:assignment, node.loc.operator, rhs.source_range)
         end
 
+        def on_casgn(node)
+          _, _, right, = *node
+
+          return unless right
+
+          check_operator(:assignment, node.loc.operator, right.source_range)
+        end
+
         def on_binary(node)
           _, rhs, = *node
 
@@ -134,7 +142,6 @@ module RuboCop
         alias on_and      on_binary
         alias on_lvasgn   on_assignment
         alias on_masgn    on_assignment
-        alias on_casgn    on_special_asgn
         alias on_ivasgn   on_assignment
         alias on_cvasgn   on_assignment
         alias on_gvasgn   on_assignment

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -955,4 +955,28 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
       RUBY
     end
   end
+
+  describe 'when Layout/ExtraSpacing has `ForceEqualSignAlignment` configured to true' do
+    let(:other_cops) do
+      { 'Layout/ExtraSpacing' => { 'Enabled' => true, 'ForceEqualSignAlignment' => true } }
+    end
+
+    it 'allows variables to be aligned' do
+      expect_no_offenses(<<~RUBY)
+        first  = {
+          x: y
+        }.freeze
+        second = true
+      RUBY
+    end
+
+    it 'allows constants to be aligned' do
+      expect_no_offenses(<<~RUBY)
+        FIRST  = {
+          x: y
+        }.freeze
+        SECOND = true
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
`casgn` nodes were being treated as "special assignment" which wasn't being laid out properly considering `Layout/ExtraSpacing`, and thus creating an infinite autocorrection loop.

Fixes #7422.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
