### PR TITLE
Fix Gemspec/RequiredRubyVersion version matcher

### DIFF
--- a/changelog/fix_fix_gemspecrequiredrubyversion_version.md
+++ b/changelog/fix_fix_gemspecrequiredrubyversion_version.md
@@ -1,0 +1,1 @@
+* [#10354](https://github.com/rubocop/rubocop/pull/10354): Fix Gemspec/RequiredRubyVersion version matcher when Gem::Requirement.new is used and initialised with multiple requirements. ([@nickpellant][])

--- a/lib/rubocop/cop/gemspec/required_ruby_version.rb
+++ b/lib/rubocop/cop/gemspec/required_ruby_version.rb
@@ -68,8 +68,11 @@ module RuboCop
 
         # @!method defined_ruby_version(node)
         def_node_matcher :defined_ruby_version, <<~PATTERN
-          {$(str _) $(array (str _) (str _))
-            (send (const (const nil? :Gem) :Requirement) :new $(str _))}
+          {
+            $(str _)
+            $(array (str _) (str _))
+            (send (const (const nil? :Gem) :Requirement) :new $str+)
+          }
         PATTERN
 
         def on_new_investigation
@@ -97,7 +100,11 @@ module RuboCop
         def extract_ruby_version(required_ruby_version)
           return unless required_ruby_version
 
-          if required_ruby_version.array_type?
+          if required_ruby_version.is_a?(Array)
+            required_ruby_version = required_ruby_version.detect do |v|
+              /[>=]/.match?(v.str_content)
+            end
+          elsif required_ruby_version.array_type?
             required_ruby_version = required_ruby_version.children.detect do |v|
               /[>=]/.match?(v.str_content)
             end

--- a/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
+++ b/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
       RUBY
     end
 
+    it 'recognizes a Gem::Requirement with multiple requirements and does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0", "<= 2.8")
+        end
+      RUBY
+    end
+
     describe 'false negatives' do
       it 'does not register an offense when `required_ruby_version` ' \
          'is assigned as a variable (string literal)' do


### PR DESCRIPTION
Fixes a bug (which I believe was introduced by #10157) where the `Gemspec/RequiredRubyVersion` cop no longer handled multiple requirements when they were passed as a `Gem::Requirement` object rather than an array.

 I.e. the following would fail when the target version was `2.6`:

```
  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0', '< 2.8')
```

Which should pass like the following does:

```
  spec.required_ruby_version = ['>= 2.6.0', '< 2.8']
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
