### PR TITLE
[Fix #10335] Fix a false positive for `Naming/BlockForwarding`

### DIFF
--- a/lib/rubocop/cop/naming/block_forwarding.rb
+++ b/lib/rubocop/cop/naming/block_forwarding.rb
@@ -53,7 +53,8 @@ module RuboCop
           register_offense(last_argument)
 
           node.each_descendant(:block_pass) do |block_pass_node|
-            next if block_pass_node.children.first&.sym_type?
+            next if block_pass_node.children.first&.sym_type? ||
+                    last_argument.source != block_pass_node.source
 
             register_offense(block_pass_node)
           end

--- a/spec/rubocop/cop/naming/block_forwarding_spec.rb
+++ b/spec/rubocop/cop/naming/block_forwarding_spec.rb
@@ -105,6 +105,22 @@ RSpec.describe RuboCop::Cop::Naming::BlockForwarding, :config do
         RUBY
       end
 
+      it 'registers and corrects an only explicit block forwarding when using multiple proc arguments' do
+        expect_offense(<<~RUBY)
+          def foo(bar, &block)
+                       ^^^^^^ Use anonymous block forwarding.
+            delegator.foo(&bar).each(&block)
+                                     ^^^^^^ Use anonymous block forwarding.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(bar, &)
+            delegator.foo(&bar).each(&)
+          end
+        RUBY
+      end
+
       it 'does not register an offense when using anonymous block forwarding' do
         expect_no_offenses(<<~RUBY)
           def foo(&)


### PR DESCRIPTION
Fixes #10335.

This PR fixes a false positive for `Naming/BlockForwarding` when using multiple proc arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
