### PR TITLE
[Fix #10488] Fix autocorrection for `Layout/MultilineMethodCallIndentation` breaks indentations

### DIFF
--- a/changelog/fix_layout_multiline_method_call_indentation_for_nesting.md
+++ b/changelog/fix_layout_multiline_method_call_indentation_for_nesting.md
@@ -1,0 +1,1 @@
+* [#10488](https://github.com/rubocop/rubocop/issues/10488): Fix autocorrection for `Layout/MultilineMethodCallIndentation` breaks indentation for nesting of method calls. ([@nobuyo][])

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -357,6 +357,14 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           end
         RUBY
       end
+
+      it 'accepts nested method calls' do
+        expect_no_offenses(<<~RUBY)
+          expect { post :action, params: params, format: :json }.to change { Foo.bar }.by(0)
+                                                                .and change { Baz.quux }.by(0)
+                                                                .and raise_error(StandardError)
+        RUBY
+      end
     end
 
     it 'accepts correctly aligned methods in operands' do


### PR DESCRIPTION
Fixes #10488.

Please see also #10549.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
