### PR TITLE
Fix a false positive for `Lint/InheritException`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_inherit_exception.md
+++ b/changelog/fix_a_false_positive_for_lint_inherit_exception.md
@@ -1,0 +1,1 @@
+* [#10406](https://github.com/rubocop/rubocop/pull/10406): Fix a false positive for `Lint/InheritException` when inheriting a standard lib exception class that is not a subclass of `StandardError`. ([@koic][])

--- a/spec/rubocop/cop/lint/inherit_exception_spec.rb
+++ b/spec/rubocop/cop/lint/inherit_exception_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe RuboCop::Cop::Lint::InheritException, :config do
           RUBY
         end
       end
+
+      context 'when inheriting a standard lib exception class that is not a subclass of `StandardError`' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            class C < Interrupt; end
+          RUBY
+        end
+      end
     end
 
     context 'with enforced style set to `standard_error`' do
@@ -53,6 +61,14 @@ RSpec.describe RuboCop::Cop::Lint::InheritException, :config do
 
           expect_correction(<<~RUBY)
             Class.new(StandardError)
+          RUBY
+        end
+      end
+
+      context 'when inheriting a standard lib exception class that is not a subclass of `StandardError`' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            class C < Interrupt; end
           RUBY
         end
       end


### PR DESCRIPTION
Fixes https://github.com/testdouble/standard/issues/388 and reverts https://github.com/rubocop/rubocop/pull/3427.

This PR prevents the following false positive and auto-correction.

```diff
 class TestClass
-  FatalError = Class.new(Interrupt)
+  FatalError = Class.new(RuntimeError)
 end
```

Below is an inheritance tree for the exception classes.

```
        ---------------
        | BasicObject |
        ---------------
               ^
               |
        ---------------
        |   Kernel    |
        ---------------
               ^
               |
        ---------------
        |   Object    |
        ---------------
               ^
               |
        ---------------
        |  Exception  |
        ---------------
               ^
               |
      |------------------|
---------------  -----------------
|StandardError|  |SignalException|
---------------  -----------------
      ^                  ^
      |                  |
---------------  -----------------
|RuntimeError |  |   Interrupt   |
---------------  -----------------
```

As the inheritance tree shows, `Interrupt` is not `is_a?` in either `StandardError` or `RuntimeError`.

```ruby
RuntimeError.new.is_a?(StandardError) #=> true
Interrupt.new.is_a?(StandardError)    #=> false
Interrupt.new.is_a?(RuntimeError)     #=> false
```

This goes against The Liskov Substitution Principle. `Interup` should not be replaced with `StandardError` or its subclasses.
Also, according to The Open/Closed Principle, `Interrup` class should be open to inheritance.

The same is true for `SystemStackError`, `NoMemoryError`, `SecurityError`, `NotImplementedError`, `LoadError`, `SyntaxError`, `ScriptError`, `SignalException`, and `SystemExit` classes.

This PR allows for exception handling according to Object-oriented principles and Ruby exception handling mechanism.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
