### PR TITLE
[Fix #10317] Fix a false positive for `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/changelog/fix_false_positive_for_style_method_call_with_args_parentheses.md
+++ b/changelog/fix_false_positive_for_style_method_call_with_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#10317](https://github.com/rubocop/rubocop/issues/10317): Fix a false positive for `Style/MethodCallWithArgsParentheses` when using hash value omission. ([@koic][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -51,11 +51,12 @@ module RuboCop
           # Require hash value omission be enclosed in parentheses to prevent the following issue:
           # https://bugs.ruby-lang.org/issues/18396.
           def require_parentheses_for_hash_value_omission?(node)
-            return unless (last_argument = node.last_argument)
+            return false unless (last_argument = node.last_argument)
 
-            return false unless (right_sibling = node.right_sibling)
+            next_line = node.parent&.assignment? ? node.parent.right_sibling : node.right_sibling
+            return false unless next_line
 
-            last_argument.hash_type? && last_argument.pairs.last&.value_omission? && right_sibling
+            last_argument.hash_type? && last_argument.pairs.last&.value_omission? && next_line
           end
 
           def syntax_like_method_call?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -444,6 +444,21 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
           foo arg
         RUBY
       end
+
+      it 'registers an offense using assignment with parentheses call expr follows' do
+        # Require hash value omission be enclosed in parentheses to prevent the following issue:
+        # https://bugs.ruby-lang.org/issues/18396.
+        expect_offense(<<~RUBY)
+          var = foo(value:)
+          foo(arg)
+             ^^^^^ Omit parentheses for method calls with arguments.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          var = foo(value:)
+          foo arg
+        RUBY
+      end
     end
 
     it 'register an offense for parens in method call without args' do


### PR DESCRIPTION
Fixes #10317 and follow up https://github.com/rubocop/rubocop/issues/10317#issuecomment-1003393863.

This PR fixes a false positive for `Style/MethodCallWithArgsParentheses` when using hash value omission.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
