### PR TITLE
[Fix #10472] Add `AllowPercentArray` option to `Layout/MultilineArrayLineBreaks`

### DIFF
--- a/changelog/new_add_option_for_multiline_array_line_breaks.md
+++ b/changelog/new_add_option_for_multiline_array_line_breaks.md
@@ -1,0 +1,1 @@
+* [#10472](https://github.com/rubocop/rubocop/issues/10472): Add `AllowPercentArray` option to `Layout/MultilineArrayLineBreaks` and the option is false by default. ([@ydah][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1014,6 +1014,8 @@ Layout/MultilineArrayLineBreaks:
                  starts on a separate line.
   Enabled: false
   VersionAdded: '0.67'
+  VersionChanged: <<next>>
+  AllowPercentArray: false
 
 Layout/MultilineAssignmentLayout:
   Description: 'Check for a newline after the assignment operator in multi-line assignments.'

--- a/lib/rubocop/cop/layout/multiline_array_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_array_line_breaks.rb
@@ -20,6 +20,22 @@ module RuboCop
       #     b,
       #     c
       #   ]
+      #
+      # @example AllowPercentArray: false (default)
+      #
+      #   # bad
+      #   %w[
+      #     1 2
+      #     3 4
+      #   ]
+      #
+      # @example AllowPercentArray: true
+      #
+      #   # good
+      #   %w[
+      #     1 2
+      #     3 4
+      #   ]
       class MultilineArrayLineBreaks < Base
         include MultilineElementLineBreaks
         extend AutoCorrector
@@ -27,7 +43,13 @@ module RuboCop
         MSG = 'Each item in a multi-line array must start on a separate line.'
 
         def on_array(node)
+          return if allowed_percent_array?(node)
+
           check_line_breaks(node, node.children)
+        end
+
+        def allowed_percent_array?(node)
+          cop_config.fetch('AllowPercentArray', false) && node.percent_literal?
         end
       end
     end

--- a/spec/rubocop/cop/layout/multiline_array_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_array_line_breaks_spec.rb
@@ -50,4 +50,17 @@ RSpec.describe RuboCop::Cop::Layout::MultilineArrayLineBreaks, :config do
       RUBY
     end
   end
+
+  context 'when AllowPercentArray: true' do
+    let(:cop_config) { { 'AllowPercentArray' => true } }
+
+    it 'does not add any offenses' do
+      expect_no_offenses(<<~RUBY)
+        %w[
+          1 2
+          3
+        ]
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Resolve: #10472

This PR add `AllowPercentArray` to `Layout/MultilineArrayLineBreaks` and the option is false by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
