### PR TITLE
[Fix #10359] Fix a false positive and negative for `Style/HashSyntax`

### DIFF
--- a/changelog/fix_false_positive_for_style_hash_syntax.md
+++ b/changelog/fix_false_positive_for_style_hash_syntax.md
@@ -1,0 +1,1 @@
+* [#10359](https://github.com/rubocop/rubocop/issues/10359): Fix a false positive and negative for `Style/HashSyntax` when using hash value omission. ([@koic][])


### PR DESCRIPTION
Fixes #10359.

This PR fixes a false positive and negative for `Style/HashSyntax` when using hash value omission.

It resolves the lack of consideration for https://bugs.ruby-lang.org/issues/18396 and false positives for modifier forms.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
