### PR TITLE
Require MFA for gem pushes

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |s|
     'changelog_uri' => 'https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md',
     'source_code_uri' => 'https://github.com/rubocop/rubocop/',
     'documentation_uri' => "https://docs.rubocop.org/rubocop/#{RuboCop::Version.document_version}/",
-    'bug_tracker_uri' => 'https://github.com/rubocop/rubocop/issues'
+    'bug_tracker_uri' => 'https://github.com/rubocop/rubocop/issues',
+    'rubygems_mfa_required' => 'true'
   }
 
   s.add_runtime_dependency('parallel', '~> 1.10')


### PR DESCRIPTION
Ruby gems now allows MFA to be required for pushes: https://guides.rubygems.org/mfa-requirement-opt-in/
This allows users to have confidence that the actual authors were responsible for updates (obviously that doesn't mean that it can't be a malicious update, but at least it's not from someone who got access to a pusher's account).

I don't have push access but I hope all of us who do have MFA set up anyways (and if anyone doesn't it's easy to set up).

If this is acceptable, I'd like to create a cop to check for this as well.