### PR TITLE
[Fix #10090] Fix a false negative for `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/fix_false_negative_for_style_arguments_forwarding.md
+++ b/changelog/fix_false_negative_for_style_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#10090](https://github.com/rubocop/rubocop/issues/10090): Fix a false negative for `Style/ArgumentsForwarding` when using only kwrest arg. ([@koic][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -30,12 +30,20 @@ module RuboCop
       #     bar(*args)
       #   end
       #
+      #   def foo(**kwargs)
+      #     bar(**kwargs)
+      #   end
+      #
       # @example AllowOnlyRestArgument: false
       #   # bad
       #   # The following code can replace the arguments with `...`,
       #   # but it will change the behavior. Because `...` forwards block also.
       #   def foo(*args)
       #     bar(*args)
+      #   end
+      #
+      #   def foo(**kwargs)
+      #     bar(**kwargs)
       #   end
       #
       class ArgumentsForwarding < Base
@@ -49,12 +57,15 @@ module RuboCop
 
         # @!method use_rest_arguments?(node)
         def_node_matcher :use_rest_arguments?, <<~PATTERN
-          (args (restarg $_) $...)
+          (args ({restarg kwrestarg} $_) $...)
         PATTERN
 
         # @!method only_rest_arguments?(node, name)
         def_node_matcher :only_rest_arguments?, <<~PATTERN
-          (send _ _ (splat (lvar %1)))
+          {
+            (send _ _ (splat (lvar %1)))
+            (send _ _ (hash (kwsplat (lvar %1))))
+          }
         PATTERN
 
         # @!method forwarding_method_arguments?(node, rest_name, block_name, kwargs_name)

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -204,6 +204,14 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
           end
         RUBY
       end
+
+      it 'does not register an offense when using only kwrest arg' do
+        expect_no_offenses(<<~RUBY)
+          def foo(**kwargs)
+            bar(**kwargs)
+          end
+        RUBY
+      end
     end
 
     context 'AllowOnlyRestArgument: false' do
@@ -215,6 +223,22 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
                   ^^^^^ Use arguments forwarding.
             bar(*args)
                 ^^^^^ Use arguments forwarding.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(...)
+            bar(...)
+          end
+        RUBY
+      end
+
+      it 'registers an offense when using only kwrest arg' do
+        expect_offense(<<~RUBY)
+          def foo(**kwargs)
+                  ^^^^^^^^ Use arguments forwarding.
+            bar(**kwargs)
+                ^^^^^^^^ Use arguments forwarding.
           end
         RUBY
 


### PR DESCRIPTION
Fixes #10090.

This PR fixes a false negative for `Style/ArgumentsForwarding` when using only kwrest arg.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
