### PR TITLE
[Fix #10388] Fix an incorrectly adds a disable statement for `Layout/SpaceInsideArrayLiteralBrackets` with `--disable-uncorrectable`

### DIFF
--- a/changelog/fix_fix_an_incorrectly_adds_a_disable_statement_for_space_inside_array_literal_brackets.md
+++ b/changelog/fix_fix_an_incorrectly_adds_a_disable_statement_for_space_inside_array_literal_brackets.md
@@ -1,0 +1,1 @@
+* [#10388](https://github.com/rubocop/rubocop/issues/10388): Fix an incorrectly adds a disable statement for `Layout/SpaceInsideArrayLiteralBrackets` with `--disable-uncorrectable`. ([@ydah][])

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -8,6 +8,10 @@ module RuboCop
         autocorrect_requested? && correctable? && autocorrect_enabled?
       end
 
+      def autocorrect_with_disable_uncorrectable?
+        autocorrect_requested? && disable_uncorrectable? && autocorrect_enabled?
+      end
+
       def autocorrect_requested?
         @options.fetch(:auto_correct, false)
       end

--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -44,7 +44,8 @@ module RuboCop
         if extra_space?(left_token, :left) && !start_ok
           space_offense(node, left_token, :right, message, NO_SPACE_COMMAND)
         end
-        return if !extra_space?(right_token, :right) || end_ok
+        return if (!extra_space?(right_token, :right) || end_ok) ||
+                  (autocorrect_with_disable_uncorrectable? && !start_ok)
 
         space_offense(node, right_token, :left, message, NO_SPACE_COMMAND)
       end
@@ -58,7 +59,8 @@ module RuboCop
         unless extra_space?(left_token, :left) || start_ok
           space_offense(node, left_token, :none, message, SPACE_COMMAND)
         end
-        return if extra_space?(right_token, :right) || end_ok
+        return if (extra_space?(right_token, :right) || end_ok) ||
+                  (autocorrect_with_disable_uncorrectable? && !start_ok)
 
         space_offense(node, right_token, :none, message, SPACE_COMMAND)
       end

--- a/spec/rubocop/cli/disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/disable_uncorrectable_spec.rb
@@ -260,5 +260,65 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
         end
       end
     end
+
+    context 'when exist offence for Layout/SpaceInsideArrayLiteralBrackets' do
+      context 'when `EnforcedStyle: no_space`' do
+        it 'does not disable anything for cops that support autocorrect' do
+          create_file('example.rb', <<~RUBY)
+            # frozen_string_literal: true
+
+            puts [ :something ]
+            # last line
+          RUBY
+          expect(exit_code).to eq(0)
+          expect($stderr.string).to eq('')
+          expect($stdout.string).to eq(<<~OUTPUT)
+            == example.rb ==
+            C:  3:  7: [Corrected] Layout/SpaceInsideArrayLiteralBrackets: Do not use space inside array brackets.
+
+            1 file inspected, 1 offense detected, 1 offense corrected
+          OUTPUT
+          expect(File.read('example.rb')).to eq(<<~RUBY)
+            # frozen_string_literal: true
+
+            puts [:something]
+            # last line
+          RUBY
+        end
+      end
+
+      context 'when `EnforcedStyle: space`' do
+        let(:setup_space_inside_array) do
+          create_file('.rubocop.yml', <<~YAML)
+            Layout/SpaceInsideArrayLiteralBrackets:
+              EnforcedStyle: space
+          YAML
+          create_file('example.rb', <<~RUBY)
+            # frozen_string_literal: true
+
+            puts [:something]
+            # last line
+          RUBY
+        end
+
+        it 'does not disable anything for cops that support autocorrect' do
+          setup_space_inside_array
+          expect(exit_code).to eq(0)
+          expect($stderr.string).to eq('')
+          expect($stdout.string).to eq(<<~OUTPUT)
+            == example.rb ==
+            C:  3:  6: [Corrected] Layout/SpaceInsideArrayLiteralBrackets: Use space inside array brackets.
+
+            1 file inspected, 1 offense detected, 1 offense corrected
+          OUTPUT
+          expect(File.read('example.rb')).to eq(<<~RUBY)
+            # frozen_string_literal: true
+
+            puts [ :something ]
+            # last line
+          RUBY
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/10388

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
