### PR TITLE
Fix an incorrect autocorrect for `Naming/BlockForwarding`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_naming_block_forwarding.md
+++ b/changelog/fix_incorrect_autocorrect_for_naming_block_forwarding.md
@@ -1,0 +1,1 @@
+* [#10333](https://github.com/rubocop/rubocop/pull/10333): Fix an incorrect autocorrect for `Naming/BlockForwarding` using explicit block forwarding without method definition parentheses. ([@koic][])

--- a/lib/rubocop/cop/naming/block_forwarding.rb
+++ b/lib/rubocop/cop/naming/block_forwarding.rb
@@ -36,6 +36,7 @@ module RuboCop
       #
       class BlockForwarding < Base
         include ConfigurableEnforcedStyle
+        include RangeHelp
         extend AutoCorrector
         extend TargetRubyVersion
 
@@ -94,6 +95,10 @@ module RuboCop
         def register_offense(block_argument)
           add_offense(block_argument, message: format(MSG, style: style)) do |corrector|
             corrector.replace(block_argument, '&')
+
+            arguments = block_argument.parent
+
+            add_parentheses(arguments, corrector) unless arguments.parenthesized_call?
           end
         end
       end

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -126,14 +126,6 @@ module RuboCop
           corrector.remove(arg_node.loc.end)
         end
 
-        def correct_definition(def_node, corrector)
-          arguments_range = def_node.arguments.source_range
-          args_with_space = range_with_surrounding_space(range: arguments_range, side: :left)
-          leading_space = range_between(args_with_space.begin_pos, arguments_range.begin_pos)
-          corrector.replace(leading_space, '(')
-          corrector.insert_after(arguments_range, ')')
-        end
-
         def forced_parentheses?(node)
           # Regardless of style, parentheses are necessary for:
           # 1. Endless methods
@@ -156,7 +148,8 @@ module RuboCop
           location = node.arguments.source_range
 
           add_offense(location, message: MSG_MISSING) do |corrector|
-            correct_definition(node, corrector)
+            add_parentheses(node.arguments, corrector)
+
             unexpected_style_detected 'require_no_parentheses'
           end
         end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -30,8 +30,15 @@ module RuboCop
         node.loc.respond_to?(:end) && node.loc.end && node.loc.end.is?(')')
       end
 
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def add_parentheses(node, corrector)
-        if !node.respond_to?(:arguments)
+        if node.args_type?
+          arguments_range = node.source_range
+          args_with_space = range_with_surrounding_space(range: arguments_range, side: :left)
+          leading_space = range_between(args_with_space.begin_pos, arguments_range.begin_pos)
+          corrector.replace(leading_space, '(')
+          corrector.insert_after(arguments_range, ')')
+        elsif !node.respond_to?(:arguments)
           corrector.wrap(node, '(', ')')
         elsif node.arguments.empty?
           corrector.insert_after(node, '()')
@@ -43,6 +50,7 @@ module RuboCop
           corrector.insert_after(args_end(node), ')')
         end
       end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       def args_begin(node)
         loc = node.loc

--- a/spec/rubocop/cop/naming/block_forwarding_spec.rb
+++ b/spec/rubocop/cop/naming/block_forwarding_spec.rb
@@ -86,6 +86,25 @@ RSpec.describe RuboCop::Cop::Naming::BlockForwarding, :config do
         RUBY
       end
 
+      it 'registers and corrects an offense when using explicit block forwarding without method definition parentheses' do
+        expect_offense(<<~RUBY)
+          def foo arg, &block
+                       ^^^^^^ Use anonymous block forwarding.
+            bar &block
+                ^^^^^^ Use anonymous block forwarding.
+            baz qux, &block
+                     ^^^^^^ Use anonymous block forwarding.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(arg, &)
+            bar(&)
+            baz(qux, &)
+          end
+        RUBY
+      end
+
       it 'does not register an offense when using anonymous block forwarding' do
         expect_no_offenses(<<~RUBY)
           def foo(&)


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Naming/BlockForwarding` using explicit block forwarding without method definition parentheses.

First, specify named block variable explicitly.

```ruby
% cat example.rb
def foo(&blk)
  bar
end
```

```console
% ruby-parse example.rb
(def :foo
  (args
    (blockarg :blk))
  (send nil :bar))
```

Next, specify anonymous block forwarding.

```ruby
% cat example.rb
def foo(&)
  bar
end
```

The structure of AST is the same.

```console
% ruby-parse example.rb
(def :foo
  (args
    (blockarg nil))
  (send nil :bar))
```

Finally, omit the method definition parentheses.

```ruby
% cat example.rb
def foo &
  bar
end
```

The structure of the AST will breaking change.

```console
% ruby-parse example.rb
(def :foo
  (args
    (blockarg :bar)) nil)
```

This PR enforces parentheses to maintain syntax compatibility for autocorrection.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
