### PR TITLE
Add new MaxAllowedLettersBeforeNumber option to Naming/VariableNumber snake_case

### DIFF
--- a/changelog/new_add_new_option_to_namingvariablenumber.md
+++ b/changelog/new_add_new_option_to_namingvariablenumber.md
@@ -1,0 +1,1 @@
+* [#10539](https://github.com/rubocop/rubocop/issues/10539): Add new MaxAllowedLettersBeforeNumber option to Naming/VariableNumber snake_case. ([@henrahmagix][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2787,6 +2787,7 @@ Naming/VariableNumber:
     - rfc822       # Time#rfc822
     - rfc2822      # Time#rfc2822
     - rfc3339      # DateTime.rfc3339
+  MaxAllowedLettersBeforeNumber: 0
 
 #################### Security ##############################
 

--- a/lib/rubocop/cop/naming/variable_number.rb
+++ b/lib/rubocop/cop/naming/variable_number.rb
@@ -102,6 +102,19 @@ module RuboCop
 
         MSG = 'Use %<style>s for %<identifier_type>s numbers.'
 
+        def max_allowed_letters_before_number
+          cop_config.fetch('MaxAllowedLettersBeforeNumber', 0)
+        end
+
+        def valid_name?(node, name, given_style = style)
+          return true if super
+
+          return false unless given_style == :snake_case
+          return false unless max_allowed_letters_before_number.to_i.positive?
+
+          name.match?(/(?:_|\b)\D{0,#{max_allowed_letters_before_number}}\d+\z/)
+        end
+
         def on_arg(node)
           @node = node
           name, = *node


### PR DESCRIPTION
Fix #10539 

Adds a new integer option called `MaxAllowedLettersBeforeNumber` to
allow a positive number of non-digits before the digits in a snake_case
style that would otherwise require separation between them, e.g. `_v1`.

-----------------

I wasn't sure how to update [docs/modules/ROOT/pages/cops_naming.adoc](docs/modules/ROOT/pages/cops_naming.adoc) to include this new option – it looks like it should go there, but I'm not familiar with the format and I wasn't sure how to explain this option that only applies to `Naming/VariableNumber` and not the other naming cops that have share config.

Just made this to get the ball rolling on #10539 (and make it more likely to be actioned =D), but I don't mind if it's not wanted, it's no sweat =)
