### PR TITLE
[Fix #10563] Fix `Style/BlockDelimiters` unexpectedly deletes block

### DIFF
--- a/changelog/fix_style_blockdelimiters_deletes_block_on_moving_comment.md
+++ b/changelog/fix_style_blockdelimiters_deletes_block_on_moving_comment.md
@@ -1,0 +1,1 @@
+* [#10563](https://github.com/rubocop/rubocop/issues/10563): Fix `Style/BlockDelimiters` unexpectedly deletes block on moving comment if methods with block are chained. ([@nobuyo][])

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -288,9 +288,14 @@ module RuboCop
         end
 
         def end_of_chain(node)
+          return end_of_chain(node.block_node) if with_block?(node)
           return node unless node.chained?
 
           end_of_chain(node.parent)
+        end
+
+        def with_block?(node)
+          node.respond_to?(:block_node) && node.block_node
         end
 
         def get_blocks(node, &block)

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -410,6 +410,20 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
 
+      it 'registers an offense and keep chained block when there is a comment after the closing brace and block body is not empty' do
+        expect_offense(<<~RUBY)
+          baz.map { |x|
+                  ^ Avoid using `{...}` for multi-line blocks.
+          foo(x) }.map { |x| x.quux } # comment
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # comment
+          baz.map do |x|
+          foo(x) end.map { |x| x.quux }
+        RUBY
+      end
+
       it 'registers an offense when there is a comment after the closing brace and using method chain' do
         expect_offense(<<~RUBY)
           baz.map { |x|


### PR DESCRIPTION
...on moving comment if methods with block are chained.

Fixes #10563.

This PR fixes `Style/BlockDelimiters` not correctly looking for the end of method chain with block. (The test is passing, but I'm worry about it's not destroying the other cases.)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
