### PR TITLE
[Fix #10216] Fix an incorrect autocorrect for `Style/SelectByRegexp`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_select_by_regexp.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_select_by_regexp.md
@@ -1,0 +1,1 @@
+* [#10216](https://github.com/rubocop/rubocop/issues/10216): Fix an incorrect autocorrect for `Style/SelectByRegexp` when using `lvar =~ blockvar` in a block. ([@koic][])

--- a/lib/rubocop/cop/style/select_by_regexp.rb
+++ b/lib/rubocop/cop/style/select_by_regexp.rb
@@ -85,7 +85,7 @@ module RuboCop
           return unless (regexp_method_send_node = extract_send_node(block_node))
           return if match_predicate_without_receiver?(regexp_method_send_node)
 
-          regexp = find_regexp(regexp_method_send_node)
+          regexp = find_regexp(regexp_method_send_node, block_node)
           register_offense(node, block_node, regexp)
         end
 
@@ -119,10 +119,11 @@ module RuboCop
           regexp_method_send_node
         end
 
-        def find_regexp(node)
+        def find_regexp(node, block)
           return node.child_nodes.first if node.match_with_lvasgn_type?
 
-          if node.receiver.lvar_type?
+          if node.receiver.lvar_type? &&
+             (block.numblock_type? || node.receiver.source == block.arguments.first.source)
             node.first_argument
           elsif node.first_argument.lvar_type?
             node.receiver

--- a/spec/rubocop/cop/style/select_by_regexp_spec.rb
+++ b/spec/rubocop/cop/style/select_by_regexp_spec.rb
@@ -38,6 +38,19 @@ RSpec.describe RuboCop::Cop::Style::SelectByRegexp, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects for `blockvar =~ lvar`' do
+        expect_offense(<<~RUBY, method: method)
+          lvar = /regexp/
+          array.#{method} { |x| x =~ lvar }
+          ^^^^^^^{method}^^^^^^^^^^^^^^^^^^ #{message}
+        RUBY
+
+        expect_correction(<<~RUBY)
+          lvar = /regexp/
+          array.#{correction}(lvar)
+        RUBY
+      end
+
       it 'registers an offense and corrects for `regexp =~ blockvar`' do
         expect_offense(<<~RUBY, method: method)
           array.#{method} { |x| /regexp/ =~ x }
@@ -46,6 +59,19 @@ RSpec.describe RuboCop::Cop::Style::SelectByRegexp, :config do
 
         expect_correction(<<~RUBY)
           array.#{correction}(/regexp/)
+        RUBY
+      end
+
+      it 'registers an offense and corrects for `lvar =~ blockvar`' do
+        expect_offense(<<~RUBY, method: method)
+          lvar = /regexp/
+          array.#{method} { |x| lvar =~ x }
+          ^^^^^^^{method}^^^^^^^^^^^^^^^^^^ #{message}
+        RUBY
+
+        expect_correction(<<~RUBY)
+          lvar = /regexp/
+          array.#{correction}(lvar)
         RUBY
       end
 


### PR DESCRIPTION
Fix #10216.

This PR fixes an incorrect autocorrect for `Style/SelectByRegexp` when using `lvar =~ blockvar` in a block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
