### PR TITLE
Enhance the autocorrect for `Style/FetchEnvVar`

### DIFF
--- a/changelog/change_enhance_the_autocorrect_for_fetch_env_var.md
+++ b/changelog/change_enhance_the_autocorrect_for_fetch_env_var.md
@@ -1,0 +1,1 @@
+* [#10585](https://github.com/rubocop/rubocop/pull/10585): Enhance the autocorrect for `RSpec/FetchEnvVar`. ([@johnny-miyake][])

--- a/changelog/change_enhance_the_autocorrect_for_fetch_env_var.md
+++ b/changelog/change_enhance_the_autocorrect_for_fetch_env_var.md
@@ -1,1 +1,1 @@
-* [#10585](https://github.com/rubocop/rubocop/pull/10585): Enhance the autocorrect for `RSpec/FetchEnvVar`. ([@johnny-miyake][])
+* [#10585](https://github.com/rubocop/rubocop/pull/10585): Enhance the autocorrect for `Style/FetchEnvVar`. ([@johnny-miyake][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3538,6 +3538,9 @@ Style/FetchEnvVar:
   VersionAdded: '1.28'
   # Environment variables to be excluded from the inspection.
   AllowedVars: []
+  # - `SecondArgOfFetch` puts the RHS to the second argument of `ENV.fetch`. (default)
+  # - `BlockContent` puts the RHS into a block.
+  BasicLiteralRhs: 'SecondArgOfFetch'
 
 Style/FileRead:
   Description: 'Favor `File.(bin)read` convenience methods.'

--- a/config/default.yml
+++ b/config/default.yml
@@ -3538,9 +3538,6 @@ Style/FetchEnvVar:
   VersionAdded: '1.28'
   # Environment variables to be excluded from the inspection.
   AllowedVars: []
-  # - `SecondArgOfFetch` puts the RHS to the second argument of `ENV.fetch`. (default)
-  # - `BlockContent` puts the RHS into a block.
-  BasicLiteralRhs: 'SecondArgOfFetch'
 
 Style/FileRead:
   Description: 'Favor `File.(bin)read` convenience methods.'

--- a/lib/rubocop/cop/style/fetch_env_var.rb
+++ b/lib/rubocop/cop/style/fetch_env_var.rb
@@ -185,13 +185,14 @@ module RuboCop
         end
 
         def new_code_default_rhs_multiline(node, expression)
+          env_indent = indent(node.parent)
           default = node.parent.rhs.source.split("\n").map do |line|
-            "#{indent(node.parent, offset: indentation_width)}#{line}"
+            "#{env_indent}#{line}"
           end.join("\n")
           <<~NEW_CODE.chomp
             ENV.fetch(#{expression.source}) do
-            #{default}
-            end
+            #{configured_indentation}#{default}
+            #{env_indent}end
           NEW_CODE
         end
 
@@ -262,8 +263,8 @@ module RuboCop
           end
         end
 
-        def indentation_width
-          config.for_cop('Layout/IndentationWidth')['Width'] || 2
+        def configured_indentation
+          ' ' * (config.for_cop('Layout/IndentationWidth')['Width'] || 2)
         end
 
         def first_line_of(source)

--- a/lib/rubocop/cop/style/fetch_env_var.rb
+++ b/lib/rubocop/cop/style/fetch_env_var.rb
@@ -11,11 +11,6 @@ module RuboCop
       #
       # When an `ENV[]` is the LHS of `||`, the autocorrect makes the RHS
       # the default value of `ENV.fetch`.
-      # In addition, when the RHS is a basic literal object (e.g., `'string'`, `true`, `1`),
-      # the autocorrect corrects the code according to the `BasicLiteralRhs` option.
-      # Available values
-      # - `SecondArgOfFetch` puts the RHS to the second argument of `ENV.fetch`. (default)
-      # - `BlockContent` puts the RHS into a block.
       #
       # @example
       #   # bad
@@ -49,9 +44,9 @@ module RuboCop
 
         # rubocop:disable Layout/LineLength
         MSG_DEFAULT_NIL = 'Use `ENV.fetch(%<key>s)` or `ENV.fetch(%<key>s, nil)` instead of `ENV[%<key>s]`.'
-        MSG_DEFAULT_RHS_SINGLE_ARG_STYLE = 'Use `ENV.fetch(%<key>s, %<default>s)` instead of `ENV[%<key>s] || %<default>s`.'
-        MSG_DEFAULT_RHS_SINGLE_BLOCK_STYLE = 'Use `ENV.fetch(%<key>s) { %<default>s }` instead of `ENV[%<key>s] || %<default>s`.'
-        MSG_DEFAULT_RHS_MULTI = 'Use `ENV.fetch(%<key>s)` with a block containing `%<default>s ...`'
+        MSG_DEFAULT_RHS_SECOND_ARG_OF_FETCH = 'Use `ENV.fetch(%<key>s, %<default>s)` instead of `ENV[%<key>s] || %<default>s`.'
+        MSG_DEFAULT_RHS_SINGLE_LINE_BLOCK = 'Use `ENV.fetch(%<key>s) { %<default>s }` instead of `ENV[%<key>s] || %<default>s`.'
+        MSG_DEFAULT_RHS_MULTILINE_BLOCK = 'Use `ENV.fetch(%<key>s)` with a block containing `%<default>s ...`'
         # rubocop:enable Layout/LineLength
 
         # @!method env_with_bracket?(node)
@@ -182,7 +177,7 @@ module RuboCop
 
         def new_code_default_rhs_single_line(node, expression)
           parent = node.parent
-          if cop_config['BasicLiteralRhs'] == 'SecondArgOfFetch' && parent.rhs.basic_literal?
+          if parent.rhs.basic_literal?
             "ENV.fetch(#{expression.source}, #{parent.rhs.source})"
           else
             "ENV.fetch(#{expression.source}) { #{parent.rhs.source} }"
@@ -259,11 +254,11 @@ module RuboCop
 
         def message_template_for(rhs)
           if rhs.multiline?
-            MSG_DEFAULT_RHS_MULTI
-          elsif cop_config['BasicLiteralRhs'] == 'SecondArgOfFetch' && rhs.basic_literal?
-            MSG_DEFAULT_RHS_SINGLE_ARG_STYLE
+            MSG_DEFAULT_RHS_MULTILINE_BLOCK
+          elsif rhs.basic_literal?
+            MSG_DEFAULT_RHS_SECOND_ARG_OF_FETCH
           else
-            MSG_DEFAULT_RHS_SINGLE_BLOCK_STYLE
+            MSG_DEFAULT_RHS_SINGLE_LINE_BLOCK
           end
         end
 

--- a/spec/rubocop/cop/style/fetch_env_var_spec.rb
+++ b/spec/rubocop/cop/style/fetch_env_var_spec.rb
@@ -607,16 +607,24 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
       context 'when the node is the left end of `||` chains' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
-            ENV['X'] || y.map do |a|
-            ^^^^^^^^ Use `ENV.fetch('X')` with a block containing `y.map do |a| ...`
-              a * 2
+            def foo
+              ENV['X'] || y.map do |a|
+              ^^^^^^^^ Use `ENV.fetch('X')` with a block containing `y.map do |a| ...`
+                3.times do |i|
+                  i * 2
+                end
+              end
             end
           RUBY
 
           expect_correction(<<~RUBY)
-            ENV.fetch('X') do
-              y.map do |a|
-                a * 2
+            def foo
+              ENV.fetch('X') do
+                y.map do |a|
+                  3.times do |i|
+                    i * 2
+                  end
+                end
               end
             end
           RUBY
@@ -626,16 +634,20 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
       context 'when the node is between `||`s' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
-            z || ENV['X'] || y.map do |a|
-                 ^^^^^^^^ Use `ENV.fetch('X')` with a block containing `y.map do |a| ...`
-              a * 2
+            def foo
+              z || ENV['X'] || y.map do |a|
+                   ^^^^^^^^ Use `ENV.fetch('X')` with a block containing `y.map do |a| ...`
+                a * 2
+              end
             end
           RUBY
 
           expect_correction(<<~RUBY)
-            z || ENV.fetch('X') do
-              y.map do |a|
-                a * 2
+            def foo
+              z || ENV.fetch('X') do
+                y.map do |a|
+                  a * 2
+                end
               end
             end
           RUBY

--- a/spec/rubocop/cop/style/fetch_env_var_spec.rb
+++ b/spec/rubocop/cop/style/fetch_env_var_spec.rb
@@ -321,66 +321,28 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
 
     context 'and followed by a basic literal' do
       context 'when the node is the left end of `||` chains' do
-        context 'with BasicLiteralSecondArg style' do
-          let(:cop_config) { { 'BasicLiteralRhs' => 'SecondArgOfFetch' } }
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            ENV['X'] || 'y'
+            ^^^^^^^^ Use `ENV.fetch('X', 'y')` instead of `ENV['X'] || 'y'`.
+          RUBY
 
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              ENV['X'] || 'y'
-              ^^^^^^^^ Use `ENV.fetch('X', 'y')` instead of `ENV['X'] || 'y'`.
-            RUBY
-
-            expect_correction(<<~RUBY)
-              ENV.fetch('X', 'y')
-            RUBY
-          end
-        end
-
-        context 'with AlwaysUseBlock style' do
-          let(:cop_config) { { 'BasicLiteralRhs' => 'BlockContent' } }
-
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              ENV['X'] || 'y'
-              ^^^^^^^^ Use `ENV.fetch('X') { 'y' }` instead of `ENV['X'] || 'y'`.
-            RUBY
-
-            expect_correction(<<~RUBY)
-              ENV.fetch('X') { 'y' }
-            RUBY
-          end
+          expect_correction(<<~RUBY)
+            ENV.fetch('X', 'y')
+          RUBY
         end
       end
 
       context 'when the node is between `||`s' do
-        context 'with BasicLiteralSecondArg style' do
-          let(:cop_config) { { 'BasicLiteralRhs' => 'SecondArgOfFetch' } }
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            z || ENV['X'] || 'y'
+                 ^^^^^^^^ Use `ENV.fetch('X', 'y')` instead of `ENV['X'] || 'y'`.
+          RUBY
 
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              z || ENV['X'] || 'y'
-                   ^^^^^^^^ Use `ENV.fetch('X', 'y')` instead of `ENV['X'] || 'y'`.
-            RUBY
-
-            expect_correction(<<~RUBY)
-              z || ENV.fetch('X', 'y')
-            RUBY
-          end
-        end
-
-        context 'with AlwaysUseBlock style' do
-          let(:cop_config) { { 'BasicLiteralRhs' => 'BlockContent' } }
-
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              z || ENV['X'] || 'y'
-                   ^^^^^^^^ Use `ENV.fetch('X') { 'y' }` instead of `ENV['X'] || 'y'`.
-            RUBY
-
-            expect_correction(<<~RUBY)
-              z || ENV.fetch('X') { 'y' }
-            RUBY
-          end
+          expect_correction(<<~RUBY)
+            z || ENV.fetch('X', 'y')
+          RUBY
         end
       end
     end


### PR DESCRIPTION
https://github.com/rubocop/rubocop/issues/10578

This PR enhances the autocorrect for `Style/FetchEnvVar`.

When an `ENV[]` is the LHS of `||`, the autocorrect makes the RHS the default value of `ENV.fetch`.

Examples

```ruby
# from
ENV['X'] || 'y'

# to
ENV.fetch('X', 'y')
```

```ruby
# from
ENV['X'] || ENV['Y'] || a

# to
ENV.fetch('X') { ENV.fetch('Y') { a } }
```

```ruby
# from
z || ENV['X'] || y || ENV['Z'] || a || ENV['B']

# to
z || ENV.fetch('X') { y } || ENV.fetch('Z') { a } || ENV.fetch('B', nil)
```

```ruby
# from
ENV['X'] || y.map do |a|
  a * 2
end

# to
ENV.fetch('X') do
  y.map do |a|
    a * 2
  end
end
```

Please refer to the RSpec file for more examples.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
