### PR TITLE
[Fix #10605] Fix autocorrect for `Style/RedundantCondition`

### DIFF
--- a/changelog/fix_autocorrect_for_style_redundant_condition_with_hash.md
+++ b/changelog/fix_autocorrect_for_style_redundant_condition_with_hash.md
@@ -1,0 +1,1 @@
+* [#10605](https://github.com/rubocop/rubocop/issues/10605): Fix autocorrect for `Style/RedundantCondition` if argument for method in else branch is hash without braces. ([@nobuyo][])

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -157,6 +157,8 @@ module RuboCop
         def else_source_if_has_method(else_branch)
           if require_parentheses?(else_branch.first_argument)
             "(#{else_branch.first_argument.source})"
+          elsif require_braces?(else_branch.first_argument)
+            "{ #{else_branch.first_argument.source} }"
           else
             else_branch.first_argument.source
           end
@@ -165,6 +167,8 @@ module RuboCop
         def else_source_if_has_assignment(else_branch)
           if require_parentheses?(else_branch.expression)
             "(#{else_branch.expression.source})"
+          elsif require_braces?(else_branch.expression)
+            "{ #{else_branch.expression.source} }"
           else
             else_branch.expression.source
           end
@@ -194,6 +198,10 @@ module RuboCop
             node.range_type? ||
             node.rescue_type? ||
             (node.respond_to?(:semantic_operator?) && node.semantic_operator?)
+        end
+
+        def require_braces?(node)
+          node.hash_type? && !node.braces?
         end
 
         def without_argument_parentheses_method?(node)

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -292,6 +292,36 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects when the branches contains method call with braced hash' do
+        expect_offense(<<~RUBY)
+          if foo
+          ^^^^^^ Use double pipes `||` instead.
+            bar foo
+          else
+            bar({ baz => quux })
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bar foo || { baz => quux }
+        RUBY
+      end
+
+      it 'registers an offense and corrects when the branches contains method call with non-braced hash' do
+        expect_offense(<<~RUBY)
+          if foo
+          ^^^^^^ Use double pipes `||` instead.
+            bar foo
+          else
+            bar baz => quux
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bar foo || { baz => quux }
+        RUBY
+      end
+
       it 'does not register offenses when using `nil?` and the branches contains assignment' do
         expect_no_offenses(<<~RUBY)
           if foo.nil?


### PR DESCRIPTION
...if argument for method in else branch is hash without braces.

Fixes #10605.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
