### PR TITLE
[FIx #10356] Add `AllowConsecutiveConditionals` option to `Style/GuardClause`

### DIFF
--- a/changelog/change_add_option_for_guard_clause.md
+++ b/changelog/change_add_option_for_guard_clause.md
@@ -1,0 +1,1 @@
+* [#10356](https://github.com/rubocop/rubocop/issues/10356): Add `AllowConsecutiveConditionals` option to `Style/GuardClause` and the option is false by default. ([@ydah][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3634,10 +3634,11 @@ Style/GuardClause:
   StyleGuide: '#no-nested-conditionals'
   Enabled: true
   VersionAdded: '0.20'
-  VersionChanged: '0.22'
+  VersionChanged: <<next>>
   # `MinBodyLength` defines the number of lines of the a body of an `if` or `unless`
   # needs to have to trigger this cop
   MinBodyLength: 1
+  AllowConsecutiveConditionals: false
 
 Style/HashAsLastArrayItem:
   Description: >-

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -269,6 +269,63 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
     end
   end
 
+  context 'AllowConsecutiveConditionals: false' do
+    let(:cop_config) { { 'AllowConsecutiveConditionals' => false } }
+
+    it 'reports an offense when not allowed same depth multiple if statement and' \
+       'preceding expression is a conditional at the same depth' do
+      expect_offense(<<~RUBY)
+        def func
+          if foo?
+            work
+          end
+
+          if bar?
+          ^^ Use a guard clause (`return unless bar?`) instead of wrapping the code inside a conditional expression.
+            work
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'AllowConsecutiveConditionals: true' do
+    let(:cop_config) { { 'AllowConsecutiveConditionals' => true } }
+
+    it 'does not register an offense when allowed same depth multiple if statement and' \
+       'preceding expression is not a conditional at the same depth' do
+      expect_no_offenses(<<~RUBY)
+        def func
+          if foo?
+            work
+          end
+
+          if bar?
+            work
+          end
+        end
+      RUBY
+    end
+
+    it 'reports an offense when allowed same depth multiple if statement and' \
+       'preceding expression is not a conditional at the same depth' do
+      expect_offense(<<~RUBY)
+        def func
+          if foo?
+            work
+          end
+
+          do_something
+
+          if bar?
+          ^^ Use a guard clause (`return unless bar?`) instead of wrapping the code inside a conditional expression.
+            work
+          end
+        end
+      RUBY
+    end
+  end
+
   shared_examples 'on if nodes which exit current scope' do |kw|
     it "registers an error with #{kw} in the if branch" do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Resolve #10356

This PR add `AllowConsecutiveConditionals` option to `Style/GuardClause` and the option is false by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
