### PR TITLE
Consider only the comments relevant for the node being checked

### DIFF
--- a/changelog/fix_comment_handling_when_allow_comments_is_true.md
+++ b/changelog/fix_comment_handling_when_allow_comments_is_true.md
@@ -1,0 +1,1 @@
+* [#10491](https://github.com/rubocop/rubocop/pull/10491): Improve the handling of comments in `Lint/EmptyConditionalBody`, `Lint/EmptyInPattern` and `Lint/EmptyWhen` when `AllowComments` is set to `true`. ([@Darhazer][])

--- a/lib/rubocop/cop/lint/empty_conditional_body.rb
+++ b/lib/rubocop/cop/lint/empty_conditional_body.rb
@@ -53,11 +53,13 @@ module RuboCop
       #   end
       #
       class EmptyConditionalBody < Base
+        include CommentsHelp
+
         MSG = 'Avoid `%<keyword>s` branches without a body.'
 
         def on_if(node)
           return if node.body
-          return if cop_config['AllowComments'] && comment_lines?(node)
+          return if cop_config['AllowComments'] && contains_comments?(node)
 
           add_offense(node, message: format(MSG, keyword: node.keyword))
         end

--- a/lib/rubocop/cop/lint/empty_in_pattern.rb
+++ b/lib/rubocop/cop/lint/empty_in_pattern.rb
@@ -44,6 +44,7 @@ module RuboCop
       #
       class EmptyInPattern < Base
         extend TargetRubyVersion
+        include CommentsHelp
 
         MSG = 'Avoid `in` branches without a body.'
 
@@ -51,7 +52,8 @@ module RuboCop
 
         def on_case_match(node)
           node.in_pattern_branches.each do |branch|
-            next if branch.body || (cop_config['AllowComments'] && comment_lines?(node))
+            next if branch.body
+            next if cop_config['AllowComments'] && contains_comments?(branch)
 
             add_offense(branch)
           end

--- a/lib/rubocop/cop/lint/empty_when.rb
+++ b/lib/rubocop/cop/lint/empty_when.rb
@@ -45,12 +45,14 @@ module RuboCop
       #   end
       #
       class EmptyWhen < Base
+        include CommentsHelp
+
         MSG = 'Avoid `when` branches without a body.'
 
         def on_case(node)
           node.each_when do |when_node|
             next if when_node.body
-            next if cop_config['AllowComments'] && comment_lines?(node)
+            next if cop_config['AllowComments'] && contains_comments?(when_node)
 
             add_offense(when_node)
           end

--- a/lib/rubocop/cop/mixin/comments_help.rb
+++ b/lib/rubocop/cop/mixin/comments_help.rb
@@ -4,13 +4,18 @@ module RuboCop
   module Cop
     # Help methods for working with nodes containing comments.
     module CommentsHelp
-      include VisibilityHelp
-
       def source_range_with_comment(node)
         begin_pos = begin_pos_with_comment(node)
         end_pos = end_position_for(node)
 
         Parser::Source::Range.new(buffer, begin_pos, end_pos)
+      end
+
+      def contains_comments?(node)
+        start_line = node.source_range.line
+        end_line = find_end_line(node)
+
+        processed_source.each_comment_in_lines(start_line...end_line).any?
       end
 
       private
@@ -36,6 +41,21 @@ module RuboCop
 
       def buffer
         processed_source.buffer
+      end
+
+      # Returns the end line of a node, which might be a comment and not part of the AST
+      # End line is considered either the line at which another node starts, or
+      # the line at which the parent node ends.
+      def find_end_line(node)
+        if node.if_type? && node.loc.else
+          node.loc.else.line
+        elsif (next_sibling = node.right_sibling)
+          next_sibling.loc.line
+        elsif (parent = node.parent)
+          parent.loc.end.line
+        else
+          node.loc.end.line
+        end
       end
     end
   end

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -39,6 +39,29 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     RUBY
   end
 
+  it 'registers an offense for missing `elsif` body that is not the one with a comment' do
+    expect_offense(<<~RUBY)
+      if condition
+        do_something
+      elsif other_condition
+      ^^^^^^^^^^^^^^^^^^^^^ Avoid `elsif` branches without a body.
+      else
+        # noop
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for missing `elsif` body with an inline comment' do
+    expect_no_offenses(<<~RUBY)
+      if condition
+        do_something
+      elsif other_condition # no op, but avoid going into the else
+      else
+        do_other_things
+      end
+    RUBY
+  end
+
   it 'registers an offense for missing `unless` body' do
     expect_offense(<<~RUBY)
       unless condition

--- a/spec/rubocop/cop/lint/empty_in_pattern_spec.rb
+++ b/spec/rubocop/cop/lint/empty_in_pattern_spec.rb
@@ -133,6 +133,17 @@ RSpec.describe RuboCop::Cop::Lint::EmptyInPattern, :config do
   context 'when `AllowComments: true`', :ruby27 do
     let(:cop_config) { { 'AllowComments' => true } }
 
+    it 'registers an offense for empty `in` when comment is in another branch' do
+      expect_offense(<<~RUBY)
+        case condition
+        in [a]
+        ^^^^^^ Avoid `in` branches without a body.
+        in [a, b]
+          # do nothing
+        end
+      RUBY
+    end
+
     it 'accepts an empty `in` body with a comment' do
       expect_no_offenses(<<~RUBY)
         case condition

--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -172,6 +172,29 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
         end
       RUBY
     end
+
+    it 'registers an offense for missing when body without a comment' do
+      expect_offense(<<~RUBY)
+        case condition
+        when foo
+          42 # magic number
+        when bar
+        ^^^^^^^^ Avoid `when` branches without a body.
+        when baz # more comments mixed
+          21 # another magic number
+        end
+      RUBY
+    end
+
+    it 'accepts an empty when ... then body with a comment' do
+      expect_no_offenses(<<~RUBY)
+        case condition
+        when foo
+          do_something
+        when bar then # do nothing
+        end
+      RUBY
+    end
   end
 
   context 'when `AllowComments: false`' do


### PR DESCRIPTION
This fixes the remaining issue in #7999 and also the same issue appearing in 2 other cops: `Lint/EmptyConditionalBody` and `Lint/EmptyInPattern`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
