### PR TITLE
[Fix #10269] Mark unsafe autocorrect for `Lint/IncompatibleIoSelectWithFiberScheduler`

### DIFF
--- a/changelog/change_mark_unsafe_autocorrect_for_lint_incompatible_io_select_with_fiber_scheduler.md
+++ b/changelog/change_mark_unsafe_autocorrect_for_lint_incompatible_io_select_with_fiber_scheduler.md
@@ -1,0 +1,1 @@
+* [#10269](https://github.com/rubocop/rubocop/issues/10269): Mark `Lint/IncompatibleIoSelectWithFiberScheduler` as unsafe auto-correction. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1796,7 +1796,9 @@ Lint/ImplicitStringConcatenation:
 Lint/IncompatibleIoSelectWithFiberScheduler:
   Description: 'Checks for `IO.select` that is incompatible with Fiber Scheduler.'
   Enabled: pending
+  SafeAutoCorrect: false
   VersionAdded: '1.21'
+  VersionChanged: '<<next>>'
 
 Lint/IneffectiveAccessModifier:
   Description: >-

--- a/lib/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler.rb
+++ b/lib/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler.rb
@@ -20,6 +20,10 @@ module RuboCop
       #   # good
       #   io.wait_writable(timeout)
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because `NoMethodError` occurs
+      #   if `require 'io/wait'` is not called.
+      #
       class IncompatibleIoSelectWithFiberScheduler < Base
         extend AutoCorrector
 


### PR DESCRIPTION
Fixes #10269.

`Lint/IncompatibleIoSelectWithFiberScheduler`cop's autocorrection is unsafe because `NoMethodError` occurs if `require 'io/wait'` is not called.

## `require 'io/wait'` is called

```console
% ruby -rio/wait -ve 'IO.new(IO.sysopen("/tmp")).wait_readable'
ruby 3.1.0dev (2021-11-21T10:23:36Z master 784f1e1538) [x86_64-darwin19]
```

## `require 'io/wait'` is not called

```console
% ruby -ve 'IO.new(IO.sysopen("/tmp")).wait_readable'
ruby 3.1.0dev (2021-11-21T10:23:36Z master 784f1e1538) [x86_64-darwin19]
-e:1:in `<main>': undefined method `wait_readable' for #<IO:fd 9> (NoMethodError)

IO.new(IO.sysopen("/tmp")).wait_readable
                          ^^^^^^^^^^^^^^
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
