### PR TITLE
Support `EnforcedShorthandSyntax: either` for `Style/HashSyntax`

### DIFF
--- a/changelog/new_support_enforced_shorthand_syntax_either_option_for_style_hash_syntax.md
+++ b/changelog/new_support_enforced_shorthand_syntax_either_option_for_style_hash_syntax.md
@@ -1,0 +1,1 @@
+* [#10351](https://github.com/rubocop/rubocop/pull/10351): Support `EnforcedShorthandSyntax: either` option for `Style/HashSyntax`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3699,6 +3699,8 @@ Style/HashSyntax:
     - always
     # forces use of explicit hash literal value.
     - never
+    # accepts both shorthand and explicit use of hash literal value.
+    - either
   # Force hashes that have a symbol value to use hash rockets
   UseHashRocketsWithSymbolValues: false
   # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -8,7 +8,7 @@ module RuboCop
       EXPLICIT_HASH_VALUE_MSG = 'Explicit the hash value.'
 
       def on_pair(node)
-        return if target_ruby_version <= 3.0
+        return if target_ruby_version <= 3.0 || enforced_shorthand_syntax == 'either'
 
         hash_key_source = node.key.source
 

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -23,6 +23,12 @@ module RuboCop
       # It can enforce either the use of the explicit hash value syntax or
       # the use of Ruby 3.1's hash value shorthand syntax.
       #
+      # The supported styles are:
+      #
+      # * always - forces use of the 3.1 syntax (e.g. {foo:})
+      # * never - forces use of explicit hash literal value
+      # * either - accepts both shorthand and explicit use of hash literal value
+      #
       # @example EnforcedStyle: ruby19 (default)
       #   # bad
       #   {:a => 2}
@@ -74,6 +80,14 @@ module RuboCop
       #
       #   # good
       #   {foo: foo, bar: bar}
+      #
+      # @example EnforcedShorthandSyntax: either
+      #
+      #   # good
+      #   {foo: foo, bar: bar}
+      #
+      #   # good
+      #   {foo:, bar:}
       #
       class HashSyntax < Base
         include ConfigurableEnforcedStyle

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -1204,7 +1204,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         .to eq(<<~YAML)
           # Configuration parameters: EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
           # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-          # SupportedShorthandSyntax: always, never
+          # SupportedShorthandSyntax: always, never, either
           Style/HashSyntax:
             EnforcedStyle: hash_rockets
         YAML
@@ -1218,7 +1218,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         .to eq(<<~YAML)
           # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
           # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-          # SupportedShorthandSyntax: always, never
+          # SupportedShorthandSyntax: always, never, either
           Style/HashSyntax:
             Exclude:
               - 'example1.rb'

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -978,4 +978,48 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       end
     end
   end
+
+  context 'configured to accept both shorthand and explicit use of hash literal value' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'ruby19',
+        'SupportedStyles' => %w[ruby19 hash_rockets],
+        'EnforcedShorthandSyntax' => 'either'
+      }
+    end
+
+    context 'Ruby >= 3.1', :ruby31 do
+      it 'does not register an offense when hash values are omitted' do
+        expect_no_offenses(<<~RUBY)
+          {foo:, bar:}
+        RUBY
+      end
+
+      it 'does not register an offense when hash key and hash value are partially the same' do
+        expect_no_offenses(<<~RUBY)
+          {foo:, bar: bar, baz: qux}
+        RUBY
+      end
+
+      it 'does not register an offense when hash key and hash value are not the same' do
+        expect_no_offenses(<<~RUBY)
+          {foo: bar, bar: foo}
+        RUBY
+      end
+
+      it 'does not register an offense when hash key and hash value are the same' do
+        expect_no_offenses(<<~RUBY)
+          {foo: foo, bar: bar}
+        RUBY
+      end
+    end
+
+    context 'Ruby <= 3.0', :ruby30 do
+      it 'does not register an offense when hash key and hash value are the same' do
+        expect_no_offenses(<<~RUBY)
+          {foo: foo, bar: bar}
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Follow up to https://github.com/testdouble/standard/issues/375#issuecomment-1007505392.

This PR supports `EnforcedShorthandSyntax: either` option for `Style/HashSyntax`.
It accepts both shorthand and explicit use of hash literal value.

```ruby
# good
{foo: foo, bar: bar}

# good
{foo:, bar:}
```

I think that we can change the default enforced style in response to future feedback and discussion. Anyway at this point it only adds the new style.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
