### PR TITLE
[Fix #10070] Fix a false positive for `Style/MutableConstant`

### DIFF
--- a/changelog/fix_false_positive_for_style_mutable_constant.md
+++ b/changelog/fix_false_positive_for_style_mutable_constant.md
@@ -1,0 +1,1 @@
+* [#10070](https://github.com/rubocop/rubocop/issues/10070): Fix a false positive for `Style/MutableConstant` when using non-interpolated heredoc in Ruby 3.0. ([@koic][])

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -115,6 +115,23 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
         let(:prefix) { '# frozen_string_literal: true' }
 
         it_behaves_like 'mutable objects', '"#{a}"'
+        it_behaves_like 'immutable objects', <<~'RUBY'
+          <<~HERE
+            foo
+            bar
+          HERE
+        RUBY
+        it 'registers an offense when using interpolated heredoc constant' do
+          expect_offense(<<~'RUBY')
+            # frozen_string_literal: true
+
+            CONST = <<~HERE
+                    ^^^^^^^ Freeze mutable objects assigned to constants.
+              foo #{use_interpolation}
+              bar
+            HERE
+          RUBY
+        end
       end
 
       context 'when the frozen string literal comment is false' do
@@ -133,6 +150,22 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
         let(:prefix) { '# frozen_string_literal: true' }
 
         it_behaves_like 'immutable objects', '"#{a}"'
+        it_behaves_like 'immutable objects', <<~'RUBY'
+          <<~HERE
+            foo
+            bar
+          HERE
+        RUBY
+        it 'does not register an offense when using interpolated heredoc constant' do
+          expect_no_offenses(<<~'RUBY')
+            # frozen_string_literal: true
+
+            CONST = <<~HERE
+              foo #{use_interpolation}
+              bar
+            HERE
+          RUBY
+        end
       end
 
       context 'when the frozen string literal comment is false' do


### PR DESCRIPTION
Fixes #10070.

This PR fixes a false positive for `Style/MutableConstant` when using non-interpolated heredoc in Ruby 3.0.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
