### PR TITLE
Fix an error for `Naming/InclusiveLanguage` string with invalid byte sequence in UTF-8

### DIFF
--- a/changelog/fix_an_error_inclusive_language.md
+++ b/changelog/fix_an_error_inclusive_language.md
@@ -1,0 +1,1 @@
+* [#10610](https://github.com/rubocop/rubocop/pull/10610): Fix an error for `Naming/InclusiveLanguage` string with invalid byte sequence in UTF-8. ([@ydah][])

--- a/lib/rubocop/cop/naming/inclusive_language.rb
+++ b/lib/rubocop/cop/naming/inclusive_language.rb
@@ -214,13 +214,14 @@ module RuboCop
         end
 
         def mask_input(str)
-          return str if @allowed_regex.nil?
-
           safe_str = if str.valid_encoding?
                        str
                      else
                        str.encode('UTF-8', invalid: :replace, undef: :replace)
                      end
+
+          return safe_str if @allowed_regex.nil?
+
           safe_str.gsub(@allowed_regex) { |match| '*' * match.size }
         end
 

--- a/spec/rubocop/cop/naming/inclusive_language_spec.rb
+++ b/spec/rubocop/cop/naming/inclusive_language_spec.rb
@@ -315,6 +315,12 @@ RSpec.describe RuboCop::Cop::Naming::InclusiveLanguage, :config do
       RUBY
     end
 
+    it 'does not register offenses and not raise `ArgumentError` for invalid byte sequence in UTF-8' do
+      expect_no_offenses(<<-RUBY)
+        %W("a\\255\\255")
+      RUBY
+    end
+
     context 'when CheckStrings config is false' do
       let(:check_strings) { false }
 


### PR DESCRIPTION
This fixes an issue when `CheckStrings: true` and string with invalid byte sequence in UTF-8 
would cause an error in the `Naming/InclusiveLanguage` cop.

In fact, when we ran RuboCop on this repository's own code as follows, an error occurred.

### rubocop.yml

```yml
Naming/InclusiveLanguage:
+  CheckStrings: true
  FlaggedTerms:
    behaviour:
      Suggestions:
        - behavior
    offence:
      Suggestions:
        - offense
  Exclude:
    - lib/rubocop/cop/naming/inclusive_language.rb
```

### command
```
bundle exec rubocop --only Naming/InclusiveLanguage
```

### result
```
6 errors occurred:
An error occurred while Naming/InclusiveLanguage cop was inspecting /Users/ydah/rubocop/spec/rubocop/cop/layout/end_of_line_spec.rb.
An error occurred while Naming/InclusiveLanguage cop was inspecting /Users/ydah/rubocop/spec/rubocop/cop/lint/percent_string_array_spec.rb.
An error occurred while Naming/InclusiveLanguage cop was inspecting /Users/ydah/rubocop/spec/rubocop/cop/lint/percent_symbol_array_spec.rb.
An error occurred while Naming/InclusiveLanguage cop was inspecting /Users/ydah/rubocop/spec/rubocop/cop/lint/syntax_spec.rb.
An error occurred while Naming/InclusiveLanguage cop was inspecting /Users/ydah/rubocop/spec/rubocop/path_util_spec.rb.
An error occurred while Naming/InclusiveLanguage cop was inspecting /Users/ydah/rubocop/spec/rubocop/result_cache_spec.rb.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop/rubocop/issues

Mention the following information in the issue report:
1.29.0 (using Parser 3.1.2.0, rubocop-ast 1.17.0, running on ruby 3.1.0 x86_64-darwin21)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
~* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
