### PR TITLE
[Fix #10096] Fix `Lint/AmbiguousOperatorPrecedence` with `and`/`or` operators

### DIFF
--- a/changelog/fix_fix_lintambiguousoperatorprecedence_with.md
+++ b/changelog/fix_fix_lintambiguousoperatorprecedence_with.md
@@ -1,0 +1,1 @@
+* [#10096](https://github.com/rubocop/rubocop/issues/10096): Fix `Lint/AmbiguousOperatorPrecedence` with `and`/`or` operators. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/ambiguous_operator_precedence.rb
+++ b/lib/rubocop/cop/lint/ambiguous_operator_precedence.rb
@@ -87,7 +87,11 @@ module RuboCop
         end
 
         def greater_precedence?(node1, node2)
-          precedence(node2) > precedence(node1)
+          node1_precedence = precedence(node1)
+          node2_precedence = precedence(node2)
+          return false unless node1_precedence && node2_precedence
+
+          node2_precedence > node1_precedence
         end
 
         def operator_name(node)

--- a/spec/rubocop/cop/lint/ambiguous_operator_precedence_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_operator_precedence_spec.rb
@@ -120,4 +120,16 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousOperatorPrecedence, :config do
       a || (b && (c | d ^ (e & (f << g >> (h + i - (j * k / l % (n ** m)))))))
     RUBY
   end
+
+  it 'allows an operator with `and`' do
+    expect_no_offenses(<<~RUBY)
+      array << i and next
+    RUBY
+  end
+
+  it 'allows an operator with `or`' do
+    expect_no_offenses(<<~RUBY)
+      array << i or return
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #10096.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
