### PR TITLE
[Fix #10118] Fix crash with `Style/RedundantSort` when the block doesn't only contain a single `send` node

### DIFF
--- a/changelog/fix_fix_crash_with_styleredundantsort_when.md
+++ b/changelog/fix_fix_crash_with_styleredundantsort_when.md
@@ -1,0 +1,1 @@
+* [#10118](https://github.com/rubocop/rubocop/issues/10118): Fix crash with `Style/RedundantSort` when the block doesn't only contain a single `send` node. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/redundant_sort.rb
+++ b/lib/rubocop/cop/style/redundant_sort.rb
@@ -93,10 +93,17 @@ module RuboCop
         private
 
         def use_size_method_in_block?(sort_node)
-          return true if sort_node.send_type? && sort_node.block_node&.body&.method?(:size)
+          return true if block_calls_send?(sort_node)
           return false unless sort_node.block_argument?
 
           sort_node.last_argument.children.first.value == :size
+        end
+
+        def block_calls_send?(node)
+          return false unless node.send_type? && node.block_node
+          return false unless node.block_node.body.send_type?
+
+          node.block_node.body.method?(:size)
         end
 
         def register_offense(ancestor, sort_node, sorter, accessor)


### PR DESCRIPTION
The check added in #10062 for `size` wasn't handling blocks that aren't just a single send node. Fixes #10118.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
