### PR TITLE
[Fix #10379] Fix an error for `Layout/EmptyLinesAroundExceptionHandlingKeywords`

### DIFF
--- a/changelog/fix_an_error_for_layout_empty_lines_around_exception_handling_keywords.md
+++ b/changelog/fix_an_error_for_layout_empty_lines_around_exception_handling_keywords.md
@@ -1,0 +1,1 @@
+* [#10379](https://github.com/rubocop/rubocop/issues/10379): Fix an error for `Layout/EmptyLinesAroundExceptionHandlingKeywords` when `rescue` and `end` are on the same line. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_lines_around_exception_handling_keywords.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_exception_handling_keywords.rb
@@ -81,7 +81,7 @@ module RuboCop
 
           locations.each do |loc|
             line = loc.line
-            next if line == line_of_def_or_kwbegin
+            next if line == line_of_def_or_kwbegin || last_rescue_and_end_on_same_line(body)
 
             keyword = loc.source
             # below the keyword
@@ -89,6 +89,10 @@ module RuboCop
             # above the keyword
             check_line(style, line - 2, message('before', keyword), &:empty?)
           end
+        end
+
+        def last_rescue_and_end_on_same_line(body)
+          body.rescue_type? && body.resbody_branches.last.loc.line == body.parent.loc.end.line
         end
 
         def message(location, keyword)

--- a/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
@@ -131,6 +131,19 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords, 
     begin; foo; rescue => e; end
   RUBY
 
+  include_examples 'accepts', '`rescue` and `end` are on the same line', <<~RUBY
+    begin
+      foo
+    rescue => e; end
+  RUBY
+
+  include_examples 'accepts', 'last `rescue` and `end` are on the same line', <<~RUBY
+    begin
+      foo
+    rescue => x
+    rescue => y; end
+  RUBY
+
   include_examples 'accepts', '`def` and `rescue` are on the same line', <<~RUBY
     def do_something; foo; rescue => e; end
   RUBY


### PR DESCRIPTION
Fix #10379.

This PR fixes an error for `Layout/EmptyLinesAroundExceptionHandlingKeywords` when `rescue` and `end` are on the same line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
