### PR TITLE
[Fix #10528] Fix an infinite loop at autocorrect for `Layout/CaseIndentation`

### DIFF
--- a/changelog/fix_an_error_for_alignment.md
+++ b/changelog/fix_an_error_for_alignment.md
@@ -1,0 +1,1 @@
+* [#10528](https://github.com/rubocop/rubocop/issues/10528): Fix an infinite loop at autocorrect for `Layout/CaseIndentation`. ([@ydah][])

--- a/lib/rubocop/cop/layout/case_indentation.rb
+++ b/lib/rubocop/cop/layout/case_indentation.rb
@@ -119,17 +119,33 @@ module RuboCop
 
         def on_case(case_node)
           return if case_node.single_line?
+          return if enforced_style_end? && end_and_last_conditional_same_line?(case_node)
 
           case_node.each_when { |when_node| check_when(when_node, 'when') }
         end
 
         def on_case_match(case_match_node)
           return if case_match_node.single_line?
+          return if enforced_style_end? && end_and_last_conditional_same_line?(case_match_node)
 
           case_match_node.each_in_pattern { |in_pattern_node| check_when(in_pattern_node, 'in') }
         end
 
         private
+
+        def end_and_last_conditional_same_line?(node)
+          end_line = node.loc.end&.line
+          last_conditional_line = if node.loc.else
+                                    node.loc.else.line
+                                  else
+                                    node.child_nodes.last.loc.begin&.line
+                                  end
+          end_line && last_conditional_line && end_line == last_conditional_line
+        end
+
+        def enforced_style_end?
+          cop_config[style_parameter_name] == 'end'
+        end
 
         def check_when(when_node, branch_type)
           when_column = when_node.loc.keyword.column

--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -608,6 +608,27 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
           end
         end
 
+        context '`else` and `end` same line' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              case variable
+              when 'value1'
+              when 'value2'
+              else 'value3' end
+            RUBY
+          end
+        end
+
+        context '`when` and `end` same line' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              case variable
+              when 'value1' then 'then1'
+              when 'value2' then 'then2' end
+            RUBY
+          end
+        end
+
         context 'regarding assignment where the right hand side is a `case`' do
           it 'accepts a correctly indented assignment' do
             expect_no_offenses(<<~RUBY)
@@ -647,6 +668,16 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
         context 'with everything on a single line' do
           it 'does not register an offense' do
             expect_no_offenses('case foo; in pattern then 1; else 0; end')
+          end
+        end
+
+        context '`in` and `end` same line' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              case variable
+              in pattern then 'output1'
+              in pattern then 'output2' end
+            RUBY
           end
         end
 


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/10528

The following rubocop.yml and run rubocop, resulted in an infinite loop.

```
Layout/BeginEndAlignment:
  EnforcedStyleAlignWith: start_of_line
  AutoCorrect: true

Layout/CaseIndentation:
  EnforcedStyle: end
```

This doesn’t always occur, but only in edge cases.
This occurs when `when` and `end` are on the same line, as in the following code:

```
# frozen_string_literal: true

case thing
when 3 then 1
when 2 then 2
else 3 end
```
This means that if `Layout/CaseIndentation` is `EnforcedStyle: end` and `when` or `else` is on the same line as `end`, it will try to adjust the indentation of `else` or `end` to match that of `end`, but will not Because they are on the same line, the indentation adjustment will run many times.
So, if `when` or `else` is on the same line as `end` and `Layout/CaseIndentation` is `EnforcedStyle: end`, do not make auto-correction.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
