### PR TITLE
[Fix #10227] Fix a false positive for `Style/ParenthesesAroundCondition`

### DIFF
--- a/changelog/fix_false_positive_for_style_parentheses_around_condition.md
+++ b/changelog/fix_false_positive_for_style_parentheses_around_condition.md
@@ -1,0 +1,1 @@
+* [#10227](https://github.com/rubocop/rubocop/issues/10227): Fix a false positive for `Style/ParenthesesAroundCondition` when parentheses in multiple expressions separated by semicolon. ([@koic][])

--- a/lib/rubocop/cop/style/parentheses_around_condition.rb
+++ b/lib/rubocop/cop/style/parentheses_around_condition.rb
@@ -56,6 +56,7 @@ module RuboCop
       class ParenthesesAroundCondition < Base
         include SafeAssignment
         include Parentheses
+        include RangeHelp
         extend AutoCorrector
 
         def on_if(node)
@@ -73,13 +74,14 @@ module RuboCop
 
         # @!method control_op_condition(node)
         def_node_matcher :control_op_condition, <<~PATTERN
-          (begin $_ ...)
+          (begin $_ $...)
         PATTERN
 
         def process_control_op(node)
           cond = node.condition
 
-          control_op_condition(cond) do |first_child|
+          control_op_condition(cond) do |first_child, rest_children|
+            return if semicolon_separated_expressions?(first_child, rest_children)
             return if modifier_op?(first_child)
             return if parens_allowed?(cond)
 
@@ -88,6 +90,14 @@ module RuboCop
               ParenthesesCorrector.correct(corrector, cond)
             end
           end
+        end
+
+        def semicolon_separated_expressions?(first_exp, rest_exps)
+          return false unless (second_exp = rest_exps.first)
+
+          range = range_between(first_exp.source_range.end_pos, second_exp.source_range.begin_pos)
+
+          range.source.include?(';')
         end
 
         def modifier_op?(node)

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -102,6 +102,14 @@ RSpec.describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
     RUBY
   end
 
+  it 'does not register an offense when parentheses in multiple expressions separated by semicolon' do
+    expect_no_offenses(<<~RUBY)
+      if (foo; bar)
+        do_something
+      end
+    RUBY
+  end
+
   context 'safe assignment is allowed' do
     it 'accepts variable assignment in condition surrounded with parentheses' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #10227.

This PR fixes a false positive for `Style/ParenthesesAroundCondition` when parentheses in multiple expressions separated by semicolon.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
