### PR TITLE
Tweak suggested RuboCop extension URL

### DIFF
--- a/lib/rubocop/cli/command/suggest_extensions.rb
+++ b/lib/rubocop/cli/command/suggest_extensions.rb
@@ -22,7 +22,7 @@ module RuboCop
                'RuboCop extension libraries might be helpful:'
 
           extensions.sort.each do |extension|
-            puts "  * #{extension} (https://github.com/rubocop/#{extension})"
+            puts "  * #{extension} (https://rubygems.org/gems/#{extension})"
           end
 
           puts


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/pull/10178#issuecomment-981897123.

RubyGems URL is better than GitHub repository URL because it is likely to match `require` extension gem name.
https://guides.rubygems.org/name-your-gem/

This makes suggested RuboCop extension URL unaffected by repository location.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
