### PR TITLE
Add simple autocorrect for `Style/GuardClause`

### DIFF
--- a/changelog/new_add_simple_autocorrect_for_style_guard_clause.md
+++ b/changelog/new_add_simple_autocorrect_for_style_guard_clause.md
@@ -1,0 +1,1 @@
+* Add simple autocorrect for `Style/GuardClause`. ([@FnControlOption][])

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1179,7 +1179,9 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
             def something
               first call
               do_other 'things'
-              more_work if other > 34
+              return unless other > 34
+
+              more_work
             end
           end
         end

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1577,7 +1577,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
             'Use snake_case for method names.',
             'def badName',
             '    ^^^^^^^',
-            'example3.rb:2:3: C: Style/GuardClause: ' \
+            'example3.rb:2:3: C: [Correctable] Style/GuardClause: ' \
             'Use a guard clause (return unless something) instead of ' \
             'wrapping the code inside a conditional expression.',
             '  if something',
@@ -1592,7 +1592,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
             '    end',
             '    ^^^',
             '',
-            '3 files inspected, 15 offenses detected, 12 offenses autocorrectable',
+            '3 files inspected, 15 offenses detected, 13 offenses autocorrectable',
             ''
           ].join("\n"))
         end

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -28,6 +28,20 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def func
+          return unless something
+            #{body}
+         #{trailing_whitespace}
+        end
+
+        def func
+          return if something
+            #{body}
+         #{trailing_whitespace}
+        end
+      RUBY
     end
 
     it 'reports an offense if method body ends with if / unless without else' do
@@ -46,6 +60,22 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
           ^^^^^^ Use a guard clause (`return if something`) instead of wrapping the code inside a conditional expression.
             #{body}
           end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def func
+          test
+          return unless something
+            #{body}
+         #{trailing_whitespace}
+        end
+
+        def func
+          test
+          return if something
+            #{body}
+         #{trailing_whitespace}
         end
       RUBY
     end
@@ -115,6 +145,8 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
         end
       end
     RUBY
+
+    expect_no_corrections
   end
 
   it 'registers an offense when using `|| raise` in `else` branch' do
@@ -128,6 +160,8 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
         end
       end
     RUBY
+
+    expect_no_corrections
   end
 
   it 'registers an offense when using `and return` in `then` branch' do
@@ -141,6 +175,8 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
         end
       end
     RUBY
+
+    expect_no_corrections
   end
 
   it 'registers an offense when using `and return` in `else` branch' do
@@ -154,6 +190,8 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
         end
       end
     RUBY
+
+    expect_no_corrections
   end
 
   it 'accepts a method which body does not end with if / unless' do
@@ -223,6 +261,20 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
           ^^^^^^ Use a guard clause (`return if something`) instead of wrapping the code inside a conditional expression.
             work
           end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def func
+          return unless something
+            work
+         #{trailing_whitespace}
+        end
+
+        def func
+          return if something
+            work
+         #{trailing_whitespace}
         end
       RUBY
     end
@@ -336,6 +388,14 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
           puts "hello"
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        #{kw} if something
+         #{trailing_whitespace}
+
+          puts "hello"
+
+      RUBY
     end
 
     it "registers an error with #{kw} in the else branch" do
@@ -346,6 +406,14 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
         else
           #{kw}
         end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #{kw} unless something
+         puts "hello"
+
+         #{trailing_whitespace}
+
       RUBY
     end
 
@@ -403,6 +471,15 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
                "blah blah blah"
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        #{kw} if something
+         #{trailing_whitespace}
+
+          puts "hello" \\
+               "blah blah blah"
+
+      RUBY
     end
   end
 
@@ -427,9 +504,22 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
               if something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line
               ^^ Use a guard clause (`unless something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line; return; end`) instead of wrapping the code inside a conditional expression.
                 if something_else
+                ^^ Use a guard clause (`return unless something_else`) instead of wrapping the code inside a conditional expression.
                   work
                 end
               end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def test
+              unless something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line
+              return
+            end
+                return unless something_else
+                  work
+               #{trailing_whitespace}
+             #{trailing_whitespace}
             end
           RUBY
         end
@@ -444,6 +534,17 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
                 work
                 more_work
               end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def test
+              unless something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line
+              return
+            end
+                work
+                more_work
+             #{trailing_whitespace}
             end
           RUBY
         end
@@ -461,6 +562,14 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
           ^^ Use a guard clause (`return unless something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line`) instead of wrapping the code inside a conditional expression.
             work
           end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def test
+          return unless something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line
+            work
+         #{trailing_whitespace}
         end
       RUBY
     end
@@ -483,6 +592,16 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        module CopTest
+          def test
+            return unless something
+              work
+           #{trailing_whitespace}
+          end
+        end
+      RUBY
     end
 
     it 'registers an offense for singleton methods' do
@@ -493,6 +612,16 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
             ^^ Use a guard clause (`return unless something && something_else`) instead of wrapping the code inside a conditional expression.
               work
             end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module CopTest
+          def self.test
+            return unless something && something_else
+              work
+           #{trailing_whitespace}
           end
         end
       RUBY


### PR DESCRIPTION
This adds autocorrection for `Style/GuardClause`. For example:

```rb
def test
  if foo1
    return foo2
  else
    foo3
  end

  if bar1
    bar2
    bar3
  end
end
```

becomes

```rb
def test
  return foo2 if foo1

  foo3

  return unless bar1

  bar2
  bar3
end
```

More complex `if-else` statements are not autocorrected and left as-is:

```rb
if foo
  bar || return
else
  baz
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
