### PR TITLE
[Fix #10284] Fix an incorrect autocorrect for `Style/RedundantRegexpCharacterClass`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_redundant_regexp_character_class.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_redundant_regexp_character_class.md
@@ -1,0 +1,1 @@
+* [#10284](https://github.com/rubocop/rubocop/issues/10284): Fix an incorrect autocorrect for `Style/RedundantRegexpCharacterClass` when regexp containing an unescaped `#`. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_regexp_character_class.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_character_class.rb
@@ -80,7 +80,11 @@ module RuboCop
         end
 
         def without_character_class(loc)
-          loc.source[1..-2]
+          without_character_class = loc.source[1..-2]
+
+          # Adds `\` to prevent auto-correction that changes to an interpolated string when `[#]`.
+          # e.g. From `/[#]{0}/` to `/#{0}/`
+          loc.source == '[#]' ? "\\#{without_character_class}" : without_character_class
         end
 
         def whitespace_in_free_space_mode?(node, elem)

--- a/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
@@ -278,6 +278,19 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpCharacterClass, :config do
     end
   end
 
+  context 'with a character class containing an unescaped-#' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~'RUBY')
+        foo = /[#]{0}/
+               ^^^ Redundant single-element character class, `[#]` can be replaced with `\#`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        foo = /\#{0}/
+      RUBY
+    end
+  end
+
   context 'with a character class containing an escaped-b' do
     # See https://github.com/rubocop/rubocop/issues/8193 for details - in short \b != [\b] - the
     # former matches a word boundary, the latter a backspace character.


### PR DESCRIPTION
Fixes #10284.

This PR fixes an incorrect autocorrect for `Style/RedundantRegexpCharacterClass` when regexp containing an unescaped `#`.

It will be the same auto-correction code as the existing escaped `\#`.
https://github.com/rubocop/rubocop/blob/v1.23.0/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb#L268-L279

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
