### PR TITLE
[Fix #9674] Disable `Style/AsciiComments` by default.

### DIFF
--- a/changelog/change_disable_styleasciicomments_by_default.md
+++ b/changelog/change_disable_styleasciicomments_by_default.md
@@ -1,0 +1,1 @@
+* [#9674](https://github.com/rubocop/rubocop/issues/9674): Disable `Style/AsciiComments` by default. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2831,9 +2831,9 @@ Style/ArrayJoin:
 Style/AsciiComments:
   Description: 'Use only ascii symbols in comments.'
   StyleGuide: '#english-comments'
-  Enabled: true
+  Enabled: false
   VersionAdded: '0.9'
-  VersionChanged: '0.52'
+  VersionChanged: '<<next>>'
   AllowedChars:
     - ©
 

--- a/lib/rubocop/cop/naming/ascii_identifiers.rb
+++ b/lib/rubocop/cop/naming/ascii_identifiers.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Style/AsciiComments
-
 module RuboCop
   module Cop
     module Naming
@@ -90,4 +88,3 @@ module RuboCop
     end
   end
 end
-# rubocop:enable Style/AsciiComments

--- a/lib/rubocop/cop/style/ascii_comments.rb
+++ b/lib/rubocop/cop/style/ascii_comments.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Style/AsciiComments
-
 module RuboCop
   module Cop
     module Style
@@ -57,4 +55,3 @@ module RuboCop
     end
   end
 end
-# rubocop:enable Style/AsciiComments

--- a/spec/fixtures/html_formatter/expected.html
+++ b/spec/fixtures/html_formatter/expected.html
@@ -367,14 +367,14 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
       <div class="infobox">
         <div class="total">
           3 files inspected,
-          23 offenses detected:
+          22 offenses detected:
         </div>
         <ul class="offenses-list">
           
             
             <li>
               <a href="#offense_app/controllers/application_controller.rb">
-                app/controllers/application_controller.rb - 2 offenses
+                app/controllers/application_controller.rb - 1 offense
               </a>
             </li>
           
@@ -400,7 +400,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
       
       <div class="offense-box" id="offense_app/controllers/application_controller.rb">
         <div class="box-title-placeholder"><h3>&nbsp;</h3></div>
-        <div class="box-title"><h3>app/controllers/application_controller.rb - 2 offenses</h3></div>
+        <div class="box-title"><h3>app/controllers/application_controller.rb - 1 offense</h3></div>
         <div class="offense-reports">
           
           <div class="report">
@@ -411,17 +411,6 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
             </div>
             
             <pre><code><span class="highlight convention">c</span>lass ApplicationController &lt; ActionController::Base</code></pre>
-            
-          </div>
-          
-          <div class="report">
-            <div class="meta">
-              <span class="location">Line #6</span> –
-              <span class="severity convention">convention:</span>
-              <span class="message">Style/AsciiComments: Use only ascii symbols in comments.</span>
-            </div>
-            
-            <pre><code>  # <span class="highlight convention">“</span>Test encoding issues by using curly quotes”</code></pre>
             
           </div>
           


### PR DESCRIPTION
`Style/AsciiComments` was decided to be disabled by default, because it is too restrictive. Fixes #9674.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
