### PR TITLE
[Fix #10241] Fix `last_column` value for `JSONFormatter`

### DIFF
--- a/changelog/fix_last_column_number_for_json_formatter.md
+++ b/changelog/fix_last_column_number_for_json_formatter.md
@@ -1,0 +1,1 @@
+* [#10242](https://github.com/rubocop/rubocop/pull/10242): Fix `last_column` value for `JSONFormatter`. ([@koic][])

--- a/lib/rubocop/formatter/json_formatter.rb
+++ b/lib/rubocop/formatter/json_formatter.rb
@@ -59,12 +59,15 @@ module RuboCop
       end
 
       # TODO: Consider better solution for Offense#real_column.
+      #       The minimum value of `start_column: real_column` is 1.
+      #       So, the minimum value of `last_column` should be 1.
+      #       And non-zero value of `last_column` should be used as is.
       def hash_for_location(offense)
         {
           start_line:   offense.line,
           start_column: offense.real_column,
           last_line:    offense.last_line,
-          last_column:  offense.last_column,
+          last_column:  offense.last_column.zero? ? 1 : offense.last_column,
           length:       offense.location.length,
           # `line` and `column` exist for compatibility.
           # Use `start_line` and `start_column` instead.

--- a/spec/rubocop/formatter/json_formatter_spec.rb
+++ b/spec/rubocop/formatter/json_formatter_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe RuboCop::Formatter::JSONFormatter do
                              start_line: 1,
                              start_column: 1,
                              last_line: 1,
-                             last_column: 0,
+                             last_column: 1,
                              length: 0,
                              line: 1,
                              column: 1


### PR DESCRIPTION
Fixes #10241.

This PR fixes `last_column` value for `JSONFormatter`.

The minimum value of `start_column: real_column` is 1. So, the minimum value of `last_column` should be 1.
And non-zero value of `last_column` should be used as is.

This patch to `last_column` seems to be required only for `JSONFormatter` and not required for other formatters.

It solves a potential `JSONFormatter` issue for cops that use `add_global_offense`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
