### PR TITLE
Fix `Layout/LineLength` reported length when ignoring directive comments

### DIFF
--- a/changelog/fix_fix_layoutlinelength_reported_length.md
+++ b/changelog/fix_fix_layoutlinelength_reported_length.md
@@ -1,0 +1,1 @@
+* [#10078](https://github.com/rubocop/rubocop/pull/10078): Fix `Layout/LineLength` reported length when ignoring directive comments. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -183,8 +183,8 @@ module RuboCop
           line_index.zero? && line.start_with?('#!')
         end
 
-        def register_offense(loc, line, line_index)
-          message = format(MSG, length: line_length(line), max: max)
+        def register_offense(loc, line, line_index, length: line_length(line))
+          message = format(MSG, length: length, max: max)
 
           self.breakable_range = breakable_range_by_line_index[line_index]
 
@@ -241,9 +241,10 @@ module RuboCop
         end
 
         def check_directive_line(line, line_index)
-          return if line_length_without_directive(line) <= max
+          length_without_directive = line_length_without_directive(line)
+          return if length_without_directive <= max
 
-          range = max..(line_length_without_directive(line) - 1)
+          range = max..(length_without_directive - 1)
           register_offense(
             source_range(
               processed_source.buffer,
@@ -251,7 +252,8 @@ module RuboCop
               range
             ),
             line,
-            line_index
+            line_index,
+            length: length_without_directive
           )
         end
 

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -345,7 +345,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       it 'highlights only the non-directive part' do
         expect_offense(<<~RUBY)
           #{'a' * 80}bcd # rubocop:enable Style/ClassVars
-          #{' ' * 80}^^^ Line is too long. [116/80]
+          #{' ' * 80}^^^ Line is too long. [83/80]
         RUBY
       end
 
@@ -353,7 +353,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
         it 'highlights only the non-directive part' do
           expect_offense(<<~RUBY)
             #{'a' * 70} # bbbbbbbbbbbbbb # rubocop:enable Style/ClassVars'
-            #{' ' * 70}          ^^^^^^^ Line is too long. [121/80]
+            #{' ' * 70}          ^^^^^^^ Line is too long. [87/80]
           RUBY
         end
       end
@@ -362,7 +362,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
         it 'registers an offense for the line' do
           expect_offense(<<-RUBY)
             LARGE_DATA_STRING_PATTERN = %r{\A([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})\z} # rubocop:disable Layout/LineLength
-            #{' ' * 68}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [153/80]
+            #{' ' * 68}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [117/80]
           RUBY
         end
       end


### PR DESCRIPTION
If `IgnoreCopDirectives` is enabled, the directive comment is not included in the calculation, but it is included in the count that is shown in the offense. This change makes it not be included there either.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
