### PR TITLE
Fix an error for `Layout/BlockAlignment` when using Ruby 3.1.0-dev

### DIFF
--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -101,11 +101,11 @@ module RuboCop
         def block_end_align_target(node)
           lineage = [node, *node.ancestors]
 
-          target = lineage.each_cons(2) do |current, parent|
-            break current if end_align_target?(current, parent)
+          lineage.each_cons(2) do |current, parent|
+            return current if end_align_target?(current, parent)
           end
 
-          target || lineage.last
+          lineage.last
         end
 
         def end_align_target?(node, parent)


### PR DESCRIPTION
This PR fixes the following build error.

```console
% bundle exec rspec ./spec/rubocop/cop/layout/block_alignment_spec.rb:222
(snip)

      # ./lib/rubocop/cop/layout/block_alignment.rb:97:in `start_for_block_node'
      # ./lib/rubocop/cop/layout/block_alignment.rb:82:in `on_block'
      # ./lib/rubocop/cop/commissioner.rb:100:in `public_send'
      # ./lib/rubocop/cop/commissioner.rb:100:in `block (2 levels) in trigger_responding_cops'
      # ./lib/rubocop/cop/commissioner.rb:160:in `with_cop_error_handling'
      # ./lib/rubocop/cop/commissioner.rb:99:in `block in trigger_responding_cops'
```

https://app.circleci.com/pipelines/github/rubocop/rubocop/5414/workflows/4a7e4b81-7380-41e5-8ede-e28d9160010d/jobs/201236

I reported on this change of behavior.
https://bugs.ruby-lang.org/issues/18268

And it was due to the following change.
https://github.com/ruby/ruby/pull/1509

This PR will be changed to the cop logic that is not affected by the above Ruby 3.1.0-dev change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
