### PR TITLE
[Fix #10607] Fix autocorrect for `Style/RedundantCondition` with parenthesized method call

### DIFF
--- a/changelog/fix_autocorrect_for_style_redundant_condition_with_parenthesized_method_call.md
+++ b/changelog/fix_autocorrect_for_style_redundant_condition_with_parenthesized_method_call.md
@@ -1,0 +1,1 @@
+* [#10607](https://github.com/rubocop/rubocop/issues/10607): Fix autocorrect for `Style/RedundantCondition` when there are parenthesized method calls in each branch. ([@nobuyo][])

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -322,6 +322,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects when the branches contains parenthesized method call' do
+        expect_offense(<<~RUBY)
+          if foo
+          ^^^^^^ Use double pipes `||` instead.
+            bar(foo)
+          else
+            bar(1..2)
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bar(foo || (1..2))
+        RUBY
+      end
+
       it 'does not register offenses when using `nil?` and the branches contains assignment' do
         expect_no_offenses(<<~RUBY)
           if foo.nil?
@@ -348,6 +363,16 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
             test.bar foo, bar
           else
             test.bar = 'baz', 'quux'
+          end
+        RUBY
+      end
+
+      it 'does not register offenses when the branches contains hash key access' do
+        expect_no_offenses(<<~RUBY)
+          if foo
+            bar[foo]
+          else
+            bar[1]
           end
         RUBY
       end
@@ -423,6 +448,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
 
         expect_correction(<<~RUBY)
           time_period = updated_during || (2.days.ago...Time.now)
+        RUBY
+      end
+
+      it 'registers an offense and corrects with ternary expression and the branches contains parenthesized method call' do
+        expect_offense(<<~RUBY)
+          foo ? bar(foo) : bar(quux)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use double pipes `||` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bar(foo || quux)
+        RUBY
+      end
+
+      it 'registers an offense and corrects with ternary expression and the branches contains chained parenthesized method call' do
+        expect_offense(<<~RUBY)
+          foo ? foo(foo).bar(foo) : foo(foo).bar(quux)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use double pipes `||` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo(foo).bar(foo || quux)
         RUBY
       end
 


### PR DESCRIPTION
Fixes #10607.

Sorry that was my bad, the cop now supports parenthesized method calls.

```ruby
if foo
  some_method(foo)
else
  some_method('bar')
end
# => some_method(foo || 'bar')

foo ? some_method(foo) : some_method('bar')
# => some_method(foo || 'bar')
```

And fixed highlight range for ternary expression when expression contains method call.

```ruby
# before
test.rb:4:5: C: [Correctable] Style/RedundantCondition: Use double pipes || instead.
foo ? some_method(foo) : some_method('bar')
    ^^^^^^^^^^^^^^^^^^^^

# after
test.rb:4:1: C: [Correctable] Style/RedundantCondition: Use double pipes || instead.
foo ? some_method(foo) : some_method('bar')
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
