### PR TITLE
[Fix #10581] Fix a false positive for `Style/FetchEnvVar`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_fetch_env_var_cop.md
+++ b/changelog/fix_a_false_positive_for_style_fetch_env_var_cop.md
@@ -1,0 +1,1 @@
+* [#10581](https://github.com/rubocop/rubocop/issues/10581): Fix a false positive for `Style/FetchEnvVar` when comparing with `ENV['TERM']`. ([@koic][])

--- a/lib/rubocop/cop/style/fetch_env_var.rb
+++ b/lib/rubocop/cop/style/fetch_env_var.rb
@@ -53,8 +53,9 @@ module RuboCop
 
         def used_as_flag?(node)
           return false if node.root?
+          return true if node.parent.if_type?
 
-          node.parent.if_type? || (node.parent.send_type? && node.parent.prefix_bang?)
+          node.parent.send_type? && (node.parent.prefix_bang? || node.parent.comparison_method?)
         end
 
         # Check if the node is a receiver and receives a message with dot syntax.

--- a/spec/rubocop/cop/style/fetch_env_var_spec.rb
+++ b/spec/rubocop/cop/style/fetch_env_var_spec.rb
@@ -49,15 +49,18 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     end
   end
 
-  context 'when it is compared with other object' do
-    it 'registers an offense' do
-      expect_offense(<<~RUBY)
+  context 'when it is compared `==` with other object' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
         ENV['X'] == 1
-        ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
       RUBY
+    end
+  end
 
-      expect_correction(<<~RUBY)
-        ENV.fetch('X', nil) == 1
+  context 'when it is compared `!=` with other object' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        ENV['X'] != 1
       RUBY
     end
   end


### PR DESCRIPTION
Fixes #10581.

This PR fixes a false positive for `Style/FetchEnvVar` when comparing with `ENV['TERM']`.
`ENV['DISABLE_DOTENV'] != '1'` could be treated the same as the already allowed in `used_as_flag?` (that is, used as a flag).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
