### PR TITLE
Support Ruby 3.1's anonymous block argument syntax

### DIFF
--- a/changelog/new_support_ruby31_anonymous_block_argument_syntax.md
+++ b/changelog/new_support_ruby31_anonymous_block_argument_syntax.md
@@ -1,0 +1,1 @@
+* [#10279](https://github.com/rubocop/rubocop/pull/10279): Support Ruby 3.1's anonymous block forwarding syntax. ([@koic][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
   s.add_runtime_dependency('rexml')
-  s.add_runtime_dependency('rubocop-ast', '>= 1.12.0', '< 2.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 1.14.0', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 3.0')
 


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop-ast/pull/218.

This PR supports Ruby 3.1's anonymous block argument syntax and fixes the following error.

```console
% ruby -v
ruby 3.1.0dev (2021-12-01T02:00:10Z master 0b53a8895f) [x86_64-darwin19]

% echo 'def foo(&) = bar(&)' | be rubocop --enable-pending-cops --stdin example.rb
Inspecting 1 file
.

0 files inspected, no offenses detected
undefined method `type' for nil:NilClass
/Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.13.0/lib/rubocop/ast/traversal.rb:131:in
`on_block_pass'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/commissioner.rb:71:in
`on_block_pass'
/Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.13.0/lib/rubocop/ast/traversal.rb:159:in
`block in on_send'
/Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.13.0/lib/rubocop/ast/traversal.rb:156:in
`each'
/Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.13.0/lib/rubocop/ast/traversal.rb:156:in
`each_with_index'
/Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.13.0/lib/rubocop/ast/traversal.rb:156:in
`on_send'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/commissioner.rb:71:in `on_send'
```

This PR makes RuboCop require Parser 1.14 or higher Because this error resolved by https://github.com/rubocop/rubocop-ast/pull/218.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
