### PR TITLE
Expose ExpectOffense methods via 'rubocop/rspec/support'

### DIFF
--- a/lib/rubocop/rspec/support.rb
+++ b/lib/rubocop/rspec/support.rb
@@ -10,4 +10,5 @@ require_relative 'expect_offense'
 RSpec.configure do |config|
   config.include CopHelper
   config.include HostEnvironmentSimulatorHelper
+  config.include RuboCop::RSpec::ExpectOffense
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,8 +46,6 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = 'spec/examples.txt'
   config.disable_monkey_patching!
 
-  config.include RuboCop::RSpec::ExpectOffense
-
   config.order = :random
   Kernel.srand config.seed
 


### PR DESCRIPTION
This allows custom cop specs to only `require 'rubocop/rspec/support'` and start using `ExpenseOffense` methods.

Closes #10081

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/