### PR TITLE
[Fix #10468] Fix a false positive for `Style/FileWrite`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_file_write.md
+++ b/changelog/fix_a_false_positive_for_style_file_write.md
@@ -1,0 +1,1 @@
+* [#10468](https://github.com/rubocop/rubocop/issues/10468): Fix a false positive for `Style/FileWrite` when a splat argument is passed to `f.write`. ([@koic][])

--- a/lib/rubocop/cop/style/file_write.rb
+++ b/lib/rubocop/cop/style/file_write.rb
@@ -5,6 +5,17 @@ module RuboCop
     module Style
       # Favor `File.(bin)write` convenience methods.
       #
+      # NOTE: There are different method signatures between `File.write` (class method)
+      # and `File#write` (instance method). The following case will be allowed because
+      # static analysis does not know the contents of the splat argument:
+      #
+      # [source,ruby]
+      # ----
+      # File.open(filename, 'w') do |f|
+      #   f.write(*objects)
+      # end
+      # ----
+      #
       # @example
       #   ## text mode
       #   # bad
@@ -85,6 +96,7 @@ module RuboCop
           content = send_write?(node) || block_write?(node) do |block_arg, lvar, write_arg|
             write_arg if block_arg == lvar
           end
+          return false if content&.splat_type?
 
           yield(content) if content
         end

--- a/spec/rubocop/cop/style/file_write_spec.rb
+++ b/spec/rubocop/cop/style/file_write_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe RuboCop::Cop::Style::FileWrite, :config do
     RUBY
   end
 
+  it 'does not register an offense when a splat argument is passed to `f.write`' do
+    expect_no_offenses(<<~RUBY)
+      File.open(filename, 'w') do |f|
+        f.write(*objects)
+      end
+    RUBY
+  end
+
   described_class::TRUNCATING_WRITE_MODES.each do |mode|
     it "registers an offense for and corrects `File.open(filename, '#{mode}').write(content)`" do
       write_method = mode.end_with?('b') ? :binwrite : :write


### PR DESCRIPTION
Fixes #10468

This PR fixes a false positive for `Style/FileWrite` when a splat argument is passed to `f.write`.

There are different method signatures between `File.write` (class method) and `File#write` (instance method).

- https://ruby-doc.org/core-3.1.1/IO.html#method-c-write
- https://ruby-doc.org/core-3.1.1/IO.html#method-i-write

This PR accepts the case of using splat argument as an argument for `File#write` because static analysis does not know the contents of the splat argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
