### PR TITLE
Docs: Interpreting ABCSize

### DIFF
--- a/lib/rubocop/cop/metrics/abc_size.rb
+++ b/lib/rubocop/cop/metrics/abc_size.rb
@@ -28,6 +28,12 @@ module RuboCop
       #    end
       #
       # This cop also takes into account `IgnoredMethods` (defaults to `[]`)
+      #
+      # ## Interpreting ABCSize
+      #
+      # - <= 17 satisfactory
+      # - 18..30 unsatisfactory
+      # - > 30 dangerous
       class AbcSize < Base
         include MethodComplexity
 


### PR DESCRIPTION
When I introduce ABC to people, they don't know how to interpret the numbers. Having a scale like this might help.

I'm basing this proposed scale partly on my own experience, and partly on CodeClimate, which uses a similar metric called `flog`.

> What’s a good Flog score? It’s subjective, of course, but Jake Scruggs .. suggested that scores above 20 indicate the method may need refactoring, and above 60 is dangerous. Similarly, Code Climate will flag methods with scores above 25, and considers anything above 60 “very complex”.
> https://codeclimate.com/blog/deciphering-ruby-code-metrics/

We can't directly compare `flog` scores and ABC, but the above is still a useful reference in determining our own scale.

-----------------

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* N/A Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* N/A Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* N/A Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
