### PR TITLE
Fix doc formatting for Layout/CaseIndentation

### DIFF
--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -483,7 +483,7 @@ blah { |i|
 | 1.16
 |===
 
-This cop checks how the `when` and `in`s of a `case` expression
+This cop checks how the `when` and ``in``s of a `case` expression
 are indented in relation to its `case` or `end` keyword.
 
 It will register a separate offense for each misaligned `when` and `in`.


### PR DESCRIPTION
The current formatting is a bit off, see here:

<img width="866" alt="Screen Shot 2022-02-08 at 22 53 57" src="https://user-images.githubusercontent.com/809707/153082140-836639e4-ff58-4cc1-94c2-d9fa794e8b56.png">

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
