### PR TITLE
[Fix #10374] Fix a false positive for `Layout/LineLength` when long URIs in yardoc comments to have titles

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_line_length.md
+++ b/changelog/fix_a_false_positive_for_layout_line_length.md
@@ -1,0 +1,1 @@
+* [#10459](https://github.com/rubocop/rubocop/pull/10459): Fix a false positive for `Layout/LineLength` when long URIs in yardoc comments to have titles. ([@ydah][])

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -100,6 +100,22 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           RUBY
         end
       end
+
+      context 'and the URL is wrapped in braces' do
+        it 'accepts the line' do
+          expect_no_offenses(<<-RUBY)
+            # See: {https://github.com/rubocop/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c}
+          RUBY
+        end
+      end
+
+      context 'and the URL is wrapped in braces with title' do
+        it 'accepts the line' do
+          expect_no_offenses(<<-RUBY)
+            # See: {https://github.com/rubocop/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c Optional Title}
+          RUBY
+        end
+      end
     end
 
     context 'and the excessive characters include a complete URL' do
@@ -127,6 +143,16 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           # See: "https://github.com/rubocop/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c" and
                                                                                                      ^^^^ Line is too long. [105/80]
           #   "http://google.com/"
+        RUBY
+      end
+    end
+
+    context 'and the excessive characters include part of a URL in braces and another word' do
+      it 'registers an offense for the line' do
+        expect_offense(<<-RUBY)
+          # See: {https://github.com/rubocop/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c} and
+                                                                                                     ^^^^ Line is too long. [105/80]
+          #   http://google.com/
         RUBY
       end
     end


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/10374

This PR fixes a false positive for `Layout/LineLength` when when long URIs in yardoc comments to have titles.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
