### PR TITLE
Fix typo for Gemspec/DateAssignment examples

### DIFF
--- a/docs/modules/ROOT/pages/cops_gemspec.adoc
+++ b/docs/modules/ROOT/pages/cops_gemspec.adoc
@@ -21,13 +21,13 @@ It is set automatically when the gem is packaged.
 ----
 # bad
 Gem::Specification.new do |spec|
-  s.name = 'your_cool_gem_name'
+  spec.name = 'your_cool_gem_name'
   spec.date = Time.now.strftime('%Y-%m-%d')
 end
 
 # good
 Gem::Specification.new do |spec|
-  s.name = 'your_cool_gem_name'
+  spec.name = 'your_cool_gem_name'
 end
 ----
 

--- a/lib/rubocop/cop/gemspec/date_assignment.rb
+++ b/lib/rubocop/cop/gemspec/date_assignment.rb
@@ -10,13 +10,13 @@ module RuboCop
       #
       #   # bad
       #   Gem::Specification.new do |spec|
-      #     s.name = 'your_cool_gem_name'
+      #     spec.name = 'your_cool_gem_name'
       #     spec.date = Time.now.strftime('%Y-%m-%d')
       #   end
       #
       #   # good
       #   Gem::Specification.new do |spec|
-      #     s.name = 'your_cool_gem_name'
+      #     spec.name = 'your_cool_gem_name'
       #   end
       #
       class DateAssignment < Base


### PR DESCRIPTION
This PR fixes typo for Gemspec/DateAssignment examples.
- Variable names are corrected from `s` to `spec`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
