### PR TITLE
Markdown formatter: skip files with no offenses

### DIFF
--- a/changelog/change_markdown_formatter_to_skip_files_with_no_offenses.md
+++ b/changelog/change_markdown_formatter_to_skip_files_with_no_offenses.md
@@ -1,0 +1,1 @@
+* [#10616](https://github.com/rubocop/rubocop/pull/10616): Markdown formatter: skip files with no offenses. ([@rickselby][])

--- a/lib/rubocop/formatter/markdown_formatter.rb
+++ b/lib/rubocop/formatter/markdown_formatter.rb
@@ -41,6 +41,8 @@ module RuboCop
 
       def write_file_messages
         files.each do |file|
+          next if file.offenses.empty?
+
           write_heading(file)
           file.offenses.each do |offense|
             write_context(offense)

--- a/spec/fixtures/markdown_formatter/expected.md
+++ b/spec/fixtures/markdown_formatter/expected.md
@@ -1,6 +1,6 @@
 # RuboCop Inspection Report
 
-3 files inspected, 22 offenses detected:
+4 files inspected, 22 offenses detected:
 
 ### app/controllers/application_controller.rb - (1 offense)
   * **Line # 1 - convention:** Style/FrozenStringLiteralComment: Missing frozen string literal comment.

--- a/spec/fixtures/markdown_formatter/project
+++ b/spec/fixtures/markdown_formatter/project
@@ -1,1 +1,0 @@
-../html_formatter/project

--- a/spec/fixtures/markdown_formatter/project/app/controllers/application_controller.rb
+++ b/spec/fixtures/markdown_formatter/project/app/controllers/application_controller.rb
@@ -1,0 +1,7 @@
+class ApplicationController < ActionController::Base
+  # Prevent CSRF attacks by raising an exception.
+  # For APIs, you may want to use :null_session instead.
+  protect_from_forgery with: :exception
+
+  # “Test encoding issues by using curly quotes”
+end

--- a/spec/fixtures/markdown_formatter/project/app/controllers/books_controller.rb
+++ b/spec/fixtures/markdown_formatter/project/app/controllers/books_controller.rb
@@ -1,0 +1,74 @@
+class BooksController < ApplicationController
+  before_action :set_book, only: [:show, :edit, :update, :destroy]
+
+  # GET /books
+  # GET /books.json
+  def index
+    @books = Book.all
+  end
+
+  # GET /books/1
+  # GET /books/1.json
+  def show
+  end
+
+  # GET /books/new
+  def new
+    @book = Book.new
+  end
+
+  # GET /books/1/edit
+  def edit
+  end
+
+  # POST /books
+  # POST /books.json
+  def create
+    @book = Book.new(book_params)
+
+    respond_to do |format|
+      if @book.save
+        format.html { redirect_to @book, notice: 'Book was successfully created.' } # aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        format.json { render :show, status: :created, location: @book }
+      else
+        format.html { render :new }
+        format.json { render json: @book.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /books/1
+  # PATCH/PUT /books/1.json
+  def update
+    respond_to do |format|
+      if @book.update(book_params)
+        format.html { redirect_to @book, notice: 'Book was successfully updated.' } # aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        format.json { render :show, status: :ok, location: @book }
+      else
+        format.html { render :edit }
+        format.json { render json: @book.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /books/1
+  # DELETE /books/1.json
+  def destroy
+    @book.destroy
+    respond_to do |format|
+      format.html { redirect_to books_url, notice: 'Book was successfully destroyed.' } # aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_book
+      @book = Book.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the allow list through. aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    def book_params
+      params.require(:book).permit(:name)
+    end
+end

--- a/spec/fixtures/markdown_formatter/project/app/models/book.rb
+++ b/spec/fixtures/markdown_formatter/project/app/models/book.rb
@@ -1,0 +1,6 @@
+class Book < ActiveRecord::Base
+  def someMethod
+    foo = bar = baz
+    Regexp.new(/\A<p>(.*)<\/p>\Z/m).match(full_document)[1] rescue full_document
+  end
+end

--- a/spec/fixtures/markdown_formatter/project/app/models/shelf.rb
+++ b/spec/fixtures/markdown_formatter/project/app/models/shelf.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Book class comment
+class Book < ActiveRecord::Base
+  def some_method
+    Regexp.new(%r{\A<p>(.*)</p>\Z}m).match(full_document)[1]
+  rescue StandardError
+    full_document
+  end
+end


### PR DESCRIPTION
I've started using the new markdown formatter with GitHub's [job summaries](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/), but the formatter is very verbose, listing all files with no offenses:

```markdown
## Gemfile - (0 offenses)
## Rakefile - (0 offenses)
...
```

This PR skips files with no offenses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
