### PR TITLE
Fix an error for `Layout/RescueEnsureAlignment`

### DIFF
--- a/changelog/fix_error_for_rescue_ensure_alignment.md
+++ b/changelog/fix_error_for_rescue_ensure_alignment.md
@@ -1,0 +1,1 @@
+* [#10017](https://github.com/rubocop/rubocop/pull/10017): Fixan error for `Layout/RescueEnsureAlignment` when using zsuper with block. ([@koic][])

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -137,17 +137,18 @@ module RuboCop
           send_node_loc = ancestor_node.send_node.loc
           do_keyword_line = ancestor_node.loc.begin.line
           rescue_keyword_column = node.loc.keyword.column
-          selector = send_node_loc.selector
+          selector = send_node_loc.respond_to?(:selector) ? send_node_loc.selector : send_node_loc
 
-          if send_node_loc.respond_to?(:dot) && (dot = send_node_loc.dot) &&
-             aligned_with_leading_dot?(do_keyword_line, dot, rescue_keyword_column)
+          if aligned_with_leading_dot?(do_keyword_line, send_node_loc, rescue_keyword_column)
             return true
           end
 
           do_keyword_line == selector.line && rescue_keyword_column == selector.column
         end
 
-        def aligned_with_leading_dot?(do_keyword_line, dot, rescue_keyword_column)
+        def aligned_with_leading_dot?(do_keyword_line, send_node_loc, rescue_keyword_column)
+          return false unless send_node_loc.respond_to?(:dot) && (dot = send_node_loc.dot)
+
           do_keyword_line == dot.line && rescue_keyword_column == dot.column
         end
 

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -769,6 +769,37 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
     end
   end
 
+  context 'when using zsuper with block' do
+    it 'registers and corrects an offense and corrects when incorrect alignment' do
+      expect_offense(<<~RUBY)
+        super do
+          nil
+            ensure
+            ^^^^^^ `ensure` at 3, 4 is not aligned with `super do` at 1, 0.
+          nil
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        super do
+          nil
+        ensure
+          nil
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when correct alignment' do
+      expect_no_offenses(<<~RUBY)
+        super do
+          nil
+        ensure
+          nil
+        end
+      RUBY
+    end
+  end
+
   describe 'excluded file', :config do
     let(:config) do
       RuboCop::Config.new('Layout/RescueEnsureAlignment' =>


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/pull/9974#issuecomment-899336636.

This PR fixes an error for `Layout/RescueEnsureAlignment` when using zsuper with block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
