### PR TITLE
Tweak uniformity of expression was implemented

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,6 +98,9 @@ Metrics/ModuleLength:
 
 Naming/InclusiveLanguage:
   FlaggedTerms:
+    behaviour:
+      Suggestions:
+        - behavior
     offence:
       Suggestions:
         - offense

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,4 +11,4 @@ patches, commit comments, etc.).
 * Participants will be tolerant of opposing views.
 * Participants must ensure that their language and actions are free of personal attacks and disparaging personal remarks.
 * When interpreting the words and actions of others, participants should always assume good intentions.
-* Behaviour which can be reasonably considered harassment will not be tolerated.
+* Behavior which can be reasonably considered harassment will not be tolerated.

--- a/docs/modules/ROOT/pages/usage/auto_correct.adoc
+++ b/docs/modules/ROOT/pages/usage/auto_correct.adoc
@@ -15,7 +15,7 @@ There are a couple of things to keep in mind about auto-correct:
 - Some automatic corrections that _are_ possible have not been implemented yet.
 - Some automatic corrections might change (slightly) the semantics of the code,
 meaning they'd produce code that's mostly equivalent to the original code, but
-not 100% equivalent. We call such auto-correct behaviour "unsafe".
+not 100% equivalent. We call such auto-correct behavior "unsafe".
 
 TIP: You should always run your test suite after using the auto-correct functionality.
 

--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -82,7 +82,7 @@ TIP: See xref:usage/auto_correct.adoc[Auto-correct] for more details.
 RuboCop comes with a preconfigured set of rules for each of its cops, based on the https://rubystyle.guide[Ruby Style Guide].
 Depending on your project, you may wish to reconfigure a cop, tell to ignore certain files, or disable it altogether.
 
-The most common way to change RuboCop's behaviour is to create a configuration file named `.rubocop.yml` in the
+The most common way to change RuboCop's behavior is to create a configuration file named `.rubocop.yml` in the
 project's root directory.
 
 For more information, see xref:configuration.adoc[Configuration].

--- a/lib/rubocop/cop/lint/ambiguous_range.rb
+++ b/lib/rubocop/cop/lint/ambiguous_range.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Lint
       # This cop checks for ambiguous ranges.
       #
-      # Ranges have quite low precedence, which leads to unexpected behaviour when
+      # Ranges have quite low precedence, which leads to unexpected behavior when
       # using a range with other operators. This cop avoids that by making ranges
       # explicit by requiring parenthesis around complex range boundaries (anything
       # that is not a literal: numerics, strings, symbols, etc.).
@@ -21,7 +21,7 @@ module RuboCop
       #   The cop auto-corrects by wrapping the entire boundary in parentheses, which
       #   makes the outcome more explicit but is possible to not be the intention of the
       #   programmer. For this reason, this cop's auto-correct is unsafe (it will not
-      #   change the behaviour of the code, but will not necessarily match the
+      #   change the behavior of the code, but will not necessarily match the
       #   intent of the program).
       #
       # @example

--- a/lib/rubocop/cop/lint/loop.rb
+++ b/lib/rubocop/cop/lint/loop.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks for uses of `begin...end while/until something`.
       #
       # @safety
-      #   The cop is unsafe because behaviour can change in some cases, including
+      #   The cop is unsafe because behavior can change in some cases, including
       #   if a local variable inside the loop body is accessed outside of it, or if the
       #   loop body raises a `StopIteration` exception (which `Kernel#loop` rescues).
       #

--- a/lib/rubocop/cop/lint/non_deterministic_require_order.rb
+++ b/lib/rubocop/cop/lint/non_deterministic_require_order.rb
@@ -18,7 +18,7 @@ module RuboCop
       #
       # @safety
       #   This cop is unsafe in the case where sorting files changes existing
-      #   expected behaviour.
+      #   expected behavior.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/or_assignment_to_constant.rb
+++ b/lib/rubocop/cop/lint/or_assignment_to_constant.rb
@@ -11,7 +11,7 @@ module RuboCop
       #
       # @safety
       #   This cop is unsafe because code that is already conditionally
-      #   assigning a constant may have its behaviour changed by
+      #   assigning a constant may have its behavior changed by
       #   auto-correction.
       #
       # @example

--- a/lib/rubocop/cop/lint/raise_exception.rb
+++ b/lib/rubocop/cop/lint/raise_exception.rb
@@ -15,7 +15,7 @@ module RuboCop
       #
       # @safety
       #   This cop is unsafe because it will change the exception class being
-      #   raised, which is a change in behaviour.
+      #   raised, which is a change in behavior.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/security/yaml_load.rb
+++ b/lib/rubocop/cop/security/yaml_load.rb
@@ -10,7 +10,7 @@ module RuboCop
       # NOTE: Ruby 3.1+ (Psych 4) uses `Psych.load` as `Psych.safe_load` by default.
       #
       # @safety
-      #   The behaviour of the code might change depending on what was
+      #   The behavior of the code might change depending on what was
       #   in the YAML payload, since `YAML.safe_load` is more restrictive.
       #
       # @example

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -10,7 +10,7 @@ module RuboCop
       # @safety
       #   Auto-correction is unsafe because there is a different operator precedence
       #   between logical operators (`&&` and `||`) and semantic operators (`and` and `or`),
-      #   and that might change the behaviour.
+      #   and that might change the behavior.
       #
       # @example EnforcedStyle: always
       #   # bad

--- a/lib/rubocop/cop/style/case_like_if.rb
+++ b/lib/rubocop/cop/style/case_like_if.rb
@@ -9,7 +9,7 @@ module RuboCop
       # @safety
       #   This cop is unsafe. `case` statements use `===` for equality,
       #   so if the original conditional used a different equality operator, the
-      #   behaviour may be different.
+      #   behavior may be different.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/date_time.rb
+++ b/lib/rubocop/cop/style/date_time.rb
@@ -11,7 +11,7 @@ module RuboCop
       #
       # @safety
       #   Autocorrection is not safe, because `DateTime` and `Time` do not have
-      #   exactly the same behaviour, although in most cases the autocorrection
+      #   exactly the same behavior, although in most cases the autocorrection
       #   will be fine.
       #
       # @example

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -13,7 +13,7 @@ module RuboCop
       #
       # @safety
       #   Auto-correction is unsafe because changing the order of method invocations
-      #   may change the behaviour of the code. For example:
+      #   may change the behavior of the code. For example:
       #
       #   [source,ruby]
       #   ----
@@ -27,7 +27,7 @@ module RuboCop
       #   ----
       #
       #   In this example, `method_that_relies_on_global_state` will be moved before
-      #   `method_that_modifies_global_state`, which changes the behaviour of the program.
+      #   `method_that_modifies_global_state`, which changes the behavior of the program.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/optional_arguments.rb
+++ b/lib/rubocop/cop/style/optional_arguments.rb
@@ -8,7 +8,7 @@ module RuboCop
       #
       # @safety
       #   This cop is unsafe because changing a method signature will
-      #   implicitly change behaviour.
+      #   implicitly change behavior.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/optional_boolean_parameter.rb
+++ b/lib/rubocop/cop/style/optional_boolean_parameter.rb
@@ -9,7 +9,7 @@ module RuboCop
       #
       # @safety
       #   This cop is unsafe because changing a method signature will
-      #   implicitly change behaviour.
+      #   implicitly change behavior.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/redundant_regexp_character_class.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_character_class.rb
@@ -99,7 +99,7 @@ module RuboCop
         end
 
         def backslash_b?(elem)
-          # \b's behaviour is different inside and outside of a character class, matching word
+          # \b's behavior is different inside and outside of a character class, matching word
           # boundaries outside but backspace (0x08) when inside.
           elem == '\b'
         end

--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -59,7 +59,7 @@ module RuboCop
         def allowed_escape?(node, char, within_character_class)
           # Strictly speaking a few single-letter metachars are currently
           # unnecessary to "escape", e.g. i, E, F, but enumerating them is
-          # rather difficult, and their behaviour could change over time with
+          # rather difficult, and their behavior could change over time with
           # different versions of Ruby so that e.g. /\i/ != /i/
           return true if /[[:alnum:]]/.match?(char)
           return true if ALLOWED_ALWAYS_ESCAPES.include?(char) || delimiter?(node, char)

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -23,7 +23,7 @@ module RuboCop
       #
       # @safety
       #   Autocorrection is unsafe because if a value is `false`, the resulting
-      #   code will have different behaviour or raise an error.
+      #   code will have different behavior or raise an error.
       #
       #   [source,ruby]
       #   ----

--- a/lib/rubocop/cop/style/string_chars.rb
+++ b/lib/rubocop/cop/style/string_chars.rb
@@ -8,7 +8,7 @@ module RuboCop
       # @safety
       #   This cop is unsafe because it cannot be guaranteed that the receiver
       #   is actually a string. If another class has a `split` method with
-      #   different behaviour, it would be registered as a false positive.
+      #   different behavior, it would be registered as a false positive.
       #
       # @example
       #   # bad


### PR DESCRIPTION
This PR is unified word fluctuation.

Use "behavior" instead of "behaviour"

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
~* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
~* [ ] Added tests.~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
~* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
