### PR TITLE
[Fix #10336] Fix a false positive for `Style/TernaryParentheses`

### DIFF
--- a/changelog/fix_false_positive_for_style_ternary_parentheses.md
+++ b/changelog/fix_false_positive_for_style_ternary_parentheses.md
@@ -1,0 +1,1 @@
+* [#10336](https://github.com/rubocop/rubocop/issues/10336): Fix a false positive for `Style/TernaryParentheses` when using `in` keyword pattern matching as a ternary condition. ([@koic][])

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -403,6 +403,32 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
       end
     end
 
+    # In Ruby 2.7, `match-pattern` node represents one line pattern matching.
+    #
+    # % ruby-parse --27 -e 'foo in bar'
+    # (match-pattern (send nil :foo) (match-var :bar))
+    #
+    context 'with one line pattern matching', :ruby27 do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          (foo in bar) ? a : b
+        RUBY
+      end
+    end
+
+    # In Ruby 3.0, `match-pattern-p` node represents one line pattern matching.
+    #
+    # % ruby-parse --30 -e 'foo in bar'
+    # (match-pattern-p (send nil :foo) (match-var :bar))
+    #
+    context 'with one line pattern matching', :ruby30 do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          (foo in bar) ? a : b
+        RUBY
+      end
+    end
+
     context 'with an assignment condition' do
       it 'accepts safe assignment' do
         expect_no_offenses('foo = (bar = find_bar) ? a : b')


### PR DESCRIPTION
Fixes #10336.

This PR fixes a false positive for `Style/TernaryParentheses` when using `in` keyword pattern matching as a ternary condition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
