### PR TITLE
Update default max for Metrics/MethodLength

### DIFF
--- a/docs/modules/ROOT/pages/cops_metrics.adoc
+++ b/docs/modules/ROOT/pages/cops_metrics.adoc
@@ -363,7 +363,7 @@ end               # 5 points
 | Boolean
 
 | Max
-| `10`
+| `16`
 | Integer
 
 | CountAsOne


### PR DESCRIPTION
I updated the default method length for rule `Metrics/MethodLength` as I noticed it appeared to be out of date.

In a brand new project, without any modifications to the rule, an offense was detected:

```
Metrics/MethodLength: Method has too many lines. [17/16]
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
