### PR TITLE
Make `Lint/DeprecatedConstants` aware of `Net::HTTPServerException`

### DIFF
--- a/changelog/change_make_deprecated_constants_aware_of_net_http_server_exception.md
+++ b/changelog/change_make_deprecated_constants_aware_of_net_http_server_exception.md
@@ -1,0 +1,1 @@
+* [#10209](https://github.com/rubocop/rubocop/pull/10209): Make `Lint/DeprecatedConstants` aware of `Net::HTTPServerException`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1568,6 +1568,7 @@ Lint/DeprecatedConstants:
   Description: 'Checks for deprecated constants.'
   Enabled: pending
   VersionAdded: '1.8'
+  VersionChanged: '<<next>>'
   # You can configure deprecated constants.
   # If there is an alternative method, you can set alternative value as `Alternative`.
   # And you can set the deprecated version as `DeprecatedVersion`.
@@ -1588,6 +1589,9 @@ Lint/DeprecatedConstants:
     'FALSE':
       Alternative: 'false'
       DeprecatedVersion: '2.4'
+    'Net::HTTPServerException':
+      Alternative: 'Net::HTTPClientException'
+      DeprecatedVersion: '2.6'
     'Random::DEFAULT':
       Alternative: 'Random.new'
       DeprecatedVersion: '3.0'

--- a/lib/rubocop/cop/lint/deprecated_constants.rb
+++ b/lib/rubocop/cop/lint/deprecated_constants.rb
@@ -42,11 +42,12 @@ module RuboCop
           #        Maybe further investigation of RuboCop AST will lead to an essential solution.
           return unless node.loc
 
-          constant = node.absolute? ? constant_name(node, node.short_name.to_s) : node.source
+          constant = node.absolute? ? constant_name(node, node.short_name) : node.source
           return unless (deprecated_constant = deprecated_constants[constant])
 
           alternative = deprecated_constant['Alternative']
           version = deprecated_constant['DeprecatedVersion']
+          return if target_ruby_version < version.to_f
 
           add_offense(node, message: message(alternative, node.source, version)) do |corrector|
             corrector.replace(node, alternative)
@@ -56,7 +57,7 @@ module RuboCop
         private
 
         def constant_name(node, nested_constant_name)
-          return nested_constant_name unless node.namespace.const_type?
+          return nested_constant_name.to_s unless node.namespace.const_type?
 
           constant_name(node.namespace, "#{node.namespace.short_name}::#{nested_constant_name}")
         end


### PR DESCRIPTION
This PR makes `Lint/DeprecatedConstants` aware of `Net::HTTPServerException`.

The following warning was introduced since Ruby 2.6.

```console
% ruby -rnet/http -vwe 'p Net::HTTPServerException'
ruby 2.6.8p205 (2021-07-07 revision 67951) [x86_64-darwin19]
-e:1: warning: constant Net::HTTPServerException is deprecated
Net::HTTPServerException
```

And `HTTPClientException` (alias) is used as an alternative to `HTTPServerException`.

The following is the quote from Ruby 2.6.0 release news.

> Add `Net::HTTPClientException` to deprecate `Net::HTTPServerException`,
> whose name is misleading. [Bug #14688]

https://github.com/ruby/ruby/blob/master/doc/NEWS-2.6.0

```console
% ruby -rnet/http -vwe 'p Net::HTTPClientException'
ruby 2.6.8p205 (2021-07-07 revision 67951) [x86_64-darwin19]
Net::HTTPServerException
```

`HTTPClientException` does not yet exist in Ruby 2.5, so the following error occurs.

```console
% ruby -rnet/http -vwe 'p Net::HTTPClientException'
ruby 2.5.9p229 (2021-04-05 revision 67939) [x86_64-darwin19]
Traceback (most recent call last):
-e:1:in `<main>': uninitialized constant
Net::HTTPClientException (NameError)
Did you mean?  Net::HTTPServerException
```

To prevent such errors, the cop's behavior is changed to detect only `DeprecatedVersion` or higher.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
