### PR TITLE
Remove obsolete AllowComments option

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2327,8 +2327,8 @@ Lint/UselessMethodDefinition:
   Description: 'Checks for useless method definitions.'
   Enabled: true
   VersionAdded: '0.90'
+  VersionChanged: '0.91'
   Safe: false
-  AllowComments: true
 
 Lint/UselessRuby2Keywords:
   Description: 'Finds unnecessary uses of `ruby2_keywords`.'

--- a/spec/rubocop/cop/lint/useless_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/useless_method_definition_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::UselessMethodDefinition, :config do
-  let(:cop_config) { { 'AllowComments' => true } }
-
   it 'does not register an offense for empty constructor' do
     expect_no_offenses(<<~RUBY)
       class Foo


### PR DESCRIPTION
The `AllowComments` was removed from the `UselessMethodDefinition` cop in 92d3fc681fff7961bdba701f9dbdffd2f08e4350 but the config was not updated to reflect that.



-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests.~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
