### PR TITLE
Update `Style/RedundantSort` to be unsafe

### DIFF
--- a/changelog/change_update_styleredundantsort_to_be_unsafe.md
+++ b/changelog/change_update_styleredundantsort_to_be_unsafe.md
@@ -1,0 +1,1 @@
+* [#10122](https://github.com/rubocop/rubocop/pull/10122): Update `Style/RedundantSort` to be unsafe, and revert the special case for `size` from [#10061](https://github.com/rubocop/rubocop/pull/10061). ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4160,7 +4160,6 @@ Style/NumericLiteralPrefix:
     - zero_with_o
     - zero_only
 
-
 Style/NumericLiterals:
   Description: >-
                  Add underscores to large numeric literals to improve their
@@ -4481,6 +4480,8 @@ Style/RedundantSort:
                   `max_by` instead of `sort_by...last`, etc.
   Enabled: true
   VersionAdded: '0.76'
+  VersionChanged: <<next>>
+  Safe: false
 
 Style/RedundantSortBy:
   Description: 'Use `sort` instead of `sort_by { |x| x }`.'

--- a/lib/rubocop/cop/style/redundant_sort.rb
+++ b/lib/rubocop/cop/style/redundant_sort.rb
@@ -12,6 +12,33 @@ module RuboCop
       # `Enumerable#max_by` can replace `Enumerable#sort_by` calls
       # after which only the first or last element is used.
       #
+      # @safety
+      #   This cop is unsafe, because `sort...last` and `max` may not return the
+      #   same element in all cases.
+      #
+      #   In an enumerable where there are multiple elements where `a <=> b == 0`,
+      #   or where the transformation done by the `sort_by` block has the
+      #   same result, `sort.last` and `max` (or `sort_by.last` and `max_by`)
+      #   will return different elements. `sort.last` will return the last
+      #   element but `max` will return the first element.
+      #
+      #   For example:
+      #
+      #   [source,ruby]
+      #   ----
+      #     class MyString < String; end
+      #     strings = [MyString.new('test'), 'test']
+      #     strings.sort.last.class   #=> String
+      #     strings.max.class         #=> MyString
+      #   ----
+      #
+      #   [source,ruby]
+      #   ----
+      #     words = %w(dog horse mouse)
+      #     words.sort_by { |word| word.length }.last   #=> 'mouse'
+      #     words.max_by { |word| word.length }         #=> 'horse'
+      #   ----
+      #
       # @example
       #   # bad
       #   [2, 1, 3].sort.first

--- a/lib/rubocop/cop/style/redundant_sort.rb
+++ b/lib/rubocop/cop/style/redundant_sort.rb
@@ -76,12 +76,8 @@ module RuboCop
 
         def on_send(node)
           if (sort_node, sorter, accessor = redundant_sort?(node.parent))
-            return if use_size_method_in_block?(sort_node)
-
             ancestor = node.parent
           elsif (sort_node, sorter, accessor = redundant_sort?(node.parent&.parent))
-            return if use_size_method_in_block?(sort_node)
-
             ancestor = node.parent.parent
           else
             return
@@ -91,20 +87,6 @@ module RuboCop
         end
 
         private
-
-        def use_size_method_in_block?(sort_node)
-          return true if block_calls_send?(sort_node)
-          return false unless sort_node.block_argument?
-
-          sort_node.last_argument.children.first.value == :size
-        end
-
-        def block_calls_send?(node)
-          return false unless node.send_type? && node.block_node
-          return false unless node.block_node.body.send_type?
-
-          node.block_node.body.method?(:size)
-        end
 
         def register_offense(ancestor, sort_node, sorter, accessor)
           message = message(ancestor, sorter, accessor)

--- a/spec/rubocop/cop/style/redundant_sort_spec.rb
+++ b/spec/rubocop/cop/style/redundant_sort_spec.rb
@@ -231,16 +231,6 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort, :config do
     expect_no_offenses('[[1, 2], [3, 4]].first.sort')
   end
 
-  # `[2, 1, 3].sort_by(&:size).last` is not equivalent to `[2, 1, 3].max_by(&:size)`.
-  it 'does not register an offense when using `sort_by(&:size).last`' do
-    expect_no_offenses('[2, 1, 3].sort_by(&:size).last')
-  end
-
-  # `[2, 1, 3].sort_by { |i| i.size }.last` is not equivalent to `[2, 1, 3].max_by { |i| i.size }`.
-  it 'does not register an offense when using `sort_by { |i| i.size }.last`' do
-    expect_no_offenses('[2, 1, 3].sort_by { |i| i.size }.last')
-  end
-
   # `[2, 1, 3].sort_by(&:size).first` is not equivalent to `[2, 1, 3].first`, but this
   # cop would "correct" it to `[2, 1, 3].min_by`.
   it 'does not register an offense when sort_by is not given a block' do


### PR DESCRIPTION
In an array where there are multiple elements where `a <=> b == 0`, or where the transformation done by the block has the same result, there will be a different element returned between `sort.last` and `max` (or `sort_by.last` and `max_by`), because `sort.last` will take the last element but `max` will return the first element. As such, this is not a safe change, as the specific element returned will change.

Honestly, we should probably revert #10062 as well because that adds a special case for `size` that doesn't really exist in reality. In that issue, `size` was the catalyst, but the exact same issue would happen with `length`, or any other transformation that results in multiple elements having the same value. If we revert #10062, then #10119 can be closed as well. If this is desired, I'll update this PR to include the revert and add the test case from #10119 which is still valueable.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
