### PR TITLE
Naming/FileName: make CheckDefinitionPathHierarchy roots configureable

### DIFF
--- a/changelog/change_namingfilename_make.md
+++ b/changelog/change_namingfilename_make.md
@@ -1,0 +1,1 @@
+* [#10220](https://github.com/rubocop/rubocop/issues/10220): Update `Naming/FileName` to make `CheckDefinitionPathHierarchy` roots configurable. ([@grosser][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2520,6 +2520,13 @@ Naming/FileName:
   # whether each source file's class or module name matches the file name --
   # not whether the nested module hierarchy matches the subdirectory path.
   CheckDefinitionPathHierarchy: true
+  # paths that are considered root directories, for example "lib" in most ruby projects
+  # or "app/models" in rails projects
+  CheckDefinitionPathHierarchyRoots:
+    - lib
+    - spec
+    - test
+    - src
   # If non-`nil`, expect all source file names to match the following regex.
   # Only the file name itself is matched, not the entire file path.
   # Use anchors as necessary if you want to match the entire name rather than

--- a/lib/rubocop/cop/naming/file_name.rb
+++ b/lib/rubocop/cop/naming/file_name.rb
@@ -123,6 +123,10 @@ module RuboCop
           cop_config['CheckDefinitionPathHierarchy']
         end
 
+        def definition_path_hierarchy_roots
+          cop_config['CheckDefinitionPathHierarchyRoots'] || []
+        end
+
         def regex
           cop_config['Regex']
         end
@@ -206,13 +210,13 @@ module RuboCop
           allowed_acronyms.any? { |acronym| expected.gsub(acronym.capitalize, acronym) == name }
         end
 
-        def to_namespace(path)
+        def to_namespace(path) # rubocop:disable Metrics/AbcSize
           components = Pathname(path).each_filename.to_a
           # To convert a pathname to a Ruby namespace, we need a starting point
           # But RC can be run from any working directory, and can check any path
           # We can't assume that the working directory, or any other, is the
           # "starting point" to build a namespace.
-          start = %w[lib spec test src]
+          start = definition_path_hierarchy_roots
           start_index = nil
 
           # To find the closest namespace root take the path components, and


### PR DESCRIPTION
fixes https://github.com/rubocop/rubocop/issues/10220

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/

confirmed that it fixes the issue:
```
parts/monitors/foo/bar.rb:1:1: C: Naming/FileName: bar.rb should define a class or module called Monitors::Foo::Bar. (https://rubystyle.guide#snake-case-files)
module Monitors
^
```