### PR TITLE
[Fix #10481] Add command-line options to return only correctable offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,6 +90,7 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Exclude:
     - lib/rubocop/config_obsoletion.rb
+    - lib/rubocop/options.rb
 
 Metrics/ModuleLength:
   Exclude:

--- a/changelog/new_add_command_line_options.md
+++ b/changelog/new_add_command_line_options.md
@@ -1,0 +1,1 @@
+* [#10481](https://github.com/rubocop/rubocop/issues/10481): Add command line options `--display-only-correctable` and `--display-only-safe-correctable`. ([@nobuyo][])

--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -163,7 +163,13 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | Displays cop names in offense messages. Default is true.
 
 | `--display-only-fail-level-offenses`
-| Only output offense messages at the specified `--fail-level` or above
+| Only output offense messages at the specified `--fail-level` or above.
+
+| `--display-only-correctable`
+| Only output correctable offense messages.
+
+| `--display-only-safe-correctable`
+| Only output safe correctable offense messages.
 
 | `--enable-pending-cops`
 | Run with pending cops.

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -123,6 +123,8 @@ module RuboCop
         option(opts, '--display-time')
         option(opts, '--display-only-failed')
         option(opts, '--display-only-fail-level-offenses')
+        option(opts, '--display-only-correctable')
+        option(opts, '--display-only-safe-correctable')
       end
     end
 
@@ -310,9 +312,12 @@ module RuboCop
         raise OptionArgumentError, '--autocorrect cannot be used with ' \
                                    '--display-only-fail-level-offenses'
       end
+
       validate_auto_gen_config
       validate_auto_correct
       validate_display_only_failed
+      validate_display_only_failed_and_display_only_correctable
+      validate_display_only_correctable_and_auto_correct
       disable_parallel_when_invalid_option_combo
 
       return if incompatible_options.size <= 1
@@ -340,6 +345,24 @@ module RuboCop
 
       raise OptionArgumentError,
             format('--display-only-failed can only be used together with --format junit.')
+    end
+
+    def validate_display_only_correctable_and_auto_correct
+      return if !@options.key?(:safe_auto_correct) && !@options.key?(:auto_correct)
+      return if !@options.key?(:display_only_correctable) &&
+                !@options.key?(:display_only_safe_correctable)
+
+      raise OptionArgumentError,
+            '--auto-correct cannot be used with --display-only-[safe-]correctable.'
+    end
+
+    def validate_display_only_failed_and_display_only_correctable
+      return unless @options.key?(:display_only_failed)
+      return if !@options.key?(:display_only_correctable) &&
+                !@options.key?(:display_only_safe_correctable)
+
+      raise OptionArgumentError,
+            format('--display-only-failed cannot be used together with other display options.')
     end
 
     def validate_auto_correct
@@ -481,6 +504,9 @@ module RuboCop
       display_only_fail_level_offenses:
                                         ['Only output offense messages at',
                                          'the specified --fail-level or above'],
+      display_only_correctable:         ['Only output correctable offense messages.'],
+      display_only_safe_correctable:    ['Only output safe-correctable offense messages',
+                                         'when combined with --display-only-correctable.'],
       show_cops:                        ['Shows the given cops, or all cops by',
                                          'default, and their configurations for the',
                                          'current directory.'],

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -120,6 +120,10 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                   --display-only-fail-level-offenses
                                                Only output offense messages at
                                                the specified --fail-level or above
+                  --display-only-correctable   Only output correctable offense messages.
+                  --display-only-safe-correctable
+                                               Only output safe-correctable offense messages
+                                               when combined with --display-only-correctable.
 
           Auto-correction:
               -a, --auto-correct               Auto-correct offenses (only when it's safe).
@@ -282,6 +286,20 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       it 'works if given with --format junit' do
         expect { options.parse %w[--format junit --display-only-failed] }
           .not_to raise_error(RuboCop::OptionArgumentError)
+      end
+    end
+
+    describe '--display-only-correctable' do
+      it 'fails if given with --display-only-failed' do
+        expect { options.parse %w[--display-only-correctable --display-only-failed] }
+          .to raise_error(RuboCop::OptionArgumentError)
+      end
+
+      it 'fails if given with --auto-correct' do
+        %w[--auto-correct -a --auto-correct-all -A].each do |o|
+          expect { options.parse ['--display-only-correctable', o] }
+            .to raise_error(RuboCop::OptionArgumentError)
+        end
       end
     end
 


### PR DESCRIPTION
Resolves #10481.

Added `--display-only-correctable` and `--display-only-safe-correctable` requested by the issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
