### PR TITLE
[Fix#10191] Add `MaxChainLength` option to `Style/SafeNavigation`

### DIFF
--- a/changelog/change_add_option_for_safe_navigation.md
+++ b/changelog/change_add_option_for_safe_navigation.md
@@ -1,0 +1,1 @@
+* [#10191](https://github.com/rubocop/rubocop/issues/10191): Add `MaxChainLength` option to `Style/SafeNavigation` and the option is 2 by default. ([@ydah][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4656,7 +4656,7 @@ Style/SafeNavigation:
                   be `nil` or truthy, but never `false`.
   Enabled: true
   VersionAdded: '0.43'
-  VersionChanged: '0.77'
+  VersionChanged: <<next>>
   # Safe navigation may cause a statement to start returning `nil` in addition
   # to whatever it used to return.
   ConvertCodeThatCanStartToReturnNil: false
@@ -4667,6 +4667,8 @@ Style/SafeNavigation:
     - try
     - try!
   SafeAutoCorrect: false
+  # Maximum length of method chains for register an offense.
+  MaxChainLength: 2
 
 Style/Sample:
   Description: >-

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -871,6 +871,48 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
             RUBY
           end
 
+          context 'MaxChainLength: 1' do
+            let(:cop_config) { { 'MaxChainLength' => 1 } }
+
+            it 'registers an offense for an object check followed by 1 chained method calls' do
+              expect_offense(<<~RUBY, variable: variable)
+                %{variable} && %{variable}.one
+                ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+              RUBY
+
+              expect_correction(<<~RUBY)
+                #{variable}&.one
+              RUBY
+            end
+
+            it 'allows an object check followed by 2 chained method calls' do
+              expect_no_offenses(<<~RUBY)
+                #{variable} && #{variable}.one.two
+              RUBY
+            end
+          end
+
+          context 'MaxChainLength: 3' do
+            let(:cop_config) { { 'MaxChainLength' => 3 } }
+
+            it 'registers an offense for an object check followed by 3 chained method calls' do
+              expect_offense(<<~RUBY, variable: variable)
+                %{variable} && %{variable}.one.two.three
+                ^{variable}^^^^^{variable}^^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+              RUBY
+
+              expect_correction(<<~RUBY)
+                #{variable}&.one&.two&.three
+              RUBY
+            end
+
+            it 'allows an object check followed by 4 chained method calls' do
+              expect_no_offenses(<<~RUBY)
+                #{variable} && #{variable}.one.two.three.fore
+              RUBY
+            end
+          end
+
           context 'with Lint/SafeNavigationChain disabled' do
             let(:config) do
               RuboCop::Config.new('Lint/SafeNavigationChain' => {


### PR DESCRIPTION
Resolve #10191

This PR add `MaxChainLength` option to `Style/SafeNavigation` and the option is 2 by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
