### PR TITLE
[Fix #10489] Fix a false positive for `Lint/LambdaWithoutLiteralBlock`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_lambda_without_literal_block.md
+++ b/changelog/fix_a_false_positive_for_lint_lambda_without_literal_block.md
@@ -1,0 +1,1 @@
+* [#10489](https://github.com/rubocop/rubocop/issues/10489): Fix a false positive for `Lint/LambdaWithoutLiteralBlock` when using lambda with a symbol proc. ([@koic][])

--- a/lib/rubocop/cop/lint/lambda_without_literal_block.rb
+++ b/lib/rubocop/cop/lint/lambda_without_literal_block.rb
@@ -31,8 +31,15 @@ module RuboCop
         MSG = 'lambda without a literal block is deprecated; use the proc without lambda instead.'
         RESTRICT_ON_SEND = %i[lambda].freeze
 
+        # @!method lambda_with_symbol_proc?(node)
+        def_node_matcher :lambda_with_symbol_proc?, <<~PATTERN
+          (send nil? :lambda (block_pass (sym _)))
+        PATTERN
+
         def on_send(node)
-          return if node.parent&.block_type? || !node.first_argument
+          if node.parent&.block_type? || !node.first_argument || lambda_with_symbol_proc?(node)
+            return
+          end
 
           add_offense(node) do |corrector|
             corrector.replace(node, node.first_argument.source.delete('&'))

--- a/spec/rubocop/cop/lint/lambda_without_literal_block_spec.rb
+++ b/spec/rubocop/cop/lint/lambda_without_literal_block_spec.rb
@@ -47,4 +47,10 @@ RSpec.describe RuboCop::Cop::Lint::LambdaWithoutLiteralBlock, :config do
       lambda.call
     RUBY
   end
+
+  it 'does not register an offense when using lambda with a symbol proc' do
+    expect_no_offenses(<<~RUBY)
+      lambda(&:do_something)
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #10489.

This PR fixes a false positive for `Lint/LambdaWithoutLiteralBlock` when using lambda with a symbol proc.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
