### PR TITLE
CI against JRuby 9.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,26 +161,26 @@ jobs:
     steps:
       *rubocop_steps
 
-  # JRuby 9.2
-  jruby-9.2-spec:
+  # JRuby 9.3
+  jruby-9.3-spec:
     docker:
-      - image: circleci/jruby:9.2
+      - image: circleci/jruby:9.3
     environment:
       <<: *common_env
       <<: *jruby_env
     steps:
       *spec_steps
-  jruby-9.2-ascii_spec:
+  jruby-9.3-ascii_spec:
     docker:
-      - image: circleci/jruby:9.2
+      - image: circleci/jruby:9.3
     environment:
       <<: *common_env
       <<: *jruby_env
     steps:
       *ascii_spec_steps
-  jruby-9.2-rubocop:
+  jruby-9.3-rubocop:
     docker:
-      - image: circleci/jruby:9.2
+      - image: circleci/jruby:9.3
     environment:
       <<: *common_env
       <<: *jruby_env
@@ -266,11 +266,11 @@ workflows:
             - cc-setup
       - ruby-head-ascii_spec
       - ruby-head-rubocop
-      - jruby-9.2-spec:
+      - jruby-9.3-spec:
           requires:
             - cc-setup
-      - jruby-9.2-ascii_spec
-      - jruby-9.2-rubocop
+      - jruby-9.3-ascii_spec
+      - jruby-9.3-rubocop
 
       - cc-upload-coverage:
           requires:
@@ -278,4 +278,4 @@ workflows:
             - ruby-2.6-spec
             - ruby-2.7-spec
             - ruby-3.0-spec
-            - jruby-9.2-spec
+            - jruby-9.3-spec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,7 +74,7 @@ RSpec.configure do |config|
     config.filter_run_excluding broken_on: :ruby_head
   end
 
-  if %w[jruby-9.2-ascii_spec jruby-9.2-spec].include? ENV['CIRCLE_STAGE']
+  if %w[jruby-9.3-ascii_spec jruby-9.3-spec].include? ENV['CIRCLE_STAGE']
     config.filter_run_excluding broken_on: :jruby
   end
 end


### PR DESCRIPTION
JRuby 9.3 has been released.
https://www.jruby.org/2021/09/22/jruby-9-3-0-0.html

```consle
% rbenv local jruby-9.3.0.0
% ruby -v
jruby 9.3.0.0 (2.6.8) 2021-09-17 85c20e780f Java HotSpot(TM) 64-Bit
Server VM 25.271-b09 on 1.8.0_271-b09 +jit [darwin-x86_64]
```

JRuby 9.3 is Ruby 2.6 compatible and RuboCop supports Ruby 2.5, so I think RuboCop can support JRuby 9.2.

On the other hand, this PR drops JRuby 9.2 from the CI matrix. This is a balance between increasing CI running time and issue detection. In fact, JRuby support could be 9.3 or higher next year (2022).
https://docs.rubocop.org/rubocop/1.22/compatibility.html

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
