### PR TITLE
Add spell checking GitHub Actions workflow

### DIFF
--- a/.github/workflows/spell_checking.yml
+++ b/.github/workflows/spell_checking.yml
@@ -1,0 +1,33 @@
+name: Spell Checking
+
+on: [pull_request]
+
+jobs:
+  codespell:
+    name: Check spelling all files with codespell
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install codespell
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Check spelling with codespell
+        run: codespell --ignore-words=codespell.txt || exit 1
+  misspell:
+    name: Check spelling all files in commit with misspell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install
+        run: wget -O - -q https://git.io/misspell | sh -s -- -b .
+      - name: Misspell
+        run: git ls-files --empty-directory | xargs ./misspell -i 'enviromnent' -error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 
 ### Bug fixes
 
-* [#10017](https://github.com/rubocop/rubocop/pull/10017): Fixan error for `Layout/RescueEnsureAlignment` when using zsuper with block. ([@koic][])
+* [#10017](https://github.com/rubocop/rubocop/pull/10017): Fix an error for `Layout/RescueEnsureAlignment` when using zsuper with block. ([@koic][])
 * [#10011](https://github.com/rubocop/rubocop/issues/10011): Fix a false positive for `Style/RedundantSelfAssignmentBranch` when using instance variable, class variable, and global variable. ([@koic][])
 * [#10010](https://github.com/rubocop/rubocop/issues/10010): Fix a false positive for `Style/DoubleNegation` when `!!` is used at return location and before `rescue` keyword. ([@koic][])
 * [#10014](https://github.com/rubocop/rubocop/issues/10014): Fix `Style/Encoding` to handle more situations properly. ([@dvandersluis][])
@@ -157,7 +157,7 @@
 * [#9882](https://github.com/rubocop/rubocop/pull/9882): Fix an incorrect auto-correct for `Layout/LineLength` when using heredoc as the first method argument and omitting parentheses. ([@koic][])
 * [#7592](https://github.com/rubocop/rubocop/pull/7592): Add cop `Layout/LineEndStringConcatenationIndentation`. ([@jonas054][])
 * [#9880](https://github.com/rubocop/rubocop/pull/9880): Fix a false positive for `Style/RegexpLiteral` when using a regexp starts with a blank as a method argument. ([@koic][])
-* [#9888](https://github.com/rubocop/rubocop/pull/9888): Fix a false positive for `Layout/ClosingParenthesisIndentation` when using keyword arguemnts. ([@koic][])
+* [#9888](https://github.com/rubocop/rubocop/pull/9888): Fix a false positive for `Layout/ClosingParenthesisIndentation` when using keyword arguments. ([@koic][])
 * [#9886](https://github.com/rubocop/rubocop/pull/9886): Fix indentation in Style/ClassAndModuleChildren. ([@markburns][])
 
 ### Changes
@@ -1371,7 +1371,7 @@
 * [#7236](https://github.com/rubocop/rubocop/pull/7236): Mark `Style/InverseMethods` auto-correct as incompatible with `Style/SymbolProc`. ([@drenmi][])
 * [#7144](https://github.com/rubocop/rubocop/issues/7144): Fix `Style/Documentation` constant visibility declaration in namespace. ([@AdrienSldy][])
 * [#7779](https://github.com/rubocop/rubocop/issues/7779): Fix a false positive for `Style/MultilineMethodCallIndentation` when using Ruby 2.7's numbered parameter. ([@koic][])
-* [#7733](https://github.com/rubocop/rubocop/issues/7733): Fix rubocop-junit-formatter imcompatibility XML for JUnit formatter. ([@koic][])
+* [#7733](https://github.com/rubocop/rubocop/issues/7733): Fix rubocop-junit-formatter incompatibility XML for JUnit formatter. ([@koic][])
 * [#7767](https://github.com/rubocop/rubocop/issues/7767): Skip array literals in `Style/HashTransformValues` and `Style/HashTransformKeys`. ([@tejasbubane][])
 * [#7791](https://github.com/rubocop/rubocop/issues/7791): Fix an error on auto-correction for `Layout/BlockEndNewline` when `}` of multiline block without processing is not on its own line. ([@koic][])
 * [#7778](https://github.com/rubocop/rubocop/issues/7778): Fix a false positive for `Layout/EndAlignment` when a non-whitespace is used before the `end` keyword. ([@koic][])
@@ -1952,7 +1952,7 @@
 ### Bug fixes
 
 * [#6627](https://github.com/rubocop/rubocop/pull/6627): Fix handling of hashes in trailing comma. ([@abrom][])
-* [#6638](https://github.com/rubocop/rubocop/pull/6638): Fix `Rails/LinkToBlank` dectection to allow `rel: 'noreferer`. ([@fwininger][])
+* [#6638](https://github.com/rubocop/rubocop/pull/6638): Fix `Rails/LinkToBlank` detection to allow `rel: 'noreferer`. ([@fwininger][])
 * [#6623](https://github.com/rubocop/rubocop/pull/6623): Fix heredoc detection in trailing comma. ([@palkan][])
 * [#6100](https://github.com/rubocop/rubocop/issues/6100): Fix a false positive in `Naming/ConstantName` cop when rhs is a conditional expression. ([@tatsuyafw][])
 * [#6526](https://github.com/rubocop/rubocop/issues/6526): Fix a wrong line highlight in `Lint/ShadowedException` cop. ([@tatsuyafw][])
@@ -3382,7 +3382,7 @@
 * [#2995](https://github.com/rubocop/rubocop/issues/2995): Removed deprecated path matching syntax. ([@gerrywastaken][])
 * [#3025](https://github.com/rubocop/rubocop/pull/3025): Removed deprecation warnings for `rubocop-todo.yml`. ([@ptarjan][])
 * [#3028](https://github.com/rubocop/rubocop/pull/3028): Add `define_method` to the default list of `IgnoredMethods` of `Style/SymbolProc`. ([@jastkand][])
-* [#3064](https://github.com/rubocop/rubocop/pull/3064): `Style/SpaceAfterNot` highlights the entire expression instead of just the exlamation mark. ([@rrosenblum][])
+* [#3064](https://github.com/rubocop/rubocop/pull/3064): `Style/SpaceAfterNot` highlights the entire expression instead of just the exclamation mark. ([@rrosenblum][])
 * [#3085](https://github.com/rubocop/rubocop/pull/3085): Enable `Style/MultilineArrayBraceLayout` and `Style/MultilineHashBraceLayout` with the `symmetrical` style by default. ([@panthomakos][])
 * [#3091](https://github.com/rubocop/rubocop/pull/3091): Enable `Style/MultilineMethodCallBraceLayout` and `Style/MultilineMethodDefinitionBraceLayout` with the `symmetrical` style by default. ([@panthomakos][])
 * [#1830](https://github.com/rubocop/rubocop/pull/1830): `Style/PredicateName` now ignores the `spec/` directory, since there is a strong convention for using `have_*` and `be_*` helper methods in RSpec. ([@gylaz][])
@@ -3681,7 +3681,7 @@
 * [#2066](https://github.com/rubocop/rubocop/issues/2066): `Style/TrivialAccessors` doesn't flag what appear to be trivial accessor method definitions, if they are nested inside a call to `instance_eval`. ([@alexdowad][])
 * `Style/SymbolArray` doesn't flag arrays of symbols if a symbol contains a space character. ([@alexdowad][])
 * `Style/SymbolArray` can auto-correct offenses. ([@alexdowad][])
-* [#2546](https://github.com/rubocop/rubocop/issues/2546): Report when two `rubocop:disable` comments (not the single line kind) for a given cop apppear in a file with no `rubocop:enable` in between. ([@jonas054][])
+* [#2546](https://github.com/rubocop/rubocop/issues/2546): Report when two `rubocop:disable` comments (not the single line kind) for a given cop appear in a file with no `rubocop:enable` in between. ([@jonas054][])
 * [#2552](https://github.com/rubocop/rubocop/issues/2552): `Style/Encoding` can auto-correct files with a blank first line. ([@alexdowad][])
 * [#2556](https://github.com/rubocop/rubocop/issues/2556): `Style/SpecialGlobalVariables` generates auto-config correctly. ([@alexdowad][])
 * [#2565](https://github.com/rubocop/rubocop/issues/2565): Let `Style/SpaceAroundOperators` leave spacing around `=>` to `Style/AlignHash`. ([@jonas054][])
@@ -3904,7 +3904,7 @@
 * [#2057](https://github.com/rubocop/rubocop/pull/2057): New cop `Lint/FormatParameterMismatch` checks for a mismatch between the number of fields expected in format/sprintf/% and what was passed to it. ([@edmz][])
 * [#2010](https://github.com/rubocop/rubocop/pull/2010): Add `space` style for SpaceInsideStringInterpolation. ([@gotrevor][])
 * [#2007](https://github.com/rubocop/rubocop/pull/2007): Allow any modifier before `def`, not only visibility modifiers. ([@fphilipe][])
-* [#1980](https://github.com/rubocop/rubocop/pull/1980): `--auto-gen-config` now outputs an excluded files list for failed cops (up to a maxiumum of 15 files). ([@bmorrall][])
+* [#1980](https://github.com/rubocop/rubocop/pull/1980): `--auto-gen-config` now outputs an excluded files list for failed cops (up to a maximum of 15 files). ([@bmorrall][])
 * [#2004](https://github.com/rubocop/rubocop/pull/2004): Introduced `--exclude-limit COUNT` to configure how many files `--auto-gen-config` will exclude. ([@awwaiid][], [@jonas054][])
 * [#1918](https://github.com/rubocop/rubocop/issues/1918): New configuration parameter `AllCops:DisabledByDefault` when set to `true` makes only cops found in user configuration enabled, which makes cop selection *opt-in*. ([@jonas054][])
 * New cop `Performance/StringReplacement` checks for usages of `gsub` that can be replaced with `tr` or `delete`. ([@rrosenblum][])
@@ -4273,7 +4273,7 @@
 * New cop `InfiniteLoop` checks for places where `Kernel#loop` should have been used. ([@bbatsov][])
 * New cop `SymbolProc` checks for places where a symbol can be used as proc instead of a block. ([@bbatsov][])
 * `UselessAssignment` cop now suggests a variable name for possible typos if there's a variable-ish identifier similar to the unused variable name in the same scope. ([@yujinakayama][])
-* `PredicateName` cop now has separate configurations for prefices that denote predicate method names and predicate prefices that should be removed. ([@bbatsov][])
+* `PredicateName` cop now has separate configurations for prefixes that denote predicate method names and predicate prefixes that should be removed. ([@bbatsov][])
 * [#1272](https://github.com/rubocop/rubocop/issues/1272): `Tab` cop does auto-correction. ([@yous][])
 * [#1274](https://github.com/rubocop/rubocop/issues/1274): `MultilineIfThen` cop does auto-correction. ([@bbatsov][])
 * [#1279](https://github.com/rubocop/rubocop/issues/1279): `DotPosition` cop does auto-correction. ([@yous][])
@@ -5281,7 +5281,7 @@
 
 * [#62](https://github.com/rubocop/rubocop/issues/62): Config files in ancestor directories are ignored if another exists in home directory.
 * [#65](https://github.com/rubocop/rubocop/issues/65): Suggests to convert symbols `:==`, `:<=>` and the like to snake_case.
-* [#66](https://github.com/rubocop/rubocop/issues/66): Does not crash on unreadable or unparseable files.
+* [#66](https://github.com/rubocop/rubocop/issues/66): Does not crash on unreadable or unparsable files.
 * [#70](https://github.com/rubocop/rubocop/issues/70): Support `alias` with bareword arguments.
 * [#64](https://github.com/rubocop/rubocop/issues/64): Performance issue with Bundler.
 * [#75](https://github.com/rubocop/rubocop/issues/75): Make it clear that some global variables require the use of the English library.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,26 @@ $ rubocop -V
 * Open a [pull request][4] that relates to *only* one subject with a clear title
   and description in grammatically correct, complete sentences.
 
+### Spell Checking
+
+We are running [misspell](https://github.com/client9/misspell) which is mainly written in
+[Golang](https://golang.org/) to check spelling with [GitHub Actions](../.github/workflows/spell_checking.yml).
+Correct commonly misspelled English words quickly with `misspell`. `misspell` is different from most other spell checkers
+because it doesn't use a custom dictionary. You can run `misspell` locally against all files with:
+
+    $ find . -type f | xargs ./misspell -i 'enviromnent' -error
+
+Notable `misspell` help options or flags are:
+
+* `-i` string: ignore the following corrections, comma separated
+* `-w`: Overwrite file with corrections (default is just to display)
+
+We also run [codespell](https://github.com/codespell-project/codespell) with GitHub Actions to check spelling and
+[codespell](https://pypi.org/project/codespell/) runs against a [small custom dictionary](../codespell.txt).
+`codespell` is written in [Python](https://www.python.org/) and you can run it with:
+
+    $ codespell --ignore-words=codespell.txt
+
 ### Creating changelog entries
 
 Changelog entries are just files under the `changelog/` folder that will be merged

--- a/codespell.txt
+++ b/codespell.txt
@@ -1,0 +1,8 @@
+ba
+enviromnent
+filetest
+fo
+irregardless
+ofo
+thi
+upto

--- a/config/default.yml
+++ b/config/default.yml
@@ -130,7 +130,7 @@ AllCops:
   # What MRI version of the Ruby interpreter is the inspected code intended to
   # run on? (If there is more than one, set this to the lowest version.)
   # If a value is specified for TargetRubyVersion then it is used. Acceptable
-  # values are specificed as a float (i.e. 3.0); the teeny version of Ruby
+  # values are specified as a float (i.e. 3.0); the teeny version of Ruby
   # should not be included. If the project specifies a Ruby version in the
   # .tool-versions or .ruby-version files, Gemfile or gems.rb file, RuboCop will
   # try to determine the desired version of Ruby by inspecting the

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -269,7 +269,7 @@ In this example the `Exclude` would only include `bar.rb`.
 
 Configuration files are pre-processed using the ERB templating mechanism. This
 makes it possible to add dynamic content that will be evaluated when the
-configuation file is read. For example, you could let RuboCop ignore all files
+configuration file is read. For example, you could let RuboCop ignore all files
 ignored by Git.
 
 [source,yaml]

--- a/docs/modules/ROOT/pages/cops_gemspec.adoc
+++ b/docs/modules/ROOT/pages/cops_gemspec.adoc
@@ -235,7 +235,7 @@ Gem::Specification.new do |spec|
 end
 
 # accepted but not recommended, since
-# Ruby does not really follow semantic versionning
+# Ruby does not really follow semantic versioning
 Gem::Specification.new do |spec|
   spec.required_ruby_version = '~> 2.5'
 end

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -428,7 +428,7 @@ if a.x != 0 && a.x != 0
   do_something
 end
 
-def childs?
+def child?
   left_child || left_child
 end
 
@@ -3476,7 +3476,7 @@ It emulates the following warning in Ruby 2.7:
   ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]
   -e:1: warning: `_1' is reserved for numbered parameter; consider another name
 
-Assiging to numbered parameter (from `_1` to `_9`) cause an error in Ruby 3.0.
+Assigning to numbered parameter (from `_1` to `_9`) cause an error in Ruby 3.0.
 
   % ruby -ve '_1 = :value'
   ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin19]
@@ -4825,7 +4825,7 @@ given by `ruby -cw` prior to Ruby 2.6:
 
 NOTE: Shadowing of variables in block passed to `Ractor.new` is allowed
 because `Ractor` should not access outer variables.
-eg. following syle is encouraged:
+eg. following style is encouraged:
 
   worker_id, pipe = env
   Ractor.new(worker_id, pipe) do |worker_id, pipe|
@@ -5292,7 +5292,7 @@ end
 | -
 |===
 
-This cop checks for "triple quotes" (strings delimted by any odd number
+This cop checks for "triple quotes" (strings delimited by any odd number
 of quotes greater than 1).
 
 Ruby allows multiple strings to be implicitly concatenated by just

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -39,7 +39,7 @@ A long-term goal of RuboCop (and its core extensions) is to cover with cops all 
 
 == Philosophy
 
-Early on RuboCop aimed to be an opinionated linter/formater that adhered very closely to the Ruby Style Guide (think `gofmt` and the like).
+Early on RuboCop aimed to be an opinionated linter/formatter that adhered very closely to the Ruby Style Guide (think `gofmt` and the like).
 In those days cops supported just a single style and you couldn't even turn individual cops off. Eventually, we realized
 that in the Ruby community there were some many competing styles and preferences that it was going to be really
 challenging to find one set of defaults that makes everyone happy. Part of this was Ruby's own culture and philosophy,

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -24,7 +24,7 @@ module RuboCop
     # `add_global_offense`. Use the `processed_source` method to
     # get the currently processed source being investigated.
     #
-    # In case of invalid syntax / unparseable content,
+    # In case of invalid syntax / unparsable content,
     # the callback `on_other_file` is called instead of all the other
     # `on_...` callbacks.
     #

--- a/lib/rubocop/cop/gemspec/required_ruby_version.rb
+++ b/lib/rubocop/cop/gemspec/required_ruby_version.rb
@@ -42,7 +42,7 @@ module RuboCop
       #   end
       #
       #   # accepted but not recommended, since
-      #   # Ruby does not really follow semantic versionning
+      #   # Ruby does not really follow semantic versioning
       #   Gem::Specification.new do |spec|
       #     spec.required_ruby_version = '~> 2.5'
       #   end

--- a/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
+++ b/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
@@ -23,7 +23,7 @@ module RuboCop
         extend AutoCorrector
         include RangeHelp
 
-        MSG = 'Preceed `%<method>s` with a `@!method` YARD directive.'
+        MSG = 'Precede `%<method>s` with a `@!method` YARD directive.'
         MSG_WRONG_NAME = '`@!method` YARD directive has invalid method name, ' \
                          'use `%<expected>s` instead of `%<actual>s`.'
         MSG_TOO_MANY = 'Multiple `@!method` YARD directives found for this matcher.'

--- a/lib/rubocop/cop/lint/binary_operator_with_identical_operands.rb
+++ b/lib/rubocop/cop/lint/binary_operator_with_identical_operands.rb
@@ -37,7 +37,7 @@ module RuboCop
       #     do_something
       #   end
       #
-      #   def childs?
+      #   def child?
       #     left_child || left_child
       #   end
       #

--- a/lib/rubocop/cop/lint/deprecated_class_methods.rb
+++ b/lib/rubocop/cop/lint/deprecated_class_methods.rb
@@ -58,12 +58,12 @@ module RuboCop
           end
 
           def to_s
-            [class_constant, method].compact.join(delimeter)
+            [class_constant, method].compact.join(delimiter)
           end
 
           private
 
-          def delimeter
+          def delimiter
             CLASS_METHOD_DELIMETER
           end
         end
@@ -81,12 +81,12 @@ module RuboCop
           end
 
           def to_s
-            [class_constant, method].compact.join(delimeter)
+            [class_constant, method].compact.join(delimiter)
           end
 
           private
 
-          def delimeter
+          def delimiter
             instance_method? ? INSTANCE_METHOD_DELIMETER : CLASS_METHOD_DELIMETER
           end
 

--- a/lib/rubocop/cop/lint/numbered_parameter_assignment.rb
+++ b/lib/rubocop/cop/lint/numbered_parameter_assignment.rb
@@ -10,7 +10,7 @@ module RuboCop
       #   ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]
       #   -e:1: warning: `_1' is reserved for numbered parameter; consider another name
       #
-      # Assiging to numbered parameter (from `_1` to `_9`) cause an error in Ruby 3.0.
+      # Assigning to a numbered parameter (from `_1` to `_9`) causes an error in Ruby 3.0.
       #
       #   % ruby -ve '_1 = :value'
       #   ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin19]

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -10,7 +10,7 @@ module RuboCop
       #
       # NOTE: Shadowing of variables in block passed to `Ractor.new` is allowed
       # because `Ractor` should not access outer variables.
-      # eg. following syle is encouraged:
+      # eg. following style is encouraged:
       #
       #   worker_id, pipe = env
       #   Ractor.new(worker_id, pipe) do |worker_id, pipe|

--- a/lib/rubocop/cop/lint/symbol_conversion.rb
+++ b/lib/rubocop/cop/lint/symbol_conversion.rb
@@ -143,7 +143,7 @@ module RuboCop
           # Although some operators can be converted to symbols normally
           # (ie. `:==`), these are not accepted as hash keys and will
           # raise a syntax error (eg. `{ ==: ... }`). Therefore, if the
-          # symbol does not start with an alpha-numeric or underscore, it
+          # symbol does not start with an alphanumeric or underscore, it
           # will be ignored.
           return unless node.value.to_s.match?(/\A[a-z0-9_]/i)
 

--- a/lib/rubocop/cop/lint/triple_quotes.rb
+++ b/lib/rubocop/cop/lint/triple_quotes.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for "triple quotes" (strings delimted by any odd number
+      # This cop checks for "triple quotes" (strings delimited by any odd number
       # of quotes greater than 1).
       #
       # Ruby allows multiple strings to be implicitly concatenated by just

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -7,7 +7,7 @@ module RuboCop
       # the end of a line.
       #
       # @safety
-      #   This cop is unsafe because it canot be guaranteed that the
+      #   This cop is unsafe because it cannot be guaranteed that the
       #   receiver is a string, in which case replacing `<<` with `\`
       #   would result in a syntax error.
       #

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -97,7 +97,7 @@ module RuboCop
           end
 
           # Identifies the most recent magic comment with valid shareable constant values
-          # thats in scope for this node
+          # that's in scope for this node
           def magic_comment_in_scope(node)
             processed_source_till_node(node).reverse_each.find do |line|
               MagicComment.parse(line).valid_shareable_constant_value?

--- a/relnotes/v0.22.0.md
+++ b/relnotes/v0.22.0.md
@@ -6,7 +6,7 @@ Below is the list of all the gory details. Enjoy!
 
 * [#974](https://github.com/rubocop/rubocop/pull/974): New cop `CommentIndentation` checks indentation of comments. ([@jonas054][])
 * Add new cop `EachWithObject` to prefer `each_with_object` over `inject` or `reduce`. ([@geniou][])
-* [#1010](https://github.com/rubocop/rubocop/issues/1010): New Cop `Next` check for conditions at the end of an interation and propose to use `next` instead. ([@geniou][])
+* [#1010](https://github.com/rubocop/rubocop/issues/1010): New Cop `Next` check for conditions at the end of an iteration and propose to use `next` instead. ([@geniou][])
 * The `GuardClause` cop now also looks for unless and it is configurable how many lines the body of an if / unless needs to have to not be ignored. ([@geniou][])
 * [#835](https://github.com/rubocop/rubocop/issues/835): New cop `UnneededPercentX` checks for `%x` when backquotes would do. ([@jonas054][])
 * Add auto-correct to `UnusedBlockArgument` and `UnusedMethodArgument` cops. ([@hannestyden][])

--- a/relnotes/v0.26.0.md
+++ b/relnotes/v0.26.0.md
@@ -14,7 +14,7 @@ Below is the list of all the gory details. Enjoy!
 * New cop `InfiniteLoop` checks for places where `Kernel#loop` should have been used. ([@bbatsov][])
 * New cop `SymbolProc` checks for places where a symbol can be used as proc instead of a block. ([@bbatsov][])
 * `UselessAssignment` cop now suggests a variable name for possible typos if there's a variable-ish identifier similar to the unused variable name in the same scope. ([@yujinakayama][])
-* `PredicateName` cop now has separate configurations for prefices that denote predicate method names and predicate prefices that should be removed. ([@bbatsov][])
+* `PredicateName` cop now has separate configurations for prefixes that denote predicate method names and predicate prefixes that should be removed. ([@bbatsov][])
 * [#1272](https://github.com/rubocop/rubocop/issues/1272): `Tab` cop does auto-correction. ([@yous][])
 * [#1274](https://github.com/rubocop/rubocop/issues/1274): `MultilineIfThen` cop does auto-correction. ([@bbatsov][])
 * [#1279](https://github.com/rubocop/rubocop/issues/1279): `DotPosition` cop does auto-correction. ([@yous][])

--- a/relnotes/v0.33.0.md
+++ b/relnotes/v0.33.0.md
@@ -4,7 +4,7 @@
 * [#2057](https://github.com/rubocop/rubocop/pull/2057): New cop `Lint/FormatParameterMismatch` checks for a mismatch between the number of fields expected in format/sprintf/% and what was passed to it. ([@edmz][])
 * [#2010](https://github.com/rubocop/rubocop/pull/2010): Add `space` style for SpaceInsideStringInterpolation. ([@gotrevor][])
 * [#2007](https://github.com/rubocop/rubocop/pull/2007): Allow any modifier before `def`, not only visibility modifiers. ([@fphilipe][])
-* [#1980](https://github.com/rubocop/rubocop/pull/1980): `--auto-gen-config` now outputs an excluded files list for failed cops (up to a maxiumum of 15 files). ([@bmorrall][])
+* [#1980](https://github.com/rubocop/rubocop/pull/1980): `--auto-gen-config` now outputs an excluded files list for failed cops (up to a maximum of 15 files). ([@bmorrall][])
 * [#2004](https://github.com/rubocop/rubocop/pull/2004): Introduced `--exclude-limit COUNT` to configure how many files `--auto-gen-config` will exclude. ([@awwaiid][], [@jonas054][])
 * [#1918](https://github.com/rubocop/rubocop/issues/1918): New configuration parameter `AllCops:DisabledByDefault` when set to `true` makes only cops found in user configuration enabled, which makes cop selection *opt-in*. ([@jonas054][])
 * New cop `Performance/StringReplacement` checks for usages of `gsub` that can be replaced with `tr` or `delete`. ([@rrosenblum][])

--- a/relnotes/v0.36.0.md
+++ b/relnotes/v0.36.0.md
@@ -119,7 +119,7 @@ Enjoy!
 * [#2066](https://github.com/rubocop/rubocop/issues/2066): `Style/TrivialAccessors` doesn't flag what appear to be trivial accessor method definitions, if they are nested inside a call to `instance_eval`. ([@alexdowad][])
 * `Style/SymbolArray` doesn't flag arrays of symbols if a symbol contains a space character. ([@alexdowad][])
 * `Style/SymbolArray` can auto-correct offenses. ([@alexdowad][])
-* [#2546](https://github.com/rubocop/rubocop/issues/2546): Report when two `rubocop:disable` comments (not the single line kind) for a given cop apppear in a file with no `rubocop:enable` in between. ([@jonas054][])
+* [#2546](https://github.com/rubocop/rubocop/issues/2546): Report when two `rubocop:disable` comments (not the single line kind) for a given cop appear in a file with no `rubocop:enable` in between. ([@jonas054][])
 * [#2552](https://github.com/rubocop/rubocop/issues/2552): `Style/Encoding` can auto-correct files with a blank first line. ([@alexdowad][])
 * [#2556](https://github.com/rubocop/rubocop/issues/2556): `Style/SpecialGlobalVariables` generates auto-config correctly. ([@alexdowad][])
 * [#2565](https://github.com/rubocop/rubocop/issues/2565): Let `Style/SpaceAroundOperators` leave spacing around `=>` to `Style/AlignHash`. ([@jonas054][])

--- a/relnotes/v0.40.0.md
+++ b/relnotes/v0.40.0.md
@@ -52,7 +52,7 @@
 * [#2995](https://github.com/rubocop/rubocop/issues/2995): Removed deprecated path matching syntax. ([@gerrywastaken][])
 * [#3025](https://github.com/rubocop/rubocop/pull/3025): Removed deprecation warnings for `rubocop-todo.yml`. ([@ptarjan][])
 * [#3028](https://github.com/rubocop/rubocop/pull/3028): Add `define_method` to the default list of `IgnoredMethods` of `Style/SymbolProc`. ([@jastkand][])
-* [#3064](https://github.com/rubocop/rubocop/pull/3064): `Style/SpaceAfterNot` highlights the entire expression instead of just the exlamation mark. ([@rrosenblum][])
+* [#3064](https://github.com/rubocop/rubocop/pull/3064): `Style/SpaceAfterNot` highlights the entire expression instead of just the exclamation mark. ([@rrosenblum][])
 * [#3085](https://github.com/rubocop/rubocop/pull/3085): Enable `Style/MultilineArrayBraceLayout` and `Style/MultilineHashBraceLayout` with the `symmetrical` style by default. ([@panthomakos][])
 * [#3091](https://github.com/rubocop/rubocop/pull/3091): Enable `Style/MultilineMethodCallBraceLayout` and `Style/MultilineMethodDefinitionBraceLayout` with the `symmetrical` style by default. ([@panthomakos][])
 * [#1830](https://github.com/rubocop/rubocop/pull/1830): `Style/PredicateName` now ignores the `spec/` directory, since there is a strong convention for using `have_*` and `be_*` helper methods in RSpec. ([@gylaz][])

--- a/relnotes/v0.68.1.md
+++ b/relnotes/v0.68.1.md
@@ -7,7 +7,7 @@
 * [#6992](https://github.com/rubocop/rubocop/pull/6992): Fix unknown default configuration for `Layout/IndentFirstParameter` cop. ([@drenmi][])
 * [#6972](https://github.com/rubocop/rubocop/issues/6972): Fix a false positive for `Style/MixinUsage` when using inside block and `if` condition is after `include`. ([@koic][])
 * [#6738](https://github.com/rubocop/rubocop/issues/6738): Prevent auto-correct conflict of `Style/Next` and `Style/SafeNavigation`. ([@hoshinotsuyoshi][])
-* [#6847](https://github.com/rubocop/rubocop/pull/6847): Fix `Style/BlockDelimiters` to properly check if the node is chaned when `braces_for_chaining` is set. ([@att14][])
+* [#6847](https://github.com/rubocop/rubocop/pull/6847): Fix `Style/BlockDelimiters` to properly check if the node is chained when `braces_for_chaining` is set. ([@att14][])
 
 [@RicardoTrindade]: https://github.com/RicardoTrindade
 [@koic]: https://github.com/koic

--- a/relnotes/v0.81.0.md
+++ b/relnotes/v0.81.0.md
@@ -23,7 +23,7 @@
 * [#7236](https://github.com/rubocop/rubocop/pull/7236): Mark `Style/InverseMethods` auto-correct as incompatible with `Style/SymbolProc`. ([@drenmi][])
 * [#7144](https://github.com/rubocop/rubocop/issues/7144): Fix `Style/Documentation` constant visibility declaration in namespace. ([@AdrienSldy][])
 * [#7779](https://github.com/rubocop/rubocop/issues/7779): Fix a false positive for `Style/MultilineMethodCallIndentation` when using Ruby 2.7's numbered parameter. ([@koic][])
-* [#7733](https://github.com/rubocop/rubocop/issues/7733): Fix rubocop-junit-formatter imcompatibility XML for JUnit formatter. ([@koic][])
+* [#7733](https://github.com/rubocop/rubocop/issues/7733): Fix rubocop-junit-formatter incompatibility XML for JUnit formatter. ([@koic][])
 * [#7767](https://github.com/rubocop/rubocop/issues/7767): Skip array literals in `Style/HashTransformValues` and `Style/HashTransformKeys`. ([@tejasbubane][])
 * [#7791](https://github.com/rubocop/rubocop/issues/7791): Fix an error on auto-correction for `Layout/BlockEndNewline` when `}` of multiline block without processing is not on its own line. ([@koic][])
 * [#7778](https://github.com/rubocop/rubocop/issues/7778): Fix a false positive for `Layout/EndAlignment` when a non-whitespace is used before the `end` keyword. ([@koic][])

--- a/relnotes/v1.18.0.md
+++ b/relnotes/v1.18.0.md
@@ -8,7 +8,7 @@
 * [#9882](https://github.com/rubocop/rubocop/pull/9882): Fix an incorrect auto-correct for `Layout/LineLength` when using heredoc as the first method argument and omitting parentheses. ([@koic][])
 * [#7592](https://github.com/rubocop/rubocop/pull/7592): Add cop `Layout/LineEndStringConcatenationIndentation`. ([@jonas054][])
 * [#9880](https://github.com/rubocop/rubocop/pull/9880): Fix a false positive for `Style/RegexpLiteral` when using a regexp starts with a blank as a method argument. ([@koic][])
-* [#9888](https://github.com/rubocop/rubocop/pull/9888): Fix a false positive for `Layout/ClosingParenthesisIndentation` when using keyword arguemnts. ([@koic][])
+* [#9888](https://github.com/rubocop/rubocop/pull/9888): Fix a false positive for `Layout/ClosingParenthesisIndentation` when using keyword arguments. ([@koic][])
 * [#9886](https://github.com/rubocop/rubocop/pull/9886): Fix indentation in Style/ClassAndModuleChildren. ([@markburns][])
 
 ### Changes

--- a/relnotes/v1.19.1.md
+++ b/relnotes/v1.19.1.md
@@ -1,6 +1,6 @@
 ### Bug fixes
 
-* [#10017](https://github.com/rubocop/rubocop/pull/10017): Fixan error for `Layout/RescueEnsureAlignment` when using zsuper with block. ([@koic][])
+* [#10017](https://github.com/rubocop/rubocop/pull/10017): Fix an error for `Layout/RescueEnsureAlignment` when using zsuper with block. ([@koic][])
 * [#10011](https://github.com/rubocop/rubocop/issues/10011): Fix a false positive for `Style/RedundantSelfAssignmentBranch` when using instance variable, class variable, and global variable. ([@koic][])
 * [#10010](https://github.com/rubocop/rubocop/issues/10010): Fix a false positive for `Style/DoubleNegation` when `!!` is used at return location and before `rescue` keyword. ([@koic][])
 * [#10014](https://github.com/rubocop/rubocop/issues/10014): Fix `Style/Encoding` to handle more situations properly. ([@dvandersluis][])

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1307,7 +1307,7 @@ RSpec.describe RuboCop::ConfigLoader do
           expect(cop_enabled?(cop_class)).to be true
         end
 
-        it 'respects cops that are disbled in the config' do
+        it 'respects cops that are disabled in the config' do
           cop_class = RuboCop::Cop::Layout::TrailingWhitespace
           expect(cop_enabled?(cop_class)).to be false
         end
@@ -1616,7 +1616,7 @@ RSpec.describe RuboCop::ConfigLoader do
               Enabled: false
           YAML
 
-          expect { load_file }.to output(%r{`Style/Encoding` is concealed by duplicat}).to_stderr
+          expect { load_file }.to output(%r{`Style/Encoding` is concealed by duplicate}).to_stderr
         end
       end
     end

--- a/spec/rubocop/cop/corrector_spec.rb
+++ b/spec/rubocop/cop/corrector_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::Cop::Corrector do
       expect { |corrector| corrector.remove_leading(operator, 2) }.to rewrite_to 'true d false'
     end
 
-    it 'allows removal of characters fron range ending' do
+    it 'allows removal of characters from range ending' do
       expect { |corrector| corrector.remove_trailing(operator, 2) }.to rewrite_to 'true a false'
     end
 

--- a/spec/rubocop/cop/internal_affairs/node_matcher_directive_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/node_matcher_directive_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeMatcherDirective, :config do
     it 'registers an offense if the matcher does not have a directive' do
       expect_offense(<<~RUBY, method: method)
         #{method} :foo?, '(str)'
-        ^{method}^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+        ^{method}^^^^^^^^^^^^^^^ Precede `#{method}` with a `@!method` YARD directive.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeMatcherDirective, :config do
     it 'registers an offense if the matcher does not have a directive and a method call is used for a pattern argument' do
       expect_offense(<<~RUBY, method: method)
         #{method} :foo?, format(PATTERN, type: 'const')
-        ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+        ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Precede `#{method}` with a `@!method` YARD directive.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -41,17 +41,17 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeMatcherDirective, :config do
       RUBY
     end
 
-    it 'registers an offense if the matcher does not have a directive but has preceeding comments' do
+    it 'registers an offense if the matcher does not have a directive but has preceding comments' do
       expect_offense(<<~RUBY, method: method)
         # foo
         #{method} :foo?, '(str)'
-        ^{method}^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+        ^{method}^^^^^^^^^^^^^^^ Precede `#{method}` with a `@!method` YARD directive.
 
         # foo bar baz
         # foo bar baz
         # foo bar baz
         #{method} :bar?, '(sym)'
-        ^{method}^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+        ^{method}^^^^^^^^^^^^^^^ Precede `#{method}` with a `@!method` YARD directive.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -94,7 +94,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeMatcherDirective, :config do
     it 'autocorrects with the right arguments if the pattern includes arguments' do
       expect_offense(<<~RUBY, method: method)
         #{method} :foo?, '(str %1)'
-        ^{method}^^^^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+        ^{method}^^^^^^^^^^^^^^^^^^ Precede `#{method}` with a `@!method` YARD directive.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -106,7 +106,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeMatcherDirective, :config do
     it 'autocorrects with the right arguments if the pattern references a non-contiguous argument' do
       expect_offense(<<~RUBY, method: method)
         #{method} :foo?, '(str %4)'
-        ^{method}^^^^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+        ^{method}^^^^^^^^^^^^^^^^^^ Precede `#{method}` with a `@!method` YARD directive.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -126,7 +126,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeMatcherDirective, :config do
       expect_offense(<<~RUBY, method: method)
         class MyCop
           #{method} :foo?, '(str)'
-          ^{method}^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+          ^{method}^^^^^^^^^^^^^^^ Precede `#{method}` with a `@!method` YARD directive.
         end
       RUBY
 
@@ -158,9 +158,9 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeMatcherDirective, :config do
     it 'inserts a blank line between multiple pattern matchers' do
       expect_offense(<<~RUBY, method: method)
         #{method} :foo?, '(str)'
-        ^{method}^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+        ^{method}^^^^^^^^^^^^^^^ Precede `#{method}` with a `@!method` YARD directive.
         #{method} :bar?, '(str)'
-        ^{method}^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+        ^{method}^^^^^^^^^^^^^^^ Precede `#{method}` with a `@!method` YARD directive.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -175,11 +175,11 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeMatcherDirective, :config do
     it 'inserts a blank line between multiple multi-line pattern matchers' do
       expect_offense(<<~RUBY, method: method)
         #{method} :foo?, <<~PATTERN
-        ^{method}^^^^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+        ^{method}^^^^^^^^^^^^^^^^^^ Precede `#{method}` with a `@!method` YARD directive.
           (str)
         PATTERN
         #{method} :bar?, <<~PATTERN
-        ^{method}^^^^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+        ^{method}^^^^^^^^^^^^^^^^^^ Precede `#{method}` with a `@!method` YARD directive.
           (str)
         PATTERN
       RUBY
@@ -200,12 +200,12 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeMatcherDirective, :config do
     it 'does not insert a blank line if one already exists' do
       expect_offense(<<~RUBY, method: method)
         #{method} :foo?, <<~PATTERN
-        ^{method}^^^^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+        ^{method}^^^^^^^^^^^^^^^^^^ Precede `#{method}` with a `@!method` YARD directive.
           (str)
         PATTERN
 
         #{method} :bar?, <<~PATTERN
-        ^{method}^^^^^^^^^^^^^^^^^^ Preceed `#{method}` with a `@!method` YARD directive.
+        ^{method}^^^^^^^^^^^^^^^^^^ Precede `#{method}` with a `@!method` YARD directive.
           (str)
         PATTERN
       RUBY

--- a/spec/rubocop/cop/layout/argument_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/argument_alignment_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe RuboCop::Cop::Layout::ArgumentAlignment, :config do
       RUBY
     end
 
-    it 'registers an offense and corrects when missed indendation kwargs' do
+    it 'registers an offense and corrects when missed indentation kwargs' do
       expect_offense(<<~RUBY)
         func1(foo: 'foo',
           bar: 'bar',
@@ -411,7 +411,7 @@ RSpec.describe RuboCop::Cop::Layout::ArgumentAlignment, :config do
       RUBY
     end
 
-    it 'registers an offense and corrects when missed indendation kwargs' do
+    it 'registers an offense and corrects when missed indentation kwargs' do
       expect_offense(<<~RUBY)
         func1(foo: 'foo',
               bar: 'bar',

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch, :config do
         RUBY
       end
 
-      it 'does not registes an offense for `#format`' do
+      it 'does not register an offense for `#format`' do
         expect_no_offenses(<<~RUBY)
           puts format("%s, %s, %s", 1, 2, 3, 4, *arr)
         RUBY

--- a/spec/rubocop/cop/lint/numbered_parameter_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/numbered_parameter_assignment_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::NumberedParameterAssignment, :config do
-  # NOTE: Assiging to numbered parameter (from `_1` to `_9`) cause an error in Ruby 3.0.
+  # NOTE: Assigning to numbered parameter (from `_1` to `_9`) cause an error in Ruby 3.0.
   context 'when Ruby 2.7 or lower', :ruby27 do
     (1..9).to_a.each do |number|
       it "registers an offense when using `_#{number}` numbered parameter" do

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
   end
 
   context 'with Ractor.new' do
-    it 'does not regiser an offense' do
+    it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
         def foo(*args)
           Ractor.new(*args) do |*args|

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -815,7 +815,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
     end
 
     context 'inside a class' do
-      it 'registers an offense when a modifier is ouside the block and a method is defined only inside the block' do
+      it 'registers an offense when a modifier is outside the block and a method is defined only inside the block' do
         expect_offense(<<~RUBY, modifier: modifier)
           class A
             %{modifier}
@@ -885,7 +885,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
     end
 
     context 'inside a class' do
-      it 'registers an offense when a modifier is ouside the block and a ' \
+      it 'registers an offense when a modifier is outside the block and a ' \
          'method is defined only inside the block' do
         expect_offense(<<~RUBY, modifier: modifier)
           class A

--- a/spec/rubocop/cop/style/accessor_grouping_spec.rb
+++ b/spec/rubocop/cop/style/accessor_grouping_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
       RUBY
     end
 
-    it 'registers offense and corrects if atleast two separate accessors without comments' do
+    it 'registers offense and corrects if at least two separate accessors without comments' do
       expect_offense(<<~RUBY)
         class Foo
           # @return [String] value of foo

--- a/spec/rubocop/cop/style/bisected_attr_accessor_spec.rb
+++ b/spec/rubocop/cop/style/bisected_attr_accessor_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe RuboCop::Cop::Style::BisectedAttrAccessor, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects when withing eigenclass' do
+  it 'registers an offense and corrects when within eigenclass' do
     expect_offense(<<~RUBY)
       class Foo
         attr_reader :bar
@@ -217,7 +217,7 @@ RSpec.describe RuboCop::Cop::Style::BisectedAttrAccessor, :config do
     RUBY
   end
 
-  it 'does not register an offense when accessors are withing different visibility scopes' do
+  it 'does not register an offense when accessors are within different visibility scopes' do
     expect_no_offenses(<<~RUBY)
       class Foo
         attr_reader :bar

--- a/spec/rubocop/cop/style/negated_if_else_condition_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_else_condition_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe RuboCop::Cop::Style::NegatedIfElseCondition, :config do
     RUBY
   end
 
-  it 'does not register an offense when not whe whole condition is negated' do
+  it 'does not register an offense when only part of the condition is negated' do
     expect_no_offenses(<<~RUBY)
       if !x && y
         do_something

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -402,7 +402,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
         RUBY
       end
 
-      it 'does not break when a method call is chaned on the offending one' do
+      it 'does not break when a method call is chained on the offending one' do
         expect_no_offenses(<<~RUBY)
           foo.bar(
             baz: 1,


### PR DESCRIPTION
This PR adds spell checking GitHub Actions workflow and fixes typos.

The following two tools are used for spell checking.

- misspell (requires Golang) ... https://github.com/client9/misspell
- codespell (requires Python) ... https://github.com/codespell-project/codespell

For contributors who don't have Golang and Python installed, it is only CONTRIBUTING.md and not run with `rake` task.

This GitHub Actions configuration is based on the Rails's spell checking workflow.
https://github.com/rails/rails/blob/v7.0.0.alpha2/.github/workflows/lint.yml

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
