### PR TITLE
Tweak changelog format doc and add a project spec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,12 +93,12 @@ Here are a few examples:
 
 * Create one file `changelog/{type}_{some_description}.md`, where `type` is `new` (New feature), `fix` or `change`, and `some_description` is unique to avoid conflicts. Task `changelog:fix` (or `:new` or `:change`) can help you.
 * Mark it up in [Markdown syntax][6].
-* The entry line should start with `* ` (an asterisk and a space).
+* The entry should be a single line, starting with `* ` (an asterisk and a space).
 * If the change has a related GitHub issue (e.g. a bug fix for a reported issue), put a link to the issue as `[#123](https://github.com/rubocop/rubocop/issues/123): `.
 * Describe the brief of the change. The sentence should end with a punctuation.
 * If this is a breaking change, mark it with `**(Breaking)**`.
 * At the end of the entry, add an implicit link to your GitHub user page as `([@username][])`.
-* Alternatively, you may modify the CHANGELOG file directly, but this may result in conflicts later on. Also, if this is your first contribution to RuboCop project, add a link definition for the implicit link to the bottom of the changelog as `[@username]: https://github.com/username`.
+* Alternatively, you may modify the CHANGELOG.md file directly, but this may result in conflicts later on. Also, if this is your first contribution to RuboCop project, add a link definition for the implicit link to the bottom of the changelog as `[@username]: https://github.com/username`.
 
 [1]: https://github.com/rubocop/rubocop/issues
 [2]: https://www.gun.io/blog/how-to-github-fork-branch-and-pull-request

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -242,6 +242,10 @@ RSpec.describe 'RuboCop Project', type: :feature do
             expect(entries).to all(match(/\(\[@\S+\]\[\](?:, \[@\S+\]\[\])*\)$/))
           end
 
+          it 'has a single line' do
+            expect(File.foreach(path).count).to eq(1)
+          end
+
           it 'starts with `new_`, `fix_`, or `change_`' do
             expect(File.basename(path)).to(match(/\A(new|fix|change)_.+/))
           end


### PR DESCRIPTION
The changelog entry file format doesn't require a link to GitHub account URL (`[@username]: https://github.com/username`), so contributors can write it in one line.
This PR tweaks CONTRIBUTING.md and adds a project spec for that.

It will prevent the following breaking changelog generation.
https://github.com/rubocop/rubocop/commit/f598124

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
