### PR TITLE
Fix sub-department cop doc generation

### DIFF
--- a/lib/rubocop/cop/documentation.rb
+++ b/lib/rubocop/cop/documentation.rb
@@ -8,7 +8,7 @@ module RuboCop
 
       # @api private
       def department_to_basename(department)
-        "cops_#{department.downcase}"
+        "cops_#{department.to_s.downcase.tr('/', '_')}"
       end
 
       # @api private


### PR DESCRIPTION
If you go to https://docs.rubocop.org/rubocop-rspec/2.0/upgrade_to_version_2.html, links to the second-level cops docs are broken. The last one is correct, https://docs.rubocop.org/rubocop-rspec/2.0/cops_rspec.html, while others have anchors, e.g. https://docs.rubocop.org/rubocop-rspec/2.0/upgrade_to_version_2.html#cops_capybara.adoc. This is probably due to `cops_docs.adoc` vs `cops_docs/` name clash.

Suspect: https://docs.antora.org/antora/2.3/page/page-id/#important

Ideally, we would generate `cops_rspec_capybara.adoc` instead of `cops_rspec/capybara.adoc.`

Other RuboCop extensions don't seem to make use of sub-departments, and will be unaffected by this change.

Related PR https://github.com/rubocop/rubocop-rspec/pull/1183


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/