### PR TITLE
Unmark `AutoCorrect: false` from `Security/JSONLoad`

### DIFF
--- a/changelog/change_unmark_autocorrect_false_from_security_json_load.md
+++ b/changelog/change_unmark_autocorrect_false_from_security_json_load.md
@@ -1,0 +1,1 @@
+* [#10176](https://github.com/rubocop/rubocop/pull/10176): Unmark `AutoCorrect: false` from `Security/JSONLoad`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2754,10 +2754,9 @@ Security/JSONLoad:
   Reference: 'https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load'
   Enabled: true
   VersionAdded: '0.43'
-  VersionChanged: '0.44'
+  VersionChanged: '<<next>>'
   # Autocorrect here will change to a method that may cause crashes depending
   # on the value of the argument.
-  AutoCorrect: false
   SafeAutoCorrect: false
 
 Security/MarshalLoad:

--- a/lib/rubocop/cop/security/json_load.rb
+++ b/lib/rubocop/cop/security/json_load.rb
@@ -7,7 +7,7 @@ module RuboCop
       # security issues.
       #
       # @safety
-      #   Autocorrect is disabled by default because it's potentially dangerous.
+      #   This cop's autocorrection is unsafe because it's potentially dangerous.
       #   If using a stream, like `JSON.load(open('file'))`, it will need to call
       #   `#read` manually, like `JSON.parse(open('file').read)`.
       #   If reading single values (rather than proper JSON objects), like

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1005,7 +1005,8 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
       expect(cli.run(['--format', 'emacs', '--display-style-guide', 'example1.rb'])).to eq(1)
 
-      output = "#{file}:1:6: C: Security/JSONLoad: Prefer `JSON.parse` over `JSON.load`. (#{url})"
+      output = "#{file}:1:6: C: [Correctable] Security/JSONLoad: " \
+               "Prefer `JSON.parse` over `JSON.load`. (#{url})"
       expect($stdout.string.lines.to_a[-1]).to eq([output, ''].join("\n"))
     end
 


### PR DESCRIPTION
This `AutoCorrect: false` looks like it was set when there was no way to safe autocorrect by `SafeAutocorrect: false`.
https://github.com/rubocop/rubocop/pull/3584

Test code for `Security/JSONLoad`'s autocorrection exists. So it can be enabled by default. However, it is still unsafe because `SafeAutocorrect: false`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
