### PR TITLE
Lint our YAML files, using yamllint

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,15 @@
+name: Linting
+on:
+  - pull_request
+jobs:
+  yamllint:
+    name: Yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Yamllint
+        uses: karancode/yamllint-github-action@master
+        with:
+          yamllint_comment: true
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -19,13 +19,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # [ ubuntu, macos, windows ]
-        os: [ windows ]
-        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', 'head' ]
+        # [ubuntu, macos, windows]
+        os: [windows]
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', 'head']
         include:
-          - { os: windows, ruby: mingw }
+          - os: windows
+            ruby: mingw
         exclude:
-          - { os: windows, ruby: head  }
+          - os: windows
+            ruby: head
 
     steps:
       - name: windows misc
@@ -42,10 +44,10 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
 
       - name: install dependencies
-        run:  bundle install --jobs 3 --retry 3
+        run: bundle install --jobs 3 --retry 3
       - name: spec
-        run:  bundle exec rake spec
+        run: bundle exec rake spec
       - name: ascii_spec
-        run:  bundle exec rake ascii_spec
+        run: bundle exec rake ascii_spec
       - name: internal_investigation
-        run:  bundle exec rake internal_investigation
+        run: bundle exec rake internal_investigation

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,7 +40,7 @@ Style/FormatStringToken:
 Style/IpAddresses:
   # The test for this cop includes strings that would cause offenses
   Exclude:
-  - spec/rubocop/cop/style/ip_addresses_spec.rb
+    - spec/rubocop/cop/style/ip_addresses_spec.rb
 
 Layout/EndOfLine:
   EnforcedStyle: lf

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,9 @@
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy:
+    check-keys: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -430,13 +430,13 @@ Layout/ClassStructure:
       - prepend
       - extend
   ExpectedOrder:
-      - module_inclusion
-      - constants
-      - public_class_methods
-      - initializer
-      - public_methods
-      - protected_methods
-      - private_methods
+    - module_inclusion
+    - constants
+    - public_class_methods
+    - initializer
+    - public_methods
+    - protected_methods
+    - private_methods
 
 Layout/ClosingHeredocIndentation:
   Description: 'Checks the indentation of here document closings.'
@@ -1900,7 +1900,7 @@ Lint/NestedPercentLiteral:
   VersionAdded: '0.52'
 
 Lint/NextWithoutAccumulator:
-  Description:  >-
+  Description: >-
                   Do not omit the accumulator when calling `next`
                   in a `reduce`/`inject` block.
   Enabled: true
@@ -3153,7 +3153,7 @@ Style/ClassMethodsDefinitions:
   StyleGuide: '#def-self-class-methods'
   Enabled: false
   VersionAdded: '0.89'
-  EnforcedStyle:  def_self
+  EnforcedStyle: def_self
   SupportedStyles:
     - def_self
     - self_class
@@ -3815,8 +3815,8 @@ Style/InverseMethods:
     :>: :<=
     # `ActiveSupport` defines some common inverse methods. They are listed below,
     # and not enabled by default.
-    #:present?: :blank?,
-    #:include?: :exclude?
+    # :present?: :blank?,
+    # :include?: :exclude?
   # `InverseBlocks` are methods that are inverted by inverting the return
   # of the block that is passed to the method
   InverseBlocks:

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -4,4 +4,4 @@ title: RuboCop
 # as patch versions should not appear in the docs.
 version: ~
 nav:
-- modules/ROOT/nav.adoc
+  - modules/ROOT/nav.adoc


### PR DESCRIPTION
Thanks to RuboCop, our Ruby files are so fine and consistently formatted. Our YAML files on the other hand…

So I thought we might want to use [yamllint](https://yamllint.readthedocs.io/en/stable/) to lint these files. Custom rules are in the .yamllint file, and you can see the enforced rules in practice on the other changed files in this PR.

This PR is almost identical to [one we added to rubocop-rspec](https://github.com/rubocop/rubocop-rspec/pull/1083) last year.

- [ ] Does this warrant a Changelog entry?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
