### PR TITLE
[Fix #10456] Fix a false positive for `Layout/MultilineMethodCallIndentation`

### DIFF
--- a/changelog/fix_false_positive_for_layout_multiline_method_call_indentation.md
+++ b/changelog/fix_false_positive_for_layout_multiline_method_call_indentation.md
@@ -1,0 +1,1 @@
+* [#10456](https://github.com/rubocop/rubocop/issues/10456): Fix a false positive for `Layout/MultilineMethodCallIndentation` when using `EnforcedStyle: indented` with indented assignment method. ([@koic][])

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -29,7 +29,9 @@ module RuboCop
       #   b c { block }.            <-- b is indented relative to a
       #   d                         <-- d is indented relative to a
       def left_hand_side(lhs)
-        lhs = lhs.parent while lhs.parent&.send_type? && lhs.parent.loc.dot
+        while lhs.parent&.send_type? && lhs.parent.loc.dot && !lhs.parent.assignment_method?
+          lhs = lhs.parent
+        end
         lhs
       end
 

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -985,6 +985,15 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
               .to_s
         RUBY
       end
+
+      it "accepts indentation of assignment to obj.#{lhs} with newline after =" do
+        expect_no_offenses(<<~RUBY)
+          obj.#{lhs} =
+            int_part
+              .abs
+              .to_s
+        RUBY
+      end
     end
 
     include_examples 'assignment', 'a'


### PR DESCRIPTION
Fixes #10456.

This PR fixes a false positive for `Layout/MultilineMethodCallIndentation` when using `EnforcedStyle: indented` with indented assignment method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
