### PR TITLE
[Fix #10130] Update `Lint/ElseLayout` to be able to handle an `else` with only a single line

### DIFF
--- a/changelog/change_update_lintelselayout_to_be_able_to.md
+++ b/changelog/change_update_lintelselayout_to_be_able_to.md
@@ -1,0 +1,1 @@
+* [#10130](https://github.com/rubocop/rubocop/issues/10130): Update `Lint/ElseLayout` to be able to handle an `else` with only a single line. ([@dvandersluis][])

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -129,8 +129,8 @@ module RuboCop
         node1.respond_to?(:loc) && node2.respond_to?(:loc) && node1.loc.line == node2.loc.line
       end
 
-      def indent(node)
-        ' ' * node.loc.column
+      def indent(node, offset: 0)
+        ' ' * (node.loc.column + offset)
       end
 
       def to_supported_styles(enforced_style)

--- a/spec/rubocop/cop/lint/else_layout_spec.rb
+++ b/spec/rubocop/cop/lint/else_layout_spec.rb
@@ -23,6 +23,24 @@ RSpec.describe RuboCop::Cop::Lint::ElseLayout, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects for the entire else body being on the same line' do
+    expect_offense(<<~RUBY)
+      if something
+        test
+      else something_else
+           ^^^^^^^^^^^^^^ Odd `else` layout detected. Did you mean to use `elsif`?
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if something
+        test
+      else
+        something_else
+      end
+    RUBY
+  end
+
   it 'accepts proper else' do
     expect_no_offenses(<<~RUBY)
       if something
@@ -30,15 +48,6 @@ RSpec.describe RuboCop::Cop::Lint::ElseLayout, :config do
       else
         something
         test
-      end
-    RUBY
-  end
-
-  it 'accepts single-expr else regardless of layout' do
-    expect_no_offenses(<<~RUBY)
-      if something
-        test
-      else bala
       end
     RUBY
   end
@@ -114,6 +123,21 @@ RSpec.describe RuboCop::Cop::Lint::ElseLayout, :config do
       else
         ()
       end
+    RUBY
+  end
+
+  it 'does not register an offense for an elsif with no body' do
+    expect_no_offenses(<<~RUBY)
+      if something
+        foo
+      elsif something_else
+      end
+    RUBY
+  end
+
+  it 'does not register an offense if the entire if is on a single line' do
+    expect_no_offenses(<<~RUBY)
+      if a then b else c end
     RUBY
   end
 end


### PR DESCRIPTION
This was previously explicitly ignored since the cop's first version, but I'm not really sure why. I think this is probably preferable.

Fixes #10130.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
