### PR TITLE
Fix doc formatting written in unescaped file path

### DIFF
--- a/lib/rubocop/cops_documentation_generator.rb
+++ b/lib/rubocop/cops_documentation_generator.rb
@@ -191,8 +191,8 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
 
   def wrap_backtick(value)
     if value.is_a?(String)
-      # Use `+` to prevent text like `**/*.gemspec` from being bold.
-      value.start_with?('*') ? "`+#{value}+`" : "`#{value}`"
+      # Use `+` to prevent text like `**/*.gemspec`, `spec/**/*` from being bold.
+      value.include?('*') ? "`+#{value}+`" : "`#{value}`"
     else
       "`#{value}`"
     end


### PR DESCRIPTION
This fixes an issue where file paths were not escaped and were displayed as follows:
![sample](https://user-images.githubusercontent.com/13041216/156969217-d45f7f49-76c8-4118-818d-8db9142172f2.png)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
  * [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
  * [-] Added tests.
  * [-] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
  * [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
