### PR TITLE
[Fix #10135] Fix `Style/WordArray` to exclude files in `--auto-gen-config` when `percent` style is given but brackets are required

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -144,3 +144,7 @@ InternalAffairs/UndefinedConfig:
   Exclude:
     - 'lib/rubocop/cop/correctors/**/*.rb'
     - 'lib/rubocop/cop/mixin/**/*.rb'
+
+InternalAffairs/StyleDetectedApiUse:
+  Exclude:
+    - 'lib/rubocop/cop/mixin/percent_array.rb'

--- a/changelog/fix_fix_stylewordarray_to_exclude_files_in.md
+++ b/changelog/fix_fix_stylewordarray_to_exclude_files_in.md
@@ -1,0 +1,1 @@
+* [#10135](https://github.com/rubocop/rubocop/issues/10135): Fix `Style/WordArray` to exclude files in `--auto-gen-config` when `percent` style is given but brackets are required. ([@dvandersluis][])

--- a/lib/rubocop/cop/mixin/percent_array.rb
+++ b/lib/rubocop/cop/mixin/percent_array.rb
@@ -36,7 +36,12 @@ module RuboCop
       def check_percent_array(node)
         array_style_detected(:percent, node.values.size)
 
-        return unless style == :brackets || invalid_percent_array_contents?(node)
+        brackets_required = invalid_percent_array_contents?(node)
+        return unless style == :brackets || brackets_required
+
+        # If in percent style but brackets are required due to
+        # string content, the file should be excluded in auto-gen-config
+        no_acceptable_style! if brackets_required
 
         bracketed_array = build_bracketed_array(node)
         message = format(self.class::ARRAY_MSG, prefer: bracketed_array)

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -327,6 +327,8 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       expect_correction(<<~RUBY)
         ['one two', 'three four']
       RUBY
+
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'does not register an offense for a %w() array containing non word characters' do


### PR DESCRIPTION
When `Style/WordArray` is in `percent` style, offenses are registered for percent arrays that contain "invalid" characters, in order to replace them with a bracketed array instead. However, when this is the case, `--auto-gen-config` doesn't handle the file properly. This updates it to exclude the file since the result is inconsistent.

Fixes #10135.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
