### PR TITLE
[Fix #10329] Fix a false positive for `Lint/ParenthesesAsGroupedExpression`

### DIFF
--- a/changelog/fix_false_positive_for_lint_parentheses_as_grouped_expression.md
+++ b/changelog/fix_false_positive_for_lint_parentheses_as_grouped_expression.md
@@ -1,0 +1,1 @@
+* [#10329](https://github.com/rubocop/rubocop/issues/10329): Fix a false positive for `Lint/ParenthesesAsGroupedExpression` and an incorrect autocorrect for the cop with `Style/TernaryParentheses` when using ternary expression as a first argument. ([@koic][])

--- a/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
+++ b/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
@@ -41,7 +41,11 @@ module RuboCop
           end
 
           node.operator_method? || node.setter_method? || chained_calls?(node) ||
-            operator_keyword?(node) || node.first_argument.hash_type?
+            valid_first_argument?(node.first_argument)
+        end
+
+        def valid_first_argument?(first_arg)
+          first_arg.operator_keyword? || first_arg.hash_type? || ternary_expression?(first_arg)
         end
 
         def first_argument_starts_with_left_parenthesis?(node)
@@ -53,9 +57,8 @@ module RuboCop
           first_argument.send_type? && (node.children.last&.children&.count || 0) > 1
         end
 
-        def operator_keyword?(node)
-          first_argument = node.first_argument
-          first_argument.operator_keyword?
+        def ternary_expression?(node)
+          node.if_type? && node.ternary?
         end
 
         def spaces_before_left_parenthesis(node)

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1801,6 +1801,23 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Style/TernaryParentheses` offenses and accepts `Lint/ParenthesesAsGroupedExpression`' do
+    create_file('example.rb', <<~RUBY)
+      json.asdf (foo || bar) ? 1 : 2
+    RUBY
+    expect(
+      cli.run(
+        [
+          '--auto-correct',
+          '--only', 'Lint/ParenthesesAsGroupedExpression,Style/TernaryParentheses'
+        ]
+      )
+    ).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      json.asdf foo || bar ? 1 : 2
+    RUBY
+  end
+
   %i[
     consistent_relative_to_receiver
     special_for_inner_method_call

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression, :config do
     RUBY
   end
 
+  it 'does not register an offense for ternary operator' do
+    expect_no_offenses(<<~RUBY)
+      foo (cond) ? 1 : 2
+    RUBY
+  end
+
   it 'accepts a method call without arguments' do
     expect_no_offenses('func')
   end


### PR DESCRIPTION
Fixes #10329.

This PR fixes a false positive for `Lint/ParenthesesAsGroupedExpression` and an incorrect autocorrect for the cop with `Style/TernaryParentheses` when using ternary expression as a first argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
