### PR TITLE
[Fix #9934] Fix configuration loading to not raise an error for an obsolete ruby version that is overridden

### DIFF
--- a/changelog/fix_fix_configuration_loading_to_not_raise.md
+++ b/changelog/fix_fix_configuration_loading_to_not_raise.md
@@ -1,0 +1,1 @@
+* [#9934](https://github.com/rubocop/rubocop/issues/9934): Fix configuration loading to not raise an error for an obsolete ruby version that is subsequently overridden. ([@dvandersluis][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -51,6 +51,11 @@ module RuboCop
       self
     end
 
+    def validate_after_resolution
+      @validator.validate_after_resolution
+      self
+    end
+
     def_delegators :@hash, :[], :[]=, :delete, :dig, :each, :key?, :keys, :each_key,
                    :fetch, :map, :merge, :replace, :to_h, :to_hash, :transform_values
     def_delegators :@validator, :validate, :target_ruby_version

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -101,6 +101,8 @@ module RuboCop
         return default_configuration if config_file == DEFAULT_FILE
 
         config = load_file(config_file, check: check)
+        config.validate_after_resolution if check
+
         if ignore_parent_exclusion?
           print 'Ignoring AllCops/Exclude from parent folders' if debug?
         else

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -44,12 +44,20 @@ module RuboCop
       check_obsoletions
 
       alert_about_unrecognized_cops(invalid_cop_names)
-      check_target_ruby
       validate_new_cops_parameter
       validate_parameter_names(valid_cop_names)
       validate_enforced_styles(valid_cop_names)
       validate_syntax_cop
       reject_mutually_exclusive_defaults
+    end
+
+    # Validations that should only be run after all config resolving has
+    # taken place:
+    # * The target ruby version is only checked once the entire inheritance
+    # chain has been loaded so that only the final value is validated, and
+    # any obsolete but overridden values are ignored.
+    def validate_after_resolution
+      check_target_ruby
     end
 
     def target_ruby_version


### PR DESCRIPTION
Previously, when a configuration file inherits another that sets `TargetRubyVersion` to an obsolete version, a config validation error is raised by RuboCop. This causes an irreconcilable issue if the inherited config is shared with other projects or not editable (from upstream, etc.).

In order to fix this, the target ruby version check is moved to happen after all the config resolution steps have completed, so at that point, all the various `TargetRubyVersion` values have been collapsed into a single value that can be verified. This allows for any number of complicated inheritence chains without causing issues.

Fixes #9934.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
