### PR TITLE
[Fix #10589] Fix autocorrect for `Style/RaiseArgs` with `EnforcedStyle: compact`

### DIFF
--- a/changelog/fix_autocorrect_for_styleraiseargs.md
+++ b/changelog/fix_autocorrect_for_styleraiseargs.md
@@ -1,0 +1,1 @@
+* [#10589](https://github.com/rubocop/rubocop/issues/10589): Fix autocorrect for `Style/RaiseArgs` with `EnforcedStyle: compact` and exception object is assigned to a local variable. ([@nobuyo][])

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -80,7 +80,7 @@ module RuboCop
           return node.source if message_nodes.size > 1
 
           argument = message_nodes.first.source
-          exception_class = exception_node.const_name || exception_node.receiver.source
+          exception_class = exception_node.receiver&.source || exception_node.source
 
           if node.parent && requires_parens?(node.parent)
             "#{node.method_name}(#{exception_class}.new(#{argument}))"

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -17,6 +17,19 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
       end
     end
 
+    context 'with a raise with 2 args and exception object is assigned to a local variable' do
+      it 'reports an offense' do
+        expect_offense(<<~RUBY)
+          raise error_class, msg
+          ^^^^^^^^^^^^^^^^^^^^^^ Provide an exception object as an argument to `raise`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          raise error_class.new(msg)
+        RUBY
+      end
+    end
+
     context 'with a raise with exception instantiation and message arguments' do
       it 'reports an offense' do
         expect_offense(<<~RUBY)
@@ -315,6 +328,10 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
 
     it 'accepts a raise with 2 args' do
       expect_no_offenses('raise RuntimeError, msg')
+    end
+
+    it 'accepts a raise when exception object is assigned to a local variable' do
+      expect_no_offenses('raise error_class, msg')
     end
 
     it 'accepts a raise with msg argument' do


### PR DESCRIPTION
…and exception object is assigned to a local variable.

Fixes #10589.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
