### PR TITLE
[Fix #6630] Updated `Style/CommentAnnotation` to be able to handle multiword keyword phrases

### DIFF
--- a/changelog/fix_updated_annotationcomment_to_be_able_to.md
+++ b/changelog/fix_updated_annotationcomment_to_be_able_to.md
@@ -1,0 +1,1 @@
+* [#6630](https://github.com/rubocop/rubocop/issues/6630): Updated `Style/CommentAnnotation` to be able to handle multiword keyword phrases. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3149,7 +3149,7 @@ Style/CommentAnnotation:
   StyleGuide: '#annotate-keywords'
   Enabled: true
   VersionAdded: '0.10'
-  VersionChanged: '1.3'
+  VersionChanged: '<<next>>'
   Keywords:
     - TODO
     - FIXME

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -57,7 +57,6 @@ require_relative 'rubocop/cop/variable_force/reference'
 require_relative 'rubocop/cop/variable_force/scope'
 require_relative 'rubocop/cop/variable_force/variable_table'
 
-require_relative 'rubocop/cop/mixin/annotation_comment'
 require_relative 'rubocop/cop/mixin/array_min_size'
 require_relative 'rubocop/cop/mixin/array_syntax'
 require_relative 'rubocop/cop/mixin/alignment'
@@ -76,6 +75,7 @@ require_relative 'rubocop/cop/mixin/def_node'
 require_relative 'rubocop/cop/mixin/documentation_comment'
 require_relative 'rubocop/cop/mixin/duplication'
 require_relative 'rubocop/cop/mixin/range_help'
+require_relative 'rubocop/cop/mixin/annotation_comment' # relies on range
 require_relative 'rubocop/cop/mixin/empty_lines_around_body' # relies on range
 require_relative 'rubocop/cop/mixin/empty_parameter'
 require_relative 'rubocop/cop/mixin/end_keyword_alignment'

--- a/lib/rubocop/cop/mixin/documentation_comment.rb
+++ b/lib/rubocop/cop/mixin/documentation_comment.rb
@@ -5,7 +5,6 @@ module RuboCop
     # Common functionality for checking documentation.
     module DocumentationComment
       extend NodePattern::Macros
-      include Style::AnnotationComment
 
       private
 
@@ -15,7 +14,7 @@ module RuboCop
         return false unless preceding_comment?(node, preceding_lines.last)
 
         preceding_lines.any? do |comment|
-          !annotation?(comment) &&
+          !AnnotationComment.new(comment, annotation_keywords).annotation? &&
             !interpreter_directive_comment?(comment) &&
             !rubocop_directive_comment?(comment)
         end
@@ -43,6 +42,10 @@ module RuboCop
 
       def rubocop_directive_comment?(comment)
         !!DirectiveComment.new(comment).match_captures
+      end
+
+      def annotation_keywords
+        config.for_cop('Style/CommentAnnotation')['Keywords']
       end
     end
   end

--- a/lib/rubocop/cop/style/comment_annotation.rb
+++ b/lib/rubocop/cop/style/comment_annotation.rb
@@ -6,6 +6,9 @@ module RuboCop
       # This cop checks that comment annotation keywords are written according
       # to guidelines.
       #
+      # Annotation keywords can be specified by overriding the cop's `Keywords`
+      # configuration. Keywords are allowed to be single words or phrases.
+      #
       # NOTE: With a multiline comment block (where each line is only a
       # comment), only the first line will be able to register an offense, even
       # if an annotation keyword starts another line. This is done to prevent

--- a/spec/rubocop/cop/annotation_comment_spec.rb
+++ b/spec/rubocop/cop/annotation_comment_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::AnnotationComment do
+  subject(:annotation) { described_class.new(comment, keywords) }
+
+  let(:keywords) { %w[TODO FIXME] }
+  let(:comment) { instance_double('Parser::Source::Comment', text: "# #{text}") }
+
+  describe '#annotation?' do
+    subject { annotation.annotation? }
+
+    context 'when given a keyword followed by a colon' do
+      let(:text) { 'TODO: note' }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when given a keyword followed by a space' do
+      let(:text) { 'TODO note' }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the keyword is not capitalized properly' do
+      let(:text) { 'todo: note' }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when annotated with a non keyword' do
+      let(:text) { 'SOMETHING: note' }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when given as the first word of a sentence' do
+      let(:text) { 'Todo in the future' }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when it includes a keyword' do
+      let(:text) { 'TODO2' }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe '#correct?' do
+    shared_examples_for 'correct' do |text|
+      let(:text) { text }
+
+      it { is_expected.to be_truthy }
+    end
+
+    shared_examples_for 'incorrect' do |text|
+      let(:text) { text }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when a colon is required' do
+      subject { annotation.correct?(colon: true) }
+
+      it_behaves_like 'correct', 'TODO: text'
+      it_behaves_like 'correct', 'FIXME: text'
+      it_behaves_like 'incorrect', 'TODO: '
+      it_behaves_like 'incorrect', 'TODO '
+      it_behaves_like 'incorrect', 'TODO'
+      it_behaves_like 'incorrect', 'TODOtext'
+      it_behaves_like 'incorrect', 'TODO:text'
+      it_behaves_like 'incorrect', 'TODO2: text'
+      it_behaves_like 'incorrect', 'TODO text'
+      it_behaves_like 'incorrect', 'todo text'
+      it_behaves_like 'incorrect', 'UPDATE: text'
+      it_behaves_like 'incorrect', 'UPDATE text'
+    end
+
+    context 'when no colon is required' do
+      subject { annotation.correct?(colon: false) }
+
+      it_behaves_like 'correct', 'TODO text'
+      it_behaves_like 'correct', 'FIXME text'
+      it_behaves_like 'incorrect', 'TODO: '
+      it_behaves_like 'incorrect', 'TODO '
+      it_behaves_like 'incorrect', 'TODO'
+      it_behaves_like 'incorrect', 'TODOtext'
+      it_behaves_like 'incorrect', 'TODO:text'
+      it_behaves_like 'incorrect', 'TODO2 text'
+      it_behaves_like 'incorrect', 'TODO: text'
+      it_behaves_like 'incorrect', 'todo text'
+      it_behaves_like 'incorrect', 'UPDATE: text'
+      it_behaves_like 'incorrect', 'UPDATE text'
+    end
+  end
+end

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -71,10 +71,21 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
       end
     end
 
-    context 'upper case keyword with colon by no note' do
+    context 'upper case keyword with colon but no note' do
       it 'registers an offense without auto-correction' do
         expect_offense(<<~RUBY)
           # HACK:
+            ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.
+        RUBY
+
+        expect_no_corrections
+      end
+    end
+
+    context 'upper case keyword with space but no note' do
+      it 'registers an offense without auto-correction' do
+        expect_offense(<<~RUBY)
+          # HACK#{trailing_whitespace}
             ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.
         RUBY
 
@@ -193,10 +204,21 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
       end
     end
 
-    context 'upper case keyword with colon by no note' do
+    context 'upper case keyword with colon but no note' do
       it 'registers an offense without auto-correction' do
         expect_offense(<<~RUBY)
           # HACK:
+            ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.
+        RUBY
+
+        expect_no_corrections
+      end
+    end
+
+    context 'upper case keyword with space but no note' do
+      it 'registers an offense without auto-correction' do
+        expect_offense(<<~RUBY)
+          # HACK#{trailing_whitespace}
             ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.
         RUBY
 

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -153,6 +153,19 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
         RUBY
       end
     end
+
+    context 'with multiword keywords' do
+      let(:cop_config) { { 'Keywords' => ['TODO', 'DO SOMETHING', 'TODO LATER'] } }
+
+      it 'registers an offense for each matching keyword' do
+        cop_config['Keywords'].each do |keyword|
+          expect_offense(<<~RUBY, keyword: keyword)
+            # #{keyword} blah blah blah
+              ^{keyword}^ Annotation keywords like `#{keyword}` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+          RUBY
+        end
+      end
+    end
   end
 
   context 'with RequireColon configuration set to false' do


### PR DESCRIPTION
This change first refactors `AnnotationComment` to be an actual class modeling an annotation comment, and then updates it to be able to handle multiword phrases as annotation keywords.

With config:
```yaml
Style/CommentAnnotation:
  Keywords:
    - TODO
    - TODO LATER
```

```sh
test.rb:1:1: C: [Correctable] Style/CommentAnnotation: Annotation keywords like TODO LATER should be all upper case, followed by a colon, and a space, then a note describing the problem.
# TODO LATER blah blah blah
  ^^^^^^^^^^^
```

Fixes #6630.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
