### PR TITLE
[Fix #10203] Fix `Style/FormatStringToken` to respect `IgnoredMethods` with nested structures

### DIFF
--- a/changelog/fix_format_string_token_nested_ignored_methods.md
+++ b/changelog/fix_format_string_token_nested_ignored_methods.md
@@ -1,0 +1,1 @@
+* [#10203](https://github.com/rubocop/rubocop/issues/10203): Fix `Style/FormatStringToken` to respect `IgnoredMethods` with nested structures. ([@tejasbubane][])

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -102,7 +102,8 @@ module RuboCop
         end
 
         def use_ignored_method?(node)
-          (parent = node.parent) && parent.send_type? && ignored_method?(parent.method_name)
+          send_parent = node.each_ancestor(:send).first
+          send_parent && ignored_method?(send_parent.method_name)
         end
 
         def unannotated_format?(node, detected_style)

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -261,6 +261,19 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
           redirect("%{foo}")
         RUBY
       end
+
+      it 'does not register an offense for value in nested structure' do
+        expect_no_offenses(<<~RUBY)
+          redirect("%{foo}", bye: "%{foo}")
+        RUBY
+      end
+
+      it 'registers an offense for different method call within ignored method' do
+        expect_offense(<<~RUBY)
+          redirect("%{foo}", bye: foo("%{foo}"))
+                                       ^^^^^^ Prefer annotated tokens (like `%<foo>s`) over template tokens (like `%{foo}`).
+        RUBY
+      end
     end
 
     context 'when `IgnoredMethods: []`' do


### PR DESCRIPTION
Closes #10203

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/