### PR TITLE
Add `Security/CompoundHash` cop

### DIFF
--- a/changelog/new_add_security_compound_hash_cop.md
+++ b/changelog/new_add_security_compound_hash_cop.md
@@ -1,0 +1,1 @@
+* [#10441](https://github.com/rubocop/rubocop/pull/10441): Add Security/CompoundHash Cop. ([@sambostock][], [@chrisseaton][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2784,6 +2784,11 @@ Naming/VariableNumber:
 
 #################### Security ##############################
 
+Security/CompoundHash:
+  Description: 'When overwriting Object#hash to combine values, prefer delegating to Array#hash over writing a custom implementation.'
+  Enabled: pending
+  VersionAdded: '<<next>>'
+
 Security/Eval:
   Description: 'The use of eval represents a serious security risk.'
   Enabled: true

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -650,6 +650,7 @@ require_relative 'rubocop/cop/style/word_array'
 require_relative 'rubocop/cop/style/yoda_condition'
 require_relative 'rubocop/cop/style/zero_length_predicate'
 
+require_relative 'rubocop/cop/security/compound_hash'
 require_relative 'rubocop/cop/security/eval'
 require_relative 'rubocop/cop/security/io_methods'
 require_relative 'rubocop/cop/security/json_load'

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -217,7 +217,7 @@ module RuboCop
       alias eql? ==
 
       def hash
-        COMPARISON_ATTRIBUTES.reduce(0) { |hash, attribute| hash ^ public_send(attribute).hash }
+        COMPARISON_ATTRIBUTES.map { |attribute| public_send(attribute) }.hash
       end
 
       # @api public

--- a/lib/rubocop/cop/security/compound_hash.rb
+++ b/lib/rubocop/cop/security/compound_hash.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Security
+      # This cop checks for implementations of the `hash` method which combine
+      # values using custom logic instead of delegating to `Array#hash`.
+      #
+      # Manually combining hashes is error prone and hard to follow, especially
+      # when there are many values. Poor implementations may also introduce
+      # performance or security concerns if they are prone to collisions.
+      # Delegating to `Array#hash` is clearer, faster, and safer.
+      #
+      # @safety
+      #   This cop may be unsafe if the application logic depends on the hash
+      #   value, however this is inadvisable anyway.
+      #
+      # @example
+      #
+      #   # bad
+      #   def hash
+      #     @foo ^ @bar
+      #   end
+      #
+      #   # good
+      #   def hash
+      #     [@foo, @bar].hash
+      #   end
+      class CompoundHash < Base
+        COMBINATOR_IN_HASH_MSG = 'Use `[...].hash` instead of combining hash values manually.'
+        MONUPLE_HASH_MSG =
+          'Delegate hash directly without wrapping in an array when only using a single value'
+        REDUNDANT_HASH_MSG = 'Calling .hash on elements of a hashed array is redundant'
+
+        # @!method hash_method_definition?(node)
+        def_node_matcher :hash_method_definition?, <<~PATTERN
+          {#static_hash_method_definition? | #dynamic_hash_method_definition?}
+        PATTERN
+
+        # @!method dynamic_hash_method_definition?(node)
+        def_node_matcher :dynamic_hash_method_definition?, <<~PATTERN
+          (block
+            (send _ {:define_method | :define_singleton_method}
+              (sym :hash))
+            (args)
+            _)
+        PATTERN
+
+        # @!method static_hash_method_definition?(node)
+        def_node_matcher :static_hash_method_definition?, <<~PATTERN
+          ({def | defs _} :hash
+            (args)
+            _)
+        PATTERN
+
+        # @!method bad_hash_combinator?(node)
+        def_node_matcher :bad_hash_combinator?, <<~PATTERN
+          ({send | op-asgn} _ {:^ | :+ | :* | :|} _)
+        PATTERN
+
+        # @!method monuple_hash?(node)
+        def_node_matcher :monuple_hash?, <<~PATTERN
+          (send (array _) :hash)
+        PATTERN
+
+        # @!method redundant_hash?(node)
+        def_node_matcher :redundant_hash?, <<~PATTERN
+          (
+            ^^(send array ... :hash)
+            _ :hash
+          )
+        PATTERN
+
+        def contained_in_hash_method?(node, &block)
+          node.each_ancestor.any? do |ancestor|
+            hash_method_definition?(ancestor, &block)
+          end
+        end
+
+        def outer_bad_hash_combinator?(node)
+          bad_hash_combinator?(node) do
+            yield true if node.each_ancestor.none? { |ancestor| bad_hash_combinator?(ancestor) }
+          end
+        end
+
+        def on_send(node)
+          outer_bad_hash_combinator?(node) do
+            contained_in_hash_method?(node) do
+              add_offense(node, message: COMBINATOR_IN_HASH_MSG)
+            end
+          end
+
+          monuple_hash?(node) do
+            add_offense(node, message: MONUPLE_HASH_MSG)
+          end
+
+          redundant_hash?(node) do
+            add_offense(node, message: REDUNDANT_HASH_MSG)
+          end
+        end
+        alias on_op_asgn on_send
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/variable_force/branch.rb
+++ b/lib/rubocop/cop/variable_force/branch.rb
@@ -127,7 +127,7 @@ module RuboCop
           alias_method :eql?, :==
 
           def hash
-            control_node.object_id.hash ^ child_node.object_id.hash
+            [control_node.object_id, control_node.object_id].hash
           end
 
           private

--- a/spec/rubocop/cop/security/compound_hash_spec.rb
+++ b/spec/rubocop/cop/security/compound_hash_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Security::CompoundHash, :config do
+  it 'registers an offense when using XOR operator in the implementation of the hash method' do
+    expect_offense(<<~RUBY)
+      def hash
+        1.hash ^ 2.hash ^ 3.hash
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using XOR operator in the implementation of the hash method, even without sub-calls to hash' do
+    expect_offense(<<~RUBY)
+      def hash
+        1 ^ 2 ^ 3
+        ^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using XOR operator in the implementation of the hash singleton method' do
+    expect_offense(<<~RUBY)
+      def object.hash
+        1.hash ^ 2.hash ^ 3.hash
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using XOR operator in the implementation of a dynamic hash method' do
+    expect_offense(<<~RUBY)
+      define_method(:hash) do
+        1.hash ^ 2.hash ^ 3.hash
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using XOR operator in the implementation of a dynamic hash singleton method' do
+    expect_offense(<<~RUBY)
+      define_singleton_method(:hash) do
+        1.hash ^ 2.hash ^ 3.hash
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when delegating to Array#hash for a single value' do
+    expect_offense(<<~RUBY)
+      def hash
+        [1].hash
+        ^^^^^^^^ Delegate hash directly without wrapping in an array when only using a single value
+      end
+    RUBY
+  end
+
+  it 'registers an offense if .hash is called on any elements of a hashed array' do
+    expect_offense(<<~RUBY)
+      [1, 2.hash, 3].hash
+          ^^^^^^ Calling .hash on elements of a hashed array is redundant
+    RUBY
+  end
+
+  it 'does not register an offense when delegating to Array#hash' do
+    expect_no_offenses(<<~RUBY)
+      def hash
+        [1, 2, 3].hash
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when delegating to a single object' do
+    expect_no_offenses(<<~RUBY)
+      def hash
+        1.hash
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using XOR operator in the implementation of the hash method, even if intermediate variable is used' do
+    expect_offense(<<~RUBY)
+      def hash
+        value = 1.hash ^ 2.hash ^ 3.hash
+                ^^^^^^^^^^^^^^^^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+        value
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using XOR assignment operator in the implementation of the hash method' do
+    expect_offense(<<~RUBY)
+      def hash
+        h = 0
+
+        things.each do |thing|
+          h ^= thing.hash
+          ^^^^^^^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+        end
+
+        h
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using addition assignment operator in the implementation of the hash method' do
+    expect_offense(<<~RUBY)
+      def hash
+        h = 0
+
+        things.each do |thing|
+          h += thing.hash
+          ^^^^^^^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+        end
+
+        h
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using multiplication assignment operator in the implementation of the hash method' do
+    expect_offense(<<~RUBY)
+      def hash
+        h = 0
+
+        things.each do |thing|
+          h *= thing.hash
+          ^^^^^^^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+        end
+
+        h
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using addition in the implementation of the hash method' do
+    expect_offense(<<~RUBY)
+      def hash
+        foo.hash + bar.hash
+        ^^^^^^^^^^^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using multiplication in the implementation of the hash method' do
+    expect_offense(<<~RUBY)
+      def hash
+        to_s.hash * -1
+        ^^^^^^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using XOR between an array hash and a class' do
+    expect_offense(<<~RUBY)
+      def hash
+        [red, blue, green, alpha].hash ^ self.class.hash
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using XOR involving super' do
+    expect_offense(<<~RUBY)
+      def hash
+        foo.hash ^ super ^ bar.hash
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using XOR and bitshifts' do
+    expect_offense(<<~RUBY)
+      def hash
+        foo.hash ^ bar.hash << 1 ^ biz.hash << 2 ^ bar.hash << 3
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+      end
+    RUBY
+  end
+
+  it 'registers an offence when using bitshift and OR' do
+    expect_offense(<<~RUBY)
+      def hash
+        ([@addr, @mask_addr, @zone_id].hash << 1) | (ipv4? ? 0 : 1)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+      end
+    RUBY
+  end
+
+  it 'registers an offense for complex usage' do
+    expect_offense(<<~RUBY)
+      def hash
+        @hash ||= begin
+          hash_ = [@factory, geometry_type].hash
+          (0...num_geometries).inject(hash_) do |h_, i_|
+            (1664525 * h_ + geometry_n(i_).hash).hash
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `[...].hash` instead of combining hash values manually.
+          end
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
# Context

Hash codes for Ruby objects are a potential security issue. Bad hash codes may make us vulnerable to denial-of-service-attacks, where users are able to craft objects that trigger hash collisions. Hash collisions may cause linear instead of constant-time behaviour, or they may cause thrashing of caches. Let Ruby's implementation manage the construction of hash codes from multiple objects using `Array#hash`, via `[...].hash`, rather than rolling your own hash.

# Summary

This cop checks implementations of the `hash` method which combine value using the XOR operator instead of delegating to `Array#hash`.
    
`Array#hash` is

- faster
- clearer
- standardized
    
Ruby has an existing way to combine multiple hash values, so users should not implement their own.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
