### PR TITLE
Support Ruby 3.1's hash value omission syntax for `Layout/SpaceAfterColon`

### DIFF
--- a/changelog/new_support_hash_value_omission_for_layout_space_after_colon.md
+++ b/changelog/new_support_hash_value_omission_for_layout_space_after_colon.md
@@ -1,0 +1,1 @@
+* [#10291](https://github.com/rubocop/rubocop/pull/10291): Support Ruby 3.1's hash value omission syntax for `Layout/SpaceAfterColon`. ([@koic][])

--- a/lib/rubocop/cop/layout/space_after_colon.rb
+++ b/lib/rubocop/cop/layout/space_after_colon.rb
@@ -19,7 +19,7 @@ module RuboCop
         MSG = 'Space missing after colon.'
 
         def on_pair(node)
-          return unless node.colon?
+          return if !node.colon? || node.value_omission?
 
           colon = node.loc.operator
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
   s.add_runtime_dependency('rexml')
-  s.add_runtime_dependency('rubocop-ast', '>= 1.14.0', '< 2.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 1.15.0', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 3.0')
 

--- a/spec/rubocop/cop/layout/space_after_colon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_colon_spec.rb
@@ -66,4 +66,16 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterColon, :config do
       end
     RUBY
   end
+
+  context 'Ruby >= 3.1', :ruby31 do
+    it 'does not register an offense colon without space after it when using hash value omission' do
+      expect_no_offenses('{x:, y:}')
+    end
+
+    it 'accepts colons denoting hash value omission argument' do
+      expect_no_offenses(<<~RUBY)
+        foo(table:, nodes:)
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This PR supports Ruby 3.1's hash value omission syntax for `Layout/SpaceAfterColon`.

The `Layout/SpaceAfterColon` cop have already accepted the following required keyword arguments:

```ruby
# good
def initialize(foo:, bar:)
end
```

This PR will also make this cop accept Ruby 3.1 hash value omission.

```ruby
# good
{foo:, bar:}
do_something(foo:, bar:)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
