### PR TITLE
[Fix #10325] Enhance `Style/RedundantCondition` for the case that variable assignments in each branch

### DIFF
--- a/changelog/fix_enhance_style_redundantcondition.md
+++ b/changelog/fix_enhance_style_redundantcondition.md
@@ -1,0 +1,1 @@
+* [#10325](https://github.com/rubocop/rubocop/issues/10325): Enhance `Style/RedundantCondition` by considering the case that variable assignments in each branch. ([@nobuyo][])

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -262,6 +262,36 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects when the branches contains assignment method' do
+        expect_offense(<<~RUBY)
+          if foo
+          ^^^^^^ Use double pipes `||` instead.
+            test.bar = foo
+          else
+            test.bar = 'baz'
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          test.bar = foo || 'baz'
+        RUBY
+      end
+
+      it 'registers an offense and corrects when the branches contains method call' do
+        expect_offense(<<~RUBY)
+          if foo
+          ^^^^^^ Use double pipes `||` instead.
+            bar foo
+          else
+            bar 1..2
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bar foo || (1..2)
+        RUBY
+      end
+
       it 'does not register offenses when using `nil?` and the branches contains assignment' do
         expect_no_offenses(<<~RUBY)
           if foo.nil?
@@ -278,6 +308,16 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
             @foo = foo
           else
             @baz = 'quux'
+          end
+        RUBY
+      end
+
+      it 'does not register offenses when using `nil?` and the branches contains method which has multiple arguments' do
+        expect_no_offenses(<<~RUBY)
+          if foo.nil?
+            test.bar foo, bar
+          else
+            test.bar = 'baz', 'quux'
           end
         RUBY
       end

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -227,6 +227,60 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
           foo || (1..2)
         RUBY
       end
+
+      it 'registers an offense and corrects when defined inside method and the branches contains assignment' do
+        expect_offense(<<~RUBY)
+          def test
+            if foo
+            ^^^^^^ Use double pipes `||` instead.
+              @value = foo
+            else
+              @value = 'bar'
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def test
+            @value = foo || 'bar'
+          end
+        RUBY
+      end
+
+      it 'registers an offense and corrects when the branches contains assignment' do
+        expect_offense(<<~RUBY)
+          if foo
+          ^^^^^^ Use double pipes `||` instead.
+            @value = foo
+          else
+            @value = 'bar'
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          @value = foo || 'bar'
+        RUBY
+      end
+
+      it 'does not register offenses when using `nil?` and the branches contains assignment' do
+        expect_no_offenses(<<~RUBY)
+          if foo.nil?
+            @value = foo
+          else
+            @value = 'bar'
+          end
+        RUBY
+      end
+
+      it 'does not register offenses when the branches contains assignment but target not matched' do
+        expect_no_offenses(<<~RUBY)
+          if foo
+            @foo = foo
+          else
+            @baz = 'quux'
+          end
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #10325.

The example using `nil?` given in the issue is not supported here, as it would destroy the code whose intent is to execute else_branch when `value  == false`.

```ruby
# not supported
def lock_retrier=(value)
  if value.nil?
    @lock_retrier = NullLockRetrier.new
  else
    @lock_retrier = value
  end
end

# supported
def lock_retrier=(value)
  if value
    @lock_retrier = NullLockRetrier.new
  else
    @lock_retrier = value
  end
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
