### PR TITLE
Fix false positive in Layout/DotPosition

### DIFF
--- a/changelog/fix_fix_false_positive_in_layoutdotposition.md
+++ b/changelog/fix_fix_false_positive_in_layoutdotposition.md
@@ -1,0 +1,1 @@
+* [#10207](https://github.com/rubocop/rubocop/pull/10207): Fix false positive in Layout/DotPosition when the selector is on the same line as the closing bracket of the receiver. ([@mvz][])

--- a/lib/rubocop/cop/layout/dot_position.rb
+++ b/lib/rubocop/cop/layout/dot_position.rb
@@ -70,7 +70,7 @@ module RuboCop
         def proper_dot_position?(node)
           selector_range = selector_range(node)
 
-          return true if same_line?(selector_range, selector_range(node.receiver))
+          return true if same_line?(selector_range, end_range(node.receiver))
 
           selector_line = selector_range.line
           receiver_line = receiver_end_line(node.receiver)
@@ -117,6 +117,10 @@ module RuboCop
 
         def heredoc?(node)
           (node.str_type? || node.dstr_type?) && node.heredoc?
+        end
+
+        def end_range(node)
+          node.source_range.end
         end
 
         def selector_range(node)

--- a/spec/rubocop/cop/layout/dot_position_spec.rb
+++ b/spec/rubocop/cop/layout/dot_position_spec.rb
@@ -316,6 +316,14 @@ RSpec.describe RuboCop::Cop::Layout::DotPosition, :config do
       expect_no_offenses('puts something')
     end
 
+    it 'does not err on method call with multi-line arguments' do
+      expect_no_offenses(<<~RUBY)
+        foo(
+          bar
+        ).baz
+      RUBY
+    end
+
     it 'does not err on method call without a method name' do
       expect_offense(<<~RUBY)
         l


### PR DESCRIPTION
This fixes a false positive in Layout/DotPosition where an offense would be registered for the trailing style when the receiver was a method call with multiline arguments, and the selector was on the same line as the receiver's closing bracket.

For example, before this change, the following offense would be registered:

```
foo(
  bar
).baz
 ^ Place the . on the previous line, together with the method call receiver.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
