### PR TITLE
Make `Style/CollectionCompact` aware of block pass

### DIFF
--- a/changelog/new_make_style_collection_compact_aware_of_block_pass.md
+++ b/changelog/new_make_style_collection_compact_aware_of_block_pass.md
@@ -1,0 +1,1 @@
+* [#10308](https://github.com/rubocop/rubocop/pull/10308): Make `Style/CollectionCompact` aware of block pass argument. ([@koic][])

--- a/spec/rubocop/cop/style/collection_compact_spec.rb
+++ b/spec/rubocop/cop/style/collection_compact_spec.rb
@@ -15,6 +15,20 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `reject` with block pass arg on array to reject nils' do
+    expect_offense(<<~RUBY)
+      array.reject(&:nil?)
+            ^^^^^^^^^^^^^^ Use `compact` instead of `reject(&:nil?)`.
+      array.reject!(&:nil?)
+            ^^^^^^^^^^^^^^^ Use `compact!` instead of `reject!(&:nil?)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array.compact
+      array.compact!
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `reject` on hash to reject nils' do
     expect_offense(<<~RUBY)
       hash.reject { |k, v| v.nil? }


### PR DESCRIPTION
This PR makes `Style/CollectionCompact` aware of the following block pass argument.

```ruby
# bad
array.reject(&:nil?)
array.reject!(&:nil?)

# good
array.compact
array.compact!
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
