### PR TITLE
[Fix #10103] Add `AllowHttpProtocol` option to `Bundler/InsecureProtocolSource`

### DIFF
--- a/changelog/new_allow_http_protocol_to_bundler_insecure_protocol_source.md
+++ b/changelog/new_allow_http_protocol_to_bundler_insecure_protocol_source.md
@@ -1,0 +1,1 @@
+* [#10103](https://github.com/rubocop/rubocop/issues/10103): Add `AllowHttpProtocol` option to `Bundler/InsecureProtocolSource`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -209,6 +209,7 @@ Bundler/InsecureProtocolSource:
                  'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
   Enabled: true
   VersionAdded: '0.50'
+  AllowHttpProtocol: true
   Include:
     - '**/*.gemfile'
     - '**/Gemfile'

--- a/lib/rubocop/cop/bundler/insecure_protocol_source.rb
+++ b/lib/rubocop/cop/bundler/insecure_protocol_source.rb
@@ -16,6 +16,9 @@ module RuboCop
       # However, you should strongly prefer `https://` where possible, as it is
       # more secure.
       #
+      # If you don't allow `http://`, please set `false` to `AllowHttpProtocol`.
+      # This option is `true` by default for safe autocorrection.
+      #
       # @example
       #   # bad
       #   source :gemcutter
@@ -24,7 +27,16 @@ module RuboCop
       #
       #   # good
       #   source 'https://rubygems.org' # strongly recommended
+      #
+      # @example AllowHttpProtocol: true (default)
+      #
+      #   # good
       #   source 'http://rubygems.org' # use only if HTTPS is unavailable
+      #
+      # @example AllowHttpProtocol: false
+      #
+      #   # bad
+      #   source 'http://rubygems.org'
       #
       class InsecureProtocolSource < Base
         include RangeHelp
@@ -34,28 +46,39 @@ module RuboCop
               'are insecure. ' \
               "Please change your source to 'https://rubygems.org' " \
               "if possible, or 'http://rubygems.org' if not."
+        MSG_HTTP_PROTOCOL = 'Use `https://rubygems.org` instead of `http://rubygems.org`.'
 
         RESTRICT_ON_SEND = %i[source].freeze
 
         # @!method insecure_protocol_source?(node)
         def_node_matcher :insecure_protocol_source?, <<~PATTERN
           (send nil? :source
-            $(sym ${:gemcutter :rubygems :rubyforge}))
+            ${(sym :gemcutter) (sym :rubygems) (sym :rubyforge) (:str "http://rubygems.org")})
         PATTERN
 
         def on_send(node)
-          insecure_protocol_source?(node) do |source_node, source|
-            message = format(MSG, source: source)
+          insecure_protocol_source?(node) do |source_node|
+            source = source_node.value
+            use_http_protocol = source == 'http://rubygems.org'
 
-            add_offense(
-              source_node,
-              message: message
-            ) do |corrector|
-              corrector.replace(
-                source_node, "'https://rubygems.org'"
-              )
+            return if allow_http_protocol? && use_http_protocol
+
+            message = if use_http_protocol
+                        MSG_HTTP_PROTOCOL
+                      else
+                        format(MSG, source: source)
+                      end
+
+            add_offense(source_node, message: message) do |corrector|
+              corrector.replace(source_node, "'https://rubygems.org'")
             end
           end
+        end
+
+        private
+
+        def allow_http_protocol?
+          cop_config.fetch('AllowHttpProtocol', true)
         end
       end
     end

--- a/spec/rubocop/cop/bundler/insecure_protocol_source_spec.rb
+++ b/spec/rubocop/cop/bundler/insecure_protocol_source_spec.rb
@@ -33,4 +33,35 @@ RSpec.describe RuboCop::Cop::Bundler::InsecureProtocolSource, :config do
       source 'https://rubygems.org'
     RUBY
   end
+
+  it "does not register an offense when using `source 'https://rubygems.org'`" do
+    expect_no_offenses(<<~RUBY)
+      source 'https://rubygems.org'
+    RUBY
+  end
+
+  context 'when `AllowHttpProtocol: true`' do
+    let(:cop_config) { { 'AllowHttpProtocol' => true } }
+
+    it "does not register an offense when using `source 'http://rubygems.org'`" do
+      expect_no_offenses(<<~RUBY)
+        source 'http://rubygems.org'
+      RUBY
+    end
+  end
+
+  context 'when `AllowHttpProtocol: false`' do
+    let(:cop_config) { { 'AllowHttpProtocol' => false } }
+
+    it "registers an offense when using `source 'http://rubygems.org'`" do
+      expect_offense(<<~RUBY)
+        source 'http://rubygems.org'
+               ^^^^^^^^^^^^^^^^^^^^^ Use `https://rubygems.org` instead of `http://rubygems.org`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        source 'https://rubygems.org'
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #10103.

This PR adds `AllowHttpProtocol` option to `Bundler/InsecureProtocolSource`.

This `AllowHttpProtocol` option is `true` by default for safe autocorrection.
If user don't allow `http://`, set `false` to the option.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
