### PR TITLE
[Fix #10397] Fix offense message for `Style/OptionalBooleanParameter`

### DIFF
--- a/lib/rubocop/cop/style/optional_boolean_parameter.rb
+++ b/lib/rubocop/cop/style/optional_boolean_parameter.rb
@@ -54,8 +54,9 @@ module RuboCop
         private
 
         def format_message(argument)
-          source = argument.source
-          format(MSG, original: source, replacement: source.sub(/\s+=/, ':'))
+          replacement = "#{argument.name}: #{argument.default_value.source}"
+
+          format(MSG, original: argument.source, replacement: replacement)
         end
       end
     end

--- a/spec/rubocop/cop/style/optional_boolean_parameter_spec.rb
+++ b/spec/rubocop/cop/style/optional_boolean_parameter_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe RuboCop::Cop::Style::OptionalBooleanParameter, :config do
     RUBY
   end
 
+  it 'registers an offense when defining method with optional boolean arg that has no space' do
+    expect_offense(<<~RUBY)
+      def some_method(bar=false)
+                      ^^^^^^^^^ Prefer keyword arguments for arguments with a boolean default value; use `bar: false` instead of `bar=false`.
+      end
+    RUBY
+  end
+
   it 'registers an offense when defining class method with optional boolean arg' do
     expect_offense(<<~RUBY)
       def self.some_method(bar = false)


### PR DESCRIPTION
Fixes #10397.

This PR fixes offense message for `Style/OptionalBooleanParameter` when defining method with optional boolean arg that has no space.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
