### PR TITLE
Upgrade RuboCop-RSpec to the latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.13.0'
 gem 'rubocop-rake', '~> 0.6.0'
-gem 'rubocop-rspec', '~> 2.9.0'
+gem 'rubocop-rspec', '~> 2.10.0'
 # Workaround for cc-test-reporter with SimpleCov 0.18.
 # Stop upgrading SimpleCov until the following issue will be resolved.
 # https://github.com/codeclimate/test-reporter/issues/418

--- a/spec/rubocop/config_obsoletion/renamed_cop_spec.rb
+++ b/spec/rubocop/config_obsoletion/renamed_cop_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::ConfigObsoletion::RenamedCop do
   subject(:rule) { described_class.new(config, old_name, new_name) }
 
-  let(:config) { instance_double('RuboCop::Config', loaded_path: '.rubocop.yml').as_null_object }
+  let(:config) { instance_double(RuboCop::Config, loaded_path: '.rubocop.yml').as_null_object }
   let(:old_name) { 'Style/MyCop' }
 
   describe '#message' do

--- a/spec/rubocop/cop/annotation_comment_spec.rb
+++ b/spec/rubocop/cop/annotation_comment_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::AnnotationComment do
   subject(:annotation) { described_class.new(comment, keywords) }
 
   let(:keywords) { ['TODO', 'FOR LATER', 'FIXME'] }
-  let(:comment) { instance_double('Parser::Source::Comment', text: "# #{text}") }
+  let(:comment) { instance_double(Parser::Source::Comment, text: "# #{text}") }
 
   describe '#annotation?' do
     subject { annotation.annotation? }

--- a/spec/rubocop/version_spec.rb
+++ b/spec/rubocop/version_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Version do
   describe '.extension_versions', :isolated_environment, :restore_registry do
     subject(:extension_versions) { described_class.extension_versions(env) }
 
-    let(:env) { instance_double('RuboCop::CLI::Environment', config_store: config_store) }
+    let(:env) { instance_double(RuboCop::CLI::Environment, config_store: config_store) }
     let(:config_store) { RuboCop::ConfigStore.new }
 
     before { RuboCop::ConfigLoader.clear_options }


### PR DESCRIPTION
You can see the new changes at https://github.com/rubocop/rubocop-rspec/releases/tag/v2.10.0 – the most relevant being the addition of an `RSpec/VerifiedDoubleReference` cop that suggests using class references instead of strings as argument to e.g. `instance_double`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
