### PR TITLE
[Fix #10134] Update `Style/MutableConstant` to not consider multiline uninterpolated strings as unfrozen in ruby 3.0

### DIFF
--- a/changelog/fix_update_stylemutableconstant_to_not.md
+++ b/changelog/fix_update_stylemutableconstant_to_not.md
@@ -1,0 +1,1 @@
+* [#10134](https://github.com/rubocop/rubocop/issues/10134): Update `Style/MutableConstant` to not consider multiline uninterpolated strings as unfrozen in ruby 3.0. ([@dvandersluis][])

--- a/lib/rubocop/cop/mixin/frozen_string_literal.rb
+++ b/lib/rubocop/cop/mixin/frozen_string_literal.rb
@@ -20,12 +20,16 @@ module RuboCop
 
       def frozen_string_literal?(node)
         frozen_string = if target_ruby_version >= 3.0
-                          node.str_type? || frozen_heredoc?(node)
+                          uninterpolated_string?(node) || frozen_heredoc?(node)
                         else
                           FROZEN_STRING_LITERAL_TYPES_RUBY27.include?(node.type)
                         end
 
         frozen_string && frozen_string_literals_enabled?
+      end
+
+      def uninterpolated_string?(node)
+        node.str_type? || (node.dstr_type? && node.each_descendant(:begin).none?)
       end
 
       def frozen_heredoc?(node)

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -21,8 +21,9 @@ module RuboCop
       #
       # NOTE: Regexp and Range literals are frozen objects since Ruby 3.0.
       #
-      # NOTE: From Ruby 3.0, this cop allows explicit freezing of interpolated
-      # string literals when `# frozen-string-literal: true` is used.
+      # NOTE: From Ruby 3.0, interpolated strings are not frozen when
+      # `# frozen-string-literal: true` is used, so this cop enforces explicit
+      # freezing for such strings.
       #
       # NOTE: From Ruby 3.0, this cop allows explicit freezing of constants when
       # the `shareable_constant_value` directive is used.

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -132,6 +132,25 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
             HERE
           RUBY
         end
+
+        it 'does not register an offense when using a multiline string' do
+          expect_no_offenses(<<~RUBY)
+            # frozen_string_literal: true
+
+            CONST = 'foo' \
+                    'bar'
+          RUBY
+        end
+
+        it 'registers an offense when using a multiline string with interpolation' do
+          expect_offense(<<~'RUBY')
+            # frozen_string_literal: true
+
+            CONST = "#{foo}" \
+                    ^^^^^^^^^^ Freeze mutable objects assigned to constants.
+                    'bar'
+          RUBY
+        end
       end
 
       context 'when the frozen string literal comment is false' do
@@ -164,6 +183,15 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
               foo #{use_interpolation}
               bar
             HERE
+          RUBY
+        end
+
+        it 'does not register an offense when using a multiline string' do
+          expect_no_offenses(<<~RUBY)
+            # frozen_string_literal: true
+
+            CONST = 'foo' \
+                    'bar'
           RUBY
         end
       end


### PR DESCRIPTION
In #10006 `Style/MutableConstant` was updated to consider `dstr` nodes as unfrozen in Ruby 3.0 even when `frozen_string_literal: true` is specified, and requires `.freeze` on those strings. However, a multiline string is considered a `dstr` node but does not contain interpolation so would still be frozen.

```ruby
# frozen_string_literal: true

CONST = 'foo' \
        'bar'

CONST.frozen? #=> true
```

Fixes #10134.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
