### PR TITLE
[Fix #10140] Fix false positive for `Layout/DotPosition` when a heredoc receives a method on the same line as the start sigil in `trailing` style

### DIFF
--- a/changelog/fix_fix_false_positive_for_layoutdotposition.md
+++ b/changelog/fix_fix_false_positive_for_layoutdotposition.md
@@ -1,0 +1,1 @@
+* [#10140](https://github.com/rubocop/rubocop/issues/10140): Fix false positive for `Layout/DotPosition` when a heredoc receives a method on the same line as the start sigil in `trailing` style. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/dot_position.rb
+++ b/lib/rubocop/cop/layout/dot_position.rb
@@ -68,13 +68,17 @@ module RuboCop
         end
 
         def proper_dot_position?(node)
-          receiver_line = receiver_end_line(node.receiver)
           selector_line = selector_range(node).line
+
+          # If the receiver is a HEREDOC and the selector is on the same line
+          # then there is nothing to do
+          return true if heredoc?(node.receiver) && node.receiver.loc.first_line == selector_line
+
+          receiver_line = receiver_end_line(node.receiver)
+          dot_line = node.loc.dot.line
 
           # receiver and selector are on the same line
           return true if selector_line == receiver_line
-
-          dot_line = node.loc.dot.line
 
           # don't register an offense if there is a line comment between the
           # dot and the selector otherwise, we might break the code while

--- a/spec/rubocop/cop/layout/dot_position_spec.rb
+++ b/spec/rubocop/cop/layout/dot_position_spec.rb
@@ -465,5 +465,15 @@ RSpec.describe RuboCop::Cop::Layout::DotPosition, :config do
         RUBY
       end
     end
+
+    context 'when there is a heredoc with a following method' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          <<~HEREDOC.squish
+            something
+          HEREDOC
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
The fix in #10113 caused a false positive when a heredoc receives a method on the same line as its start, such as

```ruby
<<HEREDOC.squish
  foo
HEREDOC
```

This should not have registered an offense because the dot is on the same line as the receiver.

Fixes #10140.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
