### PR TITLE
[Fix #10230] Fix a false positive for `Lint/AmbiguousRange`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_ambiguous_range.md
+++ b/changelog/fix_a_false_positive_for_lint_ambiguous_range.md
@@ -1,0 +1,1 @@
+* [#10230](https://github.com/rubocop/rubocop/issues/10230): Fix a false positive for `Lint/AmbiguousRange` when a range is composed of all literals except basic literals. ([@koic][])

--- a/lib/rubocop/cop/lint/ambiguous_range.rb
+++ b/lib/rubocop/cop/lint/ambiguous_range.rb
@@ -8,7 +8,7 @@ module RuboCop
       # Ranges have quite low precedence, which leads to unexpected behaviour when
       # using a range with other operators. This cop avoids that by making ranges
       # explicit by requiring parenthesis around complex range boundaries (anything
-      # that is not a basic literal: numerics, strings, symbols, etc.).
+      # that is not a literal: numerics, strings, symbols, etc.).
       #
       # This cop can be configured with `RequireParenthesesForMethodChains` in order to
       # specify whether method chains (including `self.foo`) should be wrapped in parens
@@ -81,7 +81,7 @@ module RuboCop
 
         def acceptable?(node)
           node.begin_type? ||
-            node.basic_literal? ||
+            node.literal? ||
             node.variable? || node.const_type? || node.self_type? ||
             (node.call_type? && acceptable_call?(node))
         end

--- a/spec/rubocop/cop/lint/ambiguous_range_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_range_spec.rb
@@ -55,10 +55,15 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRange, :config do
         RUBY
       end
 
-      it 'does not register an offense if the range is composed of basic literals' do
+      it 'does not register an offense if the range is composed of literals' do
         expect_no_offenses(<<~RUBY)
           1#{operator}2
           'a'#{operator}'z'
+          "\#{foo}-\#{bar}"#{operator}'123-4567'
+          `date`#{operator}'foobar'
+          :"\#{foo}-\#{bar}"#{operator}:baz
+          /a/#{operator}/b/
+          42#{operator}nil
         RUBY
       end
 


### PR DESCRIPTION
Fixes #10230.

This PR fixes a false positive for `Lint/AmbiguousRange` when a range is composed of some literals.
If it's just literals, it's clear even without parentheses, so this PR will accept them.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
