### PR TITLE
Tweak offense range for `Layout/SpaceInLambdaLiteral`

### DIFF
--- a/lib/rubocop/cop/layout/space_in_lambda_literal.rb
+++ b/lib/rubocop/cop/layout/space_in_lambda_literal.rb
@@ -30,15 +30,17 @@ module RuboCop
         def on_send(node)
           return unless arrow_lambda_with_args?(node)
 
-          lambda_node = range_of_offense(node)
-
           if style == :require_space && !space_after_arrow?(node)
+            lambda_node = range_of_offense(node)
+
             add_offense(lambda_node, message: MSG_REQUIRE_SPACE) do |corrector|
-              corrector.insert_before(node.parent.children[1], ' ')
+              corrector.insert_before(lambda_arguments(node), ' ')
             end
           elsif style == :require_no_space && space_after_arrow?(node)
-            add_offense(lambda_node, message: MSG_REQUIRE_NO_SPACE) do |corrector|
-              corrector.remove(space_after_arrow(node))
+            space = space_after_arrow(node)
+
+            add_offense(space, message: MSG_REQUIRE_NO_SPACE) do |corrector|
+              corrector.remove(space)
             end
           end
         end
@@ -65,6 +67,10 @@ module RuboCop
             node.parent.loc.expression.begin_pos,
             node.parent.arguments.loc.expression.end_pos
           )
+        end
+
+        def lambda_arguments(node)
+          node.parent.children[1]
         end
       end
     end

--- a/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     it 'registers an offense and corrects a space between -> and (' do
       expect_offense(<<~RUBY)
         a = -> (b, c) { b + c }
-            ^^^^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
+              ^ Do not use spaces between `->` and `(` in lambda literals.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -101,7 +101,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     it 'registers an offense and corrects spaces between -> and (' do
       expect_offense(<<~RUBY)
         a = ->   (b, c) { b + c }
-            ^^^^^^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
+              ^^^ Do not use spaces between `->` and `(` in lambda literals.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -112,7 +112,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     it 'registers an offense and corrects a space in the inner nested lambda' do
       expect_offense(<<~RUBY)
         a = ->(b = -> (c) {}, d) { b + d }
-                   ^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
+                     ^ Do not use spaces between `->` and `(` in lambda literals.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -123,7 +123,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     it 'registers an offense and corrects a space in the outer nested lambda' do
       expect_offense(<<~RUBY)
         a = -> (b = ->(c) {}, d) { b + d }
-            ^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
+              ^ Do not use spaces between `->` and `(` in lambda literals.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -134,8 +134,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     it 'register offenses and correct spaces in both lambdas when nested' do
       expect_offense(<<~RUBY)
         a = -> (b = -> (c) {}, d) { b + d }
-                    ^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
-            ^^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
+                      ^ Do not use spaces between `->` and `(` in lambda literals.
+              ^ Do not use spaces between `->` and `(` in lambda literals.
       RUBY
 
       expect_correction(<<~RUBY)


### PR DESCRIPTION
This PR tweaks offense range for `Layout/SpaceInLambdaLiteral` when `EnforcedStyle`' is `require_no_space`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
