### PR TITLE
Fix inconsistent capitalization of `RuboCop`

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -136,7 +136,7 @@ module RuboCop
         end
       end
 
-      # Returns the path rubocop inferred as the root of the project. No file
+      # Returns the path RuboCop inferred as the root of the project. No file
       # searches will go past this directory.
       def project_root
         @project_root ||= find_project_root

--- a/lib/rubocop/rake_task.rb
+++ b/lib/rubocop/rake_task.rb
@@ -33,7 +33,7 @@ module RuboCop
     private
 
     def run_cli(verbose, options)
-      # We lazy-load rubocop so that the task doesn't dramatically impact the
+      # We lazy-load RuboCop so that the task doesn't dramatically impact the
       # load time of your Rakefile.
       require 'rubocop'
 

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -6,7 +6,7 @@ require 'etc'
 require 'zlib'
 
 module RuboCop
-  # Provides functionality for caching rubocop runs.
+  # Provides functionality for caching RuboCop runs.
   # @api private
   class ResultCache
     NON_CHANGING = %i[color format formatters out debug fail_level auto_correct
@@ -170,7 +170,7 @@ module RuboCop
       attr_accessor :source_checksum, :inhibit_cleanup
     end
 
-    # The checksum of the rubocop program running the inspection.
+    # The checksum of the RuboCop program running the inspection.
     def rubocop_checksum
       ResultCache.source_checksum ||=
         begin

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -60,7 +60,7 @@ module RuboCop
 
     private
 
-    # Warms up the RuboCop cache by forking a suitable number of rubocop
+    # Warms up the RuboCop cache by forking a suitable number of RuboCop
     # instances that each inspects its allotted group of files.
     def warm_cache(target_files)
       puts 'Running parallel inspection' if @options[:debug]

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1390,7 +1390,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     # Being immune to bad configuration files in excluded directories has
     # become important due to a bug in rubygems
     # (https://github.com/rubygems/rubygems/issues/680) that makes
-    # installations of, for example, rubocop lack their .rubocop.yml in the
+    # installations of, for example, RuboCop lack their .rubocop.yml in the
     # root directory.
     it 'can exclude a vendor directory with an erroneous config file' do
       create_file('vendor/bundle/ruby/1.9.1/gems/parser-2.0.0/.rubocop.yml',


### PR DESCRIPTION
Fix some instances of `rubocop` => `RuboCop`.