### PR TITLE
[Fix #10004] Fix a false positive for `Style/RedundantBegin`

### DIFF
--- a/changelog/fix_false_positive_for_style_redundant_begin.md
+++ b/changelog/fix_false_positive_for_style_redundant_begin.md
@@ -1,0 +1,1 @@
+* [#10004](https://github.com/rubocop/rubocop/issues/10004): Fix a false positive for `Style/RedundantBegin` when using one-liner with semicolon. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -415,4 +415,51 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
       end
     RUBY
   end
+
+  it 'accepts when one-liner `begin` block has multiple statements with modifier condition' do
+    expect_no_offenses(<<~RUBY)
+      begin foo; bar; end unless condition
+    RUBY
+  end
+
+  it 'accepts when multi-line `begin` block has multiple statements with modifier condition' do
+    expect_no_offenses(<<~RUBY)
+      begin
+        foo; bar
+      end unless condition
+    RUBY
+  end
+
+  it 'reports an offense when one-liner `begin` block has single statement with modifier condition' do
+    expect_offense(<<~RUBY)
+      begin foo end unless condition
+      ^^^^^ Redundant `begin` block detected.
+    RUBY
+
+    expect_correction(" foo  unless condition\n")
+  end
+
+  it 'reports an offense when multi-line `begin` block has single statement with modifier condition' do
+    expect_offense(<<~RUBY)
+      begin
+      ^^^^^ Redundant `begin` block detected.
+        foo
+      end unless condition
+    RUBY
+
+    expect_correction("\n  foo unless condition\n")
+  end
+
+  it 'reports an offense when multi-line `begin` block has single statement and it is inside condition' do
+    expect_offense(<<~RUBY)
+      unless condition
+        begin
+        ^^^^^ Redundant `begin` block detected.
+          foo
+        end
+      end
+    RUBY
+
+    expect_correction("unless condition\n  \n    foo\n  \nend\n")
+  end
 end


### PR DESCRIPTION
Fixes #10004.

This PR fixes a false positive for `Style/RedundantBegin` when using one-liner with semicolon.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
