### PR TITLE
[Fix #10462] Fix an incorrect autocorrect for `Lint/SymbolConversion`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_symbol_conversion.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_symbol_conversion.md
@@ -1,0 +1,1 @@
+* [#10462](https://github.com/rubocop/rubocop/issues/10462): Fix an incorrect autocorrect for `Lint/SymbolConversion` when using a quoted symbol key with hash rocket. ([@koic][])

--- a/lib/rubocop/cop/lint/symbol_conversion.rb
+++ b/lib/rubocop/cop/lint/symbol_conversion.rb
@@ -147,13 +147,14 @@ module RuboCop
           # will be ignored.
           return unless node.value.to_s.match?(/\A[a-z0-9_]/i)
 
-          correction = node.value.inspect.delete_prefix(':')
+          correction = node.value.inspect
+          correction = correction.delete_prefix(':') if node.parent.colon?
           return if properly_quoted?(node.source, correction)
 
           register_offense(
             node,
             correction: correction,
-            message: format(MSG, correction: "#{correction}:")
+            message: format(MSG, correction: node.parent.colon? ? "#{correction}:" : correction)
           )
         end
 

--- a/spec/rubocop/cop/lint/symbol_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/symbol_conversion_spec.rb
@@ -121,7 +121,18 @@ RSpec.describe RuboCop::Cop::Lint::SymbolConversion, :config do
         RUBY
       end
 
-      it 'registers an offense for a quoted symbol' do
+      it 'registers an offense for a quoted symbol key' do
+        expect_offense(<<~RUBY)
+          { :'foo' => :bar }
+            ^^^^^^ Unnecessary symbol conversion; use `:foo` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          { :foo => :bar }
+        RUBY
+      end
+
+      it 'registers an offense for a quoted symbol value' do
         expect_offense(<<~RUBY)
           { foo: :'bar' }
                  ^^^^^^ Unnecessary symbol conversion; use `:bar` instead.


### PR DESCRIPTION
Fixes #10462.

This PR fixes an incorrect autocorrect for `Lint/SymbolConversion` when using a quoted symbol key with hash rocket.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
