### PR TITLE
[Fix #10401] Fix a false positive for `Style/HashSyntax`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_hash_syntax.md
+++ b/changelog/fix_a_false_positive_for_style_hash_syntax.md
@@ -1,0 +1,1 @@
+* [#10401](https://github.com/rubocop/rubocop/issues/10401): Fix a false positive for `Style/HashSyntax` when local variable hash key and hash value are the same. ([@koic][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -41,7 +41,7 @@ module RuboCop
       end
 
       def require_hash_value?(hash_key_source, node)
-        return true if require_hash_value_for_around_hash_literal?(node)
+        return true if !node.key.sym_type? || require_hash_value_for_around_hash_literal?(node)
 
         hash_value = node.value
         return true unless hash_value.send_type? || hash_value.lvar_type?

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -959,6 +959,19 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'does not register an offense when method call hash key and hash value are the same' do
+        expect_no_offenses(<<~RUBY)
+          {foo => foo}
+        RUBY
+      end
+
+      it 'does not register an offense when lvar hash key and hash value are the same' do
+        expect_no_offenses(<<~RUBY)
+          foo = 42
+          {foo => foo}
+        RUBY
+      end
+
       it 'does not register an offense when without parentheses call expr follows' do
         # Prevent syntax errors shown in the URL: https://bugs.ruby-lang.org/issues/18396
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #10401.

This PR fixes a false positive for `Style/HashSyntax` when local variable hash key and hash value are the same.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
