### PR TITLE
[Fix #10016] Fix conflict between `Style/SoleNestedConditional` and `Style/NegatedIf` or `Style/NegatedUnless`

### DIFF
--- a/changelog/fix_fix_conflict_between.md
+++ b/changelog/fix_fix_conflict_between.md
@@ -1,0 +1,1 @@
+* [#10016](https://github.com/rubocop/rubocop/issues/10016): Fix conflict between `Style/SoleNestedConditional` and `Style/NegatedIf`/`Style/NegatedUnless`. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -38,6 +38,10 @@ module RuboCop
 
         MSG = 'Consider merging nested conditions into outer `%<conditional_type>s` conditions.'
 
+        def self.autocorrect_incompatible_with
+          [Style::NegatedIf, Style::NegatedUnless]
+        end
+
         def on_if(node)
           return if node.ternary? || node.else? || node.elsif?
 


### PR DESCRIPTION
When both `Style/SoleNestedConditional` and one of `Style/NegatedIf` or `Style/NegatedUnless` detect offenses on the same nested if, both corrections are applied, which results in the second clause of the resulting conditional to be inverted.

Fixes #10016.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
