### PR TITLE
Update the `rake new_cop` instructions for changelogs

### DIFF
--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -19,11 +19,14 @@ File modified:
   - `require_relative 'rubocop/cop/department/name'` added into lib/rubocop.rb
   - A configuration for the cop is added into config/default.yml
 
-Do 3 steps:
-  1. Add an entry to the "New features" section in CHANGELOG.md,
-     e.g. "Add new `Department/Name` cop. ([@your_id][])"
-  2. Modify the description of Department/Name in config/default.yml
-  3. Implement your new cop in the generated file!
+Do 4 steps:
+  1. Modify the description of Department/Name in config/default.yml
+  2. Implement your new cop in the generated file!
+  3. Commit your new cop with a message such as
+     e.g. "Add new `Department/Name` cop."
+  4. Run `bundle exec rake changelog:new` to generate a changelog entry
+     for your new cop.
+
 ----
 
 == Basics

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -111,9 +111,8 @@ module RuboCop
         '[modify] A configuration for the cop is added into ' \
         '%<configuration_file_path>s.'
 
-      def initialize(name, github_user, output: $stdout)
+      def initialize(name, output: $stdout)
         @badge = Badge.parse(name)
-        @github_user = github_user
         @output = output
         return if badge.qualified?
 
@@ -147,17 +146,19 @@ module RuboCop
 
       def todo
         <<~TODO
-          Do 3 steps:
-            1. Add an entry to the "New features" section in CHANGELOG.md,
-               e.g. "Add new `#{badge}` cop. ([@#{github_user}][])"
-            2. Modify the description of #{badge} in config/default.yml
-            3. Implement your new cop in the generated file!
+          Do 4 steps:
+            1. Modify the description of #{badge} in config/default.yml
+            2. Implement your new cop in the generated file!
+            3. Commit your new cop with a message such as
+               e.g. "Add new `#{badge}` cop."
+            4. Run `bundle exec rake changelog:new` to generate a changelog entry
+               for your new cop.
         TODO
       end
 
       private
 
-      attr_reader :badge, :github_user, :output
+      attr_reader :badge, :output
 
       def write_unless_file_exists(path, contents)
         if File.exist?(path)

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Generator do
-  subject(:generator) { described_class.new(cop_identifier, 'your_id', output: stdout) }
+  subject(:generator) { described_class.new(cop_identifier, output: stdout) }
 
   let(:stdout) { StringIO.new }
   let(:cop_identifier) { 'Style/FakeCop' }
@@ -92,7 +92,7 @@ RSpec.describe RuboCop::Cop::Generator do
     end
 
     it 'refuses to overwrite existing files' do
-      new_cop = described_class.new('Layout/IndentationStyle', 'your_id')
+      new_cop = described_class.new('Layout/IndentationStyle')
 
       allow(new_cop).to receive(:exit!)
       expect { new_cop.write_source }
@@ -139,7 +139,7 @@ RSpec.describe RuboCop::Cop::Generator do
     end
 
     it 'refuses to overwrite existing files' do
-      new_cop = described_class.new('Layout/IndentationStyle', 'your_id')
+      new_cop = described_class.new('Layout/IndentationStyle')
 
       allow(new_cop).to receive(:exit!)
       expect { new_cop.write_spec }
@@ -153,18 +153,20 @@ RSpec.describe RuboCop::Cop::Generator do
   describe '#todo' do
     it 'provides a checklist for implementing the cop' do
       expect(generator.todo).to eql(<<~TODO)
-        Do 3 steps:
-          1. Add an entry to the "New features" section in CHANGELOG.md,
-             e.g. "Add new `Style/FakeCop` cop. ([@your_id][])"
-          2. Modify the description of Style/FakeCop in config/default.yml
-          3. Implement your new cop in the generated file!
+        Do 4 steps:
+          1. Modify the description of Style/FakeCop in config/default.yml
+          2. Implement your new cop in the generated file!
+          3. Commit your new cop with a message such as
+             e.g. "Add new `Style/FakeCop` cop."
+          4. Run `bundle exec rake changelog:new` to generate a changelog entry
+             for your new cop.
       TODO
     end
   end
 
   describe '.new' do
     it 'does not accept an unqualified cop' do
-      expect { described_class.new('FakeCop', 'your_id') }
+      expect { described_class.new('FakeCop') }
         .to raise_error(ArgumentError)
         .with_message('Specify a cop name with Department/Name style')
     end

--- a/tasks/new_cop.rake
+++ b/tasks/new_cop.rake
@@ -9,10 +9,7 @@ task :new_cop, [:cop] do |_task, args|
     exit!
   end
 
-  github_user = `git config github.user`.chop
-  github_user = 'your_id' if github_user.empty?
-
-  generator = RuboCop::Cop::Generator.new(cop_name, github_user)
+  generator = RuboCop::Cop::Generator.new(cop_name)
 
   generator.write_source
   generator.write_spec


### PR DESCRIPTION
I also removed `github_user` from the Generator as it is no longer necessary (since the changelog rake tasks insert the username themselves).
