### PR TITLE
Fix an error when using regexp with non-encoding option

### DIFF
--- a/changelog/fix_an_error_when_using_regexp_with_noencoding_option.md
+++ b/changelog/fix_an_error_when_using_regexp_with_noencoding_option.md
@@ -1,0 +1,1 @@
+* [#10432](https://github.com/rubocop/rubocop/pull/10432): Fix an error when using regexp with non-encoding option. ([@koic][])

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -186,11 +186,7 @@ module RuboCop
       end
 
       def regexp_captured_names(node)
-        regexp_string = node.children.select(&:str_type?).map do |child|
-          child.children.first
-        end.join || ''
-
-        regexp = Regexp.new(regexp_string) # FIXME: Need to be handle `Regexp.new(/\x82/n)`.
+        regexp = node.to_regexp
 
         regexp.named_captures.keys
       end


### PR DESCRIPTION
This PR fixes the following error when using regexp with non-encoding option.

```console
% cat /tmp/example.rb
/\x82/n =~ 'a'

% rubocop -d /tmp/example.rb
(snip)

For /tmp: An error occurred while VariableForce cop was inspecting /tmp/example.rb.
invalid multibyte escape: /\x82/
/Users/koic/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/rubocop-1.25.1/lib/rubocop/cop/variable_force.rb:193:in
`initialize'
/Users/koic/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/rubocop-1.25.1/lib/rubocop/cop/variable_force.rb:193:in `new'
```

This error is due to `VariableForce#regexp_captured_names` not processing the regexp option.
This PR uses `RegexpNode#to_regexp` to prevent the regexp option from being cut.

In addition, the test code replaces the Parser gem (plain) AST with `ProcessedSource#ast` so that it can call `RegexpNode#to_regexp` defined in the RuboCop AST.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
