### PR TITLE
Fix cop generator for nested departments

### DIFF
--- a/changelog/fix_cop_generator_for_nested_departments.md
+++ b/changelog/fix_cop_generator_for_nested_departments.md
@@ -1,0 +1,1 @@
+* [#10331](https://github.com/rubocop/rubocop/pull/10331): Fix cop generator for nested departments. ([@fatkodima][])

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -182,7 +182,8 @@ module RuboCop
       end
 
       def generate(template)
-        format(template, department: badge.department, cop_name: badge.cop_name)
+        format(template, department: badge.department.to_s.gsub('/', '::'),
+                         cop_name: badge.cop_name)
       end
 
       def spec_path
@@ -209,8 +210,8 @@ module RuboCop
         return 'rspec' if camel_case_string == 'RSpec'
 
         camel_case_string
-          .gsub(/([^A-Z])([A-Z]+)/, '\1_\2')
-          .gsub(/([A-Z])([A-Z][^A-Z\d]+)/, '\1_\2')
+          .gsub(%r{([^A-Z/])([A-Z]+)}, '\1_\2')
+          .gsub(%r{([A-Z])([A-Z][^A-Z\d/]+)}, '\1_\2')
           .downcase
       end
     end

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -310,8 +310,30 @@ RSpec.describe RuboCop::Cop::Generator do
       expect(generator.__send__(:snake_case, 'FooBar')).to eq('foo_bar')
     end
 
+    it 'converts "FooBar/Baz" to snake_case' do
+      expect(generator.__send__(:snake_case, 'FooBar/Baz')).to eq('foo_bar/baz')
+    end
+
     it 'converts "RSpec" to snake_case' do
       expect(generator.__send__(:snake_case, 'RSpec')).to eq('rspec')
+    end
+  end
+
+  context 'nested departments' do
+    let(:cop_identifier) { 'Plugin/Style/FakeCop' }
+
+    include_context 'cli spec behavior'
+
+    it 'generates source and spec files correctly namespaced within departments' do
+      expect(File).to receive(:write).with('lib/rubocop/cop/plugin/style/fake_cop.rb',
+                                           an_instance_of(String))
+      generator.write_source
+      expect(stdout.string).to eq("[create] lib/rubocop/cop/plugin/style/fake_cop.rb\n")
+
+      expect(File).to receive(:write).with('spec/rubocop/cop/plugin/style/fake_cop_spec.rb',
+                                           an_instance_of(String))
+      generator.write_spec
+      expect(stdout.string).to include("[create] spec/rubocop/cop/plugin/style/fake_cop_spec.rb\n")
     end
   end
 


### PR DESCRIPTION
Fixes #10117 

Unfortunately, currently the generator will generate 
```ruby
module TopDepartment::SecondDepartment
end
``` 

instead of 
```ruby
module TopDepartment
  module SecondDepartment
  end
end
```

inside the cop source code, which then raises `NameError: uninitialized constant RuboCop::Cop::TopDepartment` if this is the first cop generated in the department and unless module `TopDepartment` exists. So the user should manually update the code to be like in the second example.

We can do this automatically, but this will require a non-trivial amount of ugly code changes to `generator.rb` to handle the case with nested departments. So I'm wondering if this is worth it? This PR already makes life easier.