### PR TITLE
Tweak uniformity of expression was implemented

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -97,6 +97,8 @@ Metrics/ModuleLength:
     - 'spec/**/*.rb'
 
 Naming/InclusiveLanguage:
+  Enabled: true
+  CheckStrings: true
   FlaggedTerms:
     behaviour:
       Suggestions:
@@ -106,6 +108,7 @@ Naming/InclusiveLanguage:
         - offense
   Exclude:
     - lib/rubocop/cop/naming/inclusive_language.rb
+    - spec/rubocop/cop/naming/inclusive_language_spec.rb
 
 RSpec/FilePath:
   Exclude:

--- a/spec/rubocop/cli/disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/disable_uncorrectable_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
       end
     end
 
-    context 'when exist offence for Layout/SpaceInsideArrayLiteralBrackets' do
+    context 'when exist offense for Layout/SpaceInsideArrayLiteralBrackets' do
       context 'when `EnforcedStyle: no_space`' do
         it 'does not disable anything for cops that support autocorrect' do
           create_file('example.rb', <<~RUBY)

--- a/spec/rubocop/cop/security/compound_hash_spec.rb
+++ b/spec/rubocop/cop/security/compound_hash_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe RuboCop::Cop::Security::CompoundHash, :config do
     RUBY
   end
 
-  it 'registers an offence when using bitshift and OR' do
+  it 'registers an offense when using bitshift and OR' do
     expect_offense(<<~RUBY)
       def hash
         ([@addr, @mask_addr, @zone_id].hash << 1) | (ipv4? ? 0 : 1)


### PR DESCRIPTION
This PR is unified word fluctuation.
Use "offense" instead of "offence"

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
~* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
~* [ ] Added tests.~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
~* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
