### PR TITLE
[Fix #10366] Fix a false positive for `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/changelog/fix_false_positive_for_style_method_call_with_args_parentheses.md
+++ b/changelog/fix_false_positive_for_style_method_call_with_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#10366](https://github.com/rubocop/rubocop/issues/10366): Fix a false positive for `Style/MethodCallWithArgsParentheses` when setting `EnforcedStyle: omit_parentheses` and using hash value omission with modifier from. ([@koic][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -48,15 +48,21 @@ module RuboCop
             node.each_ancestor(:def, :defs).any?(&:endless?) && node.arguments.any?
           end
 
-          # Require hash value omission be enclosed in parentheses to prevent the following issue:
-          # https://bugs.ruby-lang.org/issues/18396.
           def require_parentheses_for_hash_value_omission?(node)
             return false unless (last_argument = node.last_argument)
+            return false if !last_argument.hash_type? || !last_argument.pairs.last&.value_omission?
 
-            next_line = node.parent&.assignment? ? node.parent.right_sibling : node.right_sibling
-            return false unless next_line
+            modifier_form?(node) || exist_next_line_expression?(node)
+          end
 
-            last_argument.hash_type? && last_argument.pairs.last&.value_omission? && next_line
+          def modifier_form?(node)
+            node.parent.respond_to?(:modifier_form?) && node.parent.modifier_form?
+          end
+
+          # Require hash value omission be enclosed in parentheses to prevent the following issue:
+          # https://bugs.ruby-lang.org/issues/18396.
+          def exist_next_line_expression?(node)
+            node.parent&.assignment? ? node.parent.right_sibling : node.right_sibling
           end
 
           def syntax_like_method_call?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -424,6 +424,23 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         RUBY
       end
 
+      it 'does not register an offense when hash value omission with parentheses and using modifier form' do
+        expect_no_offenses(<<~RUBY)
+          do_something(value:) if condition
+        RUBY
+      end
+
+      it 'registers and corrects an offense when explicit hash value with parentheses and using modifier form' do
+        expect_offense(<<~RUBY)
+          do_something(value: value) if condition
+                      ^^^^^^^^^^^^^^ Omit parentheses for method calls with arguments.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          do_something value: value if condition
+        RUBY
+      end
+
       it 'does not register an offense when without parentheses call expr follows' do
         expect_no_offenses(<<~RUBY)
           foo value:


### PR DESCRIPTION
Fixes #10366.

This PR fixes a false positive for `Style/MethodCallWithArgsParentheses` when setting `EnforcedStyle: omit_parentheses` and using hash value omission with modifier from.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
