### PR TITLE
[Fix #10364] Fix an infinite loop error for `Style/HashAlignment`

### DIFF
--- a/changelog/fix_an_error_for_style_hash_alignment.md
+++ b/changelog/fix_an_error_for_style_hash_alignment.md
@@ -1,0 +1,1 @@
+* [#10364](https://github.com/rubocop/rubocop/issues/10364): Fix an infinite loop error for `Layout/HashAlignment` when `EnforcedStyle: with_fixed_indentation` is specified for `Layout/ArgumentAlignment`. ([@koic][])

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -222,9 +222,14 @@ module RuboCop
                               node.pairs.any? &&
                               node.parent&.call_type?
 
+          left_sibling = argument_before_hash(node)
           parent_loc = node.parent.loc
-          selector = parent_loc.selector || parent_loc.expression
+          selector = left_sibling || parent_loc.selector || parent_loc.expression
           same_line?(selector, node.pairs.first)
+        end
+
+        def argument_before_hash(hash_node)
+          hash_node.left_sibling.respond_to?(:loc) ? hash_node.left_sibling : nil
         end
 
         def reset!

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1919,6 +1919,11 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
 
       do_something.(foo: bar, baz: qux,
                     quux: corge)
+
+      do_something(
+        arg, foo: bar,
+          baz: qux
+      )
     RUBY
 
     create_file('.rubocop.yml', <<~YAML)
@@ -1945,6 +1950,11 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
 
       do_something.(foo: bar, baz: qux,
         quux: corge)
+
+      do_something(
+        arg, foo: bar,
+        baz: qux
+      )
     RUBY
   end
 


### PR DESCRIPTION
Fixes #10364.

This PR fixes an infinite loop error for `Layout/HashAlignment` when `EnforcedStyle: with_fixed_indentation` is specified for `Layout/ArgumentAlignment`.
The issue context is that the first keyword argument and the argument before it
are on the same line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
