### PR TITLE
[Fix #10310] Add InspectBlocksOnAllLevels config param

### DIFF
--- a/changelog/change_InspectBlocksOnAllLevels_param.md
+++ b/changelog/change_InspectBlocksOnAllLevels_param.md
@@ -1,0 +1,1 @@
+* [#10310](https://github.com/rubocop/rubocop/issues/10310): Add `InspectBlocksOnAllLevels` parameter in `Layout/RedundantLineBreak`. ([@jonas054][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1166,6 +1166,7 @@ Layout/RedundantLineBreak:
                  on a single line.
   Enabled: false
   InspectBlocks: false
+  InspectBlocksOnAllLevels: true
   VersionAdded: '1.13'
 
 Layout/RescueEnsureAlignment:


### PR DESCRIPTION
Add a configuration parameter to `Layout/RedundantLineBreak` to signal whether blocks on any level (depth) should be inspected. If `false`, only the innermost level of blocks within blocks will be inspected. If `true`, all levels will be inspected.

To achieve backwards compatibility, the default value for the new parameter is set to `true`.