### PR TITLE
Fix a false positive for `Style/CollectionCompact`

### DIFF
--- a/changelog/fix_false_positive_for_style_collection_compact.md
+++ b/changelog/fix_false_positive_for_style_collection_compact.md
@@ -1,0 +1,1 @@
+* [#10344](https://github.com/rubocop/rubocop/pull/10344): Fix a false positive for `Style/CollectionCompact` when without receiver for bad methods. ([@koic][])

--- a/lib/rubocop/cop/style/collection_compact.rb
+++ b/lib/rubocop/cop/style/collection_compact.rb
@@ -41,7 +41,7 @@ module RuboCop
 
         # @!method reject_method_with_block_pass?(node)
         def_node_matcher :reject_method_with_block_pass?, <<~PATTERN
-          (send _ {:reject :reject!}
+          (send !nil? {:reject :reject!}
             (block_pass
               (sym :nil?)))
         PATTERN
@@ -50,7 +50,7 @@ module RuboCop
         def_node_matcher :reject_method?, <<~PATTERN
           (block
             (send
-              _ {:reject :reject!})
+              !nil? {:reject :reject!})
             $(args ...)
             (send
               $(lvar _) :nil?))
@@ -60,7 +60,7 @@ module RuboCop
         def_node_matcher :select_method?, <<~PATTERN
           (block
             (send
-              _ {:select :select!})
+              !nil? {:select :select!})
             $(args ...)
             (send
               (send

--- a/spec/rubocop/cop/style/collection_compact_spec.rb
+++ b/spec/rubocop/cop/style/collection_compact_spec.rb
@@ -57,17 +57,6 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects when using `reject` without a receiver to reject nils' do
-    expect_offense(<<~RUBY)
-      reject { |e| e.nil? }
-      ^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `reject { |e| e.nil? }`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      compact
-    RUBY
-  end
-
   it 'does not register an offense when using `reject` to not to rejecting nils' do
     expect_no_offenses(<<~RUBY)
       array.reject { |e| e.odd? }
@@ -79,5 +68,21 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config do
       array.compact
       array.compact!
     RUBY
+  end
+
+  context 'when without receiver' do
+    it 'does not register an offense and corrects when using `reject` on array to reject nils' do
+      expect_no_offenses(<<~RUBY)
+        reject { |e| e.nil? }
+        reject! { |e| e.nil? }
+      RUBY
+    end
+
+    it 'does not register an offense and corrects when using `select/select!` to reject nils' do
+      expect_no_offenses(<<~RUBY)
+        select { |e| !e.nil? }
+        select! { |k, v| !v.nil? }
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
This PR fixes a false positive for `Style/CollectionCompact` when without receiver for bad methods.

If no receiver is specified, it may be used in a custom method or open class. For custom methods, there is no guarantee that `compact` corresponding to `reject` will exist.

The following is a use case of false positive.
https://github.com/artichoke/artichoke/pull/1582/commits/250bf7e

In fact, without a receiver may lead to false positives for these cases.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
