### PR TITLE
[Fix #10031] Fix a false positive for `Style/HashExcept`

### DIFF
--- a/changelog/fix_false_positive_for_style_hash_except.md
+++ b/changelog/fix_false_positive_for_style_hash_except.md
@@ -1,0 +1,1 @@
+* [#10031](https://github.com/rubocop/rubocop/issues/10031): Fix a false positive for `Style/HashExcept` when comparing with hash value. ([@koic][])

--- a/lib/rubocop/cop/style/hash_except.rb
+++ b/lib/rubocop/cop/style/hash_except.rb
@@ -49,7 +49,7 @@ module RuboCop
           return unless bad_method?(block) && semantically_except_method?(node, block)
 
           except_key = except_key(block)
-          return unless safe_to_register_offense?(block, except_key)
+          return if except_key.nil? || !safe_to_register_offense?(block, except_key)
 
           range = offense_range(node)
           preferred_method = "except(#{except_key.source})"
@@ -81,10 +81,11 @@ module RuboCop
         end
 
         def except_key(node)
-          key_argument = node.argument_list.first
+          key_argument = node.argument_list.first.source
           lhs, _method_name, rhs = *node.body
+          return if [lhs, rhs].map(&:source).none?(key_argument)
 
-          [lhs, rhs].find { |operand| operand.source != key_argument.source }
+          [lhs, rhs].find { |operand| operand.source != key_argument }
         end
 
         def offense_range(node)

--- a/spec/rubocop/cop/style/hash_except_spec.rb
+++ b/spec/rubocop/cop/style/hash_except_spec.rb
@@ -96,6 +96,12 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
         {foo: 1, bar: 2, baz: 3}.keep_if { |k, v| k != :bar }
       RUBY
     end
+
+    it 'does not register an offense when comparing with hash value' do
+      expect_no_offenses(<<~RUBY)
+        {foo: 1, bar: 2, baz: 3}.reject { |k, v| v.eql? :bar }
+      RUBY
+    end
   end
 
   context 'Ruby 2.7 or lower', :ruby27 do


### PR DESCRIPTION
Fixes #10031.

This PR fixes a false positive for `Style/HashExcept` when comparing with hash value.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
