### PR TITLE
[Fix #10415] Fix an error for `Lint/UselessTimes`

### DIFF
--- a/changelog/fix_an_error_for_lint_useless_times.md
+++ b/changelog/fix_an_error_for_lint_useless_times.md
@@ -1,0 +1,1 @@
+* [#10415](https://github.com/rubocop/rubocop/issues/10415): Fix an error for `Lint/UselessTimes` when using `1.times` with method chain. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_times.rb
+++ b/lib/rubocop/cop/lint/useless_times.rb
@@ -51,19 +51,23 @@ module RuboCop
           node = node.block_node if node.block_literal?
 
           add_offense(node, message: format(MSG, count: count)) do |corrector|
-            next unless own_line?(node)
+            next if !own_line?(node) || node.parent&.send_type?
 
-            if never_process?(count, node)
-              remove_node(corrector, node)
-            elsif !proc_name.empty?
-              autocorrect_block_pass(corrector, node, proc_name)
-            else
-              autocorrect_block(corrector, node)
-            end
+            autocorrect(corrector, count, node, proc_name)
           end
         end
 
         private
+
+        def autocorrect(corrector, count, node, proc_name)
+          if never_process?(count, node)
+            remove_node(corrector, node)
+          elsif !proc_name.empty?
+            autocorrect_block_pass(corrector, node, proc_name)
+          else
+            autocorrect_block(corrector, node)
+          end
+        end
 
         def never_process?(count, node)
           count < 1 || (node.block_type? && node.body.nil?)

--- a/spec/rubocop/cop/lint/useless_times_spec.rb
+++ b/spec/rubocop/cop/lint/useless_times_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe RuboCop::Cop::Lint::UselessTimes, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects with 1.times with method chain' do
+    expect_offense(<<~RUBY)
+      1.times.reverse_each do
+      ^^^^^^^ Useless call to `1.times` detected.
+        foo
+      end
+    RUBY
+
+    expect_no_corrections
+  end
+
   it 'registers an offense and corrects when 1.times with empty block argument' do
     expect_offense(<<~RUBY)
       def foo


### PR DESCRIPTION
Fixes #10415.

This PR fixes an error for `Lint/UselessTimes` when using `1.times` with method chain.

This bug fix case does not support auto-correction because it is complicated to cover the usage of the methods of `Enumerator` returned by `Integer#times` method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
