### PR TITLE
[Fix #10110] Update `Layout/DotPosition` to be able to handle heredocs

### DIFF
--- a/changelog/fix_update_layoutdotposition_to_be_able_to.md
+++ b/changelog/fix_update_layoutdotposition_to_be_able_to.md
@@ -1,0 +1,1 @@
+* [#10110](https://github.com/rubocop/rubocop/issues/10110): Update `Layout/DotPosition` to be able to handle heredocs. ([@dvandersluis][])


### PR DESCRIPTION
Updates `Layout/DotPosition` to be able to detect misplaced dots when the dot is on the same line as a heredoc start.

Fixes #10110.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
