### PR TITLE
Fix a false positive for `Bundler/DuplicatedGem` when a gem conditionally duplicated within multi-statement bodies

### DIFF
--- a/changelog/fix_false_positive_bundler_duplicated_gem.md
+++ b/changelog/fix_false_positive_bundler_duplicated_gem.md
@@ -1,0 +1,1 @@
+* [#10309](https://github.com/rubocop/rubocop/pull/10309): Fix a false positive for `Bundler/DuplicatedGem` when a gem conditionally duplicated within multi-statement bodies. ([@fatkodima][])

--- a/lib/rubocop/cop/bundler/duplicated_gem.rb
+++ b/lib/rubocop/cop/bundler/duplicated_gem.rb
@@ -68,7 +68,7 @@ module RuboCop
         end
 
         def conditional_declaration?(nodes)
-          parent = nodes[0].parent
+          parent = nodes[0].each_ancestor.find { |ancestor| !ancestor.begin_type? }
           return false unless parent&.if_type? || parent&.when_type?
 
           root_conditional_node = parent.if_type? ? parent : parent.parent

--- a/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
       expect_no_offenses(<<-GEM, 'Gemfile')
         if Dir.exist?(local)
           gem 'rubocop', path: local
+          gem 'flog', path: local
         else
           gem 'rubocop', '~> 0.90.0'
         end


### PR DESCRIPTION
On the following code

```ruby
if defined?(@ar_gem_requirement)
  gem "activerecord", @ar_gem_requirement
  gem "railties", @ar_gem_requirement
else
  gem "activerecord"
  gem "railties" # to test generator
end
```

I got this output:
```
Offenses:

Gemfile:15:3: C: Bundler/DuplicatedGem: Gem activerecord requirements already given on line 12 of the Gemfile.
  gem "activerecord"
  ^^^^^^^^^^^^^^^^^^
Gemfile:16:3: C: Bundler/DuplicatedGem: Gem railties requirements already given on line 13 of the Gemfile.
  gem "railties" # to test generator
  ^^^^^^^^^^^^^^

1 file inspected, 2 offenses detected
```

`Bundler/DuplicatedGem` does not take into account that conditional branches can have multiple statements.