### PR TITLE
[Fix #10320] Fix an incorrect autocorrect for `Style/FileWrite`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_file_write.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_file_write.md
@@ -1,0 +1,1 @@
+* [#10320](https://github.com/rubocop/rubocop/issues/10320): Fix an incorrect autocorrect for `Style/FileWrite` when using heredoc argument. ([@koic][])

--- a/spec/rubocop/cop/style/file_write_spec.rb
+++ b/spec/rubocop/cop/style/file_write_spec.rb
@@ -63,5 +63,24 @@ RSpec.describe RuboCop::Cop::Style::FileWrite, :config do
         File.#{write_method}(filename, content)
       RUBY
     end
+
+    it "registers an offense for and corrects the `File.open` with multiline write block (mode '#{mode}') with heredoc" do
+      write_method = mode.end_with?('b') ? :binwrite : :write
+
+      expect_offense(<<~RUBY)
+        File.open(filename, '#{mode}') do |f|
+        ^^^^^^^^^^^^^^^^^^^^^#{'^' * mode.length}^^^^^^^^^ Use `File.#{write_method}`.
+          f.write(<<~EOS)
+            content
+          EOS
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        File.#{write_method}(filename, <<~EOS)
+            content
+          EOS
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fixes #10320.

This PR fixes an incorrect autocorrect for `Style/FileWrite` when using heredoc argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
