### PR TITLE
Add Sorbet's `typed` sigil as a magic comment

### DIFF
--- a/changelog/new_add_sorbets_typed_sigil_as_a_magic_comment.md
+++ b/changelog/new_add_sorbets_typed_sigil_as_a_magic_comment.md
@@ -1,0 +1,1 @@
+* [#10620](https://github.com/rubocop/rubocop/pull/10620): Add Sorbet's `typed` sigil as a magic comment. ([@zachahn][])

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -11,7 +11,8 @@ module RuboCop
     KEYWORDS = {
       encoding: '(?:en)?coding',
       frozen_string_literal: 'frozen[_-]string[_-]literal',
-      shareable_constant_value: 'shareable[_-]constant[_-]value'
+      shareable_constant_value: 'shareable[_-]constant[_-]value',
+      typed: 'typed'
     }.freeze
 
     # Detect magic comment format and pass it to the appropriate wrapper.
@@ -33,7 +34,10 @@ module RuboCop
     end
 
     def any?
-      frozen_string_literal_specified? || encoding_specified? || shareable_constant_value_specified?
+      frozen_string_literal_specified? ||
+        encoding_specified? ||
+        shareable_constant_value_specified? ||
+        typed_specified?
     end
 
     def valid?
@@ -99,6 +103,17 @@ module RuboCop
 
     def encoding_specified?
       specified?(encoding)
+    end
+
+    # Was the Sorbet `typed` sigil specified?
+    #
+    # @return [Boolean]
+    def typed_specified?
+      specified?(extract_typed)
+    end
+
+    def typed
+      extract_typed
     end
 
     private
@@ -187,6 +202,9 @@ module RuboCop
       def extract_shareable_constant_value
         match(KEYWORDS[:shareable_constant_value])
       end
+
+      # Emacs comments cannot specify Sorbet typechecking behavior.
+      def extract_typed; end
     end
 
     # Wrapper for Vim style magic comments.
@@ -222,6 +240,9 @@ module RuboCop
 
       # Vim comments cannot specify shareable constant values behavior.
       def shareable_constant_value; end
+
+      # Vim comments cannot specify Sorbet typechecking behavior.
+      def extract_typed; end
     end
 
     # Wrapper for regular magic comments not bound to an editor.
@@ -267,6 +288,10 @@ module RuboCop
 
       def extract_shareable_constant_value
         extract(/\A\s*#\s*#{KEYWORDS[:shareable_constant_value]}:\s*(#{TOKEN})\s*\z/io)
+      end
+
+      def extract_typed
+        extract(/\A\s*#\s*#{KEYWORDS[:typed]}:\s*(#{TOKEN})\s*\z/io)
       end
     end
   end

--- a/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
@@ -15,6 +15,20 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
     RUBY
   end
 
+  it 'registers an offense when code that immediately follows typed comment' do
+    expect_offense(<<~RUBY)
+      # typed: true
+      class Foo; end
+      ^ Add an empty line after magic comments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # typed: true
+
+      class Foo; end
+    RUBY
+  end
+
   it 'registers an offense for documentation immediately following comment' do
     expect_offense(<<~RUBY)
       # frozen_string_literal: true
@@ -66,6 +80,22 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
 
     expect_no_offenses(<<~RUBY)
       # shareable_constant_value: experimental_everything
+      # frozen_string_literal: true
+
+      class Foo; end
+    RUBY
+  end
+
+  it 'accepts magic comment with typed' do
+    expect_no_offenses(<<~RUBY)
+      # frozen_string_literal: true
+      # typed: true
+
+      class Foo; end
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      # typed: true
       # frozen_string_literal: true
 
       class Foo; end

--- a/spec/rubocop/magic_comment_spec.rb
+++ b/spec/rubocop/magic_comment_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe RuboCop::MagicComment do
     encoding = expectations[:encoding]
     frozen_string = expectations[:frozen_string_literal]
     shareable_constant_value = expectations[:shareable_constant_value]
+    typed = expectations[:typed]
 
     it "returns #{encoding.inspect} for encoding when comment is #{comment}" do
       expect(described_class.parse(comment).encoding).to eql(encoding)
@@ -18,6 +19,10 @@ RSpec.describe RuboCop::MagicComment do
        "when comment is #{comment}" do
       expect(described_class.parse(comment)
                             .shareable_constant_value).to eql(shareable_constant_value)
+    end
+
+    it "returns #{typed.inspect} for typed when comment is #{comment}" do
+      expect(described_class.parse(comment).typed).to eql(typed)
     end
   end
 
@@ -68,6 +73,22 @@ RSpec.describe RuboCop::MagicComment do
   include_examples 'magic comment', '# xyz shareable_constant_value: literal'
 
   include_examples 'magic comment', '# xyz shareable_constant_value: literal xyz'
+
+  include_examples 'magic comment', '# typed: ignore', typed: 'ignore'
+
+  include_examples 'magic comment', '# typed: false', typed: 'false'
+
+  include_examples 'magic comment', '# typed: true', typed: 'true'
+
+  include_examples 'magic comment', '# typed: strict', typed: 'strict'
+
+  include_examples 'magic comment', '# typed: strong', typed: 'strong'
+
+  include_examples 'magic comment', '#typed:strict', typed: 'strict'
+
+  include_examples 'magic comment', '#    typed:strict', typed: 'strict'
+
+  include_examples 'magic comment', '# @typed'
 
   include_examples(
     'magic comment',
@@ -125,9 +146,8 @@ RSpec.describe RuboCop::MagicComment do
 
   include_examples(
     'magic comment',
-    '# -*- coding: ASCII-8BIT; frozen_string_literal: true -*-',
-    encoding: 'ascii-8bit',
-    frozen_string_literal: true
+    '# -*- coding: ASCII-8BIT; typed: strict -*-',
+    encoding: 'ascii-8bit'
   )
 
   include_examples 'magic comment',
@@ -142,6 +162,10 @@ RSpec.describe RuboCop::MagicComment do
 
   include_examples 'magic comment',
                    '#vim: filetype=ruby, fileencoding=ascii-8bit',
+                   encoding: 'ascii-8bit'
+
+  include_examples 'magic comment',
+                   '#vim: filetype=ruby, fileencoding=ascii-8bit, typed=strict',
                    encoding: 'ascii-8bit'
 
   include_examples(


### PR DESCRIPTION
Hello! This PR adds Sorbet's `typed` sigil as a magic comment. I'm aware of the `rubocop-sorbet` project, but I thought this might belong here here because of the existing rules around magic comments.

I'm aware I didn't check all of the boxes below! I will come back and finish this up if you too believe this belongs here.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
