### PR TITLE
Fix an incorrect auto-correct for `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_method_call_with_args_parentheses.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_method_call_with_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#10264](https://github.com/rubocop/rubocop/pull/10264): Fix the following incorrect auto-correct for `Style/MethodCallWithArgsParentheses` with `Layout/SpaceBeforeFirstArg`. ([@koic][])

--- a/lib/rubocop/cop/layout/space_before_first_arg.rb
+++ b/lib/rubocop/cop/layout/space_before_first_arg.rb
@@ -28,6 +28,10 @@ module RuboCop
 
         MSG = 'Put one space between the method name and the first argument.'
 
+        def self.autocorrect_incompatible_with
+          [Style::MethodCallWithArgsParentheses]
+        end
+
         def on_send(node)
           return unless regular_method_call_with_arguments?(node)
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -302,6 +302,28 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `EnforcedStyle: require_parentheses` of `Style/MethodCallWithArgsParentheses` with ' \
+     '`Layout/SpaceBeforeFirstArg`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/MethodCallWithArgsParentheses:
+        EnforcedStyle: require_parentheses
+    YAML
+    create_file('example.rb', <<~RUBY)
+      obj.do_something"message"
+    RUBY
+    expect(
+      cli.run(
+        [
+          '--auto-correct',
+          '--only', 'Style/MethodCallWithArgsParentheses,Layout/SpaceBeforeFirstArg'
+        ]
+      )
+    ).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      obj.do_something("message")
+    RUBY
+  end
+
   it 'corrects `Style/IfUnlessModifier` with `Style/SoleNestedConditional`' do
     source = <<~RUBY
       def foo


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Style/MethodCallWithArgsParentheses` with `Layout/SpaceBeforeFirstArg`.

```console
% bundle exec rubocop -A --only Style/MethodCallWithArgsParentheses,Layout/SpaceBeforeFirstArg

Offenses:

example.rb:1:1: C: [Corrected] Style/MethodCallWithArgsParentheses: Use
parentheses for method calls with arguments.
obj.do_something"message"
^^^^^^^^^^^^^^^^^^^^^^^^^
example.rb:1:17: C: [Corrected] Layout/SpaceBeforeFirstArg: Put one
space between the method name and the first argument.
obj.do_something"message"

1 file inspected, 2 offenses detected, 2 offenses corrected

% g diff .
diff --git a/foo/example.rb b/foo/example.rb
index fc0d118..e7d6c14 100644
--- a/foo/example.rb
+++ b/foo/example.rb
@@ -1 +1 @@
-obj.do_something"message"
+obj.do_something (message")

% ruby -c example.rb
example.rb:1: unterminated string meets end of file obj.do_something (message")
example.rb:1: syntax error, unexpected end-of-input, expecting ')'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
