### PR TITLE
Fix a false positive for `Layout/SingleLineBlockChain`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_single_line_block_chain.md
+++ b/changelog/fix_a_false_positive_for_layout_single_line_block_chain.md
@@ -1,0 +1,1 @@
+* [#10063](https://github.com/rubocop/rubocop/pull/10063): Fix a false positive for `Layout/SingleLineBlockChain` when method call chained on a new line after a single line block with trailing dot. ([@koic][])

--- a/lib/rubocop/cop/layout/single_line_block_chain.rb
+++ b/lib/rubocop/cop/layout/single_line_block_chain.rb
@@ -37,15 +37,26 @@ module RuboCop
           return unless receiver&.block_type?
 
           receiver_location = receiver.loc
-          closing_block_delimiter_line_number = receiver_location.end.line
-          return if receiver_location.begin.line < closing_block_delimiter_line_number
+          closing_block_delimiter_line_num = receiver_location.end.line
+          return if receiver_location.begin.line < closing_block_delimiter_line_num
 
           node_location = node.loc
           dot_range = node_location.dot
           return unless dot_range
-          return if dot_range.line > closing_block_delimiter_line_number
+          return unless call_method_after_block?(node, dot_range, closing_block_delimiter_line_num)
 
-          range_between(dot_range.begin_pos, node_location.selector.end_pos)
+          range_between(dot_range.begin_pos, selector_range(node).end_pos)
+        end
+
+        def call_method_after_block?(node, dot_range, closing_block_delimiter_line_num)
+          return false if dot_range.line > closing_block_delimiter_line_num
+
+          dot_range.column < selector_range(node).column
+        end
+
+        def selector_range(node)
+          # l.(1) has no selector, so we use the opening parenthesis instead
+          node.loc.selector || node.loc.begin
         end
       end
     end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2070,6 +2070,21 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Layout/DotPosition` and `Layout/SingleLineBlockChain` offenses' do
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~RUBY)
+      example.select { |item| item.cond? }.
+              join('-')
+    RUBY
+
+    expect(cli.run(['-a', '--only', 'Layout/DotPosition,Layout/SingleLineBlockChain'])).to eq(0)
+
+    expect(source_file.read).to eq(<<~RUBY)
+      example.select { |item| item.cond? }
+              .join('-')
+    RUBY
+  end
+
   it 'does not correct Style/IfUnlessModifier offense disabled by a comment directive and ' \
      'does not fire Lint/RedundantCopDisableDirective offense even though that directive ' \
      'would make the modifier form too long' do

--- a/spec/rubocop/cop/layout/single_line_block_chain_spec.rb
+++ b/spec/rubocop/cop/layout/single_line_block_chain_spec.rb
@@ -13,10 +13,29 @@ RSpec.describe RuboCop::Cop::Layout::SingleLineBlockChain, :config do
     RUBY
   end
 
+  it 'registers an offense for no selector method call chained on the same line as a block' do
+    expect_offense(<<~RUBY)
+      example.select { |item| item.cond? }.(42)
+                                          ^^ Put method call on a separate line if chained to a single line block.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      example.select { |item| item.cond? }
+      .(42)
+    RUBY
+  end
+
   it 'does not register an offense for method call chained on a new line after a single line block' do
     expect_no_offenses(<<~RUBY)
       example.select { |item| item.cond? }
              .join('-')
+    RUBY
+  end
+
+  it 'does not register an offense for method call chained on a new line after a single line block with trailing dot' do
+    expect_no_offenses(<<~RUBY)
+      example.select { |item| item.cond? }.
+              join('-')
     RUBY
   end
 


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Layout/SingleLineBlockChain` when method call chained on a new line after a single line block with trailing dot.

It also fixes the following incorrect auto-correction between `Layout/SingleLineBlockChain` and `Layout/DotPosition` cops.

```console
% cat example.rb
example.select { |item| item.cond? }.
        join('-')
% ruby -c example.rb
Syntax OK
% bundle exec rubocop -a --only Layout/DotPosition,Layout/SingleLineBlockChain example.rb

% cat example.rb
example.select { |item| item.cond? }

        .join('-')
% ruby -c example.rb
example.rb:3: syntax error, unexpected '.', expecting end-of-input
        .join('-')
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
