### PR TITLE
[Fix #10145] Update `Style/SelectByRegexp` to ignore cases where the receiver appears to be a hash

### DIFF
--- a/changelog/fix_update_styleselectbyregexp_to_ignore.md
+++ b/changelog/fix_update_styleselectbyregexp_to_ignore.md
@@ -1,0 +1,1 @@
+* [#10145](https://github.com/rubocop/rubocop/issues/10145): Update `Style/SelectByRegexp` to ignore cases where the receiver appears to be a hash. ([@dvandersluis][])


### PR DESCRIPTION
Since `hash.grep` does not work in the same way as other enumerables, this update looks for receivers that look like hashes and does not register `Style/SelectByRegexp` offenses on them. This includes literal hashes (`{}`), `Hash.new`, `Hash[]`, `to_h` and `to_hash` (the latter two could potentially cause a false negative if they're overridden to not return hashes, but I can live with that).

I added explicit tests for receivers that I have confirmed works as expected (array, range, set). In case we ever extend this with more exceptions those will be covered.

Fixes #10145.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
