### PR TITLE
Use `:ambiguous_regexp` to detect ambiguous Regexp in Ruby 3

### DIFF
--- a/changelog/fix_use_different_symbol_in_ruby_3.md
+++ b/changelog/fix_use_different_symbol_in_ruby_3.md
@@ -1,0 +1,1 @@
+* [#10353](https://github.com/rubocop/rubocop/pull/10353): Use `:ambiguous_regexp` to detect ambiguous Regexp in Ruby 3. ([@danieldiekmeier][], [@joergschiller][])

--- a/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
+++ b/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
@@ -30,7 +30,11 @@ module RuboCop
 
         def on_new_investigation
           processed_source.diagnostics.each do |diagnostic|
-            next unless diagnostic.reason == :ambiguous_literal
+            if target_ruby_version >= 3.0
+              next unless diagnostic.reason == :ambiguous_regexp
+            else
+              next unless diagnostic.reason == :ambiguous_literal
+            end
 
             offense_node = find_offense_node_by(diagnostic)
 

--- a/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral, :config do
-  context 'with a regexp literal in the first argument' do
+  shared_examples 'with a regexp literal in the first argument' do
     context 'without parentheses' do
       it 'registers an offense and corrects when single argument' do
         expect_offense(<<~RUBY)
@@ -177,5 +177,13 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral, :config do
         end
       end
     end
+  end
+
+  context 'Ruby <= 2.7', :ruby27 do
+    include_examples 'with a regexp literal in the first argument'
+  end
+
+  context 'Ruby >= 3.0', :ruby30 do
+    include_examples 'with a regexp literal in the first argument'
   end
 end


### PR DESCRIPTION
At work, we recently started using Rubocop via [Standard](https://github.com/testdouble/standard), and we still have a long `.rubocop_todo.yml`. Luckily, this helped to uncover a bug in RuboCop! :D

After upgrading a Rails app to Ruby 3.0 and setting `TargetRubyVersion: 3.0`, I noticed that all todos relating to `Lint/AmbiguousRegexpLiteral` disappeared. But we hadn't changed the files, and the "bad" code was still in there.

```diff
- # Offense count: 7
- # Cop supports --auto-correct.
- Lint/AmbiguousRegexpLiteral:
-   Exclude:
-     - 'spec/features/example/example_spec.rb'
-     - 'spec/models/example.rb'
-     - 'spec/views/admin/example/example.haml_spec.rb'
```

Digging further, a colleague and I noticed that this _only_ happened with `TargetRubyVersion: 3.0`, and that the offenses showed up when setting `TargetRubyVersion: 2.7`.

It took a while, but we finally found this code in the parser: https://github.com/whitequark/parser/blob/e160eeb50bf505453c5a9b1538451d2d62e6144a/lib/parser/lexer.rl#L1571-L1578, added in this commit: https://github.com/whitequark/parser/pull/768/files

It adds a new symbol alongside `:ambiguous_literal`, namely `:ambiguous_regexp`.

RuboCop only checks for  `:ambiguous_literal`, so the warning didn't propagate and was ultimately not displayed.

This PR uses the new `:ambiguous_regexp` if `target_ruby_version >= 3.0`.

Thanks for your consideration!

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
