### PR TITLE
[Fix #10313] Fix autocorrect `Style/MapToHash` with multiline code

### DIFF
--- a/changelog/fix_map_to_hash_newline.md
+++ b/changelog/fix_map_to_hash_newline.md
@@ -1,0 +1,1 @@
+* [#10313](https://github.com/rubocop/rubocop/issues/10313): Fix autocorrect `Style/MapToHash` with multiline code. ([@tejasbubane][])

--- a/lib/rubocop/cop/style/map_to_hash.rb
+++ b/lib/rubocop/cop/style/map_to_hash.rb
@@ -59,7 +59,7 @@ module RuboCop
         def autocorrect(corrector, to_h, map)
           removal_range = range_between(to_h.loc.dot.begin_pos, to_h.loc.selector.end_pos)
 
-          corrector.remove(removal_range)
+          corrector.remove(range_with_surrounding_space(range: removal_range, side: :left))
           corrector.replace(map.loc.selector, 'to_h')
         end
       end

--- a/spec/rubocop/cop/style/map_to_hash_spec.rb
+++ b/spec/rubocop/cop/style/map_to_hash_spec.rb
@@ -86,6 +86,24 @@ RSpec.describe RuboCop::Cop::Style::MapToHash, :config do
           expect_no_corrections
         end
       end
+
+      context "`map` and `#{method}.to_h` with newlines" do
+        it 'registers an offense and corrects with newline removal' do
+          expect_offense(<<~RUBY, method: method)
+            {foo: bar}
+              .#{method} { |k, v| [k.to_s, v.do_something] }
+               ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+              .to_h
+              .freeze
+          RUBY
+
+          expect_correction(<<~RUBY)
+            {foo: bar}
+              .to_h { |k, v| [k.to_s, v.do_something] }
+              .freeze
+          RUBY
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #10313

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/