### PR TITLE
[Fix #10008] Tweak offense message for `Style/WordArray` and `Style/SymbolArray` cops

### DIFF
--- a/lib/rubocop/cop/mixin/percent_array.rb
+++ b/lib/rubocop/cop/mixin/percent_array.rb
@@ -38,8 +38,11 @@ module RuboCop
 
         return unless style == :brackets || invalid_percent_array_contents?(node)
 
-        add_offense(node, message: self.class::ARRAY_MSG) do |corrector|
-          correct_bracketed(corrector, node)
+        bracketed_array = build_bracketed_array(node)
+        message = format(self.class::ARRAY_MSG, prefer: bracketed_array)
+
+        add_offense(node, message: message) do |corrector|
+          corrector.replace(node, bracketed_array)
         end
       end
 

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -35,7 +35,7 @@ module RuboCop
         extend AutoCorrector
 
         PERCENT_MSG = 'Use `%i` or `%I` for an array of symbols.'
-        ARRAY_MSG = 'Use `[]` for an array of symbols.'
+        ARRAY_MSG = 'Use `%<prefer>s` for an array of symbols.'
 
         class << self
           attr_accessor :largest_brackets
@@ -60,7 +60,7 @@ module RuboCop
           end
         end
 
-        def correct_bracketed(corrector, node)
+        def build_bracketed_array(node)
           syms = node.children.map do |c|
             if c.dsym_type?
               string_literal = to_string_literal(c.source)
@@ -71,7 +71,7 @@ module RuboCop
             end
           end
 
-          corrector.replace(node, "[#{syms.join(', ')}]")
+          "[#{syms.join(', ')}]"
         end
 
         def to_symbol_literal(string)

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -44,7 +44,7 @@ module RuboCop
         extend AutoCorrector
 
         PERCENT_MSG = 'Use `%w` or `%W` for an array of words.'
-        ARRAY_MSG = 'Use `[]` for an array of words.'
+        ARRAY_MSG = 'Use `%<prefer>s` for an array of words.'
 
         class << self
           attr_accessor :largest_brackets
@@ -82,7 +82,7 @@ module RuboCop
           Regexp.new(cop_config['WordRegex'])
         end
 
-        def correct_bracketed(corrector, node)
+        def build_bracketed_array(node)
           words = node.children.map do |word|
             if word.dstr_type?
               string_literal = to_string_literal(word.source)
@@ -93,7 +93,7 @@ module RuboCop
             end
           end
 
-          corrector.replace(node, "[#{words.join(', ')}]")
+          "[#{words.join(', ')}]"
         end
       end
     end

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
     it 'registers an offense for array starting with %i' do
       expect_offense(<<~RUBY)
         %i(one two three)
-        ^^^^^^^^^^^^^^^^^ Use `[]` for an array of symbols.
+        ^^^^^^^^^^^^^^^^^ Use `[:one, :two, :three]` for an array of symbols.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -212,7 +212,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
     it 'autocorrects an array starting with %i' do
       expect_offense(<<~RUBY)
         %i(one @two $three four-five)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `[]` for an array of symbols.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `[:one, :@two, :$three, :'four-five']` for an array of symbols.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -223,7 +223,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
     it 'autocorrects an array has interpolations' do
       expect_offense(<<~'RUBY')
         %I(#{foo} #{foo}bar foo#{bar} foo)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `[]` for an array of symbols.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `[:"#{foo}", :"#{foo}bar", :"foo#{bar}", :foo]` for an array of symbols.
       RUBY
 
       expect_correction(<<~'RUBY')

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -321,7 +321,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     it 'registers an offense for a %w() array containing spaces' do
       expect_offense(<<~'RUBY')
         %w(one\ two three\ four)
-        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `[]` for an array of words.
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `['one two', 'three four']` for an array of words.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -373,7 +373,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     it 'registers an offense for a %w() array' do
       expect_offense(<<~RUBY)
         %w(one two three)
-        ^^^^^^^^^^^^^^^^^ Use `[]` for an array of words.
+        ^^^^^^^^^^^^^^^^^ Use `['one', 'two', 'three']` for an array of words.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -384,7 +384,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     it 'autocorrects a %w() array which uses single quotes' do
       expect_offense(<<~RUBY)
         %w(one's two's three's)
-        ^^^^^^^^^^^^^^^^^^^^^^^ Use `[]` for an array of words.
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `["one's", "two's", "three's"]` for an array of words.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -395,7 +395,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     it 'autocorrects a %W() array which uses escapes' do
       expect_offense(<<~'RUBY')
         %W(\n \t \b \v \f)
-        ^^^^^^^^^^^^^^^^^^ Use `[]` for an array of words.
+        ^^^^^^^^^^^^^^^^^^ Use `["\n", "\t", "\b", "\v", "\f"]` for an array of words.
       RUBY
 
       expect_correction(<<~'RUBY')
@@ -406,7 +406,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     it 'autocorrects a %w() array which uses string with hyphen' do
       expect_offense(<<~RUBY)
         %w(foo bar foo-bar)
-        ^^^^^^^^^^^^^^^^^^^ Use `[]` for an array of words.
+        ^^^^^^^^^^^^^^^^^^^ Use `['foo', 'bar', 'foo-bar']` for an array of words.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -417,7 +417,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     it 'autocorrects a %W() array which uses string with hyphen' do
       expect_offense(<<~'RUBY')
         %W(foo bar #{foo}-bar)
-        ^^^^^^^^^^^^^^^^^^^^^^ Use `[]` for an array of words.
+        ^^^^^^^^^^^^^^^^^^^^^^ Use `['foo', 'bar', "#{foo}-bar"]` for an array of words.
       RUBY
 
       expect_correction(<<~'RUBY')
@@ -428,7 +428,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     it 'autocorrects a %W() array which uses string interpolation' do
       expect_offense(<<~'RUBY')
         %W(#{foo}bar baz)
-        ^^^^^^^^^^^^^^^^^ Use `[]` for an array of words.
+        ^^^^^^^^^^^^^^^^^ Use `["#{foo}bar", 'baz']` for an array of words.
       RUBY
 
       expect_correction(<<~'RUBY')


### PR DESCRIPTION
Fixes #10007 and #10008.

This PR tweaks offense message for `Style/WordArray` and `Style/SymbolArray` cops. It is a clear message suggested by #10008.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
