### PR TITLE
`Lint/BooleanSymbol` should be marked as `SafeAutoCorrect: false` rather than `Safe: false`

### DIFF
--- a/changelog/change_lintbooleansymbol_should_be_marked_as.md
+++ b/changelog/change_lintbooleansymbol_should_be_marked_as.md
@@ -1,0 +1,1 @@
+* [#10088](https://github.com/rubocop/rubocop/pull/10088): Update `Lint/BooleanSymbol` to be `SafeAutoCorrect: false` rather than `Safe: false`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1491,9 +1491,9 @@ Lint/BinaryOperatorWithIdenticalOperands:
 Lint/BooleanSymbol:
   Description: 'Check for `:true` and `:false` symbols.'
   Enabled: true
-  Safe: false
+  SafeAutoCorrect: false
   VersionAdded: '0.50'
-  VersionChanged: '0.83'
+  VersionChanged: '<<next>>'
 
 Lint/CircularArgumentReference:
   Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."


### PR DESCRIPTION
Although the correction is unsafe, the cop itself will not find false positives.