### PR TITLE
[Fix #10396] Fix autocorrect for `Layout/IndentationWidth` to leave module/class body unchanged to avoid infinite autocorrect loop with `Layout/IndentationConsistency` when body trails after class/module definition

### DIFF
--- a/changelog/fix_autocorrect_for_indentationwidth_to_avoid_infinite_autocorrect_loop.md
+++ b/changelog/fix_autocorrect_for_indentationwidth_to_avoid_infinite_autocorrect_loop.md
@@ -1,0 +1,1 @@
+* [#10396](https://github.com/rubocop/rubocop/issues/10396): Fix autocorrect for `Layout/IndentationWidth` to leave module/class body unchanged to avoid infinite autocorrect loop with `Layout/IndentationConsistency` when body trails after class/module definition. ([@johnny-miyake][])

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -91,7 +91,10 @@ module RuboCop
         end
 
         def on_class(node)
-          check_members(node.loc.keyword, [node.body])
+          base = node.loc.keyword
+          return if same_line?(base, node.body)
+
+          check_members(base, [node.body])
         end
         alias on_sclass on_class
         alias on_module on_class

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1060,6 +1060,35 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     expect(File.read('example.rb')).to eq(corrected)
   end
 
+  it 'corrects IndentationWidth and IndentationConsistency offenses' \
+     'without correcting `Style/TrailingBodyOnClass`' do
+    source = <<~'RUBY'
+      class Test foo
+          def func1
+          end
+            def func2
+            end
+      end
+    RUBY
+    create_file('example.rb', source)
+
+    expect(cli.run([
+                     '--auto-correct-all',
+                     '--only',
+                     ['Layout/IndentationConsistency', 'Layout/IndentationWidth'].join(',')
+                   ])).to eq(0)
+
+    corrected = <<~'RUBY'
+      class Test foo
+                 def func1
+                 end
+                 def func2
+                 end
+      end
+    RUBY
+    expect(File.read('example.rb')).to eq(corrected)
+  end
+
   it 'corrects SymbolProc and SpaceBeforeBlockBraces offenses' do
     source = ['foo.map{ |a| a.nil? }']
     create_file('example.rb', source)

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1195,9 +1195,33 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         RUBY
       end
 
+      it 'leaves body unchanged if the first body line is on the same line with class keyword' do
+        # The class body will be corrected by IndentationConsistency.
+        expect_no_offenses(<<~RUBY)
+          class Test foo
+              def func1
+              end
+                def func2
+                end
+          end
+        RUBY
+      end
+
       it 'accepts an empty class body' do
         expect_no_offenses(<<~RUBY)
           class Test
+          end
+        RUBY
+      end
+
+      it 'leaves body unchanged if the first body line is on the same line with an opening of singleton class' do
+        # The class body will be corrected by IndentationConsistency.
+        expect_no_offenses(<<~RUBY)
+          class << self; foo
+              def func1
+              end
+                def func2
+                end
           end
         RUBY
       end
@@ -1370,6 +1394,18 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
             end
           RUBY
         end
+      end
+
+      it 'leaves body unchanged if the first body line is on the same line with module keyword' do
+        # The module body will be corrected by IndentationConsistency.
+        expect_no_offenses(<<~RUBY)
+          module Test foo
+              def func1
+              end
+                def func2
+                end
+          end
+        RUBY
       end
 
       context 'when consistency style is indented_internal_methods' do


### PR DESCRIPTION
Fixes #10396.

This PR fixes an infinite autocorrect loop caused by [Layout/IndentationWidth](https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/IndentationWidth) and  [Layout/IndentationConsistency](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/IndentationConsistency)  when the body trails after class/module definition. In that condition, the two cops indents/outdents each other, and that causes the infinite loop.

With this fix, the autocorrect for [Layout/IndentationWidth](https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/IndentationWidth) no longer indents back the indentation after `Layout/IndentationConsistency` aligns the second line of the body to the first line next to module/class keyword.

For example, the combination of autocorrects for `Layout/IndentationWidth` and `Layout/IndentationConsistency`  correct this code
```ruby
module Foo bar
  puts 1
end

class Foo bar
  puts 1
end

class Foo
  class << self; bar
    def func
      puts 1
    end
  end
end
```
to
```ruby
module Foo bar
           puts 1
end

class Foo bar
          puts 1
end

class Foo
  class << self; bar
                 def func
                   puts 1
                 end
  end
end
```

The corrected code above will be corrected by [Style/TrailingBodyOnModule](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingBodyOnModule) and [Style/TrailingBodyOnClass](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingBodyOnClass) in the next autocorrect iteration like this.
```ruby
module Foo
  bar
  puts 1
end

class Foo
  bar
  puts 1
end

class Foo
  class << self; bar # <-------- Currently there is no cops to fix this
                 def func
                   puts 1
                 end
  end
end
```
---

Besides, this is not in this PR's scope, however, I found the autocorrect for `Style/TrailingBodyOnClass` breaks the code when the body trails after the singleton class definition. (Issue opened  https://github.com/rubocop/rubocop/issues/10618)
```ruby
class Foo bar # <------------
  class << self; baz  # <------------
    def func
      puts 1
    end
  end
end
```
to
```ruby
class Foo 
  bar    
  class << self baz  # syntax error
    def func
      puts 1
     end
  end
end
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
