### PR TITLE
Change `EnforcedStyle` to `standard_error` for `Lint/InheritException`

### DIFF
--- a/changelog/change_enforced_style_for_lint_inherit_exception.md
+++ b/changelog/change_enforced_style_for_lint_inherit_exception.md
@@ -1,0 +1,1 @@
+* [#10407](https://github.com/rubocop/rubocop/pull/10407): Change `EnforcedStyle` from `runtime_error` to `standard_error` for `Lint/InheritException`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1820,10 +1820,10 @@ Lint/InheritException:
   VersionAdded: '0.41'
   VersionChanged: '<<next>>'
   # The default base class in favour of `Exception`.
-  EnforcedStyle: runtime_error
+  EnforcedStyle: standard_error
   SupportedStyles:
-    - runtime_error
     - standard_error
+    - runtime_error
 
 Lint/InterpolationCheck:
   Description: 'Raise warning for interpolation in single q strs.'

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -6,27 +6,14 @@ module RuboCop
       # This cop looks for error classes inheriting from `Exception`
       # and its standard library subclasses, excluding subclasses of
       # `StandardError`. It is configurable to suggest using either
-      # `RuntimeError` (default) or `StandardError` instead.
+      # `StandardError` (default) or `RuntimeError` instead.
       #
       # @safety
       #   This cop's autocorrection is unsafe because `rescue` that omit
       #   exception class handle `StandardError` and its subclasses,
       #   but not `Exception` and its subclasses.
       #
-      # @example EnforcedStyle: runtime_error (default)
-      #   # bad
-      #
-      #   class C < Exception; end
-      #
-      #   C = Class.new(Exception)
-      #
-      #   # good
-      #
-      #   class C < RuntimeError; end
-      #
-      #   C = Class.new(RuntimeError)
-      #
-      # @example EnforcedStyle: standard_error
+      # @example EnforcedStyle: standard_error (default)
       #   # bad
       #
       #   class C < Exception; end
@@ -38,6 +25,19 @@ module RuboCop
       #   class C < StandardError; end
       #
       #   C = Class.new(StandardError)
+      #
+      # @example EnforcedStyle: runtime_error
+      #   # bad
+      #
+      #   class C < Exception; end
+      #
+      #   C = Class.new(Exception)
+      #
+      #   # good
+      #
+      #   class C < RuntimeError; end
+      #
+      #   C = Class.new(RuntimeError)
       class InheritException < Base
         include ConfigurableEnforcedStyle
         extend AutoCorrector


### PR DESCRIPTION
This PR change `EnforcedStyle` from `runtime_error` to `standard_error` for `Lint/InheritException`.

I noticed this while investigating #10406.

Below is the inheritance tree for the exception classes.

```
---------------
|  Exception  |
---------------
      ^
      |
---------------
|StandardError| (default for `rescue`)
---------------
      ^
      |
---------------
|RuntimeError | (default for `raise`)
---------------
```

AFAIK, it seems that custom exceptions generally inherit from `StandardError`.
Subclasses of `StandardError` are handled with `rescue` by default.

`raise` creates a `RuntimeError` when the exception class is omitted.
If custom exception inherits from `RuntimeError`, the custom exception and `RuntimeError` will be is-a.
If custom exception inherits from `StandardError`, the custom exception and `RuntimeError` will not be is-a.
In other words, inheriting `StandardError` will not be mistakenly handled as `raise` which omits the exception class.

So, inheriting `StandardError` rather than `RuntimeError` does not include unnecessary inheritance for `rescue` handling.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
