### PR TITLE
[Fix #10186] Explicit block arg is not counted for `Metrics/ParameterLists`

### DIFF
--- a/changelog/change_explicit_block_arg_is_not_counted_for_metrics_parameter_lists.md
+++ b/changelog/change_explicit_block_arg_is_not_counted_for_metrics_parameter_lists.md
@@ -1,0 +1,1 @@
+* [#10186](https://github.com/rubocop/rubocop/issues/10186): Explicit block arg is not counted for `Metrics/ParameterLists`. ([@koic][])

--- a/lib/rubocop/cop/metrics/parameter_lists.rb
+++ b/lib/rubocop/cop/metrics/parameter_lists.rb
@@ -9,6 +9,9 @@ module RuboCop
       # Keyword arguments can optionally be excluded from the total count,
       # as they add less complexity than positional or optional parameters.
       #
+      # NOTE: Explicit block argument `&block` is not counted to prevent
+      #       erroneous change that is avoided by making block argument implicit.
+      #
       # @example Max: 3
       #   # good
       #   def foo(a, b, c = 1)
@@ -94,9 +97,9 @@ module RuboCop
 
         def args_count(node)
           if count_keyword_args?
-            node.children.size
+            node.children.count { |a| !a.blockarg_type? }
           else
-            node.children.count { |a| !NAMED_KEYWORD_TYPES.include?(a.type) }
+            node.children.count { |a| !NAMED_KEYWORD_TYPES.include?(a.type) && !a.blockarg_type? }
           end
         end
 

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -82,4 +82,18 @@ RSpec.describe RuboCop::Cop::Metrics::ParameterLists, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense when method has allowed amount of args with block arg' do
+    expect_no_offenses(<<~RUBY)
+      def foo(a, b, c, d, &block)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when method has no args' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #10186.

Explicit block arg `&block` is not counted by default to prevent erroneous change that is avoided by making block arg implicit.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
