### PR TITLE
[Fix #10066] Fix how `MinDigits` is calculated for `Style/NumericLiterals` when generating a configuration file

### DIFF
--- a/changelog/fix_fix_how_mindigits_is_calculated_for.md
+++ b/changelog/fix_fix_how_mindigits_is_calculated_for.md
@@ -1,0 +1,1 @@
+* [#10066](https://github.com/rubocop/rubocop/issues/10066): Fix how `MinDigits` is calculated for `Style/NumericLiterals` when generating a configuration file. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/numeric_literals.rb
+++ b/lib/rubocop/cop/style/numeric_literals.rb
@@ -58,18 +58,17 @@ module RuboCop
 
           case int
           when /^\d+$/
-            return unless (self.min_digits = int.size + 1)
-
-            register_offense(node)
+            register_offense(node) { self.min_digits = int.size + 1 }
           when /\d{4}/, short_group_regex
-            return unless (self.config_to_allow_offenses = { 'Enabled' => false })
-
-            register_offense(node)
+            register_offense(node) { self.config_to_allow_offenses = { 'Enabled' => false } }
           end
         end
 
-        def register_offense(node)
-          add_offense(node) { |corrector| corrector.replace(node, format_number(node)) }
+        def register_offense(node, &_block)
+          add_offense(node) do |corrector|
+            yield
+            corrector.replace(node, format_number(node))
+          end
         end
 
         def short_group_regex

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -49,7 +49,7 @@ module CopHelper
     team = RuboCop::Cop::Team.new([cop], nil, raise_error: true)
     report = team.investigate(processed_source)
     @last_corrector = report.correctors.first || RuboCop::Cop::Corrector.new(processed_source)
-    report.offenses
+    report.offenses.reject(&:disabled?)
   end
 end
 

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       context 'and the source contains non-directive #s as non-comment' do
         it 'registers an offense for the line' do
           expect_offense(<<-RUBY)
-            LARGE_DATA_STRING_PATTERN = %r{\A([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})\z} # rubocop:disable Layout/LineLength
+            LARGE_DATA_STRING_PATTERN = %r{\A([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})\z} # rubocop:disable Style/ClassVars
             #{' ' * 68}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [117/80]
           RUBY
         end


### PR DESCRIPTION
Previously, `MinDigits` is incremented regardless of if the offense is disabled or not.

Fixes #10066.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
