### PR TITLE
Update the documentation for `Lint/BinaryOperatorWithIdenticalOperands`

### DIFF
--- a/lib/rubocop/cop/lint/binary_operator_with_identical_operands.rb
+++ b/lib/rubocop/cop/lint/binary_operator_with_identical_operands.rb
@@ -5,11 +5,17 @@ module RuboCop
     module Lint
       # This cop checks for places where binary operator has identical operands.
       #
-      # It covers arithmetic operators: `+`, `-`, `*`, `/`, `%`, `**`;
+      # It covers arithmetic operators: `-`, `/`, `%`;
       # comparison operators: `==`, `===`, `=~`, `>`, `>=`, `<`, `<=`;
-      # bitwise operators: `|`, `^`, `&`, `<<`, `>>`;
+      # bitwise operators: `|`, `^`, `&`;
       # boolean operators: `&&`, `||`
       # and "spaceship" operator - `<=>`.
+      #
+      # Simple arithmetic operations are allowed by this cop: `+`, `*`, `**`, `<<` and `>>`.
+      # Although these can be rewritten in a different way, it should not be necessary to
+      # do so. This does not include operations such as `-` or `/` where the result will
+      # always be the same (`x - x` will always be 0; `x / x` will always be 1), and
+      # thus are legitimate offenses.
       #
       # This cop is marked as unsafe as it does not consider side effects when calling methods
       # and thus can generate false positives:


### PR DESCRIPTION
In #9221, `Lint/BinaryOperatorWithIdenticalOperands` was updated to ignore some simple arithmetic operands, but this was not reflected in the documentation.