### PR TITLE
Replace `Cop` with `Base` in tests to prepare for deprecating `Cop`

### DIFF
--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
           module RuboCop
             module Cop
               module Style
-                class SomeCop < Cop
+                class SomeCop < Base
                 end
               end
             end
@@ -330,7 +330,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
           module RuboCop
             module Cop
               module Style
-                class SomeCop < Cop
+                class SomeCop < Base
                 end
               end
             end
@@ -378,7 +378,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
             module RuboCop
               module Cop
                 module Style
-                  class SomeCop < Cop
+                  class SomeCop < Base
                   end
                 end
               end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -736,7 +736,7 @@ RSpec.describe RuboCop::ConfigLoader do
             module RuboCop
               module Cop
                 module Custom
-                  class Loop < Cop
+                  class Loop < Base
                   end
                 end
               end

--- a/spec/rubocop/cop/internal_affairs/undefined_config_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/undefined_config_spec.rb
@@ -192,6 +192,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::UndefinedConfig, :config, :isolate
     RUBY
   end
 
+  # TODO: Remove this test when the `Cop` base class is removed
   it 'works when the base class is `Cop` instead of `Base`' do
     expect_offense(<<~RUBY)
       module RuboCop

--- a/spec/support/cops/class_must_be_a_module_cop.rb
+++ b/spec/support/cops/class_must_be_a_module_cop.rb
@@ -3,13 +3,13 @@
 module RuboCop
   module Cop
     module Test
-      class ClassMustBeAModuleCop < RuboCop::Cop::Cop # rubocop:disable InternalAffairs/InheritDeprecatedCopClass
-        def on_class(node)
-          add_offense(node, message: 'Class must be a Module')
-        end
+      class ClassMustBeAModuleCop < RuboCop::Cop::Base
+        extend AutoCorrector
 
-        def autocorrect(node)
-          ->(corrector) { corrector.replace(node.loc.keyword, 'module') }
+        def on_class(node)
+          add_offense(node, message: 'Class must be a Module') do |corrector|
+            corrector.replace(node.loc.keyword, 'module')
+          end
         end
       end
     end

--- a/spec/support/cops/module_must_be_a_class_cop.rb
+++ b/spec/support/cops/module_must_be_a_class_cop.rb
@@ -3,13 +3,13 @@
 module RuboCop
   module Cop
     module Test
-      class ModuleMustBeAClassCop < RuboCop::Cop::Cop # rubocop:disable InternalAffairs/InheritDeprecatedCopClass
-        def on_module(node)
-          add_offense(node, message: 'Module must be a Class')
-        end
+      class ModuleMustBeAClassCop < RuboCop::Cop::Base
+        extend AutoCorrector
 
-        def autocorrect(node)
-          ->(corrector) { corrector.replace(node.loc.keyword, 'class') }
+        def on_module(node)
+          add_offense(node, message: 'Module must be a Class') do |corrector|
+            corrector.replace(node.loc.keyword, 'class')
+          end
         end
       end
     end


### PR DESCRIPTION
This should replace be the last official uses of `Cop` in RuboCop itself. Follows #7868.