### PR TITLE
Fix a false negative for `Lint/IncompatibleIoSelectWithFiberScheduler`

### DIFF
--- a/changelog/fix_false_negative_for_lint_incompatible_io_select_with_fiber_scheduler.md
+++ b/changelog/fix_false_negative_for_lint_incompatible_io_select_with_fiber_scheduler.md
@@ -1,0 +1,1 @@
+* [#10350](https://github.com/rubocop/rubocop/pull/10350): Fix a false negative for `Lint/IncompatibleIoSelectWithFiberScheduler` when using `IO.select` with the first argument only. ([@koic][])

--- a/spec/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler_spec.rb
+++ b/spec/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Lint::IncompatibleIoSelectWithFiberScheduler, :conf
     RUBY
   end
 
+  it 'registers and corrects an offense when using `IO.select` with single read argument and specify the first argument only' do
+    expect_offense(<<~RUBY)
+      IO.select([io])
+      ^^^^^^^^^^^^^^^ Use `io.wait_readable` instead of `IO.select([io])`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      io.wait_readable
+    RUBY
+  end
+
   it 'registers and corrects an offense when using `IO.select` with single read and timeout arguments' do
     expect_offense(<<~RUBY)
       IO.select([io], [], [], timeout)
@@ -117,6 +128,12 @@ RSpec.describe RuboCop::Cop::Lint::IncompatibleIoSelectWithFiberScheduler, :conf
     RUBY
   end
 
+  it 'registers and corrects an offense when using `IO.select` with multiple read argument and specify the first argument only' do
+    expect_no_offenses(<<~RUBY)
+      IO.select([foo, bar])
+    RUBY
+  end
+
   it 'does not register an offense when using `IO.select` with multiple write arguments' do
     expect_no_offenses(<<~RUBY)
       IO.select([], [foo, bar], [])
@@ -126,6 +143,12 @@ RSpec.describe RuboCop::Cop::Lint::IncompatibleIoSelectWithFiberScheduler, :conf
   it 'does not register an offense when using `IO.select` with read and write arguments' do
     expect_no_offenses(<<~RUBY)
       IO.select([rp], [wp], [])
+    RUBY
+  end
+
+  it 'does not register an offense when using `Enumerable#select`' do
+    expect_no_offenses(<<~RUBY)
+      collection.select { |item| item.do_something? }
     RUBY
   end
 end


### PR DESCRIPTION
This PR fixes the following false negative for `Lint/IncompatibleIoSelectWithFiberScheduler` when using `IO.select` with the first argument only.

```ruby
IO.select([io])
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
