### PR TITLE
Fix a false positive for `Security/YamlLoad`

### DIFF
--- a/changelog/fix_a_false_positive_for_security_yaml_load.md
+++ b/changelog/fix_a_false_positive_for_security_yaml_load.md
@@ -1,0 +1,1 @@
+* [#10424](https://github.com/rubocop/rubocop/pull/10424): Fix a false positive for `Security/YamlLoad` when using Ruby 3.1+ (Psych 4). ([@koic][])

--- a/lib/rubocop/cop/security/yaml_load.rb
+++ b/lib/rubocop/cop/security/yaml_load.rb
@@ -7,17 +7,21 @@ module RuboCop
       # potential security issues leading to remote code execution when
       # loading from an untrusted source.
       #
+      # NOTE: Ruby 3.1+ (Psych 4) uses `Psych.load` as `Psych.safe_load` by default.
+      #
       # @safety
       #   The behaviour of the code might change depending on what was
       #   in the YAML payload, since `YAML.safe_load` is more restrictive.
       #
       # @example
       #   # bad
-      #   YAML.load("--- foo")
+      #   YAML.load("--- !ruby/object:Foo {}") # Psych 3 is unsafe by default
       #
       #   # good
-      #   YAML.safe_load("--- foo")
-      #   YAML.dump("foo")
+      #   YAML.safe_load("--- !ruby/object:Foo {}", [Foo])                    # Ruby 2.5  (Psych 3)
+      #   YAML.safe_load("--- !ruby/object:Foo {}", permitted_classes: [Foo]) # Ruby 3.0- (Psych 3)
+      #   YAML.load("--- !ruby/object:Foo {}", permitted_classes: [Foo])      # Ruby 3.1+ (Psych 4)
+      #   YAML.dump(foo)
       #
       class YAMLLoad < Base
         extend AutoCorrector
@@ -31,6 +35,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return if target_ruby_version >= 3.1
+
           yaml_load(node) do
             add_offense(node.loc.selector) do |corrector|
               corrector.replace(node.loc.selector, 'safe_load')

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -190,7 +190,7 @@ module RuboCop
           child.children.first
         end.join || ''
 
-        regexp = Regexp.new(regexp_string)
+        regexp = Regexp.new(regexp_string) # FIXME: Need to be handle `Regexp.new(/\x82/n)`.
 
         regexp.named_captures.keys
       end


### PR DESCRIPTION
This PR fixes a false positive for `Security/YamlLoad` when using Ruby 3.1+ (Psych 4).
And it also makes the examples a bit more specific.

Ruby 3.1+ (Psych 4) uses `Psych.load` as `Psych.safe_load` by default.
https://github.com/ruby/psych/pull/487

We may consider removing this cop in the future, but not yet.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
