### PR TITLE
Add rubocop-graphql to suggested extensions

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -150,6 +150,7 @@ AllCops:
     rubocop-minitest: [minitest]
     rubocop-sequel: [sequel]
     rubocop-rake: [rake]
+    rubocop-graphql: [graphql]
 
 #################### Bundler ###############################
 


### PR DESCRIPTION
This PR adds [rubocop-graphql](https://github.com/DmitryTsepelev/rubocop-graphql) to the `SuggestExtensions` list.