### PR TITLE
[Fix #10579] Fix a false positive for `Style/FetchEnvVar`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_fetch_env_var.md
+++ b/changelog/fix_a_false_positive_for_style_fetch_env_var.md
@@ -1,0 +1,1 @@
+* [#10579](https://github.com/rubocop/rubocop/issues/10579): Fix a false positive for `Style/FetchEnvVar` when calling a method with safe navigation`. ([@koic][])

--- a/lib/rubocop/cop/style/fetch_env_var.rb
+++ b/lib/rubocop/cop/style/fetch_env_var.rb
@@ -61,7 +61,10 @@ module RuboCop
         def message_chained_with_dot?(node)
           return false if node.root?
 
-          node.parent.send_type? && node.parent.children.first == node && node.parent.dot?
+          parent = node.parent
+          return false if !parent.call_type? || parent.children.first != node
+
+          parent.dot? || parent.safe_navigation?
         end
 
         # The following are allowed cases:

--- a/spec/rubocop/cop/style/fetch_env_var_spec.rb
+++ b/spec/rubocop/cop/style/fetch_env_var_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     end
   end
 
+  context 'when it receives a message with safe navigation' do
+    it 'registers no offenses' do
+      expect_no_offenses(<<~RUBY)
+        ENV['X']&.some_method
+      RUBY
+    end
+  end
+
   context 'when it is compared with other object' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #10579.

This PR fixes a false positive for `Style/FetchEnvVar` when calling a method with safe navigation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
