### PR TITLE
[Fix #10569] Fix a false positive for `Style/FetchEnvVar`

### DIFF
--- a/changelog/fix_a_false_for_style_fetch_env_var.md
+++ b/changelog/fix_a_false_for_style_fetch_env_var.md
@@ -1,0 +1,1 @@
+* [#10569](https://github.com/rubocop/rubocop/issues/10569): Fix a false positive for `Style/FetchEnvVar` when using the same `ENV` var as `if` condition in the body. ([@koic][])

--- a/lib/rubocop/cop/style/fetch_env_var.rb
+++ b/lib/rubocop/cop/style/fetch_env_var.rb
@@ -97,7 +97,9 @@ module RuboCop
 
         def used_as_flag?(node)
           return false if node.root?
-          return true if node.parent.if_type?
+
+          if_node = node.ancestors.find(&:if_type?)
+          return true if if_node&.condition == node
 
           node.parent.send_type? && (node.parent.prefix_bang? || node.parent.comparison_method?)
         end

--- a/spec/rubocop/cop/style/fetch_env_var_spec.rb
+++ b/spec/rubocop/cop/style/fetch_env_var_spec.rb
@@ -296,6 +296,23 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
         end
       RUBY
     end
+
+    it 'registers no offenses when using the same `ENV` var as `if` condition in the body' do
+      expect_no_offenses(<<~RUBY)
+        if ENV['X']
+          puts ENV['X']
+        end
+      RUBY
+    end
+
+    it 'registers no offenses when using an `ENV` var that is different from `if` condition in the body' do
+      expect_offense(<<~RUBY)
+        if ENV['X']
+          puts ENV['Y']
+               ^^^^^^^^ Use `ENV.fetch('Y')` or `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
+        end
+      RUBY
+    end
   end
 
   context 'when the env val is excluded from the inspection by the config' do


### PR DESCRIPTION
Fixes #10569.

This PR fixes a false positive for `Style/FetchEnvVar` when using the same value of `ENV` as `if` condition in the body.

The `ENV` var as a `if` condition is currently allowed.
So the `ENV` var already used in the condition will be accepted as well.

And the following (maybe) corner case is accepted in this PR.

```ruby
if ENV['foo']
  ENV.delete('foo')
  puts 'some code'
  puts ENV['foo']
  puts 'other code'
end
```

https://github.com/rubocop/rubocop/issues/10569#issuecomment-1106213970

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
