### PR TITLE
Support auto-correction for `Lint/DuplicateRequire`

### DIFF
--- a/changelog/new_support_autocorrect_for_lint_duplicate_require.md
+++ b/changelog/new_support_autocorrect_for_lint_duplicate_require.md
@@ -1,0 +1,1 @@
+* [#10544](https://github.com/rubocop/rubocop/pull/10544): Support auto-correction for `Lint/DuplicateRequire`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1661,7 +1661,9 @@ Lint/DuplicateRegexpCharacterClassElement:
 Lint/DuplicateRequire:
   Description: 'Check for duplicate `require`s and `require_relative`s.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.90'
+  VersionChanged: '<<next>>'
 
 Lint/DuplicateRescueException:
   Description: 'Checks that there are no repeated exceptions used in `rescue` expressions.'

--- a/spec/rubocop/cop/lint/duplicate_require_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_require_spec.rb
@@ -1,31 +1,43 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::DuplicateRequire, :config do
-  it 'registers an offense when duplicate `require` is detected' do
+  it 'registers and corrects an offense when duplicate `require` is detected' do
     expect_offense(<<~RUBY)
       require 'foo'
       require 'foo'
       ^^^^^^^^^^^^^ Duplicate `require` detected.
     RUBY
+
+    expect_correction(<<~RUBY)
+      require 'foo'
+    RUBY
   end
 
-  it 'registers an offense when duplicate `require_relative` is detected' do
+  it 'registers and corrects an offense when duplicate `require_relative` is detected' do
     expect_offense(<<~RUBY)
       require_relative '../bar'
       require_relative '../bar'
       ^^^^^^^^^^^^^^^^^^^^^^^^^ Duplicate `require_relative` detected.
     RUBY
+
+    expect_correction(<<~RUBY)
+      require_relative '../bar'
+    RUBY
   end
 
-  it 'registers an offense when duplicate `require` through `Kernel` is detected' do
+  it 'registers and corrects an offense when duplicate `require` through `Kernel` is detected' do
     expect_offense(<<~RUBY)
       require 'foo'
       Kernel.require 'foo'
       ^^^^^^^^^^^^^^^^^^^^ Duplicate `require` detected.
     RUBY
+
+    expect_correction(<<~RUBY)
+      require 'foo'
+    RUBY
   end
 
-  it 'registers an offense for multiple duplicate requires' do
+  it 'registers and corrects an offense for multiple duplicate requires' do
     expect_offense(<<~RUBY)
       require 'foo'
       require_relative '../bar'
@@ -36,9 +48,16 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateRequire, :config do
       ^^^^^^^^^^^^^^^^^^^^ Duplicate `require` detected.
       require 'quux'
     RUBY
+
+    expect_correction(<<~RUBY)
+      require 'foo'
+      require_relative '../bar'
+      require 'foo/baz'
+      require 'quux'
+    RUBY
   end
 
-  it 'registers an offense when duplicate requires are interleaved with some other code' do
+  it 'registers and corrects an offense when duplicate requires are interleaved with some other code' do
     expect_offense(<<~RUBY)
       require 'foo'
       def m
@@ -46,14 +65,26 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateRequire, :config do
       require 'foo'
       ^^^^^^^^^^^^^ Duplicate `require` detected.
     RUBY
+
+    expect_correction(<<~RUBY)
+      require 'foo'
+      def m
+      end
+    RUBY
   end
 
-  it 'registers an offense for duplicate non top-level requires' do
+  it 'registers and corrects an offense for duplicate non top-level requires' do
     expect_offense(<<~RUBY)
       def m
         require 'foo'
         require 'foo'
         ^^^^^^^^^^^^^ Duplicate `require` detected.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def m
+        require 'foo'
       end
     RUBY
   end


### PR DESCRIPTION
This PR supports auto-correction for `Lint/DuplicateRequire`.
The auto-correction is unsafe because it may break the dependency order of `require`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
