### PR TITLE
Fix an incorrect auto-correct for `Style/MultilineTernaryOperator`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_multiline_ternary_operator.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_multiline_ternary_operator.md
@@ -1,0 +1,1 @@
+* [#10537](https://github.com/rubocop/rubocop/pull/10537): Fix an incorrect auto-correct for `Style/MultilineTernaryOperator` when returning a multiline ternary operator expression with `break`, `next`, or method call. ([@koic][])

--- a/lib/rubocop/cop/style/multiline_ternary_operator.rb
+++ b/lib/rubocop/cop/style/multiline_ternary_operator.rb
@@ -6,7 +6,8 @@ module RuboCop
       # This cop checks for multi-line ternary op expressions.
       #
       # NOTE: `return if ... else ... end` is syntax error. If `return` is used before
-      # multiline ternary operator expression, it cannot be auto-corrected.
+      # multiline ternary operator expression, it will be auto-corrected to single-line
+      # ternary operator. The same is true for `break`, `next`, and method call.
       #
       # @example
       #   # bad
@@ -18,6 +19,10 @@ module RuboCop
       #       b :
       #       c
       #
+      #   return cond ?
+      #          b :
+      #          c
+      #
       #   # good
       #   a = cond ? b : c
       #   a = if cond
@@ -25,20 +30,39 @@ module RuboCop
       #   else
       #     c
       #   end
+      #
+      #   return cond ? b : c
+      #
       class MultilineTernaryOperator < Base
         extend AutoCorrector
 
-        MSG = 'Avoid multi-line ternary operators, use `if` or `unless` instead.'
+        MSG_IF = 'Avoid multi-line ternary operators, use `if` or `unless` instead.'
+        MSG_SINGLE_LINE = 'Avoid multi-line ternary operators, use single-line instead.'
+        SINGLE_LINE_TYPES = %i[return break next send].freeze
 
         def on_if(node)
           return unless offense?(node)
 
-          add_offense(node) do |corrector|
-            # `return if ... else ... end` is syntax error. If `return` is used before
-            # multiline ternary operator expression, it cannot be auto-corrected.
-            next unless offense?(node) && !node.parent.return_type?
+          message = enforce_single_line_ternary_operator?(node) ? MSG_SINGLE_LINE : MSG_IF
 
-            corrector.replace(node, <<~RUBY.chop)
+          add_offense(node, message: message) do |corrector|
+            next unless offense?(node)
+
+            corrector.replace(node, replacement(node))
+          end
+        end
+
+        private
+
+        def offense?(node)
+          node.ternary? && node.multiline?
+        end
+
+        def replacement(node)
+          if enforce_single_line_ternary_operator?(node)
+            "#{node.condition.source} ? #{node.if_branch.source} : #{node.else_branch.source}"
+          else
+            <<~RUBY.chop
               if #{node.condition.source}
                 #{node.if_branch.source}
               else
@@ -48,10 +72,8 @@ module RuboCop
           end
         end
 
-        private
-
-        def offense?(node)
-          node.ternary? && node.multiline?
+        def enforce_single_line_ternary_operator?(node)
+          SINGLE_LINE_TYPES.include?(node.parent.type)
         end
       end
     end

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -51,15 +51,56 @@ RSpec.describe RuboCop::Cop::Style::MultilineTernaryOperator, :config do
     RUBY
   end
 
-  it 'register an offense and does not auto-correct when returning a multiline ternary operator expression' do
+  it 'register an offense and corrects when returning a multiline ternary operator expression with `return`' do
     expect_offense(<<~RUBY)
       return cond ?
-             ^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
+             ^^^^^^ Avoid multi-line ternary operators, use single-line instead.
              foo :
              bar
     RUBY
 
-    expect_no_corrections
+    expect_correction(<<~RUBY)
+      return cond ? foo : bar
+    RUBY
+  end
+
+  it 'register an offense and corrects when returning a multiline ternary operator expression with `break`' do
+    expect_offense(<<~RUBY)
+      break cond ?
+            ^^^^^^ Avoid multi-line ternary operators, use single-line instead.
+            foo :
+            bar
+    RUBY
+
+    expect_correction(<<~RUBY)
+      break cond ? foo : bar
+    RUBY
+  end
+
+  it 'register an offense and corrects when returning a multiline ternary operator expression with `next`' do
+    expect_offense(<<~RUBY)
+      next cond ?
+           ^^^^^^ Avoid multi-line ternary operators, use single-line instead.
+           foo :
+           bar
+    RUBY
+
+    expect_correction(<<~RUBY)
+      next cond ? foo : bar
+    RUBY
+  end
+
+  it 'register an offense and corrects when returning a multiline ternary operator expression with method call' do
+    expect_offense(<<~RUBY)
+      do_something cond ?
+                   ^^^^^^ Avoid multi-line ternary operators, use single-line instead.
+                   foo :
+                   bar
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something cond ? foo : bar
+    RUBY
   end
 
   it 'accepts a single line ternary operator expression' do


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/8661.

This PR fixes an incorrect auto-correct for `Style/MultilineTernaryOperator` when returning a multiline ternary operator expression. Using `break`, `next`, or method call also causes the same syntax error as `return`.
And this PR will change these auto-correct to single-line ternary operator as valid syntax.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
