### PR TITLE
[Fix #10189] Support --display-style-guide with -f offenses

### DIFF
--- a/changelog/fix_display-style-guide.md
+++ b/changelog/fix_display-style-guide.md
@@ -1,0 +1,1 @@
+* [#10189](https://github.com/rubocop/rubocop/issues/10189): Fix `--display-style-guide` so it works together with `--format offenses`. ([@jonas054][])

--- a/lib/rubocop/formatter/offense_count_formatter.rb
+++ b/lib/rubocop/formatter/offense_count_formatter.rb
@@ -17,6 +17,7 @@ module RuboCop
       def started(target_files)
         super
         @offense_counts = Hash.new(0)
+        @style_guide_links = {}
 
         return unless output.tty?
 
@@ -37,6 +38,9 @@ module RuboCop
 
       def file_finished(_file, offenses)
         offenses.each { |o| @offense_counts[o.cop_name] += 1 }
+        if options[:display_style_guide]
+          offenses.each { |o| @style_guide_links[o.cop_name] ||= o.message[/ \(http\S+\)\Z/] }
+        end
         @progressbar.increment if instance_variable_defined?(:@progressbar)
       end
 
@@ -52,7 +56,8 @@ module RuboCop
         output.puts
 
         per_cop_counts.each do |cop_name, count|
-          output.puts "#{count.to_s.ljust(total_count.to_s.length + 2)}#{cop_name}\n"
+          output.puts "#{count.to_s.ljust(total_count.to_s.length + 2)}#{cop_name}" \
+                      "#{@style_guide_links[cop_name]}\n"
         end
         output.puts '--'
         output.puts "#{total_count}  Total"


### PR DESCRIPTION
Up until now, a `--display-style-guide` given together with `--format offenses` has just been swallowed without affecting the output. This is probably not what users expect.

Let the `OffenseCountFormatter` retrieve style guide links by checking if `--display-style-guide` was given and then parse the offense messages.