### PR TITLE
[Fix #10136] Update `Lint/AssignmentInCondition` to not consider assignments within blocks in conditions

### DIFF
--- a/changelog/fix_update_lintassignmentincondition_to_not.md
+++ b/changelog/fix_update_lintassignmentincondition_to_not.md
@@ -1,0 +1,1 @@
+* [#10136](https://github.com/rubocop/rubocop/issues/10136): Update `Lint/AssignmentInCondition` to not consider assignments within blocks in conditions. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -49,7 +49,7 @@ module RuboCop
         def on_if(node)
           return if node.condition.block_type?
 
-          traverse_node(node.condition, ASGN_TYPES) do |asgn_node|
+          traverse_node(node.condition) do |asgn_node|
             next :skip_children if skip_children?(asgn_node)
             next if allowed_construct?(asgn_node)
 
@@ -83,13 +83,15 @@ module RuboCop
             (safe_assignment_allowed? && safe_assignment?(asgn_node))
         end
 
-        # each_node/visit_descendants_with_types with :skip_children
-        def traverse_node(node, types, &block)
-          result = yield node if types.include?(node.type)
+        def traverse_node(node, &block)
+          # if the node is a block, any assignments are irrelevant
+          return if node.block_type?
+
+          result = yield node if ASGN_TYPES.include?(node.type)
 
           return if result == :skip_children
 
-          node.each_child_node { |child| traverse_node(child, types, &block) }
+          node.each_child_node { |child| traverse_node(child, &block) }
         end
       end
     end

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -90,6 +90,21 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     expect_no_offenses('return 1 if any_errors? { o = file }.present?')
   end
 
+  it 'accepts assignment in a block after ||' do
+    expect_no_offenses(<<~RUBY)
+      if x?(bar) || y? { z = baz }
+        foo
+      end
+    RUBY
+  end
+
+  it 'registers an offense for = in condition inside a block' do
+    expect_offense(<<~RUBY)
+      foo { x if y = z }
+                   ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
+    RUBY
+  end
+
   it 'accepts ||= in condition' do
     expect_no_offenses('raise StandardError unless foo ||= bar')
   end


### PR DESCRIPTION
Assignments within a block are not relevant to this cop because they don't affect the same scope.

Fixes #10136.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
