### PR TITLE
Address `frozen_string_literal` no longer applying to interpolated strings in Ruby 3.0 or higher

### DIFF
--- a/changelog/change_interpolated_string_literals_are_no.md
+++ b/changelog/change_interpolated_string_literals_are_no.md
@@ -1,0 +1,1 @@
+* [#10006](https://github.com/rubocop/rubocop/pull/10006): Interpolated string literals are no longer frozen since Ruby 3.0. ([@splattael][])

--- a/lib/rubocop/cop/mixin/frozen_string_literal.rb
+++ b/lib/rubocop/cop/mixin/frozen_string_literal.rb
@@ -8,9 +8,10 @@ module RuboCop
 
       FROZEN_STRING_LITERAL = '# frozen_string_literal:'
       FROZEN_STRING_LITERAL_ENABLED = '# frozen_string_literal: true'
-      FROZEN_STRING_LITERAL_TYPES = %i[str dstr].freeze
+      FROZEN_STRING_LITERAL_TYPES_RUBY27 = %i[str dstr].freeze
+      FROZEN_STRING_LITERAL_TYPES_RUBY30 = %i[str].freeze
 
-      private_constant :FROZEN_STRING_LITERAL_TYPES
+      private_constant :FROZEN_STRING_LITERAL_TYPES_RUBY27, :FROZEN_STRING_LITERAL_TYPES_RUBY30
 
       def frozen_string_literal_comment_exists?
         leading_comment_lines.any? { |line| MagicComment.parse(line).valid_literal_value? }
@@ -19,7 +20,13 @@ module RuboCop
       private
 
       def frozen_string_literal?(node)
-        FROZEN_STRING_LITERAL_TYPES.include?(node.type) && frozen_string_literals_enabled?
+        literal_types = if target_ruby_version >= 3.0
+                          FROZEN_STRING_LITERAL_TYPES_RUBY30
+                        else
+                          FROZEN_STRING_LITERAL_TYPES_RUBY27
+                        end
+
+        literal_types.include?(node.type) && frozen_string_literals_enabled?
       end
 
       def frozen_string_literals_enabled?

--- a/lib/rubocop/cop/mixin/frozen_string_literal.rb
+++ b/lib/rubocop/cop/mixin/frozen_string_literal.rb
@@ -10,11 +10,17 @@ module RuboCop
       FROZEN_STRING_LITERAL_ENABLED = '# frozen_string_literal: true'
       FROZEN_STRING_LITERAL_TYPES = %i[str dstr].freeze
 
+      private_constant :FROZEN_STRING_LITERAL_TYPES
+
       def frozen_string_literal_comment_exists?
         leading_comment_lines.any? { |line| MagicComment.parse(line).valid_literal_value? }
       end
 
       private
+
+      def frozen_string_literal?(node)
+        FROZEN_STRING_LITERAL_TYPES.include?(node.type) && frozen_string_literals_enabled?
+      end
 
       def frozen_string_literals_enabled?
         ruby_version = processed_source.ruby_version

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -141,7 +141,7 @@ module RuboCop
 
         def frozen_string_literal_comment(processed_source)
           processed_source.find_token do |token|
-            token.text.start_with?(FrozenStringLiteral::FROZEN_STRING_LITERAL)
+            token.text.start_with?(FROZEN_STRING_LITERAL)
           end
         end
 

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -151,8 +151,8 @@ module RuboCop
           range_enclosed_in_parentheses = range_enclosed_in_parentheses?(value)
           return unless mutable_literal?(value) ||
                         target_ruby_version <= 2.7 && range_enclosed_in_parentheses
-          return if FROZEN_STRING_LITERAL_TYPES.include?(value.type) &&
-                    frozen_string_literals_enabled?
+
+          return if frozen_string_literal?(value)
           return if shareable_constant_value?(value)
 
           add_offense(value) { |corrector| autocorrect(corrector, value) }
@@ -181,10 +181,6 @@ module RuboCop
 
         def immutable_literal?(node)
           frozen_regexp_or_range_literals?(node) || node.immutable_literal?
-        end
-
-        def frozen_string_literal?(node)
-          FROZEN_STRING_LITERAL_TYPES.include?(node.type) && frozen_string_literals_enabled?
         end
 
         def shareable_constant_value?(node)

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -21,6 +21,9 @@ module RuboCop
       #
       # NOTE: Regexp and Range literals are frozen objects since Ruby 3.0.
       #
+      # NOTE: From Ruby 3.0, this cop allows explicit freezing of interpolated
+      # string literals when `# frozen-string-literal: true` is used.
+      #
       # @example EnforcedStyle: literals (default)
       #   # bad
       #   CONST = [1, 2, 3]

--- a/lib/rubocop/cop/style/redundant_freeze.rb
+++ b/lib/rubocop/cop/style/redundant_freeze.rb
@@ -37,9 +37,7 @@ module RuboCop
           node = strip_parenthesis(node)
 
           return true if node.immutable_literal?
-
-          return true if FROZEN_STRING_LITERAL_TYPES.include?(node.type) &&
-                         frozen_string_literals_enabled?
+          return true if frozen_string_literal?(node)
 
           target_ruby_version >= 3.0 && (node.regexp_type? || node.range_type?)
         end

--- a/lib/rubocop/cop/style/redundant_freeze.rb
+++ b/lib/rubocop/cop/style/redundant_freeze.rb
@@ -7,6 +7,9 @@ module RuboCop
       #
       # NOTE: Regexp and Range literals are frozen objects since Ruby 3.0.
       #
+      # NOTE: From Ruby 3.0, this cop allows explicit freezing of interpolated
+      # string literals when `# frozen-string-literal: true` is used.
+      #
       # @example
       #   # bad
       #   CONST = 1.freeze

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -106,20 +106,40 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
       end
     end
 
-    context 'when the frozen string literal comment is missing' do
-      it_behaves_like 'mutable objects', '"#{a}"'
+    context 'Ruby 3.0 or higher', :ruby30 do
+      context 'when the frozen string literal comment is missing' do
+        it_behaves_like 'mutable objects', '"#{a}"'
+      end
+
+      context 'when the frozen string literal comment is true' do
+        let(:prefix) { '# frozen_string_literal: true' }
+
+        it_behaves_like 'mutable objects', '"#{a}"'
+      end
+
+      context 'when the frozen string literal comment is false' do
+        let(:prefix) { '# frozen_string_literal: false' }
+
+        it_behaves_like 'mutable objects', '"#{a}"'
+      end
     end
 
-    context 'when the frozen string literal comment is true' do
-      let(:prefix) { '# frozen_string_literal: true' }
+    context 'Ruby 2.7 or lower', :ruby27 do
+      context 'when the frozen string literal comment is missing' do
+        it_behaves_like 'mutable objects', '"#{a}"'
+      end
 
-      it_behaves_like 'immutable objects', '"#{a}"'
-    end
+      context 'when the frozen string literal comment is true' do
+        let(:prefix) { '# frozen_string_literal: true' }
 
-    context 'when the frozen string literal comment is false' do
-      let(:prefix) { '# frozen_string_literal: false' }
+        it_behaves_like 'immutable objects', '"#{a}"'
+      end
 
-      it_behaves_like 'mutable objects', '"#{a}"'
+      context 'when the frozen string literal comment is false' do
+        let(:prefix) { '# frozen_string_literal: false' }
+
+        it_behaves_like 'mutable objects', '"#{a}"'
+      end
     end
   end
 

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -80,6 +80,49 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
     it_behaves_like 'immutable objects', "::ENV['foo']"
   end
 
+  shared_examples 'string literal' do
+    # TODO : It is not yet decided when frozen string will be the default.
+    # It has been abandoned in the Ruby 3.0 period, but may default in
+    # the long run. So these tests are left with a provisional value of 4.0.
+    if RuboCop::TargetRuby.supported_versions.include?(4.0)
+      context 'when the target ruby version >= 4.0' do
+        let(:ruby_version) { 4.0 }
+
+        context 'when the frozen string literal comment is missing' do
+          it_behaves_like 'immutable objects', '"#{a}"'
+        end
+
+        context 'when the frozen string literal comment is true' do
+          let(:prefix) { '# frozen_string_literal: true' }
+
+          it_behaves_like 'immutable objects', '"#{a}"'
+        end
+
+        context 'when the frozen string literal comment is false' do
+          let(:prefix) { '# frozen_string_literal: false' }
+
+          it_behaves_like 'immutable objects', '"#{a}"'
+        end
+      end
+    end
+
+    context 'when the frozen string literal comment is missing' do
+      it_behaves_like 'mutable objects', '"#{a}"'
+    end
+
+    context 'when the frozen string literal comment is true' do
+      let(:prefix) { '# frozen_string_literal: true' }
+
+      it_behaves_like 'immutable objects', '"#{a}"'
+    end
+
+    context 'when the frozen string literal comment is false' do
+      let(:prefix) { '# frozen_string_literal: false' }
+
+      it_behaves_like 'mutable objects', '"#{a}"'
+    end
+  end
+
   context 'Strict: false' do
     let(:cop_config) { { 'EnforcedStyle' => 'literals' } }
 
@@ -294,48 +337,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
       end
     end
 
-    context 'when the constant is a frozen string literal' do
-      # TODO : It is not yet decided when frozen string will be the default.
-      # It has been abandoned in the Ruby 3.0 period, but may default in
-      # the long run. So these tests are left with a provisional value of 4.0.
-      if RuboCop::TargetRuby.supported_versions.include?(4.0)
-        context 'when the target ruby version >= 4.0' do
-          let(:ruby_version) { 4.0 }
-
-          context 'when the frozen string literal comment is missing' do
-            it_behaves_like 'immutable objects', '"#{a}"'
-          end
-
-          context 'when the frozen string literal comment is true' do
-            let(:prefix) { '# frozen_string_literal: true' }
-
-            it_behaves_like 'immutable objects', '"#{a}"'
-          end
-
-          context 'when the frozen string literal comment is false' do
-            let(:prefix) { '# frozen_string_literal: false' }
-
-            it_behaves_like 'immutable objects', '"#{a}"'
-          end
-        end
-      end
-
-      context 'when the frozen string literal comment is missing' do
-        it_behaves_like 'mutable objects', '"#{a}"'
-      end
-
-      context 'when the frozen string literal comment is true' do
-        let(:prefix) { '# frozen_string_literal: true' }
-
-        it_behaves_like 'immutable objects', '"#{a}"'
-      end
-
-      context 'when the frozen string literal comment is false' do
-        let(:prefix) { '# frozen_string_literal: false' }
-
-        it_behaves_like 'mutable objects', '"#{a}"'
-      end
-    end
+    it_behaves_like 'string literal'
   end
 
   context 'Strict: true' do
@@ -558,20 +560,6 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
       RUBY
     end
 
-    context 'when the frozen string literal comment is missing' do
-      it_behaves_like 'mutable objects', '"#{a}"'
-    end
-
-    context 'when the frozen string literal comment is true' do
-      let(:prefix) { '# frozen_string_literal: true' }
-
-      it_behaves_like 'immutable objects', '"#{a}"'
-    end
-
-    context 'when the frozen string literal comment is false' do
-      let(:prefix) { '# frozen_string_literal: false' }
-
-      it_behaves_like 'mutable objects', '"#{a}"'
-    end
+    it_behaves_like 'string literal'
   end
 end

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze, :config do
     expect_no_offenses('TOP_TEST = Something.new.freeze')
   end
 
-  context 'when the receiver is a frozen string literal' do
+  context 'when the receiver is a string literal' do
     # TODO : It is not yet decided when frozen string will be the default.
     # It has been abandoned in the Ruby 3.0 period, but may default in
     # the long run. So these tests are left with a provisional value of 4.0.

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -75,20 +75,40 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze, :config do
       end
     end
 
-    context 'when the frozen string literal comment is missing' do
-      it_behaves_like 'mutable objects', '"#{a}"'
+    context 'Ruby 3.0 or higher', :ruby30 do
+      context 'when the frozen string literal comment is missing' do
+        it_behaves_like 'mutable objects', '"#{a}"'
+      end
+
+      context 'when the frozen string literal comment is true' do
+        let(:prefix) { '# frozen_string_literal: true' }
+
+        it_behaves_like 'mutable objects', '"#{a}"'
+      end
+
+      context 'when the frozen string literal comment is false' do
+        let(:prefix) { '# frozen_string_literal: false' }
+
+        it_behaves_like 'mutable objects', '"#{a}"'
+      end
     end
 
-    context 'when the frozen string literal comment is true' do
-      let(:prefix) { '# frozen_string_literal: true' }
+    context 'Ruby 2.7 or lower', :ruby27 do
+      context 'when the frozen string literal comment is missing' do
+        it_behaves_like 'mutable objects', '"#{a}"'
+      end
 
-      it_behaves_like 'immutable objects', '"#{a}"'
-    end
+      context 'when the frozen string literal comment is true' do
+        let(:prefix) { '# frozen_string_literal: true' }
 
-    context 'when the frozen string literal comment is false' do
-      let(:prefix) { '# frozen_string_literal: false' }
+        it_behaves_like 'immutable objects', '"#{a}"'
+      end
 
-      it_behaves_like 'mutable objects', '"#{a}"'
+      context 'when the frozen string literal comment is false' do
+        let(:prefix) { '# frozen_string_literal: false' }
+
+        it_behaves_like 'mutable objects', '"#{a}"'
+      end
     end
 
     describe 'Regexp and Range literals' do


### PR DESCRIPTION
Note, this PR is strongly inspired by https://github.com/rubocop/rubocop/pull/8743. Kudos to @sambostock :heart: 

----

Since [Ruby 3.0 or higher](https://bugs.ruby-lang.org/issues/17104) interpolated strings are not frozen automatically anymore.

Therefore, two changes must happen to how we treat interpolated literals

* `Style/MutableConstant` should enforce freezing them
* `Style/RedundantFreeze` should not consider it redundant to freeze them

The behaviour for Ruby 2.7 or lower is kept.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
