### PR TITLE
Implemented Layout/SpaceInsideParens with EnforcedStyle: compact

### DIFF
--- a/changelog/new_space_inside_parens_compact.md
+++ b/changelog/new_space_inside_parens_compact.md
@@ -1,0 +1,1 @@
+* [#10025](https://github.com/rubocop/rubocop/pull/10025): Changed cop `SpaceInsideParens` to include a `compact` style.  ([@itay-grudev][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1347,10 +1347,11 @@ Layout/SpaceInsideParens:
   StyleGuide: '#spaces-braces'
   Enabled: true
   VersionAdded: '0.49'
-  VersionChanged: '0.55'
+  VersionChanged: '<<next>>'
   EnforcedStyle: no_space
   SupportedStyles:
     - space
+    - compact
     - no_space
 
 Layout/SpaceInsidePercentLiteralDelimiters:

--- a/lib/rubocop/cop/layout/space_inside_parens.rb
+++ b/lib/rubocop/cop/layout/space_inside_parens.rb
@@ -35,7 +35,7 @@ module RuboCop
       #
       # @example EnforcedStyle: compact
       #   # The `compact` style enforces that parentheses have a space at the
-      #   # beginning with the exception that successive right parentheses are allowed.
+      #   # beginning with the exception that successive parentheses are allowed.
       #   # Note: Empty parentheses should not have spaces.
       #
       #   # bad

--- a/spec/rubocop/cop/layout/space_inside_parens_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_parens_spec.rb
@@ -151,4 +151,134 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParens, :config do
       RUBY
     end
   end
+
+  context 'when EnforcedStyle is compact' do
+    let(:cop_config) { { 'EnforcedStyle' => 'compact' } }
+
+    it 'registers an offense for no spaces inside parens' do
+      expect_offense(<<~RUBY)
+        f( 3)
+            ^ No space inside parentheses detected.
+        g = (a + 3 )
+             ^ No space inside parentheses detected.
+        split("\\n")
+              ^ No space inside parentheses detected.
+                  ^ No space inside parentheses detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        f( 3 )
+        g = ( a + 3 )
+        split( "\\n" )
+      RUBY
+    end
+
+    it 'registers an offense for space inside empty parens' do
+      expect_offense(<<~RUBY)
+        f( )
+          ^ Space inside parentheses detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        f()
+      RUBY
+    end
+
+    it 'registers an offense in block parameter list with no spaces' do
+      expect_offense(<<~RUBY)
+        list.inject( Tms.new ) { |sum, (label, item)|
+                                        ^ No space inside parentheses detected.
+                                                   ^ No space inside parentheses detected.
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        list.inject( Tms.new ) { |sum, ( label, item )|
+        }
+      RUBY
+    end
+
+    it 'registers an offense for no space around heredoc start' do
+      expect_offense(<<~RUBY)
+        f(<<~HEREDOC)
+                    ^ No space inside parentheses detected.
+          ^ No space inside parentheses detected.
+          This is my text
+        HEREDOC
+      RUBY
+
+      expect_correction(<<~RUBY)
+        f( <<~HEREDOC )
+          This is my text
+        HEREDOC
+      RUBY
+    end
+
+    it 'accepts empty parentheses without spaces' do
+      expect_no_offenses('f()')
+    end
+
+    it 'accepts parentheses with spaces' do
+      expect_no_offenses(<<~RUBY)
+        f( 3 )
+        g = ( a + 3 )
+        split( "\\n" )
+      RUBY
+    end
+
+    it 'accepts parentheses with line break' do
+      expect_no_offenses(<<~RUBY)
+        f(
+          1 )
+      RUBY
+    end
+
+    it 'accepts parentheses with comment and line break' do
+      expect_no_offenses(<<~RUBY)
+        f( # Comment
+          1 )
+      RUBY
+    end
+
+    it 'accepts two consecutive right parentheses' do
+      expect_no_offenses(<<~RUBY)
+        f( x( 3 ))
+        g( f( x( 3 )), 5 )
+      RUBY
+    end
+
+    it 'accepts three consecutive right parentheses' do
+      expect_no_offenses(<<~RUBY)
+        g( f( x( 3 )))
+        w( g( f( x( 3 ))), 5 )
+      RUBY
+    end
+
+    it 'registers an offense for space between consecutive brackets' do
+      expect_offense(<<~RUBY)
+        f( x( 3 ) )
+                 ^ Space inside parentheses detected.
+        g( f( x( 3 ) ), 5 )
+                    ^ Space inside parentheses detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        f( x( 3 ))
+        g( f( x( 3 )), 5 )
+      RUBY
+    end
+
+    it 'registers multiple offense for a missing and extra space between consecutive brackets' do
+      expect_offense(<<~RUBY)
+        (g( f( x( 3 ) ), 5 ) )
+                            ^ Space inside parentheses detected.
+                     ^ Space inside parentheses detected.
+         ^ No space inside parentheses detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ( g( f( x( 3 )), 5 ))
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/space_inside_parens_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_parens_spec.rb
@@ -240,10 +240,22 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParens, :config do
       RUBY
     end
 
+    it 'accepts two consecutive left parentheses' do
+      expect_no_offenses(<<~RUBY)
+        f(( 3 + 5 ) * x )
+      RUBY
+    end
+
     it 'accepts two consecutive right parentheses' do
       expect_no_offenses(<<~RUBY)
         f( x( 3 ))
         g( f( x( 3 )), 5 )
+      RUBY
+    end
+
+    it 'accepts three consecutive left parentheses' do
+      expect_no_offenses(<<~RUBY)
+        g((( 3 + 5 ) * f ) ** x, 5 )
       RUBY
     end
 
@@ -256,6 +268,11 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParens, :config do
 
     it 'registers an offense for space between consecutive brackets' do
       expect_offense(<<~RUBY)
+        f( ( 3 + 5 ) * x )
+          ^ Space inside parentheses detected.
+        g( ( ( 3 + 5 ) * f ) ** x, 5 )
+            ^ Space inside parentheses detected.
+          ^ Space inside parentheses detected.
         f( x( 3 ) )
                  ^ Space inside parentheses detected.
         g( f( x( 3 ) ), 5 )
@@ -263,6 +280,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParens, :config do
       RUBY
 
       expect_correction(<<~RUBY)
+        f(( 3 + 5 ) * x )
+        g((( 3 + 5 ) * f ) ** x, 5 )
         f( x( 3 ))
         g( f( x( 3 )), 5 )
       RUBY
@@ -270,6 +289,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParens, :config do
 
     it 'registers multiple offense for a missing and extra space between consecutive brackets' do
       expect_offense(<<~RUBY)
+        g( (( 3 + 5 ) * f) ** x, 5)
+                                  ^ No space inside parentheses detected.
+                         ^ No space inside parentheses detected.
+          ^ Space inside parentheses detected.
         (g( f( x( 3 ) ), 5 ) )
                             ^ Space inside parentheses detected.
                      ^ Space inside parentheses detected.
@@ -277,6 +300,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParens, :config do
       RUBY
 
       expect_correction(<<~RUBY)
+        g((( 3 + 5 ) * f ) ** x, 5 )
         ( g( f( x( 3 )), 5 ))
       RUBY
     end


### PR DESCRIPTION
```yml
Layout/SpaceInsideParens:
  EnforcedStyle: compact
```

```ruby
@example 
# The `compact` style enforces that parentheses have a space at the
# beginning with the exception that successive right parentheses are allowed.
# Note: Empty parentheses should not have spaces.

# bad
f(3)
g = (a + 3)
y( )
g( f( x ) )
g( f( x( 3 ) ), 5 )

# good
f( 3 )
g = ( a + 3 )
y()
g( f( x ))
g( f( x( 3 )), 5 )
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
