### PR TITLE
Removed stray `puts` from changelog.rb

### DIFF
--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -129,7 +129,6 @@ class Changelog
 
   def contributors
     contributors = @entries.values.flat_map do |entry|
-      puts entry
       entry.match(/\. \((?<contributors>.+)\)\n/)[:contributors].split(',')
     end
 


### PR DESCRIPTION
I noticed that the changelog specs were outputting text by accident, there was a leftover debugging puts.