### PR TITLE
[Fix #10036] Mark `Style/StructInheritance` as unsafe auto-correction

### DIFF
--- a/changelog/change_mark_style_struct_inheritance_as_unsafe_auto_correction.md
+++ b/changelog/change_mark_style_struct_inheritance_as_unsafe_auto_correction.md
@@ -1,0 +1,1 @@
+* [#10036](https://github.com/rubocop/rubocop/issues/10036): Mark `Style/StructInheritance` as unsafe auto-correction. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4694,8 +4694,9 @@ Style/StructInheritance:
   Description: 'Checks for inheritance from Struct.new.'
   StyleGuide: '#no-extend-struct-new'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.29'
-  VersionChanged: '0.86'
+  VersionChanged: '<<next>>'
 
 Style/SwapValues:
   Description: 'This cop enforces the use of shorthand-style swapping of 2 variables.'

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -5,6 +5,9 @@ module RuboCop
     module Style
       # This cop checks for inheritance from Struct.new.
       #
+      # It is marked as unsafe auto-correction because it will change the
+      # inheritance tree (e.g. return value of `Module#ancestors`).
+      #
       # @example
       #   # bad
       #   class Person < Struct.new(:first_name, :last_name)


### PR DESCRIPTION
Fixes #10036.

This PR marks `Style/StructInheritance` as unsafe auto-correction.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
