### PR TITLE
Add kind instruction to cop development documentation

### DIFF
--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -7,6 +7,9 @@ and testing.
 
 == Create a new cop
 
+NOTE: Clone the repository and run `bundle install` if not done yet.
+The following rake task can only be run inside the rubocop project directory itself.
+
 Use the bundled rake task `new_cop` to generate a cop template:
 
 [source,sh]


### PR DESCRIPTION
This PR adds a few sentences in docs of development section.

It would be clear if the rake task 'new_cop' can only be run inside the project directory itself.
By this documentation, there will be no more confusion like the conversation in the gitter; link: https://gitter.im/bbatsov/rubocop?at=5c3607a11d1c2c3f9ce7c23d .

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
