### PR TITLE
Fix a false positive for `Style/StringLiterals`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_string_literals.md
+++ b/changelog/fix_a_false_positive_for_style_string_literals.md
@@ -1,0 +1,1 @@
+* [#10229](https://github.com/rubocop/rubocop/pull/10229): Fix a false positive for `Style/StringLiterals` when `EnforcedStyle: double_quotes` and using single quoted string with backslash. ([@koic][])

--- a/lib/rubocop/cop/mixin/string_literals_help.rb
+++ b/lib/rubocop/cop/mixin/string_literals_help.rb
@@ -13,11 +13,7 @@ module RuboCop
         if style == :single_quotes
           !double_quotes_required?(src)
         else
-          # The string needs single quotes if:
-          # 1. It contains a double quote
-          # 2. It contains text that would become an escape sequence with double quotes
-          # 3. It contains text that would become an interpolation with double quotes
-          !/" | (?<!\\)\\[aAbcdefkMnprsStuUxzZ0-7] | \#[@{$]/x.match?(src)
+          !/" | \\[^'\\] | \#[@{$]/x.match?(src)
         end
       end
     end

--- a/lib/rubocop/cop/style/quoted_symbols.rb
+++ b/lib/rubocop/cop/style/quoted_symbols.rb
@@ -46,7 +46,7 @@ module RuboCop
 
           message = style == :single_quotes ? MSG_SINGLE : MSG_DOUBLE
 
-          if wrong_quotes?(node)
+          if wrong_quotes?(node) || invalid_double_quotes?(node.source)
             add_offense(node, message: message) do |corrector|
               opposite_style_detected
               autocorrect(corrector, node)
@@ -57,6 +57,16 @@ module RuboCop
         end
 
         private
+
+        def invalid_double_quotes?(source)
+          return false unless style == :double_quotes
+
+          # The string needs single quotes if:
+          # 1. It contains a double quote
+          # 2. It contains text that would become an escape sequence with double quotes
+          # 3. It contains text that would become an interpolation with double quotes
+          !/" | (?<!\\)\\[aAbcdefkMnprsStuUxzZ0-7] | \#[@{$]/x.match?(source)
+        end
 
         def autocorrect(corrector, node)
           str = if hash_colon_key?(node)

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -254,6 +254,14 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
       expect_no_offenses('a = %(x)')
     end
 
+    it 'accepts single quoted string with backslash' do
+      expect_no_offenses(<<~'RUBY')
+        '\,'
+        '100\%'
+        '(\)'
+      RUBY
+    end
+
     it 'accepts heredocs' do
       expect_no_offenses(<<~RUBY)
         execute <<-SQL


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/pull/10166#issuecomment-956190960.

This PR fixes a false positive for `Style/StringLiterals` when `EnforcedStyle: double_quotes` and using single quoted string with backslash.
It has moved a separate implementation for `Style/QuotedSymbols` to resolve #10152 to `Style/QuotedSymbols` to prevent impact on `Style/StringLiterals`'s false positives.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
