### PR TITLE
[Fix #10614] Make `Lint/NonDeterministicRequireOrder` aware of `require_relative`

### DIFF
--- a/changelog/fix_make_lint_non_deterministic_require_order_aware_of_require_relative.md
+++ b/changelog/fix_make_lint_non_deterministic_require_order_aware_of_require_relative.md
@@ -1,0 +1,1 @@
+* [#10614](https://github.com/rubocop/rubocop/issues/10614): Make `Lint/NonDeterministicRequireOrder` aware of `require_relative`. ([@koic][])

--- a/lib/rubocop/cop/lint/non_deterministic_require_order.rb
+++ b/lib/rubocop/cop/lint/non_deterministic_require_order.rb
@@ -143,19 +143,19 @@ module RuboCop
 
         # @!method method_require?(node)
         def_node_matcher :method_require?, <<~PATTERN
-          (block-pass (send nil? :method (sym :require)))
+          (block-pass (send nil? :method (sym {:require :require_relative})))
         PATTERN
 
         # @!method unsorted_dir_glob_pass?(node)
         def_node_matcher :unsorted_dir_glob_pass?, <<~PATTERN
           (send (const {nil? cbase} :Dir) :glob ...
-            (block-pass (send nil? :method (sym :require))))
+            (block-pass (send nil? :method (sym {:require :require_relative}))))
         PATTERN
 
         # @!method unsorted_dir_each_pass?(node)
         def_node_matcher :unsorted_dir_each_pass?, <<~PATTERN
           (send (send (const {nil? cbase} :Dir) {:[] :glob} ...) :each
-            (block-pass (send nil? :method (sym :require))))
+            (block-pass (send nil? :method (sym {:require :require_relative}))))
         PATTERN
 
         # @!method loop_variable(node)
@@ -165,7 +165,7 @@ module RuboCop
 
         # @!method var_is_required?(node, name)
         def_node_search :var_is_required?, <<~PATTERN
-          (send nil? :require (lvar %1))
+          (send nil? {:require :require_relative} (lvar %1))
         PATTERN
       end
     end

--- a/spec/rubocop/cop/lint/non_deterministic_require_order_spec.rb
+++ b/spec/rubocop/cop/lint/non_deterministic_require_order_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe RuboCop::Cop::Lint::NonDeterministicRequireOrder, :config do
 
     context 'when Ruby 2.7 or lower', :ruby27 do
       context 'with unsorted index' do
-        it 'registers an offsense and autocorrects to add .sort' do
+        it 'registers an offsense and autocorrects to add .sort when the block has `require`' do
           expect_offense(<<~RUBY)
             Dir["./lib/**/*.rb"].each do |file|
             ^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
@@ -127,6 +127,21 @@ RSpec.describe RuboCop::Cop::Lint::NonDeterministicRequireOrder, :config do
           expect_correction(<<~RUBY)
             Dir["./lib/**/*.rb"].sort.each do |file|
               require file
+            end
+          RUBY
+        end
+
+        it 'registers an offsense and autocorrects to add .sort when the block has `require_relative`' do
+          expect_offense(<<~RUBY)
+            Dir["./lib/**/*.rb"].each do |file|
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
+              require_relative file
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            Dir["./lib/**/*.rb"].sort.each do |file|
+              require_relative file
             end
           RUBY
         end
@@ -163,6 +178,19 @@ RSpec.describe RuboCop::Cop::Lint::NonDeterministicRequireOrder, :config do
 
             expect_correction(<<~RUBY)
               Dir["./lib/**/*.rb"].sort.each(&method(:require))
+            RUBY
+          end
+        end
+
+        context 'with require_relative block passed as parameter' do
+          it 'registers an offense an autocorrects to add sort' do
+            expect_offense(<<~RUBY)
+              Dir["./lib/**/*.rb"].each(&method(:require_relative))
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              Dir["./lib/**/*.rb"].sort.each(&method(:require_relative))
             RUBY
           end
         end
@@ -264,6 +292,26 @@ RSpec.describe RuboCop::Cop::Lint::NonDeterministicRequireOrder, :config do
                 Rails.root.join('./lib/**/*.rb'),
                 File::FNM_DOTMATCH
               ).sort.each(&method(:require))
+            RUBY
+          end
+        end
+
+        context 'with require_relative block passed as parameter' do
+          it 'registers an offense and autocorrects to add sort' do
+            expect_offense(<<~RUBY)
+              Dir.glob(
+              ^^^^^^^^^ Sort files before requiring them.
+                Rails.root.join('./lib/**/*.rb'),
+                File::FNM_DOTMATCH,
+                &method(:require_relative)
+              )
+            RUBY
+
+            expect_correction(<<~RUBY)
+              Dir.glob(
+                Rails.root.join('./lib/**/*.rb'),
+                File::FNM_DOTMATCH
+              ).sort.each(&method(:require_relative))
             RUBY
           end
         end


### PR DESCRIPTION
Fixes #10614.

This PR makes `Lint/NonDeterministicRequireOrder` aware of `require_relative`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
