### PR TITLE
Fix a false positive for `Layout/SpaceAroundOperators`

### DIFF
--- a/changelog/fix_false_positive_for_layout_space_around_operators.md
+++ b/changelog/fix_false_positive_for_layout_space_around_operators.md
@@ -1,0 +1,1 @@
+* [#10054](https://github.com/rubocop/rubocop/pull/10054): Fix a false positive for `Layout/SpaceAroundOperators` when match operators between `<<` and `+=`. ([@koic][])

--- a/lib/rubocop/cop/mixin/preceding_following_alignment.rb
+++ b/lib/rubocop/cop/mixin/preceding_following_alignment.rb
@@ -93,7 +93,13 @@ module RuboCop
       end
 
       def aligned_assignment?(range, line)
-        range.source[-1] == '=' && line[range.last_column - 1] == '='
+        range.source[-1] == '=' && line[range.last_column - 1] == '=' ||
+          aligned_with_append_operator?(range, line)
+      end
+
+      def aligned_with_append_operator?(range, line)
+        range.source == '<<' && line[range.last_column - 1] == '=' ||
+          range.source[-1] == '=' && line[(range.last_column - 2)..(range.last_column - 1)] == '<<'
       end
 
       def aligned_identical?(range, line)

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -858,6 +858,20 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
       RUBY
     end
 
+    it 'does not register an offenses match operators between `<<` and `+=`' do
+      expect_no_offenses(<<~RUBY)
+        x  << foo
+        yz += bar
+      RUBY
+    end
+
+    it 'does not register an offenses match operators between `+=` and `<<`' do
+      expect_no_offenses(<<~RUBY)
+        x  += foo
+        yz << bar
+      RUBY
+    end
+
     it 'registers an offense and corrects various assignments with too many spaces' do
       expect_offense(<<~RUBY)
         x ||=  0


### PR DESCRIPTION
This PR fixes a false positive for `Layout/SpaceAroundOperators` when match operators between `<<` and `+=`.

This change makes the following behavior consistent:

## before

Does not register an offense when aligned between `<<`.

```consle
% cat example.rb
# It does not register an offense.
x  << foo
yz << bar
```

An offense is registered when either is updated to `+=`.

```console
% cat example.rb
# It does not register an offense.
x  << foo
yz += bar

% bundle exec rubocop --only Layout/SpaceAroundOperators
(snip)

example.rb:2:4: C: [Correctable] Layout/SpaceAroundOperators: Operator
<< should be surrounded by a single space.
x  << foo
^^

1 file inspected, 1 offense detected, 1 offense auto-correctable
```

## After

Both does not register an offense.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
