### PR TITLE
Change `AllowAdjacentOneLineDefs` config parameter of `Layout/EmptyLineBetweenDefs` to `true` by default

### DIFF
--- a/changelog/change_allow_adjacent_one_line_defs_true_by_default.md
+++ b/changelog/change_allow_adjacent_one_line_defs_true_by_default.md
@@ -1,0 +1,1 @@
+* [#10199](https://github.com/rubocop/rubocop/pull/10199): Change `AllowAdjacentOneLineDefs` config parameter of `Layout/EmptyLineBetweenDefs` to `true` by default . ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -511,13 +511,13 @@ Layout/EmptyLineBetweenDefs:
   StyleGuide: '#empty-lines-between-methods'
   Enabled: true
   VersionAdded: '0.49'
-  VersionChanged: '1.7'
+  VersionChanged: '<<next>>'
   EmptyLineBetweenMethodDefs: true
   EmptyLineBetweenClassDefs: true
   EmptyLineBetweenModuleDefs: true
-  # If `true`, this parameter means that single line method definitions don't
-  # need an empty line between them.
-  AllowAdjacentOneLineDefs: false
+  # `AllowAdjacentOneLineDefs` means that single line method definitions don't
+  # need an empty line between them. `true` by default.
+  AllowAdjacentOneLineDefs: true
   # Can be array to specify minimum and maximum number of empty lines, e.g. [1, 2]
   NumberOfEmptyLines: 1
 

--- a/lib/rubocop/cop/layout/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/layout/empty_line_between_defs.rb
@@ -77,11 +77,32 @@ module RuboCop
       #   def b
       #   end
       #
-      # @example AllowAdjacentOneLineDefs: true
+      # @example AllowAdjacentOneLineDefs: true (default)
       #
       #   # good
       #   class ErrorA < BaseError; end
       #   class ErrorB < BaseError; end
+      #   class ErrorC < BaseError; end
+      #
+      #   # good
+      #   class ErrorA < BaseError; end
+      #
+      #   class ErrorB < BaseError; end
+      #
+      #   class ErrorC < BaseError; end
+      #
+      # @example AllowAdjacentOneLineDefs: false
+      #
+      #   # bad
+      #   class ErrorA < BaseError; end
+      #   class ErrorB < BaseError; end
+      #   class ErrorC < BaseError; end
+      #
+      #   # good
+      #   class ErrorA < BaseError; end
+      #
+      #   class ErrorB < BaseError; end
+      #
       #   class ErrorC < BaseError; end
       #
       class EmptyLineBetweenDefs < Base


### PR DESCRIPTION
This PR changes `AllowAdjacentOneLineDefs` config parameter of `Layout/EmptyLineBetweenDefs` to `true` by default.

Currently, warnings that occur are different for each type of definition grouped as shown below.

```console
% cat example.rb
class FooError < StandardError; end
class BarError < StandardError; end
class BazError < StandardError; end

attr_accessor :foo
attr_accessor :bar
attr_accessor :baz

before_action :do_foo
before_action :do_bar
before_action :do_baz
```

```console
% bundle exec rubocop
(snip)

Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Correctable] Style/FrozenStringLiteralComment:
Missing frozen string literal comment.
class FooError < StandardError; end
^
example.rb:2:1: C: [Correctable] Layout/EmptyLineBetweenDefs: Expected 1
empty line between class definitions; found 0.
class BarError < StandardError; end
^^^^^^^^^^^^^^
example.rb:3:1: C: [Correctable] Layout/EmptyLineBetweenDefs: Expected 1
empty line between class definitions; found 0.
class BazError < StandardError; end
^^^^^^^^^^^^^^

1 file inspected, 3 offenses detected, 3 offenses auto-correctable
```

This `AllowAdjacentOneLineDefs: true` makes it consistent so that there are no blank lines when grouped by one liner definitions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
