### PR TITLE
Mark `Style/AndOr` as unsafe auto-correction

### DIFF
--- a/changelog/change_mark_style_and_or_as_unsafe_auto_correction.md
+++ b/changelog/change_mark_style_and_or_as_unsafe_auto_correction.md
@@ -1,0 +1,1 @@
+* [#10068](https://github.com/rubocop/rubocop/pull/10068): Mark `Style/AndOr` as unsafe auto-correction. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2802,8 +2802,9 @@ Style/AndOr:
   Description: 'Use &&/|| instead of and/or.'
   StyleGuide: '#no-and-or-or'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.9'
-  VersionChanged: '0.25'
+  VersionChanged: '<<next>>'
   # Whether `and` and `or` are banned only in conditionals (conditionals)
   # or completely (always).
   EnforcedStyle: conditionals

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -7,6 +7,10 @@ module RuboCop
       # `||` instead. It can be configured to check only in conditions or in
       # all contexts.
       #
+      # It is marked as unsafe auto-correction because it may change the
+      # operator precedence between logical operators (`&&` and `||`) and
+      # semantic operators (`and` and `or`).
+      #
       # @example EnforcedStyle: always
       #   # bad
       #   foo.save and return

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       end
     RUBY
     expect(
-      cli.run(['--auto-correct', '--only', 'Style/MethodCallWithArgsParentheses,Style/AndOr'])
+      cli.run(['--auto-correct-all', '--only', 'Style/MethodCallWithArgsParentheses,Style/AndOr'])
     ).to eq(0)
     expect(File.read('example.rb')).to eq(<<~RUBY)
       if foo && bar(:arg)


### PR DESCRIPTION
This PR marks `Style/AndOr` as unsafe auto-correction.

cf: https://github.com/rubocop/rubocop-rails/issues/210

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
