### PR TITLE
[Fix #10185] Fix a false positive for `Lint/AmbiguousRange`

### DIFF
--- a/changelog/fix_false_positive_for_lint_ambiguous_range.md
+++ b/changelog/fix_false_positive_for_lint_ambiguous_range.md
@@ -1,0 +1,1 @@
+* [#10185](https://github.com/rubocop/rubocop/issues/10185): Fix a false positive for `Lint/AmbiguousRange` when using `self` in a range literal. ([@koic][])

--- a/lib/rubocop/cop/lint/ambiguous_range.rb
+++ b/lib/rubocop/cop/lint/ambiguous_range.rb
@@ -82,7 +82,7 @@ module RuboCop
         def acceptable?(node)
           node.begin_type? ||
             node.basic_literal? ||
-            node.variable? || node.const_type? ||
+            node.variable? || node.const_type? || node.self_type? ||
             (node.call_type? && acceptable_call?(node))
         end
 

--- a/spec/rubocop/cop/lint/ambiguous_range_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_range_spec.rb
@@ -74,6 +74,13 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRange, :config do
         RUBY
       end
 
+      it 'does not register an offense for `self`' do
+        expect_no_offenses(<<~RUBY)
+          self#{operator}42
+          42#{operator}self
+        RUBY
+      end
+
       it 'can handle an endless range', :ruby26 do
         expect_offense(<<~RUBY)
           x || 1#{operator}


### PR DESCRIPTION
Fixes #10185.

This PR fixes a false positive for `Lint/AmbiguousRange` when using `self` in a range literal.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
