### PR TITLE
Improve the messaging for `Style/Documentation`

### DIFF
--- a/changelog/change_improve_the_messaging_for.md
+++ b/changelog/change_improve_the_messaging_for.md
@@ -1,0 +1,1 @@
+* [#10051](https://github.com/rubocop/rubocop/pull/10051): Improve the messaging for `Style/Documentation` to be more clear about what class/module needs documentation. ([@dvandersluis][])

--- a/spec/fixtures/html_formatter/expected.html
+++ b/spec/fixtures/html_formatter/expected.html
@@ -439,10 +439,10 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
             <div class="meta">
               <span class="location">Line #1</span> –
               <span class="severity convention">convention:</span>
-              <span class="message">Style/Documentation: Missing top-level class documentation comment.</span>
+              <span class="message">Style/Documentation: Missing top-level documentation comment for <code>class BooksController</code>.</span>
             </div>
             
-            <pre><code><span class="highlight convention">class</span> BooksController &lt; ApplicationController</code></pre>
+            <pre><code><span class="highlight convention">class BooksController</span> &lt; ApplicationController</code></pre>
             
           </div>
           
@@ -603,10 +603,10 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
             <div class="meta">
               <span class="location">Line #1</span> –
               <span class="severity convention">convention:</span>
-              <span class="message">Style/Documentation: Missing top-level class documentation comment.</span>
+              <span class="message">Style/Documentation: Missing top-level documentation comment for <code>class Book</code>.</span>
             </div>
             
-            <pre><code><span class="highlight convention">class</span> Book &lt; ActiveRecord::Base</code></pre>
+            <pre><code><span class="highlight convention">class Book</span> &lt; ActiveRecord::Base</code></pre>
             
           </div>
           

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -830,7 +830,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       == example.rb ==
       C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
       C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
-      C:  3:  1: Style/Documentation: Missing top-level class documentation comment.
+      C:  3:  1: Style/Documentation: Missing top-level documentation comment for class A.
       W:  4:  3: [Corrected] Lint/RedundantCopDisableDirective: Unnecessary disabling of Metrics/MethodLength.
       C:  5:  3: [Corrected] Layout/IndentationWidth: Use 2 (not 6) spaces for indentation.
       W:  5: 22: [Corrected] Lint/RedundantCopEnableDirective: Unnecessary enabling of Metrics/MethodLength.
@@ -1247,7 +1247,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
     e = abs('example.rb')
     expect($stdout.string).to eq(<<~RESULT)
-      #{e}:1:1: C: Style/Documentation: Missing top-level class documentation comment.
+      #{e}:1:1: C: Style/Documentation: Missing top-level documentation comment for `class Dsl`.
       #{e}:2:1: C: [Corrected] Layout/AccessModifierIndentation: Indent access modifiers like `private`.
       #{e}:3:7: C: [Corrected] Style/WordArray: Use `%w` or `%W` for an array of words.
       #{e}:3:21: C: [Corrected] Style/TrailingCommaInArrayLiteral: Avoid comma after the last item of an array.

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
 
   it 'registers an offense for non-empty class' do
     expect_offense(<<~RUBY)
-      class My_Class
-      ^^^^^ Missing top-level class documentation comment.
+      class MyClass
+      ^^^^^^^^^^^^^ Missing top-level documentation comment for `class MyClass`.
         def method
         end
       end
@@ -22,8 +22,8 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
       # Copyright 2014
       # Some company
 
-      class My_Class
-      ^^^^^ Missing top-level class documentation comment.
+      class MyClass
+      ^^^^^^^^^^^^^ Missing top-level documentation comment for `class MyClass`.
         def method
         end
       end
@@ -32,8 +32,8 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
 
   it 'registers an offense for non-namespace' do
     expect_offense(<<~RUBY)
-      module My_Class
-      ^^^^^^ Missing top-level module documentation comment.
+      module MyModule
+      ^^^^^^^^^^^^^^^ Missing top-level documentation comment for `module MyModule`.
         def method
         end
       end
@@ -45,7 +45,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
     # explanation.
     expect_offense(<<~RUBY)
       module Test
-      ^^^^^^ Missing top-level module documentation comment.
+      ^^^^^^^^^^^ Missing top-level documentation comment for `module Test`.
       end
     RUBY
   end
@@ -53,7 +53,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
   it 'accepts non-empty class with documentation' do
     expect_no_offenses(<<~RUBY)
       # class comment
-      class My_Class
+      class MyClass
         def method
         end
       end
@@ -63,8 +63,8 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
   it 'registers an offense for non-empty class with annotation comment' do
     expect_offense(<<~RUBY)
       # OPTIMIZE: Make this faster.
-      class My_Class
-      ^^^^^ Missing top-level class documentation comment.
+      class MyClass
+      ^^^^^^^^^^^^^ Missing top-level documentation comment for `class MyClass`.
         def method
         end
       end
@@ -74,8 +74,8 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
   it 'registers an offense for non-empty class with directive comment' do
     expect_offense(<<~RUBY)
       # rubocop:disable Style/For
-      class My_Class
-      ^^^^^ Missing top-level class documentation comment.
+      class MyClass
+      ^^^^^^^^^^^^^ Missing top-level documentation comment for `class MyClass`.
         def method
         end
       end
@@ -85,8 +85,8 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
   it 'registers offense for non-empty class with frozen string comment' do
     expect_offense(<<~RUBY)
       # frozen_string_literal: true
-      class My_Class
-      ^^^^^ Missing top-level class documentation comment.
+      class MyClass
+      ^^^^^^^^^^^^^ Missing top-level documentation comment for `class MyClass`.
         def method
         end
       end
@@ -96,8 +96,8 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
   it 'registers an offense for non-empty class with encoding comment' do
     expect_offense(<<~RUBY)
       # encoding: ascii-8bit
-      class My_Class
-      ^^^^^ Missing top-level class documentation comment.
+      class MyClass
+      ^^^^^^^^^^^^^ Missing top-level documentation comment for `class MyClass`.
         def method
         end
       end
@@ -108,7 +108,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
     expect_no_offenses(<<~RUBY)
       # OPTIMIZE: Make this faster.
       # Class comment.
-      class My_Class
+      class MyClass
         def method
         end
       end
@@ -129,7 +129,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
   it 'accepts non-empty module with documentation' do
     expect_no_offenses(<<~RUBY)
       # class comment
-      module My_Class
+      module MyModule
         def method
         end
       end
@@ -138,7 +138,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
 
   it 'accepts empty class without documentation' do
     expect_no_offenses(<<~RUBY)
-      class My_Class
+      class MyClass
       end
     RUBY
   end
@@ -236,7 +236,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
       it 'registers offense for macro with other methods' do
         expect_offense(<<~RUBY)
           module Foo
-          ^^^^^^ Missing top-level module documentation comment.
+          ^^^^^^^^^^ Missing top-level documentation comment for `module Foo`.
             extend B
             include C
 
@@ -251,7 +251,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
     expect do
       expect_offense(<<~RUBY)
         class Test
-        ^^^^^ Missing top-level class documentation comment.
+        ^^^^^^^^^^ Missing top-level documentation comment for `class Test`.
           if //
           end
         end
@@ -263,7 +263,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
     expect_offense(<<~RUBY)
       module A # The A Module
         class B
-        ^^^^^ Missing top-level class documentation comment.
+        ^^^^^^^ Missing top-level documentation comment for `class A::B`.
           C = 1
           def method
           end
@@ -275,7 +275,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
   it 'registers an offense for compact-style nested module' do
     expect_offense(<<~RUBY)
       module A::B
-      ^^^^^^ Missing top-level module documentation comment.
+      ^^^^^^^^^^^ Missing top-level documentation comment for `module A::B`.
         C = 1
         def method
         end
@@ -286,9 +286,25 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
   it 'registers an offense for compact-style nested class' do
     expect_offense(<<~RUBY)
       class A::B
-      ^^^^^ Missing top-level class documentation comment.
+      ^^^^^^^^^^ Missing top-level documentation comment for `class A::B`.
         C = 1
         def method
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a deeply nested class' do
+    expect_offense(<<~RUBY)
+      module A::B
+        module C
+          class D
+            class E::F
+            ^^^^^^^^^^ Missing top-level documentation comment for `class A::B::C::D::E::F`.
+              def method
+              end
+            end
+          end
         end
       end
     RUBY
@@ -312,7 +328,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
         expect_offense(<<~RUBY, keyword: keyword)
           module TestModule
             %{keyword} Test
-            ^{keyword} Missing top-level #{keyword} documentation comment.
+            ^{keyword}^^^^^ Missing top-level documentation comment for `#{keyword} TestModule::Test`.
               def method
               end
               # sparse comment
@@ -348,7 +364,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
           module TestModule #:nodoc:
             TEST = 20
             %{keyword} Test
-            ^{keyword} Missing top-level #{keyword} documentation comment.
+            ^{keyword}^^^^^ Missing top-level documentation comment for `#{keyword} TestModule::Test`.
               def method
               end
             end
@@ -387,7 +403,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
           module TestModule #:nodoc:
             TEST = 20
             class Test < Parent
-            ^^^^^ Missing top-level class documentation comment.
+            ^^^^^^^^^^ Missing top-level documentation comment for `class TestModule::Test`.
               def method
               end
             end


### PR DESCRIPTION
`Style/Documentation` does not make it clear what definition needs documentation, so this change improves that by adding the qualified class/module name to the message and increasing the highlighted area.

```sh
test.rb:2:3: C: Style/Documentation: Missing top-level documentation comment for `class A::B`.
  class B
  ^^^^^^^
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
