### PR TITLE
Fix an error for `InternalAffairs/RedundantMethodDispatchNode

### DIFF
--- a/lib/rubocop/cop/internal_affairs/redundant_method_dispatch_node.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_method_dispatch_node.rb
@@ -33,8 +33,9 @@ module RuboCop
 
         def on_send(node)
           return unless (dispatch_node = dispatch_method(node))
+          return unless (dot = dispatch_node.loc.dot)
 
-          range = range_between(dispatch_node.loc.dot.begin_pos, dispatch_node.loc.selector.end_pos)
+          range = range_between(dot.begin_pos, dispatch_node.loc.selector.end_pos)
 
           add_offense(range) do |corrector|
             corrector.remove(range)

--- a/spec/rubocop/cop/internal_affairs/redundant_method_dispatch_node_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_method_dispatch_node_spec.rb
@@ -40,4 +40,10 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantMethodDispatchNode, :conf
       node.send_node.arguments?
     RUBY
   end
+
+  it 'does not register an offense when using `send_node.method_name`' do
+    expect_no_offenses(<<~RUBY)
+      send_node.method_name
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes the following error for `InternalAffairs/RedundantMethodDispatchNode`
when using `send_node.method_name`.

```console
undefined method `begin_pos' for nil:NilClass

          range = range_between(dispatch_node.loc.dot.begin_pos, dispatch_node.loc.selector.end_pos)
                                                     ^^^^^^^^^^
/Users/koic/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/rubocop-1.24.0/lib/rubocop/cop/internal_affairs/redundant_method_dispatch_node.rb:37:in `on_send'
````

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
