### PR TITLE
Require Parser 3.1.0.0 or higher

### DIFF
--- a/changelog/change_require_parser_3_1_0_0.md
+++ b/changelog/change_require_parser_3_1_0_0.md
@@ -1,0 +1,1 @@
+* [#10343](https://github.com/rubocop/rubocop/pull/10343): Require Parser 3.1.0.0 or higher. ([@koic][])

--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -31,7 +31,7 @@ The following table is the support matrix.
 | 2.6 | -
 | 2.7 | -
 | 3.0 | -
-| 3.1 (experimental) | -
+| 3.1 | -
 |===
 
 NOTE: The compatibility xref:configuration.adoc#setting-the-target-ruby-version[target Ruby version mentioned here] is about code analysis (what RuboCop can analyze), not runtime (is RuboCop capable of running on some Ruby or not).

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   }
 
   s.add_runtime_dependency('parallel', '~> 1.10')
-  s.add_runtime_dependency('parser', '>= 3.0.0.0')
+  s.add_runtime_dependency('parser', '>= 3.1.0.0')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
   s.add_runtime_dependency('rexml')


### PR DESCRIPTION
Ruby 3.1 and Parser 3.1.0.0 have been released.

- https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/
- https://rubygems.org/gems/parser/versions/3.1.0.0

This PR requires Parser 3.1.0.0 or higher and removes "experimental" label from support matrix.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
