### PR TITLE
Fix a false positive for `Lint/SymbolConversion`

### DIFF
--- a/changelog/fix_false_positive_for_lint_symbol_conversion.md
+++ b/changelog/fix_false_positive_for_lint_symbol_conversion.md
@@ -1,0 +1,1 @@
+* [#10196](https://github.com/rubocop/rubocop/pull/10196): Fix a false positive for `Lint/SymbolConversion` when using a Hash key with a mixture of multibyte characters starting with an ascii alphabet character. ([@koic][])

--- a/lib/rubocop/cop/lint/symbol_conversion.rb
+++ b/lib/rubocop/cop/lint/symbol_conversion.rb
@@ -145,7 +145,7 @@ module RuboCop
           # raise a syntax error (eg. `{ ==: ... }`). Therefore, if the
           # symbol does not start with an alphanumeric or underscore, it
           # will be ignored.
-          return unless node.value.to_s.match?(/\A[a-z0-9_]/i)
+          return unless node.value.to_s.match?(/\A([a-z0-9_!?]+\z)/i)
 
           correction = node.value.inspect.delete_prefix(':')
           return if properly_quoted?(node.source, correction)

--- a/spec/rubocop/cop/lint/symbol_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/symbol_conversion_spec.rb
@@ -62,6 +62,18 @@ RSpec.describe RuboCop::Cop::Lint::SymbolConversion, :config do
         RUBY
       end
 
+      it 'does not register an offense for a string key that is a multibyte character' do
+        expect_no_offenses(<<~RUBY)
+          { 'あ': 'bar' }
+        RUBY
+      end
+
+      it 'does not register an offense for a string key with a mixture of multibyte characters starting with ascii alphabet' do
+        expect_no_offenses(<<~RUBY)
+          { 'Aあ': 'bar' }
+        RUBY
+      end
+
       it 'does not register an offense for a require quoted symbol that contains `:`' do
         expect_no_offenses(<<~RUBY)
           { 'foo:bar': 'bar' }


### PR DESCRIPTION
When using multibyte characters as a Hash key string, it seems natural in my opinion to be quoted. Currently, it is detected when starting with an alphabet as shown below.

```console
% echo '{ "あ": "foo", "Aあ": "bar" }' | bundle exec rubocop --stdin \
  example.rb --only Lint/SymbolConversion -A
Inspecting 1 file
W

Offenses:

example.rb:1:15: W: [Corrected] Lint/SymbolConversion: Unnecessary
symbol conversion; use Aあ: instead.
{ "あ": "foo", "Aあ": "bar" }
               ^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
====================
{ "あ": "foo", Aあ: "bar" }
```

This PR will consistently allow key strings that use quoted multibyte characters.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
