### PR TITLE
[Fix #10285] Fix an incorrect autocorrect for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_sole_nested_conditional.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#10285](https://github.com/rubocop/rubocop/issues/10285): Fix an incorrect autocorrect for `Style/SoleNestedConditional` when using nested `if` within `if foo = bar`. ([@koic][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -82,7 +82,9 @@ module RuboCop
         end
 
         def autocorrect(corrector, node, if_branch)
-          corrector.wrap(node.condition, '(', ')') if node.condition.or_type?
+          if node.condition.or_type? || node.condition.assignment?
+            corrector.wrap(node.condition, '(', ')')
+          end
 
           correct_from_unless_to_if(corrector, node) if node.unless?
 

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -72,6 +72,23 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using nested `if` within `if foo = bar`' do
+    expect_offense(<<~RUBY)
+      if foo = bar
+        if baz
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if (foo = bar) && baz
+          do_something
+        end
+    RUBY
+  end
+
   it 'registers an offense and corrects when using nested `unless` within `unless`' do
     expect_offense(<<~RUBY)
       unless foo


### PR DESCRIPTION
Fixes #10285.

This PR fixes an incorrect autocorrect for `Style/SoleNestedConditional` when using nested `if` within `if foo = bar`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
