### PR TITLE
Clarify relationship between `Layout/MultilineMethodArgumentLineBreaks` and `Layout/FirstMethodArgumentLineBreak`

### DIFF
--- a/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
@@ -6,6 +6,9 @@ module RuboCop
       # This cop ensures that each argument in a multi-line method call
       # starts on a separate line.
       #
+      # NOTE: this cop does not move the first argument, if you want that to
+      # be on a separate line, see `Layout/FirstMethodArgumentLineBreak`.
+      #
       # @example
       #
       #   # bad

--- a/spec/rubocop/cop/layout/multiline_method_argument_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_argument_line_breaks_spec.rb
@@ -141,4 +141,22 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodArgumentLineBreaks, :config 
       RUBY
     end
   end
+
+  context 'when there are multiple arguments on the first line' do
+    it 'registers an offense and corrects starting from the 2nd argument' do
+      expect_offense(<<~RUBY)
+        do_something(foo, bar, baz,
+                               ^^^ Each argument in a multi-line method call must start on a separate line.
+                          ^^^ Each argument in a multi-line method call must start on a separate line.
+          quux)
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something(foo,#{trailing_whitespace}
+        bar,#{trailing_whitespace}
+        baz,
+          quux)
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Just a documentation change following https://github.com/rubocop/rubocop/issues/7689#issuecomment-905822940 to clarify that the first argument is not moved by `Layout/MultilineMethodArgumentLineBreaks` but rather by `Layout/FirstMethodArgumentLineBreak`.