### PR TITLE
[Fix #10319] Fix a false positive for `Style/CombinableLoop`

### DIFF
--- a/changelog/fix_a_false_positive_for_combinable_loop.md
+++ b/changelog/fix_a_false_positive_for_combinable_loop.md
@@ -1,0 +1,1 @@
+* [#10319](https://github.com/rubocop/rubocop/issues/10319): Require rubocop-ast 1.15.1 to fix a false positive for `Style/CombinableLoop` when the same method with different arguments and safe navigation. ([@koic][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
   s.add_runtime_dependency('rexml')
-  s.add_runtime_dependency('rubocop-ast', '>= 1.15.0', '< 2.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 1.15.1', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 3.0')
 

--- a/spec/rubocop/cop/style/combinable_loops_spec.rb
+++ b/spec/rubocop/cop/style/combinable_loops_spec.rb
@@ -58,6 +58,13 @@ RSpec.describe RuboCop::Cop::Style::CombinableLoops, :config do
         each_slice(3) { |slice| do_something(slice) }
       RUBY
     end
+
+    it 'does not register an offense for when the same method with different arguments and safe navigation' do
+      expect_no_offenses(<<~RUBY)
+        foo(:bar)&.each { |item| do_something(item) }
+        foo(:baz)&.each { |item| do_something(item) }
+      RUBY
+    end
   end
 
   context 'when for loop' do


### PR DESCRIPTION
Fixes #10319.

This PR requires rubocop-ast 1.15.1 (https://github.com/rubocop/rubocop-ast/pull/220) to fix a false positive for `Style/CombinableLoop` when the same method with different arguments and safe navigation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
