### PR TITLE
[Fix #10524] Mark `Style/RedundantInitialize` as unsafe

### DIFF
--- a/changelog/change_mark_unsafe_for_style_redundant_initialize.md
+++ b/changelog/change_mark_unsafe_for_style_redundant_initialize.md
@@ -1,0 +1,1 @@
+* [#10524](https://github.com/rubocop/rubocop/issues/10524): Mark `Style/RedundantInitialize` as unsafe. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4539,7 +4539,9 @@ Style/RedundantFreeze:
 Style/RedundantInitialize:
   Description: 'Checks for redundant `initialize` methods.'
   Enabled: pending
+  Safe: false
   VersionAdded: '1.27'
+  VersionChanged: '<<next>>'
 
 Style/RedundantInterpolation:
   Description: 'Checks for strings that are just an interpolated expression.'

--- a/lib/rubocop/cop/style/redundant_initialize.rb
+++ b/lib/rubocop/cop/style/redundant_initialize.rb
@@ -18,6 +18,10 @@ module RuboCop
       # to purposely create an empty `initialize` method to override a superclass's
       # initializer.
       #
+      # @safety
+      #   This cop is unsafe because if subclass overrides `initialize` method with
+      #   a different arity than superclass.
+      #
       # @example
       #   # bad
       #   def initialize


### PR DESCRIPTION
Fixes #10524.

This PR marks `Style/RedundantInitialize` as unsafe because if subclass overrides `initialize` method with a different arity than superclass.

```ruby
class Base
  def initialize
  end
end

class Derived < Base
  def initialize(arg)
  end
end

Derived.new(arg) # Requires one argument.
```

Therefore, the following is a false positive.

```console
% bundle exec rubocop example.rb --only Style/RedundantInitialize
Inspecting 1 file
C

Offenses:

example.rb:8:3: C: Style/RedundantInitialize: Remove unnecessary empty initialize method.
  def initialize(a) ...
  ^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

The same can be said for Module mix-in, which cannot be determined by static analysis.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
