### PR TITLE
Update auto-gen-config's auto-correction comments

### DIFF
--- a/changelog/change_auto_correct_message.md
+++ b/changelog/change_auto_correct_message.md
@@ -1,0 +1,1 @@
+* [#10414](https://github.com/rubocop/rubocop/pull/10414): Update auto-gen-config's auto-correction comments to be more clear. ([@maxjacobson][])

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -124,9 +124,9 @@ module RuboCop
         default_cfg = default_config(cop_name)
 
         if supports_safe_auto_correct?(cop_class, default_cfg)
-          output_buffer.puts '# Cop supports --auto-correct.'
+          output_buffer.puts '# This cop supports safe auto-correction (--auto-correct).'
         elsif supports_unsafe_autocorrect?(cop_class, default_cfg)
-          output_buffer.puts '# Cop supports --auto-correct-all.'
+          output_buffer.puts '# This cop supports unsafe auto-correction (--auto-correct-all).'
         end
 
         return unless default_cfg

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             .to eq(<<~YAML)
 
               # Offense count: 1
-              # Cop supports --auto-correct.
+              # This cop supports safe auto-correction (--auto-correct).
               Style/IfUnlessModifier:
                 Exclude:
                   - 'example.rb'
 
               # Offense count: 2
-              # Cop supports --auto-correct.
+              # This cop supports safe auto-correction (--auto-correct).
               # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
               # URISchemes: http, https
               Layout/LineLength:
@@ -165,14 +165,14 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             .to eq(<<~YAML)
 
               # Offense count: 1
-              # Cop supports --auto-correct.
+              # This cop supports safe auto-correction (--auto-correct).
               # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
               # URISchemes: http, https
               Layout/LineLength:
                 Max: 99
 
               # Offense count: 1
-              # Cop supports --auto-correct.
+              # This cop supports safe auto-correction (--auto-correct).
               # Configuration parameters: EnforcedStyle.
               # SupportedStyles: always, always_true, never
               Style/FrozenStringLiteralComment:
@@ -220,7 +220,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             .to eq(<<~YAML)
 
               # Offense count: 1
-              # Cop supports --auto-correct.
+              # This cop supports safe auto-correction (--auto-correct).
               # Configuration parameters: EnforcedStyle.
               # SupportedStyles: always, always_true, never
               Style/FrozenStringLiteralComment:
@@ -228,7 +228,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                   - 'example.rb'
 
               # Offense count: 1
-              # Cop supports --auto-correct.
+              # This cop supports safe auto-correction (--auto-correct).
               Style/IfUnlessModifier:
                 Exclude:
                   - 'example.rb'
@@ -269,7 +269,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             .to eq(<<~YAML)
 
               # Offense count: 1
-              # Cop supports --auto-correct.
+              # This cop supports safe auto-correction (--auto-correct).
               # Configuration parameters: EnforcedStyle.
               # SupportedStyles: always, always_true, never
               Style/FrozenStringLiteralComment:
@@ -277,7 +277,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                   - 'example.rb'
 
               # Offense count: 1
-              # Cop supports --auto-correct.
+              # This cop supports safe auto-correction (--auto-correct).
               Style/IfUnlessModifier:
                 Exclude:
                   - 'example.rb'
@@ -315,7 +315,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
       expect(cli.run(['--auto-gen-config'])).to eq(0)
       expect(File.readlines('.rubocop_todo.yml')[8..-1].map(&:chomp))
         .to eq(['# Offense count: 1',
-                '# Cop supports --auto-correct.',
+                '# This cop supports safe auto-correction (--auto-correct).',
                 '# Configuration parameters: AllowForAlignment, ' \
                 'EnforcedStyleForExponentOperator.',
                 '# SupportedStylesForExponentOperator: space, no_space',
@@ -324,14 +324,14 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                 "    - 'example1.rb'",
                 '',
                 '# Offense count: 2',
-                '# Cop supports --auto-correct.',
+                '# This cop supports safe auto-correction (--auto-correct).',
                 '# Configuration parameters: AllowInHeredoc.',
                 'Layout/TrailingWhitespace:',
                 '  Exclude:',
                 "    - 'example1.rb'",
                 '',
                 '# Offense count: 1',
-                '# Cop supports --auto-correct.',
+                '# This cop supports safe auto-correction (--auto-correct).',
                 '# Configuration parameters: AllowHeredoc, ' \
                 'AllowURI, URISchemes, IgnoreCopDirectives, ' \
                 'IgnoredPatterns.',
@@ -357,20 +357,20 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
       expect(cli.run(['--auto-gen-config'])).to eq(0)
       expect(File.readlines('.rubocop_todo.yml')[8..-1].join)
         .to eq(['# Offense count: 1',
-                '# Cop supports --auto-correct.',
+                '# This cop supports safe auto-correction (--auto-correct).',
                 '# Configuration parameters: AllowInHeredoc.',
                 'Layout/TrailingWhitespace:',
                 '  Exclude:',
                 "    - 'example1.rb'",
                 '',
                 '# Offense count: 2',
-                '# Cop supports --auto-correct.',
+                '# This cop supports safe auto-correction (--auto-correct).',
                 'Migration/DepartmentName:',
                 '  Exclude:',
                 "    - 'example1.rb'",
                 '',
                 '# Offense count: 1',
-                '# Cop supports --auto-correct.',
+                '# This cop supports safe auto-correction (--auto-correct).',
                 '# Configuration parameters: EnforcedStyle.',
                 '# SupportedStyles: always, always_true, never',
                 'Style/FrozenStringLiteralComment:',
@@ -378,13 +378,13 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                 "    - 'example1.rb'",
                 '',
                 '# Offense count: 1',
-                '# Cop supports --auto-correct.',
+                '# This cop supports safe auto-correction (--auto-correct).',
                 '# Configuration parameters: Strict, AllowedNumbers.',
                 'Style/NumericLiterals:',
                 '  MinDigits: 7',
                 '',
                 '# Offense count: 1',
-                '# Cop supports --auto-correct.',
+                '# This cop supports safe auto-correction (--auto-correct).',
                 '# Configuration parameters: AllowHeredoc, ' \
                 'AllowURI, URISchemes, IgnoreCopDirectives, ' \
                 'IgnoredPatterns.',
@@ -408,7 +408,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         todo_contents = File.read('.rubocop_todo.yml').lines[8..-1].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
-          # Cop supports --auto-correct.
+          # This cop supports safe auto-correction (--auto-correct).
           # Configuration parameters: EnforcedStyle.
           # SupportedStyles: always, always_true, never
           Style/FrozenStringLiteralComment:
@@ -455,7 +455,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             EnforcedStyle: camelCase
 
           # Offense count: 1
-          # Cop supports --auto-correct.
+          # This cop supports safe auto-correction (--auto-correct).
           # Configuration parameters: EnforcedStyle.
           # SupportedStyles: always, always_true, never
           Style/FrozenStringLiteralComment:
@@ -491,7 +491,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         todo_contents = File.read('.rubocop_todo.yml').lines[8..-1].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
-          # Cop supports --auto-correct-all.
+          # This cop supports unsafe auto-correction (--auto-correct-all).
           # Configuration parameters: Mode.
           Style/StringConcatenation:
             Exclude:
@@ -525,7 +525,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         todo_contents = File.read('.rubocop_todo.yml').lines[8..-1].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
-          # Cop supports --auto-correct.
+          # This cop supports safe auto-correction (--auto-correct).
           # Configuration parameters: EnforcedStyle.
           # SupportedStyles: always, always_true, never
           Style/FrozenStringLiteralComment:
@@ -563,7 +563,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         todo_contents = File.read('dir/.rubocop_todo.yml').lines[8..-1].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
-          # Cop supports --auto-correct.
+          # This cop supports safe auto-correction (--auto-correct).
           # Configuration parameters: EnforcedStyle.
           # SupportedStyles: always, always_true, never
           Style/FrozenStringLiteralComment:
@@ -668,14 +668,14 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          'again.',
          '',
          '# Offense count: 1',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: AllowForAlignment.',
          'Layout/CommentIndentation:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
          '# Offense count: 2',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: EnforcedStyle.',
          '# SupportedStyles: normal, indented_internal_methods',
          'Layout/IndentationConsistency:',
@@ -683,7 +683,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example2.rb'",
          '',
          '# Offense count: 1',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: IndentationWidth, EnforcedStyle.',
          '# SupportedStyles: spaces, tabs',
          'Layout/IndentationStyle:',
@@ -691,13 +691,13 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example2.rb'",
          '',
          '# Offense count: 1',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          'Layout/InitialIndentation:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
          '# Offense count: 1',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: AllowForAlignment, ' \
          'EnforcedStyleForExponentOperator.',
          '# SupportedStylesForExponentOperator: space, no_space',
@@ -706,7 +706,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example1.rb'",
          '',
          '# Offense count: 2',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: AllowInHeredoc.',
          'Layout/TrailingWhitespace:',
          '  Exclude:',
@@ -727,7 +727,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example1.rb'",
          '',
          '# Offense count: 2',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: AllowHeredoc, ' \
          'AllowURI, URISchemes, IgnoreCopDirectives, ' \
          'IgnoredPatterns.',
@@ -770,14 +770,14 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          'again.',
          '',
          '# Offense count: 1',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: AllowForAlignment.',
          'Layout/CommentIndentation:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
          '# Offense count: 1',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: EnforcedStyle.',
          '# SupportedStyles: normal, indented_internal_methods',
          'Layout/IndentationConsistency:',
@@ -785,7 +785,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example2.rb'",
          '',
          '# Offense count: 1',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: IndentationWidth, EnforcedStyle.',
          '# SupportedStyles: spaces, tabs',
          'Layout/IndentationStyle:',
@@ -793,13 +793,13 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example2.rb'",
          '',
          '# Offense count: 1',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          'Layout/InitialIndentation:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
          '# Offense count: 1',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: AllowForAlignment, ' \
          'EnforcedStyleForExponentOperator.',
          '# SupportedStylesForExponentOperator: space, no_space',
@@ -808,7 +808,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example1.rb'",
          '',
          '# Offense count: 3',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: AllowInHeredoc.',
          'Layout/TrailingWhitespace:',
          '  Enabled: false', # Offenses in 2 files, limit is 1, so no Exclude
@@ -820,7 +820,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example1.rb'",
          '',
          '# Offense count: 3',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: AllowHeredoc, ' \
          'AllowURI, URISchemes, IgnoreCopDirectives, ' \
          'IgnoredPatterns.',
@@ -933,14 +933,14 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         # versions of RuboCop, may require this file to be generated again.
 
         # Offense count: 1
-        # Cop supports --auto-correct.
+        # This cop supports safe auto-correction (--auto-correct).
         # Configuration parameters: AllowForAlignment.
         Layout/CommentIndentation:
           Exclude:
             - 'example2.rb'
 
         # Offense count: 1
-        # Cop supports --auto-correct.
+        # This cop supports safe auto-correction (--auto-correct).
         # Configuration parameters: EnforcedStyle.
         # SupportedStyles: normal, indented_internal_methods
         Layout/IndentationConsistency:
@@ -948,7 +948,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             - 'example2.rb'
 
         # Offense count: 1
-        # Cop supports --auto-correct.
+        # This cop supports safe auto-correction (--auto-correct).
         # Configuration parameters: IndentationWidth, EnforcedStyle.
         # SupportedStyles: spaces, tabs
         Layout/IndentationStyle:
@@ -956,7 +956,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             - 'example2.rb'
 
         # Offense count: 1
-        # Cop supports --auto-correct.
+        # This cop supports safe auto-correction (--auto-correct).
         Layout/InitialIndentation:
           Exclude:
             - 'example2.rb'
@@ -982,7 +982,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          'again.',
          '',
          '# Offense count: 1',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: EnforcedStyle, AllowInnerSlashes.',
          '# SupportedStyles: slashes, percent_r, mixed',
          'Style/RegexpLiteral:',
@@ -1038,32 +1038,32 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '# versions of RuboCop, may require this file to be generated ' \
          'again.',
          '',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: AllowForAlignment.',
          'Layout/CommentIndentation:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: EnforcedStyle.',
          '# SupportedStyles: normal, indented_internal_methods',
          'Layout/IndentationConsistency:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: IndentationWidth, EnforcedStyle.',
          '# SupportedStyles: spaces, tabs',
          'Layout/IndentationStyle:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          'Layout/InitialIndentation:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: AllowForAlignment, ' \
          'EnforcedStyleForExponentOperator.',
          '# SupportedStylesForExponentOperator: space, no_space',
@@ -1071,7 +1071,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '  Exclude:',
          "    - 'example1.rb'",
          '',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: AllowInHeredoc.',
          'Layout/TrailingWhitespace:',
          '  Exclude:',
@@ -1089,7 +1089,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '  Exclude:',
          "    - 'example1.rb'",
          '',
-         '# Cop supports --auto-correct.',
+         '# This cop supports safe auto-correction (--auto-correct).',
          '# Configuration parameters: AllowHeredoc, ' \
          'AllowURI, URISchemes, IgnoreCopDirectives, ' \
          'IgnoredPatterns.',
@@ -1171,14 +1171,14 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         expect(File.readlines('.rubocop_todo.yml')[8..-1].join)
           .to eq(<<~YAML)
             # Offense count: 3
-            # Cop supports --auto-correct.
+            # This cop supports safe auto-correction (--auto-correct).
             # Configuration parameters: EnforcedStyle.
             # SupportedStyles: always, always_true, never
             Style/FrozenStringLiteralComment:
               Enabled: false
 
             # Offense count: 2
-            # Cop supports --auto-correct.
+            # This cop supports safe auto-correction (--auto-correct).
             # Configuration parameters: RequireEnglish, EnforcedStyle.
             # SupportedStyles: use_perl_names, use_english_names
             Style/SpecialGlobalVars:
@@ -1192,7 +1192,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         expect(File.readlines('.rubocop_todo.yml')[8..-1].join)
           .to eq(<<~YAML)
             # Offense count: 4
-            # Cop supports --auto-correct.
+            # This cop supports safe auto-correction (--auto-correct).
             # Configuration parameters: EnforcedStyle.
             # SupportedStyles: always, always_true, never
             Style/FrozenStringLiteralComment:
@@ -1203,7 +1203,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                 - 'example4.rb'
 
             # Offense count: 3
-            # Cop supports --auto-correct.
+            # This cop supports safe auto-correction (--auto-correct).
             # Configuration parameters: RequireEnglish, EnforcedStyle.
             # SupportedStyles: use_perl_names, use_english_names
             Style/SpecialGlobalVars:

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
     let(:expected_rubocop_todo) do
       [heading,
        '# Offense count: 1',
-       '# Cop supports --auto-correct.',
+       '# This cop supports safe auto-correction (--auto-correct).',
        'Test/Cop3:',
        '  Exclude:',
        "    - 'test_auto_correct.rb'",


### PR DESCRIPTION
This is a follow-up to https://github.com/rubocop/rubocop/pull/10384, following a suggestion from bbatsov in the code review.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
