### PR TITLE
[Fix #10559] Fix crash in code length calculation

### DIFF
--- a/changelog/fix_crash_in_codelength.md
+++ b/changelog/fix_crash_in_codelength.md
@@ -1,0 +1,1 @@
+ * [#10559](https://github.com/rubocop/rubocop/issues/10559): Fix crash in code length calculation. ([@tejasbubane][])

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -156,7 +156,7 @@ module RuboCop
 
           def omit_length(descendant)
             parent = descendant.parent
-            return 0 if another_args?(parent)
+            return 0 if another_args?(parent) || pos_missing?(parent)
 
             [
               parent.loc.begin.end_pos != descendant.loc.expression.begin_pos,
@@ -166,6 +166,11 @@ module RuboCop
 
           def another_args?(node)
             node.call_type? && node.arguments.count > 1
+          end
+
+          def pos_missing?(node)
+            loc = node.loc
+            !(loc.begin && loc.end)
           end
         end
       end

--- a/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
@@ -158,6 +158,17 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::CodeLengthCalculator do
         expect(length).to eq(1)
       end
 
+      it 'counts single line correctly if asked folding without parens' do
+        source = parse_source(<<~RUBY)
+          def test
+            foo foo: :bar, baz: :quux
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, foldable_types: %i[hash]).calculate
+        expect(length).to eq(1)
+      end
+
       it 'counts single line hash with line breaks correctly if asked folding' do
         source = parse_source(<<~RUBY)
           def test


### PR DESCRIPTION
Closes https://github.com/rubocop/rubocop/issues/10559

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/