### PR TITLE
[Fix #10339] Support auto-correction for `Naming/BlockForwarding`

### DIFF
--- a/changelog/new_support_auto_correction_for_naming_forwarding.md
+++ b/changelog/new_support_auto_correction_for_naming_forwarding.md
@@ -1,0 +1,1 @@
+* [#10339](https://github.com/rubocop/rubocop/issues/10339): Support auto-correction for `EnforcedStyle: explicit` of `Naming/BlockForwarding`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2496,6 +2496,7 @@ Naming/BlockForwarding:
   SupportedStyles:
     - anonymous
     - explicit
+  BlockForwardingName: block
 
 Naming/BlockParameterName:
   Description: >-


### PR DESCRIPTION
Fixes #10339 and Follow up to https://github.com/rubocop/rubocop/pull/10290#issuecomment-999708816.

This PR supports auto-correction for `EnforcedStyle: explicit` of `Naming/BlockForwarding`.

User can specify the block variable name for auto-correction with `BlockForwardingName`. The default variable name is `block`. If the name is already in use, it will not be auto-corrected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
