### PR TITLE
Fix #10311 Layout/RedundantLineBreak inside block

### DIFF
--- a/changelog/fix_RedundantLineBreak_inside_block.md
+++ b/changelog/fix_RedundantLineBreak_inside_block.md
@@ -1,0 +1,1 @@
+* [#10311](https://github.com/rubocop/rubocop/issues/10311): Fix false negative inside `do`..`end` for `Layout/RedundantLineBreak`. ([@jonas054][])

--- a/lib/rubocop/cop/bundler/duplicated_gem.rb
+++ b/lib/rubocop/cop/bundler/duplicated_gem.rb
@@ -46,11 +46,7 @@ module RuboCop
 
           duplicated_gem_nodes.each do |nodes|
             nodes[1..-1].each do |node|
-              register_offense(
-                node,
-                node.first_argument.to_a.first,
-                nodes.first.first_line
-              )
+              register_offense(node, node.first_argument.to_a.first, nodes.first.first_line)
             end
           end
         end

--- a/lib/rubocop/cop/gemspec/duplicated_assignment.rb
+++ b/lib/rubocop/cop/gemspec/duplicated_assignment.rb
@@ -52,11 +52,7 @@ module RuboCop
 
           duplicated_assignment_method_nodes.each do |nodes|
             nodes[1..-1].each do |node|
-              register_offense(
-                node,
-                node.method_name,
-                nodes.first.first_line
-              )
+              register_offense(node, node.method_name, nodes.first.first_line)
             end
           end
         end

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -185,8 +185,7 @@ module RuboCop
 
         def check_members_for_indented_internal_methods_style(members)
           each_member(members) do |member, previous_modifier|
-            check_indentation(previous_modifier, member,
-                              indentation_consistency_style)
+            check_indentation(previous_modifier, member, indentation_consistency_style)
           end
         end
 

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -105,10 +105,9 @@ module RuboCop
         end
 
         def convertible_block?(node)
-          return false unless node.parent&.block_type?
-
-          send_node = node.parent&.send_node
-          send_node.parenthesized? || !send_node.arguments?
+          parent = node.parent
+          parent&.block_type? && node == parent.send_node &&
+            (node.parenthesized? || !node.arguments?)
         end
 
         def comment_within?(node)

--- a/lib/rubocop/cop/lint/syntax.rb
+++ b/lib/rubocop/cop/lint/syntax.rb
@@ -9,8 +9,7 @@ module RuboCop
         def on_other_file
           add_offense_from_error(processed_source.parser_error) if processed_source.parser_error
           processed_source.diagnostics.each do |diagnostic|
-            add_offense_from_diagnostic(diagnostic,
-                                        processed_source.ruby_version)
+            add_offense_from_diagnostic(diagnostic, processed_source.ruby_version)
           end
           super
         end

--- a/lib/rubocop/cop/metrics/utils/abc_size_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/abc_size_calculator.rb
@@ -101,8 +101,7 @@ module RuboCop
             children = node.masgn_type? ? node.children[0].children : node.children
 
             will_be_miscounted = children.count do |child|
-              child.respond_to?(:setter_method?) &&
-                !child.setter_method?
+              child.respond_to?(:setter_method?) && !child.setter_method?
             end
             @assignment += will_be_miscounted
 

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -196,8 +196,7 @@ module RuboCop
 
       def not_for_this_cop?(node)
         node.ancestors.any? do |ancestor|
-          grouped_expression?(ancestor) ||
-            inside_arg_list_parentheses?(node, ancestor)
+          grouped_expression?(ancestor) || inside_arg_list_parentheses?(node, ancestor)
         end
       end
 

--- a/lib/rubocop/cop/style/empty_case_condition.rb
+++ b/lib/rubocop/cop/style/empty_case_condition.rb
@@ -47,8 +47,7 @@ module RuboCop
           branch_bodies = [*case_node.when_branches.map(&:body), case_node.else_branch].compact
 
           return if branch_bodies.any? do |body|
-            body.return_type? ||
-            body.each_descendant.any?(&:return_type?)
+            body.return_type? || body.each_descendant.any?(&:return_type?)
           end
 
           add_offense(case_node.loc.keyword) { |corrector| autocorrect(corrector, case_node) }

--- a/lib/rubocop/cop/style/redundant_capital_w.rb
+++ b/lib/rubocop/cop/style/redundant_capital_w.rb
@@ -37,8 +37,7 @@ module RuboCop
 
         def requires_interpolation?(node)
           node.child_nodes.any? do |string|
-            string.dstr_type? ||
-              double_quotes_required?(string.source)
+            string.dstr_type? || double_quotes_required?(string.source)
           end
         end
       end

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -184,8 +184,7 @@ module RuboCop
 
         def unsafe_autocorrect?(condition)
           condition.children.any? do |child|
-            unparenthesized_method_call?(child) ||
-              below_ternary_precedence?(child)
+            unparenthesized_method_call?(child) || below_ternary_precedence?(child)
           end
         end
 

--- a/lib/rubocop/cop/style/trailing_method_end_statement.rb
+++ b/lib/rubocop/cop/style/trailing_method_end_statement.rb
@@ -42,10 +42,7 @@ module RuboCop
           return if node.endless? || !trailing_end?(node)
 
           add_offense(node.loc.end) do |corrector|
-            corrector.insert_before(
-              node.loc.end,
-              "\n#{' ' * node.loc.keyword.column}"
-            )
+            corrector.insert_before(node.loc.end, "\n#{' ' * node.loc.keyword.column}")
           end
         end
 

--- a/lib/rubocop/formatter/offense_count_formatter.rb
+++ b/lib/rubocop/formatter/offense_count_formatter.rb
@@ -52,8 +52,7 @@ module RuboCop
         output.puts
 
         per_cop_counts.each do |cop_name, count|
-          output.puts "#{count.to_s.ljust(total_count.to_s.length + 2)}" \
-                      "#{cop_name}\n"
+          output.puts "#{count.to_s.ljust(total_count.to_s.length + 2)}#{cop_name}\n"
         end
         output.puts '--'
         output.puts "#{total_count}  Total"

--- a/lib/rubocop/formatter/worst_offenders_formatter.rb
+++ b/lib/rubocop/formatter/worst_offenders_formatter.rb
@@ -40,8 +40,7 @@ module RuboCop
         output.puts
 
         per_file_counts.each do |file_name, count|
-          output.puts "#{count.to_s.ljust(total_count.to_s.length + 2)}" \
-                      "#{file_name}\n"
+          output.puts "#{count.to_s.ljust(total_count.to_s.length + 2)}#{file_name}\n"
         end
         output.puts '--'
         output.puts "#{total_count}  Total"

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -199,10 +199,7 @@ RSpec.describe 'RuboCop Project', type: :feature do
       describe 'body' do
         let(:bodies) do
           entries.map do |entry|
-            entry
-              .gsub(/`[^`]+`/, '``')
-              .sub(/^\*\s*(?:\[.+?\):\s*)?/, '')
-              .sub(/\s*\([^)]+\)$/, '')
+            entry.gsub(/`[^`]+`/, '``').sub(/^\*\s*(?:\[.+?\):\s*)?/, '').sub(/\s*\([^)]+\)$/, '')
           end
         end
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -702,8 +702,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
 
   describe 'caching' do
     let(:cache) do
-      instance_double(RuboCop::ResultCache, 'valid?' => true,
-                                            'load' => cached_offenses)
+      instance_double(RuboCop::ResultCache, 'valid?' => true, 'load' => cached_offenses)
     end
     let(:source) { %(puts "Hi"\n) }
 

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1260,8 +1260,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
           context 'and offenses come from the cache' do
             context 'and a message has binary encoding' do
               let(:message_from_cache) do
-                (+'Cyclomatic complexity for 文 is too high. [8/6]')
-                  .force_encoding('ASCII-8BIT')
+                (+'Cyclomatic complexity for 文 is too high. [8/6]').force_encoding('ASCII-8BIT')
               end
               let(:data_from_cache) do
                 [

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe RuboCop::Cop::Commissioner do
     let(:processed_source) { parse_source(source, 'file.rb') }
     let(:cop_offenses) { [] }
     let(:cop_report) do
-      RuboCop::Cop::Base::InvestigationReport
-        .new(nil, processed_source, cop_offenses, nil)
+      RuboCop::Cop::Base::InvestigationReport.new(nil, processed_source, cop_offenses, nil)
     end
 
     around { |example| RuboCop::Cop::Registry.with_temporary_global { example.run } }

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -102,8 +102,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
     end
 
     before do
-      allow(processed_source.comment_config).to receive(:cop_enabled_at_line?)
-        .and_return(false)
+      allow(processed_source.comment_config).to receive(:cop_enabled_at_line?).and_return(false)
     end
 
     context 'ignore_disable_comments is false' do

--- a/spec/rubocop/cop/generator/require_file_injector_spec.rb
+++ b/spec/rubocop/cop/generator/require_file_injector_spec.rb
@@ -4,11 +4,7 @@ RSpec.describe RuboCop::Cop::Generator::RequireFileInjector do
   let(:stdout) { StringIO.new }
   let(:root_file_path) { 'lib/root.rb' }
   let(:injector) do
-    described_class.new(
-      source_path: source_path,
-      root_file_path: root_file_path,
-      output: stdout
-    )
+    described_class.new(source_path: source_path, root_file_path: root_file_path, output: stdout)
   end
 
   around do |example|

--- a/spec/rubocop/cop/layout/line_end_string_concatenation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/line_end_string_concatenation_indentation_spec.rb
@@ -173,9 +173,7 @@ RSpec.describe RuboCop::Cop::Layout::LineEndStringConcatenationIndentation, :con
     ['X =', '$x =', '@x =', 'x =', 'x +=', 'x ||='].each do |lhs_and_operator|
       context "for assignment with #{lhs_and_operator}" do
         let(:aligned_strings) do
-          [%(#{lhs_and_operator} "a" \\),
-           "#{' ' * lhs_and_operator.length} 'b'",
-           ''].join("\n")
+          [%(#{lhs_and_operator} "a" \\), "#{' ' * lhs_and_operator.length} 'b'", ''].join("\n")
         end
 
         it 'accepts aligned strings' do
@@ -263,9 +261,7 @@ RSpec.describe RuboCop::Cop::Layout::LineEndStringConcatenationIndentation, :con
     ['X =', '$x =', '@x =', 'x =', 'x +=', 'x ||='].each do |lhs_and_operator|
       context "for assignment with #{lhs_and_operator}" do
         let(:indented_strings) do
-          [%(#{lhs_and_operator} "a" \\),
-           "  'b'",
-           ''].join("\n")
+          [%(#{lhs_and_operator} "a" \\), "  'b'", ''].join("\n")
         end
 
         it 'accepts indented strings' do

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
                             ^^^^^^^^^^^^^^^^^^^^ Redundant line break detected.
                                   "can't inherit configuration from the rubocop gem"
                           end
-            #{'      '}
+
                           hash['inherit_from'] = Array(hash['inherit_from'])
                           Array(config_path).reverse_each do |path|
                             # Put gem configuration first so local configuration overrides it.
@@ -148,7 +148,7 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
                           if gem_name == 'rubocop'
                             raise ArgumentError, "can't inherit configuration from the rubocop gem"
                           end
-            #{'      '}
+
                           hash['inherit_from'] = Array(hash['inherit_from'])
                           Array(config_path).reverse_each do |path|
                             # Put gem configuration first so local configuration overrides it.
@@ -170,6 +170,23 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
 
         expect_correction(<<~RUBY)
           my_method(1, 2, "x")
+        RUBY
+      end
+
+      it 'registers an offense for a method call on multiple lines inside a block' do
+        expect_offense(<<~RUBY)
+          some_array.map do |something|
+            my_method(
+            ^^^^^^^^^^ Redundant line break detected.
+              something,
+            )
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          some_array.map do |something|
+            my_method( something, )
+          end
         RUBY
       end
 

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -123,39 +123,39 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
 
         it 'registers an offense for a method without parentheses on multiple lines' do
           expect_offense(<<~RUBY)
-                      def resolve_inheritance_from_gems(hash)
-                        gems = hash.delete('inherit_gem')
-                        (gems || {}).each_pair do |gem_name, config_path|
-                          if gem_name == 'rubocop'
-                            raise ArgumentError,
-                            ^^^^^^^^^^^^^^^^^^^^ Redundant line break detected.
-                                  "can't inherit configuration from the rubocop gem"
-                          end
+            def resolve_inheritance_from_gems(hash)
+              gems = hash.delete('inherit_gem')
+              (gems || {}).each_pair do |gem_name, config_path|
+                if gem_name == 'rubocop'
+                  raise ArgumentError,
+                  ^^^^^^^^^^^^^^^^^^^^ Redundant line break detected.
+                        "can't inherit configuration from the rubocop gem"
+                end
 
-                          hash['inherit_from'] = Array(hash['inherit_from'])
-                          Array(config_path).reverse_each do |path|
-                            # Put gem configuration first so local configuration overrides it.
-                            hash['inherit_from'].unshift gem_config_path(gem_name, path)
-                          end
-                        end
-                      end
+                hash['inherit_from'] = Array(hash['inherit_from'])
+                Array(config_path).reverse_each do |path|
+                  # Put gem configuration first so local configuration overrides it.
+                  hash['inherit_from'].unshift gem_config_path(gem_name, path)
+                end
+              end
+            end
           RUBY
 
           expect_correction(<<~RUBY)
-                      def resolve_inheritance_from_gems(hash)
-                        gems = hash.delete('inherit_gem')
-                        (gems || {}).each_pair do |gem_name, config_path|
-                          if gem_name == 'rubocop'
-                            raise ArgumentError, "can't inherit configuration from the rubocop gem"
-                          end
+            def resolve_inheritance_from_gems(hash)
+              gems = hash.delete('inherit_gem')
+              (gems || {}).each_pair do |gem_name, config_path|
+                if gem_name == 'rubocop'
+                  raise ArgumentError, "can't inherit configuration from the rubocop gem"
+                end
 
-                          hash['inherit_from'] = Array(hash['inherit_from'])
-                          Array(config_path).reverse_each do |path|
-                            # Put gem configuration first so local configuration overrides it.
-                            hash['inherit_from'].unshift gem_config_path(gem_name, path)
-                          end
-                        end
-                      end
+                hash['inherit_from'] = Array(hash['inherit_from'])
+                Array(config_path).reverse_each do |path|
+                  # Put gem configuration first so local configuration overrides it.
+                  hash['inherit_from'].unshift gem_config_path(gem_name, path)
+                end
+              end
+            end
           RUBY
         end
       end

--- a/spec/rubocop/cop/lint/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/multiple_comparison_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe RuboCop::Cop::Lint::MultipleComparison, :config do
   end
 
   %w[< > <= >=].repeated_permutation(2) do |operator1, operator2|
-    include_examples 'Check to use two comparison operator',
-                     operator1, operator2
+    include_examples 'Check to use two comparison operator', operator1, operator2
   end
 
   it 'accepts to use one compare operator' do

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -103,11 +103,7 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
 
   context 'when checking for methods with no side effects' do
     let(:config) do
-      RuboCop::Config.new(
-        'Lint/Void' => {
-          'CheckForMethodsWithNoSideEffects' => true
-        }
-      )
+      RuboCop::Config.new('Lint/Void' => { 'CheckForMethodsWithNoSideEffects' => true })
     end
 
     it 'registers an offense if not on last line' do
@@ -129,11 +125,7 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
 
   context 'when not checking for methods with no side effects' do
     let(:config) do
-      RuboCop::Config.new(
-        'Lint/Void' => {
-          'CheckForMethodsWithNoSideEffects' => false
-        }
-      )
+      RuboCop::Config.new('Lint/Void' => { 'CheckForMethodsWithNoSideEffects' => false })
     end
 
     it 'does not register an offense for void nonmutating methods' do

--- a/spec/rubocop/cop/message_annotator_spec.rb
+++ b/spec/rubocop/cop/message_annotator_spec.rb
@@ -62,9 +62,7 @@ RSpec.describe RuboCop::Cop::MessageAnnotator do
 
     context 'when StyleGuide is set in the config' do
       let(:config) do
-        RuboCop::Config.new(
-          'Cop/Cop' => { 'StyleGuide' => 'http://example.org/styleguide' }
-        )
+        RuboCop::Config.new('Cop/Cop' => { 'StyleGuide' => 'http://example.org/styleguide' })
       end
 
       it 'adds style guide url' do
@@ -158,11 +156,7 @@ RSpec.describe RuboCop::Cop::MessageAnnotator do
   describe '#urls' do
     let(:urls) { annotator.urls }
     let(:config) do
-      RuboCop::Config.new(
-        'AllCops' => {
-          'StyleGuideBaseURL' => 'http://example.org/styleguide'
-        }
-      )
+      RuboCop::Config.new('AllCops' => { 'StyleGuideBaseURL' => 'http://example.org/styleguide' })
     end
 
     it 'returns an empty array without StyleGuide URL' do

--- a/spec/rubocop/cop/naming/file_name_spec.rb
+++ b/spec/rubocop/cop/naming/file_name_spec.rb
@@ -278,10 +278,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
 
   context 'when CheckDefinitionPathHierarchy is false' do
     let(:cop_config) do
-      super().merge(
-        'ExpectMatchingDefinition' => true,
-        'CheckDefinitionPathHierarchy' => false
-      )
+      super().merge('ExpectMatchingDefinition' => true, 'CheckDefinitionPathHierarchy' => false)
     end
 
     context 'on a file with a matching class' do
@@ -417,10 +414,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
 
   context 'with acronym namespace' do
     let(:cop_config) do
-      super().merge(
-        'ExpectMatchingDefinition' => true,
-        'AllowedAcronyms' => ['CLI']
-      )
+      super().merge('ExpectMatchingDefinition' => true, 'AllowedAcronyms' => ['CLI'])
     end
 
     it 'does not register an offense' do
@@ -437,10 +431,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
 
   context 'with acronym class name' do
     let(:cop_config) do
-      super().merge(
-        'ExpectMatchingDefinition' => true,
-        'AllowedAcronyms' => ['CLI']
-      )
+      super().merge('ExpectMatchingDefinition' => true, 'AllowedAcronyms' => ['CLI'])
     end
 
     it 'does not register an offense' do
@@ -455,10 +446,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
 
   context 'with include acronym name' do
     let(:cop_config) do
-      super().merge(
-        'ExpectMatchingDefinition' => true,
-        'AllowedAcronyms' => ['HTTP']
-      )
+      super().merge('ExpectMatchingDefinition' => true, 'AllowedAcronyms' => ['HTTP'])
     end
 
     it 'does not register an offense' do

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -60,9 +60,7 @@ RSpec.describe RuboCop::Cop::Offense do
 
   describe '#severity_level' do
     subject(:severity_level) do
-      described_class.new(severity, location, 'message', 'CopName')
-                     .severity
-                     .level
+      described_class.new(severity, location, 'message', 'CopName').severity.level
     end
 
     context 'when severity is :info' do
@@ -137,8 +135,7 @@ RSpec.describe RuboCop::Cop::Offense do
 
   context 'offenses that span multiple lines' do
     subject(:offense) do
-      described_class
-        .new(:convention, location, 'message', 'CopName', :corrected)
+      described_class.new(:convention, location, 'message', 'CopName', :corrected)
     end
 
     let(:location) do
@@ -160,8 +157,7 @@ RSpec.describe RuboCop::Cop::Offense do
 
   context 'offenses that span part of a line' do
     subject(:offense) do
-      described_class
-        .new(:convention, location, 'message', 'CopName', :corrected)
+      described_class.new(:convention, location, 'message', 'CopName', :corrected)
     end
 
     let(:location) do

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -252,9 +252,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
 
     context 'when double-quoted string literals are preferred' do
       let(:other_cops) do
-        super().merge('Style/StringLiterals' => {
-                        'EnforcedStyle' => 'double_quotes'
-                      })
+        super().merge('Style/StringLiterals' => { 'EnforcedStyle' => 'double_quotes' })
       end
 
       it 'registers an offense for String.new' do

--- a/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
+++ b/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
@@ -2,9 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Style::NestedParenthesizedCalls, :config do
   let(:config) do
-    RuboCop::Config.new(
-      'Style/NestedParenthesizedCalls' => { 'AllowedMethods' => ['be'] }
-    )
+    RuboCop::Config.new('Style/NestedParenthesizedCalls' => { 'AllowedMethods' => ['be'] })
   end
 
   context 'on a non-parenthesized method call' do

--- a/spec/rubocop/cop/style/redundant_fetch_block_spec.rb
+++ b/spec/rubocop/cop/style/redundant_fetch_block_spec.rb
@@ -3,11 +3,7 @@
 RSpec.describe RuboCop::Cop::Style::RedundantFetchBlock, :config do
   context 'with SafeForConstants: true' do
     let(:config) do
-      RuboCop::Config.new(
-        'Style/RedundantFetchBlock' => {
-          'SafeForConstants' => true
-        }
-      )
+      RuboCop::Config.new('Style/RedundantFetchBlock' => { 'SafeForConstants' => true })
     end
 
     it 'registers an offense and corrects when using `#fetch` with Integer in the block' do
@@ -129,11 +125,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFetchBlock, :config do
 
   context 'with SafeForConstants: false' do
     let(:config) do
-      RuboCop::Config.new(
-        'Style/RedundantFetchBlock' => {
-          'SafeForConstants' => false
-        }
-      )
+      RuboCop::Config.new('Style/RedundantFetchBlock' => { 'SafeForConstants' => false })
     end
 
     it 'does not register an offense when using `#fetch` with constant in the block' do

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -210,9 +210,7 @@ RSpec.describe RuboCop::Cop::Style::RescueModifier, :config do
 
   describe 'excluded file', :config do
     let(:config) do
-      RuboCop::Config.new('Style/RescueModifier' =>
-                          { 'Enabled' => true,
-                            'Exclude' => ['**/**'] })
+      RuboCop::Config.new('Style/RescueModifier' => { 'Enabled' => true, 'Exclude' => ['**/**'] })
     end
 
     it 'processes excluded files with issue' do

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -246,9 +246,7 @@ RSpec.describe RuboCop::Cop::Team do
 
     context 'when only some cop classes are passed to .new' do
       let(:cop_classes) do
-        RuboCop::Cop::Registry.new(
-          [RuboCop::Cop::Lint::Void, RuboCop::Cop::Layout::LineLength]
-        )
+        RuboCop::Cop::Registry.new([RuboCop::Cop::Lint::Void, RuboCop::Cop::Layout::LineLength])
       end
 
       it 'returns only instances of the classes' do

--- a/spec/rubocop/formatter/clang_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/clang_style_formatter_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe RuboCop::Formatter::ClangStyleFormatter, :config do
     let(:file) { '/path/to/file' }
 
     let(:offense) do
-      RuboCop::Cop::Offense.new(:convention, location,
-                                'This is a message.', 'CopName', status)
+      RuboCop::Cop::Offense.new(:convention, location, 'This is a message.', 'CopName', status)
     end
 
     let(:source) { ('aa'..'az').to_a.join($RS) }

--- a/spec/rubocop/formatter/emacs_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/emacs_style_formatter_spec.rb
@@ -33,8 +33,7 @@ RSpec.describe RuboCop::Formatter::EmacsStyleFormatter, :config do
       let(:file) { '/path/to/file' }
 
       let(:offense) do
-        RuboCop::Cop::Offense.new(:convention, location,
-                                  'This is a message.', 'CopName', status)
+        RuboCop::Cop::Offense.new(:convention, location, 'This is a message.', 'CopName', status)
       end
 
       let(:location) do
@@ -55,8 +54,7 @@ RSpec.describe RuboCop::Formatter::EmacsStyleFormatter, :config do
       let(:file) { '/path/to/file' }
 
       let(:offense) do
-        RuboCop::Cop::Offense.new(:convention, location,
-                                  'This is a message.', 'CopName', status)
+        RuboCop::Cop::Offense.new(:convention, location, 'This is a message.', 'CopName', status)
       end
 
       let(:location) do

--- a/spec/rubocop/formatter/json_formatter_spec.rb
+++ b/spec/rubocop/formatter/json_formatter_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe RuboCop::Formatter::JSONFormatter do
     Parser::Source::Range.new(source_buffer, 2, 10)
   end
   let(:offense) do
-    RuboCop::Cop::Offense.new(:convention, location,
-                              'This is message', 'CopName', :corrected)
+    RuboCop::Cop::Offense.new(:convention, location, 'This is message', 'CopName', :corrected)
   end
 
   describe '#started' do

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -288,22 +288,19 @@ RSpec.describe RuboCop::Options, :isolated_environment do
     describe '--fail-level' do
       it 'accepts full severity names' do
         %w[info refactor convention warning error fatal].each do |severity|
-          expect { options.parse(['--fail-level', severity]) }
-            .not_to raise_error
+          expect { options.parse(['--fail-level', severity]) }.not_to raise_error
         end
       end
 
       it 'accepts severity initial letters' do
         %w[I R C W E F].each do |severity|
-          expect { options.parse(['--fail-level', severity]) }
-            .not_to raise_error
+          expect { options.parse(['--fail-level', severity]) }.not_to raise_error
         end
       end
 
       it 'accepts the "fake" severities A/autocorrect' do
         %w[autocorrect A].each do |severity|
-          expect { options.parse(['--fail-level', severity]) }
-            .not_to raise_error
+          expect { options.parse(['--fail-level', severity]) }.not_to raise_error
         end
       end
     end

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -7,11 +7,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
 
   let(:registry) { RuboCop::Cop::Registry.global }
   let(:team) do
-    RuboCop::Cop::Team.mobilize(
-      registry,
-      RuboCop::ConfigLoader.default_configuration,
-      options
-    )
+    RuboCop::Cop::Team.mobilize(registry, RuboCop::ConfigLoader.default_configuration, options)
   end
 
   let(:file) { 'example.rb' }
@@ -283,8 +279,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
           "unused var \xF0",
           (+'unused var あ').force_encoding(::Encoding::ASCII_8BIT)
         ].map do |message|
-          RuboCop::Cop::Offense.new(:warning, location, message,
-                                    'Lint/UselessAssignment')
+          RuboCop::Cop::Offense.new(:warning, location, message, 'Lint/UselessAssignment')
         end
       end
 

--- a/tasks/cut_release.rake
+++ b/tasks/cut_release.rake
@@ -31,18 +31,14 @@ namespace :cut_release do
   # Replace `<<next>>` (and variations) with version being cut.
   def update_cop_versions(_old_version, new_version)
     update_file('config/default.yml') do |default|
-      default.gsub(/['"]?<<\s*next\s*>>['"]?/i,
-                   "'#{version_sans_patch(new_version)}'")
+      default.gsub(/['"]?<<\s*next\s*>>['"]?/i, "'#{version_sans_patch(new_version)}'")
     end
     RuboCop::ConfigLoader.default_configuration = nil # invalidate loaded conf
   end
 
   def update_docs(old_version, new_version)
     update_file('docs/antora.yml') do |antora_metadata|
-      antora_metadata.sub(
-        'version: ~',
-        "version: '#{version_sans_patch(new_version)}'"
-      )
+      antora_metadata.sub('version: ~', "version: '#{version_sans_patch(new_version)}'")
     end
 
     update_file('docs/modules/ROOT/pages/installation.adoc') do |installation|
@@ -55,19 +51,13 @@ namespace :cut_release do
 
   def update_issue_template(old_version, new_version)
     update_file('.github/ISSUE_TEMPLATE/bug_report.md') do |issue_template|
-      issue_template.sub(
-        "#{old_version} (using Parser ",
-        "#{new_version} (using Parser "
-      )
+      issue_template.sub("#{old_version} (using Parser ", "#{new_version} (using Parser ")
     end
   end
 
   def update_contributing_doc(old_version, new_version)
     update_file('CONTRIBUTING.md') do |contributing_doc|
-      contributing_doc.sub(
-        "#{old_version} (using Parser ",
-        "#{new_version} (using Parser "
-      )
+      contributing_doc.sub("#{old_version} (using Parser ", "#{new_version} (using Parser ")
     end
   end
 


### PR DESCRIPTION
When `Layout/RedundantLineBreak` inspects a send node, it starts by expanding the node to inspect. It does this by traversing the AST upwards as long as the parent is a send node of a block node.
    
The problem was that if the inspected node is a single node inside a `do`..`end` block, we shouldn't move to the parent block and inspect it for redundant line breaks. It's only send nodes before the `do`..`end` that we want to expand in order to inspect "the whole expression". So we should check what kind of block/send relationship it is before moving upwards in the AST.