### PR TITLE
[Fix #10494] Fix a false positive for `Style/HashSyntax`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_hash_syntax.md
+++ b/changelog/fix_a_false_positive_for_style_hash_syntax.md
@@ -1,0 +1,1 @@
+* [#10494](https://github.com/rubocop/rubocop/issues/10494): Fix a false positive for `Style/HashSyntax` when `return` with one line `if` condition follows (without parentheses). ([@koic][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -65,9 +65,8 @@ module RuboCop
 
       def use_modifier_form_without_parenthesized_method_call?(ancestor)
         return false if ancestor.respond_to?(:parenthesized?) && ancestor.parenthesized?
-        return false unless (parent = ancestor.parent)
 
-        parent.respond_to?(:modifier_form?) && parent.modifier_form?
+        ancestor.ancestors.any? { |node| node.respond_to?(:modifier_form?) && node.modifier_form? }
       end
 
       def without_parentheses_call_expr_follows?(ancestor)

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1001,6 +1001,12 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'does not register an offense when `return` with one line `if` condition follows (without parentheses)' do
+        expect_no_offenses(<<~RUBY)
+          return foo value: value if bar
+        RUBY
+      end
+
       it 'registers an offense when one line `until` condition follows (with parentheses)' do
         expect_offense(<<~RUBY)
           foo(value: value) until bar


### PR DESCRIPTION
Fixes #10494.

This PR fixes a false positive for `Style/HashSyntax` when `return` with one line `if` condition follows (without parentheses).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
