### PR TITLE
[Fix #10345] Update docs for MultilineOperationIndentation

### DIFF
--- a/lib/rubocop/cop/layout/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_operation_indentation.rb
@@ -3,27 +3,26 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks the indentation of the right hand side operand in
-      # binary operations that span more than one line.
+      # This cop checks the indentation of the right hand side operand in binary operations that
+      # span more than one line.
       #
-      # The `aligned` style checks that operators are aligned if they are part
-      # of an `if` or `while` condition, a `return` statement, etc. In other
-      # contexts, the second operand should be indented regardless of enforced
-      # style.
+      # The `aligned` style checks that operators are aligned if they are part of an `if` or `while`
+      # condition, an explicit `return` statement, etc. In other contexts, the second operand should
+      # be indented regardless of enforced style.
       #
       # @example EnforcedStyle: aligned (default)
       #   # bad
       #   if a +
       #       b
       #     something &&
-      #       something_else
+      #     something_else
       #   end
       #
       #   # good
       #   if a +
       #      b
       #     something &&
-      #     something_else
+      #       something_else
       #   end
       #
       # @example EnforcedStyle: indented


### PR DESCRIPTION
It was unclear that the special rule for `return` statements (and other cases where an operation follows a keyword) did not include implicit returns.

Also, the examples given for the `aligned` style did not reflect was was said about the second operand always being indented except after a keyword.