### PR TITLE
Support Ruby 2.7's numbered parameter for `Metrics/*Length` cops

### DIFF
--- a/changelog/new_support_numbered_parameter_for_metrics_length_cops.md
+++ b/changelog/new_support_numbered_parameter_for_metrics_length_cops.md
@@ -1,0 +1,1 @@
+* [#10307](https://github.com/rubocop/rubocop/pull/10307): Support Ruby 2.7's numbered parameter for `Metrics/BlockLength`, `Metrics/ClassLength`, `Metrics/MethodLength`, and `Metrics/ModuleLength` cops. ([@koic][])

--- a/lib/rubocop/cop/metrics/block_length.rb
+++ b/lib/rubocop/cop/metrics/block_length.rb
@@ -50,6 +50,7 @@ module RuboCop
 
           check_code_length(node)
         end
+        alias on_numblock on_block
 
         private
 

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -52,6 +52,7 @@ module RuboCop
 
           check_code_length(node)
         end
+        alias on_numblock on_block
 
         private
 

--- a/lib/rubocop/cop/metrics/module_length.rb
+++ b/lib/rubocop/cop/metrics/module_length.rb
@@ -44,7 +44,7 @@ module RuboCop
 
         # @!method module_definition?(node)
         def_node_matcher :module_definition?, <<~PATTERN
-          (casgn nil? _ (block (send (const {nil? cbase} :Module) :new) ...))
+          (casgn nil? _ ({block numblock} (send (const {nil? cbase} :Module) :new) ...))
         PATTERN
 
         def message(length, max_length)

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -135,7 +135,7 @@ module RuboCop
 
           def extract_body(node)
             case node.type
-            when :class, :module, :block, :def, :defs
+            when :class, :module, :block, :numblock, :def, :defs
               node.body
             when :casgn
               _scope, _name, value = *node

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -72,6 +72,52 @@ RSpec.describe RuboCop::Cop::Metrics::BlockLength, :config do
     RUBY
   end
 
+  context 'when using numbered parameter', :ruby27 do
+    it 'rejects a block with more than 5 lines' do
+      expect_offense(<<~RUBY)
+        something do
+        ^^^^^^^^^^^^ Block has too many lines. [3/2]
+          a = _1
+          a = _2
+          a = _3
+        end
+      RUBY
+    end
+
+    it 'reports the correct beginning and end lines' do
+      offenses = expect_offense(<<~RUBY)
+        something do
+        ^^^^^^^^^^^^ Block has too many lines. [3/2]
+          a = _1
+          a = _2
+          a = _3
+        end
+      RUBY
+      offense = offenses.first
+      expect(offense.location.last_line).to eq(5)
+    end
+
+    it 'accepts a block with less than 3 lines' do
+      expect_no_offenses(<<~RUBY)
+        something do
+          a = _1
+          a = _2
+        end
+      RUBY
+    end
+
+    it 'does not count blank lines' do
+      expect_no_offenses(<<~RUBY)
+        something do
+          a = _1
+
+
+          a = _2
+        end
+      RUBY
+    end
+  end
+
   it 'accepts a block with multiline receiver and less than 3 lines of body' do
     expect_no_offenses(<<~RUBY)
       [

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -35,6 +35,24 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
     end
   end
 
+  context 'when using numbered parameter', :ruby27 do
+    context 'when method is defined with `define_method`' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          define_method(:m) do
+          ^^^^^^^^^^^^^^^^^^^^ Method has too many lines. [6/5]
+            a = _1
+            a = _2
+            a = _3
+            a = _4
+            a = _5
+            a = _6
+          end
+        RUBY
+      end
+    end
+  end
+
   context 'when method is a class method' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -256,4 +256,38 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
       RUBY
     end
   end
+
+  context 'when using numbered parameter', :ruby27 do
+    context 'when inspecting a class defined with Module.new' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          Foo = Module.new do
+          ^^^ Module has too many lines. [6/5]
+            a(_1)
+            b(_1)
+            c(_1)
+            d(_1)
+            e(_1)
+            f(_1)
+          end
+        RUBY
+      end
+    end
+
+    context 'when inspecting a class defined with ::Module.new' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          Foo = ::Module.new do
+          ^^^ Module has too many lines. [6/5]
+            a(_1)
+            b(_1)
+            c(_1)
+            d(_1)
+            e(_1)
+            f(_1)
+          end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR supports Ruby 2.7's numbered parameter for `Metrics/BlockLength`, `Metrics/ClassLength`, `Metrics/MethodLength`, and `Metrics/ModuleLength` cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
