### PR TITLE
[Fix #8032] Improve argument alignment correction for kwargs

### DIFF
--- a/changelog/fix_improve_argument_alignment_correction.md
+++ b/changelog/fix_improve_argument_alignment_correction.md
@@ -1,0 +1,1 @@
+* [#8032](https://github.com/rubocop/rubocop/issues/8032): Improve ArgumentAlignment detection and correction for keyword arguments. ([@mvz][])

--- a/spec/rubocop/cop/layout/argument_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/argument_alignment_spec.rb
@@ -381,9 +381,11 @@ RSpec.describe RuboCop::Cop::Layout::ArgumentAlignment, :config do
       expect_offense(<<~RUBY)
         create :transaction, :closed,
                account:     account,
-               ^^^^^^^^^^^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
+               ^^^^^^^^^^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
                open_price:  1.29,
+               ^^^^^^^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
                close_price: 1.30
+               ^^^^^^^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -398,9 +400,11 @@ RSpec.describe RuboCop::Cop::Layout::ArgumentAlignment, :config do
       expect_offense(<<~RUBY)
         create :transaction, :closed,
         account:     account,
-        ^^^^^^^^^^^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
+        ^^^^^^^^^^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
         open_price:  1.29,
+        ^^^^^^^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
         close_price: 1.30
+        ^^^^^^^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -420,9 +424,11 @@ RSpec.describe RuboCop::Cop::Layout::ArgumentAlignment, :config do
               ^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
         func2(do_something,
               foo: 'foo',
-              ^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
+              ^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
               bar: 'bar',
+              ^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
               baz: 'baz')
+              ^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -436,13 +442,31 @@ RSpec.describe RuboCop::Cop::Layout::ArgumentAlignment, :config do
       RUBY
     end
 
+    it 'corrects indentation for kwargs starting on same line as other args' do
+      expect_offense(<<~RUBY)
+        func(do_something, foo: 'foo',
+                           bar: 'bar',
+                           ^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
+                           baz: 'baz')
+                           ^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        func(do_something, foo: 'foo',
+          bar: 'bar',
+          baz: 'baz')
+      RUBY
+    end
+
     it 'autocorrects when first line is indented' do
       expect_offense(<<-RUBY.strip_margin('|'))
         |  create :transaction, :closed,
         |  account:     account,
-        |  ^^^^^^^^^^^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
+        |  ^^^^^^^^^^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
         |  open_price:  1.29,
+        |  ^^^^^^^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
         |  close_price: 1.30
+        |  ^^^^^^^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
       RUBY
 
       expect_correction(<<-RUBY.strip_margin('|'))


### PR DESCRIPTION
This fixes detection of incorrect indentation for the case where
- ArgumentAlignment is configured with EnforcedStyle `with_fixed_indentation`
- A method call has both regular arguments and keyword arguments
- The first keyword argument is on the same line as at least one of the regular arguments

In the original code, the keyword arguments would be seen as one single argument, and because it starts on the same line as the previous argument, alignment adjustment would be skipped.

Also, because of the fixed indentation style, HashAlignment always skips adjustment of the keyword argument block. This means neither cop would correct the alignment.

This change adjusts this behaviour by treating each keyword argument as a separate argument if EnforcedStyle is `with_fixed_indentation`.

This has an additional effect in that each keyword argument will be separately annotated.


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
