### PR TITLE
[Fix #10317] Fix a false positive for `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/changelog/fix_false_positive_for_style_method_call_with_args_parentheses.md
+++ b/changelog/fix_false_positive_for_style_method_call_with_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#10317](https://github.com/rubocop/rubocop/issues/10317): Fix a false positive for `Style/MethodCallWithArgsParentheses` when using hash value omission. ([@koic][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -43,9 +43,11 @@ module RuboCop
       # NOTE: Parentheses are still allowed in cases where omitting them
       # results in ambiguous or syntactically incorrect code. For example,
       # parentheses are required around a method with arguments when inside an
-      # endless method definition introduced in Ruby 3.0.  Parentheses are also
+      # endless method definition introduced in Ruby 3.0. Parentheses are also
       # allowed when forwarding arguments with the triple-dot syntax introduced
       # in Ruby 2.7 as omitting them starts an endless range.
+      # And Ruby 3.1's hash omission syntax has a case that requires parentheses
+      # because the issue https://bugs.ruby-lang.org/issues/18396.
       #
       # @example EnforcedStyle: require_parentheses (default)
       #

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -412,6 +412,40 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       end
     end
 
+    context 'hash value omission in 3.1', :ruby31 do
+      it 'registers an offense when last argument is a hash value omission' do
+        expect_offense(<<~RUBY)
+          foo(bar:, baz:)
+             ^^^^^^^^^^^^ Omit parentheses for method calls with arguments.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo bar:, baz:
+        RUBY
+      end
+
+      it 'does not register an offense when without parentheses call expr follows' do
+        expect_no_offenses(<<~RUBY)
+          foo value:
+        RUBY
+      end
+
+      it 'registers an offense when with parentheses call expr follows' do
+        # Require hash value omission be enclosed in parentheses to prevent the following issue:
+        # https://bugs.ruby-lang.org/issues/18396.
+        expect_offense(<<~RUBY)
+          foo(value:)
+          foo(arg)
+             ^^^^^ Omit parentheses for method calls with arguments.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo(value:)
+          foo arg
+        RUBY
+      end
+    end
+
     it 'register an offense for parens in method call without args' do
       trailing_whitespace = ' '
 


### PR DESCRIPTION
Fixes #10317.

This PR fixes a false positive for `Style/MethodCallWithArgsParentheses` when using hash value omission.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
