### PR TITLE
Fix obsolete department checker

### DIFF
--- a/lib/rubocop/config_obsoletion/extracted_cop.rb
+++ b/lib/rubocop/config_obsoletion/extracted_cop.rb
@@ -33,7 +33,9 @@ module RuboCop
         return old_name unless old_name.end_with?('*')
 
         # Handle whole departments (expressed as `Department/*`)
-        config.keys.grep(Regexp.new("^#{department}"))
+        config.keys.select do |key|
+          key == department || key.start_with?("#{department}/")
+        end
       end
 
       def feature_loaded?


### PR DESCRIPTION
The current implementation has the problem of not being able to create a Cop named `RailsFoo/Bar` or `PerformanceFoo/Bar`.

In fact, I tried to create a Cop named `RailsDeprecation/ToFormattedS` in the following gem, but it didn't work because of this problem (I renamed it with `Deprecation/ToFormattedS` as a workaround for now):

- https://github.com/r7kamura/rubocop-rails_deprecation

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
