### PR TITLE
Guard against `expect_corrections` with no changes

### DIFF
--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -126,7 +126,7 @@ module RuboCop
         @offenses
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
       def expect_correction(correction, loop: true, source: nil)
         if source
           expected_annotations = parse_annotations(source, raise_error: false)
@@ -135,6 +135,8 @@ module RuboCop
         end
 
         raise '`expect_correction` must follow `expect_offense`' unless @processed_source
+
+        source = @processed_source.raw_source
 
         iteration = 0
         new_source = loop do
@@ -155,9 +157,11 @@ module RuboCop
           _investigate(cop, @processed_source)
         end
 
+        raise 'Use `expect_no_corrections` if the code will not change' if new_source == source
+
         expect(new_source).to eq(correction)
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
 
       def expect_no_corrections
         raise '`expect_no_corrections` must follow `expect_offense`' unless @processed_source

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -1094,9 +1094,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [66/40]
           RUBY
 
-          expect_correction(<<~RUBY)
-            "00000000000000000;0000000000000000000'000000;00000'0000;0000;000"
-          RUBY
+          expect_no_corrections
         end
       end
     end

--- a/spec/rubocop/cop/lint/heredoc_method_call_position_spec.rb
+++ b/spec/rubocop/cop/lint/heredoc_method_call_position_spec.rb
@@ -131,14 +131,7 @@ RSpec.describe RuboCop::Cop::Lint::HeredocMethodCallPosition, :config do
           3).foo
         RUBY
 
-        # Should not autocorrect -- cannot always be done safely.
-        expect_correction(<<~RUBY)
-          <<-SQL
-            foo
-          SQL
-          .abc(1, 2,
-          3).foo
-        RUBY
+        expect_no_corrections
       end
     end
 
@@ -153,14 +146,7 @@ RSpec.describe RuboCop::Cop::Lint::HeredocMethodCallPosition, :config do
           .foo
         RUBY
 
-        # Should not autocorrect -- cannot always be done safely.
-        expect_correction(<<~RUBY)
-          <<-SQL
-            foo
-          SQL
-          .abc
-          .foo
-        RUBY
+        expect_no_corrections
       end
     end
   end

--- a/spec/rubocop/cop/lint/script_permission_spec.rb
+++ b/spec/rubocop/cop/lint/script_permission_spec.rb
@@ -36,9 +36,7 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission, :config do
           ^^^^^^^^^^^^^^^ Script file #{filename} doesn't have execute permission.
         RUBY
 
-        expect_correction(<<~RUBY)
-          #!/usr/bin/ruby
-        RUBY
+        expect_no_corrections
         expect(file.stat.executable?).to be_truthy
       end
 

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -117,23 +117,18 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
       end
 
       context 'with an empty comment' do
-        let(:source) { <<~RUBY }
-          if cond
-            something
-          else
-          ^^^^ Redundant `else`-clause.
-            # TODO
-          end
-        RUBY
-        let(:corrected_source) { <<~RUBY }
-          if cond
-            something
-          else
-            # TODO
-          end
-        RUBY
+        it 'does not auto-correct' do
+          expect_offense(<<~RUBY)
+            if cond
+              something
+            else
+            ^^^^ Redundant `else`-clause.
+              # TODO
+            end
+          RUBY
 
-        it_behaves_like 'auto-correct', 'if'
+          expect_no_corrections
+        end
       end
     end
 


### PR DESCRIPTION
If autocorrection doesn't change anything, `expect_no_corrections` is clearer about what will happen (vs having to figure out if there is some small change that is not immediately evident). This change also fixes the existing specs that use the wrong method.
