### PR TITLE
[Fix #10421] Make `Style/DefWithParentheses` aware of endless method definition

### DIFF
--- a/changelog/fix_make_style_def_with_parentheses_aware_of_endless_method_definition.md
+++ b/changelog/fix_make_style_def_with_parentheses_aware_of_endless_method_definition.md
@@ -1,0 +1,1 @@
+* [#10421](https://github.com/rubocop/rubocop/issues/10421): Make `Style/DefWithParentheses` aware of endless method definition. ([@koic][])

--- a/lib/rubocop/cop/style/def_with_parentheses.rb
+++ b/lib/rubocop/cop/style/def_with_parentheses.rb
@@ -11,27 +11,33 @@ module RuboCop
       #
       #   # bad
       #   def foo()
-      #     # does a thing
+      #     do_something
       #   end
       #
       #   # good
       #   def foo
-      #     # does a thing
+      #     do_something
       #   end
       #
-      #   # also good
-      #   def foo() does_a_thing end
+      #   # bad
+      #   def foo() = do_something
+      #
+      #   # good
+      #   def foo = do_something
+      #
+      #   # good (without parentheses it's a syntax error)
+      #   def foo() do_something end
       #
       # @example
       #
       #   # bad
       #   def Baz.foo()
-      #     # does a thing
+      #     do_something
       #   end
       #
       #   # good
       #   def Baz.foo
-      #     # does a thing
+      #     do_something
       #   end
       class DefWithParentheses < Base
         extend AutoCorrector
@@ -39,7 +45,7 @@ module RuboCop
         MSG = "Omit the parentheses in defs when the method doesn't accept any arguments."
 
         def on_def(node)
-          return if node.single_line?
+          return if node.single_line? && !node.endless?
           return unless !node.arguments? && (node_arguments = node.arguments.source_range)
 
           add_offense(node_arguments) do |corrector|

--- a/spec/rubocop/cop/style/def_with_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/def_with_parentheses_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe RuboCop::Cop::Style::DefWithParentheses, :config do
     RUBY
   end
 
+  context 'Ruby >= 3.0', :ruby30 do
+    it 'reports an offense for endless method definition with empty parens' do
+      expect_offense(<<~RUBY)
+        def foo() = do_something
+               ^^ Omit the parentheses in defs when the method doesn't accept any arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo = do_something
+      RUBY
+    end
+  end
+
   it 'accepts def with arg and parens' do
     expect_no_offenses(<<~RUBY)
       def func(a)


### PR DESCRIPTION
Fixes #10421.

This PR makes `Style/DefWithParentheses` aware of endless method definition.

`def foo() do_something end` will continue to allow because `def foo do_something end` is a syntax error.
On the other hand, be aware that the endless method definition's parentheses can be omitted.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
