### PR TITLE
[Fix #10375] Defer auto-correction of nested unless/else

### DIFF
--- a/changelog/fix_unless_else_autocorrect.md
+++ b/changelog/fix_unless_else_autocorrect.md
@@ -1,0 +1,1 @@
+* [#10375](https://github.com/rubocop/rubocop/pull/10375): Fix error for auto-correction of `unless`/`else` nested inside each other. ([@jonas054][])

--- a/lib/rubocop/cop/style/unless_else.rb
+++ b/lib/rubocop/cop/style/unless_else.rb
@@ -32,10 +32,14 @@ module RuboCop
             body_range = range_between_condition_and_else(node, node.condition)
             else_range = range_between_else_and_end(node)
 
+            next if part_of_ignored_node?(node)
+
             corrector.replace(node.loc.keyword, 'if')
             corrector.replace(body_range, else_range.source)
             corrector.replace(else_range, body_range.source)
           end
+
+          ignore_node(node)
         end
 
         def range_between_condition_and_else(node, condition)

--- a/spec/rubocop/cop/style/unless_else_spec.rb
+++ b/spec/rubocop/cop/style/unless_else_spec.rb
@@ -20,6 +20,36 @@ RSpec.describe RuboCop::Cop::Style::UnlessElse, :config do
         end
       RUBY
     end
+
+    context 'and nested unless with else' do
+      it 'registers offenses for both but corrects only the outer unless/else' do
+        expect_offense(<<~RUBY)
+          unless abc
+          ^^^^^^^^^^ Do not use `unless` with `else`. Rewrite these with the positive case first.
+            a
+          else
+            unless cde
+            ^^^^^^^^^^ Do not use `unless` with `else`. Rewrite these with the positive case first.
+              b
+            else
+              c
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if abc
+            unless cde
+              b
+            else
+              c
+            end
+          else
+            a
+          end
+        RUBY
+      end
+    end
   end
 
   context 'unless with nested if-else' do


### PR DESCRIPTION
An `unless`/`else` nested inside another `unless`/`else` would cause rewrite clobbering when auto-correcting both offenses. By ignoring the node after correcting it and skipping auto-correction for inner nodes with the same offense, we avoid this problem.

The auto-correct loop will pick up the remaining offense and fix it. No test case is added for this particular aspect, but it's standard RuboCop behavior.