### PR TITLE
Changed default percent regex delimiters to singlequotes

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -4378,7 +4378,7 @@ Style/PercentLiteralDelimiters:
     default: ()
     '%i': '[]'
     '%I': '[]'
-    '%r': '{}'
+    '%r': "''"
     '%w': '[]'
     '%W': '[]'
   VersionChanged: '0.48'


### PR DESCRIPTION
Delimiters should be symbols that are unlikely (ideally, guaranteed!) to appear in the body. Curly braces have a meaning in regex, as do most other symbols, unfortunately, with the prominent exceptions of single and double quotes, so let's use either or both as delimiters for regexp literals!