### PR TITLE
[Fix #10474] Fix a false positive for `Style/DoubleNegation` with `EnforcedStyle: allowed_in_returns` when inside returned conditional clauses

### DIFF
--- a/changelog/fix_fix_false_positive_for_double_negation.md
+++ b/changelog/fix_fix_false_positive_for_double_negation.md
@@ -1,0 +1,1 @@
+* [#10474](https://github.com/rubocop/rubocop/issues/10474): Fix a false positive for `Style/DoubleNegation` with `EnforcedStyle: allowed_in_returns` when inside returned conditional clauses. ([@ydah][])

--- a/spec/rubocop/cop/style/double_negation_spec.rb
+++ b/spec/rubocop/cop/style/double_negation_spec.rb
@@ -48,6 +48,249 @@ RSpec.describe RuboCop::Cop::Style::DoubleNegation, :config do
 
     include_examples 'common'
 
+    it 'registers an offense and corrects for `!!` when not return location and using `unless`' do
+      expect_offense(<<~RUBY)
+        def foo?
+          unless condition_foo?
+            !!foo
+            ^ Avoid the use of double negation (`!!`).
+            do_something
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          unless condition_foo?
+            !foo.nil?
+            do_something
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for `!!` when not return location' \
+       'and using `if`, `elsif`, and `else`' do
+      expect_offense(<<~RUBY)
+        def foo?
+          if condition_foo?
+            !!foo
+            ^ Avoid the use of double negation (`!!`).
+            do_something
+          elsif condition_bar?
+            !!bar
+            ^ Avoid the use of double negation (`!!`).
+            do_something
+          else
+            !!baz
+            ^ Avoid the use of double negation (`!!`).
+            do_something
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          if condition_foo?
+            !foo.nil?
+            do_something
+          elsif condition_bar?
+            !bar.nil?
+            do_something
+          else
+            !baz.nil?
+            do_something
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for `!!` with hash when not return location' \
+       'and using `if`, `elsif`, and `else`' do
+      expect_offense(<<~RUBY)
+        def foo?
+          if condition_foo?
+            { foo: !!foo0, bar: bar0, baz: baz0 }
+                   ^ Avoid the use of double negation (`!!`).
+            do_something
+          elsif condition_bar?
+            { foo: !!foo1, bar: bar1, baz: baz1 }
+                   ^ Avoid the use of double negation (`!!`).
+            do_something
+          else
+            { foo: !!foo2, bar: bar2, baz: baz2 }
+                   ^ Avoid the use of double negation (`!!`).
+            do_something
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          if condition_foo?
+            { foo: !foo0.nil?, bar: bar0, baz: baz0 }
+            do_something
+          elsif condition_bar?
+            { foo: !foo1.nil?, bar: bar1, baz: baz1 }
+            do_something
+          else
+            { foo: !foo2.nil?, bar: bar2, baz: baz2 }
+            do_something
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for `!!` with array when not return location' \
+       'and using `if`, `elsif`, and `else`' do
+      expect_offense(<<~RUBY)
+        def foo?
+          if condition_foo?
+            [!!foo0, bar0, baz0]
+             ^ Avoid the use of double negation (`!!`).
+            do_something
+          elsif condition_bar?
+            [!!foo1, bar1, baz1]
+             ^ Avoid the use of double negation (`!!`).
+            do_something
+          else
+            [!!foo2, bar2, baz2]
+             ^ Avoid the use of double negation (`!!`).
+            do_something
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          if condition_foo?
+            [!foo0.nil?, bar0, baz0]
+            do_something
+          elsif condition_bar?
+            [!foo1.nil?, bar1, baz1]
+            do_something
+          else
+            [!foo2.nil?, bar2, baz2]
+            do_something
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for `!!` when not return location' \
+       'and using `case`, `when`, and `else`' do
+      expect_offense(<<~RUBY)
+        def foo?
+          case condition
+          when foo
+            !!foo
+            ^ Avoid the use of double negation (`!!`).
+            do_something
+          when bar
+            !!bar
+            ^ Avoid the use of double negation (`!!`).
+            do_something
+          else
+            !!baz
+            ^ Avoid the use of double negation (`!!`).
+            do_something
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          case condition
+          when foo
+            !foo.nil?
+            do_something
+          when bar
+            !bar.nil?
+            do_something
+          else
+            !baz.nil?
+            do_something
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for `!!` with hash when not return location' \
+       'and using `case`, `when`, and `else`' do
+      expect_offense(<<~RUBY)
+        def foo?
+          case condition
+          when foo
+            { foo: !!foo0, bar: bar0, baz: baz0 }
+                   ^ Avoid the use of double negation (`!!`).
+            do_something
+          when bar
+            { foo: !!foo1, bar: bar1, baz: baz1 }
+                   ^ Avoid the use of double negation (`!!`).
+            do_something
+          else
+            { foo: !!foo2, bar: bar2, baz: baz2 }
+                   ^ Avoid the use of double negation (`!!`).
+            do_something
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          case condition
+          when foo
+            { foo: !foo0.nil?, bar: bar0, baz: baz0 }
+            do_something
+          when bar
+            { foo: !foo1.nil?, bar: bar1, baz: baz1 }
+            do_something
+          else
+            { foo: !foo2.nil?, bar: bar2, baz: baz2 }
+            do_something
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for `!!` with array when not return location' \
+       'and using `case`, `when`, and `else`' do
+      expect_offense(<<~RUBY)
+        def foo?
+          case condition
+          when foo
+            [!!foo0, bar0, baz0]
+             ^ Avoid the use of double negation (`!!`).
+            do_something
+          when bar
+            [!!foo1, bar1, baz1]
+             ^ Avoid the use of double negation (`!!`).
+            do_something
+          else
+            [!!foo2, bar2, baz2]
+             ^ Avoid the use of double negation (`!!`).
+            do_something
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          case condition
+          when foo
+            [!foo0.nil?, bar0, baz0]
+            do_something
+          when bar
+            [!foo1.nil?, bar1, baz1]
+            do_something
+          else
+            [!foo2.nil?, bar2, baz2]
+            do_something
+          end
+        end
+      RUBY
+    end
+
     it 'does not register an offense for `!!` when return location' do
       expect_no_offenses(<<~RUBY)
         def foo?
@@ -113,6 +356,191 @@ RSpec.describe RuboCop::Cop::Style::DoubleNegation, :config do
           quux
         ensure
           corge
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `!!` when return location and using `unless`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          unless condition_foo?
+            !!foo
+          end
+        end
+
+        def bar?
+          unless condition_bar?
+            do_something
+            !!bar
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `!!` when return location and using `if`, `elsif`, and `else`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          if condition_foo?
+            !!foo
+          elsif condition_bar?
+            !!bar
+          else
+            !!baz
+          end
+        end
+
+        def bar?
+          if condition_foo?
+            do_something
+            !!foo
+          elsif condition_bar?
+            do_something
+            !!bar
+          else
+            do_something
+            !!baz
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `!!` with hash when return location and using `if`, `elsif`, and `else`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          if condition_foo?
+            { foo: !!foo0, bar: bar0, baz: baz0 }
+          elsif condition_bar?
+            { foo: !!foo1, bar: bar1, baz: baz1 }
+          else
+            { foo: !!foo2, bar: bar2, baz: baz2 }
+          end
+        end
+
+        def bar?
+          if condition_foo?
+            do_something
+            { foo: !!foo0, bar: bar0, baz: baz0 }
+          elsif condition_bar?
+            do_something
+            { foo: !!foo1, bar: bar1, baz: baz1 }
+          else
+            do_something
+            { foo: !!foo2, bar: bar2, baz: baz2 }
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `!!` with array when return location and using `if`, `elsif`, and `else`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          if condition_foo?
+            [!!foo0, bar0, baz0]
+          elsif condition_bar?
+            [!!foo1, bar1, baz1]
+          else
+            [!!foo2, bar2, baz2]
+          end
+        end
+
+        def bar?
+          if condition_foo?
+            do_something
+            [!!foo0, bar0, baz0]
+          elsif condition_bar?
+            do_something
+            [!!foo1, bar1, baz1]
+          else
+            do_something
+            [!!foo2, bar2, baz2]
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `!!` when return location and using `case`, `when`, and `else`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          case condition
+          when foo
+            !!foo
+          when bar
+            !!bar
+          else
+            !!baz
+          end
+        end
+
+        def bar?
+          case condition
+          when foo
+            do_something
+            !!foo
+          when bar
+            do_something
+            !!bar
+          else
+            do_something
+            !!baz
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `!!` with hash when return location and using `case`, `when`, and `else`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          case condition
+          when foo
+            { foo: !!foo0, bar: bar0, baz: baz0 }
+          when bar
+            { foo: !!foo1, bar: bar1, baz: baz1 }
+          else
+            { foo: !!foo2, bar: bar2, baz: baz2 }
+          end
+        end
+
+        def bar?
+          case condition
+          when foo
+            do_something
+            { foo: !!foo0, bar: bar0, baz: baz0 }
+          when bar
+            do_something
+            { foo: !!foo1, bar: bar1, baz: baz1 }
+          else
+            do_something
+            { foo: !!foo2, bar: bar2, baz: baz2 }
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `!!` with array when return location and using `case`, `when`, and `else`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          case condition
+          when foo
+            [!!foo0, bar0, baz0]
+          when bar
+            [!!foo1, bar1, baz1]
+          else
+            [!!foo2, bar2, baz2]
+          end
+        end
+
+        def foo?
+          case condition
+          when foo
+            do_something
+            [!!foo0, bar0, baz0]
+          when bar
+            do_something
+            [!!foo1, bar1, baz1]
+          else
+            do_something
+            [!!foo2, bar2, baz2]
+          end
         end
       RUBY
     end


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/10474

This PR fixes a false positive for `Style/DoubleNegation` when code like the following:

```ruby
def foo?
  if condition_foo?
    !!foo
  elsif condition_bar?
    do_something
    !!bar
  else
    !!baz
  end
end

def foo
  if condition_foo?
    { foo: !!foo0, bar: bar0, baz: baz0 }
  elsif condition_bar?
    do_something
    { foo: !!foo1, bar: bar1, baz: baz1 }
  else
    { foo: !!foo2, bar: bar2, baz: baz2 }
  end
end

def foo
  case condition
  when foo
    [ !!foo0, bar0, baz0 ]
  when bar
    do_something
    [ !!foo1, bar1, baz1 ]
  else
    [ !!foo2, bar2, baz2 ]
  end
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
