### PR TITLE
[Fix #10557] Fix a false positive for `Style/FetchEnvVar`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_fetch_env_var.md
+++ b/changelog/fix_a_false_positive_for_style_fetch_env_var.md
@@ -1,0 +1,1 @@
+* [#10557](https://github.com/rubocop/rubocop/issues/10557): Fix a false positive for `Style/FetchEnvVar` when `ENV['key']` is a receiver of `||=`. ([@koic][])

--- a/lib/rubocop/cop/style/fetch_env_var.rb
+++ b/lib/rubocop/cop/style/fetch_env_var.rb
@@ -64,11 +64,14 @@ module RuboCop
           node.parent.send_type? && node.parent.children.first == node && node.parent.dot?
         end
 
-        # Allow if used as a flag (e.g., `if ENV['X']` or `!ENV['X']`) because
-        # it simply checks whether the variable is set.
-        # Also allow if receiving a message with dot syntax, e.g. `ENV['X'].nil?`.
+        # The following are allowed cases:
+        #
+        # - Used as a flag (e.g., `if ENV['X']` or `!ENV['X']`) because
+        #   it simply checks whether the variable is set.
+        # - Receiving a message with dot syntax, e.g. `ENV['X'].nil?`.
+        # - `ENV['key']` is a receiver of `||=`, e.g. `ENV['X'] ||= y`.
         def allowable_use?(node)
-          used_as_flag?(node) || message_chained_with_dot?(node)
+          used_as_flag?(node) || message_chained_with_dot?(node) || node.parent&.or_asgn_type?
         end
       end
     end

--- a/spec/rubocop/cop/style/fetch_env_var_spec.rb
+++ b/spec/rubocop/cop/style/fetch_env_var_spec.rb
@@ -85,6 +85,14 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     end
   end
 
+  context 'when the node is a receiver of `||=`' do
+    it 'does not register an offense with `||`' do
+      expect_no_offenses(<<~RUBY)
+        ENV['X'] ||= y
+      RUBY
+    end
+  end
+
   context 'when it is an argument of a method' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #10557.

This PR fixes a false positive for `Style/FetchEnvVar` when `ENV['key']` is a receiver of `||=`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
