### PR TITLE
[Fix #10143] Fix an error for `Lint/RequireRelativeSelfPath`

### DIFF
--- a/changelog/fix_an_error_for_lint_require_relative_self_path.md
+++ b/changelog/fix_an_error_for_lint_require_relative_self_path.md
@@ -1,0 +1,1 @@
+* [#10143](https://github.com/rubocop/rubocop/issues/10143): Fix an error for `Lint/RequireRelativeSelfPath` when using a variable as an argument of `require_relative`. ([@koic][])

--- a/lib/rubocop/cop/lint/require_relative_self_path.rb
+++ b/lib/rubocop/cop/lint/require_relative_self_path.rb
@@ -27,6 +27,7 @@ module RuboCop
 
         def on_send(node)
           return unless (required_feature = node.first_argument)
+          return unless required_feature.respond_to?(:value)
           return unless same_file?(processed_source.file_path, required_feature.value)
 
           add_offense(node) do |corrector|

--- a/spec/rubocop/cop/lint/require_relative_self_path_spec.rb
+++ b/spec/rubocop/cop/lint/require_relative_self_path_spec.rb
@@ -42,4 +42,10 @@ RSpec.describe RuboCop::Cop::Lint::RequireRelativeSelfPath, :config do
       require_relative 'foo.racc'
     RUBY
   end
+
+  it 'does not register an offense when using a variable as an argument of `require_relative`' do
+    expect_no_offenses(<<~RUBY, 'foo.rb')
+      Dir['test/**/test_*.rb'].each { |f| require_relative f }
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #10143.

This PR fixes an error for `Lint/RequireRelativeSelfPath` when using a variable as an argument of `require_relative`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
