### PR TITLE
Typo in docs for config option for Naming/BlockParameterName

### DIFF
--- a/lib/rubocop/cop/naming/block_parameter_name.rb
+++ b/lib/rubocop/cop/naming/block_parameter_name.rb
@@ -24,7 +24,7 @@ module RuboCop
       #   # With `AllowNamesEndingInNumbers` set to false
       #   foo { |num1, num2| num1 * num2 }
       #
-      #   # With `MinParamNameLength` set to number greater than 1
+      #   # With `MinNameLength` set to number greater than 1
       #   baz { |a, b, c| do_stuff(a, b, c) }
       #
       #   # good


### PR DESCRIPTION
Fix a typo in docs for config option name for Naming/BlockParameterName in the code example

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
