### PR TITLE
Fix an error for `Lint/NumberConversion`

### DIFF
--- a/changelog/fix_error_for_lint_number_conversion.md
+++ b/changelog/fix_error_for_lint_number_conversion.md
@@ -1,0 +1,1 @@
+* [#10067](https://github.com/rubocop/rubocop/pull/10067): Fix an error for `Lint/NumberConversion` when using nested number conversion methods. ([@koic][])

--- a/spec/rubocop/cop/lint/number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/number_conversion_spec.rb
@@ -13,17 +13,6 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
       RUBY
     end
 
-    it 'when using `#to_i` for integer' do
-      expect_offense(<<~RUBY)
-        10.to_i
-        ^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using `10.to_i`, use stricter `Integer(10, 10)`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        Integer(10, 10)
-      RUBY
-    end
-
     it 'when using `#to_f`' do
       expect_offense(<<~RUBY)
         "10.2".to_f
@@ -43,6 +32,27 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
 
       expect_correction(<<~RUBY)
         Complex("10")
+      RUBY
+    end
+
+    it 'when using `#to_i` for number literals' do
+      expect_no_offenses(<<~RUBY)
+        42.to_i
+        42.0.to_i
+      RUBY
+    end
+
+    it 'when using `#to_f` for number literals' do
+      expect_no_offenses(<<~RUBY)
+        42.to_f
+        42.0.to_f
+      RUBY
+    end
+
+    it 'when using `#to_c` for number literals' do
+      expect_no_offenses(<<~RUBY)
+        42.to_c
+        42.0.to_c
       RUBY
     end
 
@@ -160,6 +170,35 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
 
       expect_correction(<<~RUBY)
         "foo".try { |i| Float(i) }
+      RUBY
+    end
+
+    it 'registers an offense when using nested number conversion methods' do
+      expect_offense(<<~RUBY)
+        var.to_i.to_f
+        ^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using `var.to_i`, use stricter `Integer(var, 10)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Integer(var, 10).to_f
+      RUBY
+    end
+
+    it 'does not register an offense when using `Integer` constructor' do
+      expect_no_offenses(<<~RUBY)
+        Integer(var, 10).to_f
+      RUBY
+    end
+
+    it 'does not register an offense when using `Float` constructor' do
+      expect_no_offenses(<<~RUBY)
+        Float(var).to_i
+      RUBY
+    end
+
+    it 'does not register an offense when using `Complex` constructor' do
+      expect_no_offenses(<<~RUBY)
+        Complex(var).to_f
       RUBY
     end
 


### PR DESCRIPTION
This PR fixes the following error for `Lint/NumberConversion` when using nested number conversion methods.

## Before

```console
% cat example.rb
var.to_i.to_f

% bundle exec rubocop --only Lint/NumberConversion -A
(snip)

Inspecting 1 file
An error occurred while Lint/NumberConversion cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/number/example.rb:1:0.
To see the complete backtrace run rubocop -d.
W

Offenses:

example.rb:1:1: W: [Corrected] Lint/NumberConversion: Replace unsafe
number conversion with number class parsing, instead of using
var.to_i.to_f, use stricter Float(var.to_i).var.to_i.to_f
                                            ^^^^^^^^^^^^^
example.rb:1:7: W: [Corrected] Lint/NumberConversion: Replace unsafe
number conversion with number class parsing, instead of using var.to_i,
use stricter Integer(var, 10).Float(var.to_i)
                                    ^^^^^^^^

1 file inspected, 2 offenses detected, 2 offenses corrected

1 error occurred:
An error occurred while Lint/NumberConversion cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/number/example.rb:1:0.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.

% cat example.rb
Float(Integer(var, 10))
```

## After

```console
% cat example.rb
var.to_i.to_f

% bundle exec rubocop --only Lint/NumberConversion -A
(snip)

Offenses:

example.rb:1:1: W: [Corrected] Lint/NumberConversion: Replace unsafe
number conversion with number class parsing, instead of using var.to_i,
use stricter Integer(var, 10).var.to_i.to_f
                              ^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
Integer(var, 10).to_f
```

The result of `Integer()` is an `Integer` object, so `to_f` does not need to be replaced with `Float()`.
Accordingly, this PR will be changed to be accepted if the receiver is a numeric literal that is an obvious numeric (e.g. `42.to_f`).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
