### PR TITLE
Remove redundant parentheses in pending cops message

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -161,7 +161,7 @@ module RuboCop
       def warn_pending_cop(cop)
         version = cop.metadata['VersionAdded'] || 'N/A'
 
-        warn Rainbow("#{cop.name}: # (new in #{version})").yellow
+        warn Rainbow("#{cop.name}: # new in #{version}").yellow
         warn Rainbow('  Enabled: true').yellow
       end
 

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -415,7 +415,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
               remaining_range = pending_cop_warning.length..-(inspected_output.length + 1)
               pending_cops = output[remaining_range]
 
-              expect(pending_cops).to include("Style/SomeCop: # (new in 0.80)\n  Enabled: true")
+              expect(pending_cops).to include("Style/SomeCop: # new in 0.80\n  Enabled: true")
 
               manual_url = output[remaining_range].split("\n").last
 
@@ -433,7 +433,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
               remaining_range = pending_cop_warning.length..-(inspected_output.length + 1)
               pending_cops = output[remaining_range]
 
-              expect(pending_cops).to include("Style/SomeCop: # (new in N/A)\n  Enabled: true")
+              expect(pending_cops).to include("Style/SomeCop: # new in N/A\n  Enabled: true")
 
               manual_url = output[remaining_range].split("\n").last
 


### PR DESCRIPTION
Follow up to #8414.

Perhaps the parentheses used in the old plain-text format message remain.
In the current YAML format comment it would look redundant.

## Past

```console
- Gemspec/DateAssignment (1.10)
```

## Present

```console
Gemspec/DateAssignment: # (new in 1.10)
  Enabled: true
```

## Future

```console
Gemspec/DateAssignment: # new in 1.10
  Enabled: true
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
