### PR TITLE
Fix an error for `Layout/EmptyLinesAroundExceptionHandlingKeywords`

### DIFF
--- a/changelog/fix_an_error_for_empty_lines_around_exception_handling_keywords.md
+++ b/changelog/fix_an_error_for_empty_lines_around_exception_handling_keywords.md
@@ -1,0 +1,1 @@
+* [#10193](https://github.com/rubocop/rubocop/pull/10193): Fix an error for `Layout/EmptyLinesAroundExceptionHandlingKeywords` when `begin` and `rescue` are on the same line. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_lines_around_exception_handling_keywords.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_exception_handling_keywords.rb
@@ -65,21 +65,24 @@ module RuboCop
         MSG = 'Extra empty line detected %<location>s the `%<keyword>s`.'
 
         def on_def(node)
-          check_body(node.body)
+          check_body(node.body, node.loc.line)
         end
         alias on_defs on_def
 
         def on_kwbegin(node)
           body, = *node
-          check_body(body)
+          check_body(body, node.loc.line)
         end
 
         private
 
-        def check_body(node)
-          locations = keyword_locations(node)
+        def check_body(body, line_of_def_or_kwbegin)
+          locations = keyword_locations(body)
+
           locations.each do |loc|
             line = loc.line
+            next if line == line_of_def_or_kwbegin
+
             keyword = loc.source
             # below the keyword
             check_line(style, line, message('after', keyword), &:empty?)

--- a/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
@@ -127,6 +127,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords, 
     end
   RUBY
 
+  include_examples 'accepts', '`begin` and `rescue` are on the same line', <<~RUBY
+    begin; foo; rescue => e; end
+  RUBY
+
+  include_examples 'accepts', '`def` and `rescue` are on the same line', <<~RUBY
+    def do_something; foo; rescue => e; end
+  RUBY
+
   it 'with complex begin-end - registers many offenses' do
     expect_offense(<<~RUBY)
       begin


### PR DESCRIPTION
This PR fixes the following error for `Layout/EmptyLinesAroundExceptionHandlingKeywords` when `begin` and `rescue` are on the same line.

```console
% echo 'begin; foo; rescue => e; end' | bundle exec rubocop --stdin
  example.rb -d
For /Users/koic/src/github.com/rubocop/rubocop: configuration from
  /Users/koic/src/github.com/rubocop/rubocop/.rubocop.yml
configuration from
  /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-performance-1.11.5/config/default.yml
configuration from
  /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-performance-1.11.5/config/default.yml
Default configuration from
  /Users/koic/src/github.com/rubocop/rubocop/config/default.yml
configuration from
  /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-rspec-2.5.0/config/default.yml
configuration from
  /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-rspec-2.5.0/config/default.yml
configuration from
  /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-rake-0.6.0/config/default.yml
configuration from
  /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-rake-0.6.0/config/default.yml
Inheriting configuration from
  /Users/koic/src/github.com/rubocop/rubocop/.rubocop_todo.yml
Inspecting 1 file
Scanning /Users/koic/src/github.com/rubocop/rubocop/example.rb
An error occurred while Layout/EmptyLinesAroundExceptionHandlingKeywords
  cop was inspecting
  /Users/koic/src/github.com/rubocop/rubocop/example.rb:1:0.
The range 29...30 is outside the bounds of the source
/Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/parser-3.0.2.0/lib/parser/source/tree_rewriter.rb:406:in
  `check_range_validity'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/corrector.rb:100:in
  `check_range_validity'
/Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/parser-3.0.2.0/lib/parser/source/tree_rewriter.rb:398:in
  `combine'
/Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/parser-3.0.2.0/lib/parser/source/tree_rewriter.rb:194:in
  `replace'
/Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/parser-3.0.2.0/lib/parser/source/tree_rewriter.rb:218:in
  `remove'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/correctors/empty_line_corrector.rb:13:in
  `correct'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/mixin/empty_lines_around_body.rb:104:in
  `block in check_line'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/base.rb:342:in
  `correct'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/base.rb:127:in `add_offense'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
