### PR TITLE
[Fix #10536] Fix validation for command-line options combination

### DIFF
--- a/changelog/fix_validation_for_commandline_options.md
+++ b/changelog/fix_validation_for_commandline_options.md
@@ -1,0 +1,1 @@
+* [#10536](https://github.com/rubocop/rubocop/issues/10536): Fix validation for command-line options combination of `--display-only-fail-level-offenses` and `--auto-correct`. ([@nobuyo][])

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -309,7 +309,7 @@ module RuboCop
       end
 
       if display_only_fail_level_offenses_with_autocorrect?
-        raise OptionArgumentError, '--autocorrect cannot be used with ' \
+        raise OptionArgumentError, '--auto-correct cannot be used with ' \
                                    '--display-only-fail-level-offenses'
       end
 
@@ -402,7 +402,8 @@ module RuboCop
     end
 
     def display_only_fail_level_offenses_with_autocorrect?
-      @options[:display_only_fail_level_offenses] && @options[:autocorrect]
+      @options[:display_only_fail_level_offenses] &&
+        (@options.key?(:auto_correct) || @options.key?(:safe_auto_correct))
     end
 
     def except_syntax?

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -290,6 +290,15 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
     end
 
+    describe '--display-only-fail-level-offenses' do
+      it 'fails if given with --auto-correct' do
+        %w[--auto-correct -a --auto-correct-all -A].each do |o|
+          expect { options.parse ['--display-only-correctable', o] }
+            .to raise_error(RuboCop::OptionArgumentError)
+        end
+      end
+    end
+
     describe '--display-only-correctable' do
       it 'fails if given with --display-only-failed' do
         expect { options.parse %w[--display-only-correctable --display-only-failed] }


### PR DESCRIPTION
… of `--display-only-fail-level-offenses` and `--auto-correct`

Fixes #10536.

I looked at the files at f3716273260a45fcb1bbcc01df47c0c87d8d770f, and there was no flag that matched `autocorrect` exactly, so I can't be sure, but I think this is a bug.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
