### PR TITLE
[Fix #10465] Fix false positive for `Naming/BlockForwarding` when the block argument is redefined

### DIFF
--- a/changelog/fix_fix_false_positive_for.md
+++ b/changelog/fix_fix_false_positive_for.md
@@ -1,0 +1,1 @@
+* [#10465](https://github.com/rubocop/rubocop/issues/10465): Fix false positive for `Naming/BlockForwarding` when the block argument is assigned. ([@dvandersluis][])

--- a/lib/rubocop/cop/naming/block_forwarding.rb
+++ b/lib/rubocop/cop/naming/block_forwarding.rb
@@ -107,7 +107,7 @@ module RuboCop
         def use_block_argument_as_local_variable?(node, last_argument)
           return if node.body.nil?
 
-          node.body.each_descendant(:lvar).any? do |lvar|
+          node.body.each_descendant(:lvar, :lvasgn).any? do |lvar|
             !lvar.parent.block_pass_type? && lvar.source == last_argument
           end
         end

--- a/spec/rubocop/cop/naming/block_forwarding_spec.rb
+++ b/spec/rubocop/cop/naming/block_forwarding_spec.rb
@@ -189,6 +189,15 @@ RSpec.describe RuboCop::Cop::Naming::BlockForwarding, :config do
           end
         RUBY
       end
+
+      it 'does not register an offense when assigning the block arg' do
+        expect_no_offenses(<<~RUBY)
+          def example(&block)
+            block ||= -> { :foo }
+            bar(&block)
+          end
+        RUBY
+      end
     end
 
     context 'Ruby < 3.0', :ruby30 do
@@ -308,6 +317,15 @@ RSpec.describe RuboCop::Cop::Naming::BlockForwarding, :config do
       it 'does not register an offense when defining without block argument method' do
         expect_no_offenses(<<~RUBY)
           def foo(arg1, arg2)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when assigning the block arg' do
+        expect_no_offenses(<<~RUBY)
+          def example(&block)
+            block ||= -> { :foo }
+            bar(&block)
           end
         RUBY
       end


### PR DESCRIPTION
If the block argument is used in an assignment, it has to be explicitly named.

Fixes #10465.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
