### PR TITLE
Add new `InternalAffairs/LocationLineEqualityComparison` cop

### DIFF
--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -3,6 +3,7 @@
 require_relative 'internal_affairs/empty_line_between_expect_offense_and_correction'
 require_relative 'internal_affairs/example_description'
 require_relative 'internal_affairs/inherit_deprecated_cop_class'
+require_relative 'internal_affairs/location_line_equality_comparison'
 require_relative 'internal_affairs/method_name_equal'
 require_relative 'internal_affairs/node_destructuring'
 require_relative 'internal_affairs/node_matcher_directive'

--- a/lib/rubocop/cop/internal_affairs/location_line_equality_comparison.rb
+++ b/lib/rubocop/cop/internal_affairs/location_line_equality_comparison.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # This cop enforces the use of `same_line?` instead of location line comparison for equality.
+      #
+      # @example
+      #   # bad
+      #   node.loc.line == node.parent.loc.line
+      #
+      #   # good
+      #   same_line?(node, node.parent)
+      #
+      class LocationLineEqualityComparison < Base
+        extend AutoCorrector
+
+        MSG = 'Use `%<preferred>s`.'
+
+        # @!method location_line_equality_comparison?(node)
+        def_node_matcher :location_line_equality_comparison?, <<~PATTERN
+          (send
+            (send (send _ :loc) :line) :==
+            (send (send _ :loc) :line))
+        PATTERN
+
+        def on_send(node)
+          return unless location_line_equality_comparison?(node)
+
+          lhs, _op, rhs = *node
+
+          lhs_receiver = lhs.receiver.receiver.source
+          rhs_receiver = rhs.receiver.receiver.source
+          preferred = "same_line?(#{lhs_receiver}, #{rhs_receiver})"
+
+          add_offense(node, message: format(MSG, preferred: preferred)) do |corrector|
+            corrector.replace(node, preferred)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -165,8 +165,7 @@ module RuboCop
         end
 
         def alignment_node_for_variable_style(node)
-          return node.parent if node.case_type? && node.argument? &&
-                                node.loc.line == node.parent.loc.line
+          return node.parent if node.case_type? && node.argument? && same_line?(node, node.parent)
 
           assignment = assignment_or_operator_method(node)
 

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -54,7 +54,7 @@ module RuboCop
       end
 
       def first_line_comment(node)
-        comment = processed_source.find_comment { |c| c.loc.line == node.loc.line }
+        comment = processed_source.find_comment { |c| same_line?(c, node) }
         return unless comment
 
         comment_source = comment.loc.expression.source

--- a/lib/rubocop/cop/style/multiline_in_pattern_then.rb
+++ b/lib/rubocop/cop/style/multiline_in_pattern_then.rb
@@ -54,7 +54,7 @@ module RuboCop
           return true if in_pattern_node.pattern.first_line != in_pattern_node.pattern.last_line
           return false unless in_pattern_node.body
 
-          in_pattern_node.loc.line == in_pattern_node.body.loc.line
+          same_line?(in_pattern_node, in_pattern_node.body)
         end
       end
     end

--- a/lib/rubocop/cop/style/multiline_when_then.rb
+++ b/lib/rubocop/cop/style/multiline_when_then.rb
@@ -54,7 +54,7 @@ module RuboCop
           end
           return false unless when_node.body
 
-          when_node.loc.line == when_node.body.loc.line
+          same_line?(when_node, when_node.body)
         end
 
         def accept_node_type?(node)

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -126,7 +126,9 @@ module RuboCop
       end
 
       def same_line?(node1, node2)
+        # rubocop:disable InternalAffairs/LocationLineEqualityComparison
         node1.respond_to?(:loc) && node2.respond_to?(:loc) && node1.loc.line == node2.loc.line
+        # rubocop:enable InternalAffairs/LocationLineEqualityComparison
       end
 
       def indent(node, offset: 0)

--- a/spec/rubocop/cop/internal_affairs/location_line_equality_comparison_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/location_line_equality_comparison_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::InternalAffairs::LocationLineEqualityComparison, :config do
+  it 'registers and corrects an offense when comparing `#loc.line` with LHS and RHS' do
+    expect_offense(<<~RUBY)
+      node.loc.line == node.parent.loc.line
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `same_line?(node, node.parent)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      same_line?(node, node.parent)
+    RUBY
+  end
+
+  it 'does not register an offense when using `same_line?`' do
+    expect_no_offenses(<<~RUBY)
+      same_line?(node, node.parent)
+    RUBY
+  end
+end


### PR DESCRIPTION
This cop enforces the use of `same_line?` instead of location line comparison for equality.

```ruby
# bad
node.loc.line == node.parent.loc.line

# good
same_line?(node, node.parent)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
