### PR TITLE
Add `AllowComments` option to `Style/RedundantInitialize`

### DIFF
--- a/changelog/new_add_allow_comments_option_for_style_redundant_initialize.md
+++ b/changelog/new_add_allow_comments_option_for_style_redundant_initialize.md
@@ -1,0 +1,1 @@
+* [#10551](https://github.com/rubocop/rubocop/pull/10551): Add `AllowComments` option to `Style/RedundantInitialize` is true by default. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4552,6 +4552,7 @@ Style/RedundantInitialize:
   Description: 'Checks for redundant `initialize` methods.'
   Enabled: pending
   Safe: false
+  AllowComments: true
   VersionAdded: '1.27'
   VersionChanged: '<<next>>'
 

--- a/spec/rubocop/cop/style/redundant_initialize_spec.rb
+++ b/spec/rubocop/cop/style/redundant_initialize_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RedundantInitialize, :config do
+  let(:cop_config) { { 'AllowComments' => true } }
+
   it 'does not register an offense for an empty method not named `initialize`' do
     expect_no_offenses(<<~RUBY)
       def do_something
@@ -24,10 +26,9 @@ RSpec.describe RuboCop::Cop::Style::RedundantInitialize, :config do
     RUBY
   end
 
-  it 'registers an offense for an `initialize` method with only a comment' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense for an `initialize` method with only a comment' do
+    expect_no_offenses(<<~RUBY)
       def initialize
-      ^^^^^^^^^^^^^^ Remove unnecessary empty `initialize` method.
         # initializer
       end
     RUBY
@@ -170,5 +171,18 @@ RSpec.describe RuboCop::Cop::Style::RedundantInitialize, :config do
       def initialize(...)
       end
     RUBY
+  end
+
+  context 'when `AllowComments: false`' do
+    let(:cop_config) { { 'AllowComments' => false } }
+
+    it 'registers an offense for an `initialize` method with only a comment' do
+      expect_offense(<<~RUBY)
+        def initialize
+        ^^^^^^^^^^^^^^ Remove unnecessary empty `initialize` method.
+          # initializer
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/issues/10524#issuecomment-1102191692.

This PR add `AllowComments` option to `Style/RedundantInitialize` is true by default.

```ruby
# AllowComments: true (default)

# good
def initialize
  # Overriding to negate superclass `initialize` method.
end

# AllowComments: false

# bad
def initialize
  # Overriding to negate superclass `initialize` method.
end
```

This cop has been reported as false positive and has already been marked as unsafe. In addition, cases such as the follow up address have been reported. This PR allows intentional overrides with explicit comments to be allowed by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
