### PR TITLE
[Fix #10512] Fix a false positive for `Lint/ShadowingOuterLocalVariable` conditional statement and block variable

### DIFF
--- a/changelog/fix_a_false_positive_for_shadowing_outer_local_variable.md
+++ b/changelog/fix_a_false_positive_for_shadowing_outer_local_variable.md
@@ -1,0 +1,1 @@
+* [#10512](https://github.com/rubocop/rubocop/issues/10512): Fix a false positive for `Lint/ShadowingOuterLocalVariable` conditional statement and block variable. ([@ydah][])

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -67,9 +67,17 @@ module RuboCop
           variable_node = variable.scope.node.parent
           return false unless variable_node.conditional?
 
-          outer_local_variable_node = outer_local_variable.scope.node
+          outer_local_variable_node =
+            find_conditional_node_from_ascendant(outer_local_variable.declaration_node)
 
           outer_local_variable_node.conditional? && variable_node == outer_local_variable_node
+        end
+
+        def find_conditional_node_from_ascendant(node)
+          return unless (parent = node.parent)
+          return parent if parent.conditional?
+
+          find_conditional_node_from_ascendant(parent)
         end
       end
     end

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
   end
 
   context 'when a block local variable has same name as an outer scope variable' \
-          'with same branches of same `if` condition node' do
+          'with same branches of same `if` condition node not in the method definition' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         if condition?
@@ -72,6 +72,48 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
           end
         else
           bar.each do |foo|
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a block local variable has same name as an outer scope variable' \
+          'with same branches of same `if` condition node' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        def some_method
+          if condition?
+            foo = 1
+            puts foo
+            bar.each do |foo|
+                         ^^^ Shadowing outer local variable - `foo`.
+            end
+          else
+            bar.each do |foo|
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a block local variable has same name as an outer scope variable' \
+          'with same branches of same nested `if` condition node' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        def some_method
+          if condition?
+            foo = 1
+            puts foo
+            if other_condition?
+              bar.each do |foo|
+                           ^^^ Shadowing outer local variable - `foo`.
+              end
+            end
+          else
+            bar.each do |foo|
+            end
           end
         end
       RUBY
@@ -82,14 +124,16 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
           'with same branches of same `unless` condition node' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
-        unless condition?
-          foo = 1
-          puts foo
-          bar.each do |foo|
-                       ^^^ Shadowing outer local variable - `foo`.
-          end
-        else
-          bar.each do |foo|
+        def some_method
+          unless condition?
+            foo = 1
+            puts foo
+            bar.each do |foo|
+                         ^^^ Shadowing outer local variable - `foo`.
+            end
+          else
+            bar.each do |foo|
+            end
           end
         end
       RUBY
@@ -100,15 +144,17 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
           'with same branches of same `case` condition node' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
-        case condition
-        when foo then
-          foo = 1
-          puts foo
-          bar.each do |foo|
-                       ^^^ Shadowing outer local variable - `foo`.
-          end
-        else
-          bar.each do |foo|
+        def some_method
+          case condition
+          when foo then
+            foo = 1
+            puts foo
+            bar.each do |foo|
+                         ^^^ Shadowing outer local variable - `foo`.
+            end
+          else
+            bar.each do |foo|
+            end
           end
         end
       RUBY
@@ -119,10 +165,12 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
           'with different branches of same `if` condition node' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
-        if condition?
-          foo = 1
-        else
-          bar.each do |foo|
+        def some_method
+          if condition?
+            foo = 1
+          else
+            bar.each do |foo|
+            end
           end
         end
       RUBY
@@ -133,10 +181,12 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
           'with different branches of same `unless` condition node' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
-        unless condition?
-          foo = 1
-        else
-          bar.each do |foo|
+        def some_method
+          unless condition?
+            foo = 1
+          else
+            bar.each do |foo|
+            end
           end
         end
       RUBY
@@ -147,11 +197,13 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
           'with different branches of same `case` condition node' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
-        case condition
-        when foo then
-          foo = 1
-        else
-          bar.each do |foo|
+        def some_method
+          case condition
+          when foo then
+            foo = 1
+          else
+            bar.each do |foo|
+            end
           end
         end
       RUBY


### PR DESCRIPTION
Fix: #10512

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
