### PR TITLE
Support autocorrection for `Style/RedundantInitialize`

### DIFF
--- a/changelog/new_support_autocorrect_for_style_redundant_initialize.md
+++ b/changelog/new_support_autocorrect_for_style_redundant_initialize.md
@@ -1,0 +1,1 @@
+* [#10552](https://github.com/rubocop/rubocop/pull/10552): Support autocorrection for `Style/RedundantInitialize`. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_initialize_spec.rb
+++ b/spec/rubocop/cop/style/redundant_initialize_spec.rb
@@ -18,12 +18,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantInitialize, :config do
     RUBY
   end
 
-  it 'registers an offense for an empty `initialize` method' do
+  it 'registers and corrects an offense for an empty `initialize` method' do
     expect_offense(<<~RUBY)
       def initialize
       ^^^^^^^^^^^^^^ Remove unnecessary empty `initialize` method.
       end
     RUBY
+
+    expect_correction('')
   end
 
   it 'does not register an offense for an `initialize` method with only a comment' do
@@ -34,31 +36,37 @@ RSpec.describe RuboCop::Cop::Style::RedundantInitialize, :config do
     RUBY
   end
 
-  it 'registers an offense for an `initialize` method that only calls `super`' do
+  it 'registers and corrects an offense for an `initialize` method that only calls `super`' do
     expect_offense(<<~RUBY)
       def initialize
       ^^^^^^^^^^^^^^ Remove unnecessary `initialize` method.
         super
       end
     RUBY
+
+    expect_correction('')
   end
 
-  it 'registers an offense for an `initialize` method with arguments that only calls `super`' do
+  it 'registers and corrects an offense for an `initialize` method with arguments that only calls `super`' do
     expect_offense(<<~RUBY)
       def initialize(a, b)
       ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `initialize` method.
         super
       end
     RUBY
+
+    expect_correction('')
   end
 
-  it 'registers an offense for an `initialize` method with arguments that only calls `super` with explicit args' do
+  it 'registers and corrects an offense for an `initialize` method with arguments that only calls `super` with explicit args' do
     expect_offense(<<~RUBY)
       def initialize(a, b)
       ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `initialize` method.
         super(a, b)
       end
     RUBY
+
+    expect_correction('')
   end
 
   it 'does not register an offense for an `initialize` method that calls another method' do
@@ -103,13 +111,15 @@ RSpec.describe RuboCop::Cop::Style::RedundantInitialize, :config do
     RUBY
   end
 
-  it 'registers an offense for an `initialize` method with no arguments that calls `super` with no arguments' do
+  it 'registers and corrects an offense for an `initialize` method with no arguments that calls `super` with no arguments' do
     expect_offense(<<~RUBY)
       def initialize()
       ^^^^^^^^^^^^^^^^ Remove unnecessary `initialize` method.
         super()
       end
     RUBY
+
+    expect_correction('')
   end
 
   it 'does not register an offense for an `initialize` method with a default argument that calls `super`' do
@@ -176,13 +186,15 @@ RSpec.describe RuboCop::Cop::Style::RedundantInitialize, :config do
   context 'when `AllowComments: false`' do
     let(:cop_config) { { 'AllowComments' => false } }
 
-    it 'registers an offense for an `initialize` method with only a comment' do
+    it 'registers and corrects an offense for an `initialize` method with only a comment' do
       expect_offense(<<~RUBY)
         def initialize
         ^^^^^^^^^^^^^^ Remove unnecessary empty `initialize` method.
           # initializer
         end
       RUBY
+
+      expect_correction('')
     end
   end
 end


### PR DESCRIPTION
This PR supports autocorrection for `Style/RedundantInitialize`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
