### PR TITLE
Update auto-gen-config's comment re auto-correct

### DIFF
--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -122,12 +122,11 @@ module RuboCop
 
         cop_class = Cop::Registry.global.find_by_cop_name(cop_name)
         default_cfg = default_config(cop_name)
-        if cop_class&.support_autocorrect?
-          if default_cfg.nil? || default_cfg['Safe'] || default_cfg['Safe'].nil?
-            output_buffer.puts '# Cop supports --auto-correct.'
-          else
-            output_buffer.puts '# Cop supports --auto-correct-all.'
-          end
+
+        if supports_safe_auto_correct?(cop_class, default_cfg)
+          output_buffer.puts '# Cop supports --auto-correct.'
+        elsif supports_unsafe_autocorrect?(cop_class, default_cfg)
+          output_buffer.puts '# Cop supports --auto-correct-all.'
         end
 
         return unless default_cfg
@@ -136,6 +135,15 @@ module RuboCop
         return if params.empty?
 
         output_cop_param_comments(output_buffer, params, default_cfg)
+      end
+
+      def supports_safe_auto_correct?(cop_class, default_cfg)
+        cop_class&.support_autocorrect? &&
+          (default_cfg.nil? || default_cfg['Safe'] || default_cfg['Safe'].nil?)
+      end
+
+      def supports_unsafe_autocorrect?(cop_class, default_cfg)
+        cop_class&.support_autocorrect? && !default_cfg.nil? && default_cfg['Safe'] == false
       end
 
       def cop_config_params(default_cfg, cfg)

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -121,9 +121,15 @@ module RuboCop
         output_buffer.puts "# Offense count: #{offense_count}" if show_offense_counts?
 
         cop_class = Cop::Registry.global.find_by_cop_name(cop_name)
-        output_buffer.puts '# Cop supports --auto-correct.' if cop_class&.support_autocorrect?
-
         default_cfg = default_config(cop_name)
+        if cop_class&.support_autocorrect?
+          if default_cfg.nil? || default_cfg['Safe'] || default_cfg['Safe'].nil?
+            output_buffer.puts '# Cop supports --auto-correct.'
+          else
+            output_buffer.puts '# Cop supports --auto-correct-all.'
+          end
+        end
+
         return unless default_cfg
 
         params = cop_config_params(default_cfg, cfg)

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -472,6 +472,41 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
       end
     end
 
+    context 'when cop is not safe to auto-correct' do
+      it 'can generate a todo list, with the appropriate flag' do
+        create_file('example1.rb', <<~RUBY)
+          # frozen_string_literal: true
+
+          users = (user.name + ' ' + user.email) * 5
+          puts users
+        RUBY
+        create_file('.rubocop.yml', <<~YAML)
+          # The following cop supports auto-correction but is not safe
+          Style/StringConcatenation:
+            Enabled: true
+        YAML
+        expect(cli.run(%w[--auto-gen-config])).to eq(0)
+        expect($stderr.string).to eq('')
+        expect(Dir['.*']).to include('.rubocop_todo.yml')
+        todo_contents = File.read('.rubocop_todo.yml').lines[8..-1].join
+        expect(todo_contents).to eq(<<~YAML)
+          # Offense count: 1
+          # Cop supports --auto-correct-all.
+          # Configuration parameters: Mode.
+          Style/StringConcatenation:
+            Exclude:
+              - 'example1.rb'
+        YAML
+        expect(File.read('.rubocop.yml')).to eq(<<~YAML)
+          inherit_from: .rubocop_todo.yml
+
+          # The following cop supports auto-correction but is not safe
+          Style/StringConcatenation:
+            Enabled: true
+        YAML
+      end
+    end
+
     context 'when existing config file has a YAML document start header' do
       it 'inserts `inherit_from` key after hearder' do
         create_file('example1.rb', <<~RUBY)


### PR DESCRIPTION
The auto-gen-config output will say "Cop supports --auto-correct" for
cops which do not support --auto-correct, but which do support
--auto-correct-all. Let's update the output to reflect that. When
someone is working on the todo list, this can be helpful information to
have at hand.

I'll often run something like:

`bin/rubocop --only Style/StringConcatenation -a` and then realize
actually that won't work, and this would save me a few seconds.

-----------------


Hi there. This is my first contribution in a few years. Happy to be back. WDYT about this idea?

Unfortunately `bundle exec rake default` is failing for me locally with this test failure, which is unrelated to my change:

<details>
 <summary>Failure</summary>

```
==> Failures

  1) RuboCop::TargetFinder#find_files prevents infinite loops when traversing symlinks
     Failure/Error: expect(found_basenames).to include('ruby1.rb').once

     NoMethodError:
       undefined method `once' for #<RSpec::Matchers::BuiltIn::Include:0x00007fc6f360f678>
     # ./spec/rubocop/target_finder_spec.rb:454:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:7:in `block (2 levels) in <top (required)>'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/runner/rspec3.rb:37:in `block (3 levels) in run_specs'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/iterator.rb:57:in `block in each'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/runner.rb:406:in `around_filter'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/iterator.rb:57:in `call'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/iterator.rb:57:in `each'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/runner/rspec3.rb:26:in `map'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/runner/rspec3.rb:26:in `block (2 levels) in run_specs'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/runner/rspec3.rb:25:in `block in run_specs'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/runner/rspec3.rb:24:in `run_specs'
     # tasks/spec_runner.rake:83:in `run_worker'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/runner.rb:301:in `block (2 levels) in spawn_workers'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/runner.rb:296:in `fork'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/runner.rb:296:in `block in spawn_workers'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/runner.rb:293:in `times'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/runner.rb:293:in `spawn_workers'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/runner.rb:238:in `execute_internal'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/test-queue-0.4.2/lib/test_queue/runner.rb:129:in `execute'
     # tasks/spec_runner.rake:38:in `block in run_specs'
     # tasks/spec_runner.rake:52:in `with_encoding'
     # tasks/spec_runner.rake:36:in `run_specs'
     # tasks/spec_runner.rake:165:in `block in <top (required)>'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/task.rb:281:in `block in execute'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/task.rb:281:in `each'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/task.rb:281:in `execute'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/task.rb:199:in `invoke_with_call_chain'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/task.rb:243:in `block in invoke_prerequisites'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/task.rb:241:in `each'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/task.rb:241:in `invoke_prerequisites'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/task.rb:218:in `block in invoke_with_call_chain'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/task.rb:199:in `invoke_with_call_chain'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/task.rb:188:in `invoke'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/application.rb:160:in `invoke_task'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/application.rb:116:in `block (2 levels) in top_level'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/application.rb:116:in `each'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/application.rb:116:in `block in top_level'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/application.rb:125:in `run_with_threads'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/application.rb:110:in `top_level'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/application.rb:83:in `block in run'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/application.rb:186:in `standard_exception_handling'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/lib/rake/application.rb:80:in `run'
     # /Users/max.jacobson/.gem/ruby/2.6.6/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'

```
</details>

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
