### PR TITLE
Fix an incorrect autocorrect for `Style/SpecialGlobalVars`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_special_global_vars.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_special_global_vars.md
@@ -1,0 +1,1 @@
+* [#10541](https://github.com/rubocop/rubocop/pull/10541): Fix an incorrect autocorrect for `Style/SpecialGlobalVars` when global variable as Perl name is used multiple times. ([@koic][])

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -145,6 +145,11 @@ module RuboCop
 
         LIBRARY_NAME = 'English'
 
+        def on_new_investigation
+          super
+          @required_english = false
+        end
+
         def on_gvar(node)
           global_var, = *node
 
@@ -172,7 +177,11 @@ module RuboCop
         def autocorrect(corrector, node, global_var)
           node = node.parent while node.parent&.begin_type? && node.parent.children.one?
 
-          ensure_required(corrector, node, LIBRARY_NAME) if should_require_english?(global_var)
+          if should_require_english?(global_var)
+            ensure_required(corrector, node, LIBRARY_NAME)
+
+            @required_english = true
+          end
 
           corrector.replace(node, replacement(node, global_var))
         end
@@ -243,6 +252,7 @@ module RuboCop
         def should_require_english?(global_var)
           style == :use_english_names &&
             add_require_english? &&
+            !@required_english &&
             !NON_ENGLISH_VARS.include?(preferred_names(global_var).first)
         end
       end

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -170,6 +170,25 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
           RUBY
         end
 
+        it 'adds require English for twice `$*` in nested code' do
+          expect_offense(<<~RUBY)
+            # frozen_string_literal: true
+
+            puts $*[0]
+                 ^^ Prefer `$ARGV` from the stdlib 'English' module (don't forget to require it) or `ARGV` over `$*`.
+            puts $*[1]
+                 ^^ Prefer `$ARGV` from the stdlib 'English' module (don't forget to require it) or `ARGV` over `$*`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            # frozen_string_literal: true
+
+            require 'English'
+            puts $ARGV[0]
+            puts $ARGV[1]
+          RUBY
+        end
+
         it 'does not add for replacement outside of English lib' do
           expect_offense(<<~RUBY)
             puts $0


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for `Style/SpecialGlobalVars` when global variable as Perl name is used multiple times.

Example:

```ruby
% cat example.rb
$*[0]
$*[1]

% bundle exec rubocop --only Style/SpecialGlobalVars -A
Inspecting 3 files
.C.

Offenses:

example.rb:1:1: C: [Corrected] Style/SpecialGlobalVars: Prefer $ARGV
from the stdlib 'English' module (don't forget to require it) or ARGV
over $*.
$*[0]
^^
example.rb:2:1: C: [Corrected] Style/SpecialGlobalVars: Prefer $ARGV
from the stdlib 'English' module (don't forget to require it) or ARGV
over $*.
$*[1]
^^

3 files inspected, 2 offenses detected, 2 offenses corrected
```

This auto-correction will add `require 'English'` twice:

```ruby
% cat example.rb
require 'English'
require 'English'
$ARGV[0]
$ARGV[1]
```

This PR ensures that `require 'English'` is added only once:

```ruby
% cat example.rb
require 'English'
$ARGV[0]
$ARGV[1]
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
