### PR TITLE
[Fix #10469] Fix code length calculation when kwargs written in single line

### DIFF
--- a/changelog/fix_code_length_calculation_when_kwargs_written_in_single_line.md
+++ b/changelog/fix_code_length_calculation_when_kwargs_written_in_single_line.md
@@ -1,0 +1,1 @@
+* [#10469](https://github.com/rubocop/rubocop/issues/10469): Fix code length calculation when kwargs written in single line. ([@nobuyo][])

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -31,7 +31,7 @@ module RuboCop
               descendant_length = code_length(descendant)
               length = length - descendant_length + 1
               # Subtract 2 length of opening and closing brace if method argument omits hash braces.
-              length -= 2 if descendant.hash_type? && !descendant.braces?
+              length -= 2 if descendant.hash_type? && !descendant.braces? && descendant.multiline?
             end
 
             length

--- a/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
@@ -97,6 +97,17 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::CodeLengthCalculator do
         expect(length).to eq(2)
       end
 
+      it 'counts single line correctly if asked folding' do
+        source = parse_source(<<~RUBY)
+          def test
+            foo(foo: :bar, baz: :quux)
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, foldable_types: %i[hash]).calculate
+        expect(length).to eq(1)
+      end
+
       it 'folds hashes as method kwargs if asked' do
         source = parse_source(<<~RUBY)
           def test


### PR DESCRIPTION
Fixes #10469.

This PR fixes a wrong calculation for code length of kwargs at single line when asked folding.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
