### PR TITLE
[Fix #10282] Fix an incorrect autocorrect for `Style/EmptyCaseCondition`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_empty_case_condition.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_empty_case_condition.md
@@ -1,0 +1,1 @@
+* [#10282](https://github.com/rubocop/rubocop/issues/10282): Fix an incorrect autocorrect for `Style/EmptyCaseCondition` when using `when ... then` in `case` in a method call. ([@koic][])

--- a/lib/rubocop/cop/style/empty_case_condition.rb
+++ b/lib/rubocop/cop/style/empty_case_condition.rb
@@ -79,6 +79,8 @@ module RuboCop
           when_nodes.each do |when_node|
             conditions = when_node.conditions
 
+            replace_then_with_line_break(corrector, conditions, when_node)
+
             next unless conditions.size > 1
 
             range = range_between(conditions.first.source_range.begin_pos,
@@ -96,6 +98,14 @@ module RuboCop
 
           line_beginning = case_range.adjust(begin_pos: -case_range.column)
           corrector.insert_before(line_beginning, comments)
+        end
+
+        def replace_then_with_line_break(corrector, conditions, when_node)
+          return unless when_node.parent.parent && when_node.then?
+
+          range = range_between(conditions.last.source_range.end_pos, when_node.loc.begin.end_pos)
+
+          corrector.replace(range, "\n")
         end
       end
     end

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -289,6 +289,50 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition, :config do
       it_behaves_like 'detect/correct empty case, accept non-empty case'
     end
 
+    context 'when using `when ... then` in `case` in `return`' do
+      let(:source) do
+        <<~RUBY
+          return case
+                 ^^^^ Do not use empty `case` condition, instead use an `if` expression.
+                 when object.nil? then Object.new
+                 else object
+                 end
+        RUBY
+      end
+      let(:corrected_source) do
+        <<~RUBY
+          return if object.nil?
+           Object.new
+                 else object
+                 end
+        RUBY
+      end
+
+      it_behaves_like 'detect/correct empty case, accept non-empty case'
+    end
+
+    context 'when using `when ... then` in `case` in a method call' do
+      let(:source) do
+        <<~RUBY
+          do_some_work case
+                       ^^^^ Do not use empty `case` condition, instead use an `if` expression.
+                       when object.nil? then Object.new
+                       else object
+                       end
+        RUBY
+      end
+      let(:corrected_source) do
+        <<~RUBY
+          do_some_work if object.nil?
+           Object.new
+                       else object
+                       end
+        RUBY
+      end
+
+      it_behaves_like 'detect/correct empty case, accept non-empty case'
+    end
+
     context 'when using `return` in `when` clause and assigning the return value of `case`' do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #10282.

This PR fixes an incorrect autocorrect for `Style/EmptyCaseCondition` when using `when ... then` in `case` in `return`.

This issue occurs not only with `return`, also with method calls.

And indentation of auto-corrected code will be entrusted to another existing cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
