### PR TITLE
[Fix #10403] Fix an error for `Style/StringConcatenation`

### DIFF
--- a/changelog/fix_an_error_for_style_string_concatenation.md
+++ b/changelog/fix_an_error_for_style_string_concatenation.md
@@ -1,0 +1,1 @@
+* [#10403](https://github.com/rubocop/rubocop/issues/10403): Fix an error for `Style/StringConcatenation` when string concatenation with multiline heredoc text. ([@koic][])

--- a/lib/rubocop/cop/style/string_concatenation.rb
+++ b/lib/rubocop/cop/style/string_concatenation.rb
@@ -134,7 +134,13 @@ module RuboCop
         end
 
         def uncorrectable?(part)
-          part.multiline? || (part.str_type? && part.heredoc?) || part.each_descendant(:block).any?
+          part.multiline? || heredoc?(part) || part.each_descendant(:block).any?
+        end
+
+        def heredoc?(node)
+          return false unless node.str_type? || node.dstr_type?
+
+          node.heredoc?
         end
 
         def corrected_ancestor?(node)

--- a/spec/rubocop/cop/style/string_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/string_concatenation_spec.rb
@@ -143,6 +143,18 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation, :config do
 
       expect_no_corrections
     end
+
+    it 'registers an offense but does not correct when string concatenation with multiline heredoc text' do
+      expect_offense(<<~RUBY)
+        "foo" + <<~TEXT
+        ^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+          bar
+          baz
+        TEXT
+      RUBY
+
+      expect_no_corrections
+    end
   end
 
   context 'double quotes inside string' do


### PR DESCRIPTION
Fixes #10403.

This PR fixes an error for `Style/StringConcatenation` when string concatenation with multiline heredoc text.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
