### PR TITLE
`Style/RedundantFreeze` stop considering `ENV` values as immutable

### DIFF
--- a/changelog/fix_redundant_freeze_env_values.md
+++ b/changelog/fix_redundant_freeze_env_values.md
@@ -1,0 +1,1 @@
+* [#10099](https://github.com/rubocop/rubocop/pull/10099): Update`Style/RedundantFreeze` to stop considering `ENV` values as immutable. ([@byroot][])

--- a/lib/rubocop/cop/style/redundant_freeze.rb
+++ b/lib/rubocop/cop/style/redundant_freeze.rb
@@ -59,7 +59,6 @@ module RuboCop
             (begin (send {float int} {:+ :- :* :** :/ :% :<<} _))
             (begin (send !{(str _) array} {:+ :- :* :** :/ :%} {float int}))
             (begin (send _ {:== :=== :!= :<= :>= :< :>} _))
-            (send (const {nil? cbase} :ENV) :[] _)
             (send _ {:count :length :size} ...)
             (block (send _ {:count :length :size} ...) ...)
           }

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze, :config do
   it_behaves_like 'immutable objects', '1.5'
   it_behaves_like 'immutable objects', ':sym'
   it_behaves_like 'immutable objects', ':""'
-  it_behaves_like 'immutable objects', "ENV['foo']"
-  it_behaves_like 'immutable objects', "::ENV['foo']"
   it_behaves_like 'immutable objects', "'foo'.count"
   it_behaves_like 'immutable objects', '(1 + 2)'
   it_behaves_like 'immutable objects', '(2 > 1)'
@@ -44,6 +42,8 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze, :config do
   it_behaves_like 'mutable objects', "('a' * 20)"
   it_behaves_like 'mutable objects', '(a + b)'
   it_behaves_like 'mutable objects', '([42] * 42)'
+  it_behaves_like 'mutable objects', "ENV['foo']"
+  it_behaves_like 'mutable objects', "::ENV['foo']"
 
   it 'allows .freeze on  method call' do
     expect_no_offenses('TOP_TEST = Something.new.freeze')


### PR DESCRIPTION
Ref: https://github.com/rubocop/rubocop/pull/6784

`ENV["foo"]` returns a new mutable string on every call.

```ruby
>> ENV["PATH"].frozen?
=> true
>> ENV["PATH"].object_id
=> 260
>> ENV["PATH"].object_id
=> 280
```

As such it's perfectly legitimate to freeze them in a pattern such as:

```ruby
PATH = ENV["PATH"].freeze
```

