### PR TITLE
[Fix #10387] Fix an error for `Style/RedundantBegin`

### DIFF
--- a/changelog/fix_an_error_for_style_redundant_begin.md
+++ b/changelog/fix_an_error_for_style_redundant_begin.md
@@ -1,0 +1,1 @@
+* [#10387](https://github.com/rubocop/rubocop/issues/10387): Fix an error for `Style/RedundantBegin` when assigning nested `begin` blocks. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -97,7 +97,7 @@ module RuboCop
           offense_range = node.loc.begin
 
           add_offense(offense_range) do |corrector|
-            if any_ancestor_assignment_node?(node)
+            if node.parent&.assignment?
               replace_begin_with_statement(corrector, offense_range, node)
             else
               corrector.remove(offense_range)
@@ -170,11 +170,7 @@ module RuboCop
         end
 
         def valid_begin_assignment?(node)
-          any_ancestor_assignment_node?(node) && !node.children.one?
-        end
-
-        def any_ancestor_assignment_node?(node)
-          node.each_ancestor.any?(&:assignment?)
+          node.parent&.assignment? && !node.children.one?
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -462,4 +462,40 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
 
     expect_correction("unless condition\n  \n    foo\n  \nend\n")
   end
+
+  it 'reports an offense when assigning nested `begin` blocks' do
+    expect_offense(<<~RUBY)
+      var = do_something do
+        begin
+        ^^^^^ Redundant `begin` block detected.
+          do_something do
+            begin
+            ^^^^^ Redundant `begin` block detected.
+              foo
+            ensure
+              bar
+            end
+          end
+        ensure
+          baz
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      var = do_something do
+       #{trailing_whitespace}
+          do_something do
+           #{trailing_whitespace}
+              foo
+            ensure
+              bar
+           #{trailing_whitespace}
+          end
+        ensure
+          baz
+       #{trailing_whitespace}
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #10387.

This PR fixes an error for `Style/RedundantBegin` when assigning nested `begin` blocks.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
