### PR TITLE
[Fix #10376] Fix an error for `Layout/RescueEnsureAlignment`

### DIFF
--- a/changelog/fix_an_error_for_layout_rescue_ensure_alignment.md
+++ b/changelog/fix_an_error_for_layout_rescue_ensure_alignment.md
@@ -1,0 +1,1 @@
+* [#10376](https://github.com/rubocop/rubocop/issues/10376): Fix an error for `Layout/RescueEnsureAlignment` when using `.()` call with block. ([@koic][])

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -143,7 +143,7 @@ module RuboCop
             return true
           end
 
-          do_keyword_line == selector.line && rescue_keyword_column == selector.column
+          do_keyword_line == selector&.line && rescue_keyword_column == selector.column
         end
 
         def aligned_with_leading_dot?(do_keyword_line, send_node_loc, rescue_keyword_column)

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -449,6 +449,16 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
     RUBY
   end
 
+  it 'accepts aligned rescue in do-end block with `.()` call' do
+    expect_no_offenses(<<~RUBY)
+      foo.() do |el|
+        el.to_s
+      rescue StandardError => _exception
+        next
+      end
+    RUBY
+  end
+
   it 'accepts aligned rescue with do-end block that line break with leading dot for method calls' do
     expect_no_offenses(<<~RUBY)
       [1, 2, 3]


### PR DESCRIPTION
Fixes #10376.

This PR fixes an error for `Layout/RescueEnsureAlignment` when using `.()` call with block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
