### PR TITLE
[Fix #10016] Fix an incorrect auto-correct for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_sole_nested_conditional.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#10016](https://github.com/rubocop/rubocop/issues/10016): Fix an incorrect auto-correct for `Style/SoleNestedConditional` with `Style/NegatedIf`. ([@koic][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -38,6 +38,10 @@ module RuboCop
 
         MSG = 'Consider merging nested conditions into outer `%<conditional_type>s` conditions.'
 
+        def self.autocorrect_incompatible_with
+          [Style::NegatedIf]
+        end
+
         def on_if(node)
           return if node.ternary? || node.else? || node.elsif?
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -326,6 +326,26 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Style/SoleNestedConditional` with `Style/NegatedIf`' do
+    source = <<~RUBY
+      if !foo.nil?
+        if foo.do_something == bar
+          baz
+        end
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--auto-correct-all',
+                     '--only', 'Style/NegatedIf,Style/SoleNestedConditional'
+                   ])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      if !foo.nil? && (foo.do_something == bar)
+          baz
+        end
+    RUBY
+  end
+
   it 'corrects `Style/SoleNestedConditional` with `Style/InverseMethods` and `Style/IfUnlessModifier`' do
     source = <<~RUBY
       unless foo.to_s == 'foo'


### PR DESCRIPTION
Fixes #10016.

This PR fixes an incorrect auto-correct for `Style/SoleNestedConditional` with `Style/NegatedIf`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
