### PR TITLE
Replace `<<-HEREDOC.gsub(indent)` with `<<~HEREDOC`

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -8,13 +8,7 @@ module RuboCop
     # and spec file when given a valid qualified cop name.
     # @api private
     class Generator
-      # NOTE: RDoc 5.1.0 or lower has the following issue.
-      # https://github.com/rubocop/rubocop/issues/7043
-      #
-      # The following `String#gsub` can be replaced with
-      # squiggly heredoc when RuboCop supports Ruby 2.5 or higher
-      # (RDoc 6.0 or higher).
-      SOURCE_TEMPLATE = <<-RUBY.gsub(/^ {8}/, '')
+      SOURCE_TEMPLATE = <<~RUBY
         # frozen_string_literal: true
 
         module RuboCop


### PR DESCRIPTION
Rubocop only supports Ruby 2.5+ now, so as per the comment we can clean this up.

I noticed while editing the generator in #10442.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* ~Added tests.~ _Not applicable_
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~
  _No user-observable changes_

[1]: https://chris.beams.io/posts/git-commit/
