### PR TITLE
[Fix #10566] Fix a falase positive for `Lint/AmbiguousBlockAssociation`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_ambiguous_block_association.md
+++ b/changelog/fix_a_false_positive_for_lint_ambiguous_block_association.md
@@ -1,0 +1,1 @@
+* [#10566](https://github.com/rubocop/rubocop/issues/10566): Fix a false positive for `Lint/AmbiguousBlockAssociation` when using proc is used as a last argument. ([@koic][])

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -44,7 +44,8 @@ module RuboCop
           return unless node.arguments?
 
           return unless ambiguous_block_association?(node)
-          return if node.parenthesized? || node.last_argument.lambda? || allowed_method?(node)
+          return if node.parenthesized? || node.last_argument.lambda? || node.last_argument.proc? ||
+                    allowed_method?(node)
 
           message = message(node)
 

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
   it_behaves_like 'accepts', 'Proc.new { puts "proc" }'
   it_behaves_like 'accepts', 'expect { order.save }.to(change { orders.size })'
   it_behaves_like 'accepts', 'scope :active, -> { where(status: "active") }'
+  it_behaves_like 'accepts', 'scope :active, proc { where(status: "active") }'
+  it_behaves_like 'accepts', 'scope :active, Proc.new { where(status: "active") }'
   it_behaves_like('accepts', 'assert_equal posts.find { |p| p.title == "Foo" }, results.first')
   it_behaves_like('accepts', 'assert_equal(posts.find { |p| p.title == "Foo" }, results.first)')
   it_behaves_like('accepts', 'assert_equal(results.first, posts.find { |p| p.title == "Foo" })')


### PR DESCRIPTION
Fixes #10566.

This PR fixes a false positive for `Lint/AmbiguousBlockAssociation` when using proc is used as a last argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
