### PR TITLE
[Fix #10010] Fix a false positive for `Style/DoubleNegation`

### DIFF
--- a/changelog/fix_false_positive_for_style_double_negation.md
+++ b/changelog/fix_false_positive_for_style_double_negation.md
@@ -1,0 +1,1 @@
+* [#10010](https://github.com/rubocop/rubocop/issues/10010): Fix a false positive for `Style/DoubleNegation` when `!!` is used at return location and before `rescue` keyword. ([@koic][])

--- a/lib/rubocop/cop/style/double_negation.rb
+++ b/lib/rubocop/cop/style/double_negation.rb
@@ -62,7 +62,7 @@ module RuboCop
         def end_of_method_definition?(node)
           return false unless (def_node = find_def_node_from_ascendant(node))
 
-          last_child = def_node.child_nodes.last
+          last_child = find_last_child(def_node.body)
 
           last_child.last_line == node.last_line
         end
@@ -72,6 +72,17 @@ module RuboCop
           return parent if parent.def_type? || parent.defs_type?
 
           find_def_node_from_ascendant(node.parent)
+        end
+
+        def find_last_child(node)
+          case node.type
+          when :rescue
+            find_last_child(node.body)
+          when :ensure
+            find_last_child(node.child_nodes.first)
+          else
+            node.child_nodes.last
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/double_negation_spec.rb
+++ b/spec/rubocop/cop/style/double_negation_spec.rb
@@ -66,6 +66,56 @@ RSpec.describe RuboCop::Cop::Style::DoubleNegation, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense for `!!` when return location and using `rescue`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          bar
+          !!baz.do_something
+        rescue
+          qux
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `!!` when return location and using `ensure`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          bar
+          !!baz.do_something
+        ensure
+          qux
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `!!` when return location and using `rescue` and `ensure`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          bar
+          !!baz.do_something
+        rescue
+          qux
+        ensure
+          corge
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `!!` when return location and using `rescue`, `else`, and `ensure`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          bar
+          !!baz.do_something
+        rescue
+          qux
+        else
+          quux
+        ensure
+          corge
+        end
+      RUBY
+    end
   end
 
   context 'when `EnforcedStyle: forbidden`' do
@@ -106,6 +156,102 @@ RSpec.describe RuboCop::Cop::Style::DoubleNegation, :config do
           return !bar.do_something.nil? if condition
           baz
           !bar.nil?
+        end
+      RUBY
+    end
+
+    it 'registers an offense for `!!` when return location and using `rescue`' do
+      expect_offense(<<~RUBY)
+        def foo?
+          bar
+          !!baz.do_something
+          ^ Avoid the use of double negation (`!!`).
+        rescue
+          qux
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          bar
+          !baz.do_something.nil?
+        rescue
+          qux
+        end
+      RUBY
+    end
+
+    it 'registers an offense for `!!` when return location and using `ensure`' do
+      expect_offense(<<~RUBY)
+        def foo?
+          bar
+          !!baz.do_something
+          ^ Avoid the use of double negation (`!!`).
+        ensure
+          qux
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          bar
+          !baz.do_something.nil?
+        ensure
+          qux
+        end
+      RUBY
+    end
+
+    it 'registers an offense for `!!` when return location and using `rescue` and `ensure`' do
+      expect_offense(<<~RUBY)
+        def foo?
+          bar
+          !!baz.do_something
+          ^ Avoid the use of double negation (`!!`).
+        rescue
+          baz
+        ensure
+          qux
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          bar
+          !baz.do_something.nil?
+        rescue
+          baz
+        ensure
+          qux
+        end
+      RUBY
+    end
+
+    it 'registers an offense for `!!` when return location and using `rescue`, `else`, and `ensure`' do
+      expect_offense(<<~RUBY)
+        def foo?
+          bar
+          !!baz.do_something
+          ^ Avoid the use of double negation (`!!`).
+        rescue
+          qux
+        else
+          quux
+        ensure
+          corge
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          bar
+          !baz.do_something.nil?
+        rescue
+          qux
+        else
+          quux
+        ensure
+          corge
         end
       RUBY
     end


### PR DESCRIPTION
Fixes #10010.

This PR fixes a false positive for `Style/DoubleNegation` when `!!` is used at return location and before `rescue` keyword.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
