### PR TITLE
[Fix #10273] Fix a false positive for `InternalAffairs/UndefinedConfig`

### DIFF
--- a/changelog/fix_false_positive_for_internal_affairs_undefined_config.md
+++ b/changelog/fix_false_positive_for_internal_affairs_undefined_config.md
@@ -1,0 +1,1 @@
+* [#10273](https://github.com/rubocop/rubocop/issues/10273): Fix a false positive for `InternalAffairs/UndefinedConfig` to suppress a false wrong namespace warning. ([@koic][])

--- a/lib/rubocop/cop/internal_affairs/undefined_config.rb
+++ b/lib/rubocop/cop/internal_affairs/undefined_config.rb
@@ -14,7 +14,9 @@ module RuboCop
 
         # @!method cop_class_def(node)
         def_node_search :cop_class_def, <<~PATTERN
-          (class _ (const _ {:Base :Cop}) ...)
+          (class _
+            (const {nil? (const nil? :Cop) (const (const {cbase nil?} :RuboCop) :Cop)}
+              {:Base :Cop}) ...)
         PATTERN
 
         # @!method cop_config_accessor?(node)

--- a/spec/rubocop/cop/internal_affairs/undefined_config_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/undefined_config_spec.rb
@@ -67,6 +67,48 @@ RSpec.describe RuboCop::Cop::InternalAffairs::UndefinedConfig, :config, :isolate
     RUBY
   end
 
+  it 'registers an offense when the cop inherits `Cop::Base`' do
+    expect_offense(<<~RUBY)
+      module Test
+        class Foo < Cop::Base
+          def configured?
+            cop_config['Defined']
+            cop_config['Missing']
+                       ^^^^^^^^^ `Missing` is not defined in the configuration for `Test/Foo` in `config/default.yml`.
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the cop inherits `RuboCop::Cop::Base`' do
+    expect_offense(<<~RUBY)
+      module Test
+        class Foo < RuboCop::Cop::Base
+          def configured?
+            cop_config['Defined']
+            cop_config['Missing']
+                       ^^^^^^^^^ `Missing` is not defined in the configuration for `Test/Foo` in `config/default.yml`.
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the cop inherits `::RuboCop::Cop::Base`' do
+    expect_offense(<<~RUBY)
+      module Test
+        class Foo < ::RuboCop::Cop::Base
+          def configured?
+            cop_config['Defined']
+            cop_config['Missing']
+                       ^^^^^^^^^ `Missing` is not defined in the configuration for `Test/Foo` in `config/default.yml`.
+          end
+        end
+      end
+    RUBY
+  end
+
   context 'element lookup' do
     it 'does not register an offense for defined configuration keys' do
       expect_no_offenses(<<~RUBY)
@@ -216,6 +258,18 @@ RSpec.describe RuboCop::Cop::InternalAffairs::UndefinedConfig, :config, :isolate
       class Test
         def configured?
           cop_config['Missing']
+        end
+      end
+    RUBY
+  end
+
+  it 'ignores `cop_config` in non-cop subclasses' do
+    expect_no_offenses(<<~RUBY)
+      module M
+        class C < ApplicationRecord::Base
+          def configured?
+            cop_config['Missing']
+          end
         end
       end
     RUBY


### PR DESCRIPTION
Fixes #10273.

This PR fixes a false positive for `InternalAffairs/UndefinedConfig` when inheriting a `Base` class other than RuboCop's `Base` class.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
