### PR TITLE
[Fix #7900] Fix `Style/FormatStringToken` false positive with formatted input and `template` style enforced, and add autocorrection

### DIFF
--- a/changelog/fix_fix_style_format_string_token_false_positive.md
+++ b/changelog/fix_fix_style_format_string_token_false_positive.md
@@ -1,0 +1,1 @@
+* [#7900](https://github.com/rubocop/rubocop/issues/7900): Fix `Style/FormatStringToken` false positive with formatted input and `template` style enforced, and add autocorrection. ([@FnControlOption][])


### PR DESCRIPTION
Fixes #7900.

Types of format strings:
- `annotated`: `'%<name>s'` (where `s` is the format type)
- `template`: `'%{name}'`
- `unannotated`: `'%s'`

The format string `'%{name}'` is only equivalent to `'%<name>s'`, so when enforcing the `template` style, no offenses should be reported if the format type is not `s` (for example, `'%<name>f'`).

The autocorrection from `template` style `%[flags][width][.precision]{name}` to `annotated` style is `%<name>[flags][width][.precision]s`, and vice versa.

Because `unannotated` has no names, it can't be autocorrected to `annotated` or `template`.

Autocorrecting from either `annotated` or `template` to `unannotated` is possible, but I haven't attempted adding this yet. The method arguments must be updated too, so `def on_send` would need to be added (maybe as a new cop). For example:

```rb
format('%<greeting>s', greeting: 'Hello')
format('%{foo} %{bar} %{foo}', foo: 'foo', bar: 'bar')
# becomes
format('%s', 'Hello')
format('%1$s %2$s %1$s', 'foo', 'bar')
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
