### PR TITLE
Make `Lint/DeprecatedClassMethods` aware of `ENV.freeze`

### DIFF
--- a/changelog/change_make_lint_deprecated_class_methods_aware_of_env_freeze.md
+++ b/changelog/change_make_lint_deprecated_class_methods_aware_of_env_freeze.md
@@ -1,0 +1,1 @@
+* [#10248](https://github.com/rubocop/rubocop/pull/10248): Make `Lint/DeprecatedClassMethods` aware of `ENV.freeze`. ([@koic][])

--- a/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
@@ -82,6 +82,23 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedClassMethods, :config do
     end
   end
 
+  context 'when using `ENV.freeze`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        ENV.freeze
+            ^^^^^^ `ENV.freeze` is deprecated in favor of `ENV`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ENV
+      RUBY
+    end
+
+    it 'does not register an offense for method calls to `ENV` other than `freeze`' do
+      expect_no_offenses('ENV.values')
+    end
+  end
+
   context 'prefer `Addrinfo#getnameinfo` over `Socket.gethostbyaddr`' do
     it 'registers an offense for Socket.gethostbyaddr' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR makes `Lint/DeprecatedClassMethods` aware of `ENV.freeze`. Calling `Env.freeze` raises `TypeError` since Ruby 2.7.

```console
% ruby -ve 'ENV.freeze'
ruby 2.6.7p197 (2021-04-05 revision 67941) [x86_64-darwin19]

% ruby -ve 'ENV.freeze'
ruby 2.7.3p183 (2021-04-05 revision 6847ee089d) [x86_64-darwin19]
Traceback (most recent call last):
        1: from -e:1:in `<main>'
-e:1:in `freeze': cannot freeze ENV (TypeError)
```

> Ruby does not allow `ENV` to be frozen, so calling `::freeze` raises `TypeError`.

https://ruby-doc.org/core-2.7.0/ENV.html#method-c-freeze

There are no deprecated warnings in Ruby 2.6 and sudden the error since Ruby 2.7. Therefore I'm not sure whether it's appropriate to do it with `Lint/DeprecatedClassMethods` cop. But, I think it would be redundant to create a new cop for `ENV.freeze`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
