### PR TITLE
Fix a false positive for `Style/HashSyntax`

### DIFF
--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -65,7 +65,9 @@ module RuboCop
       end
 
       def without_parentheses_call_expr_follows?(ancestor)
-        return false unless (right_sibling = ancestor.right_sibling)
+        right_sibling = ancestor.right_sibling
+        right_sibling ||= ancestor.each_ancestor.find(&:assignment?)&.right_sibling
+        return false unless right_sibling
 
         ancestor.respond_to?(:parenthesized?) && !ancestor.parenthesized? && right_sibling
       end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -985,6 +985,14 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'does not register an offense when with parentheses call expr follows assignment expr' do
+        # Prevent syntax semantic changes shown in the URL: https://bugs.ruby-lang.org/issues/18396
+        expect_no_offenses(<<~RUBY)
+          var = foo value: value
+          foo(arg)
+        RUBY
+      end
+
       it 'does not register an offense when hash key and hash value are partially the same' do
         expect_no_offenses(<<~RUBY)
           def do_something


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/pull/10363#issuecomment-1016233254.

This PR fixes a false positive for `Style/HashSyntax` when using hash value omission.
It does not have a changelog entry because a regression of unreleased #10363.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
