### PR TITLE
Update docs and tests for `Security/Open`

### DIFF
--- a/lib/rubocop/cop/security/open.rb
+++ b/lib/rubocop/cop/security/open.rb
@@ -3,13 +3,17 @@
 module RuboCop
   module Cop
     module Security
-      # This cop checks for the use of `Kernel#open` and `URI.open`.
+      # This cop checks for the use of `Kernel#open` and `URI.open` with dynamic
+      # data.
       #
       # `Kernel#open` and `URI.open` enable not only file access but also process
       # invocation by prefixing a pipe symbol (e.g., `open("| ls")`).
       # So, it may lead to a serious security risk by using variable input to
       # the argument of `Kernel#open` and `URI.open`. It would be better to use
       # `File.open`, `IO.popen` or `URI.parse#open` explicitly.
+      #
+      # NOTE: `open` and `URI.open` with literal strings are not flagged by this
+      # cop.
       #
       # @safety
       #   This cop could register false positives if `open` is redefined
@@ -18,12 +22,18 @@ module RuboCop
       # @example
       #   # bad
       #   open(something)
+      #   open("| #{something}")
       #   URI.open(something)
       #
       #   # good
       #   File.open(something)
       #   IO.popen(something)
       #   URI.parse(something).open
+      #
+      #   # good (literal strings)
+      #   open("foo.text")
+      #   open("| foo")
+      #   URI.open("http://example.com")
       class Open < Base
         MSG = 'The use of `%<receiver>sopen` is a serious security risk.'
         RESTRICT_ON_SEND = %i[open].freeze

--- a/spec/rubocop/cop/security/open_spec.rb
+++ b/spec/rubocop/cop/security/open_spec.rb
@@ -29,6 +29,15 @@ RSpec.describe RuboCop::Cop::Security::Open, :config do
     RUBY
   end
 
+  it 'registers an offense for open with a block' do
+    expect_offense(<<~'RUBY')
+      open("#{foo}.txt") do |f|
+      ^^^^ The use of `Kernel#open` is a serious security risk.
+        f.gets
+      end
+    RUBY
+  end
+
   it 'registers an offense for `URI.open` with string that starts with a pipe' do
     expect_offense(<<~'RUBY')
       URI.open("| #{foo}")
@@ -40,6 +49,15 @@ RSpec.describe RuboCop::Cop::Security::Open, :config do
     expect_offense(<<~'RUBY')
       ::URI.open("| #{foo}")
             ^^^^ The use of `::URI.open` is a serious security risk.
+    RUBY
+  end
+
+  it 'registers an offense for `URI.open` with a block' do
+    expect_offense(<<~'RUBY')
+      ::URI.open("| #{foo}") do |f|
+            ^^^^ The use of `::URI.open` is a serious security risk.
+        f.gets
+      end
     RUBY
   end
 
@@ -69,5 +87,9 @@ RSpec.describe RuboCop::Cop::Security::Open, :config do
 
   it 'accepts open with a string that interpolates a literal' do
     expect_no_offenses('open "foo#{2}.txt"')
+  end
+
+  it 'accepts open with a literal string starting with a pipe' do
+    expect_no_offenses('open "| foo"')
   end
 end


### PR DESCRIPTION
Following #10249, I was taking a look at `Security/Open` and I think it's not completely clear about what it is expected to report on.

The cop only is interested in cases where it can be dynamically opening a pipe, but this is not super clear from the documentation, examples, or tests.

I added more examples and fleshed out the tests a bit.