### PR TITLE
[Fix #10106] Fix `Style/RedundantSelf` for pattern matching

### DIFF
--- a/changelog/fix_fix_styleredundantself_for_pattern.md
+++ b/changelog/fix_fix_styleredundantself_for_pattern.md
@@ -1,0 +1,1 @@
+* [#10106](https://github.com/rubocop/rubocop/issues/10106): Fix `Style/RedundantSelf` for pattern matching. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -100,6 +100,10 @@ module RuboCop
           add_lhs_to_local_variables_scopes(rhs, lhs)
         end
 
+        def on_in_pattern(node)
+          add_match_var_scopes(node)
+        end
+
         def on_send(node)
           return unless node.self_receiver? && regular_method_call?(node)
           return if node.parent&.mlhs_type?
@@ -183,6 +187,12 @@ module RuboCop
         def add_masgn_lhs_variables(rhs, lhs)
           lhs.children.each do |child|
             add_lhs_to_local_variables_scopes(rhs, child.to_a.first)
+          end
+        end
+
+        def add_match_var_scopes(in_pattern_node)
+          in_pattern_node.each_descendant(:match_var) do |match_var_node|
+            @local_variables_scopes[in_pattern_node] << match_var_node.children.first
           end
         end
       end


### PR DESCRIPTION
A `match-as` node creates a local variable within an `in-pattern` node that wasn't being registered by `Style/RedundantSelf`. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
