### PR TITLE
Fix an error for `Style/Documentation`

### DIFF
--- a/changelog/fix_error_for_style_documentation
+++ b/changelog/fix_error_for_style_documentation
@@ -1,0 +1,1 @@
+* [#10234](https://github.com/rubocop/rubocop/pull/10234): Fix an error for `Style/Documentation` when using a cbase class. ([@koic][])

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -176,7 +176,7 @@ module RuboCop
         end
 
         def qualify_const(node)
-          return if node.nil?
+          return if node.nil? || node.cbase_type?
 
           [qualify_const(node.namespace), node.short_name].compact
         end

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
     RUBY
   end
 
+  it 'registers an offense for non-empty cbase class' do
+    expect_offense(<<~RUBY)
+      class ::MyClass
+      ^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class MyClass`.
+        def method
+        end
+      end
+    RUBY
+  end
+
   it 'does not consider comment followed by empty line to be class documentation' do
     expect_offense(<<~RUBY)
       # Copyright 2014


### PR DESCRIPTION
This PR fixes the following error for `Style/Documentation` when using a cbase class.

```ruby
% cat example.rb
class ::MyClass
  def method
  end
end
```

```console
% bundle exec rubocop --only Style/Documentation -d
(snip)

An error occurred while Style/Documentation cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/bar/example.rb:1:0.
undefined method `namespace' for s(:cbase):RuboCop::AST::Node
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/documentation.rb:181:in `qualify_const'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
