### PR TITLE
[Fix #10276] Fix an incorrect autocorrect for `Style/RedundantInterpolation`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_redundant_interpolation.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_redundant_interpolation.md
@@ -1,0 +1,1 @@
+* [#10276](https://github.com/rubocop/rubocop/issues/10276): Fix an incorrect autocorrect for `Style/RedundantInterpolation` when using a method call without parentheses in string interpolation. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_interpolation_spec.rb
@@ -177,6 +177,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantInterpolation, :config do
     RUBY
   end
 
+  it 'registers an offense for "#{do_something 42}"' do
+    expect_offense(<<~'RUBY')
+      "#{do_something 42}"
+      ^^^^^^^^^^^^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      do_something(42).to_s
+    RUBY
+  end
+
+  it 'registers an offense for "#{foo.do_something 42}"' do
+    expect_offense(<<~'RUBY')
+      "#{foo.do_something 42}"
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      foo.do_something(42).to_s
+    RUBY
+  end
+
   it 'registers an offense for "#{var}"' do
     expect_offense(<<~'RUBY')
       var = 1; "#{var}"


### PR DESCRIPTION
Fixes #10276.

This PR fixes an incorrect autocorrect for `Style/RedundantInterpolation` when using a method call without parentheses in string interpolation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
