### PR TITLE
[Fix #10200] Fix an error when inspecting a directory named `*`

### DIFF
--- a/changelog/fix_error_when_inspecting_dir_named_wildcard.md
+++ b/changelog/fix_error_when_inspecting_dir_named_wildcard.md
@@ -1,0 +1,1 @@
+* [#10200](https://github.com/rubocop/rubocop/issues/10200): Fix an error when inspecting a directory named `*`. ([@koic][])

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -95,7 +95,7 @@ module RuboCop
 
     def wanted_dir_patterns(base_dir, exclude_pattern, flags)
       base_dir = base_dir.gsub('/{}/', '/\{}/')
-      dirs = Dir.glob(File.join(base_dir.gsub('/**/', '/\**/'), '*/'), flags)
+      dirs = Dir.glob(File.join(base_dir.gsub('/*/', '/\*/').gsub('/**/', '/\**/'), '*/'), flags)
                 .reject do |dir|
                   next true if dir.end_with?('/./', '/../')
                   next true if File.fnmatch?(exclude_pattern, dir, flags)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -258,6 +258,20 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         end
       end
     end
+
+    context 'when a directory is named `*`' do
+      before do
+        FileUtils.mkdir('*')
+      end
+
+      after do
+        FileUtils.rmdir('*')
+      end
+
+      it 'does not crash' do
+        expect(cli.run([])).to eq(0)
+      end
+    end
   end
 
   describe 'rubocop:disable comment' do


### PR DESCRIPTION
Fixes #10200.

This PR fixes an error when inspecting a directory named `*`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
