### PR TITLE
Add new `Naming/BlockForwarding` cop

### DIFF
--- a/changelog/new_add_new_naming_block_forwarding_cop.md
+++ b/changelog/new_add_new_naming_block_forwarding_cop.md
@@ -1,0 +1,1 @@
+* [#10290](https://github.com/rubocop/rubocop/pull/10290): Add new `Naming/BlockForwarding` cop. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2487,6 +2487,15 @@ Naming/BinaryOperatorParameterName:
   VersionAdded: '0.50'
   VersionChanged: '1.2'
 
+Naming/BlockForwarding:
+  Description: 'Use anonymous block forwarding.'
+  Enabled: pending
+  VersionAdded: '<<next>>'
+  EnforcedStyle: anonymous
+  SupportedStyles:
+    - anonymous
+    - explicit
+
 Naming/BlockParameterName:
   Description: >-
                  Checks for block parameter names that contain capital letters,

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -407,6 +407,7 @@ require_relative 'rubocop/cop/metrics/perceived_complexity'
 
 require_relative 'rubocop/cop/naming/accessor_method_name'
 require_relative 'rubocop/cop/naming/ascii_identifiers'
+require_relative 'rubocop/cop/naming/block_forwarding'
 require_relative 'rubocop/cop/naming/block_parameter_name'
 require_relative 'rubocop/cop/naming/class_and_module_camel_case'
 require_relative 'rubocop/cop/naming/constant_name'

--- a/lib/rubocop/cop/naming/block_forwarding.rb
+++ b/lib/rubocop/cop/naming/block_forwarding.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Naming
+      # In Ruby 3.1, anonymous block forwarding has been added.
+      #
+      # This cop identifies places where `do_something(&block)` can be replaced
+      # by `do_something(&)`.
+      #
+      # It also supports the opposite style by alternative `explicit` option.
+      #
+      # @example EnforcedStyle: anonymous (default)
+      #
+      #   # bad
+      #   def foo(&block)
+      #     bar(&block)
+      #   end
+      #
+      #   # good
+      #   def foo(&)
+      #     bar(&)
+      #   end
+      #
+      # @example EnforcedStyle: explicit
+      #
+      #   # bad
+      #   def foo(&)
+      #     bar(&)
+      #   end
+      #
+      #   # good
+      #   def foo(&block)
+      #     bar(&block)
+      #   end
+      #
+      class BlockForwarding < Base
+        include ConfigurableEnforcedStyle
+        extend AutoCorrector
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 3.1
+
+        MSG = 'Use %<style>s block forwarding.'
+
+        def on_def(node)
+          return if node.arguments.empty?
+
+          last_argument = node.arguments.last
+          return if expected_block_forwarding_style?(node, last_argument)
+
+          register_offense(last_argument)
+
+          node.each_descendant(:block_pass) do |block_pass_node|
+            next if block_pass_node.children.first&.sym_type?
+
+            register_offense(block_pass_node)
+          end
+        end
+        alias on_defs on_def
+
+        private
+
+        def expected_block_forwarding_style?(node, last_argument)
+          if style == :anonymous
+            !explicit_block_argument?(last_argument) ||
+              use_kwarg_in_method_definition?(node) ||
+              use_block_argument_as_local_variable?(node, last_argument)
+          else
+            !anonymous_block_argument?(last_argument)
+          end
+        end
+
+        def use_kwarg_in_method_definition?(node)
+          node.arguments.each_descendant(:kwarg, :kwoptarg).any?
+        end
+
+        def anonymous_block_argument?(node)
+          node.blockarg_type? && node.name.nil?
+        end
+
+        def explicit_block_argument?(node)
+          node.blockarg_type? && !node.name.nil?
+        end
+
+        def use_block_argument_as_local_variable?(node, last_argument)
+          return if node.body.nil?
+
+          node.body.each_descendant(:lvar).any? do |lvar|
+            !lvar.parent.block_pass_type? && lvar.source == last_argument.source[1..-1]
+          end
+        end
+
+        def register_offense(block_argument)
+          add_offense(block_argument, message: format(MSG, style: style)) do |corrector|
+            corrector.replace(block_argument, '&')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/naming/block_forwarding_spec.rb
+++ b/spec/rubocop/cop/naming/block_forwarding_spec.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Naming::BlockForwarding, :config do
+  context 'when `EnforcedStyle: anonymous' do
+    let(:cop_config) { { 'EnforcedStyle' => 'anonymous' } }
+
+    context 'Ruby >= 3.1', :ruby31 do
+      it 'registers and corrects an offense when using explicit block forwarding' do
+        expect_offense(<<~RUBY)
+          def foo(&block)
+                  ^^^^^^ Use anonymous block forwarding.
+            bar(&block)
+                ^^^^^^ Use anonymous block forwarding.
+            baz(qux, &block)
+                     ^^^^^^ Use anonymous block forwarding.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(&)
+            bar(&)
+            baz(qux, &)
+          end
+        RUBY
+      end
+
+      it 'registers and corrects an offense when using explicit block forwarding in singleton method' do
+        expect_offense(<<~RUBY)
+          def self.foo(&block)
+                       ^^^^^^ Use anonymous block forwarding.
+            self.bar(&block)
+                     ^^^^^^ Use anonymous block forwarding.
+            self.baz(qux, &block)
+                          ^^^^^^ Use anonymous block forwarding.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self.foo(&)
+            self.bar(&)
+            self.baz(qux, &)
+          end
+        RUBY
+      end
+
+      it 'registers and corrects an offense when using symbol proc argument in method body' do
+        expect_offense(<<~RUBY)
+          def foo(&block)
+                  ^^^^^^ Use anonymous block forwarding.
+            bar(&:do_something)
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(&)
+            bar(&:do_something)
+          end
+        RUBY
+      end
+
+      it 'registers and corrects an offense when using `yield` in method body' do
+        expect_offense(<<~RUBY)
+          def foo(&block)
+                  ^^^^^^ Use anonymous block forwarding.
+            yield
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(&)
+            yield
+          end
+        RUBY
+      end
+
+      it 'registers and corrects an offense when using explicit block forwarding without method body' do
+        expect_offense(<<~RUBY)
+          def foo(&block)
+                  ^^^^^^ Use anonymous block forwarding.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(&)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using anonymous block forwarding' do
+        expect_no_offenses(<<~RUBY)
+          def foo(&)
+            bar(&)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using anonymous block forwarding without method body' do
+        expect_no_offenses(<<~RUBY)
+          def foo(&)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using block argument as a variable' do
+        expect_no_offenses(<<~RUBY)
+          def foo(&block)
+            bar(&block) if block
+          end
+
+          def foo(&block)
+            block.call
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when defining without block argument method' do
+        expect_no_offenses(<<~RUBY)
+          def foo(arg1, arg2)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when defining kwarg with block args method' do
+        # Prevents the following syntax error:
+        #
+        # % ruby -cve 'def foo(k:, &); bar(&); end'
+        # ruby 3.1.0dev (2021-12-05T10:23:42Z master 19f037e452) [x86_64-darwin19]
+        # -e:1: no anonymous block parameter
+        #
+        expect_no_offenses(<<~RUBY)
+          def foo(k:, &block)
+            bar(&block)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when defining kwoptarg with block args method' do
+        # Prevents the following syntax error:
+        #
+        # % ruby -cve 'def foo(k: v, &); bar(&); end'
+        # ruby 3.1.0dev (2021-12-05T10:23:42Z master 19f037e452) [x86_64-darwin19]
+        # -e:1: no anonymous block parameter
+        #
+        expect_no_offenses(<<~RUBY)
+          def foo(k: v, &block)
+            bar(&block)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when defining no arguments method' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+          end
+        RUBY
+      end
+    end
+
+    context 'Ruby < 3.0', :ruby30 do
+      it 'does not register an offense when not using anonymous block forwarding' do
+        expect_no_offenses(<<~RUBY)
+          def foo(&block)
+            bar(&block)
+          end
+        RUBY
+      end
+    end
+  end
+
+  context 'when `EnforcedStyle: explicit' do
+    let(:cop_config) { { 'EnforcedStyle' => 'explicit' } }
+
+    context 'Ruby >= 3.1', :ruby31 do
+      it 'registers an offense when using anonymous block forwarding' do
+        expect_offense(<<~RUBY)
+          def foo(&)
+                  ^ Use explicit block forwarding.
+            bar(&)
+                ^ Use explicit block forwarding.
+            baz(qux, &)
+                     ^ Use explicit block forwarding.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when using anonymous block forwarding in singleton method' do
+        expect_offense(<<~RUBY)
+          def self.foo(&)
+                       ^ Use explicit block forwarding.
+            self.bar(&)
+                     ^ Use explicit block forwarding.
+            self.baz(qux, &)
+                          ^ Use explicit block forwarding.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when using symbol proc argument in method body' do
+        expect_offense(<<~RUBY)
+          def foo(&)
+                  ^ Use explicit block forwarding.
+            bar(&:do_something)
+          end
+        RUBY
+      end
+
+      it 'registers an offense when using `yield` in method body' do
+        expect_offense(<<~RUBY)
+          def foo(&)
+                  ^ Use explicit block forwarding.
+            yield
+          end
+        RUBY
+      end
+
+      it 'registers and corrects an offense when using anonymous block forwarding without method body' do
+        expect_offense(<<~RUBY)
+          def foo(&)
+                  ^ Use explicit block forwarding.
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using explicit block forwarding' do
+        expect_no_offenses(<<~RUBY)
+          def foo(&block)
+            bar(&block)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using explicit block forwarding without method body' do
+        expect_no_offenses(<<~RUBY)
+          def foo(&block)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when defining without block argument method' do
+        expect_no_offenses(<<~RUBY)
+          def foo(arg1, arg2)
+          end
+        RUBY
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds new `Naming/BlockForwarding` cop.

Ruby 3.1 will be introduced anonymous block forwarding syntax:
https://bugs.ruby-lang.org/issues/11256

This cop identifies places where `do_something(&block)` can be replaced by `do_something(&)`.

```ruby
# bad
def foo(&block)
  bar(&block)
end

# good
def foo(&)
  bar(&)
end
```

AFAIK, in most cases, block argument is given name similar to `&block` or `&proc`. Their names have no information and `&` will be sufficient for syntactic meaning.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
