### PR TITLE
Fix confusing test in case_indentation_spec.rb

### DIFF
--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -818,20 +818,17 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
     end
   end
 
-  context 'when `case` is preceded by something else than whitespace' do
+  context 'when `when` is on the same line as `case`' do
     let(:cop_config) { {} }
 
-    it 'registers an offense and auto-corrects' do
+    it 'registers an offense but does not auto-correct' do
       expect_offense(<<~RUBY)
         case test when something
                   ^^^^ Indent `when` as deep as `case`.
         end
       RUBY
 
-      expect_correction(<<~RUBY)
-        case test when something
-        end
-      RUBY
+      expect_no_corrections
     end
   end
 end


### PR DESCRIPTION
This test has been around for a while but eventually was [changed](https://github.com/rubocop/rubocop/commit/ddb1ba77c7947e04a226fe57ae7789c2eca7a74b#diff-cbedb596a9e288e54ae57df6b0110c55194521811c147de4a0dbb9f6749af655L597-R447) to use `expect_corrections`, and then the test statement was [inverted](https://github.com/rubocop/rubocop/commit/9a06e8407cde299fe4814292d9b7ff0f83723f9e#diff-cbedb596a9e288e54ae57df6b0110c55194521811c147de4a0dbb9f6749af655L435-R435) accidentally.

This fixes up the test to be clearer.