### PR TITLE
Make `Lint/Debugger` aware of debug.rb

### DIFF
--- a/changelog/new_make_lint_debugger_aware_of_debug_rb.md
+++ b/changelog/new_make_lint_debugger_aware_of_debug_rb.md
@@ -1,0 +1,1 @@
+* [#10040](https://github.com/rubocop/rubocop/pull/10040): Make `Lint/Debugger` aware of debug.rb. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1519,6 +1519,11 @@ Lint/Debugger:
     Capybara:
       - save_and_open_page
       - save_and_open_screenshot
+    debug.rb:
+      - binding.b
+      - binding.break
+      - Kernel.binding.b
+      - Kernel.binding.break
     Pry:
       - binding.pry
       - binding.remote_pry

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -7,8 +7,8 @@ module RuboCop
       # not be kept for production code.
       #
       # The cop can be configured using `DebuggerMethods`. By default, a number of gems
-      # debug entrypoints are configured (`Kernel`, `Byebug`, `Capybara`, `Pry`, `Rails`,
-      # `RubyJard` and `WebConsole`). Additional methods can be added.
+      # debug entrypoints are configured (`Kernel`, `Byebug`, `Capybara`, `debug.rb`,
+      # `Pry`, `Rails`, `RubyJard`, and `WebConsole`). Additional methods can be added.
       #
       # Specific default groups can be disabled if necessary:
       #

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -114,6 +114,36 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
     end
   end
 
+  context 'debug.rb' do
+    it 'registers an offense for a `b` binding call' do
+      expect_offense(<<~RUBY)
+        binding.b
+        ^^^^^^^^^ Remove debugger entry point `binding.b`.
+      RUBY
+    end
+
+    it 'registers an offense for a `break` binding call' do
+      expect_offense(<<~RUBY)
+        binding.break
+        ^^^^^^^^^^^^^ Remove debugger entry point `binding.break`.
+      RUBY
+    end
+
+    it 'registers an offense for a `binding.b` with `Kernel` call' do
+      expect_offense(<<~RUBY)
+        Kernel.binding.b
+        ^^^^^^^^^^^^^^^^ Remove debugger entry point `Kernel.binding.b`.
+      RUBY
+    end
+
+    it 'registers an offense for a `binding.break` with `Kernel` call' do
+      expect_offense(<<~RUBY)
+        Kernel.binding.break
+        ^^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `Kernel.binding.break`.
+      RUBY
+    end
+  end
+
   context 'pry' do
     it 'registers an offense for a pry binding call' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR makes `Lint/Debugger` aware of debug.rb.
https://github.com/ruby/debug

debug.rb has `binding.break` and `binding.b` commands (`b` for short).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
