### PR TITLE
Add autocorrect for `Lint/EmptyConditionalBody` cop.

### DIFF
--- a/changelog/new_autocorrect_empty_conditional_body.md
+++ b/changelog/new_autocorrect_empty_conditional_body.md
@@ -1,0 +1,1 @@
+* Add autocorrect for `Lint/EmptyConditionalBody` cop. ([@OwlKing][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1698,6 +1698,7 @@ Lint/EmptyConditionalBody:
   Enabled: true
   AllowComments: true
   VersionAdded: '0.89'
+  SafeAutoCorrect: false
 
 Lint/EmptyEnsure:
   Description: 'Checks for empty ensure block.'

--- a/lib/rubocop/cop/lint/empty_conditional_body.rb
+++ b/lib/rubocop/cop/lint/empty_conditional_body.rb
@@ -53,7 +53,9 @@ module RuboCop
       #   end
       #
       class EmptyConditionalBody < Base
+        extend AutoCorrector
         include CommentsHelp
+        include RangeHelp
 
         MSG = 'Avoid `%<keyword>s` branches without a body.'
 
@@ -61,7 +63,26 @@ module RuboCop
           return if node.body
           return if cop_config['AllowComments'] && contains_comments?(node)
 
-          add_offense(node, message: format(MSG, keyword: node.keyword))
+          add_offense(node, message: format(MSG, keyword: node.keyword)) do |corrector|
+            remove_case(corrector, node)
+            remove_comments(corrector, node)
+          end
+        end
+
+        private
+
+        def remove_case(corrector, node)
+          end_pos = node.loc.else.nil? ? node.loc.expression.end_pos + 1 : node.loc.else.begin_pos
+          corrector.remove(range_between(node.loc.expression.begin_pos, end_pos))
+        end
+
+        def remove_comments(corrector, node)
+          start_line = node.source_range.line
+          end_line = find_end_line(node)
+
+          processed_source.each_comment_in_lines(start_line...end_line).each do |c|
+            corrector.remove(range_by_whole_lines(c.loc.expression, include_final_newline: true))
+          end
         end
       end
     end

--- a/lib/rubocop/cop/lint/empty_conditional_body.rb
+++ b/lib/rubocop/cop/lint/empty_conditional_body.rb
@@ -4,6 +4,12 @@ module RuboCop
   module Cop
     module Lint
       # This cop checks for the presence of `if`, `elsif` and `unless` branches without a body.
+      #
+      # @safety
+      #   This cop's autocorrection is unsafe because
+      #   it's possible that the condition itself results
+      #   in some side-effect.
+      #
       # @example
       #   # bad
       #   if condition

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       ^^^^^^^^^^^^ Avoid `if` branches without a body.
       end
     RUBY
+
+    expect_correction('')
   end
 
   it 'does not register an offense for missing `if` body with a comment' do
@@ -26,6 +28,14 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       elsif other_condition
       ^^^^^^^^^^^^^^^^^^^^^ Avoid `elsif` branches without a body.
       end
+      # comment outside scope
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if condition
+        do_something
+      end
+      # comment outside scope
     RUBY
   end
 
@@ -49,6 +59,14 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
         # noop
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      if condition
+        do_something
+      else
+        # noop
+      end
+    RUBY
   end
 
   it 'does not register an offense for missing `elsif` body with an inline comment' do
@@ -68,6 +86,8 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       ^^^^^^^^^^^^^^^^ Avoid `unless` branches without a body.
       end
     RUBY
+
+    expect_correction('')
   end
 
   it 'does not register an offense for missing `unless` body with a comment' do
@@ -88,6 +108,8 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
           # noop
         end
       RUBY
+
+      expect_correction('')
     end
 
     it 'registers an offense for missing `elsif` body with a comment' do
@@ -99,6 +121,12 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
           # noop
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        if condition
+          do_something
+        end
+      RUBY
     end
 
     it 'registers an offense for missing `unless` body with a comment' do
@@ -108,6 +136,8 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
           # noop
         end
       RUBY
+
+      expect_correction('')
     end
   end
 end


### PR DESCRIPTION
Hi!

I've recently inherited some really poor quality code and ran rubocop autocorrect on it. I noticed it changed code blocks like this:
```ruby
if condition
  do_something
else
  do_something
end
```
to

```ruby
if condition
end
do_something
```
which is sort of half way there :) So this is my attempt at improving it. I see no reason why we can't just remove those empty conditional blocks.
Curious to see what others think. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
