### PR TITLE
[Fix #10574] Fix a false positive for `Style/SingleArgumentDig`

### DIFF
--- a/changelog/fix_a_false_positive_for_single_argment_dig.md
+++ b/changelog/fix_a_false_positive_for_single_argment_dig.md
@@ -1,0 +1,1 @@
+* [#10574](https://github.com/rubocop/rubocop/issues/10574): Fix a false positive for `Style/SingleArgumentDig` when using dig with arguments forwarding. ([@ydah][])

--- a/lib/rubocop/cop/style/single_argument_dig.rb
+++ b/lib/rubocop/cop/style/single_argument_dig.rb
@@ -44,6 +44,7 @@ module RuboCop
 
           expression = single_argument_dig?(node)
           return unless expression
+          return if expression.forwarded_args_type?
 
           receiver = node.receiver.source
           argument = expression.source

--- a/spec/rubocop/cop/style/single_argument_dig_spec.rb
+++ b/spec/rubocop/cop/style/single_argument_dig_spec.rb
@@ -32,6 +32,18 @@ RSpec.describe RuboCop::Cop::Style::SingleArgumentDig, :config do
     end
   end
 
+  context '>= Ruby 2.7', :ruby27 do
+    context 'when using dig with arguments forwarding' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def foo(...)
+            { key: 'value' }.dig(...)
+          end
+        RUBY
+      end
+    end
+  end
+
   describe 'dig over a variable as caller' do
     context 'with single argument' do
       it 'registers an offense and corrects unsuitable use of dig' do


### PR DESCRIPTION
Fixes: #10574

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
