### PR TITLE
[Fix #10174] Fix inherit_from_remote should follow remote includes path starting with `./`

### DIFF
--- a/changelog/fix_inherit_from_remote_should_follow_remote_includes_path.md
+++ b/changelog/fix_inherit_from_remote_should_follow_remote_includes_path.md
@@ -1,0 +1,1 @@
+* [#10174](https://github.com/rubocop/rubocop/issues/10174): Fix inherit_from_remote should follow remote includes path starting with `./`. ([@hirasawayuki][])

--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -33,7 +33,7 @@ module RuboCop
 
     def inherit_from_remote(file, path)
       new_uri = @uri.dup
-      new_uri.path.gsub!(%r{/[^/]*$}, "/#{file}")
+      new_uri.path.gsub!(%r{/[^/]*$}, "/#{file.delete_prefix('./')}")
       RemoteConfig.new(new_uri.to_s, File.dirname(path))
     end
 

--- a/spec/rubocop/remote_config_spec.rb
+++ b/spec/rubocop/remote_config_spec.rb
@@ -189,4 +189,17 @@ RSpec.describe RuboCop::RemoteConfig do
       end
     end
   end
+
+  describe '.inherit_from_remote' do
+    context 'when the remote includes file starting with `./`' do
+      let(:includes_file) { './base.yml' }
+
+      it 'returns remote includes URI' do
+        remote_config = described_class.new(remote_config_url, base_dir)
+        includes_config = remote_config.inherit_from_remote(includes_file, remote_config_url)
+
+        expect(includes_config.uri).to eq URI.parse('http://example.com/base.yml')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #10174.
This PR is fix inherit_from_remote should follow remote includes path starting with `./`
In the example of issue, it tries to load `./base.yml` in the same hierarchy as `ruby-2.7.yml`, but the uri of `./base.yml` is 

`https://raw.githubusercontent.com/testdouble/standard/main/config/./base.yml`.

If the uri is `https:// ~ /./base.yml`, [ ConfigLoaderResolver#remote_file?](https://github.com/rubocop/rubocop/blob/df440defe93aa94306fe22b674be7214edcfa4b9/lib/rubocop/config_loader_resolver.rb#L221) returns false, so an instance of URI::Generic is created and an error occurs.

In this PR, if remote includes path starts with `./`, it will be removed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
