### PR TITLE
[Fix #10321] Make `Style/MethodDefParentheses` aware of anonymous block forwarding

### DIFF
--- a/changelog/fix_false_positive_for_style_method_def_parentheses.md
+++ b/changelog/fix_false_positive_for_style_method_def_parentheses.md
@@ -1,0 +1,1 @@
+* [#10321](https://github.com/rubocop/rubocop/issues/10321): Make `Style/MethodDefParentheses` aware of Ruby 3.1's anonymous block forwarding. ([@koic][])

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -6,8 +6,13 @@ module RuboCop
       # This cop checks for parentheses around the arguments in method
       # definitions. Both instance and class/singleton methods are checked.
       #
-      # This cop does not consider endless methods, since parentheses are
-      # always required for them.
+      # Regardless of style, parentheses are necessary for:
+      #
+      # 1. Endless methods
+      # 2. Argument lists containing a `forward-arg` (`...`)
+      # 3. Argument lists containing an anonymous block forwarding (`&`)
+      #
+      # Removing the parens would be a syntax error here.
       #
       # @example EnforcedStyle: require_parentheses (default)
       #   # The `require_parentheses` style requires method definitions
@@ -133,9 +138,9 @@ module RuboCop
           # Regardless of style, parentheses are necessary for:
           # 1. Endless methods
           # 2. Argument lists containing a `forward-arg` (`...`)
+          # 3. Argument lists containing an anonymous block forwarding (`&`)
           # Removing the parens would be a syntax error here.
-
-          node.endless? || node.arguments.any?(&:forward_arg_type?)
+          node.endless? || node.arguments.any?(&:forward_arg_type?) || anonymous_block_arg?(node)
         end
 
         def require_parentheses?(args)
@@ -162,6 +167,12 @@ module RuboCop
             correct_arguments(args, corrector)
             unexpected_style_detected 'require_parentheses'
           end
+        end
+
+        def anonymous_block_arg?(node)
+          return false unless (last_argument = node.arguments.last)
+
+          last_argument.blockarg_type? && last_argument.name.nil?
         end
       end
     end

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -99,6 +99,14 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         end
       RUBY
     end
+
+    it 'requires parens for anonymous block forwarding', :ruby31 do
+      expect_no_offenses(<<~RUBY)
+        def foo(&)
+          bar(&)
+        end
+      RUBY
+    end
   end
 
   shared_examples 'endless methods' do


### PR DESCRIPTION
Fixes #10321.

This PR fixes a false positive for `Style/MethodDefParentheses` when using `EnforcedStyle: require_no_parentheses` and Ruby 3.1's anonymous block forwarding.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
