### PR TITLE
[Fix #10514] Fix an error for `Lint/EmptyConditionalBody`

### DIFF
--- a/changelog/fix_an_error_for_lint_empty_conditional_body.md
+++ b/changelog/fix_an_error_for_lint_empty_conditional_body.md
@@ -1,0 +1,1 @@
+* [#10514](https://github.com/rubocop/rubocop/issues/10514): Fix an error for `Lint/EmptyConditionalBody` when missing second `elsif` body. ([@koic][])

--- a/lib/rubocop/cop/mixin/comments_help.rb
+++ b/lib/rubocop/cop/mixin/comments_help.rb
@@ -46,17 +46,19 @@ module RuboCop
       # Returns the end line of a node, which might be a comment and not part of the AST
       # End line is considered either the line at which another node starts, or
       # the line at which the parent node ends.
+      # rubocop:disable Metrics/AbcSize
       def find_end_line(node)
         if node.if_type? && node.loc.else
           node.loc.else.line
         elsif (next_sibling = node.right_sibling)
           next_sibling.loc.line
         elsif (parent = node.parent)
-          parent.loc.end.line
+          parent.loc.end ? parent.loc.end.line : parent.loc.line
         else
           node.loc.end.line
         end
       end
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -62,6 +62,18 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     RUBY
   end
 
+  it 'registers an offense for missing second `elsif` body without an inline comment' do
+    expect_offense(<<~RUBY)
+      if foo
+        do_foo
+      elsif bar
+        do_bar
+      elsif baz
+      ^^^^^^^^^ Avoid `elsif` branches without a body.
+      end
+    RUBY
+  end
+
   it 'registers an offense for missing `unless` body' do
     expect_offense(<<~RUBY)
       unless condition


### PR DESCRIPTION
Fixes #10514.

This PR fixes an error for `Lint/EmptyConditionalBody` when missing second `elsif` body.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
