### PR TITLE
[Fix #10033] Fix an incorrect auto-correct for `Style/BlockDelimiters`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_block_delimiters.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_block_delimiters.md
@@ -1,0 +1,1 @@
+* [#10033](https://github.com/rubocop/rubocop/issues/10033): Fix an incorrect auto-correct for `Style/BlockDelimiters` when there is a comment after the closing brace and using method chanin. ([@koic][])

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 module RuboCop
   module Cop
     module Style
@@ -275,12 +276,18 @@ module RuboCop
         end
 
         def move_comment_before_block(corrector, comment, block_node, closing_brace)
-          range = range_between(closing_brace.end_pos, comment.loc.expression.end_pos)
-
-          corrector.remove(range_with_surrounding_space(range: range, side: :right))
-          corrector.insert_after(closing_brace, "\n")
+          range = block_node.chained? ? end_of_chain(block_node.parent).source_range : closing_brace
+          comment_range = range_between(range.end_pos, comment.loc.expression.end_pos)
+          corrector.remove(range_with_surrounding_space(range: comment_range, side: :right))
+          corrector.insert_after(range, "\n")
 
           corrector.insert_before(block_node, "#{comment.text}\n")
+        end
+
+        def end_of_chain(node)
+          return node unless node.chained?
+
+          end_of_chain(node.parent)
         end
 
         def get_blocks(node, &block)
@@ -411,3 +418,4 @@ module RuboCop
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -368,6 +368,20 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
 
+      it 'registers an offense when there is a comment after the closing brace and using method chain' do
+        expect_offense(<<~RUBY)
+          baz.map { |x|
+                  ^ Avoid using `{...}` for multi-line blocks.
+          foo(x) }.qux.quux # comment
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # comment
+          baz.map do |x|
+          foo(x) end.qux.quux
+        RUBY
+      end
+
       it 'registers an offense when there is a comment after the closing brace and block body is empty' do
         expect_offense(<<~RUBY)
           baz.map { |x|


### PR DESCRIPTION
Fixes #10033.

This PR fixes an incorrect auto-correct for `Style/BlockDelimiters` when there is a comment after the closing brace and using method chain.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
