### PR TITLE
[Fix #9816] Add a ShortCircuit option to Lint/SafeNavigationConsistency

### DIFF
--- a/changelog/new_add_a_shortcircuit_option_to.md
+++ b/changelog/new_add_a_shortcircuit_option_to.md
@@ -1,0 +1,1 @@
+* [#9816](https://github.com/rubocop/rubocop/issues/9816): Add a ShortCircuit option to Lint/SafeNavigationConsistency. ([@rrosenblum][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2246,7 +2246,8 @@ Lint/SafeNavigationConsistency:
                  for all method calls on that same object.
   Enabled: true
   VersionAdded: '0.55'
-  VersionChanged: '0.77'
+  VersionChanged: '1.26'
+  ShortCircuit: false
   AllowedMethods:
     - present?
     - blank?

--- a/lib/rubocop/cop/lint/safe_navigation_consistency.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_consistency.rb
@@ -7,6 +7,11 @@ module RuboCop
       # call in an `&&` or `||` condition that safe navigation is used for all
       # method calls on that same object.
       #
+      # Options:
+      # `ShortCircuit` (default `false`) - Enforces short circuit syntax for `&&` conditions. Only
+      # the first method call is required to use safe navigation. All other method calls do not
+      # use safe navigation. There is no impact on `||` conditions.
+      #
       # @example
       #   # bad
       #   foo&.bar && foo.baz
@@ -26,31 +31,76 @@ module RuboCop
       #   # good
       #   foo&.bar && (foobar.baz || foo&.baz)
       #
+      # @example ShortCircuit: true
+      #   # bad
+      #   foo.bar && foo&.baz
+      #
+      #   # bad
+      #   foo.bar || foo&.baz
+      #
+      #   # bad
+      #   foo&.bar && foo&.baz
+      #
+      #   # bad
+      #   foo.bar || foo.bar && foo.qux
+      #
+      #   # good
+      #   foo&.bar && foo.baz
+      #
+      #   # good
+      #   foo&.bar || foo&.baz
+      #
+      #   # good
+      #   foo&.bar && foo.baz
+      #
+      #   # good
+      #   foo&.bar || foo&.bar && foo.qux
+      #
       class SafeNavigationConsistency < Base
         include IgnoredNode
         include NilMethods
         extend AutoCorrector
 
         MSG = 'Ensure that safe navigation is used consistently inside of `&&` and `||`.'
+        SHORT_CIRCUIT_MSG = 'Only use safe navigation for the first operand of `&&`.'
+        VARIABLE_ASSIGNMENT_TYPES = %i[casgn cvasgn gvasgn ivasgn lvasgn].freeze
+        DOT_METHODS = %i[send csend].freeze
 
         def on_csend(node)
-          return unless node.parent&.operator_keyword?
+          return unless node.parent&.operator_keyword? # This filters out block calls
 
-          check(node)
+          if cop_config['ShortCircuit']
+            check_with_short_circuit(node)
+          else
+            check_for_unsafe_methods(node)
+          end
         end
 
-        def check(node)
-          ancestor = top_conditional_ancestor(node)
-          conditions = ancestor.conditions
-          safe_nav_receiver = node.receiver
+        def check_with_short_circuit(node)
+          method_calls = extract_conditions(node, DOT_METHODS)
 
-          method_calls = conditions.select(&:send_type?)
-          unsafe_method_calls = unsafe_method_calls(method_calls, safe_nav_receiver)
+          first_method, *other_methods_with_same_receiver =
+            methods_with_same_receiver(method_calls, node.receiver)
+
+          return if all_methods_compliant_with_short_circuit(first_method,
+                                                             other_methods_with_same_receiver)
+
+          other_methods_with_same_receiver.each do |method|
+            add_short_circuit_offense(first_method, method)
+          end
+        end
+
+        def check_for_unsafe_methods(node)
+          method_calls = extract_conditions(node, [:send])
+          safe_nav_receiver = node.receiver
+          unsafe_method_calls = methods_with_same_receiver(method_calls, safe_nav_receiver)
 
           unsafe_method_calls.each do |unsafe_method_call|
             location = location(node, unsafe_method_call)
 
-            add_offense(location) { |corrector| autocorrect(corrector, unsafe_method_call) }
+            add_offense(location) do |corrector|
+              add_safe_navigation(corrector, unsafe_method_call)
+            end
 
             ignore_node(unsafe_method_call)
           end
@@ -58,14 +108,60 @@ module RuboCop
 
         private
 
-        def autocorrect(corrector, node)
+        def extract_conditions(node, method_types)
+          ancestor = top_conditional_ancestor(node)
+          conditions = ancestor.conditions
+          conditions.select { |condition| method_types.include?(condition.type) }
+        end
+
+        def all_methods_compliant_with_short_circuit(first_method, other_methods)
+          # e.g. `foo&.bar && foo.baz && foo.qux`
+          first_method.csend_type? &&
+            other_methods.all?(&:send_type?) &&
+            other_methods.map(&:parent).all?(&:and_type?)
+        end
+
+        def add_short_circuit_offense(first_method, node)
+          location = first_method.loc.expression.join(node.loc.expression)
+          conditional_parent = next_conditional_ancestor(node)
+
+          operator = if conditional_parent.rhs == node
+                       conditional_parent
+                     else
+                       next_conditional_ancestor(conditional_parent)
+                     end
+
+          if operator.and_type?
+            add_offense(location, message: SHORT_CIRCUIT_MSG)
+          elsif operator.or_type?
+            add_offense(location)
+          end
+        end
+
+        def add_safe_navigation(corrector, node)
           return unless node.dot?
 
           corrector.insert_before(node.loc.dot, '&')
         end
 
+        def remove_safe_navigation(corrector, node)
+          return unless node.safe_navigation?
+
+          corrector.replace(node.loc.dot, '.')
+        end
+
         def location(node, unsafe_method_call)
           node.source_range.join(unsafe_method_call.source_range)
+        end
+
+        def next_conditional_ancestor(node)
+          parent = node&.parent
+          return parent if parent&.operator_keyword?
+
+          grandparent = parent.parent
+          return unless parent&.begin_type?
+
+          return grandparent if grandparent.operator_keyword?
         end
 
         def top_conditional_ancestor(node)
@@ -79,12 +175,16 @@ module RuboCop
           top_conditional_ancestor(parent)
         end
 
-        def unsafe_method_calls(method_calls, safe_nav_receiver)
+        def methods_with_same_receiver(method_calls, safe_nav_receiver)
           method_calls.select do |method_call|
             safe_nav_receiver == method_call.receiver &&
               !nil_methods.include?(method_call.method_name) &&
               !ignored_node?(method_call)
           end
+        end
+
+        def dot_style_method_call?(node)
+          node.dot? || node.safe_navigation?
         end
       end
     end


### PR DESCRIPTION
This closes #9816. Add a ShortCircuit option to Lint/SafeNavigationConsistency. `ShortCircuit` does not support auto-correct. I found a few edge case conditions that could make auto-correct with `ShortCircuit` unsafe.

example:
```ruby
foo + 1 && foo&.even?
```
non-dot method needing safe nav. We don't auto-correct safe nav onto non-dot methods so removing safe nav `foo&.even?` would change the code and make this cop unable to flag it on subsequent passes. I think we can detect this an not auto-correct this use case, however I also discovered that this cop doesn't currently support methods with a block or non-dot methods. 

There's some sizeable work that can be done to this cop. I think it would be beneficial to change the entry point from looking for safe nav to looking for `&&` and `||`. We should be able to more reliable always start at the beginning of a condition rather than starting anywhere and going up the chain. I think this will make the variable scope easier to work with and make auto-correction easier.