### PR TITLE
Fix bad indenting in docs

### DIFF
--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -9,7 +9,7 @@ module RuboCop
       # to go on its own line (expanded style).
       #
       # NOTE: A method definition is not considered empty if it contains
-      #       comments.
+      # comments.
       #
       # @example EnforcedStyle: compact (default)
       #   # bad


### PR DESCRIPTION
Hopefully fixes this:

![image](https://user-images.githubusercontent.com/509837/141344601-abd13c29-6b0f-4c99-9c49-e4d46a58e7c1.png)
