### PR TITLE
Make `Lint/NumberConversion` aware of `to_r`

### DIFF
--- a/changelog/change_make_lint_number_conversion_aware_of_rational.md
+++ b/changelog/change_make_lint_number_conversion_aware_of_rational.md
@@ -1,0 +1,1 @@
+* [#10236](https://github.com/rubocop/rubocop/pull/10236): Make `Lint/NumberConversion` aware of `to_r`. ([@koic][])

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -30,6 +30,7 @@ module RuboCop
       #   '10'.to_i
       #   '10.2'.to_f
       #   '10'.to_c
+      #   '1/3'.to_r
       #   ['1', '2', '3'].map(&:to_i)
       #   foo.try(:to_f)
       #   bar.send(:to_c)
@@ -39,6 +40,7 @@ module RuboCop
       #   Integer('10', 10)
       #   Float('10.2')
       #   Complex('10')
+      #   Rational('1/3')
       #   ['1', '2', '3'].map { |i| Integer(i, 10) }
       #   foo.try { |i| Float(i) }
       #   bar.send { |i| Complex(i) }
@@ -59,13 +61,14 @@ module RuboCop
         CONVERSION_METHOD_CLASS_MAPPING = {
           to_i: "#{Integer.name}(%<number_object>s, 10)",
           to_f: "#{Float.name}(%<number_object>s)",
-          to_c: "#{Complex.name}(%<number_object>s)"
+          to_c: "#{Complex.name}(%<number_object>s)",
+          to_r: "#{Rational.name}(%<number_object>s)"
         }.freeze
         MSG = 'Replace unsafe number conversion with number '\
               'class parsing, instead of using '\
               '`%<current>s`, use stricter '\
               '`%<corrected_method>s`.'
-        CONVERSION_METHODS = %i[Integer Float Complex to_i to_f to_c].freeze
+        CONVERSION_METHODS = %i[Integer Float Complex Rational to_i to_f to_c to_r].freeze
         METHODS = CONVERSION_METHOD_CLASS_MAPPING.keys.map(&:inspect).join(' ')
 
         # @!method to_method(node)

--- a/spec/rubocop/cop/lint/number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/number_conversion_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
       RUBY
     end
 
+    it 'when using `#to_r`' do
+      expect_offense(<<~RUBY)
+        "1/3".to_r
+        ^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using `"1/3".to_r`, use stricter `Rational("1/3")`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Rational("1/3")
+      RUBY
+    end
+
     it 'when using `#to_i` for number literals' do
       expect_no_offenses(<<~RUBY)
         42.to_i
@@ -53,6 +64,13 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
       expect_no_offenses(<<~RUBY)
         42.to_c
         42.0.to_c
+      RUBY
+    end
+
+    it 'when using `#to_r` for number literals' do
+      expect_no_offenses(<<~RUBY)
+        42.to_r
+        42.0.to_r
       RUBY
     end
 


### PR DESCRIPTION
This PR makes `Lint/NumberConversion` aware of `to_r`. It treats `Rational` the same as` Integer`, `Float`, and `Complex`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
