### PR TITLE
[Fix #10180] Fix an error for `Style/SelectByRegexp`

### DIFF
--- a/changelog/fix_an_error_for_style_select_by_regexp.md
+++ b/changelog/fix_an_error_for_style_select_by_regexp.md
@@ -1,0 +1,1 @@
+* [#10180](https://github.com/rubocop/rubocop/issues/10180): Fix an error for `Style/SelectByRegexp` when using `match?` without a receiver. ([@koic][])

--- a/lib/rubocop/cop/style/select_by_regexp.rb
+++ b/lib/rubocop/cop/style/select_by_regexp.rb
@@ -83,6 +83,7 @@ module RuboCop
           return if block_node.body.begin_type?
           return if receiver_allowed?(block_node.receiver)
           return unless (regexp_method_send_node = extract_send_node(block_node))
+          return if match_predicate_without_receiver?(regexp_method_send_node)
 
           regexp = find_regexp(regexp_method_send_node)
           register_offense(node, block_node, regexp)
@@ -126,6 +127,10 @@ module RuboCop
           elsif node.first_argument.lvar_type?
             node.receiver
           end
+        end
+
+        def match_predicate_without_receiver?(node)
+          node.send_type? && node.method?(:match?) && node.receiver.nil?
         end
       end
     end

--- a/spec/rubocop/cop/style/select_by_regexp_spec.rb
+++ b/spec/rubocop/cop/style/select_by_regexp_spec.rb
@@ -279,6 +279,12 @@ RSpec.describe RuboCop::Cop::Style::SelectByRegexp, :config do
             array.#{method} { /regexp/.match?(foo(_1)) }
           RUBY
         end
+
+        it 'does not register an offense when using `match?` without a receiver' do
+          expect_no_offenses(<<~RUBY)
+            array.#{method} { |item| match?(item) }
+          RUBY
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #10180.

This PR fixes an error for `Style/SelectByRegexp` when using `match?` without a receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
