### PR TITLE
[Fix #10553] Fix crash with trailing tabs in heredocs for `Layout/TrailingWhitespace`

### DIFF
--- a/changelog/fix_fix_crash_with_trailing_tabs_in_heredocs.md
+++ b/changelog/fix_fix_crash_with_trailing_tabs_in_heredocs.md
@@ -1,0 +1,1 @@
+* [#10553](https://github.com/rubocop/rubocop/issues/10553): Fix crash with trailing tabs in heredocs for `Layout/TrailingWhitespace`. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/trailing_whitespace.rb
+++ b/lib/rubocop/cop/layout/trailing_whitespace.rb
@@ -85,7 +85,7 @@ module RuboCop
         end
 
         def whitespace_is_indentation?(range, level)
-          range.source[/ +/].length <= level
+          range.source[/[ \t]+/].length <= level
         end
 
         def whitespace_only?(range)

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
     RUBY
   end
 
+  it 'registers an offense for a tab in a heredoc' do
+    expect_offense(<<~RUBY)
+      <<~X
+      \t
+      ^ Trailing whitespace detected.
+      X
+    RUBY
+  end
+
   it 'registers offenses before __END__ but not after' do
     expect_offense(<<~RUBY)
       x = 0\t


### PR DESCRIPTION
Fix `undefined method ``length' for nil:NilClass` when encountering a trailing tab in a heredoc.

Fixes #10553.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
