### PR TITLE
Fix a false negative for `Style/HashSyntax`

### DIFF
--- a/changelog/fix_false_negative_for_style_hash_syntax.md
+++ b/changelog/fix_false_negative_for_style_hash_syntax.md
@@ -1,0 +1,1 @@
+* [#10371](https://github.com/rubocop/rubocop/pull/10371): Fix a false negative for `Style/HashSyntax` when `Hash[foo: foo]` or `{foo: foo}` is followed by a next expression. ([@koic][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -8,7 +8,7 @@ module RuboCop
       EXPLICIT_HASH_VALUE_MSG = 'Explicit the hash value.'
 
       def on_pair(node)
-        return if target_ruby_version <= 3.0 || enforced_shorthand_syntax == 'either'
+        return if ignore_hash_shorthand_syntax?(node)
 
         hash_key_source = node.key.source
 
@@ -31,12 +31,17 @@ module RuboCop
 
       private
 
+      def ignore_hash_shorthand_syntax?(pair_node)
+        target_ruby_version <= 3.0 || enforced_shorthand_syntax == 'either' ||
+          !pair_node.parent.hash_type?
+      end
+
       def enforced_shorthand_syntax
         cop_config.fetch('EnforcedShorthandSyntax', 'always')
       end
 
       def require_hash_value?(hash_key_source, node)
-        return true if require_hash_value_for_around_hash_literal(node)
+        return true if require_hash_value_for_around_hash_literal?(node)
 
         hash_value = node.value
         return true unless hash_value.send_type? || hash_value.lvar_type?
@@ -44,10 +49,11 @@ module RuboCop
         hash_key_source != hash_value.source || hash_key_source.end_with?('!', '?')
       end
 
-      def require_hash_value_for_around_hash_literal(node)
+      def require_hash_value_for_around_hash_literal?(node)
         return false unless (ancestor = node.parent.parent)
+        return false if ancestor.send_type? && ancestor.method?(:[])
 
-        !use_element_of_hash_literal_as_receiver?(ancestor, node.parent) &&
+        !node.parent.braces? && !use_element_of_hash_literal_as_receiver?(ancestor, node.parent) &&
           (use_modifier_form_without_parenthesized_method_call?(ancestor) ||
            without_parentheses_call_expr_follows?(ancestor))
       end
@@ -69,7 +75,7 @@ module RuboCop
         right_sibling ||= ancestor.each_ancestor.find(&:assignment?)&.right_sibling
         return false unless right_sibling
 
-        ancestor.respond_to?(:parenthesized?) && !ancestor.parenthesized? && right_sibling
+        ancestor.respond_to?(:parenthesized?) && !ancestor.parenthesized? && !!right_sibling
       end
     end
   end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -830,6 +830,19 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'registers and corrects an offense when `Hash[foo: foo]` and an expression follows' do
+        expect_offense(<<~RUBY)
+          Hash[foo: foo]
+                    ^^^ Omit the hash value.
+          do_something
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Hash[foo:]
+          do_something
+        RUBY
+      end
+
       it 'registers and corrects an offense when hash key and hash value are the same and it in the method body' do
         expect_offense(<<~RUBY)
           def do_something
@@ -849,6 +862,31 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
               bar:
             }
           end
+        RUBY
+      end
+
+      it 'registers and corrects an offense when hash key and hash value are the same and it in the method body' \
+         'and an expression follows' do
+        expect_offense(<<~RUBY)
+          def do_something
+            {
+              foo: foo,
+                   ^^^ Omit the hash value.
+              bar: bar
+                   ^^^ Omit the hash value.
+            }
+          end
+          do_something
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def do_something
+            {
+              foo:,
+              bar:
+            }
+          end
+          do_something
         RUBY
       end
 
@@ -881,6 +919,15 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
 
         expect_correction(<<~RUBY)
           {foo:}.do_something[key]
+        RUBY
+      end
+
+      it 'does not register an offense when hash pattern matching' do
+        expect_no_offenses(<<~RUBY)
+          case pattern
+          in {foo: 42}
+          in {foo: foo}
+          end
         RUBY
       end
 


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/pull/10368#issuecomment-1017488540.

This PR fixes a false negative for `Style/HashSyntax` when `Hash[foo: foo]` or `{foo: foo}` is followed by a next expression.
https://bugs.ruby-lang.org/issues/18396 issue does not occur when hash syntax is enclosed in `[]`, `{}`, or `()`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
