### PR TITLE
[Fix #10065] Add new `Gemspec/TestFilesAssignment` cop

### DIFF
--- a/changelog/new_add_new_gemspec_test_files_assignment_cop.md
+++ b/changelog/new_add_new_gemspec_test_files_assignment_cop.md
@@ -1,0 +1,1 @@
+* [#10065](https://github.com/rubocop/rubocop/issues/10065): Add new `Gemspec/TestFilesAssignment` cop. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -273,6 +273,13 @@ Gemspec/RubyVersionGlobalsUsage:
   Include:
     - '**/*.gemspec'
 
+Gemspec/TestFilesAssignment:
+  Description: Checks that the `test_files` attribute is not set in a gemspec file.
+  Enabled: pending
+  VersionAdded: '<<next>>'
+  Include:
+    - '**/*.gemspec'
+
 #################### Layout ###########################
 
 Layout/AccessModifierIndentation:

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -162,6 +162,7 @@ require_relative 'rubocop/cop/gemspec/duplicated_assignment'
 require_relative 'rubocop/cop/gemspec/ordered_dependencies'
 require_relative 'rubocop/cop/gemspec/required_ruby_version'
 require_relative 'rubocop/cop/gemspec/ruby_version_globals_usage'
+require_relative 'rubocop/cop/gemspec/test_files_assignment'
 
 require_relative 'rubocop/cop/layout/access_modifier_indentation'
 require_relative 'rubocop/cop/layout/argument_alignment'

--- a/lib/rubocop/cop/gemspec/test_files_assignment.rb
+++ b/lib/rubocop/cop/gemspec/test_files_assignment.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Gemspec
+      # This cop checks that the `test_files` attribute is not set in a gemspec file.
+      # Removing it allows the user to receive smaller packed gems.
+      #
+      # @example
+      #
+      #   # bad
+      #   Gem::Specification.new do |spec|
+      #     spec.name = 'your_cool_gem_name'
+      #     spec.test_files = Dir.glob('test/**/*')
+      #   end
+      #
+      #   # bad
+      #   Gem::Specification.new do |spec|
+      #     spec.name = 'your_cool_gem_name'
+      #     spec.test_files += Dir.glob('test/**/*')
+      #   end
+      #
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.name = 'your_cool_gem_name'
+      #   end
+      #
+      class TestFilesAssignment < Base
+        include RangeHelp
+        extend AutoCorrector
+
+        MSG = 'Do not set `test_files` in gemspec.'
+
+        # @!method gem_specification(node)
+        def_node_matcher :gem_specification, <<~PATTERN
+          (block
+            (send
+              (const
+                (const {cbase nil?} :Gem) :Specification) :new)
+            ...)
+        PATTERN
+
+        def on_block(block_node)
+          return unless gem_specification(block_node)
+
+          block_parameter = block_node.arguments.first.source
+
+          date_assignment = block_node.descendants.detect do |node|
+            use_test_files?(node, block_parameter)
+          end
+
+          return unless date_assignment
+
+          add_offense(date_assignment) do |corrector|
+            range = range_by_whole_lines(date_assignment.source_range, include_final_newline: true)
+
+            corrector.remove(range)
+          end
+        end
+
+        private
+
+        def use_test_files?(node, block_parameter)
+          node, method_name = if node.op_asgn_type?
+                                lhs, _op, _rhs = *node
+
+                                [lhs, :test_files]
+                              else
+                                [node, :test_files=]
+                              end
+
+          node.send_type? && node.receiver&.source == block_parameter && node.method?(method_name)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/gemspec/test_files_assignment_spec.rb
+++ b/spec/rubocop/cop/gemspec/test_files_assignment_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Gemspec::TestFilesAssignment, :config do
+  it 'registers and corrects an offense when using `s.test_files =`' do
+    expect_offense(<<~RUBY)
+      Gem::Specification.new do |s|
+        s.name = 'your_cool_gem_name'
+        s.test_files = Dir.glob('test/**/*')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not set `test_files` in gemspec.
+        s.bindir = 'exe'
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Gem::Specification.new do |s|
+        s.name = 'your_cool_gem_name'
+        s.bindir = 'exe'
+      end
+    RUBY
+  end
+
+  it 'registers and corrects an offense when using `s.test_files +=`' do
+    expect_offense(<<~RUBY)
+      Gem::Specification.new do |s|
+        s.name = 'your_cool_gem_name'
+        s.test_files += Dir.glob('test/**/*')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not set `test_files` in gemspec.
+        s.bindir = 'exe'
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Gem::Specification.new do |s|
+        s.name = 'your_cool_gem_name'
+        s.bindir = 'exe'
+      end
+    RUBY
+  end
+
+  it 'registers and corrects an offense when using `spec.test_files =`' do
+    expect_offense(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.name = 'your_cool_gem_name'
+        spec.test_files = Dir.glob('test/**/*')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not set `test_files` in gemspec.
+        spec.bindir = 'exe'
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.name = 'your_cool_gem_name'
+        spec.bindir = 'exe'
+      end
+    RUBY
+  end
+
+  it 'registers and corrects an offense when using `spec.test_files +=`' do
+    expect_offense(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.name = 'your_cool_gem_name'
+        spec.test_files += Dir.glob('test/**/*')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not set `test_files` in gemspec.
+        spec.bindir = 'exe'
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.name = 'your_cool_gem_name'
+        spec.bindir = 'exe'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `s.test_files =` outside `Gem::Specification.new`' do
+    expect_no_offenses(<<~RUBY)
+      s.test_files = Dir.glob('test/**/*')
+    RUBY
+  end
+
+  it 'does not register an offense when using `test_files =` and receiver is not `Gem::Specification.new` block variable' do
+    expect_no_offenses(<<~RUBY)
+      Gem::Specification.new do |spec|
+        s.test_files = Dir.glob('test/**/*')
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Fixes #10065.

This PR adds new `Gemspec/TestFilesAssignment` cop.

This cop checks that `test_files =` is not used in gemspec file.
if removing `test_files =`, then user could receive smaller packed gems.

```ruby
# bad
Gem::Specification.new do |spec|
  spec.name = 'your_cool_gem_name'
  spec.test_files = Dir.glob('test/**/*')
end

# bad
Gem::Specification.new do |spec|
  spec.name = 'your_cool_gem_name'
  spec.test_files += Dir.glob('test/**/*')
end

# good
Gem::Specification.new do |spec|
  spec.name = 'your_cool_gem_name'
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
