### PR TITLE
Add `RubyJard` debugger calls to Lint/Debugger/DebuggerMethods

### DIFF
--- a/changelog/change_add_rubyjard_debugger_calls_to.md
+++ b/changelog/change_add_rubyjard_debugger_calls_to.md
@@ -1,0 +1,1 @@
+* [#10034](https://github.com/rubocop/rubocop/pull/10034): Add `RubyJard` debugger calls to Lint/Debugger/DebuggerMethods. ([@DanielVartanov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1527,6 +1527,8 @@ Lint/Debugger:
     Rails:
       - debugger
       - Kernel.debugger
+    RubyJard:
+      - jard
     WebConsole:
       - binding.console
 

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -8,7 +8,7 @@ module RuboCop
       #
       # The cop can be configured using `DebuggerMethods`. By default, a number of gems
       # debug entrypoints are configured (`Kernel`, `Byebug`, `Capybara`, `Pry`, `Rails`,
-      # and `WebConsole`). Additional methods can be added.
+      # `RubyJard` and `WebConsole`). Additional methods can be added.
       #
       # Specific default groups can be disabled if necessary:
       #

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -218,6 +218,15 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
     end
   end
 
+  context 'RubyJard' do
+    it 'registers an offense for a jard call' do
+      expect_offense(<<~RUBY)
+        jard
+        ^^^^ Remove debugger entry point `jard`.
+      RUBY
+    end
+  end
+
   context 'web console' do
     it 'registers an offense for a `binding.console` call' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR adds a call to [RubyJard](https://rubyjard.org/) debugger, which is `jard`, to `Lint/Debugger/DebuggerMethods`

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
