### PR TITLE
[Fix #8431] Add `Safety` section to documentation for all cops that are `Safe: false` or `SafeAutoCorrect: false`

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,2 +1,3 @@
 --markup markdown
 --hide-void-return
+--tag safety:"Cop Safety Information"

--- a/changelog/change_add_safety_section_to_all_cops_that_are.md
+++ b/changelog/change_add_safety_section_to_all_cops_that_are.md
@@ -1,0 +1,1 @@
+* [#8431](https://github.com/rubocop/rubocop/issues/8431): Add `Safety` section to documentation for all cops that are `Safe: false` or `SafeAutoCorrect: false`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3708,7 +3708,7 @@ Style/InPatternThen:
 Style/InfiniteLoop:
   Description: >-
                  Use Kernel#loop for infinite loops.
-                 This cop is unsafe in the body may raise a `StopIteration` exception.
+                 This cop is unsafe if the body may raise a `StopIteration` exception.
   Safe: false
   StyleGuide: '#infinite-loop'
   Enabled: true

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -24,6 +24,11 @@ module RuboCop
               # `SupportedStyle` and unique configuration, there needs to be examples.
               # Examples must have valid Ruby syntax. Do not use upticks.
               #
+              # @safety
+              #   Delete this section if the cop is not unsafe (`Safe: false` or
+              #   `SafeAutoCorrect: false`), or use it to explain how the cop is
+              #   unsafe.
+              #
               # @example EnforcedStyle: bar (default)
               #   # Description of the `bar` style.
               #

--- a/lib/rubocop/cop/lint/ambiguous_range.rb
+++ b/lib/rubocop/cop/lint/ambiguous_range.rb
@@ -10,18 +10,19 @@ module RuboCop
       # explicit by requiring parenthesis around complex range boundaries (anything
       # that is not a basic literal: numerics, strings, symbols, etc.).
       #
-      # NOTE: The cop auto-corrects by wrapping the entire boundary in parentheses, which
-      # makes the outcome more explicit but is possible to not be the intention of the
-      # programmer. For this reason, this cop's auto-correct is marked as unsafe (it
-      # will not change the behaviour of the code, but will not necessarily match the
-      # intent of the program).
-      #
       # This cop can be configured with `RequireParenthesesForMethodChains` in order to
       # specify whether method chains (including `self.foo`) should be wrapped in parens
       # by this cop.
       #
       # NOTE: Regardless of this configuration, if a method receiver is a basic literal
       # value, it will be wrapped in order to prevent the ambiguity of `1..2.to_a`.
+      #
+      # @safety
+      #   The cop auto-corrects by wrapping the entire boundary in parentheses, which
+      #   makes the outcome more explicit but is possible to not be the intention of the
+      #   programmer. For this reason, this cop's auto-correct is unsafe (it will not
+      #   change the behaviour of the code, but will not necessarily match the
+      #   intent of the program).
       #
       # @example
       #   # bad
@@ -55,7 +56,6 @@ module RuboCop
       #
       #   # good
       #   (a.foo)..(b.bar)
-      #
       class AmbiguousRange < Base
         extend AutoCorrector
 

--- a/lib/rubocop/cop/lint/binary_operator_with_identical_operands.rb
+++ b/lib/rubocop/cop/lint/binary_operator_with_identical_operands.rb
@@ -17,9 +17,16 @@ module RuboCop
       # always be the same (`x - x` will always be 0; `x / x` will always be 1), and
       # thus are legitimate offenses.
       #
-      # This cop is marked as unsafe as it does not consider side effects when calling methods
-      # and thus can generate false positives:
+      # @safety
+      #   This cop is unsafe as it does not consider side effects when calling methods
+      #   and thus can generate false positives, for example:
+      #
+      #   [source,ruby]
+      #   ----
       #   if wr.take_char == '\0' && wr.take_char == '\0'
+      #     # ...
+      #   end
+      #   ----
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/boolean_symbol.rb
+++ b/lib/rubocop/cop/lint/boolean_symbol.rb
@@ -6,6 +6,11 @@ module RuboCop
       # This cop checks for `:true` and `:false` symbols.
       # In most cases it would be a typo.
       #
+      # @safety
+      #   Autocorrection is unsafe for this cop because code relying
+      #   on `:true` or `:false` symbols will break when those are
+      #   changed to actual booleans.
+      #
       # @example
       #
       #   # bad

--- a/lib/rubocop/cop/lint/disjunctive_assignment_in_constructor.rb
+++ b/lib/rubocop/cop/lint/disjunctive_assignment_in_constructor.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks constructors for disjunctive assignments that should
+      # This cop checks constructors for disjunctive assignments (`||=`) that should
       # be plain assignments.
       #
       # So far, this cop is only concerned with disjunctive assignment of
@@ -11,6 +11,29 @@ module RuboCop
       #
       # In ruby, an instance variable is nil until a value is assigned, so the
       # disjunction is unnecessary. A plain assignment has the same effect.
+      #
+      # @safety
+      #   This cop is unsafe because it can register a false positive when a
+      #   method is redefined in a subclass that calls super. For example:
+      #
+      #   [source,ruby]
+      #   ----
+      #   class Base
+      #     def initialize
+      #       @config ||= 'base'
+      #     end
+      #   end
+      #
+      #   class Derived < Base
+      #     def initialize
+      #       @config = 'derived'
+      #       super
+      #     end
+      #   end
+      #   ----
+      #
+      #   Without the disjunctive assignment, `Derived` will be unable to override
+      #   the value for `@config`.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/hash_compare_by_identity.rb
+++ b/lib/rubocop/cop/lint/hash_compare_by_identity.rb
@@ -3,10 +3,19 @@
 module RuboCop
   module Cop
     module Lint
-      # Prefer using `Hash#compare_by_identity` than using `object_id` for hash keys.
+      # Prefer using `Hash#compare_by_identity` rather than using `object_id`
+      # for hash keys.
       #
-      # This cop is marked as unsafe as a hash possibly can contain other keys
-      # besides `object_id`s.
+      # This cop looks for hashes being keyed by objects' `object_id`, using
+      # one of these methods: `key?`, `has_key?`, `fetch`, `[]` and `[]=`.
+      #
+      # @safety
+      #   This cop is unsafe. Although unlikely, the hash could store both object
+      #   ids and other values that need be compared by value, and thus
+      #   could be a false positive.
+      #
+      #   Furthermore, this cop cannot guarantee that the receiver of one of the
+      #   methods (`key?`, etc.) is actually a hash.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/interpolation_check.rb
+++ b/lib/rubocop/cop/lint/interpolation_check.rb
@@ -5,6 +5,11 @@ module RuboCop
     module Lint
       # This cop checks for interpolation in a single quoted string.
       #
+      # @safety
+      #   This cop is generally safe, but is marked as unsafe because
+      #   it is possible to actually intentionally have text inside
+      #   `#{...}` in a single quoted string.
+      #
       # @example
       #
       #   # bad

--- a/lib/rubocop/cop/lint/loop.rb
+++ b/lib/rubocop/cop/lint/loop.rb
@@ -5,9 +5,10 @@ module RuboCop
     module Lint
       # This cop checks for uses of `begin...end while/until something`.
       #
-      # The cop is marked as unsafe because behaviour can change in some cases, including
-      # if a local variable inside the loop body is accessed outside of it, or if the
-      # loop body raises a `StopIteration` exception (which `Kernel#loop` rescues).
+      # @safety
+      #   The cop is unsafe because behaviour can change in some cases, including
+      #   if a local variable inside the loop body is accessed outside of it, or if the
+      #   loop body raises a `StopIteration` exception (which `Kernel#loop` rescues).
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/non_deterministic_require_order.rb
+++ b/lib/rubocop/cop/lint/non_deterministic_require_order.rb
@@ -14,7 +14,11 @@ module RuboCop
       # `Dir.glob` and `Dir[]` sort globbed results by default in Ruby 3.0.
       # So all bad cases are acceptable when Ruby 3.0 or higher are used.
       #
-      # This cop will be deprecated and removed when supporting only Ruby 3.0 and higher.
+      # NOTE: This cop will be deprecated and removed when supporting only Ruby 3.0 and higher.
+      #
+      # @safety
+      #   This cop is unsafe in the case where sorting files changes existing
+      #   expected behaviour.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -18,6 +18,11 @@ module RuboCop
       # cop by default). Similarly, Rails' duration methods do not work well
       # with `Integer()` and can be ignored with `IgnoredMethods`.
       #
+      # @safety
+      #   Autocorrection is unsafe because it is not guaranteed that the
+      #   replacement `Kernel` methods are able to properly handle the
+      #   input if it is not a standard class.
+      #
       # @example
       #
       #   # bad

--- a/lib/rubocop/cop/lint/or_assignment_to_constant.rb
+++ b/lib/rubocop/cop/lint/or_assignment_to_constant.rb
@@ -9,8 +9,10 @@ module RuboCop
       # should always be the same. If constants are assigned in multiple
       # locations, the result may vary depending on the order of `require`.
       #
-      # Also, if you already have such an implementation, auto-correction may
-      # change the result.
+      # @safety
+      #   This cop is unsafe because code that is already conditionally
+      #   assigning a constant may have its behaviour changed by
+      #   auto-correction.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
+++ b/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
@@ -6,6 +6,23 @@ module RuboCop
       # This cops looks for references of Regexp captures that are out of range
       # and thus always returns nil.
       #
+      # @safety
+      #   This cop is unsafe because it is naive in how it determines what
+      #   references are available based on the last encountered regexp, but
+      #   it cannot handle some cases, such as conditional regexp matches, which
+      #   leads to false positives, such as:
+      #
+      #   [source,ruby]
+      #   ----
+      #   foo ? /(c)(b)/ =~ str : /(b)/ =~ str
+      #   do_something if $2
+      #   # $2 is defined for the first condition but not the second, however
+      #   # the cop will mark this as an offense.
+      #   ----
+      #
+      #   This might be a good indication of code that should be refactored,
+      #   however.
+      #
       # @example
       #
       #   /(foo)bar/ =~ 'foobar'

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -9,6 +9,16 @@ module RuboCop
       # example, mistranslating an array of literals to percent string notation)
       # rather than meant to be part of the resulting strings.
       #
+      # @safety
+      #   The cop is unsafe because the correction changes the values in the array
+      #   and that might have been done purposely.
+      #
+      #   [source,ruby]
+      #   ----
+      #   %w('foo', "bar") #=> ["'foo',", '"bar"']
+      #   %w(foo bar)      #=> ['foo', 'bar']
+      #   ----
+      #
       # @example
       #
       #   # bad

--- a/lib/rubocop/cop/lint/raise_exception.rb
+++ b/lib/rubocop/cop/lint/raise_exception.rb
@@ -13,6 +13,10 @@ module RuboCop
       # `Exception`. Alternatively, make `Exception` a fully qualified class
       # name with an explicit namespace.
       #
+      # @safety
+      #   This cop is unsafe because it will change the exception class being
+      #   raised, which is a change in behaviour.
+      #
       # @example
       #   # bad
       #   raise Exception, 'Error message here'

--- a/lib/rubocop/cop/lint/redundant_safe_navigation.rb
+++ b/lib/rubocop/cop/lint/redundant_safe_navigation.rb
@@ -7,12 +7,13 @@ module RuboCop
       # `instance_of?`, `kind_of?`, `is_a?`, `eql?`, `respond_to?`, and `equal?` methods
       # are checked by default. These are customizable with `AllowedMethods` option.
       #
-      # This cop is marked as unsafe, because auto-correction can change the
-      # return type of the expression. An offending expression that previously
-      # could return `nil` will be auto-corrected to never return `nil`.
-      #
       # In the example below, the safe navigation operator (`&.`) is unnecessary
       # because `NilClass` has methods like `respond_to?` and `is_a?`.
+      #
+      # @safety
+      #   This cop is unsafe, because auto-correction can change the return type of
+      #   the expression. An offending expression that previously could return `nil`
+      #   will be auto-corrected to never return `nil`.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/unexpected_block_arity.rb
+++ b/lib/rubocop/cop/lint/unexpected_block_arity.rb
@@ -13,14 +13,19 @@ module RuboCop
       # Keyword arguments (including `**kwargs`) do not get counted towards
       # this, as they are not used by the methods in question.
       #
-      # NOTE: This cop matches for method names only and hence cannot tell apart
-      # methods with same name in different classes.
-      #
       # Method names and their expected arity can be configured like this:
       #
+      # [source,yaml]
+      # ----
       # Methods:
       #   inject: 2
       #   reduce: 2
+      # ----
+      #
+      # @safety
+      #  This cop matches for method names only and hence cannot tell apart
+      #  methods with same name in different classes, which may lead to a
+      #  false positive.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/useless_method_definition.rb
+++ b/lib/rubocop/cop/lint/useless_method_definition.rb
@@ -6,8 +6,9 @@ module RuboCop
       # This cop checks for useless method definitions, specifically: empty constructors
       # and methods just delegating to `super`.
       #
-      # This cop is marked as unsafe as it can trigger false positives for cases when
-      # an empty constructor just overrides the parent constructor, which is bad anyway.
+      # @safety
+      #   This cop is unsafe as it can register false positives for cases when an empty
+      #   constructor just overrides the parent constructor, which is bad anyway.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -5,11 +5,14 @@ module RuboCop
     module Lint
       # This cop checks for setter call to local variable as the final
       # expression of a function definition.
-      # Its auto-correction is marked as unsafe because return value will be changed.
       #
-      # NOTE: There are edge cases in which the local variable references a
-      # value that is also accessible outside the local scope. This is not
-      # detected by the cop, and it can yield a false positive.
+      # @safety
+      #   There are edge cases in which the local variable references a
+      #   value that is also accessible outside the local scope. This is not
+      #   detected by the cop, and it can yield a false positive.
+      #
+      #   As well, auto-correction is unsafe because the method's
+      #   return value will be changed.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/useless_times.rb
+++ b/lib/rubocop/cop/lint/useless_times.rb
@@ -7,8 +7,9 @@ module RuboCop
       # (when the integer <= 0) or that will only ever yield once
       # (`1.times`).
       #
-      # This cop is marked as unsafe as `times` returns its receiver, which
-      # is *usually* OK, but might change behavior.
+      # @safety
+      #   This cop is unsafe as `times` returns its receiver, which is
+      #   *usually* OK, but might change behavior.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
+++ b/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
@@ -14,6 +14,11 @@ module RuboCop
       # convention that is used to implicitly indicate that an ivar should not
       # be set or referenced outside of the memoization method.
       #
+      # @safety
+      #   This cop relies on the pattern `@instance_var ||= ...`,
+      #   but this is sometimes used for other purposes than memoization
+      #   so this cop is considered unsafe.
+      #
       # @example EnforcedStyleForLeadingUnderscores: disallowed (default)
       #   # bad
       #   # Method foo is memoized using an instance variable that is
@@ -139,10 +144,6 @@ module RuboCop
       #   define_method(:foo) do
       #     @_foo ||= calculate_expensive_thing
       #   end
-      #
-      # This cop relies on the pattern `@instance_var ||= ...`,
-      # but this is sometimes used for other purposes than memoization
-      # so this cop is considered unsafe.
       class MemoizedInstanceVariableName < Base
         include ConfigurableEnforcedStyle
 

--- a/lib/rubocop/cop/security/json_load.rb
+++ b/lib/rubocop/cop/security/json_load.rb
@@ -6,13 +6,14 @@ module RuboCop
       # This cop checks for the use of JSON class methods which have potential
       # security issues.
       #
-      # Autocorrect is disabled by default because it's potentially dangerous.
-      # If using a stream, like `JSON.load(open('file'))`, it will need to call
-      # `#read` manually, like `JSON.parse(open('file').read)`.
-      # If reading single values (rather than proper JSON objects), like
-      # `JSON.load('false')`, it will need to pass the `quirks_mode: true`
-      # option, like `JSON.parse('false', quirks_mode: true)`.
-      # Other similar issues may apply.
+      # @safety
+      #   Autocorrect is disabled by default because it's potentially dangerous.
+      #   If using a stream, like `JSON.load(open('file'))`, it will need to call
+      #   `#read` manually, like `JSON.parse(open('file').read)`.
+      #   If reading single values (rather than proper JSON objects), like
+      #   `JSON.load('false')`, it will need to pass the `quirks_mode: true`
+      #   option, like `JSON.parse('false', quirks_mode: true)`.
+      #   Other similar issues may apply.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/security/open.rb
+++ b/lib/rubocop/cop/security/open.rb
@@ -11,6 +11,10 @@ module RuboCop
       # the argument of `Kernel#open` and `URI.open`. It would be better to use
       # `File.open`, `IO.popen` or `URI.parse#open` explicitly.
       #
+      # @safety
+      #   This cop could register false positives if `open` is redefined
+      #   in a class and then used without a receiver in that class.
+      #
       # @example
       #   # bad
       #   open(something)

--- a/lib/rubocop/cop/security/yaml_load.rb
+++ b/lib/rubocop/cop/security/yaml_load.rb
@@ -7,6 +7,10 @@ module RuboCop
       # potential security issues leading to remote code execution when
       # loading from an untrusted source.
       #
+      # @safety
+      #   The behaviour of the code might change depending on what was
+      #   in the YAML payload, since `YAML.safe_load` is more restrictive.
+      #
       # @example
       #   # bad
       #   YAML.load("--- foo")

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -7,9 +7,10 @@ module RuboCop
       # `||` instead. It can be configured to check only in conditions or in
       # all contexts.
       #
-      # It is marked as unsafe auto-correction because it may change the
-      # operator precedence between logical operators (`&&` and `||`) and
-      # semantic operators (`and` and `or`).
+      # @safety
+      #   Auto-correction is unsafe because there is a different operator precedence
+      #   between logical operators (`&&` and `||`) and semantic operators (`and` and `or`),
+      #   and that might change the behaviour.
       #
       # @example EnforcedStyle: always
       #   # bad

--- a/lib/rubocop/cop/style/array_coercion.rb
+++ b/lib/rubocop/cop/style/array_coercion.rb
@@ -5,9 +5,27 @@ module RuboCop
     module Style
       # This cop enforces the use of `Array()` instead of explicit `Array` check or `[*var]`.
       #
-      # This cop is disabled by default because false positive will occur if
-      # the argument of `Array()` is not an array (e.g. Hash, Set),
-      # an array will be returned as an incompatibility result.
+      # The cop is disabled by default due to safety concerns.
+      #
+      # @safety
+      #   This cop is unsafe because a false positive may occur if
+      #   the argument of `Array()` is (or could be) nil or depending
+      #   on how the argument is handled by `Array()` (which can be
+      #   different than just wrapping the argument in an array).
+      #
+      #   For example:
+      #
+      #   [source,ruby]
+      #   ----
+      #   [nil]             #=> [nil]
+      #   Array(nil)        #=> []
+      #
+      #   [{a: 'b'}]        #= [{a: 'b'}]
+      #   Array({a: 'b'})   #=> [[:a, 'b']]
+      #
+      #   [Time.now]        #=> [#<Time ...>]
+      #   Array(Time.now)   #=> [14, 16, 14, 16, 9, 2021, 4, 259, true, "EDT"]
+      #   ----
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/case_like_if.rb
+++ b/lib/rubocop/cop/style/case_like_if.rb
@@ -6,6 +6,11 @@ module RuboCop
       # This cop identifies places where `if-elsif` constructions
       # can be replaced with `case-when`.
       #
+      # @safety
+      #   This cop is unsafe. `case` statements use `===` for equality,
+      #   so if the original conditional used a different equality operator, the
+      #   behaviour may be different.
+      #
       # @example
       #   # bad
       #   if status == :active

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -6,6 +6,15 @@ module RuboCop
       # This cop checks the style of children definitions at classes and
       # modules. Basically there are two different styles:
       #
+      # @safety
+      #   Autocorrection is unsafe.
+      #
+      #   Moving from compact to nested children requires knowledge of whether the
+      #   outer parent is a module or a class. Moving from nested to compact requires
+      #   verification that the outer parent is defined elsewhere. Rubocop does not
+      #   have the knowledge to perform either operation safely and thus requires
+      #   manual oversight.
+      #
       # @example EnforcedStyle: nested (default)
       #   # good
       #   # have each child on its own line

--- a/lib/rubocop/cop/style/collection_compact.rb
+++ b/lib/rubocop/cop/style/collection_compact.rb
@@ -6,11 +6,13 @@ module RuboCop
       # This cop checks for places where custom logic on rejection nils from arrays
       # and hashes can be replaced with `{Array,Hash}#{compact,compact!}`.
       #
-      # It is marked as unsafe by default because false positives may occur in the
-      # nil check of block arguments to the receiver object.
-      # For example, `[[1, 2], [3, nil]].reject { |first, second| second.nil? }`
-      # and `[[1, 2], [3, nil]].compact` are not compatible. This will work fine
-      # when the receiver is a hash object.
+      # @safety
+      #   It is unsafe by default because false positives may occur in the
+      #   `nil` check of block arguments to the receiver object.
+      #
+      #   For example, `[[1, 2], [3, nil]].reject { |first, second| second.nil? }`
+      #   and `[[1, 2], [3, nil]].compact` are not compatible. This will work fine
+      #   when the receiver is a hash object.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/collection_methods.rb
+++ b/lib/rubocop/cop/style/collection_methods.rb
@@ -6,10 +6,6 @@ module RuboCop
       # This cop enforces the use of consistent method names
       # from the Enumerable module.
       #
-      # Unfortunately we cannot actually know if a method is from
-      # Enumerable or not (static analysis limitation), so this cop
-      # can yield some false positives.
-      #
       # You can customize the mapping from undesired method to desired method.
       #
       # e.g. to use `detect` over `find`:
@@ -18,9 +14,14 @@ module RuboCop
       #     PreferredMethods:
       #       find: detect
       #
-      # The default mapping for `PreferredMethods` behaves as follows.
+      # @safety
+      #   This cop is unsafe because it finds methods by name, without actually
+      #   being able to determine if the receiver is an Enumerable or not, so
+      #   this cop may register false positives.
       #
       # @example
+      #   # These examples are based on the default mapping for `PreferredMethods`.
+      #
       #   # bad
       #   items.collect
       #   items.collect!

--- a/lib/rubocop/cop/style/combinable_loops.rb
+++ b/lib/rubocop/cop/style/combinable_loops.rb
@@ -7,8 +7,9 @@ module RuboCop
       # can be combined into a single loop. It is very likely that combining them
       # will make the code more efficient and more concise.
       #
-      # It is marked as unsafe, because the first loop might modify
-      # a state that the second loop depends on; these two aren't combinable.
+      # @safety
+      #   The cop is unsafe, because the first loop might modify state that the
+      #   second loop depends on; these two aren't combinable.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -12,7 +12,10 @@ module RuboCop
       #
       # Auto-correction removes comments from `end` keyword and keeps comments
       # for `class`, `module`, `def` and `begin` above the keyword.
-      # It is marked as unsafe auto-correction as it may remove meaningful comments.
+      #
+      # @safety
+      #   Auto-correction is unsafe because it may remove a comment that is
+      #   meaningful.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/date_time.rb
+++ b/lib/rubocop/cop/style/date_time.rb
@@ -9,6 +9,11 @@ module RuboCop
       # replaceable in certain situations when dealing with multiple timezones
       # and/or DST.
       #
+      # @safety
+      #   Autocorrection is not safe, because `DateTime` and `Time` do not have
+      #   exactly the same behaviour, although in most cases the autocorrection
+      #   will be fine.
+      #
       # @example
       #
       #   # bad - uses `DateTime` for current time

--- a/lib/rubocop/cop/style/double_negation.rb
+++ b/lib/rubocop/cop/style/double_negation.rb
@@ -9,6 +9,21 @@ module RuboCop
       # that use boolean as a return value. When using `EnforcedStyle: forbidden`, double negation
       # should be forbidden always.
       #
+      # NOTE: when `something` is a boolean value
+      # `!!something` and `!something.nil?` are not the same thing.
+      # As you're unlikely to write code that can accept values of any type
+      # this is rarely a problem in practice.
+      #
+      # @safety
+      #   Autocorrection is unsafe when the value is `false`, because the result
+      #   of the expression will change.
+      #
+      #   [source,ruby]
+      #   ----
+      #   !!false     #=> false
+      #   !false.nil? #=> true
+      #   ----
+      #
       # @example
       #   # bad
       #   !!something
@@ -27,11 +42,6 @@ module RuboCop
       #   def foo?
       #     !!return_value
       #   end
-      #
-      # Please, note that when something is a boolean value
-      # !!something and !something.nil? are not the same thing.
-      # As you're unlikely to write code that can accept values of any type
-      # this is rarely a problem in practice.
       class DoubleNegation < Base
         include ConfigurableEnforcedStyle
         extend AutoCorrector

--- a/lib/rubocop/cop/style/float_division.rb
+++ b/lib/rubocop/cop/style/float_division.rb
@@ -7,8 +7,16 @@ module RuboCop
       # It is recommended to either always use `fdiv` or coerce one side only.
       # This cop also provides other options for code consistency.
       #
-      # This cop is marked as unsafe, because if operand variable is a string object
-      # then `.to_f` will be removed and an error will occur.
+      # @safety
+      #   This cop is unsafe, because if the operand variable is a string object
+      #   then `.to_f` will be removed and an error will occur.
+      #
+      #   [source,ruby]
+      #   ----
+      #   a = '1.2'
+      #   b = '3.4'
+      #   a.to_f / b.to_f # Both `to_f` calls are required here
+      #   ----
       #
       # @example EnforcedStyle: single_coerce (default)
       #   # bad

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -10,11 +10,16 @@ module RuboCop
       # default in future Ruby. The comment will be added below a shebang and
       # encoding comment.
       #
-      # Note that the cop will ignore files where the comment exists but is set
+      # Note that the cop will accept files where the comment exists but is set
       # to `false` instead of `true`.
       #
       # To require a blank line after this comment, please see
       # `Layout/EmptyLineAfterMagicComment` cop.
+      #
+      # @safety
+      #  This cop's autocorrection is unsafe since any strings mutations will
+      #  change from being accepted to raising `FrozenError`, as all strings
+      #  will become frozen by default, and will need to be manually refactored.
       #
       # @example EnforcedStyle: always (default)
       #   # The `always` style will always add the frozen string literal comment

--- a/lib/rubocop/cop/style/global_std_stream.rb
+++ b/lib/rubocop/cop/style/global_std_stream.rb
@@ -8,6 +8,10 @@ module RuboCop
       # reassign (possibly to redirect some stream) constants in Ruby, you'll get
       # an interpreter warning if you do so.
       #
+      # @safety
+      #   Autocorrection is unsafe because `STDOUT` and `$stdout` may point to different
+      #   objects, for example.
+      #
       # @example
       #   # bad
       #   STDOUT.puts('hello')

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -9,6 +9,11 @@ module RuboCop
       #   parentheses around the block arguments to indicate that you're not
       #   working with a hash, and suppress RuboCop offenses.
       #
+      # @safety
+      #   This cop is unsafe because it cannot be guaranteed that the receiver
+      #   is a `Hash`. The `AllowedReceivers` configuration can mitigate,
+      #   but not fully resolve, this safety issue.
+      #
       # @example
       #   # bad
       #   hash.keys.each { |k| p k }

--- a/lib/rubocop/cop/style/hash_transform_keys.rb
+++ b/lib/rubocop/cop/style/hash_transform_keys.rb
@@ -8,12 +8,10 @@ module RuboCop
       # transforming the keys of a hash, and tries to use a simpler & faster
       # call to `transform_keys` instead.
       #
-      # This can produce false positives if we are transforming an enumerable
-      # of key-value-like pairs that isn't actually a hash, e.g.:
-      # `[[k1, v1], [k2, v2], ...]`
-      #
-      # This cop should only be enabled on Ruby version 2.5 or newer
-      # (`transform_keys` was added in Ruby 2.5.)
+      # @safety
+      #   This cop is unsafe, as it can produce false positives if we are
+      #   transforming an enumerable of key-value-like pairs that isn't actually
+      #   a hash, e.g.: `[[k1, v1], [k2, v2], ...]`
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/hash_transform_values.rb
+++ b/lib/rubocop/cop/style/hash_transform_values.rb
@@ -8,12 +8,10 @@ module RuboCop
       # transforming the values of a hash, and tries to use a simpler & faster
       # call to `transform_values` instead.
       #
-      # This can produce false positives if we are transforming an enumerable
-      # of key-value-like pairs that isn't actually a hash, e.g.:
-      # `[[k1, v1], [k2, v2], ...]`
-      #
-      # This cop should only be enabled on Ruby version 2.4 or newer
-      # (`transform_values` was added in Ruby 2.4.)
+      # @safety
+      #   This cop is unsafe, as it can produce false positives if we are
+      #   transforming an enumerable of key-value-like pairs that isn't actually
+      #   a hash, e.g.: `[[k1, v1], [k2, v2], ...]`
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -7,25 +7,27 @@ module RuboCop
       # each branch of a conditional expression. Such expressions should normally
       # be placed outside the conditional expression - before or after it.
       #
-      # This cop is marked unsafe auto-correction as the order of method invocations
-      # must be guaranteed in the following case:
-      #
-      # [source,ruby]
-      # ----
-      # if method_that_modifies_global_state # 1
-      #   method_that_relies_on_global_state # 2
-      #   foo                                # 3
-      # else
-      #   method_that_relies_on_global_state # 2
-      #   bar                                # 3
-      # end
-      # ----
-      #
-      # In such a case, auto-correction may change the invocation order.
-      #
       # NOTE: The cop is poorly named and some people might think that it actually
       # checks for duplicated conditional branches. The name will probably be changed
       # in a future major RuboCop release.
+      #
+      # @safety
+      #   Auto-correction is unsafe because changing the order of method invocations
+      #   may change the behaviour of the code. For example:
+      #
+      #   [source,ruby]
+      #   ----
+      #   if method_that_modifies_global_state # 1
+      #     method_that_relies_on_global_state # 2
+      #     foo                                # 3
+      #   else
+      #     method_that_relies_on_global_state # 2
+      #     bar                                # 3
+      #   end
+      #   ----
+      #
+      #   In this example, `method_that_relies_on_global_state` will be moved before
+      #   `method_that_modifies_global_state`, which changes the behaviour of the program.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
+++ b/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
@@ -6,8 +6,10 @@ module RuboCop
       # This cop checks for redundant `if` with boolean literal branches.
       # It checks only conditions to return boolean value (`true` or `false`) for safe detection.
       # The conditions to be checked are comparison methods, predicate methods, and double negative.
-      # However, auto-correction is unsafe because there is no guarantee that all predicate methods
-      # will return boolean value. Those methods can be allowed with `AllowedMethods` config.
+      #
+      # @safety
+      #   Auto-correction is unsafe because there is no guarantee that all predicate methods
+      #   will return a boolean value. Those methods can be allowed with `AllowedMethods` config.
       #
       # @example
       #   # bad
@@ -22,6 +24,17 @@ module RuboCop
       #
       #   # good
       #   foo == bar
+      #
+      # @example
+      #   # bad
+      #   if foo.do_something?
+      #     true
+      #   else
+      #     false
+      #   end
+      #
+      #   # good (but potentially an unsafe correction)
+      #   foo.do_something?
       #
       # @example AllowedMethods: ['nonzero?']
       #   # good

--- a/lib/rubocop/cop/style/infinite_loop.rb
+++ b/lib/rubocop/cop/style/infinite_loop.rb
@@ -5,9 +5,10 @@ module RuboCop
     module Style
       # Use `Kernel#loop` for infinite loops.
       #
-      # This cop is marked as unsafe as the rule does not necessarily
-      # apply if the body might raise a `StopIteration` exception; contrary to
-      # other infinite loops, `Kernel#loop` silently rescues that and returns `nil`.
+      # @safety
+      #   This cop is unsafe as the rule should not necessarily apply if the loop
+      #   body might raise a `StopIteration` exception; contrary to other infinite
+      #   loops, `Kernel#loop` silently rescues that and returns `nil`.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -5,11 +5,18 @@ module RuboCop
     module Style
       # This cop check for usages of not (`not` or `!`) called on a method
       # when an inverse of that method can be used instead.
+      #
       # Methods that can be inverted by a not (`not` or `!`) should be defined
-      # in `InverseMethods`
+      # in `InverseMethods`.
+      #
       # Methods that are inverted by inverting the return
       # of the block that is passed to the method should be defined in
-      # `InverseBlocks`
+      # `InverseBlocks`.
+      #
+      # @safety
+      #   This cop is unsafe because it cannot be guaranteed that the method
+      #   and its inverse method are both defined on receiver, and also are
+      #   actually inverse of each other.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -6,6 +6,19 @@ module RuboCop
       # This cop checks for string literal concatenation at
       # the end of a line.
       #
+      # @safety
+      #   This cop is unsafe because it canot be guaranteed that the
+      #   receiver is a string, in which case replacing `<<` with `\`
+      #   would result in a syntax error.
+      #
+      #   For example, this would be a false positive:
+      #   [source,ruby]
+      #   ----
+      #   array << 'foo' <<
+      #            'bar' <<
+      #            'baz'
+      #   ----
+      #
       # @example
       #
       #   # bad

--- a/lib/rubocop/cop/style/module_function.rb
+++ b/lib/rubocop/cop/style/module_function.rb
@@ -6,7 +6,14 @@ module RuboCop
       # This cop checks for use of `extend self` or `module_function` in a
       # module.
       #
-      # Supported styles are: module_function, extend_self, forbidden.
+      # Supported styles are: module_function, extend_self, forbidden. `forbidden`
+      # style prohibits the usage of both styles.
+      #
+      # NOTE: the cop won't be activated when the module contains any private methods.
+      #
+      # @safety
+      #   Autocorrection is unsafe (and is disabled by default) because `extend self`
+      #   and `module_function` do not behave exactly the same.
       #
       # @example EnforcedStyle: module_function (default)
       #   # bad
@@ -20,9 +27,6 @@ module RuboCop
       #     module_function
       #     # ...
       #   end
-      #
-      # In case there are private methods, the cop won't be activated.
-      # Otherwise, it forces to change the flow of the default code.
       #
       # @example EnforcedStyle: module_function (default)
       #   # good
@@ -46,8 +50,6 @@ module RuboCop
       #     # ...
       #   end
       #
-      # The option `forbidden` prohibits the usage of both styles.
-      #
       # @example EnforcedStyle: forbidden
       #   # bad
       #   module Test
@@ -68,9 +70,6 @@ module RuboCop
       #     private
       #     # ...
       #   end
-      #
-      # These offenses are not safe to auto-correct since there are different
-      # implications to each approach.
       class ModuleFunction < Base
         include ConfigurableEnforcedStyle
         extend AutoCorrector

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -24,6 +24,14 @@ module RuboCop
       # NOTE: From Ruby 3.0, this cop allows explicit freezing of interpolated
       # string literals when `# frozen-string-literal: true` is used.
       #
+      # NOTE: From Ruby 3.0, this cop allows explicit freezing of constants when
+      # the `shareable_constant_value` directive is used.
+      #
+      # @safety
+      #   This cop's autocorrection is unsafe since any mutations on objects that
+      #   are made frozen will change from being accepted to raising `FrozenError`,
+      #   and will need to be manually refactored.
+      #
       # @example EnforcedStyle: literals (default)
       #   # bad
       #   CONST = [1, 2, 3]
@@ -70,10 +78,6 @@ module RuboCop
       #   # good
       #   # shareable_constant_value: literal
       #   CONST = [1, 2, 3]
-      #
-      # NOTE: This special directive helps to create constants
-      # that hold only immutable objects, or Ractor-shareable
-      # constants. - ruby docs
       #
       class MutableConstant < Base
         # Handles magic comment shareable_constant_value with O(n ^ 2) complexity

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -16,6 +16,11 @@ module RuboCop
       # populated with objects which can be compared with integers, but are
       # not themselves `Integer` polymorphic.
       #
+      # @safety
+      #   This cop is unsafe because it cannot be guaranteed that the receiver
+      #   defines the predicates or can be compared to a number, which may lead
+      #   to a false positive for non-standard classes.
+      #
       # @example EnforcedStyle: predicate (default)
       #   # bad
       #

--- a/lib/rubocop/cop/style/optional_arguments.rb
+++ b/lib/rubocop/cop/style/optional_arguments.rb
@@ -6,6 +6,10 @@ module RuboCop
       # This cop checks for optional arguments to methods
       # that do not come at the end of the argument list.
       #
+      # @safety
+      #   This cop is unsafe because changing a method signature will
+      #   implicitly change behaviour.
+      #
       # @example
       #   # bad
       #   def foo(a = 1, b, c)

--- a/lib/rubocop/cop/style/optional_boolean_parameter.rb
+++ b/lib/rubocop/cop/style/optional_boolean_parameter.rb
@@ -7,6 +7,10 @@ module RuboCop
       # boolean arguments when defining methods. `respond_to_missing?` method is allowed by default.
       # These are customizable with `AllowedMethods` option.
       #
+      # @safety
+      #   This cop is unsafe because changing a method signature will
+      #   implicitly change behaviour.
+      #
       # @example
       #   # bad
       #   def some_method(bar = false)

--- a/lib/rubocop/cop/style/preferred_hash_methods.rb
+++ b/lib/rubocop/cop/style/preferred_hash_methods.rb
@@ -3,10 +3,15 @@
 module RuboCop
   module Cop
     module Style
-      # This cop (by default) checks for uses of methods Hash#has_key? and
-      # Hash#has_value? where it enforces Hash#key? and Hash#value?
-      # It is configurable to enforce the inverse, using `verbose` method
-      # names also.
+      # This cop checks for uses of methods `Hash#has_key?` and
+      # `Hash#has_value?`, and suggests using `Hash#key?` and `Hash#value?` instead.
+      #
+      # It is configurable to enforce the verbose method names, by using the
+      # `EnforcedStyle: verbose` configuration.
+      #
+      # @safety
+      #   This cop is unsafe because it cannot be guaranteed that the receiver
+      #   is a `Hash` or responds to the replacement methods.
       #
       # @example EnforcedStyle: short (default)
       #  # bad

--- a/lib/rubocop/cop/style/redundant_argument.rb
+++ b/lib/rubocop/cop/style/redundant_argument.rb
@@ -5,22 +5,29 @@ module RuboCop
     module Style
       # This cop checks for a redundant argument passed to certain methods.
       #
-      # Limitations:
-      #
-      # 1. This cop matches for method names only and hence cannot tell apart
-      #    methods with same name in different classes.
-      # 2. This cop is limited to methods with single parameter.
-      # 3. This cop is unsafe if certain special global variables (e.g. `$;`, `$/`) are set.
-      #    That depends on the nature of the target methods, of course.
+      # NOTE: This cop is limited to methods with single parameter.
       #
       # Method names and their redundant arguments can be configured like this:
       #
+      # [source,yaml]
+      # ----
       # Methods:
       #   join: ''
       #   split: ' '
       #   chomp: "\n"
       #   chomp!: "\n"
       #   foo: 2
+      # ----
+      #
+      # @safety
+      #   This cop is unsafe because of the following limitations:
+      #
+      #   1. This cop matches by method names only and hence cannot tell apart
+      #      methods with same name in different classes.
+      #   2. This cop may be unsafe if certain special global variables (e.g. `$;`, `$/`) are set.
+      #      That depends on the nature of the target methods, of course. For example, the default
+      #      argument to join is `$OUTPUT_FIELD_SEPARATOR` (or `$,`) rather than `''`, and if that
+      #      global is changed, `''` is no longer a redundant argument.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/redundant_fetch_block.rb
+++ b/lib/rubocop/cop/style/redundant_fetch_block.rb
@@ -9,6 +9,10 @@ module RuboCop
       # In such cases `fetch(key, value)` method is faster
       # than `fetch(key) { value }`.
       #
+      # @safety
+      #   This cop is unsafe because it cannot be guaranteed that the receiver
+      #   does not have a different implementation of `fetch`.
+      #
       # @example SafeForConstants: false (default)
       #   # bad
       #   hash.fetch(:key) { 5 }

--- a/lib/rubocop/cop/style/redundant_self_assignment.rb
+++ b/lib/rubocop/cop/style/redundant_self_assignment.rb
@@ -6,9 +6,10 @@ module RuboCop
       # This cop checks for places where redundant assignments are made for in place
       # modification methods.
       #
-      # This cop is marked as unsafe, because it can produce false positives for
-      # user defined methods having one of the expected names, but not modifying
-      # its receiver in place.
+      # @safety
+      #   This cop is unsafe, because it can produce false positives for
+      #   user defined methods having one of the expected names, but not modifying
+      #   its receiver in place.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -10,13 +10,24 @@ module RuboCop
       # need to be changed to use safe navigation. We have limited the cop to
       # not register an offense for method chains that exceed 2 methods.
       #
-      # Configuration option: ConvertCodeThatCanStartToReturnNil
-      # The default for this is `false`. When configured to `true`, this will
+      # The default for `ConvertCodeThatCanStartToReturnNil` is `false`.
+      # When configured to `true`, this will
       # check for code in the format `!foo.nil? && foo.bar`. As it is written,
       # the return of this code is limited to `false` and whatever the return
       # of the method is. If this is converted to safe navigation,
       # `foo&.bar` can start returning `nil` as well as what the method
       # returns.
+      #
+      # @safety
+      #   Autocorrection is unsafe because if a value is `false`, the resulting
+      #   code will have different behaviour or raise an error.
+      #
+      #   [source,ruby]
+      #   ----
+      #   x = false
+      #   x && x.foo  # return false
+      #   x&.foo      # raises NoMethodError
+      #   ----
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/single_argument_dig.rb
+++ b/lib/rubocop/cop/style/single_argument_dig.rb
@@ -6,6 +6,11 @@ module RuboCop
       # Sometimes using dig method ends up with just a single
       # argument. In such cases, dig should be replaced with [].
       #
+      # @safety
+      #   This cop is unsafe because it cannot be guaranteed that the receiver
+      #   is an `Enumerable` or does not have a nonstandard implementation
+      #   of `dig`.
+      #
       # @example
       #   # bad
       #   { key: 'value' }.dig(:key)

--- a/lib/rubocop/cop/style/slicing_with_range.rb
+++ b/lib/rubocop/cop/style/slicing_with_range.rb
@@ -6,6 +6,19 @@ module RuboCop
       # This cop checks that arrays are sliced with endless ranges instead of
       # `ary[start..-1]` on Ruby 2.6+.
       #
+      # @safety
+      #   This cop is unsafe because `x..-1` and `x..` are only guaranteed to
+      #   be equivalent for `Array#[]`, and the cop cannot determine what class
+      #   the receiver is.
+      #
+      #   For example:
+      #   [source,ruby]
+      #   ----
+      #   sum = proc { |ary| ary.sum }
+      #   sum[-3..-1] # => -6
+      #   sum[-3..] # Hangs forever
+      #   ----
+      #
       # @example
       #   # bad
       #   items[1..-1]

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -9,6 +9,10 @@ module RuboCop
       # will add a require statement to the top of the file if
       # enabled by RequireEnglish config.
       #
+      # @safety
+      #   Autocorrection is marked as unsafe because if `RequireEnglish` is not
+      #   true, replacing perl-style variables with english variables will break.
+      #
       # @example EnforcedStyle: use_english_names (default)
       #   # good
       #   require 'English' # or this could be in another file.

--- a/lib/rubocop/cop/style/static_class.rb
+++ b/lib/rubocop/cop/style/static_class.rb
@@ -7,9 +7,10 @@ module RuboCop
       # replaced with a module. Classes should be used only when it makes sense to create
       # instances out of them.
       #
-      # This cop is marked as unsafe, because it is possible that this class is a parent
-      # for some other subclass, monkey-patched with instance methods or
-      # a dummy instance is instantiated from it somewhere.
+      # @safety
+      #   This cop is unsafe, because it is possible that this class is a parent
+      #   for some other subclass, monkey-patched with instance methods or
+      #   a dummy instance is instantiated from it somewhere.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/string_chars.rb
+++ b/lib/rubocop/cop/style/string_chars.rb
@@ -5,8 +5,10 @@ module RuboCop
     module Style
       # Checks for uses of `String#split` with empty string or regexp literal argument.
       #
-      # This cop is marked as unsafe. But probably it's quite unlikely that some other class would
-      # define a `split` method that takes exactly the same arguments.
+      # @safety
+      #   This cop is unsafe because it cannot be guaranteed that the receiver
+      #   is actually a string. If another class has a `split` method with
+      #   different behaviour, it would be registered as a false positive.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/string_concatenation.rb
+++ b/lib/rubocop/cop/style/string_concatenation.rb
@@ -23,6 +23,10 @@ module RuboCop
       # This is useful when the receiver is some expression that returns string like `Pathname`
       # instead of a string literal.
       #
+      # @safety
+      #   This cop is unsafe in `aggressive` mode, as it cannot be guaranteed that
+      #   the receiver is actually a string, which can result in a false positive.
+      #
       # @example Mode: aggressive (default)
       #   # bad
       #   email_with_name = user.name + ' <' + user.email + '>'

--- a/lib/rubocop/cop/style/string_hash_keys.rb
+++ b/lib/rubocop/cop/style/string_hash_keys.rb
@@ -6,6 +6,10 @@ module RuboCop
       # This cop checks for the use of strings as keys in hashes. The use of
       # symbols is preferred instead.
       #
+      # @safety
+      #   This cop is unsafe because while symbols are preferred for hash keys,
+      #   there are instances when string keys are required.
+      #
       # @example
       #   # bad
       #   { 'one' => 1, 'two' => 2, 'three' => 3 }

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -5,8 +5,9 @@ module RuboCop
     module Style
       # This cop checks for inheritance from Struct.new.
       #
-      # It is marked as unsafe auto-correction because it will change the
-      # inheritance tree (e.g. return value of `Module#ancestors`).
+      # @safety
+      #   Auto-correction is unsafe because it will change the inheritance
+      #   tree (e.g. return value of `Module#ancestors`) of the constant.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/swap_values.rb
+++ b/lib/rubocop/cop/style/swap_values.rb
@@ -4,8 +4,10 @@ module RuboCop
   module Cop
     module Style
       # This cop enforces the use of shorthand-style swapping of 2 variables.
-      # Its autocorrection is marked as unsafe, because it can erroneously remove
-      # the temporary variable which is used later.
+      #
+      # @safety
+      #   Autocorrection is unsafe, because the temporary variable used to
+      #   swap variables will be removed, but may be referred to elsewhere.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -8,6 +8,32 @@ module RuboCop
       # If you prefer a style that allows block for method with arguments,
       # please set `true` to `AllowMethodsWithArguments`.
       #
+      # @safety
+      #   This cop is unsafe because `proc`s and blocks work differently
+      #   when additional arguments are passed in. A block will silently
+      #   ignore additional arguments, but a `proc` will raise
+      #   an `ArgumentError`.
+      #
+      #   For example:
+      #
+      #   [source,ruby]
+      #   ----
+      #   class Foo
+      #     def bar
+      #       :bar
+      #     end
+      #   end
+      #
+      #   def call(options = {}, &block)
+      #     block.call(Foo.new, options)
+      #   end
+      #
+      #   call { |x| x.bar }
+      #   #=> :bar
+      #   call(&:bar)
+      #   # ArgumentError: wrong number of arguments (given 1, expected 0)
+      #   ----
+      #
       # @example
       #   # bad
       #   something.map { |s| s.upcase }

--- a/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
@@ -8,6 +8,25 @@ module RuboCop
       # that comma to be present. Blocks with more than one argument never
       # require a trailing comma.
       #
+      # @safety
+      #   This cop is unsafe because a trailing comma can indicate there are
+      #   more parameters that are not used.
+      #
+      #   For example:
+      #   [source,ruby]
+      #   ----
+      #   # with a trailing comma
+      #   {foo: 1, bar: 2, baz: 3}.map {|key,| key }
+      #   #=> [:foo, :bar, :baz]
+      #
+      #   # without a trailing comma
+      #   {foo: 1, bar: 2, baz: 3}.map {|key| key }
+      #   #=> [[:foo, 1], [:bar, 2], [:baz, 3]]
+      #   ----
+      #
+      #   This can be fixed by replacing the trailing comma with a placeholder
+      #   argument (such as `|key, _value|`).
+      #
       # @example
       #   # bad
       #   add { |foo, bar,| foo + bar }

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -7,6 +7,26 @@ module RuboCop
       # i.e. comparison operations where the order of expression is reversed.
       # eg. `5 == x`
       #
+      # @safety
+      #   This cop is unsafe because comparison operators can be defined
+      #   differently on different classes, and are not guaranteed to
+      #   have the same result if reversed.
+      #
+      #   For example:
+      #
+      #   [source,ruby]
+      #   ----
+      #   class MyKlass
+      #     def ==(other)
+      #       true
+      #     end
+      #   end
+      #
+      #   obj = MyKlass.new
+      #   obj == 'string'   #=> true
+      #   'string' == obj   #=> false
+      #   ----
+      #
       # @example EnforcedStyle: forbid_for_all_comparison_operators (default)
       #   # bad
       #   99 == foo

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -9,6 +9,12 @@ module RuboCop
       # receiver.length < 1 and receiver.size == 0 that can be
       # replaced by receiver.empty? and !receiver.empty?.
       #
+      # @safety
+      #   This cop is unsafe because it cannot be guaranteed that the receiver
+      #   has an `empty?` method that is defined in terms of `length`. If there
+      #   is a non-standard class that redefines `length` or `empty?`, the cop
+      #   may register a false positive.
+      #
       # @example
       #   # bad
       #   [1, 2, 3].length == 0

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe RuboCop::Cop::Generator do
               # `SupportedStyle` and unique configuration, there needs to be examples.
               # Examples must have valid Ruby syntax. Do not use upticks.
               #
+              # @safety
+              #   Delete this section if the cop is not unsafe (`Safe: false` or
+              #   `SafeAutoCorrect: false`), or use it to explain how the cop is
+              #   unsafe.
+              #
               # @example EnforcedStyle: bar (default)
               #   # Description of the `bar` style.
               #


### PR DESCRIPTION
Documents safety concerns for every cop that is either `Safe: false` or `SafeAutoCorrect: false`. This documentation will show up as a separate subsection in each cop's documentation once the .adoc files are generated.

For example: 
<img width="714" alt="image" src="https://user-images.githubusercontent.com/57964/133690375-c624ac8e-9bf2-435a-8d60-e7d5cfd2f8fc.png">

In order to make this happen, I added a custom `@safety` YARD tag that is used to process the documentation, which should make it simple when creating a new unsafe cop (I also updated the `rake new_cop` template) or changing a cop to be unsafe.

The text for the safety section comes either from the text that already existed in the cop (🙌 to everyone who added a reason when marking a cop unsafe); looking through many old PRs in order to try to determine why the cop was made unsafe; or using my best guess if I could not find a better reason. While I was going through documentation I took the opportunity to make some minor tweaks as well.

I tried writing a `project_spec` test to ensure a `@safety` block is added for cops that are unsafe, but could not find a way to get the yard code object for a class (the documentation generator relies on yard's generation rake task, which I did not want to run in a spec). If anyone has any suggestions please let me know!

Altogether, 66 cops were updated by this change.

Fixes #8431.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
