### PR TITLE
Fix `Layout/RedundantLineBreak` adding extra space within method chains

### DIFF
--- a/changelog/fix_fix_layoutredundantlinebreak_adding.md
+++ b/changelog/fix_fix_layoutredundantlinebreak_adding.md
@@ -1,0 +1,1 @@
+* [#10124](https://github.com/rubocop/rubocop/pull/10124): Fix `Layout/RedundantLineBreak` adding extra space within method chains. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/dot_position.rb
+++ b/lib/rubocop/cop/layout/dot_position.rb
@@ -109,9 +109,7 @@ module RuboCop
 
         def last_heredoc_line(node)
           if node.send_type?
-            node.arguments.select { |arg| heredoc?(arg) }
-                .map { |arg| arg.loc.heredoc_end.line }
-                .max
+            node.arguments.select { |arg| heredoc?(arg) }.map { |arg| arg.loc.heredoc_end.line }.max
           elsif heredoc?(node)
             node.loc.heredoc_end.line
           end

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -128,6 +128,7 @@ module RuboCop
             .gsub(/' *\\\n\s*"/, %q(' + ")) # Single quote, backslash, and then double quote
             .gsub(/(["']) *\\\n\s*\1/, '')  # Double or single quote, backslash, then same quote
             .gsub(/\s*\\?\n\s*/, ' ')       # Any other line break, with or without backslash
+            .gsub(/\s+(?=\.\w)/, '')        # Extra space within method chaining
         end
 
         def max_line_length

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -127,8 +127,8 @@ module RuboCop
             .gsub(/" *\\\n\s*'/, %q(" + ')) # Double quote, backslash, and then single quote
             .gsub(/' *\\\n\s*"/, %q(' + ")) # Single quote, backslash, and then double quote
             .gsub(/(["']) *\\\n\s*\1/, '')  # Double or single quote, backslash, then same quote
+            .gsub(/\n\s*(?=\.\w)/, '')      # Extra space within method chaining
             .gsub(/\s*\\?\n\s*/, ' ')       # Any other line break, with or without backslash
-            .gsub(/\s+(?=\.\w)/, '')        # Extra space within method chaining
         end
 
         def max_line_length

--- a/lib/rubocop/cop/mixin/heredoc.rb
+++ b/lib/rubocop/cop/mixin/heredoc.rb
@@ -21,9 +21,7 @@ module RuboCop
       private
 
       def indent_level(str)
-        indentations = str.lines
-                          .map { |line| line[/^\s*/] }
-                          .reject { |line| line.end_with?("\n") }
+        indentations = str.lines.map { |line| line[/^\s*/] }.reject { |line| line.end_with?("\n") }
         indentations.empty? ? 0 : indentations.min_by(&:size).size
       end
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1010,8 +1010,7 @@ RSpec.describe RuboCop::ConfigLoader do
           gem_class = Struct.new(:gem_dir)
           %w[gemone gemtwo].each do |gem_name|
             mock_spec = gem_class.new(File.join(gem_root, gem_name))
-            allow(Gem::Specification).to receive(:find_by_name)
-              .with(gem_name).and_return(mock_spec)
+            allow(Gem::Specification).to receive(:find_by_name).with(gem_name).and_return(mock_spec)
           end
           allow(Gem).to receive(:path).and_return([gem_root])
         end

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -192,8 +192,7 @@ RSpec.describe RuboCop::Config do
       end
 
       it 'raises validation error' do
-        expect { configuration.validate }
-          .to raise_error(RuboCop::ValidationError, /trailing_comma/)
+        expect { configuration.validate }.to raise_error(RuboCop::ValidationError, /trailing_comma/)
       end
     end
 

--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -2,8 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
   let(:config) do
-    merged = RuboCop::ConfigLoader
-             .default_configuration['Layout/CaseIndentation'].merge(cop_config)
+    merged = RuboCop::ConfigLoader.default_configuration['Layout/CaseIndentation'].merge(cop_config)
     RuboCop::Config.new('Layout/CaseIndentation' => merged,
                         'Layout/IndentationWidth' => { 'Width' => 2 })
   end

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -272,17 +272,58 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
         RUBY
       end
 
-      it 'properly corrects a method chain on multiple lines' do
-        expect_offense(<<~RUBY)
-          foo
-          ^^^ Redundant line break detected.
-            .bar
-            .baz
-        RUBY
+      context 'method chains' do
+        it 'properly corrects a method chain on multiple lines' do
+          expect_offense(<<~RUBY)
+            foo(' .x')
+            ^^^^^^^^^^ Redundant line break detected.
+              .bar
+              .baz
+          RUBY
 
-        expect_correction(<<~RUBY)
-          foo.bar.baz
-        RUBY
+          expect_correction(<<~RUBY)
+            foo(' .x').bar.baz
+          RUBY
+        end
+
+        it 'registers an offense and corrects with a arguments on multiple lines' do
+          expect_offense(<<~RUBY)
+            foo(x,
+            ^^^^^^ Redundant line break detected.
+                y,
+                z)
+              .bar
+              .baz
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo(x, y, z).bar.baz
+          RUBY
+        end
+
+        it 'registers an offense and corrects with a string argument on multiple lines' do
+          expect_offense(<<~RUBY)
+            foo('....' \\
+            ^^^^^^^^^^^^ Redundant line break detected.
+                '....')
+              .bar
+              .baz
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo('........').bar.baz
+          RUBY
+        end
+
+        it 'does not register an offense with a heredoc argument' do
+          expect_no_offenses(<<~RUBY)
+            foo(<<~EOS)
+              xyz
+            EOS
+              .bar
+              .baz
+          RUBY
+        end
       end
     end
 

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -271,6 +271,19 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
             m(7 + 8 + 9)
         RUBY
       end
+
+      it 'properly corrects a method chain on multiple lines' do
+        expect_offense(<<~RUBY)
+          foo
+          ^^^ Redundant line break detected.
+            .bar
+            .baz
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo.bar.baz
+        RUBY
+      end
     end
 
     context 'for an expression that does not fit on a single line' do

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -365,8 +365,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
 
       it 'fails if given without --auto-gen-config' do
-        expect { options.parse %w[--exclude-limit 10] }
-          .to raise_error(RuboCop::OptionArgumentError)
+        expect { options.parse %w[--exclude-limit 10] }.to raise_error(RuboCop::OptionArgumentError)
       end
     end
 

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -226,8 +226,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
             cache2.save(offenses)
 
             expect(cache2.valid?).to eq(true)
-            expect($stderr.string)
-              .not_to match(/Warning: .* is a symlink, which is not allowed.\n/)
+            expect($stderr.string).not_to match(/Warning: .* is a symlink, which is not allowed.\n/)
           end
         end
       end


### PR DESCRIPTION
When `Layout/RedundantLineBreak` finds a multiline method chain that can be collapsed to a single line, it adds an extra space between each method. Although the spaces could also be detected by `Layout/SpaceAroundMethodCallOperator`, this change allows the cop to calculate if a correction will fit on the line better (as demonstrated by the fixes in the 2nd commit).

```ruby
foo.
  bar.
  baz
```

Before:
```ruby
foo. bar. baz
```

After:
```ruby
foo.bar.baz
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
