### PR TITLE
Clarify documentation for `Style/QuotedSymbols`

### DIFF
--- a/lib/rubocop/cop/style/quoted_symbols.rb
+++ b/lib/rubocop/cop/style/quoted_symbols.rb
@@ -4,7 +4,8 @@ module RuboCop
   module Cop
     module Style
       # Checks if the quotes used for quoted symbols match the configured defaults.
-      # By default uses the same configuration as `Style/StringLiterals`.
+      # By default uses the same configuration as `Style/StringLiterals`; if that
+      # cop is not enabled, the default `EnforcedStyle` is `single_quotes`.
       #
       # String interpolation is always kept in double quotes.
       #


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/issues/10154#issuecomment-932497540.

Improves documentation for `Style/QuotedSymbols` to clarify what style is chosen by default when not configured.