### PR TITLE
[Fix #10024] Fix an incorrect auto-correct for `Style/RedundantSelfAssignmentBranch`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_redundant_self_assignment_branch.md
+++ b/changelog/fix_incorrect_autocorrect_for_redundant_self_assignment_branch.md
@@ -1,0 +1,1 @@
+* [#10024](https://github.com/rubocop/rubocop/issues/10024): Fix an incorrect auto-correct for `Style/RedundantSelfAssignmentBranch` when using multiline `if` / `else` conditional assignment. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_self_assignment_branch_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_assignment_branch_spec.rb
@@ -34,9 +34,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelfAssignmentBranch, :config do
     RUBY
 
     expect_correction(<<~RUBY)
-      foo = if condition
-              bar
-            end
+      foo = bar if condition
     RUBY
   end
 
@@ -51,44 +49,26 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelfAssignmentBranch, :config do
     RUBY
 
     expect_correction(<<~RUBY)
-      foo = unless condition
-              bar
-            end
+      foo = bar unless condition
     RUBY
   end
 
-  it 'registers and corrects an offense when self-assigning redundant else branch and multiline if branch' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when self-assigning redundant else branch and multiline if branch' do
+    expect_no_offenses(<<~RUBY)
       foo = if condition
               bar
               baz
             else
               foo
-              ^^^ Remove the self-assignment branch.
-            end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      foo = if condition
-              bar
-              baz
             end
     RUBY
   end
 
-  it 'registers and corrects an offense when self-assigning redundant else branch and multiline else branch' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when self-assigning redundant else branch and multiline else branch' do
+    expect_no_offenses(<<~RUBY)
       foo = if condition
               foo
-              ^^^ Remove the self-assignment branch.
             else
-              bar
-              baz
-            end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      foo = unless condition
               bar
               baz
             end
@@ -105,8 +85,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelfAssignmentBranch, :config do
     RUBY
 
     expect_correction(<<~RUBY)
-      foo = if condition
-            end
+      foo = nil if condition
     RUBY
   end
 
@@ -120,8 +99,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelfAssignmentBranch, :config do
     RUBY
 
     expect_correction(<<~RUBY)
-      foo = unless condition
-            end
+      foo = nil unless condition
     RUBY
   end
 
@@ -170,20 +148,11 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelfAssignmentBranch, :config do
     RUBY
   end
 
-  it 'registers and corrects an offense when using `elsif` and self-assigning the value of `then` branch' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when using `elsif` and self-assigning the value of `then` branch' do
+    expect_no_offenses(<<~RUBY)
       foo = if condition
         foo
-        ^^^ Remove the self-assignment branch.
       elsif another_condtion
-        bar
-      else
-        baz
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      foo = if another_condtion
         bar
       else
         baz
@@ -191,9 +160,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelfAssignmentBranch, :config do
     RUBY
   end
 
-  # It may be possible to extend it to register an offense in future.
-  # auto-correction test patterns should be considered and implemented.
-  it 'registers and corrects an offense when using `elsif` and self-assigning the value of `elsif` branch' do
+  it 'does not register an offense when using `elsif` and self-assigning the value of `elsif` branch' do
     expect_no_offenses(<<~RUBY)
       foo = if condition
               bar
@@ -205,9 +172,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelfAssignmentBranch, :config do
     RUBY
   end
 
-  # It may be possible to extend it to register an offense in future.
-  # auto-correction test patterns should be considered and implemented.
-  it 'registers and corrects an offense when using `elsif` and self-assigning the value of `else` branch' do
+  it 'does not register an offense when using `elsif` and self-assigning the value of `else` branch' do
     expect_no_offenses(<<~RUBY)
       foo = if condition
               bar


### PR DESCRIPTION
Fixes #10024.

This PR fixes an incorrect auto-correct for `Style/RedundantSelfAssignmentBranch` when using multiline `if` / `else` conditional assignment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
