### PR TITLE
[Fix #10297] Fix a false positive for `Lint/DeprecatedOpenSSLConstant`

### DIFF
--- a/changelog/fix_false_positive_for_lint_deprecated_open_ssl_constant.md
+++ b/changelog/fix_false_positive_for_lint_deprecated_open_ssl_constant.md
@@ -1,0 +1,1 @@
+* [#10297](https://github.com/rubocop/rubocop/issues/10297): Fix a false positive for `Lint/DeprecatedOpenSSLConstant` when building digest using an algorithm string and nested digest constants. ([@koic][])

--- a/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
+++ b/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
@@ -55,8 +55,14 @@ module RuboCop
             ...)
         PATTERN
 
+        # @!method digest_const?(node)
+        def_node_matcher :digest_const?, <<~PATTERN
+          (const _ :Digest)
+        PATTERN
+
         def on_send(node)
           return if node.arguments.any? { |arg| arg.variable? || arg.send_type? || arg.const_type? }
+          return if digest_const?(node.receiver)
           return unless algorithm_const(node)
 
           message = message(node)

--- a/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
@@ -161,6 +161,12 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedOpenSSLConstant, :config do
     RUBY
   end
 
+  it 'does not register an offense when building digest using an algorithm string and nested digest constants' do
+    expect_no_offenses(<<~RUBY)
+      OpenSSL::Digest::Digest.new('SHA256')
+    RUBY
+  end
+
   it 'does not register an offense when using ::Digest class methods with an algorithm string and value' do
     expect_no_offenses(<<~RUBY)
       OpenSSL::Digest.digest('SHA256', 'foo')


### PR DESCRIPTION
Fixes #10297.

This PR fixes a false positive for `Lint/DeprecatedOpenSSLConstant` when building digest using an algorithm string and nested digest constants.

It aims to prevent the false positive. I may open a separated PR for another cop about detection of redundant constants.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
