### PR TITLE
Fix Style/Sample crash on beginless or endless range shuffle indexes

### DIFF
--- a/changelog/fix_style_sample_chrash.md
+++ b/changelog/fix_style_sample_chrash.md
@@ -1,0 +1,1 @@
+* [#10358](https://github.com/rubocop/rubocop/pull/10358): Fix Style/Sample crash on beginless and endless range shuffle indexes. ([@gsamokovarov][])

--- a/lib/rubocop/cop/style/sample.rb
+++ b/lib/rubocop/cop/style/sample.rb
@@ -91,11 +91,12 @@ module RuboCop
           second.int_type? ? second.to_a.first : :unknown
         end
 
-        def range_size(range_node) # rubocop:todo Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        def range_size(range_node)
           vals = range_node.to_a
-          return :unknown unless vals.all?(&:int_type?)
+          return :unknown unless vals.all? { |val| val.nil? || val.int_type? }
 
-          low, high = vals.map { |val| val.children[0] }
+          low, high = vals.map { |val| val.nil? ? 0 : val.children[0] }
           return :unknown unless low.zero? && high >= 0
 
           case range_node.type
@@ -105,6 +106,7 @@ module RuboCop
             (low..high).size
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def source_range(shuffle_node, node)
           Parser::Source::Range.new(shuffle_node.source_range.source_buffer,

--- a/spec/rubocop/cop/style/sample_spec.rb
+++ b/spec/rubocop/cop/style/sample_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe RuboCop::Cop::Style::Sample, :config do
   it_behaves_like('offense', 'shuffle.last', 'sample')
   it_behaves_like('offense', 'shuffle[0]', 'sample')
   it_behaves_like('offense', 'shuffle[-1]', 'sample')
+  context 'Ruby >= 2.7', :ruby27 do
+    it_behaves_like('offense', 'shuffle[...3]', 'sample(3)')
+  end
+
   it_behaves_like('offense', 'shuffle[0, 3]', 'sample(3)')
   it_behaves_like('offense', 'shuffle[0..3]', 'sample(4)')
   it_behaves_like('offense', 'shuffle[0...3]', 'sample(3)')
@@ -46,28 +50,33 @@ RSpec.describe RuboCop::Cop::Style::Sample, :config do
 
   it_behaves_like('accepts', 'sample')
   it_behaves_like('accepts', 'shuffle')
-  it_behaves_like('accepts', 'shuffle.at(2)')          # nil if coll.size < 3
+  it_behaves_like('accepts', 'shuffle.at(2)')           # nil if coll.size < 3
   it_behaves_like('accepts', 'shuffle.at(foo)')
-  it_behaves_like('accepts', 'shuffle.slice(2)')       # nil if coll.size < 3
-  it_behaves_like('accepts', 'shuffle.slice(3, 3)')    # nil if coll.size < 3
-  it_behaves_like('accepts', 'shuffle.slice(2..3)')    # empty if coll.size < 3
+  it_behaves_like('accepts', 'shuffle.slice(2)')        # nil if coll.size < 3
+  it_behaves_like('accepts', 'shuffle.slice(3, 3)')     # nil if coll.size < 3
+  it_behaves_like('accepts', 'shuffle.slice(2..3)')     # empty if coll.size < 3
   it_behaves_like('accepts',
-                  'shuffle.slice(2..-3)')   # can't compute range size
+                  'shuffle.slice(2..-3)')               # can't compute range size
   it_behaves_like('accepts',
-                  'shuffle.slice(foo..3)')  # can't compute range size
-  it_behaves_like('accepts', 'shuffle.slice(-4..-3)')  # nil if coll.size < 3
-  it_behaves_like('accepts', 'shuffle.slice(foo)')     # foo could be a Range
-  it_behaves_like('accepts', 'shuffle.slice(foo, 3)')  # nil if coll.size < foo
+                  'shuffle.slice(foo..3)')              # can't compute range size
+  it_behaves_like('accepts', 'shuffle.slice(-4..-3)')   # nil if coll.size < 3
+  it_behaves_like('accepts', 'shuffle.slice(foo)')      # foo could be a Range
+  it_behaves_like('accepts', 'shuffle.slice(foo, 3)')   # nil if coll.size < foo
   it_behaves_like('accepts', 'shuffle.slice(foo..bar)')
   it_behaves_like('accepts', 'shuffle.slice(foo, bar)')
-  it_behaves_like('accepts', 'shuffle[2]')           # nil if coll.size < 3
-  it_behaves_like('accepts', 'shuffle[3, 3]')        # nil if coll.size < 3
-  it_behaves_like('accepts', 'shuffle[2..3]')        # empty if coll.size < 3
-  it_behaves_like('accepts', 'shuffle[2..-3]')       # can't compute range size
-  it_behaves_like('accepts', 'shuffle[foo..3]')      # can't compute range size
-  it_behaves_like('accepts', 'shuffle[-4..-3]')      # nil if coll.size < 3
-  it_behaves_like('accepts', 'shuffle[foo]')         # foo could be a Range
-  it_behaves_like('accepts', 'shuffle[foo, 3]')      # nil if coll.size < foo
+  it_behaves_like('accepts', 'shuffle[2]')              # nil if coll.size < 3
+  it_behaves_like('accepts', 'shuffle[3, 3]')           # nil if coll.size < 3
+  it_behaves_like('accepts', 'shuffle[2..3]')           # empty if coll.size < 3
+  it_behaves_like('accepts', 'shuffle[2..-3]')          # can't compute range size
+  it_behaves_like('accepts', 'shuffle[foo..3]')         # can't compute range size
+  context 'Ruby >= 2.6', :ruby26 do
+    it_behaves_like('accepts', 'shuffle[3..]')          # can't compute range size
+    it_behaves_like('accepts', 'shuffle[3...]')         # can't compute range size
+  end
+
+  it_behaves_like('accepts', 'shuffle[-4..-3]')         # nil if coll.size < 3
+  it_behaves_like('accepts', 'shuffle[foo]')            # foo could be a Range
+  it_behaves_like('accepts', 'shuffle[foo, 3]')         # nil if coll.size < foo
   it_behaves_like('accepts', 'shuffle[foo..bar]')
   it_behaves_like('accepts', 'shuffle[foo, bar]')
   it_behaves_like('accepts', 'shuffle(random: Random.new)')


### PR DESCRIPTION
`Style/Sample` crashes when `Array#shuffle` is indexed with beginless or endless range:

```ruby
items.shuffle[...5]
```

This change adds support for reasonable auto-corrections and accepted inputs:

```ruby
items.shuffle[..6]  # => auto-corrects to `items.sample(5)`
items.shuffle[...5] # => auto-corrects to `items.sample(5)` as well

items.shuffle[5...] # accepted, takes everting but the first 5 items
```