### PR TITLE
Support Ruby 3.1's hash value omission for `Layout/HashAlignment`

### DIFF
--- a/changelog/new_support_hash_value_omission_for_layout_hash_alignment.md
+++ b/changelog/new_support_hash_value_omission_for_layout_hash_alignment.md
@@ -1,0 +1,1 @@
+* [#10295](https://github.com/rubocop/rubocop/pull/10295): Support Ruby 3.1's hash value omission syntax for `Layout/HashAlignment`. ([@koic][])

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -313,7 +313,7 @@ module RuboCop
           # just give each lambda the same reference and they would all get the
           # last value of each. A local variable fixes the problem.
 
-          if node.value
+          if node.value && node.respond_to?(:value_omission?) && !node.value_omission?
             correct_key_value(corrector, delta, node.key.source_range,
                               node.value.source_range,
                               node.loc.operator)

--- a/lib/rubocop/cop/mixin/hash_alignment_styles.rb
+++ b/lib/rubocop/cop/mixin/hash_alignment_styles.rb
@@ -43,7 +43,7 @@ module RuboCop
         end
 
         def value_delta(pair)
-          return 0 if pair.value_on_new_line?
+          return 0 if pair.value_on_new_line? || pair.value_omission?
 
           correct_value_column = pair.loc.operator.end.column + 1
           actual_value_column = pair.value.loc.column
@@ -111,7 +111,8 @@ module RuboCop
           correct_value_column = first_pair.key.loc.column +
                                  current_pair.delimiter(true).length +
                                  max_key_width
-          correct_value_column - current_pair.value.loc.column
+
+          current_pair.value_omission? ? 0 : correct_value_column - current_pair.value.loc.column
         end
       end
 
@@ -134,7 +135,7 @@ module RuboCop
         end
 
         def value_delta(first_pair, current_pair)
-          first_pair.value_delta(current_pair)
+          current_pair.value_omission? ? 0 : first_pair.value_delta(current_pair)
         end
       end
 

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -36,6 +36,33 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
         end
       RUBY
     end
+
+    context 'when using hash value omission', :ruby31 do
+      it 'accepts single line hash' do
+        expect_no_offenses('func(a:, bb:)')
+      end
+
+      it 'accepts several pairs per line' do
+        expect_no_offenses(<<~RUBY)
+          func(a:, bb:,
+               ccc:, dddd:)
+        RUBY
+      end
+
+      it "accepts pairs that don't start a line" do
+        expect_no_offenses(<<~RUBY)
+          render :json => {a:,
+                           b:}, :status => 404
+          def example
+            a(
+              b:,
+              c: d(
+                e:
+              ), f:)
+          end
+        RUBY
+      end
+    end
   end
 
   context 'always inspect last argument hash' do
@@ -118,6 +145,34 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
                b: 1})
       RUBY
     end
+
+    context 'when using hash value omission', :ruby31 do
+      it 'registers offense and corrects misaligned keys in implicit hash' do
+        expect_offense(<<~RUBY)
+          func(a:,
+            b:)
+            ^^ Align the keys of a hash literal if they span more than one line.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          func(a:,
+               b:)
+        RUBY
+      end
+
+      it 'registers offense and corrects misaligned keys in explicit hash' do
+        expect_offense(<<~RUBY)
+          func({a:,
+            b:})
+            ^^ Align the keys of a hash literal if they span more than one line.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          func({a:,
+                b:})
+        RUBY
+      end
+    end
   end
 
   context 'when `EnforcedStyle: with_fixed_indentation` of `ArgumentAlignment`' do
@@ -161,6 +216,36 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           region: ENV['S3_REGION'],
         )
       RUBY
+    end
+
+    context 'when using hash value omission', :ruby31 do
+      it 'register and corrects an offense' do
+        expect_offense(<<~RUBY)
+          THINGS = {
+            oh:,
+              hi:
+              ^^^ Align the keys of a hash literal if they span more than one line.
+              }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          THINGS = {
+            oh:,
+            hi:
+              }
+        RUBY
+      end
+
+      it 'does not register and corrects an offense when using aligned keyword arguments' do
+        expect_no_offenses(<<~RUBY)
+          config.fog_credentials_as_kwargs(
+            provider:,
+            aws_access_key_id:,
+            aws_secret_access_key:,
+            region:
+          )
+        RUBY
+      end
     end
 
     it 'does not register an offense using aligned hash literal' do
@@ -316,6 +401,28 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
         func({a: 0,
           b: 1})
       RUBY
+    end
+
+    context 'when using hash value omission', :ruby31 do
+      it 'registers an offense and corrects misaligned keys in implicit hash' do
+        expect_offense(<<~RUBY)
+          func(a:,
+            b:)
+            ^^ Align the keys of a hash literal if they span more than one line.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          func(a:,
+               b:)
+        RUBY
+      end
+
+      it 'accepts misaligned keys in explicit hash' do
+        expect_no_offenses(<<~RUBY)
+          func({a:,
+            b:})
+        RUBY
+      end
     end
 
     it 'registers an offense and corrects misaligned keys in implicit hash for super' do
@@ -640,6 +747,22 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_no_offenses('h = {}')
     end
 
+    context 'when using hash value omission', :ruby31 do
+      it 'accepts aligned hash keys and values' do
+        expect_no_offenses(<<~RUBY)
+          hash1 = {
+            'a'   => 0,
+            'bbb' => 1
+          }
+          hash2 = {
+            a:   0,
+            bbb: 1,
+            ccc:
+          }
+        RUBY
+      end
+    end
+
     it 'accepts a multiline array of single line hashes' do
       expect_no_offenses(<<~RUBY)
         def self.scenarios_order
@@ -797,6 +920,38 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           'bbb' => 1
         }
       RUBY
+    end
+
+    context 'when using hash value omission', :ruby31 do
+      it 'accepts aligned hash keys' do
+        expect_no_offenses(<<~RUBY)
+          hash1 = {
+              a: 0,
+            bbb: 1,
+            ccc:
+          }
+          hash2 = {
+              'a' => 0,
+            'bbb' => 1
+          }
+        RUBY
+      end
+
+      it 'registers an offense and corrects mixed indentation and spacing' do
+        expect_offense(<<~RUBY)
+          hash1 = { a: 0,
+               bb:,
+               ^^^ Align the separators of a hash literal if they span more than one line.
+                     ccc: 2 }
+                     ^^^^^^ Align the separators of a hash literal if they span more than one line.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          hash1 = { a: 0,
+                   bb:,
+                  ccc: 2 }
+        RUBY
+      end
     end
 
     it 'accepts an empty hash' do
@@ -1191,6 +1346,17 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           foo ab: 1,
               c:  2
         RUBY
+      end
+    end
+
+    context 'when using hash value omission', :ruby31 do
+      context 'and aligned keys' do
+        it 'does not register an offense and corrects' do
+          expect_no_offenses(<<~RUBY)
+            foo ab: 1,
+                c:
+          RUBY
+        end
       end
     end
 


### PR DESCRIPTION
This PR supports Ruby 3.1's hash value omission syntax for `Layout/HashAlignment`.

And it prevents the following false positive and incorrect auto-correction.

```console
% cat hash_value_omission.rb
{
  foo: 42,
  bar:
}

% bundle exec rubocop --only Layout/HashAlignment -a hash_value_omission.rb
(snip)

Inspecting 1 file
C

Offenses:

hash_value_omission.rb:3:3: C: [Corrected] Layout/HashAlignment: Align
the keys of a hash literal if they span more than one line.
  bar:
  ^^^^
hash_value_omission.rb:3:8: C: [Corrected] Layout/HashAlignment:
Align the keys of a hash literal if they span more than one line.
  bar:
  ^^^^

0 files inspected, 2 offenses detected, 2 offenses corrected
Infinite loop detected in
/Users/koic/src/github.com/koic/rubocop-issues/ruby31/hash_value_omission.rb
and caused by Layout/HashAlignment
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/runner.rb:298:in
`check_for_infinite_loop'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/runner.rb:281:in
`block in iterate_until_no_changes'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/runner.rb:280:in
`loop'
```

The indent breaks unexpectedly and this PR fixes this issue.

```ruby
% cat hash_value_omission.rb
{
  foo: 42,
       bar:
}
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
