### PR TITLE
[Fix #10147] Fix `Lint/ElseLayout` for else nodes with a single line body

### DIFF
--- a/changelog/fix_fix_lintelselayout_for_else_nodes_with_a.md
+++ b/changelog/fix_fix_lintelselayout_for_else_nodes_with_a.md
@@ -1,0 +1,1 @@
+* [#10147](https://github.com/rubocop/rubocop/issues/10147): Fix `Lint/ElseLayout` for else nodes with a single line body. ([@jkeck][])

--- a/lib/rubocop/cop/lint/else_layout.rb
+++ b/lib/rubocop/cop/lint/else_layout.rb
@@ -73,8 +73,17 @@ module RuboCop
 
           return unless first_else
           return unless same_line?(first_else, node.loc.else)
+          return if else_branch_with_no_body?(node)
 
           add_offense(first_else) { |corrector| autocorrect(corrector, node, first_else) }
+        end
+
+        def else_branch_with_no_body?(node)
+          child_lines = node.else_branch.children.collect do |child|
+            child.loc.line if child.is_a?(RuboCop::AST::Node)
+          end.compact
+
+          child_lines.push(node.else_branch.loc.line).all?(node.loc.else.line)
         end
 
         def autocorrect(corrector, node, first_else)

--- a/spec/rubocop/cop/lint/else_layout_spec.rb
+++ b/spec/rubocop/cop/lint/else_layout_spec.rb
@@ -23,24 +23,6 @@ RSpec.describe RuboCop::Cop::Lint::ElseLayout, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects for the entire else body being on the same line' do
-    expect_offense(<<~RUBY)
-      if something
-        test
-      else something_else
-           ^^^^^^^^^^^^^^ Odd `else` layout detected. Did you mean to use `elsif`?
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      if something
-        test
-      else
-        something_else
-      end
-    RUBY
-  end
-
   it 'accepts proper else' do
     expect_no_offenses(<<~RUBY)
       if something
@@ -138,6 +120,15 @@ RSpec.describe RuboCop::Cop::Lint::ElseLayout, :config do
   it 'does not register an offense if the entire if is on a single line' do
     expect_no_offenses(<<~RUBY)
       if a then b else c end
+    RUBY
+  end
+
+  it 'does not register an offense when the entire else body is on a single line' do
+    expect_no_offenses(<<~RUBY)
+      if something
+        foo
+      else something_else
+      end
     RUBY
   end
 end


### PR DESCRIPTION
The ElseLayout cop, in spirit, is trying to prevent accidentally using
else when a user meant to use elsif based on the fact that they used
else in a similar way as elsif (by passing an argument to it).

However; the syntax of having a compact single line else statement with
no other body is valid and likely shouldn't be flagged as problematic.

This commit stops ElseLayout cop from reporting an offense when all the
else branch's children are on the same line as the else node itself,
while still reporting errors if there are children on other lines in the
else branch (which is likely a mistake)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
