### PR TITLE
[Fix #10148] Fix `Style/QuotedSymbols` handling escaped characters incorrectly

### DIFF
--- a/changelog/fix_fix_stylequotedsymbols_handling_escaped.md
+++ b/changelog/fix_fix_stylequotedsymbols_handling_escaped.md
@@ -1,0 +1,1 @@
+* [#10148](https://github.com/rubocop/rubocop/issues/10148): Fix `Style/QuotedSymbols` handling escaped characters incorrectly. ([@dvandersluis][])

--- a/lib/rubocop/cop/mixin/string_literals_help.rb
+++ b/lib/rubocop/cop/mixin/string_literals_help.rb
@@ -13,7 +13,11 @@ module RuboCop
         if style == :single_quotes
           !double_quotes_required?(src)
         else
-          !/" | \\[^'\\] | \#[@{$]/x.match?(src)
+          # The string needs single quotes if:
+          # 1. It contains a double quote
+          # 2. It contains text that would become an escape sequence with double quotes
+          # 3. It contains text that would become an interpolation with double quotes
+          !/" | (?<!\\)\\[abcefMnrtuUx0-7] | \#[@{$]/x.match?(src)
         end
       end
     end

--- a/lib/rubocop/cop/style/quoted_symbols.rb
+++ b/lib/rubocop/cop/style/quoted_symbols.rb
@@ -75,11 +75,14 @@ module RuboCop
         end
 
         def correct_quotes(str)
-          if style == :single_quotes
-            to_string_literal(str)
-          else
-            str.inspect
-          end
+          correction = if style == :single_quotes
+                         to_string_literal(str)
+                       else
+                         str.gsub("\\'", "'").inspect
+                       end
+
+          # The conversion process doubles escaped slashes, so they have to be reverted
+          correction.gsub('\\\\', '\\')
         end
 
         def style

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -113,7 +113,8 @@ module RuboCop
         if needs_escaping?(string) && compatible_external_encoding_for?(string)
           string.inspect
         else
-          "'#{string.gsub('\\') { '\\\\' }}'"
+          # In a single-quoted strings, double quotes don't need to be escaped
+          "'#{string.gsub('\"', '"').gsub('\\') { '\\\\' }}'"
         end
       end
 

--- a/spec/rubocop/cop/style/quoted_symbols_spec.rb
+++ b/spec/rubocop/cop/style/quoted_symbols_spec.rb
@@ -113,6 +113,34 @@ RSpec.describe RuboCop::Cop::Style::QuotedSymbols, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects for an escaped quote within double quotes' do
+      expect_offense(<<~'RUBY')
+        :"my\"quote"
+        ^^^^^^^^^^^^ Prefer single-quoted symbols when you don't need string interpolation or special symbols.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        :'my"quote'
+      RUBY
+    end
+
+    it 'registers an offense and corrects escape characters properly' do
+      expect_offense(<<~'RUBY')
+        :"foo\\bar"
+        ^^^^^^^^^^^ Prefer single-quoted symbols when you don't need string interpolation or special symbols.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        :'foo\\bar'
+      RUBY
+    end
+
+    it 'accepts single quoted symbol with an escaped quote' do
+      expect_no_offenses(<<~'RUBY')
+        :'o\'clock'
+      RUBY
+    end
+
     context 'hash with hashrocket style' do
       it 'accepts properly quoted symbols' do
         expect_no_offenses(<<~RUBY)
@@ -210,6 +238,34 @@ RSpec.describe RuboCop::Cop::Style::QuotedSymbols, :config do
 
       expect_correction(<<~RUBY)
         :"a"
+      RUBY
+    end
+
+    it 'registers an offense and corrects for an escaped quote within single quotes' do
+      expect_offense(<<~'RUBY')
+        :'o\'clock'
+        ^^^^^^^^^^^ Prefer double-quoted symbols unless you need single quotes to avoid extra backslashes for escaping.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        :"o'clock"
+      RUBY
+    end
+
+    it 'registers an offense and corrects escape characters properly' do
+      expect_offense(<<~'RUBY')
+        :'foo\\bar'
+        ^^^^^^^^^^^ Prefer double-quoted symbols unless you need single quotes to avoid extra backslashes for escaping.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        :"foo\\bar"
+      RUBY
+    end
+
+    it 'accepts double quoted symbol with an escaped quote' do
+      expect_no_offenses(<<~'RUBY')
+        :"my\"quote"
       RUBY
     end
 

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -157,6 +157,17 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
       RUBY
     end
 
+    it 'registers an offense for "\\"' do
+      expect_offense(<<~'RUBY')
+        "\\"
+        ^^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        '\\'
+      RUBY
+    end
+
     it 'registers an offense for words with non-ascii chars' do
       expect_offense(<<~RUBY)
         "España"


### PR DESCRIPTION
Two cases are improved here:
1. Escaped double quotes (`\"`) within a double-quoted string are handled correctly (replaced with an unescaped double quote) when converting to a single-quoted string.
2. Escaped backslashes (`\\`) are treated properly and not doubled for both single- and double-quoted strings.

Fixes #10148.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
