### PR TITLE
[Fix #10011] Fix a false positive for `Style/RedundantSelfAssignmentBranch`

### DIFF
--- a/changelog/fix_false_positive_for_style_redundant_self_assignment_branch.md
+++ b/changelog/fix_false_positive_for_style_redundant_self_assignment_branch.md
@@ -1,0 +1,1 @@
+* [#10011](https://github.com/rubocop/rubocop/issues/10011): Fix a false positive for `Style/RedundantSelfAssignmentBranch` when using instance variable, class variable, and global variable. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_self_assignment_branch.rb
+++ b/lib/rubocop/cop/style/redundant_self_assignment_branch.rb
@@ -5,6 +5,9 @@ module RuboCop
     module Style
       # This cop checks for places where conditional branch makes redundant self-assignment.
       #
+      # It only detects local variable because it may replace state of instance variable,
+      # class variable, and global variable that have state across methods with `nil`.
+      #
       # @example
       #
       #   # bad
@@ -44,10 +47,6 @@ module RuboCop
             register_offense(expression, else_branch, if_branch, 'if')
           end
         end
-
-        alias on_ivasgn on_lvasgn
-        alias on_cvasgn on_lvasgn
-        alias on_gvasgn on_lvasgn
 
         private
 

--- a/spec/rubocop/cop/style/redundant_self_assignment_branch_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_assignment_branch_spec.rb
@@ -125,36 +125,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelfAssignmentBranch, :config do
     RUBY
   end
 
-  it 'registers and corrects an offense when self-assigning redundant else ternary branch for ivar' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when self-assigning redundant else ternary branch for ivar' do
+    expect_no_offenses(<<~RUBY)
       @foo = condition ? @bar : @foo
-                                ^^^^ Remove the self-assignment branch.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      @foo = @bar if condition
     RUBY
   end
 
-  it 'registers and corrects an offense when self-assigning redundant else ternary branch for cvar' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when self-assigning redundant else ternary branch for cvar' do
+    expect_no_offenses(<<~RUBY)
       @@foo = condition ? @@bar : @@foo
-                                  ^^^^^ Remove the self-assignment branch.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      @@foo = @@bar if condition
     RUBY
   end
 
-  it 'registers and corrects an offense when self-assigning redundant else ternary branch for gvar' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when self-assigning redundant else ternary branch for gvar' do
+    expect_no_offenses(<<~RUBY)
       $foo = condition ? $bar : $foo
-                                ^^^^ Remove the self-assignment branch.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      $foo = $bar if condition
     RUBY
   end
 


### PR DESCRIPTION
Fixes #10011.

This PR fixes a false positive for `Style/RedundantSelfAssignmentBranch` when using instance variable, class variable, and global variable.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
