### PR TITLE
Fix a false positive and a true negative for `Style/FetchEnvVar`

### DIFF
--- a/changelog/fix_a_style_fetch_env_var.md
+++ b/changelog/fix_a_style_fetch_env_var.md
@@ -1,0 +1,1 @@
+* [#10565](https://github.com/rubocop/rubocop/pull/10565): Fix a false positive and a true negative for `Style/FetchEnvVar`. ([@koic][])

--- a/lib/rubocop/cop/style/fetch_env_var.rb
+++ b/lib/rubocop/cop/style/fetch_env_var.rb
@@ -69,9 +69,20 @@ module RuboCop
         # - Used as a flag (e.g., `if ENV['X']` or `!ENV['X']`) because
         #   it simply checks whether the variable is set.
         # - Receiving a message with dot syntax, e.g. `ENV['X'].nil?`.
-        # - `ENV['key']` is a receiver of `||=`, e.g. `ENV['X'] ||= y`.
+        # - `ENV['key']` assigned by logical AND/OR assignment.
         def allowable_use?(node)
-          used_as_flag?(node) || message_chained_with_dot?(node) || node.parent&.or_asgn_type?
+          used_as_flag?(node) || message_chained_with_dot?(node) || assigned?(node)
+        end
+
+        # The following are allowed cases:
+        #
+        # - `ENV['key']` is a receiver of `||=`, e.g. `ENV['X'] ||= y`.
+        # - `ENV['key']` is a receiver of `&&=`, e.g. `ENV['X'] &&= y`.
+        def assigned?(node)
+          return false unless (parent = node.parent)&.assignment?
+
+          lhs, _method, _rhs = *parent
+          node == lhs
         end
       end
     end

--- a/spec/rubocop/cop/style/fetch_env_var_spec.rb
+++ b/spec/rubocop/cop/style/fetch_env_var_spec.rb
@@ -86,9 +86,37 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
   end
 
   context 'when the node is a receiver of `||=`' do
-    it 'does not register an offense with `||`' do
+    it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
         ENV['X'] ||= y
+        x ||= ENV['X'] ||= y
+      RUBY
+    end
+  end
+
+  context 'when the node is a receiver of `&&=`' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        ENV['X'] &&= y
+        x &&= ENV['X'] ||= y
+      RUBY
+    end
+  end
+
+  context 'when the node is a assigned by `||=`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        y ||= ENV['X']
+              ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+      RUBY
+    end
+  end
+
+  context 'when the node is a assigned by `&&=`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        y &&= ENV['X']
+              ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
       RUBY
     end
   end


### PR DESCRIPTION
This PR improves the edge case of `Style/FetchEnvVar`.
There are cases that are false positive and true negative, and it improves them.

false positive cases are as follows:
```ruby
ENV['X'] &&= y
```

true negative cases are as follows:
```ruby
y ||= ENV['X']
y &&= ENV['X']
```

This PR follows up on the same issue as the Issue raised at https://github.com/rubocop/rubocop/issues/10557.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
