### PR TITLE
[Fix #10014] Fix `Style/Encoding` to handle more situations properly

### DIFF
--- a/changelog/fix_fix_styleencoding_to_handle_more.md
+++ b/changelog/fix_fix_styleencoding_to_handle_more.md
@@ -1,0 +1,1 @@
+* [#10014](https://github.com/rubocop/rubocop/issues/10014): Fix `Style/Encoding` to handle more situations properly. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -1,15 +1,22 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::Encoding, :config do
-  it 'registers no offense when no encoding present' do
+  it 'does not register an offense when no encoding present' do
     expect_no_offenses(<<~RUBY)
       def foo() end
     RUBY
   end
 
-  it 'registers no offense when encoding present but not UTF-8' do
+  it 'does not register an offense when encoding present but not UTF-8' do
     expect_no_offenses(<<~RUBY)
       # encoding: us-ascii
+      def foo() end
+    RUBY
+  end
+
+  it 'does not register an offense on a different magic comment type' do
+    expect_no_offenses(<<~RUBY)
+      # frozen-string-literal: true
       def foo() end
     RUBY
   end
@@ -40,10 +47,12 @@ RSpec.describe RuboCop::Cop::Style::Encoding, :config do
     RUBY
   end
 
-  it 'registers an offense for vim-style encoding comments' do
+  it 'registers an offense and corrects if there are multiple encoding magic comments' do
     expect_offense(<<~RUBY)
-      # vim:filetype=ruby, fileencoding=utf-8
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
+      # encoding: utf-8
+      ^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
+      # coding: utf-8
+      ^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
       def foo() end
     RUBY
 
@@ -52,22 +61,75 @@ RSpec.describe RuboCop::Cop::Style::Encoding, :config do
     RUBY
   end
 
-  it 'registers no offense when encoding is in the wrong place' do
+  it 'registers an offense and corrects the magic comment follows another magic comment' do
+    expect_offense(<<~RUBY)
+      # frozen-string-literal: true
+      # encoding: utf-8
+      ^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
+      def foo() end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # frozen-string-literal: true
+      def foo() end
+    RUBY
+  end
+
+  it 'does not register an offense when encoding is not at the top of the file' do
+    expect_no_offenses(<<~RUBY)
+      # frozen-string-literal: true
+
+      # encoding: utf-8
+      def foo() end
+    RUBY
+  end
+
+  it 'does not register an offense when encoding is in the wrong place' do
     expect_no_offenses(<<~RUBY)
       def foo() end
       # encoding: utf-8
     RUBY
   end
 
-  it 'registers an offense for encoding inserted by magic_encoding gem' do
-    expect_offense(<<~RUBY)
-      # -*- encoding : utf-8 -*-
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
-      def foo() 'ä' end
-    RUBY
+  context 'vim comments' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        # vim:filetype=ruby, fileencoding=utf-8
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
+        def foo() end
+      RUBY
 
-    expect_correction(<<~RUBY)
-      def foo() 'ä' end
-    RUBY
+      expect_correction(<<~RUBY)
+        # vim: filetype=ruby
+        def foo() end
+      RUBY
+    end
+  end
+
+  context 'emacs comment' do
+    it 'registers an offense for encoding' do
+      expect_offense(<<~RUBY)
+        # -*- encoding : utf-8 -*-
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
+        def foo() 'ä' end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo() 'ä' end
+      RUBY
+    end
+
+    it 'only removes encoding if there are other editor comments' do
+      expect_offense(<<~RUBY)
+        # -*- encoding : utf-8; mode: enh-ruby -*-
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
+        def foo() 'ä' end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # -*- mode: enh-ruby -*-
+        def foo() 'ä' end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Refactors `Style/Encoding` to make use of the `MagicComment` class. Now `Style/Encoding` can handle the following situations:
* multiple encoding magic comments
* encoding magic comments following other magic comments
* magic comments containing multiple directives (only the encoding is removed)

Fixes #10014.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
