### PR TITLE
[Fix #10570] Add new `Gemspec/DependencyVersion` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -149,3 +149,6 @@ InternalAffairs/UndefinedConfig:
 InternalAffairs/StyleDetectedApiUse:
   Exclude:
     - 'lib/rubocop/cop/mixin/percent_array.rb'
+
+Gemspec/DependencyVersion:
+  Enabled: true

--- a/changelog/new_add_gemspec_dependency_version_cop.md
+++ b/changelog/new_add_gemspec_dependency_version_cop.md
@@ -1,0 +1,1 @@
+* [#10570](https://github.com/rubocop/rubocop/issues/10570): Add new `Gemspec/DependencyVersion` cop. ([@nobuyo][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -242,6 +242,18 @@ Gemspec/DateAssignment:
   Include:
     - '**/*.gemspec'
 
+Gemspec/DependencyVersion:
+  Description: 'Requires or forbids specifying gem dependency versions.'
+  Enabled: false
+  VersionAdded: '<<next>>'
+  EnforcedStyle: 'required'
+  SupportedStyles:
+    - 'required'
+    - 'forbidden'
+  Include:
+    - '**/*.gemspec'
+  AllowedGems: []
+
 Gemspec/DuplicatedAssignment:
   Description: 'An attribute assignment method calls should be listed only once in a gemspec.'
   Enabled: true

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -161,6 +161,7 @@ require_relative 'rubocop/cop/bundler/insecure_protocol_source'
 require_relative 'rubocop/cop/bundler/ordered_gems'
 
 require_relative 'rubocop/cop/gemspec/date_assignment'
+require_relative 'rubocop/cop/gemspec/dependency_version'
 require_relative 'rubocop/cop/gemspec/duplicated_assignment'
 require_relative 'rubocop/cop/gemspec/ordered_dependencies'
 require_relative 'rubocop/cop/gemspec/require_mfa'

--- a/lib/rubocop/cop/gemspec/dependency_version.rb
+++ b/lib/rubocop/cop/gemspec/dependency_version.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Gemspec
+      # Enforce that gem dependency version specifications or a commit reference (branch,
+      # ref, or tag) are either required or forbidden.
+      #
+      # @example EnforcedStyle: required (default)
+      #
+      #   # bad
+      #   Gem::Specification.new do |spec|
+      #     spec.add_dependency 'parser'
+      #   end
+      #
+      #   # bad
+      #   Gem::Specification.new do |spec|
+      #     spec.add_development_dependency 'parser'
+      #   end
+      #
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.add_dependency 'parser', '>= 2.3.3.1', '< 3.0'
+      #   end
+      #
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.add_development_dependency 'parser', '>= 2.3.3.1', '< 3.0'
+      #   end
+      #
+      # @example EnforcedStyle: forbidden
+      #
+      #   # bad
+      #   Gem::Specification.new do |spec|
+      #     spec.add_dependency 'parser', '>= 2.3.3.1', '< 3.0'
+      #   end
+      #
+      #   # bad
+      #   Gem::Specification.new do |spec|
+      #     spec.add_development_dependency 'parser', '>= 2.3.3.1', '< 3.0'
+      #   end
+      #
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.add_dependency 'parser'
+      #   end
+      #
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.add_development_dependency 'parser'
+      #   end
+      #
+      class DependencyVersion < Base
+        include ConfigurableEnforcedStyle
+        include GemspecHelp
+
+        REQUIRED_MSG = 'Dependency version specification is required.'
+        FORBIDDEN_MSG = 'Dependency version specification is forbidden.'
+        VERSION_SPECIFICATION_REGEX = /^\s*[~<>=]*\s*[0-9.]+/.freeze
+
+        # @!method add_dependency_method_declarations(node)
+        def_node_search :add_dependency_method_declarations, <<~PATTERN
+          (send
+            (lvar #match_block_variable_name?) #add_dependency_method? ...)
+        PATTERN
+
+        # @!method includes_version_specification?(node)
+        def_node_matcher :includes_version_specification?, <<~PATTERN
+          (send _ #add_dependency_method? <(str #version_specification?) ...>)
+        PATTERN
+
+        # @!method includes_commit_reference?(node)
+        def_node_matcher :includes_commit_reference?, <<~PATTERN
+          (send _ #add_dependency_method? <(hash <(pair (sym {:branch :ref :tag}) (str _)) ...>) ...>)
+        PATTERN
+
+        def on_new_investigation
+          return if processed_source.blank?
+
+          add_dependency_method_nodes.each do |node|
+            next if allowed_gem?(node)
+
+            if offense?(node)
+              add_offense(node)
+              opposite_style_detected
+            else
+              correct_style_detected
+            end
+          end
+        end
+
+        private
+
+        def allowed_gem?(node)
+          allowed_gems.include?(node.first_argument.value)
+        end
+
+        def allowed_gems
+          Array(cop_config['AllowedGems'])
+        end
+
+        def message(range)
+          gem_specification = range.source
+
+          if required_style?
+            format(REQUIRED_MSG, gem_specification: gem_specification)
+          elsif forbidden_style?
+            format(FORBIDDEN_MSG, gem_specification: gem_specification)
+          end
+        end
+
+        def match_block_variable_name?(receiver_name)
+          gem_specification(processed_source.ast) do |block_variable_name|
+            return block_variable_name == receiver_name
+          end
+        end
+
+        def add_dependency_method?(method_name)
+          method_name.to_s.end_with?('_dependency')
+        end
+
+        def add_dependency_method_nodes
+          add_dependency_method_declarations(processed_source.ast)
+        end
+
+        def offense?(node)
+          required_offense?(node) || forbidden_offense?(node)
+        end
+
+        def required_offense?(node)
+          return unless required_style?
+
+          !includes_version_specification?(node) && !includes_commit_reference?(node)
+        end
+
+        def forbidden_offense?(node)
+          return unless forbidden_style?
+
+          includes_version_specification?(node) || includes_commit_reference?(node)
+        end
+
+        def forbidden_style?
+          style == :forbidden
+        end
+
+        def required_style?
+          style == :required
+        end
+
+        def version_specification?(expression)
+          expression.match?(VERSION_SPECIFICATION_REGEX)
+        end
+      end
+    end
+  end
+end

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('parser', '>= 3.1.0.0')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
-  s.add_runtime_dependency('rexml')
+  s.add_runtime_dependency('rexml', '~> 3.2', '>= 3.2.5')
   s.add_runtime_dependency('rubocop-ast', '>= 1.17.0', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 3.0')

--- a/spec/rubocop/cop/gemspec/dependency_version_spec.rb
+++ b/spec/rubocop/cop/gemspec/dependency_version_spec.rb
@@ -1,0 +1,704 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Gemspec::DependencyVersion, :config do
+  let(:cop_config) do
+    {
+      'Enabled' => true,
+      'EnforcedStyle' => enforced_style,
+      'AllowedGems' => allowed_gems
+    }
+  end
+  let(:allowed_gems) { [] }
+  let(:config) do
+    base = RuboCop::ConfigLoader
+           .default_configuration['Gemspec/DependencyVersion']
+           .merge(cop_config)
+    RuboCop::Config.new('Gemspec/DependencyVersion' => base)
+  end
+
+  context 'with `EnforcedStyle: required`' do
+    let(:enforced_style) { 'required' }
+
+    context 'using add_dependency' do
+      it 'registers an offense when adding dependency without version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency 'parser'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is required.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding dependency by parenthesized call without version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency('parser')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is required.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding dependency using git option without version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is required.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding dependency using git option by parenthesized call without version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency('rubocop', git: 'https://github.com/rubocop/rubocop')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is required.
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding dependency with version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency 'parser', '~> 3.1', '>= 3.1.1.0'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding dependency by parenthesized call with version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency('parser', '>= 3.1.1.0')
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding dependency with commit ref specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', ref: '54f4c8228'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding dependency by parenthesized call with commit ref specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', ref: '54f4c8228')
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding dependency with tag specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', tag: 'v1.28.0'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding dependency by parenthesized call with tag specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', tag: 'v1.28.0')
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding dependency with branch specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', branch: 'main'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding dependency by parenthesized call with branch specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', branch: 'main')
+          end
+        RUBY
+      end
+    end
+
+    context 'using add_development_dependency' do
+      it 'registers an offense when adding development dependency without version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency 'parser'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is required.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding development dependency by parenthesized call without version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency('parser')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is required.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding development dependency using git option without version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is required.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding development dependency using git option by parenthesized call without version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency('rubocop', git: 'https://github.com/rubocop/rubocop')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is required.
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding development dependency with version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency 'parser', '~> 3.1', '>= 3.1.1.0'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding development dependency by parenthesized call with version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency('parser', '>= 3.1.1.0')
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding development dependency with commit ref specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', ref: '54f4c8228'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding development dependency by parenthesized call with commit ref specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', ref: '54f4c8228')
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding development dependency with tag specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', tag: 'v1.28.0'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding development dependency by parenthesized call with tag specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', tag: 'v1.28.0')
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding development dependency with branch specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', branch: 'main'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding development dependency by parenthesized call with branch specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', branch: 'main')
+          end
+        RUBY
+      end
+    end
+
+    context 'using add_runtime_dependency' do
+      it 'registers an offense when adding runtime dependency without version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency 'parser'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is required.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding runtime dependency by parenthesized call without version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency('parser')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is required.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding runtime dependency using git option without version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is required.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding runtime dependency using git option by parenthesized call without version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency('rubocop', git: 'https://github.com/rubocop/rubocop')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is required.
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding runtime dependency with version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency 'parser', '~> 3.1', '>= 3.1.1.0'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding runtime dependency by parenthesized call with version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency('parser', '>= 3.1.1.0')
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding runtime dependency with commit ref specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', ref: '54f4c8228'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding runtime dependency by parenthesized call with commit ref specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', ref: '54f4c8228')
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding runtime dependency with tag specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', tag: 'v1.28.0'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding runtime dependency by parenthesized call with tag specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', tag: 'v1.28.0')
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding runtime dependency with branch specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', branch: 'main'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding runtime dependency by parenthesized call with branch specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', branch: 'main')
+          end
+        RUBY
+      end
+    end
+
+    context 'with `AllowedGems`' do
+      let(:allowed_gems) { ['rubocop'] }
+
+      it 'registers an offense when adding dependency without version specification excepts allowed gems' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency 'rubocop'
+            spec.add_development_dependency 'rubocop-ast', '~> 0.1'
+
+            spec.add_dependency 'parser'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is required.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding dependency by parenthesized call without version specification excepts allowed gems' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency('rubocop')
+            spec.add_development_dependency('rubocop-ast', '~> 0.1')
+
+            spec.add_dependency('parser')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is required.
+          end
+        RUBY
+      end
+    end
+  end
+
+  context 'with `EnforcedStyle: forbidden`' do
+    let(:enforced_style) { 'forbidden' }
+
+    context 'using add_dependency' do
+      it 'does not register an offense when adding dependency without version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency 'parser'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding dependency by parenthesized call without version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency('parser')
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding dependency using git option without version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop'
+          end
+        RUBY
+      end
+
+      it 'does not registers an offense when adding dependency using git option by parenthesized call without version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency('rubocop', git: 'https://github.com/rubocop/rubocop')
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding dependency with version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency 'parser', '~> 3.1', '>= 3.1.1.0'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding dependency by parenthesized call with version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency('parser', '>= 3.1.1.0')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding dependency with commit ref specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', ref: '54f4c8228'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding dependency by parenthesized call with commit ref specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', ref: '54f4c8228')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding dependency with tag specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', tag: 'v1.28.0'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding dependency by parenthesized call with tag specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', tag: 'v1.28.0')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding dependency with branch specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', branch: 'main'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding dependency by parenthesized call with branch specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', branch: 'main')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+    end
+
+    context 'using add_development_dependency' do
+      it 'does not register an offense when adding development dependency without version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency 'parser'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding development dependency by parenthesized call without version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency('parser')
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding development dependency using git option without version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop'
+          end
+        RUBY
+      end
+
+      it 'does not registers an offense when adding development dependency using git option by parenthesized call without version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency('rubocop', git: 'https://github.com/rubocop/rubocop')
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding development dependency with version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency 'parser', '~> 3.1', '>= 3.1.1.0'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding development dependency by parenthesized call with version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency('parser', '>= 3.1.1.0')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding development dependency with commit ref specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', ref: '54f4c8228'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding development dependency by parenthesized call with commit ref specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', ref: '54f4c8228')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding development dependency with tag specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', tag: 'v1.28.0'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding development dependency by parenthesized call with tag specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', tag: 'v1.28.0')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding development dependency with branch specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', branch: 'main'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding development dependency by parenthesized call with branch specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_development_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', branch: 'main')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+    end
+
+    context 'using add_runtime_dependency' do
+      it 'does not register an offense when adding runtime dependency without version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency 'parser'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding runtime dependency by parenthesized call without version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency('parser')
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when adding runtime dependency using git option without version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop'
+          end
+        RUBY
+      end
+
+      it 'does not registers an offense when adding runtime dependency using git option by parenthesized call without version specification' do
+        expect_no_offenses(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency('rubocop', git: 'https://github.com/rubocop/rubocop')
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding runtime dependency with version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency 'parser', '~> 3.1', '>= 3.1.1.0'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding runtime dependency by parenthesized call with version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency('parser', '>= 3.1.1.0')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding runtime dependency with commit ref specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', ref: '54f4c8228'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding runtime dependency by parenthesized call with commit ref specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', ref: '54f4c8228')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding runtime dependency with tag specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', tag: 'v1.28.0'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding runtime dependency by parenthesized call with tag specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', tag: 'v1.28.0')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding runtime dependency with branch specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency 'rubocop', git: 'https://github.com/rubocop/rubocop', branch: 'main'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding runtime dependency by parenthesized call with branch specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_runtime_dependency('rubocop', git: 'https://github.com/rubocop/rubocop', branch: 'main')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+    end
+
+    context 'with `AllowedGems`' do
+      let(:allowed_gems) { ['rubocop'] }
+
+      it 'registers an offense when adding dependency without version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency 'parser'
+            spec.add_dependency 'rubocop', '~> 1.28'
+            spec.add_development_dependency 'rubocop-ast', '~> 0.1'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when adding dependency by parenthesized call without version specification' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency('rubocop')
+            spec.add_dependency('parser')
+            spec.add_development_dependency('rubocop-ast', '~> 0.1')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is forbidden.
+          end
+        RUBY
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #10570.

This cop requires/forbids version specifications or a commit reference for gem dependency in gemspec.

The name for cop suggested in the issue was `GemVersion`, but I'm renaming it because cop is interested in the version of the dependency, not the gem owning gemspec.

## example

```ruby
# EnforcedStyle: required (default)

# bad
Gem::Specification.new do |spec|
  spec.add_dependency 'rubocop'
end

# good
Gem::Specification.new do |spec|
  spec.add_dependency 'rubocop', '~> 1.28'
end
```

```ruby
# EnforcedStyle: forbidden

# bad
Gem::Specification.new do |spec|
  spec.add_dependency 'rubocop', '~> 1.28'
end

# good
Gem::Specification.new do |spec|
  spec.add_dependency 'rubocop'
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
