### PR TITLE
[Fix #10002] Fix an incorrect auto-correct for `Lint/AmbigousRegexpLiteral`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_lint_ambiguous_regexp_literal.md
+++ b/changelog/fix_incorrect_autocorrect_for_lint_ambiguous_regexp_literal.md
@@ -1,0 +1,1 @@
+* [#10002](https://github.com/rubocop/rubocop/issues/10002): Fix an incorrect auto-correct for `Lint/AmbigousRegexpLiteral` when using nested method arguments without parentheses. ([@koic][])

--- a/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
+++ b/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
@@ -46,12 +46,11 @@ module RuboCop
           node = processed_source.ast.each_node(:regexp).find do |regexp_node|
             regexp_node.source_range.begin_pos == diagnostic.location.begin_pos
           end
-
           find_offense_node(node.parent, node)
         end
 
         def find_offense_node(node, regexp_receiver)
-          return node unless node.parent
+          return node if first_argument_is_regexp?(node) || !node.parent
 
           if (node.parent.send_type? && node.receiver) ||
              method_chain_to_regexp_receiver?(node, regexp_receiver)
@@ -59,6 +58,10 @@ module RuboCop
           end
 
           node
+        end
+
+        def first_argument_is_regexp?(node)
+          node.send_type? && node.first_argument&.regexp_type?
         end
 
         def method_chain_to_regexp_receiver?(node, regexp_receiver)

--- a/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
@@ -127,6 +127,17 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral, :config do
           end
         RUBY
       end
+
+      it 'registers an offense and corrects when using nested method arguments without parentheses' do
+        expect_offense(<<~RUBY)
+          puts line.grep /pattern/
+                         ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts line.grep(/pattern/)
+        RUBY
+      end
     end
 
     context 'with parentheses' do


### PR DESCRIPTION
Fixes #10002.

This PR fixes an incorrect auto-correct for `Lint/AmbigousRegexpLiteral` when using nested method arguments without parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
