### PR TITLE
Fix false positive for `Lint/RequireRelativeSelfPath` when requiring  file with the same name but different extension

### DIFF
--- a/lib/rubocop/cop/lint/require_relative_self_path.rb
+++ b/lib/rubocop/cop/lint/require_relative_self_path.rb
@@ -27,7 +27,7 @@ module RuboCop
 
         def on_send(node)
           return unless (required_feature = node.first_argument)
-          return unless remove_ext(processed_source.file_path) == remove_ext(required_feature.value)
+          return unless same_file?(processed_source.file_path, required_feature.value)
 
           add_offense(node) do |corrector|
             corrector.remove(range_by_whole_lines(node.source_range, include_final_newline: true))
@@ -35,6 +35,10 @@ module RuboCop
         end
 
         private
+
+        def same_file?(file_path, required_feature)
+          file_path == required_feature || remove_ext(file_path) == required_feature
+        end
 
         def remove_ext(file_path)
           File.basename(file_path, File.extname(file_path))

--- a/spec/rubocop/cop/lint/require_relative_self_path_spec.rb
+++ b/spec/rubocop/cop/lint/require_relative_self_path_spec.rb
@@ -36,4 +36,10 @@ RSpec.describe RuboCop::Cop::Lint::RequireRelativeSelfPath, :config do
       require_relative
     RUBY
   end
+
+  it 'does not register an offense when the filename is the same but the extension does not match' do
+    expect_no_offenses(<<~RUBY, 'foo.rb')
+      require_relative 'foo.racc'
+    RUBY
+  end
 end


### PR DESCRIPTION
Running RuboCop on `rubocop-ast`:

```sh
lib/rubocop/ast/node_pattern/lexer.rb:4:3: W: [Correctable] Lint/RequireRelativeSelfPath: Remove the require_relative that requires itself.
  require_relative 'lexer.rex'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/ast/node_pattern/parser.rb:3:1: W: [Correctable] Lint/RequireRelativeSelfPath: Remove the require_relative that requires itself.
require_relative 'parser.racc'
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Those files are requiring different files but they have the same name so `Lint/RequireRelativeSelfPath` is registering a false positive. This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
