### PR TITLE
Display deprecation message for `EnforceSuperclass` module

### DIFF
--- a/changelog/change_display_deprecation_message_for_enforce_super_class_module.md
+++ b/changelog/change_display_deprecation_message_for_enforce_super_class_module.md
@@ -1,0 +1,1 @@
+* [#10253](https://github.com/rubocop/rubocop/pull/10253): Deprecate `RuboCop::Cop::EnforceSuperclass` module. ([@koic][])

--- a/lib/rubocop/cop/mixin/enforce_superclass.rb
+++ b/lib/rubocop/cop/mixin/enforce_superclass.rb
@@ -13,6 +13,11 @@ module RuboCop
     # @api private
     module EnforceSuperclass
       def self.included(base)
+        warn Rainbow(
+          '`RuboCop::Cop::EnforceSuperclass` is deprecated and will be removed in RuboCop 2.0. ' \
+          'Please upgrade to RuboCop Rails 2.9 or newer to continue.'
+        ).yellow
+
         # @!method class_definition(node)
         base.def_node_matcher :class_definition, <<~PATTERN
           (class (const _ !:#{base::SUPERCLASS}) #{base::BASE_PATTERN} ...)


### PR DESCRIPTION
Follow up to #9087.

This PR displays deprecation message for `EnforceSuperclass` module.

> https://github.com/rubocop/rubocop-rails/pull/390 is ready to be removed from RuboCop core.
> First of all, as soft deprecation, the document only indicates that it is a deprecation warning.
> After releasing RuboCop Rails several times, I will display a deprecation warning and
> will remove it in RuboCop 2.0.

After #9087, I've released RuboCop Rails more than 10 times in about a year, so it's time to get a deprecated warning.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
