### PR TITLE
[Fix #10504] Fix a false positive for `Lint/UnusedMethodArgument`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_unused_method_argument.md
+++ b/changelog/fix_a_false_positive_for_lint_unused_method_argument.md
@@ -1,0 +1,1 @@
+* [#10504](https://github.com/rubocop/rubocop/issues/10504): Fix a false positive for `Lint/UnusedMethodArgument` when using `raise NotImplementedError` with optional arguments. ([@koic][])

--- a/lib/rubocop/cop/lint/unused_method_argument.rb
+++ b/lib/rubocop/cop/lint/unused_method_argument.rb
@@ -64,7 +64,7 @@ module RuboCop
 
         # @!method not_implemented?(node)
         def_node_matcher :not_implemented?, <<~PATTERN
-          {(send nil? :raise (const {nil? cbase} :NotImplementedError))
+          {(send nil? :raise (const {nil? cbase} :NotImplementedError) ...)
            (send nil? :fail ...)}
         PATTERN
 

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -466,6 +466,14 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       RUBY
     end
 
+    it 'accepts a method with a single unused parameter & raises NotImplementedError, message' do
+      expect_no_offenses(<<~RUBY)
+        def method(arg)
+          raise NotImplementedError, message
+        end
+      RUBY
+    end
+
     it 'accepts a method with a single unused parameter & raises ::NotImplementedError' do
       expect_no_offenses(<<~RUBY)
         def method(arg)


### PR DESCRIPTION
Fixes #10504.

This PR fixes a false positive for `Lint/UnusedMethodArgument` when using `raise NotImplementedError` with optional arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
