### PR TITLE
[Fix #10530] Fix a false positive for `Style/RedundantRegexpCharacterClass`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_regexp_character_class.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_regexp_character_class.md
@@ -1,0 +1,1 @@
+* [#10530](https://github.com/rubocop/rubocop/issues/10530): Fix a false positive for `Style/RedundantRegexpCharacterClass` when using regexp character class with a character class containing multiple unicode code-points. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_regexp_character_class.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_character_class.rb
@@ -63,6 +63,7 @@ module RuboCop
             next if expr.type != :set || expr.expressions.size != 1
             next if expr.negative?
             next if %i[set posixclass nonposixclass].include?(expr.expressions.first.type)
+            next if multiple_codepoins?(expr.expressions.first)
 
             yield expr
           end
@@ -77,6 +78,10 @@ module RuboCop
             requires_escape_outside_char_class?(class_elem)
 
           !non_redundant
+        end
+
+        def multiple_codepoins?(expression)
+          expression.respond_to?(:codepoints) && expression.codepoints.count >= 2
         end
 
         def without_character_class(loc)

--- a/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
@@ -239,6 +239,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpCharacterClass, :config do
     end
   end
 
+  context 'with a character class containing multiple unicode code-points' do
+    it 'does not register an offense and corrects' do
+      expect_no_offenses(<<~'RUBY')
+        foo = /[\u{0061 0062}]/
+      RUBY
+    end
+  end
+
   context 'with a character class containing a single unicode character property' do
     it 'registers an offense and corrects' do
       expect_offense(<<~'RUBY')


### PR DESCRIPTION
Fixes #10530.

This PR fixes a false positive for `Style/RedundantRegexpCharacterClass` when using regexp character class with a character class containing multiple unicode code-points.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
