### PR TITLE
[Fix #10427] Style/For: Mark auto-correction as unsafe

### DIFF
--- a/changelog/change_mark_style_for_as_unsafe.md
+++ b/changelog/change_mark_style_for_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#10427](https://github.com/rubocop/rubocop/issues/10427): Mark `Style/For` as unsafe auto-correction. ([@issyl0][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3544,8 +3544,9 @@ Style/For:
   Description: 'Checks use of for or each in multiline loops.'
   StyleGuide: '#no-for-loops'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.13'
-  VersionChanged: '0.59'
+  VersionChanged: '<<next>>'
   EnforcedStyle: each
   SupportedStyles:
     - each

--- a/lib/rubocop/cop/style/for.rb
+++ b/lib/rubocop/cop/style/for.rb
@@ -38,6 +38,10 @@ module RuboCop
       #     end
       #   end
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because the scope of
+      #   variables is different between `each` and `for`.
+      #
       class For < Base
         include ConfigurableEnforcedStyle
         include RangeHelp


### PR DESCRIPTION
- The Ruby Style Guide (https://rubystyle.guide/#no-for-loops) states that "for doesn’t introduce a new scope (unlike each) and variables defined in its block will be visible outside it". This means that auto-correcting can break existing, working code because of the change in variable scope.
- Fixes #10427.

The only thing I didn't do in the PR checklist is add tests, because a recent, different PR to mark a cop as unsafe (10408) didn't have any. Hope that's OK!

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
