### PR TITLE
[#10221] Update `Naming::FileName` to recognize `Struct`s as classes that satisfy the `ExpectMatchingDefinition` requirement

### DIFF
--- a/changelog/change_update_namingfilename_to_recognize.md
+++ b/changelog/change_update_namingfilename_to_recognize.md
@@ -1,0 +1,1 @@
+* [#10221](https://github.com/rubocop/rubocop/issues/10221): Update `Naming::FileName` to recognize `Struct`s as classes that satisfy the `ExpectMatchingDefinition` requirement. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2501,6 +2501,7 @@ Naming/FileName:
   StyleGuide: '#snake-case-files'
   Enabled: true
   VersionAdded: '0.50'
+  VersionChanged: '<<next>>'
   # Camel case file names listed in `AllCops:Include` and all file names listed
   # in `AllCops:Exclude` are excluded by default. Add extra excludes here.
   Exclude: []

--- a/lib/rubocop/cop/naming/file_name.rb
+++ b/lib/rubocop/cop/naming/file_name.rb
@@ -14,6 +14,18 @@ module RuboCop
       # (i.e. `bundler-console` becomes `Bundler::Console`). As such, the
       # gemspec is supposed to be named `bundler-console.gemspec`.
       #
+      # When `ExpectMatchingDefinition` (default: `false`) is `true`, the cop requires
+      # each file to have a class, module or `Struct` defined in it that matches
+      # the filename. This can be further configured using
+      # `CheckDefinitionPathHierarchy` (default: `true`) to determine whether the
+      # path should match the namespace of the above definition.
+      #
+      # When `IgnoreExecutableScripts` (default: `true`) is `true`, files that start
+      # with a shebang line are not considered by the cop.
+      #
+      # When `Regex` is set, the cop will flag any filename that does not match
+      # the regular expression.
+      #
       # @example
       #   # bad
       #   lib/layoutManager.rb

--- a/lib/rubocop/cop/naming/file_name.rb
+++ b/lib/rubocop/cop/naming/file_name.rb
@@ -28,7 +28,7 @@ module RuboCop
         include RangeHelp
 
         MSG_SNAKE_CASE = 'The name of this source file (`%<basename>s`) should use snake_case.'
-        MSG_NO_DEFINITION = '%<basename>s should define a class or module called `%<namespace>s`.'
+        MSG_NO_DEFINITION = '`%<basename>s` should define a class or module called `%<namespace>s`.'
         MSG_REGEX = '`%<basename>s` should match `%<regex>s`.'
 
         SNAKE_CASE = /^[\d[[:lower:]]_.?!]+$/.freeze

--- a/spec/rubocop/cop/naming/file_name_spec.rb
+++ b/spec/rubocop/cop/naming/file_name_spec.rb
@@ -17,93 +17,90 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
   end
 
   let(:includes) { ['**/*.rb'] }
-  let(:source) { 'print 1' }
-  let(:processed_source) { parse_source(source) }
-  let(:offenses) { _investigate(cop, processed_source) }
-  let(:messages) { offenses.sort.map(&:message) }
-
-  before { allow(processed_source.buffer).to receive(:name).and_return(filename) }
 
   context 'with camelCase file names ending in .rb' do
-    let(:filename) { '/some/dir/testCase.rb' }
-
-    it 'reports an offense' do
-      expect(offenses.size).to eq(1)
+    it 'registers an offense' do
+      expect_offense(<<~RUBY, '/some/dir/testCase.rb')
+        print 1
+        ^ The name of this source file (`testCase.rb`) should use snake_case.
+      RUBY
     end
   end
 
   context 'with camelCase file names without file extension' do
-    let(:filename) { '/some/dir/testCase' }
-
-    it 'reports an offense' do
-      expect(offenses.size).to eq(1)
+    it 'registers an offense' do
+      expect_offense(<<~RUBY, '/some/dir/testCase')
+        print 1
+        ^ The name of this source file (`testCase`) should use snake_case.
+      RUBY
     end
   end
 
   context 'with snake_case file names ending in .rb' do
-    let(:filename) { '/some/dir/test_case.rb' }
-
-    it 'reports an offense' do
-      expect(offenses.empty?).to be(true)
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, '/some/dir/test_case.rb')
+        print 1
+      RUBY
     end
   end
 
   context 'with snake_case file names without file extension' do
-    let(:filename) { '/some/dir/test_case' }
-
-    it 'does not report an offense' do
-      expect(offenses.empty?).to be(true)
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, '/some/dir/test_case')
+        print 1
+      RUBY
     end
   end
 
   context 'with snake_case file names with non-rb extension' do
-    let(:filename) { '/some/dir/some_task.rake' }
-
-    it 'does not report an offense' do
-      expect(offenses.empty?).to be(true)
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, '/some/dir/test_case.rake')
+        print 1
+      RUBY
     end
   end
 
   context 'with snake_case file names with multiple extensions' do
-    let(:filename) { 'some/dir/some_view.html.slim_spec.rb' }
-
-    it 'does not report an offense' do
-      expect(offenses.empty?).to be(true)
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, 'some/dir/some_view.html.slim_spec.rb')
+        print 1
+      RUBY
     end
   end
 
   context 'with snake_case names which use ? and !' do
-    let(:filename) { 'some/dir/file?!.rb' }
-
-    it 'does not report an offense' do
-      expect(offenses.empty?).to be(true)
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, 'some/dir/file?!.rb')
+        print 1
+      RUBY
     end
   end
 
   context 'with snake_case names which use +' do
-    let(:filename) { 'some/dir/some_file.xlsx+mobile.axlsx' }
-
-    it 'does not report an offense' do
-      expect(offenses.empty?).to be(true)
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, 'some/dir/some_file.xlsx+mobile.axlsx')
+        print 1
+      RUBY
     end
   end
 
   context 'with non-snake-case file names with a shebang' do
-    let(:filename) { '/some/dir/test-case' }
-    let(:source) { <<~RUBY }
-      #!/usr/bin/env ruby
-      print 1
-    RUBY
-
-    it 'does not report an offense' do
-      expect(offenses.empty?).to be(true)
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, '/some/dir/test-case')
+        #!/usr/bin/env ruby
+        print 1
+      RUBY
     end
 
     context 'when IgnoreExecutableScripts is disabled' do
       let(:cop_config) { { 'IgnoreExecutableScripts' => false } }
 
-      it 'reports an offense' do
-        expect(offenses.size).to eq(1)
+      it 'registers an offense' do
+        expect_offense(<<~RUBY, '/some/dir/test-case')
+          #!/usr/bin/env ruby
+          ^ The name of this source file (`test-case`) should use snake_case.
+          print 1
+        RUBY
       end
     end
   end
@@ -112,10 +109,10 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
     let(:includes) { ['**/Gemfile'] }
 
     context 'with a non-snake_case file name' do
-      let(:filename) { '/some/dir/Gemfile' }
-
-      it 'does not report an offense' do
-        expect(offenses.empty?).to be(true)
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY, '/some/dir/Gemfile')
+          print 1
+        RUBY
       end
     end
   end
@@ -132,129 +129,118 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
     context 'on a file which defines no class or module at all' do
       %w[lib src test spec].each do |dir|
         context "under #{dir}" do
-          let(:filename) { "/some/dir/#{dir}/file/test_case.rb" }
-
           it 'registers an offense' do
-            expect(offenses.size).to eq(1)
-            expect(messages).to eq(['test_case.rb should define a class ' \
-                                    'or module called `File::TestCase`.'])
+            expect_offense(<<~RUBY, "/some/dir/#{dir}/file/test_case.rb")
+              print 1
+              ^ `test_case.rb` should define a class or module called `File::TestCase`.
+            RUBY
           end
         end
       end
 
       context 'under some other random directory' do
-        let(:filename) { '/some/other/dir/test_case.rb' }
-
         it 'registers an offense' do
-          expect(offenses.size).to eq(1)
-          expect(messages).to eq(['test_case.rb should define a class ' \
-                                  'or module called `TestCase`.'])
+          expect_offense(<<~RUBY, '/some/other/dir/test_case.rb')
+            print 1
+            ^ `test_case.rb` should define a class or module called `TestCase`.
+          RUBY
         end
       end
     end
 
     context 'on an empty file' do
-      let(:source) { '' }
-      let(:filename) { '/lib/rubocop/blah.rb' }
-
       it 'registers an offense' do
-        expect(offenses.size).to eq(1)
-        expect(messages).to eq(['blah.rb should define a class or module called `Rubocop::Blah`.'])
+        expect_offense(<<~RUBY, '/lib/rubocop/blah.rb')
+          ^ `blah.rb` should define a class or module called `Rubocop::Blah`.
+        RUBY
       end
     end
 
     context 'on an empty file with a space in its filename' do
-      let(:source) { '' }
-      let(:filename) { 'a file.rb' }
-
       it 'registers an offense' do
-        expect(offenses.size).to eq(1)
-        expect(messages).to eq(['The name of this source file (`a file.rb`) ' \
-                                'should use snake_case.'])
+        expect_offense(<<~RUBY, 'a file.rb')
+          ^ The name of this source file (`a file.rb`) should use snake_case.
+        RUBY
       end
     end
 
-    shared_examples 'matching module or class' do
+    shared_examples 'matching module or class' do |source|
       %w[lib src test spec].each do |dir|
         context "in a matching directory under #{dir}" do
-          let(:filename) { "/some/dir/#{dir}/a/b.rb" }
-
           it 'does not register an offense' do
-            expect(offenses.empty?).to be(true)
+            expect_no_offenses(<<~RUBY, "/some/dir/#{dir}/a/b.rb")
+              #{source}
+            RUBY
           end
         end
 
         context "in a non-matching directory under #{dir}" do
-          let(:filename) { "/some/dir/#{dir}/c/b.rb" }
-
           it 'registers an offense' do
-            expect(offenses.size).to eq(1)
-            expect(messages).to eq(['b.rb should define a class or module called `C::B`.'])
+            expect_offense(<<~RUBY, "/some/dir/#{dir}/c/b.rb")
+              # b.rb
+              ^ `b.rb` should define a class or module called `C::B`.
+              #{source}
+            RUBY
           end
         end
 
         context "in a directory with multiple instances of #{dir}" do
-          let(:filename) { "/some/dir/#{dir}/project/#{dir}/a/b.rb" }
-
           it 'does not register an offense' do
-            expect(offenses.empty?).to be(true)
+            expect_no_offenses(<<~RUBY, "/some/dir/#{dir}/project/#{dir}/a/b.rb")
+              #{source}
+            RUBY
           end
         end
       end
 
       context 'in a directory elsewhere which only matches the module name' do
-        let(:filename) { '/some/dir/b.rb' }
-
         it 'does not register an offense' do
-          expect(offenses.empty?).to be(true)
+          expect_no_offenses(<<~RUBY, '/some/dir/b.rb')
+            #{source}
+          RUBY
         end
       end
 
       context 'in a directory elsewhere which does not match the module name' do
-        let(:filename) { '/some/dir/e.rb' }
-
         it 'registers an offense' do
-          expect(offenses.size).to eq(1)
-          expect(messages).to eq(['e.rb should define a class or module called `E`.'])
+          expect_offense(<<~RUBY, '/some/dir/e.rb')
+            # start of file
+            ^ `e.rb` should define a class or module called `E`.
+            #{source}
+          RUBY
         end
       end
     end
 
     context 'on a file which defines a nested module' do
-      let(:source) { <<~RUBY }
+      include_examples 'matching module or class', <<~RUBY
         module A
           module B
           end
         end
       RUBY
-
-      include_examples 'matching module or class'
     end
 
     context 'on a file which defines a nested class' do
-      let(:source) { <<~RUBY }
+      include_examples 'matching module or class', <<~RUBY
         module A
           class B
           end
         end
       RUBY
-
-      include_examples 'matching module or class'
     end
 
     context 'on a file which uses Name::Spaced::Module syntax' do
-      let(:source) { <<~RUBY }
+      include_examples 'matching module or class', <<~RUBY
         begin
           module A::B
           end
         end
       RUBY
-
-      include_examples 'matching module or class'
     end
 
     context 'on a file which defines multiple classes' do
-      let(:source) { <<~RUBY }
+      include_examples 'matching module or class', <<~RUBY
         class X
         end
         module M
@@ -264,8 +250,6 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
           end
         end
       RUBY
-
-      include_examples 'matching module or class'
     end
   end
 
@@ -279,88 +263,70 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
     end
 
     context 'on a file with a matching class' do
-      let(:source) { <<~RUBY }
-        begin
-          class ImageCollection
-          end
-        end
-      RUBY
-      let(:filename) { '/lib/image_collection.rb' }
-
       it 'does not register an offense' do
-        expect(offenses.empty?).to be(true)
+        expect_no_offenses(<<~RUBY, '/lib/image_collection.rb')
+          begin
+            class ImageCollection
+            end
+          end
+        RUBY
       end
     end
 
     context 'on a file with a non-matching class' do
-      let(:source) { <<~RUBY }
-        begin
-          class PictureCollection
-          end
-        end
-      RUBY
-      let(:filename) { '/lib/image_collection.rb' }
-
       it 'registers an offense' do
-        expect(offenses.size).to eq(1)
-        expect(messages).to eq(['image_collection.rb should define a ' \
-                                'class or module called `ImageCollection`.'])
+        expect_offense(<<~RUBY, '/lib/image_collection.rb')
+          begin
+          ^ `image_collection.rb` should define a class or module called `ImageCollection`.
+            class PictureCollection
+            end
+          end
+        RUBY
       end
     end
 
     context 'on an empty file' do
-      let(:source) { '' }
-      let(:filename) { '/lib/rubocop/foo.rb' }
-
       it 'registers an offense' do
-        expect(offenses.size).to eq(1)
-        expect(messages).to eq(['foo.rb should define a class or module called `Foo`.'])
+        expect_offense(<<~RUBY, '/lib/rubocop/foo.rb')
+          ^ `foo.rb` should define a class or module called `Foo`.
+        RUBY
       end
     end
 
     context 'in a non-matching directory, but with a matching class' do
-      let(:source) { <<~RUBY }
-        begin
-          module Foo
-          end
-        end
-      RUBY
-      let(:filename) { '/lib/some/path/foo.rb' }
-
       it 'does not register an offense' do
-        expect(offenses.empty?).to be(true)
+        expect_no_offenses(<<~RUBY, '/lib/some/path/foo.rb')
+          begin
+            module Foo
+            end
+          end
+        RUBY
       end
     end
 
     context 'with a non-matching module containing a matching class' do
-      let(:source) { <<~RUBY }
-        begin
-          module NonMatching
-            class Foo
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY, 'lib/foo.rb')
+          begin
+            module NonMatching
+              class Foo
+              end
             end
           end
-        end
-      RUBY
-      let(:filename) { 'lib/foo.rb' }
-
-      it 'does not register an offense' do
-        expect(offenses.empty?).to be(true)
+        RUBY
       end
     end
 
     context 'with a matching module containing a non-matching class' do
-      let(:source) { <<~RUBY }
-        begin
-          module Foo
-            class NonMatching
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY, 'lib/foo.rb')
+          begin
+            module Foo
+              class NonMatching
+              end
             end
           end
-        end
-      RUBY
-      let(:filename) { 'lib/foo.rb' }
-
-      it 'does not register an offense' do
-        expect(offenses.empty?).to be(true)
+        RUBY
       end
     end
   end
@@ -369,19 +335,19 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
     let(:cop_config) { { 'Regex' => /\A[aeiou]\z/i } }
 
     context 'with a matching name' do
-      let(:filename) { 'a.rb' }
-
       it 'does not register an offense' do
-        expect(offenses.empty?).to be(true)
+        expect_no_offenses(<<~RUBY, 'a.rb')
+          print 1
+        RUBY
       end
     end
 
     context 'with a non-matching name' do
-      let(:filename) { 'z.rb' }
-
       it 'registers an offense' do
-        expect(offenses.size).to eq(1)
-        expect(messages).to eq(['`z.rb` should match `(?i-mx:\\A[aeiou]\\z)`.'])
+        expect_offense(<<~RUBY, 'z.rb')
+          print 1
+          ^ `z.rb` should match `(?i-mx:\\A[aeiou]\\z)`.
+        RUBY
       end
     end
   end
@@ -395,19 +361,15 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
       }
     end
 
-    let(:filename) { '/lib/my/cli/admin_user.rb' }
-
-    let(:source) { <<~RUBY }
-      module My
-        module CLI
-          class AdminUser
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, '/lib/my/cli/admin_user.rb')
+        module My
+          module CLI
+            class AdminUser
+            end
           end
         end
-      end
-    RUBY
-
-    it 'does not register an offense' do
-      expect(offenses.empty?).to be(true)
+      RUBY
     end
   end
 
@@ -420,17 +382,13 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
       }
     end
 
-    let(:filename) { '/lib/my/cli.rb' }
-
-    let(:source) { <<~RUBY }
-      module My
-        class CLI
-        end
-      end
-    RUBY
-
     it 'does not register an offense' do
-      expect(offenses.empty?).to be(true)
+      expect_no_offenses(<<~RUBY, '/lib/my/cli.rb')
+        module My
+          class CLI
+          end
+        end
+      RUBY
     end
   end
 
@@ -443,33 +401,29 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
       }
     end
 
-    let(:filename) { '/lib/my/http_server.rb' }
-
-    let(:source) { <<~RUBY }
-      module My
-        class HTTPServer
-        end
-      end
-    RUBY
-
     it 'does not register an offense' do
-      expect(offenses.empty?).to be(true)
+      expect_no_offenses(<<~RUBY, '/lib/my/http_server.rb')
+        module My
+          class HTTPServer
+          end
+        end
+      RUBY
     end
   end
 
   context 'with dotfiles' do
-    let(:filename) { '.pryrc' }
-
-    it 'does not report an offense' do
-      expect(offenses.empty?).to be(true)
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, '.pryrc')
+        print 1
+      RUBY
     end
   end
 
   context 'with non-ascii characters in filename' do
-    let(:filename) { '/some/dir/ünbound_sérvér.rb' }
-
-    it 'reports an offense' do
-      expect(offenses.empty?).to be(true)
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, '/some/dir/ünbound_sérvér.rb')
+        print 1
+      RUBY
     end
   end
 end


### PR DESCRIPTION
Allows `Struct`s assigned to constants to be used for `ExpectMatchingDefinition` of `Naming::FileName`.

Allow refactors the cop's tests to use `expect_offense` and adds some documentation for options that aren't explained.

Fixes #10221.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
