### PR TITLE
[Fix #10479] Fix a false positive for `Lint/ShadowingOuterLocalVariable` conditional statement and block variable

### DIFF
--- a/changelog/fix_fix_false_positive_for_shadowing_outer_local_variable_conditional_statement.md
+++ b/changelog/fix_fix_false_positive_for_shadowing_outer_local_variable_conditional_statement.md
@@ -1,0 +1,1 @@
+* [#10479](https://github.com/rubocop/rubocop/issues/10479): Fix a false positive for `Lint/ShadowingOuterLocalVariable` conditional statement and block variable. ([@ydah][])

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -57,9 +57,19 @@ module RuboCop
 
           outer_local_variable = variable_table.find_variable(variable.name)
           return unless outer_local_variable
+          return if same_conditions_node_different_branch?(variable, outer_local_variable)
 
           message = format(MSG, variable: variable.name)
           add_offense(variable.declaration_node, message: message)
+        end
+
+        def same_conditions_node_different_branch?(variable, outer_local_variable)
+          variable_node = variable.scope.node.parent
+          return false unless variable_node.conditional?
+
+          outer_local_variable_node = outer_local_variable.scope.node
+
+          outer_local_variable_node.conditional? && variable_node == outer_local_variable_node
         end
       end
     end

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -60,6 +60,104 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
     end
   end
 
+  context 'when a block local variable has same name as an outer scope variable' \
+          'with same branches of same `if` condition node' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        if condition?
+          foo = 1
+          puts foo
+          bar.each do |foo|
+                       ^^^ Shadowing outer local variable - `foo`.
+          end
+        else
+          bar.each do |foo|
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a block local variable has same name as an outer scope variable' \
+          'with same branches of same `unless` condition node' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        unless condition?
+          foo = 1
+          puts foo
+          bar.each do |foo|
+                       ^^^ Shadowing outer local variable - `foo`.
+          end
+        else
+          bar.each do |foo|
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a block local variable has same name as an outer scope variable' \
+          'with same branches of same `case` condition node' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        case condition
+        when foo then
+          foo = 1
+          puts foo
+          bar.each do |foo|
+                       ^^^ Shadowing outer local variable - `foo`.
+          end
+        else
+          bar.each do |foo|
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a block local variable has same name as an outer scope variable' \
+          'with different branches of same `if` condition node' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        if condition?
+          foo = 1
+        else
+          bar.each do |foo|
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a block local variable has same name as an outer scope variable' \
+          'with different branches of same `unless` condition node' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        unless condition?
+          foo = 1
+        else
+          bar.each do |foo|
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a block local variable has same name as an outer scope variable' \
+          'with different branches of same `case` condition node' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        case condition
+        when foo then
+          foo = 1
+        else
+          bar.each do |foo|
+          end
+        end
+      RUBY
+    end
+  end
+
   context 'when a block argument has different name with outer scope variables' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/10479

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
