### PR TITLE
[Fix #10280] Add `AllowComments` option to `Style/SymbolProc`

### DIFF
--- a/changelog/change_add_option_for_symbol_proc.md
+++ b/changelog/change_add_option_for_symbol_proc.md
@@ -1,0 +1,1 @@
+* [#10280](https://github.com/rubocop/rubocop/issues/10280): Add `AllowComments` option to `Style/SymbolProc` and the option is false by default. ([@ydah][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4909,13 +4909,14 @@ Style/SymbolProc:
   Enabled: true
   Safe: false
   VersionAdded: '0.26'
-  VersionChanged: '1.5'
+  VersionChanged: <<next>>
   AllowMethodsWithArguments: false
   # A list of method names to be ignored by the check.
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
   IgnoredMethods:
     - respond_to
     - define_method
+  AllowComments: false
 
 Style/TernaryParentheses:
   Description: 'Checks for use of parentheses around ternary conditions.'

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -191,6 +191,56 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
     end
   end
 
+  context 'AllowComments: true' do
+    let(:cop_config) { { 'AllowComments' => true } }
+
+    it 'registers an offense for a block with parameterless method call on param' \
+       'and not contains a comment' do
+      expect_offense(<<~RUBY)
+        # comment a
+        something do |e|
+                  ^^^^^^ Pass `&:upcase` as an argument to `something` instead of a block.
+          e.upcase
+        end # comment b
+        # comment c
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # comment a
+        something(&:upcase) # comment b
+        # comment c
+      RUBY
+    end
+
+    it 'accepts block with parameterless method call on param and contains a comment' do
+      expect_no_offenses(<<~RUBY)
+        something do |e| # comment
+          e.upcase
+        end
+      RUBY
+
+      expect_no_offenses(<<~RUBY)
+        something do |e|
+          # comment
+          e.upcase
+        end
+      RUBY
+
+      expect_no_offenses(<<~RUBY)
+        something do |e|
+          e.upcase # comment
+        end
+      RUBY
+
+      expect_no_offenses(<<~RUBY)
+        something do |e|
+          e.upcase
+          # comment
+        end
+      RUBY
+    end
+  end
+
   context 'when `super` has no arguments' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Resolve: https://github.com/rubocop/rubocop/issues/10280

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
