### PR TITLE
[Fix #10586] Fix a false positive for `Style/DoubleNegation`

### DIFF
--- a/changelog/fix_a_false_positive_double_negation.md
+++ b/changelog/fix_a_false_positive_double_negation.md
@@ -1,0 +1,1 @@
+* [#10586](https://github.com/rubocop/rubocop/issues/10586): Fix a false positive for `Style/DoubleNegation` when using `define_method` or `define_singleton_method`. ([@ydah][])

--- a/spec/rubocop/cop/style/double_negation_spec.rb
+++ b/spec/rubocop/cop/style/double_negation_spec.rb
@@ -352,6 +352,24 @@ RSpec.describe RuboCop::Cop::Style::DoubleNegation, :config do
       RUBY
     end
 
+    it 'does not register an offense for `!!` when return location by `define_method`' do
+      expect_no_offenses(<<~RUBY)
+        define_method :foo? do
+          bar
+          !!qux
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `!!` when return location by `define_singleton_method`' do
+      expect_no_offenses(<<~RUBY)
+        define_singleton_method :foo? do
+          bar
+          !!qux
+        end
+      RUBY
+    end
+
     it 'does not register an offense for `!!` when return location and using `rescue`' do
       expect_no_offenses(<<~RUBY)
         def foo?


### PR DESCRIPTION
Fixes: #10586

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
