### PR TITLE
CONTRIBUTING: Remove instruction for first-timers to edit the CHANGELOG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,6 @@ Here are a few examples:
 * Describe the brief of the change. The sentence should end with a punctuation.
 * If this is a breaking change, mark it with `**(Breaking)**`.
 * At the end of the entry, add an implicit link to your GitHub user page as `([@username][])`.
-* Alternatively, you may modify the CHANGELOG.md file directly, but this may result in conflicts later on.
 
 [1]: https://github.com/rubocop/rubocop/issues
 [2]: https://www.gun.io/blog/how-to-github-fork-branch-and-pull-request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Here are a few examples:
 * Describe the brief of the change. The sentence should end with a punctuation.
 * If this is a breaking change, mark it with `**(Breaking)**`.
 * At the end of the entry, add an implicit link to your GitHub user page as `([@username][])`.
-* Alternatively, you may modify the CHANGELOG.md file directly, but this may result in conflicts later on. Also, if this is your first contribution to RuboCop project, add a link definition for the implicit link to the bottom of the changelog as `[@username]: https://github.com/username`.
+* Alternatively, you may modify the CHANGELOG.md file directly, but this may result in conflicts later on.
 
 [1]: https://github.com/rubocop/rubocop/issues
 [2]: https://www.gun.io/blog/how-to-github-fork-branch-and-pull-request


### PR DESCRIPTION
- Apparently this is no longer necessary, automation populates the username links: https://github.com/rubocop/rubocop/pull/10429#discussion_r810593622.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
