### PR TITLE
Remove an old reference to version 1.0

### DIFF
--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -25,9 +25,6 @@ in your `Gemfile`:
 gem 'rubocop', '~> 1.28', require: false
 ----
 
-NOTE: You can check out our progress on the road to version 1.0 https://github.com/rubocop/rubocop/milestone/4[here].
-You can also help us get there faster! :-)
-
 .A Modular RuboCop
 ****
 Originally RuboCop bundled cops focused on performance and Ruby on Rails, but those were


### PR DESCRIPTION
Version 1.0 is already out, so this note feels unnecessary.

I just edited this on GitHub. Apologies for the poor branch name, let me know if you need a better one :)