### PR TITLE
Add YARD node matcher annotation to generator

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -68,6 +68,7 @@ module RuboCop
                 # For example
                 MSG = 'Use `#good_method` instead of `#bad_method`.'
 
+                # @!method bad_method?(node)
                 def_node_matcher :bad_method?, <<~PATTERN
                   (send nil? :bad_method ...)
                 PATTERN

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe RuboCop::Cop::Generator do
                 # For example
                 MSG = 'Use `#good_method` instead of `#bad_method`.'
 
+                # @!method bad_method?(node)
                 def_node_matcher :bad_method?, <<~PATTERN
                   (send nil? :bad_method ...)
                 PATTERN


### PR DESCRIPTION
After generating a new cop, we get the following offense:

    InternalAffairs/NodeMatcherDirective: Precede def_node_matcher with a @!method YARD directive.

Since this is mandatory, the generator template should include it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~
  _No user observable change_

[1]: https://chris.beams.io/posts/git-commit/
