### PR TITLE
[Fix #10510] Fix an error for `Style/SingleArgumentDig`

### DIFF
--- a/changelog/fix_an_error_for_style_single_argument_dig.md
+++ b/changelog/fix_an_error_for_style_single_argument_dig.md
@@ -1,0 +1,1 @@
+* [#10510](https://github.com/rubocop/rubocop/issues/10510): Fix an error for `Style/SingleArgumentDig` when using multiple `dig` in a method chain. ([@koic][])

--- a/lib/rubocop/cop/style/single_argument_dig.rb
+++ b/lib/rubocop/cop/style/single_argument_dig.rb
@@ -50,9 +50,13 @@ module RuboCop
 
           message = format(MSG, receiver: receiver, argument: argument, original: node.source)
           add_offense(node, message: message) do |corrector|
+            next if part_of_ignored_node?(node)
+
             correct_access = "#{receiver}[#{argument}]"
             corrector.replace(node, correct_access)
           end
+
+          ignore_node(node)
         end
       end
     end

--- a/spec/rubocop/cop/style/single_argument_dig_spec.rb
+++ b/spec/rubocop/cop/style/single_argument_dig_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe RuboCop::Cop::Style::SingleArgumentDig, :config do
       end
     end
 
+    context 'when using multiple `dig` in a method chain' do
+      it 'registers and corrects an offense' do
+        expect_offense(<<~RUBY)
+          data.dig(var1)[0].dig(var2)
+          ^^^^^^^^^^^^^^ Use `data[var1]` instead of `data.dig(var1)`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `data.dig(var1)[0][var2]` instead of `data.dig(var1)[0].dig(var2)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          data.dig(var1)[0][var2]
+        RUBY
+      end
+    end
+
     context 'when using dig with splat operator' do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #10510.

This PR fixes an error for `Style/SingleArgumentDig` when using multiple `dig` in a method chain.
And this is the same solution as #10461.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
