### PR TITLE
[Fix #10529] Fix autocorrect for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_autocorrect_for_style_sole_nested_confitional.md
+++ b/changelog/fix_autocorrect_for_style_sole_nested_confitional.md
@@ -1,0 +1,1 @@
+* [#10529](https://github.com/rubocop/rubocop/issues/10529): Fix autocorrect for `Style/SoleNestedConditional` causes logical error when using a outer condition of method call by omitting parentheses for method arguments. ([@nobuyo][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -110,9 +110,12 @@ module RuboCop
         def autocorrect_outer_condition_basic(corrector, node, if_branch)
           correct_from_unless_to_if(corrector, node) if node.unless?
 
+          outer_condition = node.condition
+          correct_outer_condition(corrector, outer_condition)
+
           and_operator = if_branch.unless? ? ' && !' : ' && '
           if if_branch.modifier_form?
-            correct_for_guard_condition_style(corrector, node, if_branch, and_operator)
+            correct_for_guard_condition_style(corrector, outer_condition, if_branch, and_operator)
           else
             correct_for_basic_condition_style(corrector, node, if_branch, and_operator)
             correct_for_comment(corrector, node, if_branch)
@@ -136,10 +139,7 @@ module RuboCop
           end
         end
 
-        def correct_for_guard_condition_style(corrector, node, if_branch, and_operator)
-          outer_condition = node.condition
-          correct_outer_condition(corrector, outer_condition)
-
+        def correct_for_guard_condition_style(corrector, outer_condition, if_branch, and_operator)
           condition = if_branch.condition
           corrector.insert_after(outer_condition, "#{and_operator}#{replace_condition(condition)}")
 
@@ -177,7 +177,7 @@ module RuboCop
         end
 
         def correct_outer_condition(corrector, condition)
-          return unless requrie_parentheses?(condition)
+          return unless require_parentheses?(condition)
 
           end_pos = condition.loc.selector.end_pos
           begin_pos = condition.first_argument.source_range.begin_pos
@@ -187,7 +187,7 @@ module RuboCop
           corrector.insert_after(condition.last_argument.source_range, ')')
         end
 
-        def requrie_parentheses?(condition)
+        def require_parentheses?(condition)
           condition.send_type? && !condition.arguments.empty? && !condition.parenthesized? &&
             !condition.comparison_method?
         end

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -348,6 +348,24 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects for multiple nested conditionals with using method call outer condition by omitting parentheses' do
+    expect_offense(<<~RUBY)
+      if foo.is_a? Foo
+        if bar && baz
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something if quux
+                       ^^ Consider merging nested conditions into outer `if` conditions.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo.is_a?(Foo) && (bar && baz) && quux
+          do_something
+        end
+    RUBY
+  end
+
   context 'when disabling `Style/IfUnlessModifier`' do
     let(:config) { RuboCop::Config.new('Style/IfUnlessModifier' => { 'Enabled' => false }) }
 


### PR DESCRIPTION
Fixes #10529

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
