### PR TITLE
Fix an incorrect autocorrect for `Gemspec/RequireMFA` when .gemspec file contains `metadata` keys assignments

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_gemspec_require_mfa.md
+++ b/changelog/fix_incorrect_autocorrect_for_gemspec_require_mfa.md
@@ -1,0 +1,1 @@
+* [#10251](https://github.com/rubocop/rubocop/issues/10251): Fix an incorrect autocorrect for `Gemspec/RequireMFA` when .gemspec file contains `metadata` keys assignments. ([@fatkodima][])

--- a/lib/rubocop/cop/gemspec/require_mfa.rb
+++ b/lib/rubocop/cop/gemspec/require_mfa.rb
@@ -117,7 +117,7 @@ module RuboCop
 
             correct_metadata(corrector, metadata)
           else
-            correct_missing_metadata(corrector, node, block_var)
+            insert_mfa_required(corrector, node, block_var)
           end
         end
 
@@ -129,11 +129,9 @@ module RuboCop
           end
         end
 
-        def correct_missing_metadata(corrector, node, block_var)
+        def insert_mfa_required(corrector, node, block_var)
           corrector.insert_before(node.loc.end, <<~RUBY)
-            #{block_var}.metadata = {
-              'rubygems_mfa_required' => 'true'
-            }
+            #{block_var}.metadata['rubygems_mfa_required'] = 'true'
           RUBY
         end
 

--- a/spec/rubocop/cop/gemspec/require_mfa_spec.rb
+++ b/spec/rubocop/cop/gemspec/require_mfa_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe RuboCop::Cop::Gemspec::RequireMFA, :config do
 
       expect_correction(<<~RUBY)
         Gem::Specification.new do |spec|
-        spec.metadata = {
-          'rubygems_mfa_required' => 'true'
-        }
+        spec.metadata['rubygems_mfa_required'] = 'true'
         end
       RUBY
     end
@@ -113,6 +111,13 @@ RSpec.describe RuboCop::Cop::Gemspec::RequireMFA, :config do
           Gem::Specification.new do |spec|
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `metadata['rubygems_mfa_required']` must be set to `'true'`.
             spec.metadata['foo'] = 'bar'
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.metadata['foo'] = 'bar'
+          spec.metadata['rubygems_mfa_required'] = 'true'
           end
         RUBY
       end


### PR DESCRIPTION
When we have `spec.metadata = {...}`, insert `rubygems_mfa_required` setting there. 
Otherwise, just always add `spec.metadata["rubygems_mfa_required"] = "true"`. 

Closes #10251
