### PR TITLE
[Fix #10061] Fix a false positive for `Style/RedundantSort`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_sort.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_sort.md
@@ -1,0 +1,1 @@
+* [#10061](https://github.com/rubocop/rubocop/issues/10061): Fix a false positive for `Style/RedundantSort` when using `size` method in the block. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_sort_spec.rb
+++ b/spec/rubocop/cop/style/redundant_sort_spec.rb
@@ -231,7 +231,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort, :config do
     expect_no_offenses('[[1, 2], [3, 4]].first.sort')
   end
 
-  # `[2, 1, 3].sort_by.first` is equivalent to `[2, 1, 3].first`, but this
+  # `[3, 1, 2].sort_by(&:size).last` is equivalent to `[3, 1, 2].max_by(&:size)`.
+  it 'does not register an offense when using `sort_by(&:size).last`' do
+    expect_no_offenses('[2, 1, 3].sort_by(&:size).last')
+  end
+
+  # `[3, 1, 2].sort_by { |i| i.size }.last` is equivalent to `[3, 1, 2].max_by { |i| i.size }`.
+  it 'does not register an offense when using `sort_by { |i| i.size }.last`' do
+    expect_no_offenses('[2, 1, 3].sort_by { |i| i.size }.last')
+  end
+
+  # `[2, 1, 3].sort_by(&:size).first` is not equivalent to `[2, 1, 3].first`, but this
   # cop would "correct" it to `[2, 1, 3].min_by`.
   it 'does not register an offense when sort_by is not given a block' do
     expect_no_offenses('[2, 1, 3].sort_by.first')


### PR DESCRIPTION
Fixes #10061.

This PR fixes a false positive for `Style/RedundantSort` when using `size` method in the block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
