### PR TITLE
[Fix #10622] Fix a false positive for `Style/RaiseArgs`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_raise_args.md
+++ b/changelog/fix_a_false_positive_for_style_raise_args.md
@@ -1,0 +1,1 @@
+* [#10622](https://github.com/rubocop/rubocop/issues/10622): Fix a false positive for `Style/RaiseArgs` when error type class constructor with keyword arguments and message argument. ([@koic][])

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -91,6 +91,9 @@ module RuboCop
 
         def check_compact(node)
           if node.arguments.size > 1
+            exception = node.first_argument
+            return if exception.send_type? && exception.first_argument&.hash_type?
+
             add_offense(node, message: format(COMPACT_MSG, method: node.method_name)) do |corrector|
               replacement = correction_exploded_to_compact(node)
 

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -145,6 +145,10 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
     it 'accepts a raise with an exception argument' do
       expect_no_offenses('raise Ex.new(msg)')
     end
+
+    it 'accepts exception constructor with keyword arguments and message argument' do
+      expect_no_offenses('raise MyKwArgError.new(a: 1, b: 2), message')
+    end
   end
 
   context 'when enforced style is exploded' do


### PR DESCRIPTION
Fixes #10622.

This PR fixes a false positive for `Style/RaiseArgs` when error type class constructor with keyword arguments and message argument.

The signature of `raise` is below.

```ruby
raise
raise(string, cause: $!)
raise(exception [, string [, array]], cause: $!)
```

https://ruby-doc.org/core-3.1.0/Kernel.html#method-i-raise

So #10622 would be a false positive because `raise MyError.new(data: 'mydata'), 'message'` and `raise MyError.new('message', data: 'mydata')` are incompatible.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
