### PR TITLE
Fix incorrect code length calculations for few more patterns

### DIFF
--- a/changelog/fix_incorrect_code_length_calculations.md
+++ b/changelog/fix_incorrect_code_length_calculations.md
@@ -1,0 +1,1 @@
+* [#10543](https://github.com/rubocop/rubocop/pull/10543): Fix incorrect code length calculation for few more patterns of hash folding asked. ([@nobuyo][])

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -30,8 +30,8 @@ module RuboCop
 
               descendant_length = code_length(descendant)
               length = length - descendant_length + 1
-              # Subtract 2 length of opening and closing brace if method argument omits hash braces.
-              length -= 2 if descendant.hash_type? && !descendant.braces? && descendant.multiline?
+              # Subtract length of opening and closing brace if method argument omits hash braces.
+              length -= omit_length(descendant) if descendant.hash_type? && !descendant.braces?
             end
 
             length
@@ -152,6 +152,20 @@ module RuboCop
 
           def count_comments?
             @count_comments
+          end
+
+          def omit_length(descendant)
+            parent = descendant.parent
+            return 0 if another_args?(parent)
+
+            [
+              parent.loc.begin.end_pos != descendant.loc.expression.begin_pos,
+              parent.loc.end.begin_pos != descendant.loc.expression.end_pos
+            ].count(true)
+          end
+
+          def another_args?(node)
+            node.call_type? && node.arguments.count > 1
           end
         end
       end

--- a/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
@@ -97,6 +97,56 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::CodeLengthCalculator do
         expect(length).to eq(2)
       end
 
+      it 'folds multiline hashes without braces as method args if asked' do
+        source = parse_source(<<~RUBY)
+          def test
+            foo(foo: :bar,
+              baz: :quux)
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, foldable_types: %i[hash]).calculate
+        expect(length).to eq(1)
+      end
+
+      it 'folds multiline hashes with line break after it as method args if asked' do
+        source = parse_source(<<~RUBY)
+          def test
+            foo(foo: :bar,
+              baz: :quux
+            )
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, foldable_types: %i[hash]).calculate
+        expect(length).to eq(1)
+      end
+
+      it 'folds multiline hashes with line break before it as method args if asked' do
+        source = parse_source(<<~RUBY)
+          def test
+            foo(
+              foo: :bar,
+              baz: :quux)
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, foldable_types: %i[hash]).calculate
+        expect(length).to eq(1)
+      end
+
+      it 'folds hashes without braces as the one of method args if asked' do
+        source = parse_source(<<~RUBY)
+          def test
+            foo(foo, foo: :bar,
+              baz: :quux)
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, foldable_types: %i[hash]).calculate
+        expect(length).to eq(1)
+      end
+
       it 'counts single line correctly if asked folding' do
         source = parse_source(<<~RUBY)
           def test
@@ -106,6 +156,75 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::CodeLengthCalculator do
 
         length = described_class.new(source.ast, source, foldable_types: %i[hash]).calculate
         expect(length).to eq(1)
+      end
+
+      it 'counts single line hash with line breaks correctly if asked folding' do
+        source = parse_source(<<~RUBY)
+          def test
+            foo(
+              foo: :bar, baz: :quux
+            )
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, foldable_types: %i[hash]).calculate
+        expect(length).to eq(1)
+      end
+
+      it 'folds hashes with comment if asked' do
+        source = parse_source(<<~RUBY)
+          def test
+            foo(
+              # foo: :bar,
+              baz: :quux
+            )
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, foldable_types: %i[hash]).calculate
+        expect(length).to eq(1)
+      end
+
+      it 'counts single line hash as the one of method args if asked folding' do
+        source = parse_source(<<~RUBY)
+          def test
+            foo(
+              bar,
+              baz: :quux
+            )
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, foldable_types: %i[hash]).calculate
+        expect(length).to eq(4)
+      end
+
+      it 'counts single line hash as the one of method args with safe navigation operator if asked folding' do
+        source = parse_source(<<~RUBY)
+          def test
+            foo&.bar(
+              baz,
+              qux: :quux
+            )
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, foldable_types: %i[hash]).calculate
+        expect(length).to eq(4)
+      end
+
+      it 'counts single line hash with other args correctly if asked folding' do
+        source = parse_source(<<~RUBY)
+          def test
+            foo(
+              { foo: :bar },
+              bar, baz
+            )
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, foldable_types: %i[hash]).calculate
+        expect(length).to eq(4)
       end
 
       it 'folds hashes as method kwargs if asked' do


### PR DESCRIPTION
Follow up #10469 and #10520.

This PR improve code length calculation for few more patterns like follows:

```rb
def test
  foo(
    foo,
    foo: :bar,
  )
end

def test
  foo(foo: :bar,
      baz: :quux)
end
```

Previously, it always subtracted 2 under certain conditions, but now it considers cases where hash begins/ends on the same line as the parentheses or there are other arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
