### PR TITLE
[Fix #10436] Fix an error for `Style/SoleNestedConditional` raises exception when inspecting `if ... end if ...`

### DIFF
--- a/changelog/fix_an_error_style_sole_nested_conditional.md
+++ b/changelog/fix_an_error_style_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#10447](https://github.com/rubocop/rubocop/pull/10447): Fix an error for `Style/SoleNestedConditional` raises exception when inspecting `if ... end if ...`. ([@ydah][])

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -409,6 +409,126 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when `if` foo do_something end `if` bar' do
+    expect_offense(<<~RUBY)
+      if foo
+      ^^ Consider merging nested conditions into outer `if` conditions.
+        do_something
+      end if bar
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if bar && foo
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when `if` foo do_something end `unless` bar' do
+    expect_offense(<<~RUBY)
+      if foo
+      ^^ Consider merging nested conditions into outer `unless` conditions.
+        do_something
+      end unless bar
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if !bar && foo
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when `unless` foo do_something end `if` bar' do
+    expect_offense(<<~RUBY)
+      unless foo
+      ^^^^^^ Consider merging nested conditions into outer `if` conditions.
+        do_something
+      end if bar
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if bar && !foo
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when `if` foo do_something end `if` bar && baz' do
+    expect_offense(<<~RUBY)
+      if foo
+      ^^ Consider merging nested conditions into outer `if` conditions.
+        do_something
+      end if bar && baz
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if (bar && baz) && foo
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when `if` foo && bar do_something end `if` baz' do
+    expect_offense(<<~RUBY)
+      if foo && bar
+      ^^ Consider merging nested conditions into outer `if` conditions.
+        do_something
+      end if baz
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if baz && foo && bar
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when `if` foo do_something end `unless` bar && baz' do
+    expect_offense(<<~RUBY)
+      if foo
+      ^^ Consider merging nested conditions into outer `unless` conditions.
+        do_something
+      end unless bar && baz
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if !(bar && baz) && foo
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when `if` foo && bar do_something end `unless` baz' do
+    expect_offense(<<~RUBY)
+      if foo && bar
+      ^^ Consider merging nested conditions into outer `unless` conditions.
+        do_something
+      end unless baz
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if !baz && foo && bar
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when `unless` foo && bar do_something end `if` baz' do
+    expect_offense(<<~RUBY)
+      unless foo && bar
+      ^^^^^^ Consider merging nested conditions into outer `if` conditions.
+        do_something
+      end if baz
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if baz && !(foo && bar)
+        do_something
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using nested ternary within conditional' do
     expect_no_offenses(<<~RUBY)
       if foo
@@ -557,7 +677,7 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
       expect_no_offenses(<<~RUBY)
         if foo
           do_something if bar
-        end
+        end if baz
       RUBY
     end
   end


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/10436.

This PR fixes an error for `Style/SoleNestedConditional` when code like the following:

```ruby
if foo
  do_something
end if bar
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
