### PR TITLE
[Fix #10506] Fix an error for `Style/RaiseArgs`

### DIFF
--- a/changelog/fix_an_error_for_style_raise_args.md
+++ b/changelog/fix_an_error_for_style_raise_args.md
@@ -1,0 +1,1 @@
+* [#10506](https://github.com/rubocop/rubocop/issues/10506): Fix an error for `Style/RaiseArgs` when `raise` with `new` method without receiver. ([@koic][])

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -107,8 +107,7 @@ module RuboCop
 
           first_arg = node.first_argument
 
-          return unless first_arg.send_type? && first_arg.method?(:new)
-          return if acceptable_exploded_args?(first_arg.arguments)
+          return if !use_new_method?(first_arg) || acceptable_exploded_args?(first_arg.arguments)
 
           return if allowed_non_exploded_type?(first_arg)
 
@@ -118,6 +117,10 @@ module RuboCop
             corrector.replace(node, replacement)
             opposite_style_detected
           end
+        end
+
+        def use_new_method?(first_arg)
+          first_arg.send_type? && first_arg.receiver && first_arg.method?(:new)
         end
 
         def acceptable_exploded_args?(args)

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -320,5 +320,9 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
     it 'accepts a raise with msg argument' do
       expect_no_offenses('raise msg')
     end
+
+    it 'accepts a raise with `new` method without receiver' do
+      expect_no_offenses('raise new')
+    end
   end
 end


### PR DESCRIPTION
Fixes #10506.

This PR fixes an error for `Style/RaiseArgs` when `raise` with `new` method without receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
