### PR TITLE
[Fix #7836] Update `Style/BlockDelimeters` to add `begin`...`end` when converting a block containing `rescue` or `ensure` to braces.

### DIFF
--- a/changelog/fix_update_styleblockdelimeters_to_add.md
+++ b/changelog/fix_update_styleblockdelimeters_to_add.md
@@ -1,0 +1,1 @@
+* [#7836](https://github.com/rubocop/rubocop/issues/7836): Update `Style/BlockDelimeters` to add `begin`...`end` when converting a block containing `rescue` or `ensure` to braces. ([@dvandersluis][])


### PR DESCRIPTION
Whenever `Style/BlockDelimiters` changes a `do-end` block to a `{}` block, there is the possibility of a resulting syntax error if the block contained `rescue` or `ensure` (the original ticket was for `semantic` style, but this affects `line_count_based` and `braces_for_chaining` styles as well). In order to fix this, if the block contains a `rescue` or `ensure` it is auto-corrected to be wrapped in `begin...end`.

The only exception is that an inline modifier is allowed (ie. `foo { x rescue z }`); this exception is covered in the tests.

```ruby
foo = [].map do |x|
  x.something_dangerous!
rescue StandardError => e
  puts 'oh no'
end
```

will be corrected to (indentation corrections are provided by the usual cops, not this one)

```ruby
foo = [].map { |x|
  begin
    x.something_dangerous!
  rescue StandardError => e
    puts 'oh no'
  end
}
```

Fixes #7836.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
