### PR TITLE
[Fix #10095] Change "auto-correct" to "autocorrect"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Just make sure they are properly named.
 Here are a few examples:
 
 ```
-* [#716](https://github.com/rubocop/rubocop/issues/716): Fixed a regression in the auto-correction logic of `MethodDefParentheses`. ([@bbatsov][])
+* [#716](https://github.com/rubocop/rubocop/issues/716): Fixed a regression in the autocorrection logic of `MethodDefParentheses`. ([@bbatsov][])
 * New cop `ElseLayout` checks for odd arrangement of code in the `else` branch of a conditional expression. ([@bbatsov][])
 * [#7542](https://github.com/rubocop/rubocop/pull/7542): **(Breaking)** Move `LineLength` cop from `Metrics` department to `Layout` department. ([@koic][])
 ```

--- a/changelog/change_auto_correct_to_autocorrect.md
+++ b/changelog/change_auto_correct_to_autocorrect.md
@@ -1,0 +1,1 @@
+* [#10095](https://github.com/rubocop/rubocop/issues/10095): Change "auto-correct" to "autocorrect" in comments/documentation/messages/specs. ([@chris-hewitt][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -916,7 +916,7 @@ Layout/IndentationStyle:
   VersionChanged: '0.82'
   # By default the indentation width from `Layout/IndentationWidth` is used,
   # but it can be overridden by setting this parameter.
-  # It is used during auto-correction to determine how many spaces should
+  # It is used during autocorrection to determine how many spaces should
   # replace each tab.
   IndentationWidth: ~
   EnforcedStyle: spaces
@@ -4672,7 +4672,7 @@ Style/SafeNavigation:
                   This cop transforms usages of a method call safeguarded by
                   a check for the existence of the object to
                   safe navigation (`&.`).
-                  Auto-correction is unsafe as it assumes the object will
+                  Autocorrection is unsafe as it assumes the object will
                   be `nil` or truthy, but never `false`.
   Enabled: true
   VersionAdded: '0.43'

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -3,7 +3,7 @@
 * xref:compatibility.adoc[Compatibility]
 * Usage
 ** xref:usage/basic_usage.adoc[Basic Usage]
-** xref:usage/auto_correct.adoc[Auto-correct]
+** xref:usage/autocorrect.adoc[Autocorrect]
 ** xref:usage/caching.adoc[Caching]
 * xref:configuration.adoc[Configuration]
 * xref:cops.adoc[Cops]

--- a/docs/modules/ROOT/pages/automated_code_review.adoc
+++ b/docs/modules/ROOT/pages/automated_code_review.adoc
@@ -19,7 +19,7 @@ https://codeclimate.com/[Code Climate] provides automated code review for test c
 
 == CodeFactor
 
-https://www.codefactor.io[CodeFactor] reports various code metrics like duplication, churn, and problems for code style, performance, complexity, and many others. CodeFactor is free for open source. It supports analysis and auto-correction for RuboCop.
+https://www.codefactor.io[CodeFactor] reports various code metrics like duplication, churn, and problems for code style, performance, complexity, and many others. CodeFactor is free for open source. It supports analysis and autocorrection for RuboCop.
 
 == Hound
 
@@ -37,4 +37,4 @@ https://github.com/reviewdog/reviewdog[ReviewDog] is similar to Pronto but with 
 == Sider
 
 https://sider.review[Sider] improves your team's productivity by automating code analysis.
-It supports RuboCop's auto-correction.
+It supports RuboCop's autocorrection.

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -202,9 +202,9 @@ value, it will be wrapped in order to prevent the ambiguity of `1..2.to_a`.
 
 === Safety
 
-The cop auto-corrects by wrapping the entire boundary in parentheses, which
+The cop autocorrects by wrapping the entire boundary in parentheses, which
 makes the outcome more explicit but is possible to not be the intention of the
-programmer. For this reason, this cop's auto-correct is unsafe (it will not
+programmer. For this reason, this cop's autocorrect is unsafe (it will not
 change the behaviour of the code, but will not necessarily match the
 intent of the program).
 
@@ -1469,7 +1469,7 @@ This cop checks for odd `else` block layout - like
 having an expression on the same line as the `else` keyword,
 which is usually a mistake.
 
-Its auto-correction tweaks layout to keep the syntax. So, this auto-correction
+Its autocorrection tweaks layout to keep the syntax. So, this autocorrection
 is compatible correction for bad case syntax, but if your code makes a mistake
 with `elsif` and `else`, you will have to correct it manually.
 
@@ -1490,7 +1490,7 @@ end
 ----
 # good
 
-# This code is compatible with the bad case. It will be auto-corrected like this.
+# This code is compatible with the bad case. It will be autocorrected like this.
 if something
   # ...
 else
@@ -2593,7 +2593,7 @@ This cop checks for `IO.select` that is incompatible with Fiber Scheduler since 
 
 NOTE: When the method is successful the return value of `IO.select` is `[[IO]]`,
 and the return value of `io.wait_readable` and `io.wait_writable` are `self`.
-They are not auto-corrected when assigning a return value because these types are different.
+They are not autocorrected when assigning a return value because these types are different.
 It's up to user how to handle the return value.
 
 === Safety
@@ -2803,7 +2803,7 @@ It emulates the following warning in Ruby 3.0:
   lambda instead
 
 This way, proc object is never converted to lambda.
-Auto-correction replaces with compatible proc argument.
+Autocorrection replaces with compatible proc argument.
 
 === Examples
 
@@ -3612,7 +3612,7 @@ locations, the result may vary depending on the order of `require`.
 
 This cop is unsafe because code that is already conditionally
 assigning a constant may have its behaviour changed by
-auto-correction.
+autocorrection.
 
 === Examples
 
@@ -4100,9 +4100,9 @@ because `NilClass` has methods like `respond_to?` and `is_a?`.
 
 === Safety
 
-This cop is unsafe, because auto-correction can change the return type of
+This cop is unsafe, because autocorrection can change the return type of
 the expression. An offending expression that previously could return `nil`
-will be auto-corrected to never return `nil`.
+will be autocorrected to never return `nil`.
 
 === Examples
 
@@ -6623,7 +6623,7 @@ There are edge cases in which the local variable references a
 value that is also accessible outside the local scope. This is not
 detected by the cop, and it can yield a false positive.
 
-As well, auto-correction is unsafe because the method's
+As well, autocorrection is unsafe because the method's
 return value will be changed.
 
 === Examples

--- a/docs/modules/ROOT/pages/cops_naming.adoc
+++ b/docs/modules/ROOT/pages/cops_naming.adoc
@@ -188,9 +188,9 @@ This cop identifies places where `do_something(&block)` can be replaced
 by `do_something(&)`.
 
 It also supports the opposite style by alternative `explicit` option.
-You can specify the block variable name for auto-correction with `BlockForwardingName`.
+You can specify the block variable name for autocorrection with `BlockForwardingName`.
 The default variable name is `block`. If the name is already in use, it will not be
-auto-corrected.
+autocorrected.
 
 === Examples
 

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -241,7 +241,7 @@ all contexts.
 
 === Safety
 
-Auto-correction is unsafe because there is a different operator precedence
+Autocorrection is unsafe because there is a different operator precedence
 between logical operators (`&&` and `||`) and semantic operators (`and` and `or`),
 and that might change the behaviour.
 
@@ -1932,12 +1932,12 @@ Note that some comments
 (`:nodoc:`, `:yields:`, `rubocop:disable` and `rubocop:todo`)
 are allowed.
 
-Auto-correction removes comments from `end` keyword and keeps comments
+Autocorrection removes comments from `end` keyword and keeps comments
 for `class`, `module`, `def` and `begin` above the keyword.
 
 === Safety
 
-Auto-correction is unsafe because it may remove a comment that is
+Autocorrection is unsafe because it may remove a comment that is
 meaningful.
 
 === Examples
@@ -5014,7 +5014,7 @@ in a future major RuboCop release.
 
 === Safety
 
-Auto-correction is unsafe because changing the order of method invocations
+Autocorrection is unsafe because changing the order of method invocations
 may change the behaviour of the code. For example:
 
 [source,ruby]
@@ -5308,7 +5308,7 @@ The conditions to be checked are comparison methods, predicate methods, and doub
 
 === Safety
 
-Auto-correction is unsafe because there is no guarantee that all predicate methods
+Autocorrection is unsafe because there is no guarantee that all predicate methods
 will return a boolean value. Those methods can be allowed with `AllowedMethods` config.
 
 === Examples
@@ -7086,7 +7086,7 @@ end
 This cop checks for multi-line ternary op expressions.
 
 NOTE: `return if ... else ... end` is syntax error. If `return` is used before
-multiline ternary operator expression, it cannot be auto-corrected.
+multiline ternary operator expression, it cannot be autocorrected.
 
 === Examples
 
@@ -8389,7 +8389,7 @@ bar.baz > 0
 Checks for uses of if/then/else/end constructs on a single line.
 AlwaysCorrectToMultiline config option can be set to true to auto-convert all offenses to
 multi-line constructs. When AlwaysCorrectToMultiline is false (default case) the
-auto-correct will first try converting them to ternary operators.
+autocorrect will first try converting them to ternary operators.
 
 === Examples
 
@@ -11250,7 +11250,7 @@ It will accept single-line methods with no body.
 Endless methods added in Ruby 3.0 are also accepted by this cop.
 
 If `Style/EndlessMethod` is enabled with `EnforcedStyle: allow_single_line` or
-`allow_always`, single-line methods will be auto-corrected to endless
+`allow_always`, single-line methods will be autocorrected to endless
 methods if there is only one statement in the body.
 
 === Examples
@@ -12035,7 +12035,7 @@ This cop checks for inheritance from Struct.new.
 
 === Safety
 
-Auto-correction is unsafe because it will change the inheritance
+Autocorrection is unsafe because it will change the inheritance
 tree (e.g. return value of `Module#ancestors`) of the constant.
 
 === Examples

--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -2,7 +2,7 @@
 
 This section of the documentation will teach you how to develop new cops.  We'll
 start with generating a cop template and then we'll address the various aspects
-of its implementation (interacting with the AST, auto-correct, configuration)
+of its implementation (interacting with the AST, autocorrect, configuration)
 and testing.
 
 == Create a new cop
@@ -299,9 +299,9 @@ offense messages with `[...]`:
 end
 ----
 
-=== Auto-correct
+=== Autocorrect
 
-The auto-correct can help humans automatically fix offenses that have been detected.
+The autocorrect can help humans automatically fix offenses that have been detected.
 It's necessary to `extend AutoCorrector`.
 The method `add_offense` yields a corrector object that is a thin wrapper on
 https://www.rubydoc.info/gems/parser/Parser/Source/TreeRewriter[parser's TreeRewriter]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -15,7 +15,7 @@ RuboCop packs a lot of features on top of what you'd normally expect from a
 linter:
 
 * Works with every major Ruby implementation
-* Auto-correction of many of the code offenses it detects
+* Autocorrection of many of the code offenses it detects
 * Robust code formatting capabilities
 * Multiple result formatters for both interactive use and for feeding data into other tools
 * Ability to have different configuration for different parts of your codebase

--- a/docs/modules/ROOT/pages/integration_with_other_tools.adoc
+++ b/docs/modules/ROOT/pages/integration_with_other_tools.adoc
@@ -3,7 +3,7 @@
 == Speeding up integrations
 
 RuboCop integrates with quite a number of other tools, including editors which may attempt
-to do auto-correction for you. In these cases, `rubocop` ends up getting called repeatedly,
+to do autocorrection for you. In these cases, `rubocop` ends up getting called repeatedly,
 which may result in some slowness, as `rubocop` has to require its entire environment on
 each call.
 
@@ -158,7 +158,7 @@ If you run `rake -T`, the following two RuboCop tasks should show up:
 [source,sh]
 ----
 $ rake rubocop                                  # Run RuboCop
-$ rake rubocop:auto_correct                     # Auto-correct RuboCop offenses
+$ rake rubocop:auto_correct                     # Autocorrect RuboCop offenses
 ----
 
 The above will use default values

--- a/docs/modules/ROOT/pages/usage/autocorrect.adoc
+++ b/docs/modules/ROOT/pages/usage/autocorrect.adoc
@@ -1,6 +1,7 @@
-= Auto-correct
+= Autocorrect
+:page-aliases: auto_correct.adoc
 
-In auto-correct mode, RuboCop will try to automatically fix offenses:
+In autocorrect mode, RuboCop will try to automatically fix offenses:
 
 [source,sh]
 ----
@@ -9,17 +10,17 @@ $ rubocop -A
 $ rubocop --auto-correct-all
 ----
 
-There are a couple of things to keep in mind about auto-correct:
+There are a couple of things to keep in mind about autocorrect:
 
 - For some offenses, it is not possible to implement automatic correction.
 - Some automatic corrections that _are_ possible have not been implemented yet.
 - Some automatic corrections might change (slightly) the semantics of the code,
 meaning they'd produce code that's mostly equivalent to the original code, but
-not 100% equivalent. We call such auto-correct behaviour "unsafe".
+not 100% equivalent. We call such autocorrect behaviour "unsafe".
 
-TIP: You should always run your test suite after using the auto-correct functionality.
+TIP: You should always run your test suite after using the autocorrect functionality.
 
-== Safe auto-correct
+== Safe autocorrect
 
 [source,sh]
 ----
@@ -30,19 +31,19 @@ $ rubocop --auto-correct
 
 In RuboCop 0.60, we began to annotate cops as `Safe` or not safe. The definition of
 safety is that the cop doesn't generate false positives. On top of that there's `SafeAutoCorrect`
-that might be set to `false` in cases where only the auto-correct performed by a cop
+that might be set to `false` in cases where only the autocorrect performed by a cop
 is unsafe, but that the offense detection logic is safe. To sum it up:
 
 * Safe (`true/false`) - indicates whether the cop can yield false positives (by
 design) or not.
-* SafeAutoCorrect (`true/false`) - indicates whether the auto-correct a cop
-does is safe (equivalent) by design. If a cop is unsafe its auto-correct automatically
+* SafeAutoCorrect (`true/false`) - indicates whether the autocorrect a cop
+does is safe (equivalent) by design. If a cop is unsafe its autocorrect automatically
 becomes unsafe as well.
 
-If a cop or its auto-correct is annotated as "not safe", it will be omitted when using `--auto-correct`.
+If a cop or its autocorrect is annotated as "not safe", it will be omitted when using `--auto-correct`.
 
 NOTE: Currently there might still be cops that aren't marked as unsafe or
-with unsafe auto-correct.  Eventually, the safety of each cop will be specified
+with unsafe autocorrect.  Eventually, the safety of each cop will be specified
 in the default configuration.
 
 === Example of Unsafe Cop
@@ -69,7 +70,7 @@ and there might not be an alternative. This cop is marked as `Safe: false`.
 str = 'hello' # => Missing magic comment `# frozen_string_literal: true`
 str << 'world'
 
-# auto-corrects to:
+# autocorrects to:
 # frozen_string_literal: true
 
 str = 'hello'
@@ -83,10 +84,10 @@ str << 'world' # => ok
 ----
 
 This diagnostic is valid since the magic comment is indeed missing (thus `Safe: true`),
-but the auto-correction is not; some string literals need to be prefixed with `+` to avoid
+but the autocorrection is not; some string literals need to be prefixed with `+` to avoid
 having them frozen.
 
-To run all auto-corrections (safe and unsafe):
+To run all autocorrections (safe and unsafe):
 
 [source,sh]
 ----

--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -63,9 +63,9 @@ test.rb:4:5: W: Layout/EndAlignment: end at 4, 4 is not aligned with if at 2, 2.
 1 file inspected, 5 offenses detected
 ----
 
-=== Auto-correcting offenses
+=== Autocorrecting offenses
 
-You can also run RuboCop in an auto-correct mode, where it will try to
+You can also run RuboCop in an autocorrect mode, where it will try to
 automatically fix the problems it found in your code:
 
 [source,sh]
@@ -75,7 +75,7 @@ $ rubocop -a
 $ rubocop --auto-correct
 ----
 
-TIP: See xref:usage/auto_correct.adoc[Auto-correct] for more details.
+TIP: See xref:usage/autocorrect.adoc[Autocorrect] for more details.
 
 === Changing what RuboCop considers to be offenses
 
@@ -101,7 +101,7 @@ $ rubocop --lint
 
 == RuboCop as a formatter
 
-There's a handy shortcut to run auto-correction only on code layout (a.k.a. formatting) offenses:
+There's a handy shortcut to run autocorrection only on code layout (a.k.a. formatting) offenses:
 
 [source,sh]
 ----
@@ -133,10 +133,10 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | Command flag | Description
 
 | `-a/--auto-correct`
-| Auto-correct offenses (only when it's safe). See xref:usage/auto_correct.adoc[Auto-correct].
+| Autocorrect offenses (only when it's safe). See xref:usage/autocorrect.adoc[Autocorrect].
 
 | `-A/--auto-correct-all`
-| Auto-correct offenses (safe and unsafe). See xref:usage/auto_correct.adoc[Auto-correct].
+| Autocorrect offenses (safe and unsafe). See xref:usage/autocorrect.adoc[Autocorrect].
 
 | `--auto-gen-config`
 | Generate a configuration file acting as a TODO list.
@@ -184,7 +184,7 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | Inspect files in order of modification time and stops after first file with offenses.
 
 | `--fail-level`
-| Minimum xref:configuration.adoc#severity[severity] for exit with error code. Full severity name or upper case initial can be given. Normally, auto-corrected offenses are ignored. Use `A` or `autocorrect` if you'd like them to trigger failure.
+| Minimum xref:configuration.adoc#severity[severity] for exit with error code. Full severity name or upper case initial can be given. Normally, autocorrected offenses are ignored. Use `A` or `autocorrect` if you'd like them to trigger failure.
 
 | `--force-exclusion`
 | Force excluding files specified in the configuration `Exclude` even if they are explicitly passed as arguments.
@@ -235,7 +235,7 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | Run only safe cops.
 
 | `--safe-auto-correct`
-| Omit cops annotated as "not safe". See xref:usage/auto_correct.adoc[Auto-correct].
+| Omit cops annotated as "not safe". See xref:usage/autocorrect.adoc[Autocorrect].
 
 | `--show-cops`
 | Shows available cops and their configuration.
@@ -250,7 +250,7 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | Pipe source from STDIN. This is useful for editor integration. Takes one argument, a path, relative to the root of the project. RuboCop will use this path to determine which cops are enabled (via eg. Include/Exclude), and so that certain cops like Naming/FileName can be checked.
 
 | `-x/--fix-layout`
-| Auto-correct only code layout (formatting) offenses.
+| Autocorrect only code layout (formatting) offenses.
 
 | `-v/--version`
 | Displays the current version and exits.
@@ -272,8 +272,8 @@ RuboCop exits with the following status codes:
 
 * `0` if no offenses are found or if the severity of all offenses are less than
 `--fail-level`. (By default, if you use `--auto-correct`, offenses which are
-auto-corrected do not cause RuboCop to fail.)
+autocorrected do not cause RuboCop to fail.)
 * `1` if one or more offenses equal or greater to `--fail-level` are found. (By
-default, this is any offense which is not auto-corrected.)
+default, this is any offense which is not autocorrected.)
 * `2` if RuboCop terminates abnormally due to invalid configuration, invalid CLI
 options, or an internal error.

--- a/docs/modules/ROOT/pages/v1_upgrade_notes.adoc
+++ b/docs/modules/ROOT/pages/v1_upgrade_notes.adoc
@@ -160,7 +160,7 @@ _Current:_ pass a range (or node as a shortcut for `node.loc.expression`), no `l
 
 Both de-dup on `range` and won't process the duplicated offenses at all.
 
-_Legacy:_ if offenses on same `node` but different `range`: considered as multiple offenses but a single auto-correct call.
+_Legacy:_ if offenses on same `node` but different `range`: considered as multiple offenses but a single autocorrect call.
 
 _Current:_ not applicable and not needed with autocorrection's API.
 
@@ -174,7 +174,7 @@ _Current:_ yields before offense is added to `#offenses`.
 
 Even the legacy mode yields a corrector, but if a developer uses it an error will be raised asking her to inherit from `Cop::Base` instead.
 
-=== Auto Correction
+=== Autocorrection
 
 ==== `#autocorrect`
 
@@ -190,7 +190,7 @@ _Current:_ No special API. Cases where no corrections are made are automatically
 
 ==== Correction timing
 
-_Legacy:_ the lambda was called only later in the process, and only under specific conditions (if the auto-correct setting is turned on, etc.)
+_Legacy:_ the lambda was called only later in the process, and only under specific conditions (if the autocorrect setting is turned on, etc.)
 
 _Current:_ correction is built immediately (assuming the cop isn't disabled for the line) and applied later in the process.
 

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -227,7 +227,7 @@ module RuboCop
         next unless cop_config.is_a?(Hash)
         next unless cop_config['Safe'] == false && cop_config['SafeAutoCorrect'] == true
 
-        msg = 'Unsafe cops cannot have a safe auto-correction ' \
+        msg = 'Unsafe cops cannot have a safe autocorrection ' \
               "(section #{name} in #{smart_loaded_path})"
         raise ValidationError, msg
       end

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -158,7 +158,7 @@ module RuboCop
         Registry.global.dismiss(self)
       end
 
-      # Returns if class supports auto_correct.
+      # Returns if class supports autocorrect.
       # It is recommended to extend AutoCorrector instead of overriding
       def self.support_autocorrect?
         false

--- a/lib/rubocop/cop/correctors/alignment_corrector.rb
+++ b/lib/rubocop/cop/correctors/alignment_corrector.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    # This class does auto-correction of nodes that should just be moved to
+    # This class does autocorrection of nodes that should just be moved to
     # the left or to the right, amount being determined by the instance
     # variable column_delta.
     class AlignmentCorrector

--- a/lib/rubocop/cop/correctors/condition_corrector.rb
+++ b/lib/rubocop/cop/correctors/condition_corrector.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    # This class does condition auto-correction
+    # This class does condition autocorrection
     class ConditionCorrector
       class << self
         def correct_negative_condition(corrector, node)

--- a/lib/rubocop/cop/correctors/each_to_for_corrector.rb
+++ b/lib/rubocop/cop/correctors/each_to_for_corrector.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    # This class auto-corrects `#each` enumeration to `for` iteration.
+    # This class autocorrects `#each` enumeration to `for` iteration.
     class EachToForCorrector
       extend NodePattern::Macros
 

--- a/lib/rubocop/cop/correctors/empty_line_corrector.rb
+++ b/lib/rubocop/cop/correctors/empty_line_corrector.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    # This class does empty line auto-correction
+    # This class does empty line autocorrection
     class EmptyLineCorrector
       class << self
         def correct(corrector, node)

--- a/lib/rubocop/cop/correctors/for_to_each_corrector.rb
+++ b/lib/rubocop/cop/correctors/for_to_each_corrector.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    # This class auto-corrects `for` iteration to `#each` enumeration.
+    # This class autocorrects `for` iteration to `#each` enumeration.
     class ForToEachCorrector
       extend NodePattern::Macros
 

--- a/lib/rubocop/cop/correctors/if_then_corrector.rb
+++ b/lib/rubocop/cop/correctors/if_then_corrector.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    # This class auto-corrects `if...then` structures to a multiline `if` statement
+    # This class autocorrects `if...then` structures to a multiline `if` statement
     class IfThenCorrector
       DEFAULT_INDENTATION_WIDTH = 2
 

--- a/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb
+++ b/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    # This class auto-corrects lambda literal to method notation.
+    # This class autocorrects lambda literal to method notation.
     class LambdaLiteralToMethodCorrector
       def initialize(block_node)
         @block_node = block_node

--- a/lib/rubocop/cop/correctors/ordered_gem_corrector.rb
+++ b/lib/rubocop/cop/correctors/ordered_gem_corrector.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    # This auto-corrects gem dependency order
+    # This autocorrects gem dependency order
     class OrderedGemCorrector
       class << self
         include OrderedGemNode

--- a/lib/rubocop/cop/correctors/parentheses_corrector.rb
+++ b/lib/rubocop/cop/correctors/parentheses_corrector.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    # This auto-corrects parentheses
+    # This autocorrects parentheses
     class ParenthesesCorrector
       class << self
         def correct(corrector, node)

--- a/lib/rubocop/cop/correctors/percent_literal_corrector.rb
+++ b/lib/rubocop/cop/correctors/percent_literal_corrector.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    # This auto-corrects percent literals
+    # This autocorrects percent literals
     class PercentLiteralCorrector
       include Util
 

--- a/lib/rubocop/cop/correctors/punctuation_corrector.rb
+++ b/lib/rubocop/cop/correctors/punctuation_corrector.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    # This auto-corrects punctuation
+    # This autocorrects punctuation
     class PunctuationCorrector
       class << self
         def remove_space(corrector, space_before)

--- a/lib/rubocop/cop/correctors/space_corrector.rb
+++ b/lib/rubocop/cop/correctors/space_corrector.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    # This auto-corrects whitespace
+    # This autocorrects whitespace
     class SpaceCorrector
       extend SurroundingSpace
 

--- a/lib/rubocop/cop/correctors/string_literal_corrector.rb
+++ b/lib/rubocop/cop/correctors/string_literal_corrector.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    # This auto-corrects string literals
+    # This autocorrects string literals
     class StringLiteralCorrector
       extend Util
 

--- a/lib/rubocop/cop/correctors/unused_arg_corrector.rb
+++ b/lib/rubocop/cop/correctors/unused_arg_corrector.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    # This auto-corrects unused arguments.
+    # This autocorrects unused arguments.
     class UnusedArgCorrector
       extend RangeHelp
 

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -269,12 +269,12 @@ module RuboCop
         end
 
         def offense(body_node, indentation, style)
-          # This cop only auto-corrects the first statement in a def body, for
+          # This cop only autocorrects the first statement in a def body, for
           # example.
           body_node = body_node.children.first if body_node.begin_type? && !parentheses?(body_node)
 
           # Since autocorrect changes a number of lines, and not only the line
-          # where the reported offending range is, we avoid auto-correction if
+          # where the reported offending range is, we avoid autocorrection if
           # this cop has already found other offenses is the same
           # range. Otherwise, two corrections can interfere with each other,
           # resulting in corrupted code.
@@ -302,7 +302,7 @@ module RuboCop
         end
 
         # Returns true if the given node is within another node that has
-        # already been marked for auto-correction by this cop.
+        # already been marked for autocorrection by this cop.
         def other_offense_in_same_range?(node)
           expr = node.source_range
           @offense_ranges ||= []

--- a/lib/rubocop/cop/layout/space_before_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_before_block_braces.rb
@@ -57,9 +57,9 @@ module RuboCop
           return if node.keywords?
 
           # Do not register an offense for multi-line braces when specifying
-          # `EnforcedStyle: no_space`. It will conflict with auto-correction
+          # `EnforcedStyle: no_space`. It will conflict with autocorrection
           # by `EnforcedStyle: line_count_based` of `Style/BlockDelimiters` cop.
-          # That means preventing auto-correction to incorrect auto-corrected
+          # That means preventing autocorrection to incorrect autocorrected
           # code.
           # See: https://github.com/rubocop/rubocop/issues/7534
           return if conflict_with_block_delimiters?(node)

--- a/lib/rubocop/cop/layout/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_block_braces.rb
@@ -86,9 +86,9 @@ module RuboCop
           return if node.keywords?
 
           # Do not register an offense for multi-line empty braces. That means
-          # preventing auto-correction to single-line empty braces. It will
-          # conflict with auto-correction by `Layout/SpaceInsideBlockBraces` cop
-          # if auto-corrected to a single-line empty braces.
+          # preventing autocorrection to single-line empty braces. It will
+          # conflict with autocorrection by `Layout/SpaceInsideBlockBraces` cop
+          # if autocorrected to a single-line empty braces.
           # See: https://github.com/rubocop/rubocop/issues/7363
           return if node.body.nil? && node.multiline?
 

--- a/lib/rubocop/cop/lint/ambiguous_range.rb
+++ b/lib/rubocop/cop/lint/ambiguous_range.rb
@@ -18,9 +18,9 @@ module RuboCop
       # value, it will be wrapped in order to prevent the ambiguity of `1..2.to_a`.
       #
       # @safety
-      #   The cop auto-corrects by wrapping the entire boundary in parentheses, which
+      #   The cop autocorrects by wrapping the entire boundary in parentheses, which
       #   makes the outcome more explicit but is possible to not be the intention of the
-      #   programmer. For this reason, this cop's auto-correct is unsafe (it will not
+      #   programmer. For this reason, this cop's autocorrect is unsafe (it will not
       #   change the behaviour of the code, but will not necessarily match the
       #   intent of the program).
       #

--- a/lib/rubocop/cop/lint/else_layout.rb
+++ b/lib/rubocop/cop/lint/else_layout.rb
@@ -7,7 +7,7 @@ module RuboCop
       # having an expression on the same line as the `else` keyword,
       # which is usually a mistake.
       #
-      # Its auto-correction tweaks layout to keep the syntax. So, this auto-correction
+      # Its autocorrection tweaks layout to keep the syntax. So, this autocorrection
       # is compatible correction for bad case syntax, but if your code makes a mistake
       # with `elsif` and `else`, you will have to correct it manually.
       #
@@ -25,7 +25,7 @@ module RuboCop
       #
       #   # good
       #
-      #   # This code is compatible with the bad case. It will be auto-corrected like this.
+      #   # This code is compatible with the bad case. It will be autocorrected like this.
       #   if something
       #     # ...
       #   else

--- a/lib/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler.rb
+++ b/lib/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler.rb
@@ -8,7 +8,7 @@ module RuboCop
       #
       # NOTE: When the method is successful the return value of `IO.select` is `[[IO]]`,
       # and the return value of `io.wait_readable` and `io.wait_writable` are `self`.
-      # They are not auto-corrected when assigning a return value because these types are different.
+      # They are not autocorrected when assigning a return value because these types are different.
       # It's up to user how to handle the return value.
       #
       # @safety

--- a/lib/rubocop/cop/lint/lambda_without_literal_block.rb
+++ b/lib/rubocop/cop/lint/lambda_without_literal_block.rb
@@ -12,7 +12,7 @@ module RuboCop
       #   lambda instead
       #
       # This way, proc object is never converted to lambda.
-      # Auto-correction replaces with compatible proc argument.
+      # Autocorrection replaces with compatible proc argument.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/or_assignment_to_constant.rb
+++ b/lib/rubocop/cop/lint/or_assignment_to_constant.rb
@@ -12,7 +12,7 @@ module RuboCop
       # @safety
       #   This cop is unsafe because code that is already conditionally
       #   assigning a constant may have its behaviour changed by
-      #   auto-correction.
+      #   autocorrection.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/redundant_safe_navigation.rb
+++ b/lib/rubocop/cop/lint/redundant_safe_navigation.rb
@@ -11,9 +11,9 @@ module RuboCop
       # because `NilClass` has methods like `respond_to?` and `is_a?`.
       #
       # @safety
-      #   This cop is unsafe, because auto-correction can change the return type of
+      #   This cop is unsafe, because autocorrection can change the return type of
       #   the expression. An offending expression that previously could return `nil`
-      #   will be auto-corrected to never return `nil`.
+      #   will be autocorrected to never return `nil`.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -11,7 +11,7 @@ module RuboCop
       #   value that is also accessible outside the local scope. This is not
       #   detected by the cop, and it can yield a false positive.
       #
-      #   As well, auto-correction is unsafe because the method's
+      #   As well, autocorrection is unsafe because the method's
       #   return value will be changed.
       #
       # @example

--- a/lib/rubocop/cop/mixin/string_help.rb
+++ b/lib/rubocop/cop/mixin/string_help.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     # Classes that include this module just implement functions to determine
-    # what is an offense and how to do auto-correction. They get help with
+    # what is an offense and how to do autocorrection. They get help with
     # adding offenses for the faulty string nodes, and with filtering out
     # nodes.
     module StringHelp

--- a/lib/rubocop/cop/naming/block_forwarding.rb
+++ b/lib/rubocop/cop/naming/block_forwarding.rb
@@ -9,9 +9,9 @@ module RuboCop
       # by `do_something(&)`.
       #
       # It also supports the opposite style by alternative `explicit` option.
-      # You can specify the block variable name for auto-correction with `BlockForwardingName`.
+      # You can specify the block variable name for autocorrection with `BlockForwardingName`.
       # The default variable name is `block`. If the name is already in use, it will not be
-      # auto-corrected.
+      # autocorrected.
       #
       # @example EnforcedStyle: anonymous (default)
       #

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -8,7 +8,7 @@ module RuboCop
       # all contexts.
       #
       # @safety
-      #   Auto-correction is unsafe because there is a different operator precedence
+      #   Autocorrection is unsafe because there is a different operator precedence
       #   between logical operators (`&&` and `||`) and semantic operators (`and` and `or`),
       #   and that might change the behaviour.
       #
@@ -111,7 +111,7 @@ module RuboCop
         end
 
         # ! is a special case:
-        # 'x and !obj.method arg' can be auto-corrected if we
+        # 'x and !obj.method arg' can be autocorrected if we
         # recurse down a level and add parens to 'obj.method arg'
         # however, 'not x' also parses as (send x :!)
         def correct_not(node, receiver, corrector)

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -10,11 +10,11 @@ module RuboCop
       # (`:nodoc:`, `:yields:`, `rubocop:disable` and `rubocop:todo`)
       # are allowed.
       #
-      # Auto-correction removes comments from `end` keyword and keeps comments
+      # Autocorrection removes comments from `end` keyword and keeps comments
       # for `class`, `module`, `def` and `begin` above the keyword.
       #
       # @safety
-      #   Auto-correction is unsafe because it may remove a comment that is
+      #   Autocorrection is unsafe because it may remove a comment that is
       #   meaningful.
       #
       # @example

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -394,7 +394,7 @@ module RuboCop
         end
 
         # If `Layout/LineLength` is enabled, we do not want to introduce an
-        # offense by auto-correcting this cop. Find the max configured line
+        # offense by autocorrecting this cop. Find the max configured line
         # length. Find the longest line of condition. Remove the assignment
         # from lines that contain the offending assignment because after
         # correcting, this will not be on the line anymore. Check if the length

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -12,7 +12,7 @@ module RuboCop
       # in a future major RuboCop release.
       #
       # @safety
-      #   Auto-correction is unsafe because changing the order of method invocations
+      #   Autocorrection is unsafe because changing the order of method invocations
       #   may change the behaviour of the code. For example:
       #
       #   [source,ruby]

--- a/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
+++ b/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
@@ -8,7 +8,7 @@ module RuboCop
       # The conditions to be checked are comparison methods, predicate methods, and double negative.
       #
       # @safety
-      #   Auto-correction is unsafe because there is no guarantee that all predicate methods
+      #   Autocorrection is unsafe because there is no guarantee that all predicate methods
       #   will return a boolean value. Those methods can be allowed with `AllowedMethods` config.
       #
       # @example

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -94,7 +94,7 @@ module RuboCop
 
             # Inverse method offenses inside of the block of an inverse method
             # offense, such as `y.reject { |key, _value| !(key =~ /c\d/) }`,
-            # can cause auto-correction to apply improper corrections.
+            # can cause autocorrection to apply improper corrections.
             ignore_node(block)
             add_offense(node, message: message(method, inverse_blocks[method])) do |corrector|
               correct_inverse_block(corrector, node)

--- a/lib/rubocop/cop/style/map_to_hash.rb
+++ b/lib/rubocop/cop/style/map_to_hash.rb
@@ -47,7 +47,7 @@ module RuboCop
 
           message = format(MSG, method: map_node.loc.selector.source)
           add_offense(map_node.loc.selector, message: message) do |corrector|
-            # If the `to_h` call already has a block, do not auto-correct.
+            # If the `to_h` call already has a block, do not autocorrect.
             next if to_h_node.block_node
 
             autocorrect(corrector, to_h_node, map_node)

--- a/lib/rubocop/cop/style/multiline_ternary_operator.rb
+++ b/lib/rubocop/cop/style/multiline_ternary_operator.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks for multi-line ternary op expressions.
       #
       # NOTE: `return if ... else ... end` is syntax error. If `return` is used before
-      # multiline ternary operator expression, it will be auto-corrected to single-line
+      # multiline ternary operator expression, it will be autocorrected to single-line
       # ternary operator. The same is true for `break`, `next`, and method call.
       #
       # @example

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Checks for uses of if/then/else/end constructs on a single line.
       # AlwaysCorrectToMultiline config option can be set to true to auto-convert all offenses to
       # multi-line constructs. When AlwaysCorrectToMultiline is false (default case) the
-      # auto-correct will first try converting them to ternary operators.
+      # autocorrect will first try converting them to ternary operators.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/redundant_regexp_character_class.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_character_class.rb
@@ -87,7 +87,7 @@ module RuboCop
         def without_character_class(loc)
           without_character_class = loc.source[1..-2]
 
-          # Adds `\` to prevent auto-correction that changes to an interpolated string when `[#]`.
+          # Adds `\` to prevent autocorrection that changes to an interpolated string when `[#]`.
           # e.g. From `/[#]{0}/` to `/#{0}/`
           loc.source == '[#]' ? "\\#{without_character_class}" : without_character_class
         end

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -9,7 +9,7 @@ module RuboCop
       # Endless methods added in Ruby 3.0 are also accepted by this cop.
       #
       # If `Style/EndlessMethod` is enabled with `EnforcedStyle: allow_single_line` or
-      # `allow_always`, single-line methods will be auto-corrected to endless
+      # `allow_always`, single-line methods will be autocorrected to endless
       # methods if there is only one statement in the body.
       #
       # @example

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks for inheritance from Struct.new.
       #
       # @safety
-      #   Auto-correction is unsafe because it will change the inheritance
+      #   Autocorrection is unsafe because it will change the inheritance
       #   tree (e.g. return value of `Module#ancestors`) of the constant.
       #
       # @example

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -68,7 +68,7 @@ module RuboCop
 
         # The autocorrection process may have to be repeated multiple times
         # until there are no corrections left to perform
-        # To speed things up, run auto-correcting cops by themselves, and only
+        # To speed things up, run autocorrecting cops by themselves, and only
         # run the other cops when no corrections are left
         on_duty = roundup_relevant_cops(processed_source.file_path)
 

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -124,9 +124,9 @@ module RuboCop
         default_cfg = default_config(cop_name)
 
         if supports_safe_auto_correct?(cop_class, default_cfg)
-          output_buffer.puts '# This cop supports safe auto-correction (--auto-correct).'
+          output_buffer.puts '# This cop supports safe autocorrection (--auto-correct).'
         elsif supports_unsafe_autocorrect?(cop_class, default_cfg)
-          output_buffer.puts '# This cop supports unsafe auto-correction (--auto-correct-all).'
+          output_buffer.puts '# This cop supports unsafe autocorrection (--auto-correct-all).'
         end
 
         return unless default_cfg

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -162,7 +162,7 @@ module RuboCop
             "#{colorize(text, :yellow)} can be corrected with `rubocop -A`"
           else
             text = pluralize(@correctable_count, 'offense')
-            "#{colorize(text, :yellow)} auto-correctable"
+            "#{colorize(text, :yellow)} autocorrectable"
           end
         end
       end

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -127,7 +127,7 @@ module RuboCop
     end
 
     def add_autocorrection_options(opts)
-      section(opts, 'Auto-correction') do
+      section(opts, 'Autocorrection') do
         option(opts, '-a', '--auto-correct') { @options[:safe_auto_correct] = true }
         option(opts, '--safe-auto-correct') do
           warn '--safe-auto-correct is deprecated; use --auto-correct'
@@ -509,10 +509,10 @@ module RuboCop
                                          'autocorrected source. This is especially useful',
                                          'when combined with --auto-correct and --stdin.'],
       list_target_files:                'List all files RuboCop will inspect.',
-      auto_correct:                     'Auto-correct offenses (only when it\'s safe).',
+      auto_correct:                     'Autocorrect offenses (only when it\'s safe).',
       safe_auto_correct:                '(same, deprecated)',
-      auto_correct_all:                 'Auto-correct offenses (safe and unsafe)',
-      fix_layout:                       'Run only layout cops, with auto-correct on.',
+      auto_correct_all:                 'Autocorrect offenses (safe and unsafe)',
+      fix_layout:                       'Run only layout cops, with autocorrect on.',
       color:                            'Force color output on or off.',
       version:                          'Display version.',
       verbose_version:                  'Display verbose version.',

--- a/lib/rubocop/rake_task.rb
+++ b/lib/rubocop/rake_task.rb
@@ -62,15 +62,15 @@ module RuboCop
 
     def setup_subtasks(name, *args, &task_block)
       namespace(name) do
-        desc 'Auto-correct RuboCop offenses'
+        desc 'Autocorrect RuboCop offenses'
 
         task(:auto_correct, *args) do |_, task_args|
           RakeFileUtils.verbose(verbose) do
             yield(*[self, task_args].slice(0, task_block.arity)) if task_block
             options = full_options.unshift('--auto-correct-all')
-            # `parallel` will automatically be removed from the options internally.
+            # `--parallel` will automatically be removed from the options internally.
             # This is a nice to have to suppress the warning message
-            # about parallel and auto-correct not being compatible.
+            # about --parallel and --auto-correct not being compatible.
             options.delete('--parallel')
             run_cli(verbose, options)
           end

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -38,7 +38,7 @@ module RuboCop
     #       'Avoid chaining a method call on a do...end block.'
     #     )
     #
-    # Auto-correction can be tested using `expect_correction` after
+    # Autocorrection can be tested using `expect_correction` after
     # `expect_offense`.
     #
     # @example `expect_offense` and `expect_correction`
@@ -58,7 +58,7 @@ module RuboCop
     # that there were no offenses. The `expect_offense` method has
     # to do more work by parsing out lines that contain carets.
     #
-    # If the code produces an offense that could not be auto-corrected, you can
+    # If the code produces an offense that could not be autocorrected, you can
     # use `expect_no_corrections` after `expect_offense`.
     #
     # @example `expect_offense` and `expect_no_corrections`

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             .to eq(<<~YAML)
 
               # Offense count: 1
-              # This cop supports safe auto-correction (--auto-correct).
+              # This cop supports safe autocorrection (--auto-correct).
               Style/IfUnlessModifier:
                 Exclude:
                   - 'example.rb'
 
               # Offense count: 2
-              # This cop supports safe auto-correction (--auto-correct).
+              # This cop supports safe autocorrection (--auto-correct).
               # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
               # URISchemes: http, https
               Layout/LineLength:
@@ -165,14 +165,14 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             .to eq(<<~YAML)
 
               # Offense count: 1
-              # This cop supports safe auto-correction (--auto-correct).
+              # This cop supports safe autocorrection (--auto-correct).
               # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
               # URISchemes: http, https
               Layout/LineLength:
                 Max: 99
 
               # Offense count: 1
-              # This cop supports safe auto-correction (--auto-correct).
+              # This cop supports safe autocorrection (--auto-correct).
               # Configuration parameters: EnforcedStyle.
               # SupportedStyles: always, always_true, never
               Style/FrozenStringLiteralComment:
@@ -220,7 +220,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             .to eq(<<~YAML)
 
               # Offense count: 1
-              # This cop supports safe auto-correction (--auto-correct).
+              # This cop supports safe autocorrection (--auto-correct).
               # Configuration parameters: EnforcedStyle.
               # SupportedStyles: always, always_true, never
               Style/FrozenStringLiteralComment:
@@ -228,7 +228,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                   - 'example.rb'
 
               # Offense count: 1
-              # This cop supports safe auto-correction (--auto-correct).
+              # This cop supports safe autocorrection (--auto-correct).
               Style/IfUnlessModifier:
                 Exclude:
                   - 'example.rb'
@@ -269,7 +269,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             .to eq(<<~YAML)
 
               # Offense count: 1
-              # This cop supports safe auto-correction (--auto-correct).
+              # This cop supports safe autocorrection (--auto-correct).
               # Configuration parameters: EnforcedStyle.
               # SupportedStyles: always, always_true, never
               Style/FrozenStringLiteralComment:
@@ -277,7 +277,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                   - 'example.rb'
 
               # Offense count: 1
-              # This cop supports safe auto-correction (--auto-correct).
+              # This cop supports safe autocorrection (--auto-correct).
               Style/IfUnlessModifier:
                 Exclude:
                   - 'example.rb'
@@ -315,7 +315,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
       expect(cli.run(['--auto-gen-config'])).to eq(0)
       expect(File.readlines('.rubocop_todo.yml')[8..-1].map(&:chomp))
         .to eq(['# Offense count: 1',
-                '# This cop supports safe auto-correction (--auto-correct).',
+                '# This cop supports safe autocorrection (--auto-correct).',
                 '# Configuration parameters: AllowForAlignment, ' \
                 'EnforcedStyleForExponentOperator.',
                 '# SupportedStylesForExponentOperator: space, no_space',
@@ -324,14 +324,14 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                 "    - 'example1.rb'",
                 '',
                 '# Offense count: 2',
-                '# This cop supports safe auto-correction (--auto-correct).',
+                '# This cop supports safe autocorrection (--auto-correct).',
                 '# Configuration parameters: AllowInHeredoc.',
                 'Layout/TrailingWhitespace:',
                 '  Exclude:',
                 "    - 'example1.rb'",
                 '',
                 '# Offense count: 1',
-                '# This cop supports safe auto-correction (--auto-correct).',
+                '# This cop supports safe autocorrection (--auto-correct).',
                 '# Configuration parameters: AllowHeredoc, ' \
                 'AllowURI, URISchemes, IgnoreCopDirectives, ' \
                 'IgnoredPatterns.',
@@ -357,20 +357,20 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
       expect(cli.run(['--auto-gen-config'])).to eq(0)
       expect(File.readlines('.rubocop_todo.yml')[8..-1].join)
         .to eq(['# Offense count: 1',
-                '# This cop supports safe auto-correction (--auto-correct).',
+                '# This cop supports safe autocorrection (--auto-correct).',
                 '# Configuration parameters: AllowInHeredoc.',
                 'Layout/TrailingWhitespace:',
                 '  Exclude:',
                 "    - 'example1.rb'",
                 '',
                 '# Offense count: 2',
-                '# This cop supports safe auto-correction (--auto-correct).',
+                '# This cop supports safe autocorrection (--auto-correct).',
                 'Migration/DepartmentName:',
                 '  Exclude:',
                 "    - 'example1.rb'",
                 '',
                 '# Offense count: 1',
-                '# This cop supports safe auto-correction (--auto-correct).',
+                '# This cop supports safe autocorrection (--auto-correct).',
                 '# Configuration parameters: EnforcedStyle.',
                 '# SupportedStyles: always, always_true, never',
                 'Style/FrozenStringLiteralComment:',
@@ -378,13 +378,13 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                 "    - 'example1.rb'",
                 '',
                 '# Offense count: 1',
-                '# This cop supports safe auto-correction (--auto-correct).',
+                '# This cop supports safe autocorrection (--auto-correct).',
                 '# Configuration parameters: Strict, AllowedNumbers.',
                 'Style/NumericLiterals:',
                 '  MinDigits: 7',
                 '',
                 '# Offense count: 1',
-                '# This cop supports safe auto-correction (--auto-correct).',
+                '# This cop supports safe autocorrection (--auto-correct).',
                 '# Configuration parameters: AllowHeredoc, ' \
                 'AllowURI, URISchemes, IgnoreCopDirectives, ' \
                 'IgnoredPatterns.',
@@ -408,7 +408,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         todo_contents = File.read('.rubocop_todo.yml').lines[8..-1].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
-          # This cop supports safe auto-correction (--auto-correct).
+          # This cop supports safe autocorrection (--auto-correct).
           # Configuration parameters: EnforcedStyle.
           # SupportedStyles: always, always_true, never
           Style/FrozenStringLiteralComment:
@@ -432,13 +432,13 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
       end
     end
 
-    context 'when working with a cop who do not support auto-correction' do
+    context 'when working with a cop who do not support autocorrection' do
       it 'can generate a todo list' do
         create_file('example1.rb', <<~RUBY)
           def fooBar; end
         RUBY
         create_file('.rubocop.yml', <<~YAML)
-          # The following cop does not support auto-correction.
+          # The following cop does not support autocorrection.
           Naming/MethodName:
             Enabled: true
         YAML
@@ -455,7 +455,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             EnforcedStyle: camelCase
 
           # Offense count: 1
-          # This cop supports safe auto-correction (--auto-correct).
+          # This cop supports safe autocorrection (--auto-correct).
           # Configuration parameters: EnforcedStyle.
           # SupportedStyles: always, always_true, never
           Style/FrozenStringLiteralComment:
@@ -465,14 +465,14 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         expect(File.read('.rubocop.yml')).to eq(<<~YAML)
           inherit_from: .rubocop_todo.yml
 
-          # The following cop does not support auto-correction.
+          # The following cop does not support autocorrection.
           Naming/MethodName:
             Enabled: true
         YAML
       end
     end
 
-    context 'when cop is not safe to auto-correct' do
+    context 'when cop is not safe to autocorrect' do
       it 'can generate a todo list, with the appropriate flag' do
         create_file('example1.rb', <<~RUBY)
           # frozen_string_literal: true
@@ -481,7 +481,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           puts users
         RUBY
         create_file('.rubocop.yml', <<~YAML)
-          # The following cop supports auto-correction but is not safe
+          # The following cop supports autocorrection but is not safe
           Style/StringConcatenation:
             Enabled: true
         YAML
@@ -491,7 +491,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         todo_contents = File.read('.rubocop_todo.yml').lines[8..-1].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
-          # This cop supports unsafe auto-correction (--auto-correct-all).
+          # This cop supports unsafe autocorrection (--auto-correct-all).
           # Configuration parameters: Mode.
           Style/StringConcatenation:
             Exclude:
@@ -500,7 +500,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         expect(File.read('.rubocop.yml')).to eq(<<~YAML)
           inherit_from: .rubocop_todo.yml
 
-          # The following cop supports auto-correction but is not safe
+          # The following cop supports autocorrection but is not safe
           Style/StringConcatenation:
             Enabled: true
         YAML
@@ -515,7 +515,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         create_file('.rubocop.yml', <<~YAML)
           # rubocop config file
           ---  # YAML document start
-          # The following cop does not support auto-correction.
+          # The following cop does not support autocorrection.
           Naming/MethodName:
             Enabled: true
         YAML
@@ -525,7 +525,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         todo_contents = File.read('.rubocop_todo.yml').lines[8..-1].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
-          # This cop supports safe auto-correction (--auto-correct).
+          # This cop supports safe autocorrection (--auto-correct).
           # Configuration parameters: EnforcedStyle.
           # SupportedStyles: always, always_true, never
           Style/FrozenStringLiteralComment:
@@ -537,7 +537,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           ---  # YAML document start
           inherit_from: .rubocop_todo.yml
 
-          # The following cop does not support auto-correction.
+          # The following cop does not support autocorrection.
           Naming/MethodName:
             Enabled: true
         YAML
@@ -563,7 +563,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         todo_contents = File.read('dir/.rubocop_todo.yml').lines[8..-1].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
-          # This cop supports safe auto-correction (--auto-correct).
+          # This cop supports safe autocorrection (--auto-correct).
           # Configuration parameters: EnforcedStyle.
           # SupportedStyles: always, always_true, never
           Style/FrozenStringLiteralComment:
@@ -668,14 +668,14 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          'again.',
          '',
          '# Offense count: 1',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: AllowForAlignment.',
          'Layout/CommentIndentation:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
          '# Offense count: 2',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: EnforcedStyle.',
          '# SupportedStyles: normal, indented_internal_methods',
          'Layout/IndentationConsistency:',
@@ -683,7 +683,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example2.rb'",
          '',
          '# Offense count: 1',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: IndentationWidth, EnforcedStyle.',
          '# SupportedStyles: spaces, tabs',
          'Layout/IndentationStyle:',
@@ -691,13 +691,13 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example2.rb'",
          '',
          '# Offense count: 1',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          'Layout/InitialIndentation:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
          '# Offense count: 1',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: AllowForAlignment, ' \
          'EnforcedStyleForExponentOperator.',
          '# SupportedStylesForExponentOperator: space, no_space',
@@ -706,7 +706,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example1.rb'",
          '',
          '# Offense count: 2',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: AllowInHeredoc.',
          'Layout/TrailingWhitespace:',
          '  Exclude:',
@@ -727,7 +727,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example1.rb'",
          '',
          '# Offense count: 2',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: AllowHeredoc, ' \
          'AllowURI, URISchemes, IgnoreCopDirectives, ' \
          'IgnoredPatterns.',
@@ -770,14 +770,14 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          'again.',
          '',
          '# Offense count: 1',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: AllowForAlignment.',
          'Layout/CommentIndentation:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
          '# Offense count: 1',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: EnforcedStyle.',
          '# SupportedStyles: normal, indented_internal_methods',
          'Layout/IndentationConsistency:',
@@ -785,7 +785,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example2.rb'",
          '',
          '# Offense count: 1',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: IndentationWidth, EnforcedStyle.',
          '# SupportedStyles: spaces, tabs',
          'Layout/IndentationStyle:',
@@ -793,13 +793,13 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example2.rb'",
          '',
          '# Offense count: 1',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          'Layout/InitialIndentation:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
          '# Offense count: 1',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: AllowForAlignment, ' \
          'EnforcedStyleForExponentOperator.',
          '# SupportedStylesForExponentOperator: space, no_space',
@@ -808,7 +808,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example1.rb'",
          '',
          '# Offense count: 3',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: AllowInHeredoc.',
          'Layout/TrailingWhitespace:',
          '  Enabled: false', # Offenses in 2 files, limit is 1, so no Exclude
@@ -820,7 +820,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example1.rb'",
          '',
          '# Offense count: 3',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: AllowHeredoc, ' \
          'AllowURI, URISchemes, IgnoreCopDirectives, ' \
          'IgnoredPatterns.',
@@ -933,14 +933,14 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         # versions of RuboCop, may require this file to be generated again.
 
         # Offense count: 1
-        # This cop supports safe auto-correction (--auto-correct).
+        # This cop supports safe autocorrection (--auto-correct).
         # Configuration parameters: AllowForAlignment.
         Layout/CommentIndentation:
           Exclude:
             - 'example2.rb'
 
         # Offense count: 1
-        # This cop supports safe auto-correction (--auto-correct).
+        # This cop supports safe autocorrection (--auto-correct).
         # Configuration parameters: EnforcedStyle.
         # SupportedStyles: normal, indented_internal_methods
         Layout/IndentationConsistency:
@@ -948,7 +948,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             - 'example2.rb'
 
         # Offense count: 1
-        # This cop supports safe auto-correction (--auto-correct).
+        # This cop supports safe autocorrection (--auto-correct).
         # Configuration parameters: IndentationWidth, EnforcedStyle.
         # SupportedStyles: spaces, tabs
         Layout/IndentationStyle:
@@ -956,7 +956,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             - 'example2.rb'
 
         # Offense count: 1
-        # This cop supports safe auto-correction (--auto-correct).
+        # This cop supports safe autocorrection (--auto-correct).
         Layout/InitialIndentation:
           Exclude:
             - 'example2.rb'
@@ -982,7 +982,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          'again.',
          '',
          '# Offense count: 1',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: EnforcedStyle, AllowInnerSlashes.',
          '# SupportedStyles: slashes, percent_r, mixed',
          'Style/RegexpLiteral:',
@@ -1038,32 +1038,32 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '# versions of RuboCop, may require this file to be generated ' \
          'again.',
          '',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: AllowForAlignment.',
          'Layout/CommentIndentation:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: EnforcedStyle.',
          '# SupportedStyles: normal, indented_internal_methods',
          'Layout/IndentationConsistency:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: IndentationWidth, EnforcedStyle.',
          '# SupportedStyles: spaces, tabs',
          'Layout/IndentationStyle:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          'Layout/InitialIndentation:',
          '  Exclude:',
          "    - 'example2.rb'",
          '',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: AllowForAlignment, ' \
          'EnforcedStyleForExponentOperator.',
          '# SupportedStylesForExponentOperator: space, no_space',
@@ -1071,7 +1071,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '  Exclude:',
          "    - 'example1.rb'",
          '',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: AllowInHeredoc.',
          'Layout/TrailingWhitespace:',
          '  Exclude:',
@@ -1089,7 +1089,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '  Exclude:',
          "    - 'example1.rb'",
          '',
-         '# This cop supports safe auto-correction (--auto-correct).',
+         '# This cop supports safe autocorrection (--auto-correct).',
          '# Configuration parameters: AllowHeredoc, ' \
          'AllowURI, URISchemes, IgnoreCopDirectives, ' \
          'IgnoredPatterns.',
@@ -1171,14 +1171,14 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         expect(File.readlines('.rubocop_todo.yml')[8..-1].join)
           .to eq(<<~YAML)
             # Offense count: 3
-            # This cop supports safe auto-correction (--auto-correct).
+            # This cop supports safe autocorrection (--auto-correct).
             # Configuration parameters: EnforcedStyle.
             # SupportedStyles: always, always_true, never
             Style/FrozenStringLiteralComment:
               Enabled: false
 
             # Offense count: 2
-            # This cop supports safe auto-correction (--auto-correct).
+            # This cop supports safe autocorrection (--auto-correct).
             # Configuration parameters: RequireEnglish, EnforcedStyle.
             # SupportedStyles: use_perl_names, use_english_names, use_builtin_english_names
             Style/SpecialGlobalVars:
@@ -1192,7 +1192,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         expect(File.readlines('.rubocop_todo.yml')[8..-1].join)
           .to eq(<<~YAML)
             # Offense count: 4
-            # This cop supports safe auto-correction (--auto-correct).
+            # This cop supports safe autocorrection (--auto-correct).
             # Configuration parameters: EnforcedStyle.
             # SupportedStyles: always, always_true, never
             Style/FrozenStringLiteralComment:
@@ -1203,7 +1203,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                 - 'example4.rb'
 
             # Offense count: 3
-            # This cop supports safe auto-correction (--auto-correct).
+            # This cop supports safe autocorrection (--auto-correct).
             # Configuration parameters: RequireEnglish, EnforcedStyle.
             # SupportedStyles: use_perl_names, use_english_names, use_builtin_english_names
             Style/SpecialGlobalVars:
@@ -1225,7 +1225,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           Inspecting 1 file
           C
 
-          1 file inspected, 1 offense detected, 1 offense auto-correctable
+          1 file inspected, 1 offense detected, 1 offense autocorrectable
           Created .rubocop_todo.yml.
         OUTPUT
       end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1341,7 +1341,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RESULT
   end
 
-  # In this example, the auto-correction (changing "fail" to "raise")
+  # In this example, the autocorrection (changing "fail" to "raise")
   # creates a new problem (alignment of parameters), which is also
   # corrected automatically.
   it 'can correct a problems and the problem it creates' do
@@ -1372,7 +1372,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RESULT
   end
 
-  # Thanks to repeated auto-correction, we can get rid of the trailing
+  # Thanks to repeated autocorrection, we can get rid of the trailing
   # spaces, and then the extra empty line.
   it 'can correct two problems in the same place' do
     create_file('example.rb', ['# Example class.', 'class Klass', '  ', '  def f; end', 'end'])

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
                   'usage when having a single-line body. Another good ' \
                   'alternative is the usage of control flow &&/||.',
                   '',
-                  '1 file inspected, 1 offense detected, 1 offense auto-correctable',
+                  '1 file inspected, 1 offense detected, 1 offense autocorrectable',
                   ''].join("\n"))
       end
 
@@ -536,7 +536,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
                     'usage when having a single-line body. Another good ' \
                     'alternative is the usage of control flow &&/||.',
                     '',
-                    '1 file inspected, 1 offense detected, 1 offense auto-correctable',
+                    '1 file inspected, 1 offense detected, 1 offense autocorrectable',
                     ''].join("\n"))
         end
       end
@@ -562,7 +562,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
             == example.rb ==
             C:  1:  6: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
-            1 file inspected, 1 offense detected, 1 offense auto-correctable
+            1 file inspected, 1 offense detected, 1 offense autocorrectable
           RESULT
       end
     end
@@ -582,7 +582,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
           C:  1:  5: [Correctable] Layout/SpaceAroundOperators: Surrounding space missing for operator ==.
           C:  2:  1: [Correctable] Layout/IndentationStyle: Tab detected in indentation.
 
-          1 file inspected, 3 offenses detected, 3 offenses auto-correctable
+          1 file inspected, 3 offenses detected, 3 offenses autocorrectable
         RESULT
       end
 
@@ -603,7 +603,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
               C:  2:  1: [Correctable] Layout/IndentationStyle: Tab detected in indentation.
               W:  2:  2: Lint/UselessAssignment: Useless assignment to variable - y.
 
-              1 file inspected, 3 offenses detected, 2 offenses auto-correctable
+              1 file inspected, 3 offenses detected, 2 offenses autocorrectable
             RESULT
         end
       end
@@ -1250,7 +1250,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
               C:  1:  1: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
               C:  1:121: Layout/LineLength: Line is too long. [130/120]
 
-              1 file inspected, 2 offenses detected, 1 offense auto-correctable
+              1 file inspected, 2 offenses detected, 1 offense autocorrectable
             RESULT
         end
       end
@@ -1394,7 +1394,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
             '    end',
             '    ^^^',
             '',
-            '3 files inspected, 15 offenses detected, 12 offenses auto-correctable',
+            '3 files inspected, 15 offenses detected, 12 offenses autocorrectable',
             ''
           ].join("\n"))
         end
@@ -1504,7 +1504,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         C:  1:  1: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
         C:  1:121: Layout/LineLength: Line is too long. [130/120]
 
-        1 file inspected, 2 offenses detected, 1 offense auto-correctable
+        1 file inspected, 2 offenses detected, 1 offense autocorrectable
       RESULT
 
       expect(File.read('emacs_output.txt'))
@@ -1619,7 +1619,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
     end
 
     context 'with --auto-correct-all' do
-      def expect_auto_corrected
+      def expect_autocorrected
         expect_offense_detected
         expect($stdout.string.lines.to_a.last)
           .to eq('1 file inspected, 1 offense detected, ' \
@@ -1631,7 +1631,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
                         '--fail-level', 'autocorrect',
                         '--only', 'Layout/IndentationWidth',
                         target_file])).to eq(1)
-        expect_auto_corrected
+        expect_autocorrected
       end
 
       it 'fails when option is A and all offenses are autocorrected' do
@@ -1639,14 +1639,14 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
                         '--fail-level', 'A',
                         '--only', 'Layout/IndentationWidth',
                         target_file])).to eq(1)
-        expect_auto_corrected
+        expect_autocorrected
       end
 
       it 'succeeds when option is not given and all offenses are autocorrected' do
         expect(cli.run(['--auto-correct-all', '--format', 'simple',
                         '--only', 'Layout/IndentationWidth',
                         target_file])).to eq(0)
-        expect_auto_corrected
+        expect_autocorrected
       end
 
       it 'succeeds when option is refactor and all offenses are autocorrected' do
@@ -1654,7 +1654,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
                         '--fail-level', 'refactor',
                         '--only', 'Layout/IndentationWidth',
                         target_file])).to eq(0)
-        expect_auto_corrected
+        expect_autocorrected
       end
     end
   end
@@ -1708,7 +1708,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       end
     end
 
-    context 'no offense corrected, 1 offense auto-correctable' do
+    context 'no offense corrected, 1 offense autocorrectable' do
       it 'succeeds when there is only a disabled offense' do
         create_file(target_file, <<~RUBY)
           a = 'Hello'.freeze
@@ -1724,7 +1724,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       end
     end
 
-    context 'a offense corrected, a offense auto-correctable' do
+    context 'a offense corrected, a offense autocorrectable' do
       it 'succeeds when there is only a disabled offense' do
         create_file(target_file, <<~RUBY)
           a = "Hello".freeze
@@ -1834,7 +1834,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         == fake.rb ==
         C:  1:  3: [Correctable] Style/SpecialGlobalVars: Prefer $INPUT_RECORD_SEPARATOR or $RS from the stdlib 'English' module (don't forget to require it) over $/.
 
-        1 file inspected, 1 offense detected, 1 offense auto-correctable
+        1 file inspected, 1 offense detected, 1 offense autocorrectable
       RESULT
     ensure
       $stdin = STDIN

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           C:  1:  1: Layout/EndOfLine: Carriage return character detected.
           C:  1:  1: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
 
-          1 file inspected, 2 offenses detected, 1 offense auto-correctable
+          1 file inspected, 2 offenses detected, 1 offense autocorrectable
       RESULT
       expect($stderr.string).to eq(<<~RESULT)
         #{abs('.rubocop.yml')}: Warning: no department given for EndOfLine.
@@ -140,7 +140,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         == example.rb ==
         C:  3:  6: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
-        1 file inspected, 1 offense detected, 1 offense auto-correctable
+        1 file inspected, 1 offense detected, 1 offense autocorrectable
     RESULT
   end
 
@@ -213,7 +213,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         end
       end
 
-      # NOTE: Cannot be auto-corrected with `parallel`.
+      # NOTE: Cannot be autocorrected with `parallel`.
       context 'when specifying `--debug` and `-a` options`' do
         it 'fails with an error message' do
           create_file('example1.rb', <<~RUBY)
@@ -797,7 +797,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               C:  9:  3: [Correctable] Layout/IndentationWidth: Use 2 (not 0) spaces for indented_internal_methods indentation.
               C: 15:  3: [Correctable] Layout/IndentationWidth: Use 2 (not 0) spaces for indented_internal_methods indentation.
 
-              1 file inspected, 2 offenses detected, 2 offenses auto-correctable
+              1 file inspected, 2 offenses detected, 2 offenses autocorrectable
           RESULT
         end
       end
@@ -882,7 +882,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               == example.rb ==
               C:  3:  6: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
-              1 file inspected, 1 offense detected, 1 offense auto-correctable
+              1 file inspected, 1 offense detected, 1 offense autocorrectable
             RESULT
         end
       end
@@ -920,7 +920,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         == example1.rb ==
         C:  3:  6: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
-        2 files inspected, 2 offenses detected, 2 offenses auto-correctable
+        2 files inspected, 2 offenses detected, 2 offenses autocorrectable
       RESULT
     end
 
@@ -946,7 +946,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         == example1.rb ==
         C:  3:  6: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
-        2 files inspected, 2 offenses detected, 2 offenses auto-correctable
+        2 files inspected, 2 offenses detected, 2 offenses autocorrectable
       RESULT
     end
 
@@ -1092,7 +1092,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         == special.dsl ==
         C:  3:  9: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
 
-        1 file inspected, 1 offense detected, 1 offense auto-correctable
+        1 file inspected, 1 offense detected, 1 offense autocorrectable
       RESULT
     end
 
@@ -1129,7 +1129,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           == example1.rb ==
           C:  3:  7: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
-          1 file inspected, 1 offense detected, 1 offense auto-correctable
+          1 file inspected, 1 offense detected, 1 offense autocorrectable
         RESULT
     end
 
@@ -1149,7 +1149,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             == example1.rb ==
             C:  3:  7: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
-            1 file inspected, 1 offense detected, 1 offense auto-correctable
+            1 file inspected, 1 offense detected, 1 offense autocorrectable
           RESULT
       end
     end
@@ -1203,7 +1203,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         C:  4:  6: [Correctable] Style/PercentLiteralDelimiters: %q-literals should be delimited by ( and ).
         C:  4:  6: [Correctable] Style/RedundantPercentQ: Use %q only for strings that contain both single quotes and double quotes.
 
-        1 file inspected, 3 offenses detected, 3 offenses auto-correctable
+        1 file inspected, 3 offenses detected, 3 offenses autocorrectable
       RESULT
     end
 
@@ -1233,7 +1233,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           C:  1:  5: [Correctable] Style/CollectionMethods: Prefer find_all over select.
           C:  1: 26: [Correctable] Style/CollectionMethods: Prefer map over collect.
 
-          1 file inspected, 2 offenses detected, 2 offenses auto-correctable
+          1 file inspected, 2 offenses detected, 2 offenses autocorrectable
         RESULT
     end
 
@@ -1257,7 +1257,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         == example1.rb ==
         C:  3:  1: [Correctable] Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
 
-        1 file inspected, 1 offense detected, 1 offense auto-correctable
+        1 file inspected, 1 offense detected, 1 offense autocorrectable
       RESULT
       expect(result).to eq(1)
     end
@@ -1277,7 +1277,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           == example_src/example1.rb ==
           C:  3:  7: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
-          1 file inspected, 1 offense detected, 1 offense auto-correctable
+          1 file inspected, 1 offense detected, 1 offense autocorrectable
         RESULT
     end
 
@@ -1571,7 +1571,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           C:  3: 46: [Correctable] Style/CommentedKeyword: Do not place comments on the same line as the def keyword.
           E:  3:121: Layout/LineLength: Line is too long. [130/120]
 
-          1 file inspected, 4 offenses detected, 1 offense auto-correctable
+          1 file inspected, 4 offenses detected, 1 offense autocorrectable
         RESULT
         expect($stderr.string).to eq('')
       end
@@ -1668,7 +1668,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         YAML
       end
 
-      it 'does not suggest `1 offense auto-correctable` for `Style/StringLiterals`' do
+      it 'does not suggest `1 offense autocorrectable` for `Style/StringLiterals`' do
         create_file('example.rb', <<~RUBY)
           # frozen_string_literal: true
 
@@ -2122,7 +2122,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           C:  1:  1: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
           I:  1: 31: Layout/LineLength: Line is too long. [47/30]
 
-          1 file inspected, 2 offenses detected, 1 offense auto-correctable
+          1 file inspected, 2 offenses detected, 1 offense autocorrectable
         RESULT
       end
     end

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -371,7 +371,7 @@ RSpec.describe RuboCop::Config do
 
     describe 'conflicting Safe settings' do
       context 'when the configuration includes an unsafe cop that is ' \
-              'explicitly declared to have a safe auto-correction' do
+              'explicitly declared to have a safe autocorrection' do
         before do
           create_file(configuration_path, <<~YAML)
             Style/PreferredHashMethods:
@@ -384,13 +384,13 @@ RSpec.describe RuboCop::Config do
           expect { configuration.validate }
             .to raise_error(
               RuboCop::ValidationError,
-              /Unsafe cops cannot have a safe auto-correction/
+              /Unsafe cops cannot have a safe autocorrection/
             )
         end
       end
 
       context 'when the configuration includes an unsafe cop without ' \
-              'a declaration of its auto-correction' do
+              'a declaration of its autocorrection' do
         before do
           create_file(configuration_path, <<~YAML)
             Style/PreferredHashMethods:

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -339,7 +339,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
       it { is_expected.to be(false) }
     end
 
-    context 'when auto-correction of the cop is declared unsafe' do
+    context 'when autocorrection of the cop is declared unsafe' do
       let(:cop_config) { { 'SafeAutoCorrect' => false } }
 
       it { is_expected.to be(false) }

--- a/spec/rubocop/cop/internal_affairs/example_description_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/example_description_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
   context 'with `expect_correction`' do
     it 'registers an offense when given an improper description' do
       expect_offense(<<~RUBY)
-        it 'does not auto-correct' do
-           ^^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_correction`.
+        it 'does not autocorrect' do
+           ^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_correction`.
           expect_correction('code', source: 'new code')
         end
       RUBY
@@ -76,8 +76,8 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
     context 'in conjunction with expect_offense' do
       it 'registers an offense when given an improper description' do
         expect_offense(<<~RUBY)
-          it 'registers an offense but does not auto-correct' do
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_correction`.
+          it 'registers an offense but does not autocorrect' do
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_correction`.
             expect_offense('code')
             expect_correction('code')
           end
@@ -87,8 +87,8 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
       context 'when the description is invalid for both methods' do
         it 'registers an offense for the first method encountered' do
           expect_offense(<<~RUBY)
-            it 'does not register an offense and does not auto-correct' do
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_offense`.
+            it 'does not register an offense and does not autocorrect' do
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_offense`.
               expect_offense('code')
               expect_correction('code')
             end
@@ -111,8 +111,8 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
     context 'in conjunction with expect_offense' do
       it 'registers an offense when given an improper description' do
         expect_offense(<<~RUBY)
-          it 'auto-corrects' do
-             ^^^^^^^^^^^^^^^ Description does not match use of `expect_no_corrections`.
+          it 'autocorrects' do
+             ^^^^^^^^^^^^^^ Description does not match use of `expect_no_corrections`.
             expect_offense('code')
             expect_no_corrections
           end

--- a/spec/rubocop/cop/internal_affairs/node_type_predicate_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/node_type_predicate_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::InternalAffairs::NodeTypePredicate, :config do
   context 'comparison node type check' do
-    it 'registers an offense and auto-corrects' do
+    it 'registers an offense and autocorrects' do
       expect_offense(<<~RUBY)
         node.type == :send
         ^^^^^^^^^^^^^^^^^^ Use `#send_type?` to check node type.

--- a/spec/rubocop/cop/layout/array_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/array_alignment_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment, :config do
       RUBY
     end
 
-    it 'auto-corrects array within array with too much indentation' do
+    it 'autocorrects array within array with too much indentation' do
       expect_offense(<<~RUBY)
         [:l1,
           [:l2,
@@ -76,7 +76,7 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment, :config do
       RUBY
     end
 
-    it 'auto-corrects array within array with too little indentation' do
+    it 'autocorrects array within array with too little indentation' do
       expect_offense(<<~RUBY)
         [:l1,
         [:l2,
@@ -142,7 +142,7 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment, :config do
       RUBY
     end
 
-    it 'auto-corrects array if the first element being on a new row' do
+    it 'autocorrects array if the first element being on a new row' do
       expect_offense(<<~RUBY)
         array = [
           a,
@@ -220,7 +220,7 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment, :config do
       RUBY
     end
 
-    it 'auto-corrects array within array with too much indentation' do
+    it 'autocorrects array within array with too much indentation' do
       expect_offense(<<~RUBY)
         [:l1,
            [:l2,
@@ -238,7 +238,7 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment, :config do
       RUBY
     end
 
-    it 'auto-corrects array within array with too little indentation' do
+    it 'autocorrects array within array with too little indentation' do
       expect_offense(<<~RUBY)
         [:l1,
          [:l2,
@@ -304,7 +304,7 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment, :config do
       RUBY
     end
 
-    it 'auto-corrects array if the first element being on a new row' do
+    it 'autocorrects array if the first element being on a new row' do
       expect_offense(<<~RUBY)
         array = [
           a,

--- a/spec/rubocop/cop/layout/assignment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/assignment_indentation_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe RuboCop::Cop::Layout::AssignmentIndentation, :config do
       RUBY
     end
 
-    it 'auto-corrects indentation' do
+    it 'autocorrects indentation' do
       expect_offense(<<~RUBY)
         a =
           if b ; end

--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -820,7 +820,7 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
   context 'when `when` is on the same line as `case`' do
     let(:cop_config) { {} }
 
-    it 'registers an offense but does not auto-correct' do
+    it 'registers an offense but does not autocorrect' do
       expect_offense(<<~RUBY)
         case test when something
                   ^^^^ Indent `when` as deep as `case`.

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
   end
 
   context 'initializer is private and comes after attribute macro' do
-    it 'registers offense and auto-corrects' do
+    it 'registers offense and autocorrects' do
       expect_offense(<<~RUBY)
         class A
           private

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     RUBY
   end
 
-  it 'auto-corrects when there are too many new lines' do
+  it 'autocorrects when there are too many new lines' do
     expect_offense(<<~RUBY)
       def a; end
 

--- a/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody, :config do
   # The cop only registers an offense if the extra line is completely empty. If
   # there is trailing whitespace, then that must be dealt with first. Having
   # two cops registering offense for the line with only spaces would cause
-  # havoc in auto-correction.
+  # havoc in autocorrection.
   it 'accepts method body starting with a line with spaces' do
     expect_no_offenses(['def some_method', '  ', '  do_something', 'end'].join("\n"))
   end

--- a/spec/rubocop/cop/layout/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_consistency_spec.rb
@@ -808,7 +808,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
       RUBY
     end
 
-    it 'does not auto-correct an offense within another offense' do # rubocop:disable InternalAffairs/ExampleDescription
+    it 'does not autocorrect an offense within another offense' do # rubocop:disable InternalAffairs/ExampleDescription
       expect_offense(<<~RUBY)
         require 'spec_helper'
         describe ArticlesController do

--- a/spec/rubocop/cop/layout/leading_empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/leading_empty_lines_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe RuboCop::Cop::Layout::LeadingEmptyLines, :config do
     RUBY
   end
 
-  context 'auto-correct' do
+  context 'autocorrect' do
     context 'in collaboration' do
       let(:config) do
         RuboCop::Config.new('Layout/SpaceAroundEqualsInParameterDefault' => {

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -330,7 +330,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout, :config do
     RUBY
   end
 
-  it 'auto-corrects nested parens correctly' do
+  it 'autocorrects nested parens correctly' do
     expect_offense(<<~RUBY)
       def f
         X.map do |

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             end
           RUBY
 
-          # Except for `rescue`, it will be aligned by `Layout/BeginEndAlignment` auto-correction.
+          # Except for `rescue`, it will be aligned by `Layout/BeginEndAlignment` autocorrection.
           expect_correction(<<~RUBY)
             x ||= begin
               1
@@ -118,7 +118,7 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
                   end
           RUBY
 
-          # Except for `rescue`, it will be aligned by `Layout/BeginEndAlignment` auto-correction.
+          # Except for `rescue`, it will be aligned by `Layout/BeginEndAlignment` autocorrection.
           expect_correction(<<~RUBY)
             x ||= begin
                     1
@@ -167,7 +167,7 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             end
           RUBY
 
-          # Except for `rescue`, it will be aligned by `Layout/BeginEndAlignment` auto-correction.
+          # Except for `rescue`, it will be aligned by `Layout/BeginEndAlignment` autocorrection.
           expect_correction(<<~RUBY)
             x ||= begin
               1

--- a/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
       RUBY
     end
 
-    it 'auto-corrects even if some lines have space' do
+    it 'autocorrects even if some lines have space' do
       expect_offense(<<~RUBY)
         x = 0
 
@@ -139,14 +139,14 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
       expect_no_offenses("x = 0\n\n")
     end
 
-    it 'auto-corrects missing blank line' do
+    it 'autocorrects missing blank line' do
       expect_correction(<<~RUBY, source: "x = 0\n")
         x = 0
 
       RUBY
     end
 
-    it 'auto-corrects missing newline' do
+    it 'autocorrects missing newline' do
       expect_correction(<<~RUBY, source: 'x = 0')
         x = 0
 

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
     expect_no_offenses('x = 0')
   end
 
-  it 'auto-corrects unwanted space' do
+  it 'autocorrects unwanted space' do
     expect_offense(<<~RUBY)
       x = 0#{trailing_whitespace}
            ^ Trailing whitespace detected.

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation, :config do
   it_behaves_like('literal interpolation in words literal', '%W')
   it_behaves_like('literal interpolation in words literal', '%I')
 
-  it 'handles nested interpolations when auto-correction' do
+  it 'handles nested interpolations when autocorrecting' do
     expect_offense(<<~'RUBY')
       "this is #{"#{1}"} silly"
                     ^ Literal interpolation detected.
@@ -242,7 +242,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation, :config do
   it_behaves_like('non-special string literal interpolation', %('foo'))
   it_behaves_like('non-special string literal interpolation', %("foo"))
 
-  it 'handles double quotes in single quotes when auto-correction' do
+  it 'handles double quotes in single quotes when autocorrecting' do
     expect_offense(<<~'RUBY')
       "this is #{'"'} silly"
                  ^^^ Literal interpolation detected.
@@ -253,7 +253,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation, :config do
     RUBY
   end
 
-  it 'handles backslach in single quotes when auto-correction' do
+  it 'handles backslash in single quotes when autocorrecting' do
     expect_offense(<<~'RUBY')
       x = "ABC".gsub(/(A)(B)(C)/, "D#{'\2'}F")
                                       ^^^^ Literal interpolation detected.
@@ -270,7 +270,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation, :config do
     RUBY
   end
 
-  it 'handles backslach in double quotes when auto-correction' do
+  it 'handles backslash in double quotes when autocorrecting' do
     expect_offense(<<~'RUBY')
       "this is #{"\n"} silly"
                  ^^^^ Literal interpolation detected.

--- a/spec/rubocop/cop/lint/rescue_type_spec.rb
+++ b/spec/rubocop/cop/lint/rescue_type_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::Lint::RescueType, :config do
   shared_examples 'offenses' do |rescues|
     context 'begin rescue' do
       context "rescuing from #{rescues}" do
-        it 'registers an offense and auto-corrects' do
+        it 'registers an offense and autocorrects' do
           expect_offense(<<~RUBY, rescues: rescues)
             begin
               foo
@@ -59,7 +59,7 @@ RSpec.describe RuboCop::Cop::Lint::RescueType, :config do
       end
 
       context "rescuing from #{rescues} before another exception" do
-        it 'registers an offense and auto-corrects' do
+        it 'registers an offense and autocorrects' do
           expect_offense(<<~RUBY, rescues: rescues)
             begin
               foo
@@ -80,7 +80,7 @@ RSpec.describe RuboCop::Cop::Lint::RescueType, :config do
       end
 
       context "rescuing from #{rescues} after another exception" do
-        it 'registers an offense and auto-corrects' do
+        it 'registers an offense and autocorrects' do
           expect_offense(<<~RUBY, rescues: rescues)
             begin
               foo
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::Lint::RescueType, :config do
 
     context 'begin rescue ensure' do
       context "rescuing from #{rescues}" do
-        it 'registers an offense and auto-corrects' do
+        it 'registers an offense and autocorrects' do
           expect_offense(<<~RUBY, rescues: rescues)
             begin
               foo
@@ -130,7 +130,7 @@ RSpec.describe RuboCop::Cop::Lint::RescueType, :config do
 
     context 'def rescue' do
       context "rescuing from #{rescues}" do
-        it 'registers an offense and auto-corrects' do
+        it 'registers an offense and autocorrects' do
           expect_offense(<<~RUBY, rescues: rescues)
             def foobar
               foo
@@ -153,7 +153,7 @@ RSpec.describe RuboCop::Cop::Lint::RescueType, :config do
 
     context 'def rescue ensure' do
       context "rescuing from #{rescues}" do
-        it 'registers an offense and auto-corrects' do
+        it 'registers an offense and autocorrects' do
           expect_offense(<<~RUBY, rescues: rescues)
             def foobar
               foo

--- a/spec/rubocop/cop/lint/script_permission_spec.rb
+++ b/spec/rubocop/cop/lint/script_permission_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission, :config do
         expect(file.stat.executable?).to be_truthy
       end
 
-      context 'if auto-correction is off' do
+      context 'if autocorrection is off' do
         # very dirty hack
         def _investigate(cop, processed_source)
           cop.instance_variable_get(:@options)[:auto_correct] = false

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
 
       context 'and all the arguments are unused' do
         it 'registers offenses and suggests the use of `*` and ' \
-           'auto-corrects to add underscore-prefix to all arguments' do
+           'autocorrects to add underscore-prefix to all arguments' do
           (foo_message, bar_message) = %w[foo bar].map do |arg|
             "Unused method argument - `#{arg}`. " \
               "If it's necessary, use `_` or `_#{arg}` " \

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
     end
 
     context 'with variable being referenced' do
-      it 'renames the variable references when auto-correcting' do
+      it 'renames the variable references when autocorrecting' do
         expect_offense(<<~RUBY)
           begin
             get something

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
         RUBY
       end
 
-      it "auto-corrects \"#{operator}\" with #{prefer} in method calls" do
+      it "autocorrects \"#{operator}\" with #{prefer} in method calls" do
         expect_offense(<<~RUBY, operator: operator)
           method a %{operator} b
                    ^{operator} Use `#{prefer}` instead of `#{operator}`.
@@ -277,7 +277,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
         RUBY
       end
 
-      it "auto-corrects \"#{operator}\" with #{prefer} in method calls (2)" do
+      it "autocorrects \"#{operator}\" with #{prefer} in method calls (2)" do
         expect_offense(<<~RUBY, operator: operator)
           method a,b %{operator} b
                      ^{operator} Use `#{prefer}` instead of `#{operator}`.
@@ -288,7 +288,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
         RUBY
       end
 
-      it "auto-corrects \"#{operator}\" with #{prefer} in method calls (3)" do
+      it "autocorrects \"#{operator}\" with #{prefer} in method calls (3)" do
         expect_offense(<<~RUBY, operator: operator)
           obj.method a %{operator} b
                        ^{operator} Use `#{prefer}` instead of `#{operator}`.
@@ -299,7 +299,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
         RUBY
       end
 
-      it "auto-corrects \"#{operator}\" with #{prefer} in method calls (4)" do
+      it "autocorrects \"#{operator}\" with #{prefer} in method calls (4)" do
         expect_offense(<<~RUBY, operator: operator)
           obj.method a,b %{operator} b
                          ^{operator} Use `#{prefer}` instead of `#{operator}`.
@@ -310,7 +310,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
         RUBY
       end
 
-      it "auto-corrects \"#{operator}\" with #{prefer} and doesn't add extra parentheses" do
+      it "autocorrects \"#{operator}\" with #{prefer} and doesn't add extra parentheses" do
         expect_offense(<<~RUBY, operator: operator)
           method(a, b) %{operator} b
                        ^{operator} Use `#{prefer}` instead of `#{operator}`.
@@ -321,7 +321,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
         RUBY
       end
 
-      it "auto-corrects \"#{operator}\" with #{prefer} and adds parentheses to expr" do
+      it "autocorrects \"#{operator}\" with #{prefer} and adds parentheses to expr" do
         expect_offense(<<~RUBY, operator: operator)
           b %{operator} method a,b
             ^{operator} Use `#{prefer}` instead of `#{operator}`.

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
 
       # A method definition that uses forwarding arguments without parentheses
       # is a syntax error. e.g. `def do_something ...`
-      # Therefore it enforces parentheses with auto-correction.
+      # Therefore it enforces parentheses with autocorrection.
       expect_correction(<<~RUBY)
         def foo(...)
           bar(...)

--- a/spec/rubocop/cop/style/attr_spec.rb
+++ b/spec/rubocop/cop/style/attr_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::Style::Attr, :config do
     RUBY
   end
 
-  context 'auto-corrects' do
+  context 'autocorrects' do
     it 'attr to attr_reader' do
       expect_offense(<<~RUBY)
         attr :name

--- a/spec/rubocop/cop/style/block_comments_spec.rb
+++ b/spec/rubocop/cop/style/block_comments_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::Style::BlockComments, :config do
     expect_no_offenses('# comment')
   end
 
-  it 'auto-corrects a block comment into a regular comment' do
+  it 'autocorrects a block comment into a regular comment' do
     expect_offense(<<~RUBY)
       =begin
       ^^^^^^ Do not use block comments.
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Cop::Style::BlockComments, :config do
     RUBY
   end
 
-  it 'auto-corrects an empty block comment by removing it' do
+  it 'autocorrects an empty block comment by removing it' do
     expect_offense(<<~RUBY)
       =begin
       ^^^^^^ Do not use block comments.
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::Style::BlockComments, :config do
     RUBY
   end
 
-  it 'auto-corrects a block comment into a regular comment (without trailingnewline)' do
+  it 'autocorrects a block comment into a regular comment (without trailingnewline)' do
     expect_offense(<<~RUBY)
       =begin
       ^^^^^^ Do not use block comments.

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
     end
 
     context 'with a procedural multi-line block' do
-      it 'auto-corrects { and } to do and end' do
+      it 'autocorrects { and } to do and end' do
         expect_offense(<<~RUBY)
           each { |x|
                ^ Prefer `do...end` over `{...}` for procedural blocks.
@@ -224,7 +224,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
 
-      it 'auto-corrects { and } to do and end with appropriate spacing' do
+      it 'autocorrects { and } to do and end with appropriate spacing' do
         expect_offense(<<~RUBY)
           each {|x|
                ^ Prefer `do...end` over `{...}` for procedural blocks.
@@ -256,7 +256,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       RUBY
     end
 
-    it 'auto-corrects do-end to {} if it is a functional block' do
+    it 'autocorrects do-end to {} if it is a functional block' do
       expect_offense(<<~RUBY)
         foo = map do |x|
                   ^^ Prefer `{...}` over `do...end` for functional blocks.
@@ -271,7 +271,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       RUBY
     end
 
-    it 'auto-corrects do-end to {} with appropriate spacing' do
+    it 'autocorrects do-end to {} with appropriate spacing' do
       expect_offense(<<~RUBY)
         foo = map do|x|
                   ^^ Prefer `{...}` over `do...end` for functional blocks.
@@ -286,7 +286,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       RUBY
     end
 
-    it 'auto-corrects do-end to {} if it is a functional block and does not change the meaning' do
+    it 'autocorrects do-end to {} if it is a functional block and does not change the meaning' do
       expect_offense(<<~RUBY)
         puts (map do |x|
                   ^^ Prefer `{...}` over `do...end` for functional blocks.
@@ -301,7 +301,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       RUBY
     end
 
-    it 'auto-corrects do-end with `rescue` to {} if it is a functional block' do
+    it 'autocorrects do-end with `rescue` to {} if it is a functional block' do
       expect_offense(<<~RUBY)
         x = map do |a|
                 ^^ Prefer `{...}` over `do...end` for functional blocks.
@@ -322,7 +322,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       RUBY
     end
 
-    it 'auto-corrects do-end with `ensure` to {} if it is a functional block' do
+    it 'autocorrects do-end with `ensure` to {} if it is a functional block' do
       expect_offense(<<~RUBY)
         x = map do |a|
                 ^^ Prefer `{...}` over `do...end` for functional blocks.
@@ -351,7 +351,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
     include_examples 'syntactic styles'
 
-    it 'auto-corrects do and end for single line blocks to { and }' do
+    it 'autocorrects do and end for single line blocks to { and }' do
       expect_offense(<<~RUBY)
         block do |x| end
               ^^ Prefer `{...}` over `do...end` for single-line blocks.
@@ -362,7 +362,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       RUBY
     end
 
-    it 'does not auto-correct do-end if {} would change the meaning' do
+    it 'does not autocorrect do-end if {} would change the meaning' do
       expect_offense(<<~RUBY)
         s.subspec 'Subspec' do |sp| end
                             ^^ Prefer `{...}` over `do...end` for single-line blocks.
@@ -371,7 +371,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       expect_no_corrections
     end
 
-    it 'does not auto-correct {} if do-end would change the meaning' do
+    it 'does not autocorrect {} if do-end would change the meaning' do
       expect_no_offenses(<<~RUBY)
         foo :bar, :baz, qux: lambda { |a|
           bar a
@@ -503,7 +503,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
 
-      it 'auto-corrects { and } to do and end' do
+      it 'autocorrects { and } to do and end' do
         expect_offense(<<~RUBY)
           each{ |x|
               ^ Avoid using `{...}` for multi-line blocks.
@@ -520,7 +520,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
 
-      it 'auto-corrects adjacent curly braces correctly' do
+      it 'autocorrects adjacent curly braces correctly' do
         expect_offense(<<~RUBY)
           (0..3).each { |a| a.times {
                                     ^ Avoid using `{...}` for multi-line blocks.
@@ -536,7 +536,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
 
-      it 'does not auto-correct {} if do-end would introduce a syntax error' do
+      it 'does not autocorrect {} if do-end would introduce a syntax error' do
         expect_no_offenses(<<~RUBY)
           my_method :arg1, arg2: proc {
             something
@@ -546,7 +546,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
     end
 
     context 'with a single line do-end block with an inline `rescue`' do
-      it 'auto-corrects properly' do
+      it 'autocorrects properly' do
         expect_offense(<<~RUBY)
           map do |x| x.y? rescue z end
               ^^ Prefer `{...}` over `do...end` for single-line blocks.
@@ -681,7 +681,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       end
     end
 
-    it 'auto-corrects do-end with `rescue` to {} if it is a functional block' do
+    it 'autocorrects do-end with `rescue` to {} if it is a functional block' do
       expect_offense(<<~RUBY)
         map do |a|
             ^^ Prefer `{...}` over `do...end` for multi-line chained blocks.
@@ -702,7 +702,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       RUBY
     end
 
-    it 'auto-corrects do-end with `ensure` to {} if it is a functional block' do
+    it 'autocorrects do-end with `ensure` to {} if it is a functional block' do
       expect_offense(<<~RUBY)
         map do |a|
             ^^ Prefer `{...}` over `do...end` for multi-line chained blocks.
@@ -752,7 +752,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       RUBY
     end
 
-    it 'does not auto-correct do-end if {} would change the meaning' do
+    it 'does not autocorrect do-end if {} would change the meaning' do
       expect_offense(<<~RUBY)
         s.subspec 'Subspec' do |sp| end
                             ^^ Prefer `{...}` over `do...end` for blocks.
@@ -830,7 +830,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       end
     end
 
-    it 'auto-corrects do-end with `rescue` to {} if it is a functional block' do
+    it 'autocorrects do-end with `rescue` to {} if it is a functional block' do
       expect_offense(<<~RUBY)
         map do |a|
             ^^ Prefer `{...}` over `do...end` for blocks.
@@ -851,7 +851,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       RUBY
     end
 
-    it 'auto-corrects do-end with `ensure` to {} if it is a functional block' do
+    it 'autocorrects do-end with `ensure` to {} if it is a functional block' do
       expect_offense(<<~RUBY)
         map do |a|
             ^^ Prefer `{...}` over `do...end` for blocks.
@@ -932,7 +932,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
 
-      it 'auto-corrects { and } to do and end' do
+      it 'autocorrects { and } to do and end' do
         expect_offense(<<~RUBY)
           each{ |x|
               ^ Avoid using `{...}` for multi-line blocks.

--- a/spec/rubocop/cop/style/character_literal_spec.rb
+++ b/spec/rubocop/cop/style/character_literal_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe RuboCop::Cop::Style::CharacterLiteral, :config do
     expect_no_offenses('%w{? A}')
   end
 
-  it 'auto-corrects ?\' to "\'"' do
+  it 'autocorrects ?\' to "\'"' do
     expect_offense(<<~RUBY)
       x = ?'
           ^^ Do not use the character literal - use string literal instead.

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'percent_x' } }
     let(:percent_literal_delimiters_config) { { 'PreferredDelimiters' => { '%x' => '[]' } } }
 
-    it 'respects the configuration when auto-correcting' do
+    it 'respects the configuration when autocorrecting' do
       expect_offense(<<~RUBY)
         `ls`
         ^^^^ Use `%x` around command string.
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       { 'PreferredDelimiters' => { 'default' => '()' } }
     end
 
-    it 'respects the configuration when auto-correcting' do
+    it 'respects the configuration when autocorrecting' do
       expect_offense(<<~'RUBY')
         `ls`
         ^^^^ Use `%x` around command string.
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       { 'PreferredDelimiters' => { '%x' => '[]', 'default' => '()' } }
     end
 
-    it 'ignores the default when auto-correcting' do
+    it 'ignores the default when autocorrecting' do
       expect_offense(<<~'RUBY')
         `ls`
         ^^^^ Use `%x` around command string.
@@ -95,7 +95,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a single-line ` string with backticks' do
-      it 'registers an offense without auto-correction' do
+      it 'registers an offense without autocorrection' do
         expect_offense(<<~'RUBY')
           foo = `echo \`ls\``
                 ^^^^^^^^^^^^^ Use `%x` around command string.
@@ -125,7 +125,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a multi-line ` string with backticks' do
-      it 'registers an offense without auto-correction' do
+      it 'registers an offense without autocorrection' do
         expect_offense(<<~'RUBY')
           foo = `
                 ^ Use `%x` around command string.
@@ -172,7 +172,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       describe 'when configured to allow inner backticks' do
         before { cop_config['AllowInnerBackticks'] = true }
 
-        it 'registers an offense without auto-correction' do
+        it 'registers an offense without autocorrection' do
           expect_offense(<<~RUBY)
             foo = %x(echo `ls`)
                   ^^^^^^^^^^^^^ Use backticks around command string.
@@ -215,7 +215,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       describe 'when configured to allow inner backticks' do
         before { cop_config['AllowInnerBackticks'] = true }
 
-        it 'registers an offense without auto-correction' do
+        it 'registers an offense without autocorrection' do
           expect_offense(<<~RUBY)
             foo = %x(
                   ^^^ Use backticks around command string.
@@ -247,7 +247,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a single-line ` string with backticks' do
-      it 'registers an offense without auto-correction' do
+      it 'registers an offense without autocorrection' do
         expect_offense(<<~'RUBY')
           foo = `echo \`ls\``
                 ^^^^^^^^^^^^^ Use `%x` around command string.
@@ -277,7 +277,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a multi-line ` string with backticks' do
-      it 'registers an offense without auto-correction' do
+      it 'registers an offense without autocorrection' do
         expect_offense(<<~'RUBY')
           foo = `
                 ^ Use `%x` around command string.
@@ -335,7 +335,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a single-line ` string with backticks' do
-      it 'registers an offense without auto-correction' do
+      it 'registers an offense without autocorrection' do
         expect_offense(<<~'RUBY')
           foo = `echo \`ls\``
                 ^^^^^^^^^^^^^ Use `%x` around command string.
@@ -373,7 +373,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a multi-line ` string with backticks' do
-      it 'registers an offense without auto-correction' do
+      it 'registers an offense without autocorrection' do
         expect_offense(<<~'RUBY')
           foo = `
                 ^ Use `%x` around command string.
@@ -407,7 +407,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       describe 'when configured to allow inner backticks' do
         before { cop_config['AllowInnerBackticks'] = true }
 
-        it 'registers an offense without auto-correction' do
+        it 'registers an offense without autocorrection' do
           expect_offense(<<~RUBY)
             foo = %x(echo `ls`)
                   ^^^^^^^^^^^^^ Use backticks around command string.

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
     end
 
     context 'upper case keyword with colon but no note' do
-      it 'registers an offense without auto-correction' do
+      it 'registers an offense without autocorrection' do
         expect_offense(<<~RUBY)
           # HACK:
             ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
     end
 
     context 'upper case keyword with space but no note' do
-      it 'registers an offense without auto-correction' do
+      it 'registers an offense without autocorrection' do
         expect_offense(<<~RUBY)
           # HACK#{trailing_whitespace}
             ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.
@@ -218,7 +218,7 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
     end
 
     context 'upper case keyword with colon but no note' do
-      it 'registers an offense without auto-correction' do
+      it 'registers an offense without autocorrection' do
         expect_offense(<<~RUBY)
           # HACK:
             ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.
@@ -229,7 +229,7 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
     end
 
     context 'upper case keyword with space but no note' do
-      it 'registers an offense without auto-correction' do
+      it 'registers an offense without autocorrection' do
         expect_offense(<<~RUBY)
           # HACK#{trailing_whitespace}
             ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -553,7 +553,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
     end
   end
 
-  shared_examples 'single line condition auto-correct' do
+  shared_examples 'single line condition autocorrect' do
     it 'corrects assignment to an if else condition' do
       expect_offense(<<~RUBY)
         bar = if foo
@@ -848,7 +848,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
       end
     end
 
-    it_behaves_like('single line condition auto-correct')
+    it_behaves_like('single line condition autocorrect')
 
     it 'corrects assignment to a namespaced constant' do
       expect_offense(<<~RUBY)
@@ -965,7 +965,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
     it_behaves_like('multiline all assignment types offense', '&&=')
     it_behaves_like('multiline all assignment types offense', '<<')
 
-    it_behaves_like('single line condition auto-correct')
+    it_behaves_like('single line condition autocorrect')
 
     it 'corrects assignment to a multiline if else condition' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -1229,7 +1229,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config, :config, :co
     RUBY
   end
 
-  describe 'auto-correct' do
+  describe 'autocorrect' do
     it 'corrects =~ in ternary operations' do
       expect_offense(<<~'RUBY')
         foo? ? bar =~ /a/ : bar =~ /b/
@@ -1947,7 +1947,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config, :config, :co
       RUBY
     end
 
-    context 'auto-correct' do
+    context 'autocorrect' do
       it 'corrects multiple assignment in if else' do
         expect_offense(<<~RUBY)
           if foo
@@ -2148,7 +2148,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config, :config, :co
   end
 
   context 'EndAlignment configured to start_of_line' do
-    context 'auto-correct' do
+    context 'autocorrect' do
       it 'uses proper end alignment in if' do
         expect_offense(<<~RUBY)
           if foo

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -3,9 +3,9 @@
 RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
   let(:missing_else_config) { {} }
 
-  shared_examples 'auto-correct' do |keyword|
+  shared_examples 'autocorrect' do |keyword|
     context 'MissingElse is disabled' do
-      it 'does auto-correction' do
+      it 'does autocorrection' do
         expect_offense(source)
 
         expect_correction(corrected_source)
@@ -20,13 +20,13 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
         end
 
         if ['both', keyword].include? missing_else_style
-          it 'does not auto-correct' do
+          it 'does not autocorrect' do
             expect_offense(source)
 
             expect_no_corrections
           end
         else
-          it 'does auto-correction' do
+          it 'does autocorrection' do
             expect_offense(source)
 
             expect_correction(corrected_source)
@@ -56,7 +56,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             if a; foo end
           RUBY
 
-          it_behaves_like 'auto-correct', 'if'
+          it_behaves_like 'autocorrect', 'if'
         end
 
         context 'not using semicolons' do
@@ -73,7 +73,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             end
           RUBY
 
-          it_behaves_like 'auto-correct', 'if'
+          it_behaves_like 'autocorrect', 'if'
         end
       end
 
@@ -113,11 +113,11 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
           end
         RUBY
 
-        it_behaves_like 'auto-correct', 'if'
+        it_behaves_like 'autocorrect', 'if'
       end
 
       context 'with an empty comment' do
-        it 'does not auto-correct' do
+        it 'does not autocorrect' do
           expect_offense(<<~RUBY)
             if cond
               something
@@ -142,7 +142,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
           unless cond; foo end
         RUBY
 
-        it_behaves_like 'auto-correct', 'if'
+        it_behaves_like 'autocorrect', 'if'
       end
 
       context 'with an else-clause containing only the literal nil' do
@@ -174,7 +174,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
           case v; when a; foo end
         RUBY
 
-        it_behaves_like 'auto-correct', 'case'
+        it_behaves_like 'autocorrect', 'case'
       end
 
       context 'with an else-clause containing only the literal nil' do
@@ -234,7 +234,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             end
           RUBY
 
-          it_behaves_like 'auto-correct', 'if'
+          it_behaves_like 'autocorrect', 'if'
         end
 
         context 'when the result is assigned to a variable' do
@@ -257,7 +257,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
                      end
           RUBY
 
-          it_behaves_like 'auto-correct', 'if'
+          it_behaves_like 'autocorrect', 'if'
         end
       end
 
@@ -271,7 +271,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             if a; foo elsif b; bar end
           RUBY
 
-          it_behaves_like 'auto-correct', 'if'
+          it_behaves_like 'autocorrect', 'if'
         end
 
         context 'with multiple elsifs' do
@@ -283,7 +283,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             if a; foo elsif b; bar; elsif c; bar end
           RUBY
 
-          it_behaves_like 'auto-correct', 'if'
+          it_behaves_like 'autocorrect', 'if'
         end
       end
 
@@ -316,7 +316,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
           unless cond; foo end
         RUBY
 
-        it_behaves_like 'auto-correct', 'if'
+        it_behaves_like 'autocorrect', 'if'
       end
 
       context 'with an else-clause with side-effects' do
@@ -349,7 +349,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             case v; when a; foo; when b; bar; end
           RUBY
 
-          it_behaves_like 'auto-correct', 'case'
+          it_behaves_like 'autocorrect', 'case'
         end
 
         context 'when the result is assigned to a variable' do
@@ -374,7 +374,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
                      end
           RUBY
 
-          it_behaves_like 'auto-correct', 'case'
+          it_behaves_like 'autocorrect', 'case'
         end
       end
 
@@ -411,7 +411,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
           if a; foo end
         RUBY
 
-        it_behaves_like 'auto-correct', 'if'
+        it_behaves_like 'autocorrect', 'if'
       end
 
       context 'with an else-clause containing only the literal nil' do
@@ -424,7 +424,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             if a; foo elsif b; bar end
           RUBY
 
-          it_behaves_like 'auto-correct', 'if'
+          it_behaves_like 'autocorrect', 'if'
         end
 
         context 'with multiple elsifs' do
@@ -436,7 +436,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             if a; foo elsif b; bar; elsif c; bar end
           RUBY
 
-          it_behaves_like 'auto-correct', 'if'
+          it_behaves_like 'autocorrect', 'if'
         end
       end
 
@@ -463,7 +463,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
           unless cond; foo end
         RUBY
 
-        it_behaves_like 'auto-correct', 'if'
+        it_behaves_like 'autocorrect', 'if'
       end
 
       context 'with an else-clause containing only the literal nil' do
@@ -475,7 +475,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
           unless cond; foo end
         RUBY
 
-        it_behaves_like 'auto-correct', 'if'
+        it_behaves_like 'autocorrect', 'if'
       end
 
       context 'with an else-clause with side-effects' do
@@ -501,7 +501,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
           case v; when a; foo end
         RUBY
 
-        it_behaves_like 'auto-correct', 'case'
+        it_behaves_like 'autocorrect', 'case'
       end
 
       context 'with an else-clause containing only the literal nil' do
@@ -513,7 +513,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
           case v; when a; foo; when b; bar; end
         RUBY
 
-        it_behaves_like 'auto-correct', 'case'
+        it_behaves_like 'autocorrect', 'case'
       end
 
       context 'with an else-clause with side-effects' do
@@ -568,6 +568,6 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
       end
     RUBY
 
-    it_behaves_like 'auto-correct', 'case'
+    it_behaves_like 'autocorrect', 'case'
   end
 end

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
       expect_no_offenses('test = Array.new(3)')
     end
 
-    it 'auto-corrects Array.new in block in block' do
+    it 'autocorrects Array.new in block in block' do
       expect_offense(<<~RUBY)
         puts { Array.new }
                ^^^^^^^^^ Use array literal `[]` instead of `Array.new`.
@@ -123,7 +123,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
       end
     end
 
-    it 'auto-corrects Hash.new in block' do
+    it 'autocorrects Hash.new in block' do
       expect_offense(<<~RUBY)
         puts { Hash.new }
                ^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
@@ -134,7 +134,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
       RUBY
     end
 
-    it 'auto-corrects Hash.new to {} in various contexts' do
+    it 'autocorrects Hash.new to {} in various contexts' do
       expect_offense(<<~RUBY)
         test = Hash.new
                ^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
@@ -151,7 +151,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
       RUBY
     end
 
-    it 'auto-correct Hash.new to {} as the only parameter to a method' do
+    it 'autocorrect Hash.new to {} as the only parameter to a method' do
       expect_offense(<<~RUBY)
         yadayada.map { a }.reduce Hash.new
                                   ^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
@@ -162,7 +162,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
       RUBY
     end
 
-    it 'auto-correct Hash.new to {} as the first parameter to a method' do
+    it 'autocorrect Hash.new to {} as the first parameter to a method' do
       expect_offense(<<~RUBY)
         yadayada.map { a }.reduce Hash.new, :merge
                                   ^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
@@ -173,7 +173,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
       RUBY
     end
 
-    it 'auto-correct changes Hash.new to {} and wraps it in parentheses ' \
+    it 'autocorrect changes Hash.new to {} and wraps it in parentheses ' \
        'when it is the only argument to super' do
       expect_offense(<<~RUBY)
         def foo
@@ -189,7 +189,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
       RUBY
     end
 
-    it 'auto-correct changes Hash.new to {} and wraps all arguments in ' \
+    it 'autocorrect changes Hash.new to {} and wraps all arguments in ' \
        'parentheses when it is the first argument to super' do
       expect_offense(<<~RUBY)
         def foo

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
       RUBY
     end
 
-    context 'auto-correct' do
+    context 'autocorrect' do
       context 'with range' do
         let(:expected_each_with_range) do
           <<~RUBY

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
       RUBY
     end
 
-    it 'registers an offense for variable argument but does not auto-correct' do
+    it 'registers an offense for variable argument but does not autocorrect' do
       expect_offense(<<~RUBY)
         puts "%f" % a
                   ^ Favor `sprintf` over `String#%`.
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
       expect_no_corrections
     end
 
-    it 'registers an offense for variable argument and assignment but does not auto-correct' do
+    it 'registers an offense for variable argument and assignment but does not autocorrect' do
       expect_offense(<<~RUBY)
         a = something()
         puts "%d" % a
@@ -134,7 +134,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
       RUBY
     end
 
-    it 'registers an offense for variable argument but does not auto-correct' do
+    it 'registers an offense for variable argument but does not autocorrect' do
       expect_offense(<<~RUBY)
         puts "%f" % a
                   ^ Favor `format` over `String#%`.
@@ -184,7 +184,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
       RUBY
     end
 
-    it 'does not auto-correct String#% with variable argument and assignment' do
+    it 'does not autocorrect String#% with variable argument and assignment' do
       expect_offense(<<~RUBY)
         a = something()
         puts "%d" % a

--- a/spec/rubocop/cop/style/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/style/hash_each_methods_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
   context 'when node matches a keys#each or values#each' do
     context 'when receiver is a send' do
-      it 'registers offense, auto-corrects foo#keys.each to foo#each_key' do
+      it 'registers offense, autocorrects foo#keys.each to foo#each_key' do
         expect_offense(<<~RUBY)
           foo.keys.each { |k| p k }
               ^^^^^^^^^ Use `each_key` instead of `keys.each`.
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         RUBY
       end
 
-      it 'registers offense, auto-corrects foo#values.each to foo#each_value' do
+      it 'registers offense, autocorrects foo#values.each to foo#each_value' do
         expect_offense(<<~RUBY)
           foo.values.each { |v| p v }
               ^^^^^^^^^^^ Use `each_value` instead of `values.each`.
@@ -35,7 +35,7 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
     end
 
     context 'when receiver is a hash literal' do
-      it 'registers offense, auto-corrects {}#keys.each with {}#each_key' do
+      it 'registers offense, autocorrects {}#keys.each with {}#each_key' do
         expect_offense(<<~RUBY)
           {}.keys.each { |k| p k }
              ^^^^^^^^^ Use `each_key` instead of `keys.each`.
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         RUBY
       end
 
-      it 'registers offense, auto-corrects {}#values.each with {}#each_value' do
+      it 'registers offense, autocorrects {}#values.each with {}#each_value' do
         expect_offense(<<~RUBY)
           {}.values.each { |k| p k }
              ^^^^^^^^^^^ Use `each_value` instead of `values.each`.

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -153,9 +153,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         expect_no_offenses('func(3, a: 0)')
       end
 
-      it 'auto-corrects even if it interferes with SpaceAroundOperators' do
+      it 'autocorrects even if it interferes with SpaceAroundOperators' do
         # Clobbering caused by two cops changing in the same range is dealt with
-        # by the auto-correct loop, so there's no reason to avoid a change.
+        # by the autocorrect loop, so there's no reason to avoid a change.
         expect_offense(<<~RUBY)
           { :a=>1, :b=>2 }
             ^^^^ Use the new Ruby 1.9 hash syntax.
@@ -168,7 +168,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       # Bug: https://github.com/rubocop/rubocop/issues/5019
-      it 'auto-corrects a missing space when hash is used as argument' do
+      it 'autocorrects a missing space when hash is used as argument' do
         expect_offense(<<~RUBY)
           foo:bar => 1
              ^^^^^^^ Use the new Ruby 1.9 hash syntax.
@@ -219,7 +219,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                             })
       end
 
-      it 'auto-corrects even if there is no space around =>' do
+      it 'autocorrects even if there is no space around =>' do
         expect_offense(<<~RUBY)
           { :a=>1, :b=>2 }
             ^^^^ Use the new Ruby 1.9 hash syntax.
@@ -312,7 +312,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
-      it 'auto-corrects to hash rockets when all elements have symbol value' do
+      it 'autocorrects to hash rockets when all elements have symbol value' do
         expect_offense(<<~RUBY)
           { a: :b, c: :d }
             ^^ Use hash rockets syntax.
@@ -541,7 +541,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
-      it 'auto-corrects to hash rockets when all elements have symbol value' do
+      it 'autocorrects to hash rockets when all elements have symbol value' do
         expect_offense(<<~RUBY)
           { a: :b, c: :d }
             ^^ Use hash rockets syntax.
@@ -755,7 +755,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       expect_no_offenses('{ a: 1, b: 2 }')
     end
 
-    it 'auto-corrects mixed key hashes' do
+    it 'autocorrects mixed key hashes' do
       expect_offense(<<~RUBY)
         { a: 1, :b => 2 }
                 ^^^^^ Don't mix styles in the same hash.

--- a/spec/rubocop/cop/style/if_inside_else_spec.rb
+++ b/spec/rubocop/cop/style/if_inside_else_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
         if b
         ^^ Convert `if` nested inside `else` to `elsif`.
           foo
-        else # This is expected to be auto-corrected by `Layout/IndentationWidth`.
+        else # This is expected to be autocorrected by `Layout/IndentationWidth`.
           bar
         end
       end
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
         blah
       elsif b
         foo
-        else # This is expected to be auto-corrected by `Layout/IndentationWidth`.
+        else # This is expected to be autocorrected by `Layout/IndentationWidth`.
           bar
       end
     RUBY
@@ -82,7 +82,7 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
         if b
         ^^ Convert `if` nested inside `else` to `elsif`.
           foo
-        elsif c # This is expected to be auto-corrected by `Layout/IndentationWidth`.
+        elsif c # This is expected to be autocorrected by `Layout/IndentationWidth`.
             bar
         elsif d
           baz
@@ -97,7 +97,7 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
         blah
       elsif b
         foo
-        elsif c # This is expected to be auto-corrected by `Layout/IndentationWidth`.
+        elsif c # This is expected to be autocorrected by `Layout/IndentationWidth`.
             bar
         elsif d
           baz

--- a/spec/rubocop/cop/style/infinite_loop_spec.rb
+++ b/spec/rubocop/cop/style/infinite_loop_spec.rb
@@ -184,8 +184,8 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop, :config do
     RUBY
   end
 
-  shared_examples_for 'auto-corrector' do |keyword, lit|
-    it "auto-corrects single line modifier #{keyword}" do
+  shared_examples_for 'autocorrector' do |keyword, lit|
+    it "autocorrects single line modifier #{keyword}" do
       expect_offense(<<~RUBY, keyword: keyword, lit: lit)
         something += 1 %{keyword} %{lit} # comment
                        ^{keyword} Use `Kernel#loop` for infinite loops.
@@ -199,7 +199,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop, :config do
     context 'with non-default indentation width' do
       let(:config) { RuboCop::Config.new('Layout/IndentationWidth' => { 'Width' => 4 }) }
 
-      it "auto-corrects multi-line modifier #{keyword} and indents correctly" do
+      it "autocorrects multi-line modifier #{keyword} and indents correctly" do
         expect_offense(<<~RUBY, keyword: keyword, lit: lit)
           # comment
           something 1, # comment 1
@@ -219,7 +219,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop, :config do
       end
     end
 
-    it "auto-corrects begin-end-#{keyword} with one statement" do
+    it "autocorrects begin-end-#{keyword} with one statement" do
       expect_offense(<<~RUBY, keyword: keyword, lit: lit)
         begin # comment 1
           something += 1 # comment 2
@@ -234,7 +234,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop, :config do
       RUBY
     end
 
-    it "auto-corrects begin-end-#{keyword} with two statements" do
+    it "autocorrects begin-end-#{keyword} with two statements" do
       expect_offense(<<~RUBY, keyword: keyword, lit: lit)
         begin
           something += 1
@@ -251,7 +251,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop, :config do
       RUBY
     end
 
-    it "auto-corrects single line modifier #{keyword} with and" do
+    it "autocorrects single line modifier #{keyword} with and" do
       expect_offense(<<~RUBY, keyword: keyword, lit: lit)
         something and something_else %{keyword} %{lit}
                                      ^{keyword} Use `Kernel#loop` for infinite loops.
@@ -262,7 +262,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop, :config do
       RUBY
     end
 
-    it "auto-corrects the usage of #{keyword} with do" do
+    it "autocorrects the usage of #{keyword} with do" do
       expect_offense(<<~RUBY, keyword: keyword, lit: lit)
         %{keyword} %{lit} do
         ^{keyword} Use `Kernel#loop` for infinite loops.
@@ -275,7 +275,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop, :config do
       RUBY
     end
 
-    it "auto-corrects the usage of #{keyword} without do" do
+    it "autocorrects the usage of #{keyword} without do" do
       expect_offense(<<~RUBY, keyword: keyword, lit: lit)
         %{keyword} %{lit}
         ^{keyword} Use `Kernel#loop` for infinite loops.
@@ -289,6 +289,6 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop, :config do
     end
   end
 
-  it_behaves_like 'auto-corrector', 'while', 'true'
-  it_behaves_like 'auto-corrector', 'until', 'false'
+  it_behaves_like 'autocorrector', 'while', 'true'
+  it_behaves_like 'autocorrector', 'until', 'false'
 end

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
       expect_no_offenses('call(a, b)')
     end
 
-    it 'auto-corrects x.call to x.()' do
+    it 'autocorrects x.call to x.()' do
       expect_offense(<<~RUBY)
         a.call
         ^^^^^^ Prefer the use of `a.()` over `a.call`.
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
       RUBY
     end
 
-    it 'auto-corrects x.call asdf, x123 to x.(asdf, x123)' do
+    it 'autocorrects x.call asdf, x123 to x.(asdf, x123)' do
       expect_offense(<<~RUBY)
         a.call asdf, x123
         ^^^^^^^^^^^^^^^^^ Prefer the use of `a.(asdf, x123)` over `a.call asdf, x123`.

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation, :config do
     RUBY
   end
 
-  # The "central auto-correction engine" can't handle intermediate states where
+  # The "central autocorrection engine" can't handle intermediate states where
   # the code has syntax errors, so it's important to fix the trailing
   # whitespace in this cop.
   it 'autocorrects a + with trailing whitespace to \\' do

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('!test')
     end
 
-    it 'auto-corrects fully parenthesized args by removing space' do
+    it 'autocorrects fully parenthesized args by removing space' do
       expect_offense(<<~RUBY)
         top.eq (1 + 2)
         ^^^^^^^^^^^^^^ Use parentheses for method calls with arguments.
@@ -207,7 +207,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'auto-corrects parenthesized args for local methods by removing space' do
+    it 'autocorrects parenthesized args for local methods by removing space' do
       expect_offense(<<~RUBY)
         def foo
           eq (1 + 2)
@@ -222,7 +222,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'auto-corrects call with multiple args by adding braces' do
+    it 'autocorrects call with multiple args by adding braces' do
       expect_offense(<<~RUBY)
         def foo
           eq 1, (2 + 3)
@@ -240,7 +240,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'auto-corrects partially parenthesized args by adding needed braces' do
+    it 'autocorrects partially parenthesized args by adding needed braces' do
       expect_offense(<<~RUBY)
         top.eq (1 + 2) + 3
         ^^^^^^^^^^^^^^^^^^ Use parentheses for method calls with arguments.
@@ -251,7 +251,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'auto-corrects calls with multiple args by adding needed braces' do
+    it 'autocorrects calls with multiple args by adding needed braces' do
       expect_offense(<<~RUBY)
         top.eq (1 + 2), 3
         ^^^^^^^^^^^^^^^^^ Use parentheses for method calls with arguments.
@@ -262,7 +262,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'auto-corrects calls where arg is method call' do
+    it 'autocorrects calls where arg is method call' do
       expect_offense(<<~RUBY)
         def my_method
           foo bar.baz(abc, xyz)
@@ -277,7 +277,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'auto-corrects calls where multiple args are method calls' do
+    it 'autocorrects calls where multiple args are method calls' do
       expect_offense(<<~RUBY)
         def my_method
           foo bar.baz(abc, xyz), foo(baz)
@@ -292,7 +292,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'auto-corrects calls where the argument node is a constant' do
+    it 'autocorrects calls where the argument node is a constant' do
       expect_offense(<<~RUBY)
         def my_method
           raise NotImplementedError
@@ -307,7 +307,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'auto-corrects calls where the argument node is a number' do
+    it 'autocorrects calls where the argument node is a number' do
       expect_offense(<<~RUBY)
         def my_method
           sleep 1
@@ -839,7 +839,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'auto-corrects single-line calls' do
+    it 'autocorrects single-line calls' do
       expect_offense(<<~RUBY)
         top.test(1, 2, foo: bar(3))
                 ^^^^^^^^^^^^^^^^^^^ Omit parentheses for method calls with arguments.
@@ -850,7 +850,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'auto-corrects multi-line calls with trailing whitespace' do
+    it 'autocorrects multi-line calls with trailing whitespace' do
       trailing_whitespace = ' '
 
       expect_offense(<<~RUBY)
@@ -867,7 +867,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'auto-corrects complex multi-line calls' do
+    it 'autocorrects complex multi-line calls' do
       expect_offense(<<~RUBY)
         foo(arg,
            ^^^^^ Omit parentheses for method calls with arguments.

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
 
   # These will be offenses for the EmptyLiteral cop. The autocorrect loop will
   # handle that.
-  it 'auto-corrects calls that could be empty literals' do
+  it 'autocorrects calls that could be empty literals' do
     expect_offense(<<~RUBY)
       Hash.new()
               ^^ Do not use parentheses for method calls with no arguments.

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
     end
 
     context 'when assigning an array without brackets' do
-      it 'adds brackets when auto-correcting' do
+      it 'adds brackets when autocorrecting' do
         expect_offense(<<~RUBY)
           XXX = YYY, ZZZ
                 ^^^^^^^^ Freeze mutable objects assigned to constants.
@@ -363,7 +363,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
       end
 
       context 'when assigning a range (irange) without parenthesis' do
-        it 'adds parenthesis when auto-correcting' do
+        it 'adds parenthesis when autocorrecting' do
           expect_offense(<<~RUBY)
             XXX = 1..99
                   ^^^^^ Freeze mutable objects assigned to constants.
@@ -387,7 +387,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
       end
 
       context 'when assigning a range (erange) without parenthesis' do
-        it 'adds parenthesis when auto-correcting' do
+        it 'adds parenthesis when autocorrecting' do
           expect_offense(<<~RUBY)
             XXX = 1...99
                   ^^^^^^ Freeze mutable objects assigned to constants.
@@ -603,7 +603,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
     end
 
     context 'when assigning an array without brackets' do
-      it 'adds brackets when auto-correcting' do
+      it 'adds brackets when autocorrecting' do
         expect_offense(<<~RUBY)
           XXX = YYY, ZZZ
                 ^^^^^^^^ Freeze mutable objects assigned to constants.

--- a/spec/rubocop/cop/style/nested_modifier_spec.rb
+++ b/spec/rubocop/cop/style/nested_modifier_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Style::NestedModifier, :config do
   shared_examples 'not correctable' do |keyword|
-    it "does not auto-correct when #{keyword} is the outer modifier" do
+    it "does not autocorrect when #{keyword} is the outer modifier" do
       expect_offense(<<~RUBY, keyword: keyword)
         something if a %{keyword} b
                   ^^ Avoid using nested modifiers.
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier, :config do
       expect_no_corrections
     end
 
-    it "does not auto-correct when #{keyword} is the inner modifier" do
+    it "does not autocorrect when #{keyword} is the inner modifier" do
       expect_offense(<<~RUBY, keyword: keyword)
         something %{keyword} a if b
                   ^{keyword} Avoid using nested modifiers.
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier, :config do
     end
   end
 
-  it 'auto-corrects if + if' do
+  it 'autocorrects if + if' do
     expect_offense(<<~RUBY)
       something if a if b
                 ^^ Avoid using nested modifiers.
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier, :config do
     RUBY
   end
 
-  it 'auto-corrects unless + unless' do
+  it 'autocorrects unless + unless' do
     expect_offense(<<~RUBY)
       something unless a unless b
                 ^^^^^^ Avoid using nested modifiers.
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier, :config do
     RUBY
   end
 
-  it 'auto-corrects if + unless' do
+  it 'autocorrects if + unless' do
     expect_offense(<<~RUBY)
       something if a unless b
                 ^^ Avoid using nested modifiers.
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier, :config do
     RUBY
   end
 
-  it 'auto-corrects unless with a comparison operator + if' do
+  it 'autocorrects unless with a comparison operator + if' do
     expect_offense(<<~RUBY)
       something unless b > 1 if true
                 ^^^^^^ Avoid using nested modifiers.
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier, :config do
     RUBY
   end
 
-  it 'auto-corrects unless + if' do
+  it 'autocorrects unless + if' do
     expect_offense(<<~RUBY)
       something unless a if b
                 ^^^^^^ Avoid using nested modifiers.
@@ -76,7 +76,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier, :config do
     RUBY
   end
 
-  it 'adds parentheses when needed in auto-correction' do
+  it 'adds parentheses when needed in autocorrection' do
     expect_offense(<<~RUBY)
       something if a || b if c || d
                 ^^ Avoid using nested modifiers.
@@ -87,7 +87,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier, :config do
     RUBY
   end
 
-  it 'adds parentheses to method arguments when needed in auto-correction' do
+  it 'adds parentheses to method arguments when needed in autocorrection' do
     expect_offense(<<~RUBY)
       a unless [1, 2].include? a if a
         ^^^^^^ Avoid using nested modifiers.
@@ -98,7 +98,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier, :config do
     RUBY
   end
 
-  it 'does not add redundant parentheses in auto-correction' do
+  it 'does not add redundant parentheses in autocorrection' do
     expect_offense(<<~RUBY)
       something if a unless c || d
                 ^^ Avoid using nested modifiers.

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -407,7 +407,7 @@ RSpec.describe RuboCop::Cop::Style::Next, :config do
       end
     end
 
-    it 'auto-corrects a misaligned end' do
+    it 'autocorrects a misaligned end' do
       expect_offense(<<~RUBY)
         [1, 2, 3, 4].each do |num|
           if !opts.nil?

--- a/spec/rubocop/cop/style/not_spec.rb
+++ b/spec/rubocop/cop/style/not_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::Style::Not, :config do
     expect_no_offenses('!test')
   end
 
-  it 'auto-corrects "not" with !' do
+  it 'autocorrects "not" with !' do
     expect_offense(<<~RUBY)
       x = 10 if not y
                 ^^^ Use `!` instead of `not`.
@@ -27,7 +27,7 @@ RSpec.describe RuboCop::Cop::Style::Not, :config do
     RUBY
   end
 
-  it 'auto-corrects "not" followed by parens with !' do
+  it 'autocorrects "not" followed by parens with !' do
     expect_offense(<<~RUBY)
       not(test)
       ^^^ Use `!` instead of `not`.

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
   end
 
-  context 'auto-correct' do
+  context 'autocorrect' do
     it 'fixes a string array in a scope' do
       expect_offense(<<~RUBY)
         module Foo

--- a/spec/rubocop/cop/style/perl_backrefs_spec.rb
+++ b/spec/rubocop/cop/style/perl_backrefs_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
-  it 'auto-corrects puts $1 to puts Regexp.last_match(1)' do
+  it 'autocorrects puts $1 to puts Regexp.last_match(1)' do
     expect_offense(<<~RUBY)
       puts $1
            ^^ Prefer `Regexp.last_match(1)` over `$1`.
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
     RUBY
   end
 
-  it 'auto-corrects $9 to Regexp.last_match(9)' do
+  it 'autocorrects $9 to Regexp.last_match(9)' do
     expect_offense(<<~RUBY)
       $9
       ^^ Prefer `Regexp.last_match(9)` over `$9`.
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
     RUBY
   end
 
-  it 'auto-corrects $& to Regexp.last_match(0)' do
+  it 'autocorrects $& to Regexp.last_match(0)' do
     expect_offense(<<~RUBY)
       $&
       ^^ Prefer `Regexp.last_match(0)` over `$&`.
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
     RUBY
   end
 
-  it 'auto-corrects $` to Regexp.last_match.pre_match' do
+  it 'autocorrects $` to Regexp.last_match.pre_match' do
     expect_offense(<<~RUBY)
       $`
       ^^ Prefer `Regexp.last_match.pre_match` over `$``.
@@ -45,7 +45,7 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
     RUBY
   end
 
-  it 'auto-corrects $\' to Regexp.last_match.post_match' do
+  it 'autocorrects $\' to Regexp.last_match.post_match' do
     expect_offense(<<~RUBY)
       $'
       ^^ Prefer `Regexp.last_match.post_match` over `$'`.
@@ -56,7 +56,7 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
     RUBY
   end
 
-  it 'auto-corrects $+ to Regexp.last_match(-1)' do
+  it 'autocorrects $+ to Regexp.last_match(-1)' do
     expect_offense(<<~RUBY)
       $+
       ^^ Prefer `Regexp.last_match(-1)` over `$+`.
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
     RUBY
   end
 
-  it 'auto-corrects $MATCH to Regexp.last_match(0)' do
+  it 'autocorrects $MATCH to Regexp.last_match(0)' do
     expect_offense(<<~RUBY)
       $MATCH
       ^^^^^^ Prefer `Regexp.last_match(0)` over `$MATCH`.
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
     RUBY
   end
 
-  it 'auto-corrects $PREMATCH to Regexp.last_match.pre_match' do
+  it 'autocorrects $PREMATCH to Regexp.last_match.pre_match' do
     expect_offense(<<~RUBY)
       $PREMATCH
       ^^^^^^^^^ Prefer `Regexp.last_match.pre_match` over `$PREMATCH`.
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
     RUBY
   end
 
-  it 'auto-corrects $POSTMATCH to Regexp.last_match.post_match' do
+  it 'autocorrects $POSTMATCH to Regexp.last_match.post_match' do
     expect_offense(<<~RUBY)
       $POSTMATCH
       ^^^^^^^^^^ Prefer `Regexp.last_match.post_match` over `$POSTMATCH`.
@@ -100,7 +100,7 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
     RUBY
   end
 
-  it 'auto-corrects $LAST_PAREN_MATCH to Regexp.last_match(-1)' do
+  it 'autocorrects $LAST_PAREN_MATCH to Regexp.last_match(-1)' do
     expect_offense(<<~RUBY)
       $LAST_PAREN_MATCH
       ^^^^^^^^^^^^^^^^^ Prefer `Regexp.last_match(-1)` over `$LAST_PAREN_MATCH`.
@@ -111,7 +111,7 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
     RUBY
   end
 
-  it 'auto-corrects "#$1" to "#{Regexp.last_match(1)}"' do
+  it 'autocorrects "#$1" to "#{Regexp.last_match(1)}"' do
     expect_offense(<<~'RUBY')
       "#$1"
         ^^ Prefer `Regexp.last_match(1)` over `$1`.
@@ -122,7 +122,7 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
     RUBY
   end
 
-  it 'auto-corrects `#$1` to `#{Regexp.last_match(1)}`' do
+  it 'autocorrects `#$1` to `#{Regexp.last_match(1)}`' do
     expect_offense(<<~'RUBY')
       `#$1`
         ^^ Prefer `Regexp.last_match(1)` over `$1`.
@@ -133,7 +133,7 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
     RUBY
   end
 
-  it 'auto-corrects /#$1/ to /#{Regexp.last_match(1)}/' do
+  it 'autocorrects /#$1/ to /#{Regexp.last_match(1)}/' do
     expect_offense(<<~'RUBY')
       /#$1/
         ^^ Prefer `Regexp.last_match(1)` over `$1`.

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
     end
 
     context 'when used in a ternary expression' do
-      it 'registers an offense and auto-corrects' do
+      it 'registers an offense and autocorrects' do
         expect_offense(<<~RUBY)
           foo ? raise(Ex, 'error') : bar
                 ^^^^^^^^^^^^^^^^^^ Provide an exception object as an argument to `raise`.
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
     end
 
     context 'when used in a logical and expression' do
-      it 'registers an offense and auto-corrects' do
+      it 'registers an offense and autocorrects' do
         expect_offense(<<~RUBY)
           bar && raise(Ex, 'error')
                  ^^^^^^^^^^^^^^^^^^ Provide an exception object as an argument to `raise`.
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
     end
 
     context 'when used in a logical or expression' do
-      it 'registers an offense and auto-corrects' do
+      it 'registers an offense and autocorrects' do
         expect_offense(<<~RUBY)
           bar || raise(Ex, 'error')
                  ^^^^^^^^^^^^^^^^^^ Provide an exception object as an argument to `raise`.
@@ -165,7 +165,7 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
       end
 
       context 'when used in a ternary expression' do
-        it 'registers an offense and auto-corrects' do
+        it 'registers an offense and autocorrects' do
           expect_offense(<<~RUBY)
             foo ? raise(Ex.new('error')) : bar
                   ^^^^^^^^^^^^^^^^^^^^^^ Provide an exception class and message as arguments to `raise`.
@@ -178,7 +178,7 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
       end
 
       context 'when used in a logical and expression' do
-        it 'registers an offense and auto-corrects' do
+        it 'registers an offense and autocorrects' do
           expect_offense(<<~RUBY)
             bar && raise(Ex.new('error'))
                    ^^^^^^^^^^^^^^^^^^^^^^ Provide an exception class and message as arguments to `raise`.
@@ -191,7 +191,7 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
       end
 
       context 'when used in a logical or expression' do
-        it 'registers an offense and auto-corrects' do
+        it 'registers an offense and autocorrects' do
           expect_offense(<<~RUBY)
             bar || raise(Ex.new('error'))
                    ^^^^^^^^^^^^^^^^^^^^^^ Provide an exception class and message as arguments to `raise`.
@@ -250,7 +250,7 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
     end
 
     context 'when an exception object is assigned to a local variable' do
-      it 'auto-corrects to exploded style' do
+      it 'autocorrects to exploded style' do
         expect_offense(<<~RUBY)
           def do_something
             klass = RuntimeError

--- a/spec/rubocop/cop/style/redundant_assignment_spec.rb
+++ b/spec/rubocop/cop/style/redundant_assignment_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantAssignment, :config do
   end
 
   context 'when inside begin-end body' do
-    it 'registers an offense and auto-corrects' do
+    it 'registers an offense and autocorrects' do
       expect_offense(<<~RUBY)
         def func
           some_preceding_statements
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantAssignment, :config do
   end
 
   context 'when rescue blocks present' do
-    it 'does register an offense and auto-corrects when inside function or rescue block' do
+    it 'does register an offense and autocorrects when inside function or rescue block' do
       expect_offense(<<~RUBY)
         def func
           1
@@ -92,7 +92,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantAssignment, :config do
   end
 
   context 'when inside an if-branch' do
-    it 'registers an offense and auto-corrects' do
+    it 'registers an offense and autocorrects' do
       expect_offense(<<~RUBY)
         def func
           some_preceding_statements
@@ -128,7 +128,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantAssignment, :config do
   end
 
   context 'when inside a when-branch' do
-    it 'registers an offense and auto-corrects' do
+    it 'registers an offense and autocorrects' do
       expect_offense(<<~RUBY)
         def func
           some_preceding_statements

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     RUBY
   end
 
-  it "doesn't modify spacing when auto-correcting" do
+  it "doesn't modify spacing when autocorrecting" do
     expect_offense(<<~RUBY)
       def method
         begin
@@ -134,7 +134,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     RUBY
   end
 
-  it 'auto-corrects when there are trailing comments' do
+  it 'autocorrects when there are trailing comments' do
     expect_offense(<<~RUBY)
       def method
         begin # comment 1

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
-      it 'auto-corrects when using `<<` method higher precedence than `||` operator' do
+      it 'autocorrects when using `<<` method higher precedence than `||` operator' do
         expect_offense(<<~RUBY)
           ary << if foo
                  ^^^^^^ Use double pipes `||` instead.

--- a/spec/rubocop/cop/style/redundant_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/redundant_percent_q_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantPercentQ, :config do
       expect_no_offenses('/%q?/')
     end
 
-    it 'auto-corrects for strings that are concatenated with backslash' do
+    it 'autocorrects for strings that are concatenated with backslash' do
       expect_offense(<<~'RUBY')
         %q(foo bar baz) \
         ^^^^^^^^^^^^^^^ Use `%q` only for strings that contain both single quotes and double quotes.
@@ -130,7 +130,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantPercentQ, :config do
       expect_no_offenses('/%Q?/')
     end
 
-    it 'auto-corrects for strings that are concatenated with backslash' do
+    it 'autocorrects for strings that are concatenated with backslash' do
       expect_offense(<<~'RUBY')
         %Q(foo bar baz) \
         ^^^^^^^^^^^^^^^ Use `%Q` only for strings that contain both single [...]

--- a/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
@@ -308,7 +308,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpCharacterClass, :config do
   end
 
   context 'with a character class containing a character requiring escape outside' do
-    # Not implemented for now, since we would have to escape on auto-correct, and the cop message
+    # Not implemented for now, since we would have to escape on autocorrect, and the cop message
     # would need to be dynamic to not be misleading.
     it 'does not register an offense' do
       expect_no_offenses('foo = /[+]/')

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
     RUBY
   end
 
-  it 'auto-corrects by removing redundant returns' do
+  it 'autocorrects by removing redundant returns' do
     expect_offense(<<~RUBY)
       def func
         one
@@ -230,7 +230,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
       RUBY
     end
 
-    it 'auto-corrects removes return when using an explicit hash' do
+    it 'autocorrects removes return when using an explicit hash' do
       expect_offense(<<~RUBY)
         def func
           return {:a => 1, :b => 2}
@@ -246,7 +246,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
       RUBY
     end
 
-    it 'auto-corrects by making an implicit hash explicit' do
+    it 'autocorrects by making an implicit hash explicit' do
       expect_offense(<<~RUBY)
         def func
           return :a => 1, :b => 2
@@ -319,7 +319,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
   end
 
   context 'when return is inside begin-end body' do
-    it 'registers an offense and auto-corrects' do
+    it 'registers an offense and autocorrects' do
       expect_offense(<<~RUBY)
         def func
           some_preceding_statements
@@ -342,7 +342,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
   end
 
   context 'when rescue and return blocks present' do
-    it 'does register an offense and auto-corrects when inside function or rescue block' do
+    it 'does register an offense and autocorrects when inside function or rescue block' do
       expect_offense(<<~RUBY)
         def func
           1
@@ -400,7 +400,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
   end
 
   context 'when return is inside an if-branch' do
-    it 'registers an offense and auto-corrects' do
+    it 'registers an offense and autocorrects' do
       expect_offense(<<~RUBY)
         def func
           some_preceding_statements
@@ -433,7 +433,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
   end
 
   context 'when return is inside a when-branch' do
-    it 'registers an offense and auto-corrects' do
+    it 'registers an offense and autocorrects' do
       expect_offense(<<~RUBY)
         def func
           some_preceding_statements

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'percent_r' } }
     let(:percent_literal_delimiters_config) { { 'PreferredDelimiters' => { '%r' => '[]' } } }
 
-    it 'respects the configuration when auto-correcting' do
+    it 'respects the configuration when autocorrecting' do
       expect_offense(<<~RUBY)
         /a/
         ^^^ Use `%r` around regular expression.
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'percent_r' } }
     let(:percent_literal_delimiters_config) { { 'PreferredDelimiters' => { '%r' => '//' } } }
 
-    it 'respects the configuration when auto-correcting' do
+    it 'respects the configuration when autocorrecting' do
       expect_offense(<<~'RUBY')
         /\//
         ^^^^ Use `%r` around regular expression.
@@ -123,7 +123,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
       context 'when configured to allow inner slashes' do
         before { cop_config['AllowInnerSlashes'] = true }
 
-        it 'remains slashes after auto-correction' do
+        it 'remains slashes after autocorrection' do
           expect_offense(<<~'RUBY')
             foo = %r/\//
                   ^^^^^^ Use `//` around regular expression.

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
     RUBY
   end
 
-  it 'auto-corrects def with semicolon after method name' do
+  it 'autocorrects def with semicolon after method name' do
     expect_offense(<<-RUBY.strip_margin('|'))
       |  def some_method; body end # Cmnt
       |  ^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
@@ -110,7 +110,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
     RUBY
   end
 
-  it 'auto-corrects defs with parentheses after method name' do
+  it 'autocorrects defs with parentheses after method name' do
     expect_offense(<<-RUBY.strip_margin('|'))
       |  def self.some_method() body end
       |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
@@ -123,7 +123,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
     RUBY
   end
 
-  it 'auto-corrects def with argument in parentheses' do
+  it 'autocorrects def with argument in parentheses' do
     expect_offense(<<-RUBY.strip_margin('|'))
       |  def some_method(arg) body end
       |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
@@ -136,7 +136,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
     RUBY
   end
 
-  it 'auto-corrects def with argument and no parentheses' do
+  it 'autocorrects def with argument and no parentheses' do
     expect_offense(<<-RUBY.strip_margin('|'))
       |  def some_method arg; body end
       |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
@@ -149,7 +149,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
     RUBY
   end
 
-  it 'auto-corrects def with semicolon before end' do
+  it 'autocorrects def with semicolon before end' do
     expect_offense(<<-RUBY.strip_margin('|'))
       |  def some_method; b1; b2; end
       |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
       end
     RUBY
 
-    # NOTE: `Style/InverseMethods` cop auto-corrects from `(!foo == bar)` to `foo != bar`.
+    # NOTE: `Style/InverseMethods` cop autocorrects from `(!foo == bar)` to `foo != bar`.
     expect_correction(<<~RUBY)
       if !(foo == bar) && baz
           do_something

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
         expect_no_offenses('puts $1')
       end
 
-      it 'auto-corrects $/ to $INPUT_RECORD_SEPARATOR' do
+      it 'autocorrects $/ to $INPUT_RECORD_SEPARATOR' do
         expect_offense(<<~RUBY)
           $/
           ^^ Prefer `$INPUT_RECORD_SEPARATOR` or `$RS` from the stdlib 'English' module (don't forget to require it) over `$/`.
@@ -80,7 +80,7 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
         RUBY
       end
 
-      it 'auto-corrects #$: to #{$LOAD_PATH}' do
+      it 'autocorrects #$: to #{$LOAD_PATH}' do
         expect_offense(<<~'RUBY')
           "#$:"
             ^^ Prefer `$LOAD_PATH` over `$:`.
@@ -91,7 +91,7 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
         RUBY
       end
 
-      it 'auto-corrects #{$!} to #{$ERROR_INFO}' do
+      it 'autocorrects #{$!} to #{$ERROR_INFO}' do
         expect_offense(<<~'RUBY')
           "#{$!}"
              ^^ Prefer `$ERROR_INFO` from the stdlib 'English' module (don't forget to require it) over `$!`.
@@ -274,7 +274,7 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
       expect_no_offenses('puts $1')
     end
 
-    it 'auto-corrects $INPUT_RECORD_SEPARATOR to $/' do
+    it 'autocorrects $INPUT_RECORD_SEPARATOR to $/' do
       expect_offense(<<~RUBY)
         $INPUT_RECORD_SEPARATOR
         ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `$/` over `$INPUT_RECORD_SEPARATOR`.
@@ -285,7 +285,7 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
       RUBY
     end
 
-    it 'auto-corrects #{$LOAD_PATH} to #$:' do
+    it 'autocorrects #{$LOAD_PATH} to #$:' do
       expect_offense(<<~'RUBY')
         "#{$LOAD_PATH}"
            ^^^^^^^^^^ Prefer `$:` over `$LOAD_PATH`.
@@ -308,7 +308,7 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
       RUBY
     end
 
-    it 'auto-corrects non-preffered builtin names' do
+    it 'autocorrects non-preffered builtin names' do
       expect_offense(<<~RUBY)
         puts $:
              ^^ Prefer `$LOAD_PATH` over `$:`.

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
     RUBY
   end
 
-  it 'auto-corrects correctly when there are no arguments in parentheses' do
+  it 'autocorrects correctly when there are no arguments in parentheses' do
     expect_offense(<<~RUBY)
       coll.map(   ) { |s| s.upcase }
                     ^^^^^^^^^^^^^^^^ Pass `&:upcase` as an argument to `map` instead of a block.
@@ -204,7 +204,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
     end
   end
 
-  it 'auto-corrects correctly when args have a trailing comma' do
+  it 'autocorrects correctly when args have a trailing comma' do
     expect_offense(<<~RUBY)
       mail(
         to: 'foo',

--- a/spec/rubocop/cop/style/trailing_body_on_class_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_class_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnClass, :config do
     RUBY
   end
 
-  it 'auto-corrects with comment after body' do
+  it 'autocorrects with comment after body' do
     expect_offense(<<~RUBY)
       class BarQux; foo # comment
                     ^^^ Place the first line of class body on its own line.
@@ -74,7 +74,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnClass, :config do
   end
 
   context 'when class is not on first line of processed_source' do
-    it 'auto-correct offense' do
+    it 'autocorrect offense' do
       expect_offense(<<-RUBY.strip_margin('|'))
         |
         |  class Foo; body#{trailing_whitespace}

--- a/spec/rubocop/cop/style/trailing_body_on_method_definition_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_method_definition_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnMethodDefinition, :config do
     end
   end
 
-  it 'auto-corrects with comment after body' do
+  it 'autocorrects with comment after body' do
     expect_offense(<<-RUBY.strip_margin('|'))
       |  def some_method; body # stuff
       |                   ^^^^ Place the first line of a multi-line method definition's body on its own line.
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnMethodDefinition, :config do
     RUBY
   end
 
-  it 'auto-corrects body with method definition with args not in parens' do
+  it 'autocorrects body with method definition with args not in parens' do
     expect_offense(<<-RUBY.strip_margin('|'))
       |  def some_method arg1, arg2; body
       |                              ^^^^ Place the first line of a multi-line method definition's body on its own line.
@@ -128,7 +128,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnMethodDefinition, :config do
     RUBY
   end
 
-  it 'auto-correction removes semicolon from method definition but not body' do
+  it 'autocorrection removes semicolon from method definition but not body' do
     expect_offense(<<-RUBY.strip_margin('|'))
       |  def some_method; body; more_body;
       |                   ^^^^ Place the first line of a multi-line method definition's body on its own line.
@@ -143,7 +143,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnMethodDefinition, :config do
   end
 
   context 'when method is not on first line of processed_source' do
-    it 'auto-corrects offense' do
+    it 'autocorrects offense' do
       expect_offense(<<-RUBY.strip_margin('|'))
         |
         |  def some_method; body

--- a/spec/rubocop/cop/style/trailing_body_on_module_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_module_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnModule, :config do
     RUBY
   end
 
-  it 'auto-corrects with comment after body' do
+  it 'autocorrects with comment after body' do
     expect_offense(<<~RUBY)
       module BarQux; foo # comment
                      ^^^ Place the first line of module body on its own line.
@@ -80,7 +80,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnModule, :config do
     RUBY
   end
 
-  it 'auto-corrects when there are multiple semicolons' do
+  it 'autocorrects when there are multiple semicolons' do
     expect_offense(<<~RUBY)
       module Bar; def bar; end
                   ^^^^^^^^^^^^ Place the first line of module body on its own line.
@@ -95,7 +95,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnModule, :config do
   end
 
   context 'when module is not on first line of processed_source' do
-    it 'auto-corrects offense' do
+    it 'autocorrects offense' do
       expect_offense(<<~RUBY)
 
         module Foo; body#{trailing_whitespace}

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
         RUBY
       end
 
-      it 'auto-corrects unwanted comma after modified heredoc parameter' do
+      it 'autocorrects unwanted comma after modified heredoc parameter' do
         expect_offense(<<~'RUBY')
           some_method(
             <<-LOREM.delete("\n"),
@@ -276,7 +276,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
           RUBY
         end
 
-        it 'auto-corrects unwanted comma inside string interpolation' do
+        it 'autocorrects unwanted comma inside string interpolation' do
           expect_offense(<<~'RUBY')
             some_method(
               bar: <<-BAR,
@@ -533,7 +533,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
         RUBY
       end
 
-      it 'auto-corrects missing comma after a heredoc' do
+      it 'autocorrects missing comma after a heredoc' do
         expect_offense(<<~RUBY)
           route(1, <<-HELP.chomp
                    ^^^^^^^^^^^^^ Put a comma after the last parameter of a multiline method call.

--- a/spec/rubocop/cop/style/trailing_comma_in_array_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_array_literal_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
         RUBY
       end
 
-      it 'auto-corrects unwanted comma where HEREDOC has commas' do
+      it 'autocorrects unwanted comma where HEREDOC has commas' do
         expect_offense(<<~RUBY)
           [
             <<-TEXT, 123,

--- a/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
+++ b/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement, :config do
     RUBY
   end
 
-  it 'auto-corrects all trailing ends for larger example' do
+  it 'autocorrects all trailing ends for larger example' do
     expect_offense(<<~RUBY)
       class Foo
         def some_method

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       RUBY
     end
 
-    it 'auto-corrects an array of words' do
+    it 'autocorrects an array of words' do
       expect_offense(<<~RUBY)
         ['one', %q(two), 'three']
         ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
@@ -206,7 +206,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       RUBY
     end
 
-    it 'auto-corrects an array with one element' do
+    it 'autocorrects an array with one element' do
       expect_offense(<<~RUBY)
         ['one']
         ^^^^^^^ Use `%w` or `%W` for an array of words.
@@ -217,7 +217,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       RUBY
     end
 
-    it 'auto-corrects an array of words and character constants' do
+    it 'autocorrects an array of words and character constants' do
       expect_offense(<<~'RUBY')
         [%|one|, %Q(two), ?\n, ?\t]
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
@@ -228,7 +228,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       RUBY
     end
 
-    it 'keeps the line breaks in place after auto-correct' do
+    it 'keeps the line breaks in place after autocorrect' do
       expect_offense(<<~RUBY)
         ['one',
         ^^^^^^^ Use `%w` or `%W` for an array of words.
@@ -241,7 +241,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       RUBY
     end
 
-    it 'auto-corrects an array of words in multiple lines' do
+    it 'autocorrects an array of words in multiple lines' do
       expect_offense(<<-RUBY)
         [
         ^ Use `%w` or `%W` for an array of words.
@@ -260,7 +260,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       RUBY
     end
 
-    it 'auto-corrects an array of words using partial newlines' do
+    it 'autocorrects an array of words using partial newlines' do
       expect_offense(<<-RUBY)
         ["foo", "bar", "baz",
         ^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::Team do
     let(:runner) { RuboCop::Runner.new(options, RuboCop::ConfigStore.new) }
     let(:file_path) { 'example.rb' }
 
-    it 'auto corrects without SyntaxError', :isolated_environment do
+    it 'autocorrects without SyntaxError', :isolated_environment do
       source = <<~'RUBY'
         foo.map{ |a| a.nil? }
 

--- a/spec/rubocop/formatter/auto_gen_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/auto_gen_config_formatter_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe RuboCop::Formatter::AutoGenConfigFormatter do
       it 'outputs report summary' do
         formatter.finished(files)
         expect(output.string).to include <<~OUTPUT
-          3 files inspected, 1 offense detected, 1 offense auto-correctable
+          3 files inspected, 1 offense detected, 1 offense autocorrectable
         OUTPUT
       end
     end

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -240,23 +240,23 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
     end
   end
 
-  context 'with auto-correct supported cop', :restore_registry do
+  context 'with autocorrect supported cop', :restore_registry do
     before do
       stub_cop_class('Test::Cop3') { extend RuboCop::Cop::AutoCorrector }
 
-      formatter.started(['test_auto_correct.rb'])
-      formatter.file_started('test_auto_correct.rb', {})
-      formatter.file_finished('test_auto_correct.rb', offenses)
-      formatter.finished(['test_auto_correct.rb'])
+      formatter.started(['test_autocorrect.rb'])
+      formatter.file_started('test_autocorrect.rb', {})
+      formatter.file_finished('test_autocorrect.rb', offenses)
+      formatter.finished(['test_autocorrect.rb'])
     end
 
     let(:expected_rubocop_todo) do
       [heading,
        '# Offense count: 1',
-       '# This cop supports safe auto-correction (--auto-correct).',
+       '# This cop supports safe autocorrection (--auto-correct).',
        'Test/Cop3:',
        '  Exclude:',
-       "    - 'test_auto_correct.rb'",
+       "    - 'test_autocorrect.rb'",
        ''].join("\n")
     end
 

--- a/spec/rubocop/formatter/fuubar_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/fuubar_style_formatter_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe RuboCop::Formatter::FuubarStyleFormatter do
       end
     end
 
-    context 'when a offense is detected in a file and auto-corrected' do
+    context 'when a offense is detected in a file and autocorrected' do
       before { formatter.file_finished(files[0], [offense(:convention, :corrected)]) }
 
       it 'is green' do

--- a/spec/rubocop/formatter/quiet_formatter_spec.rb
+++ b/spec/rubocop/formatter/quiet_formatter_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Formatter::QuietFormatter do
         formatter.report_summary(1, 1, 0, 1)
         expect(output.string).to eq(<<~OUTPUT)
 
-          1 file inspected, 1 offense detected, 1 offense auto-correctable
+          1 file inspected, 1 offense detected, 1 offense autocorrectable
         OUTPUT
       end
     end
@@ -123,7 +123,7 @@ RSpec.describe RuboCop::Formatter::QuietFormatter do
         formatter.report_summary(2, 2, 0, 2)
         expect(output.string).to eq(<<~OUTPUT)
 
-          2 files inspected, 2 offenses detected, 2 offenses auto-correctable
+          2 files inspected, 2 offenses detected, 2 offenses autocorrectable
         OUTPUT
       end
     end
@@ -153,7 +153,7 @@ RSpec.describe RuboCop::Formatter::QuietFormatter do
         formatter.report_summary(1, 1, 2, 2)
         expect(output.string).to eq(<<~OUTPUT)
 
-          1 file inspected, 1 offense detected, 2 offenses corrected, 2 offenses auto-correctable
+          1 file inspected, 1 offense detected, 2 offenses corrected, 2 offenses autocorrectable
         OUTPUT
       end
     end

--- a/spec/rubocop/formatter/simple_text_formatter_spec.rb
+++ b/spec/rubocop/formatter/simple_text_formatter_spec.rb
@@ -121,12 +121,12 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
       end
     end
 
-    context 'when a offense detected and a offense auto-correctable' do
+    context 'when a offense detected and a offense autocorrectable' do
       it 'handles pluralization correctly' do
         formatter.report_summary(1, 1, 0, 1)
         expect(output.string).to eq(<<~OUTPUT)
 
-          1 file inspected, 1 offense detected, 1 offense auto-correctable
+          1 file inspected, 1 offense detected, 1 offense autocorrectable
         OUTPUT
       end
     end
@@ -141,12 +141,12 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
       end
     end
 
-    context 'when 2 offenses detected and 2 offenses auto-correctable' do
+    context 'when 2 offenses detected and 2 offenses autocorrectable' do
       it 'handles pluralization correctly' do
         formatter.report_summary(2, 2, 0, 2)
         expect(output.string).to eq(<<~OUTPUT)
 
-          2 files inspected, 2 offenses detected, 2 offenses auto-correctable
+          2 files inspected, 2 offenses detected, 2 offenses autocorrectable
         OUTPUT
       end
     end
@@ -171,12 +171,12 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
       end
     end
 
-    context 'when 2 offenses are corrected and 2 offenses auto-correctable' do
+    context 'when 2 offenses are corrected and 2 offenses autocorrectable' do
       it 'handles pluralization correctly' do
         formatter.report_summary(1, 1, 2, 2)
         expect(output.string).to eq(<<~OUTPUT)
 
-          1 file inspected, 1 offense detected, 2 offenses corrected, 2 offenses auto-correctable
+          1 file inspected, 1 offense detected, 2 offenses corrected, 2 offenses autocorrectable
         OUTPUT
       end
     end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
 
           Basic Options:
               -l, --lint                       Run only lint cops.
-              -x, --fix-layout                 Run only layout cops, with auto-correct on.
+              -x, --fix-layout                 Run only layout cops, with autocorrect on.
                   --safe                       Run only safe cops.
                   --except [COP1,COP2,...]     Exclude the given cop(s).
                   --only [COP1,COP2,...]       Run only the given cop(s).
@@ -121,10 +121,10 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                Only output offense messages at
                                                the specified --fail-level or above
 
-          Auto-correction:
-              -a, --auto-correct               Auto-correct offenses (only when it's safe).
+          Autocorrection:
+              -a, --auto-correct               Autocorrect offenses (only when it's safe).
                   --safe-auto-correct          (same, deprecated)
-              -A, --auto-correct-all           Auto-correct offenses (safe and unsafe)
+              -A, --auto-correct-all           Autocorrect offenses (safe and unsafe)
                   --disable-uncorrectable      Used with --auto-correct to annotate any
                                                offenses that do not support autocorrect
                                                with `rubocop:todo` comments.

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe RuboCop::RakeTask do
       expect($stderr.string.strip).to eq 'RuboCop failed!'
     end
 
-    context 'auto_correct' do
+    context 'autocorrect' do
       it 'runs with --auto-correct-all' do
         described_class.new
 


### PR DESCRIPTION
Resolves #10095.

More detailed searches for existing usage:
```bash
[~/projects/rubocop ⌥ master]$ git grep -E 'autocorrect|Autocorrect' -- ':!relnotes/*' ':!CHANGELOG.md' | wc -l
1283
[~/projects/rubocop ⌥ master]$ (git grep -iE 'auto-correct|auto_correct|auto correct' -- ':!relnotes/*' ':!CHANGELOG.md'; git grep -E 'autoCorrect|AutoCorrect' -- ':!relnotes/*' ':!CHANGELOG.md') | wc -l
1160
```

This PR changes usage to "autocorrect" when possible without making breaking changes.

-----------------

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] N/A - Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
