### PR TITLE
[Fix #10394] Fix an error for `Style/SwapValues`

### DIFF
--- a/changelog/fix_an_error_for_style_swap_values.md
+++ b/changelog/fix_an_error_for_style_swap_values.md
@@ -1,0 +1,1 @@
+* [#10394](https://github.com/rubocop/rubocop/issues/10394): Fix an error for `Style/SwapValues` when assigning receiver object at `def`. ([@koic][])

--- a/lib/rubocop/cop/style/swap_values.rb
+++ b/lib/rubocop/cop/style/swap_values.rb
@@ -58,6 +58,8 @@ module RuboCop
         end
 
         def simple_assignment?(node)
+          return false unless node.respond_to?(:type)
+
           SIMPLE_ASSIGNMENT_TYPES.include?(node.type)
         end
 

--- a/spec/rubocop/cop/style/swap_values_spec.rb
+++ b/spec/rubocop/cop/style/swap_values_spec.rb
@@ -52,4 +52,11 @@ RSpec.describe RuboCop::Cop::Style::SwapValues, :config do
       y = not_a_tmp
     RUBY
   end
+
+  it 'does not register an offense when assigning receiver object at `def`' do
+    expect_no_offenses(<<~RUBY)
+      def (foo = Object.new).do_something
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #10394.

This PR fixes an error for `Style/SwapValues` when assigning receiver object at `def`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
