### PR TITLE
Make `Style/SelectByRegexp` aware of `ENV` const

### DIFF
--- a/changelog/fix_make_style_select_by_regexp_aware_of_env_const.md
+++ b/changelog/fix_make_style_select_by_regexp_aware_of_env_const.md
@@ -1,0 +1,1 @@
+* [#10457](https://github.com/rubocop/rubocop/pull/10457): Make `Style/SelectByRegexp` aware of `ENV` const. ([@koic][])

--- a/lib/rubocop/cop/style/select_by_regexp.rb
+++ b/lib/rubocop/cop/style/select_by_regexp.rb
@@ -69,6 +69,11 @@ module RuboCop
           }
         PATTERN
 
+        # @!method env_const?(node)
+        def_node_matcher :env_const?, <<~PATTERN
+          (const {nil? cbase} :ENV)
+        PATTERN
+
         # @!method calls_lvar?(node, name)
         def_node_matcher :calls_lvar?, <<~PATTERN
           {
@@ -94,7 +99,7 @@ module RuboCop
         def receiver_allowed?(node)
           return false unless node
 
-          node.hash_type? || creates_hash?(node)
+          node.hash_type? || creates_hash?(node) || env_const?(node)
         end
 
         def register_offense(node, block_node, regexp)

--- a/spec/rubocop/cop/style/select_by_regexp_spec.rb
+++ b/spec/rubocop/cop/style/select_by_regexp_spec.rb
@@ -249,6 +249,13 @@ RSpec.describe RuboCop::Cop::Style::SelectByRegexp, :config do
         RUBY
       end
 
+      it 'does not register an offense when the receiver is `ENV`' do
+        expect_no_offenses(<<~RUBY)
+          ENV.#{method} { |x| x.match? /regexp/ }
+          ::ENV.#{method} { |x| x.match? /regexp/ }
+        RUBY
+      end
+
       context 'with `numblock`s', :ruby27 do
         it 'registers an offense and corrects for `match?`' do
           expect_offense(<<~RUBY, method: method)


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10155#issuecomment-1071477282.

This PR makes `Style/SelectByRegexp` aware of `ENV` const.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
