### PR TITLE
[Fix #10305] Fix an incorrect autocorrect for `Style/HashConversion`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_hash_conversion.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_hash_conversion.md
@@ -1,0 +1,1 @@
+* [#10305](https://github.com/rubocop/rubocop/issues/10305): Fix an incorrect autocorrect for `Style/HashConversion` when using `Hash[a || b]`. ([@koic][])

--- a/lib/rubocop/cop/style/hash_conversion.rb
+++ b/lib/rubocop/cop/style/hash_conversion.rb
@@ -101,7 +101,8 @@ module RuboCop
         end
 
         def requires_parens?(node)
-          node.call_type? && node.arguments.any? && !node.parenthesized?
+          (node.call_type? && node.arguments.any? && !node.parenthesized?) ||
+            node.or_type? || node.and_type?
         end
 
         def multi_argument(node)

--- a/spec/rubocop/cop/style/hash_conversion_spec.rb
+++ b/spec/rubocop/cop/style/hash_conversion_spec.rb
@@ -120,6 +120,50 @@ RSpec.describe RuboCop::Cop::Style::HashConversion, :config do
     RUBY
   end
 
+  it 'reports different offense for Hash[a || b]' do
+    expect_offense(<<~RUBY)
+      Hash[a || b]
+      ^^^^^^^^^^^^ Prefer ary.to_h to Hash[ary].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (a || b).to_h
+    RUBY
+  end
+
+  it 'reports different offense for Hash[(a || b)]' do
+    expect_offense(<<~RUBY)
+      Hash[(a || b)]
+      ^^^^^^^^^^^^^^ Prefer ary.to_h to Hash[ary].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (a || b).to_h
+    RUBY
+  end
+
+  it 'reports different offense for Hash[a && b]' do
+    expect_offense(<<~RUBY)
+      Hash[a && b]
+      ^^^^^^^^^^^^ Prefer ary.to_h to Hash[ary].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (a && b).to_h
+    RUBY
+  end
+
+  it 'reports different offense for Hash[(a && b)]' do
+    expect_offense(<<~RUBY)
+      Hash[(a && b)]
+      ^^^^^^^^^^^^^^ Prefer ary.to_h to Hash[ary].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (a && b).to_h
+    RUBY
+  end
+
   it 'registers and corrects an offense when using `zip` with argument in `Hash[]`' do
     expect_offense(<<~RUBY)
       Hash[array.zip([1, 2, 3])]


### PR DESCRIPTION
Fixes #10305.

This PR fixes an incorrect autocorrect for `Style/HashConversion` when using `Hash[a || b]`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
