### PR TITLE
Style/ExplicitBlockArgument: do not assume the block parameter name

### DIFF
--- a/changelog/fix_hardcoded_block_parameter_name.md
+++ b/changelog/fix_hardcoded_block_parameter_name.md
@@ -1,0 +1,1 @@
+* [#10064](https://github.com/rubocop/rubocop/pull/10064): Fix `Style/ExplicitBlockArgument` corrector assuming any existing block argument was named `block`. ([@byroot][])

--- a/spec/rubocop/cop/style/explicit_block_argument_spec.rb
+++ b/spec/rubocop/cop/style/explicit_block_argument_spec.rb
@@ -41,15 +41,15 @@ RSpec.describe RuboCop::Cop::Style::ExplicitBlockArgument, :config do
 
   it 'correctly corrects when method already has an explicit block argument' do
     expect_offense(<<~RUBY)
-      def m(&block)
+      def m(&blk)
         items.something { |i| yield i }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
       end
     RUBY
 
     expect_correction(<<~RUBY)
-      def m(&block)
-        items.something(&block)
+      def m(&blk)
+        items.something(&blk)
       end
     RUBY
   end


### PR DESCRIPTION
The autocorector would generate invalid code if the old code already defined the block parameter with any other name than `&block`.
