### PR TITLE
Add AllowedPatterns to Naming/VariableNumber,VariableName

### DIFF
--- a/changelog/new_add_new_option_to_namingvariablenumber.md
+++ b/changelog/new_add_new_option_to_namingvariablenumber.md
@@ -1,0 +1,1 @@
+* [#10539](https://github.com/rubocop/rubocop/issues/10539): Add AllowedPatterns option to Naming/VariableNumber and Naming/VariableName. ([@henrahmagix][])

--- a/changelog/new_add_new_option_to_namingvariablenumber.md
+++ b/changelog/new_add_new_option_to_namingvariablenumber.md
@@ -1,1 +1,1 @@
-* [#10539](https://github.com/rubocop/rubocop/issues/10539): Add AllowedPatterns option to Naming/VariableNumber and Naming/VariableName. ([@henrahmagix][])
+* [#10539](https://github.com/rubocop/rubocop/issues/10539): Add `AllowedPatterns` configuration option to `Naming/VariableNumber` and `Naming/VariableName`. ([@henrahmagix][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2772,6 +2772,7 @@ Naming/VariableName:
     - snake_case
     - camelCase
   AllowedIdentifiers: []
+  AllowedPatterns: []
 
 Naming/VariableNumber:
   Description: 'Use the configured style when numbering symbols, methods and variables.'
@@ -2793,6 +2794,7 @@ Naming/VariableNumber:
     - rfc822       # Time#rfc822
     - rfc2822      # Time#rfc2822
     - rfc3339      # DateTime.rfc3339
+  AllowedPatterns: []
 
 #################### Security ##############################
 

--- a/lib/rubocop/cop/naming/variable_name.rb
+++ b/lib/rubocop/cop/naming/variable_name.rb
@@ -19,11 +19,20 @@ module RuboCop
       #
       #   # good
       #   fooBar = 1
+      #
+      # @example AllowedPatterns: ['_v\d+\z']
+      #   # good
+      #   :release_v1
       class VariableName < Base
         include AllowedIdentifiers
         include ConfigurableNaming
+        include AllowedPattern
 
         MSG = 'Use %<style>s for variable names.'
+
+        def valid_name?(node, name, given_style = style)
+          super || matches_allowed_pattern?(name)
+        end
 
         def on_lvasgn(node)
           name, = *node

--- a/lib/rubocop/cop/naming/variable_number.rb
+++ b/lib/rubocop/cop/naming/variable_number.rb
@@ -96,11 +96,20 @@ module RuboCop
       #   # good
       #   expect(Open3).to receive(:capture3)
       #
+      # @example AllowedPatterns: ['_v\d+\z']
+      #   # good
+      #   :some_sym_v1
+      #
       class VariableNumber < Base
         include AllowedIdentifiers
         include ConfigurableNumbering
+        include AllowedPattern
 
         MSG = 'Use %<style>s for %<identifier_type>s numbers.'
+
+        def valid_name?(node, name, given_style = style)
+          super || matches_allowed_pattern?(name)
+        end
 
         def on_arg(node)
           @node = node
@@ -112,6 +121,7 @@ module RuboCop
         alias on_lvasgn on_arg
         alias on_ivasgn on_arg
         alias on_cvasgn on_arg
+        alias on_gvasgn on_arg
 
         def on_def(node)
           @node = node

--- a/spec/rubocop/cop/naming/variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/variable_name_spec.rb
@@ -68,6 +68,47 @@ RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
     end
   end
 
+  shared_examples 'allowed patterns' do |pattern, identifier|
+    context 'when AllowedPatterns is set' do
+      let(:cop_config) { super().merge('AllowedPatterns' => [pattern]) }
+
+      it 'does not register an offense for a local variable name that matches the allowed pattern' do
+        expect_no_offenses(<<~RUBY)
+          #{identifier} = :foo
+        RUBY
+      end
+
+      it 'does not register an offense for a instance variable name that matches the allowed pattern' do
+        expect_no_offenses(<<~RUBY)
+          @#{identifier} = :foo
+        RUBY
+      end
+
+      it 'does not register an offense for a class variable name that matches the allowed pattern' do
+        expect_no_offenses(<<~RUBY)
+          @@#{identifier} = :foo
+        RUBY
+      end
+
+      it 'does not register an offense for a global variable name that matches the allowed pattern' do
+        expect_no_offenses(<<~RUBY)
+          $#{identifier} = :foo
+        RUBY
+      end
+
+      it 'does not register an offense for a method name that matches the allowed pattern' do
+        expect_no_offenses(<<~RUBY)
+          def #{identifier}
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for a symbol that matches the allowed pattern' do
+        expect_no_offenses(":#{identifier}")
+      end
+    end
+  end
+
   context 'when configured for snake_case' do
     let(:cop_config) { { 'EnforcedStyle' => 'snake_case' } }
 
@@ -164,6 +205,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
 
     include_examples 'always accepted'
     include_examples 'allowed identifiers', 'firstArg'
+    include_examples 'allowed patterns', 'st[A-Z]', 'firstArg'
   end
 
   context 'when configured for camelCase' do
@@ -261,5 +303,6 @@ RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
 
     include_examples 'always accepted'
     include_examples 'allowed identifiers', 'first_arg'
+    include_examples 'allowed patterns', 'st_[a-z]', 'first_arg'
   end
 end

--- a/spec/rubocop/cop/naming/variable_number_spec.rb
+++ b/spec/rubocop/cop/naming/variable_number_spec.rb
@@ -104,6 +104,13 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
             ^^^^^^^ Use snake_case for method name numbers.
       RUBY
     end
+
+    it 'registers an offense for normal case numbering in a global variable name' do
+      expect_offense(<<~RUBY)
+        $arg1 = :foo
+        ^^^^^ Use snake_case for variable numbers.
+      RUBY
+    end
   end
 
   context 'when configured for normal' do
@@ -167,6 +174,13 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
       expect_offense(<<~RUBY)
         def method_1; end
             ^^^^^^^^ Use normalcase for method name numbers.
+      RUBY
+    end
+
+    it 'registers an offense for snake case numbering in a global variable name' do
+      expect_offense(<<~RUBY)
+        $arg_1 = :foo
+        ^^^^^^ Use normalcase for variable numbers.
       RUBY
     end
   end
@@ -316,6 +330,107 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
 
     it 'does not register an offense for a symbol that is allowed' do
       expect_no_offenses(':capture3')
+    end
+  end
+
+  context 'when AllowedPatterns is set' do
+    let(:cop_config) do
+      {
+        'AllowedIdentifiers' => [],
+        'AllowedPatterns' => [
+          '_v\d+\z',
+          'allow_me'
+        ],
+        'CheckSymbols' => true,
+        'CheckMethodNames' => true,
+        'EnforcedStyle' => 'snake_case'
+      }
+    end
+
+    it 'registers an offense for a local variable name that does not match an allowed pattern' do
+      expect_offense(<<~RUBY)
+        foo_a1 = :foo
+        ^^^^^^ Use snake_case for variable numbers.
+      RUBY
+    end
+
+    it 'does not register an offense for a local variable name that matches an allowed pattern' do
+      expect_no_offenses(<<~RUBY)
+        foo_v1 = :foo
+        foo_allow_me_a1 = :allowed
+      RUBY
+    end
+
+    it 'registers an offense for a instance variable name that does not match an allowed pattern' do
+      expect_offense(<<~RUBY)
+        @foo_a1 = :foo
+        ^^^^^^^ Use snake_case for variable numbers.
+      RUBY
+    end
+
+    it 'does not register an offense for a instance variable name that matches an allowed pattern' do
+      expect_no_offenses(<<~RUBY)
+        @foo_v1 = :foo
+        @foo_allow_me_a1 = :allowed
+      RUBY
+    end
+
+    it 'registers an offense for a class variable name that does not match an allowed pattern' do
+      expect_offense(<<~RUBY)
+        @@foo_a1 = :foo
+        ^^^^^^^^ Use snake_case for variable numbers.
+      RUBY
+    end
+
+    it 'does not register an offense for a class variable name that matches an allowed pattern' do
+      expect_no_offenses(<<~RUBY)
+        @@foo_v1 = :foo
+        @@foo_allow_me_a1 = :allowed
+      RUBY
+    end
+
+    it 'registers an offense for a global variable name that does not match an allowed pattern' do
+      expect_offense(<<~RUBY)
+        $foo_a1 = :foo
+        ^^^^^^^ Use snake_case for variable numbers.
+      RUBY
+    end
+
+    it 'does not register an offense for a global variable name that matches an allowed pattern' do
+      expect_no_offenses(<<~RUBY)
+        $foo_v1 = :foo
+        $foo_allow_me_a1 = :allowed
+      RUBY
+    end
+
+    it 'registers an offense for a method name that does not match an allowed pattern' do
+      expect_offense(<<~RUBY)
+        def foo_a1
+            ^^^^^^ Use snake_case for method name numbers.
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for a method name that matches an allowed pattern' do
+      expect_no_offenses(<<~RUBY)
+        def foo_v1
+        end
+
+        def foo_allow_me_a1
+        end
+      RUBY
+    end
+
+    it 'registers an offense for a symbol that does not match an allowed pattern' do
+      expect_offense(<<~RUBY)
+        :foo_a1
+        ^^^^^^^ Use snake_case for symbol numbers.
+      RUBY
+    end
+
+    it 'does not register an offense for a symbol that matches an allowed pattern' do
+      expect_no_offenses(':foo_v1')
+      expect_no_offenses(':foo_allow_me_a1')
     end
   end
 end


### PR DESCRIPTION
Fix #10539, redo of #10540

Also fix global variables not being matched correctly, discovered by
filling in the tests with global variable examples and having failures.
