### PR TITLE
[Fix #10464] Fix an incorrect autocorrect for `Lint/IncompatibleIoSelectWithFiberScheduler`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_incompatible_io_select_with_fiber_scheduler.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_incompatible_io_select_with_fiber_scheduler.md
@@ -1,0 +1,1 @@
+* [#10464](https://github.com/rubocop/rubocop/issues/10464): Fix an incorrect autocorrect for `Lint/IncompatibleIoSelectWithFiberScheduler` when using `IO.select` with read (or write) argument and using return value. ([@koic][])

--- a/spec/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler_spec.rb
+++ b/spec/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler_spec.rb
@@ -122,6 +122,24 @@ RSpec.describe RuboCop::Cop::Lint::IncompatibleIoSelectWithFiberScheduler, :conf
     RUBY
   end
 
+  it 'registers an offense when using `IO.select` with read argument and using return value but does not autocorrect' do
+    expect_offense(<<~RUBY)
+      rs, _ = IO.select([rp], [])
+              ^^^^^^^^^^^^^^^^^^^ Use `rp.wait_readable` instead of `IO.select([rp], [])`.
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers an offense when using `IO.select` with write argument and using return value but does not autocorrect' do
+    expect_offense(<<~RUBY)
+      _, ws = IO.select([], [wp])
+              ^^^^^^^^^^^^^^^^^^^ Use `wp.wait_writable` instead of `IO.select([], [wp])`.
+    RUBY
+
+    expect_no_corrections
+  end
+
   it 'does not register an offense when using `IO.select` with multiple read arguments' do
     expect_no_offenses(<<~RUBY)
       IO.select([foo, bar], [], [])


### PR DESCRIPTION
Fixes #10464.

This PR fixes an incorrect autocorrect for `Lint/IncompatibleIoSelectWithFiberScheduler` when using `IO.select` with read (or write) argument and using return value.

When the method is successful the return value of `IO.select` is `[[IO]]`, and the return value of `io.wait_readable` and `io.wait_writable` are `self`.

They are not auto-corrected when assigning a return value because these types are different. It's up to user how to handle the return value.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
