### PR TITLE
Mark `Lint/InheritException` as unsafe auto-correction

### DIFF
--- a/changelog/change_mark_lint_inherit_exception_as_unsafe.md
+++ b/changelog/change_mark_lint_inherit_exception_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#10408](https://github.com/rubocop/rubocop/pull/10408): Mark `Lint/InheritException` as unsafe auto-correction. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1816,7 +1816,9 @@ Lint/IneffectiveAccessModifier:
 Lint/InheritException:
   Description: 'Avoid inheriting from the `Exception` class.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.41'
+  VersionChanged: '<<next>>'
   # The default base class in favour of `Exception`.
   EnforcedStyle: runtime_error
   SupportedStyles:

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -8,6 +8,11 @@ module RuboCop
       # `StandardError`. It is configurable to suggest using either
       # `RuntimeError` (default) or `StandardError` instead.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because `rescue` that omit
+      #   exception class handle `StandardError` and its subclasses,
+      #   but not `Exception` and its subclasses.
+      #
       # @example EnforcedStyle: runtime_error (default)
       #   # bad
       #


### PR DESCRIPTION
This PR marks `Lint/InheritException` as unsafe auto-correction.

This cop's autocorrection is unsafe because `rescue` that omit exception class handle `StandardError` and its subclasses,
but not `Exception` and its subclasses.

```ruby
begin
rescue # Handles only `StandardError` and its subclasses because exception class is omitted.
end
```

It's still unsafe after #10406 is resolved.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
