### PR TITLE
[Fix #10303] Add `AllowedNumbers` option to `Style/NumericLiterals`

### DIFF
--- a/changelog/new_allowed_numbers_option_to_style_numeric_literals.md
+++ b/changelog/new_allowed_numbers_option_to_style_numeric_literals.md
@@ -1,0 +1,1 @@
+* [#10303](https://github.com/rubocop/rubocop/issues/10303): Add `AllowedNumbers` option to `Style/NumericLiterals`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4223,6 +4223,8 @@ Style/NumericLiterals:
   VersionChanged: '0.48'
   MinDigits: 5
   Strict: false
+  # You can specify allowed numbers. (e.g. port number 3000, 8080, and etc)
+  AllowedNumbers: []
 
 Style/NumericPredicate:
   Description: >-

--- a/lib/rubocop/cop/style/numeric_literals.rb
+++ b/lib/rubocop/cop/style/numeric_literals.rb
@@ -27,6 +27,11 @@ module RuboCop
       #   # bad
       #   10_000_00 # typical representation of $10,000 in cents
       #
+      # @example AllowedNumbers: [3000]
+      #
+      #   # good
+      #   3000 # You can specify allowed numbers. (e.g. port number)
+      #
       class NumericLiterals < Base
         include IntegerNode
         extend AutoCorrector
@@ -51,9 +56,9 @@ module RuboCop
 
         def check(node)
           int = integer_part(node)
-
           # TODO: handle non-decimal literals as well
           return if int.start_with?('0')
+          return if allowed_numbers.include?(int)
           return unless int.size >= min_digits
 
           case int
@@ -98,6 +103,10 @@ module RuboCop
 
         def min_digits
           cop_config['MinDigits']
+        end
+
+        def allowed_numbers
+          cop_config.fetch('AllowedNumbers', []).map(&:to_s)
         end
       end
     end

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -379,7 +379,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                 '',
                 '# Offense count: 1',
                 '# Cop supports --auto-correct.',
-                '# Configuration parameters: Strict.',
+                '# Configuration parameters: Strict, AllowedNumbers.',
                 'Style/NumericLiterals:',
                 '  MinDigits: 7',
                 '',

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -219,4 +219,38 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
       end
     end
   end
+
+  context 'when `3000` is specified for `AllowedNumbers`' do
+    let(:cop_config) { { 'MinDigits' => 4, 'AllowedNumbers' => [3000] } }
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        3000
+      RUBY
+    end
+
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        1234
+        ^^^^ Use underscores(_) as thousands separator and separate every 3 digits with them.
+      RUBY
+    end
+  end
+
+  context "when `'3000'` is specified for `AllowedNumbers`" do
+    let(:cop_config) { { 'MinDigits' => 4, 'AllowedNumbers' => ['3000'] } }
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        3000
+      RUBY
+    end
+
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        1234
+        ^^^^ Use underscores(_) as thousands separator and separate every 3 digits with them.
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #10303.

This PR adds `AllowedNumbers` option to `Style/NumericLiterals`.

```ruby
# @example AllowedNumbers: [3000]
#
#   # good
#   3000 # You can specify allowed numbers. (e.g. server port)
```

Any default values will not set because false negatives occur when `3000`, `8080` (,and other values) are used other than the port numbers.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
