### PR TITLE
[Fix #10625] Restore the specification to `TargetRubyVersion: 2.5`

### DIFF
--- a/changelog/fix_restore_target_ruby_version_ruby_25.md
+++ b/changelog/fix_restore_target_ruby_version_ruby_25.md
@@ -1,0 +1,1 @@
+* [#10625](https://github.com/rubocop/rubocop/issues/10625): Restore the specification to `TargetRubyVersion: 2.5`. ([@koic][])

--- a/lib/rubocop/cop/lint/erb_new_arguments.rb
+++ b/lib/rubocop/cop/lint/erb_new_arguments.rb
@@ -62,6 +62,9 @@ module RuboCop
       class ErbNewArguments < Base
         include RangeHelp
         extend AutoCorrector
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.6
 
         MESSAGES = [
           'Passing safe_level with the 2nd argument of `ERB.new` is ' \

--- a/lib/rubocop/cop/style/map_to_hash.rb
+++ b/lib/rubocop/cop/style/map_to_hash.rb
@@ -29,7 +29,10 @@ module RuboCop
       #
       class MapToHash < Base
         extend AutoCorrector
+        extend TargetRubyVersion
         include RangeHelp
+
+        minimum_target_ruby_version 2.6
 
         MSG = 'Pass a block to `to_h` instead of calling `%<method>s.to_h`.'
         RESTRICT_ON_SEND = %i[to_h].freeze

--- a/lib/rubocop/cop/style/slicing_with_range.rb
+++ b/lib/rubocop/cop/style/slicing_with_range.rb
@@ -27,6 +27,9 @@ module RuboCop
       #   items[1..]
       class SlicingWithRange < Base
         extend AutoCorrector
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.6
 
         MSG = 'Prefer ary[n..] over ary[n..-1].'
         RESTRICT_ON_SEND = %i[[]].freeze

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -116,6 +116,10 @@ RSpec.shared_context 'mock console output' do
   end
 end
 
+RSpec.shared_context 'ruby 2.5', :ruby25 do
+  let(:ruby_version) { 2.5 }
+end
+
 RSpec.shared_context 'ruby 2.6', :ruby26 do
   let(:ruby_version) { 2.6 }
 end

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -4,7 +4,7 @@ module RuboCop
   # The kind of Ruby that code inspected by RuboCop is written in.
   # @api private
   class TargetRuby
-    KNOWN_RUBIES = [2.6, 2.7, 3.0, 3.1, 3.2].freeze
+    KNOWN_RUBIES = [2.5, 2.6, 2.7, 3.0, 3.1, 3.2].freeze
     DEFAULT_VERSION = KNOWN_RUBIES.first
 
     OBSOLETE_RUBIES = {

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect($stderr.string).to eq ''
     expect($stdout.string)
       .to eq(["#{abs('example.rb')}:3:1: E: Lint/Syntax: unexpected " \
-              'token $end (Using Ruby 2.6 parser; configure using ' \
+              'token $end (Using Ruby 2.5 parser; configure using ' \
               '`TargetRubyVersion` parameter, under `AllCops`)',
               ''].join("\n"))
   end
@@ -1693,7 +1693,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect($stderr.string.strip).to start_with(
           'Error: RuboCop found unknown Ruby version 4.0 in `TargetRubyVersion`'
         )
-        expect($stderr.string.strip).to match(/Supported versions: 2.6, 2.7, 3.0, 3.1, 3.2/)
+        expect($stderr.string.strip).to match(/Supported versions: 2.5, 2.6, 2.7, 3.0, 3.1, 3.2/)
       end
     end
 
@@ -1714,7 +1714,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           /2\.0-compatible analysis was dropped after version 0\.50/
         )
 
-        expect($stderr.string.strip).to match(/Supported versions: 2.6/)
+        expect($stderr.string.strip).to match(/Supported versions: 2.5/)
       end
     end
   end

--- a/spec/rubocop/cop/lint/ambiguous_range_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_range_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRange, :config do
         RUBY
       end
 
-      it 'can handle an endless range' do
+      it 'can handle an endless range', :ruby26 do
         expect_offense(<<~RUBY)
           x || 1#{operator}
           ^^^^^^ Wrap complex range boundaries with parentheses to avoid ambiguity.

--- a/spec/rubocop/cop/lint/deprecated_constants_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_constants_spec.rb
@@ -51,15 +51,25 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedConstants, :config do
     RUBY
   end
 
-  it 'registers and corrects an offense when using `Net::HTTPServerException`' do
-    expect_offense(<<~RUBY)
-      Net::HTTPServerException
-      ^^^^^^^^^^^^^^^^^^^^^^^^ Use `Net::HTTPClientException` instead of `Net::HTTPServerException`, deprecated since Ruby 2.6.
-    RUBY
+  context 'Ruby <= 2.5', :ruby25 do
+    it 'does not register an offense when using `Net::HTTPServerException`' do
+      expect_no_offenses(<<~RUBY)
+        Net::HTTPServerException
+      RUBY
+    end
+  end
 
-    expect_correction(<<~RUBY)
-      Net::HTTPClientException
-    RUBY
+  context 'Ruby >= 2.6', :ruby26 do
+    it 'registers and corrects an offense when using `Net::HTTPServerException`' do
+      expect_offense(<<~RUBY)
+        Net::HTTPServerException
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `Net::HTTPClientException` instead of `Net::HTTPServerException`, deprecated since Ruby 2.6.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Net::HTTPClientException
+      RUBY
+    end
   end
 
   context 'Ruby <= 2.7', :ruby27 do

--- a/spec/rubocop/cop/lint/duplicate_hash_key_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_hash_key_spec.rb
@@ -63,7 +63,9 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateHashKey, :config do
   it_behaves_like 'duplicated literal key', 'false'
   it_behaves_like 'duplicated literal key', 'nil'
   it_behaves_like 'duplicated literal key', "'str'"
-  it_behaves_like 'duplicated literal key', '(42..)'
+  context 'target ruby version >= 2.6', :ruby26 do
+    it_behaves_like 'duplicated literal key', '(42..)'
+  end
 
   shared_examples 'duplicated non literal key' do |key|
     it "does not register an offense for duplicated `#{key}` hash keys" do

--- a/spec/rubocop/cop/lint/erb_new_arguments_spec.rb
+++ b/spec/rubocop/cop/lint/erb_new_arguments_spec.rb
@@ -1,101 +1,111 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::ErbNewArguments, :config do
-  it 'registers an offense when using `ERB.new` with non-keyword 2nd argument' do
-    expect_offense(<<~RUBY)
-      ERB.new(str, nil)
-                   ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      ERB.new(str)
-    RUBY
+  context '<= Ruby 2.5', :ruby25 do
+    it 'does not register an offense when using `ERB.new` with non-keyword arguments' do
+      expect_no_offenses(<<~RUBY)
+        ERB.new(str, nil, '-', '@output_buffer')
+      RUBY
+    end
   end
 
-  it 'registers an offense when using `ERB.new` with non-keyword 2nd and 3rd arguments' do
-    expect_offense(<<~RUBY)
-      ERB.new(str, nil, '-')
-                        ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
-                   ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
-    RUBY
+  context '>= Ruby 2.6', :ruby26 do
+    it 'registers an offense when using `ERB.new` with non-keyword 2nd argument' do
+      expect_offense(<<~RUBY)
+        ERB.new(str, nil)
+                     ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      ERB.new(str, trim_mode: '-')
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        ERB.new(str)
+      RUBY
+    end
 
-  it 'registers an offense when using `ERB.new` with non-keyword 2nd, 3rd and 4th arguments' do
-    expect_offense(<<~RUBY)
-      ERB.new(str, nil, '-', '@output_buffer')
-                             ^^^^^^^^^^^^^^^^ Passing eoutvar with the 4th argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, eoutvar: '@output_buffer')` instead.
-                        ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
-                   ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
-    RUBY
+    it 'registers an offense when using `ERB.new` with non-keyword 2nd and 3rd arguments' do
+      expect_offense(<<~RUBY)
+        ERB.new(str, nil, '-')
+                          ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
+                     ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        ERB.new(str, trim_mode: '-')
+      RUBY
+    end
 
-  it 'registers an offense when using `ERB.new` ' \
-     'with non-keyword 2nd, 3rd and 4th arguments and' \
-     'keyword 5th argument' do
-    expect_offense(<<~RUBY)
-      ERB.new(str, nil, '-', '@output_buffer', trim_mode: '-', eoutvar: '@output_buffer')
-                             ^^^^^^^^^^^^^^^^ Passing eoutvar with the 4th argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, eoutvar: '@output_buffer')` instead.
-                        ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
-                   ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
-    RUBY
-  end
-
-  it 'registers an offense when using `ERB.new` ' \
-     'with non-keyword 2nd and 3rd arguments and' \
-     'keyword 4th argument' do
-    expect_offense(<<~RUBY)
-      ERB.new(str, nil, '-', trim_mode: '-', eoutvar: '@output_buffer')
-                        ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
-                   ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
-    RUBY
-  end
-
-  it 'registers an offense when using `::ERB.new` with non-keyword 2nd, 3rd and 4th arguments' do
-    expect_offense(<<~RUBY)
-      ::ERB.new(str, nil, '-', '@output_buffer')
+    it 'registers an offense when using `ERB.new` with non-keyword 2nd, 3rd and 4th arguments' do
+      expect_offense(<<~RUBY)
+        ERB.new(str, nil, '-', '@output_buffer')
                                ^^^^^^^^^^^^^^^^ Passing eoutvar with the 4th argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, eoutvar: '@output_buffer')` instead.
                           ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
                      ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      ::ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
-    RUBY
-  end
-
-  it 'does not register an offense when using `ERB.new` with keyword arguments' do
-    expect_no_offenses(<<~RUBY)
-      ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
-    RUBY
-  end
-
-  it 'does not register an offense when using `ERB.new` without optional arguments' do
-    expect_no_offenses(<<~RUBY)
-      ERB.new(str)
-    RUBY
-  end
-
-  context 'when using `ActionView::Template::Handlers::ERB.new`' do
-    it 'does not register an offense when using `ERB.new` without arguments' do
-      expect_no_offenses(<<~RUBY)
-        ERB.new
       RUBY
+
+      expect_correction(<<~RUBY)
+        ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
+      RUBY
+    end
+
+    it 'registers an offense when using `ERB.new` ' \
+       'with non-keyword 2nd, 3rd and 4th arguments and' \
+       'keyword 5th argument' do
+      expect_offense(<<~RUBY)
+        ERB.new(str, nil, '-', '@output_buffer', trim_mode: '-', eoutvar: '@output_buffer')
+                               ^^^^^^^^^^^^^^^^ Passing eoutvar with the 4th argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, eoutvar: '@output_buffer')` instead.
+                          ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
+                     ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
+      RUBY
+    end
+
+    it 'registers an offense when using `ERB.new` ' \
+       'with non-keyword 2nd and 3rd arguments and' \
+       'keyword 4th argument' do
+      expect_offense(<<~RUBY)
+        ERB.new(str, nil, '-', trim_mode: '-', eoutvar: '@output_buffer')
+                          ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
+                     ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
+      RUBY
+    end
+
+    it 'registers an offense when using `::ERB.new` with non-keyword 2nd, 3rd and 4th arguments' do
+      expect_offense(<<~RUBY)
+        ::ERB.new(str, nil, '-', '@output_buffer')
+                                 ^^^^^^^^^^^^^^^^ Passing eoutvar with the 4th argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, eoutvar: '@output_buffer')` instead.
+                            ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
+                       ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ::ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
+      RUBY
+    end
+
+    it 'does not register an offense when using `ERB.new` with keyword arguments' do
+      expect_no_offenses(<<~RUBY)
+        ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
+      RUBY
+    end
+
+    it 'does not register an offense when using `ERB.new` without optional arguments' do
+      expect_no_offenses(<<~RUBY)
+        ERB.new(str)
+      RUBY
+    end
+
+    context 'when using `ActionView::Template::Handlers::ERB.new`' do
+      it 'does not register an offense when using `ERB.new` without arguments' do
+        expect_no_offenses(<<~RUBY)
+          ERB.new
+        RUBY
+      end
     end
   end
 end

--- a/spec/rubocop/cop/style/hash_transform_keys_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_keys_spec.rb
@@ -248,44 +248,54 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
     RUBY
   end
 
-  it 'flags _.to_h{...} when transform_keys could be used' do
-    expect_offense(<<~RUBY)
-      x.to_h {|k, v| [k.to_sym, v]}
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `to_h {...}`.
-    RUBY
+  context 'when using Ruby 2.6 or newer', :ruby26 do
+    it 'flags _.to_h{...} when transform_keys could be used' do
+      expect_offense(<<~RUBY)
+        x.to_h {|k, v| [k.to_sym, v]}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `to_h {...}`.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      x.transform_keys {|k| k.to_sym}
-    RUBY
+      expect_correction(<<~RUBY)
+        x.transform_keys {|k| k.to_sym}
+      RUBY
+    end
+
+    it 'does not flag `_.to_h{...}` when both key & value are transformed' do
+      expect_no_offenses(<<~RUBY)
+        x.to_h { |k, v| [k.to_sym, foo(v)] }
+      RUBY
+    end
+
+    it 'does not flag `_.to_h{...}` when its receiver is an array literal' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].to_h { |k, v| [k.to_sym, v] }
+      RUBY
+    end
+
+    it 'does not flag `_.to_h{...}` when its receiver is `each_with_index`' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].each_with_index.to_h { |k, v| [k.to_sym, v] }
+      RUBY
+    end
+
+    it 'does not flag `_.to_h{...}` when its receiver is `with_index`' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].each.with_index.to_h { |k, v| [k.to_sym, v] }
+      RUBY
+    end
+
+    it 'does not flag `_.to_h{...}` when its receiver is `zip`' do
+      expect_no_offenses(<<~RUBY)
+        %i[a b c].zip([1, 2, 3]).to_h { |k, v| [k.to_sym, v] }
+      RUBY
+    end
   end
 
-  it 'does not flag `_.to_h{...}` when both key & value are transformed' do
-    expect_no_offenses(<<~RUBY)
-      x.to_h { |k, v| [k.to_sym, foo(v)] }
-    RUBY
-  end
-
-  it 'does not flag `_.to_h{...}` when its receiver is an array literal' do
-    expect_no_offenses(<<~RUBY)
-      [1, 2, 3].to_h { |k, v| [k.to_sym, v] }
-    RUBY
-  end
-
-  it 'does not flag `_.to_h{...}` when its receiver is `each_with_index`' do
-    expect_no_offenses(<<~RUBY)
-      [1, 2, 3].each_with_index.to_h { |k, v| [k.to_sym, v] }
-    RUBY
-  end
-
-  it 'does not flag `_.to_h{...}` when its receiver is `with_index`' do
-    expect_no_offenses(<<~RUBY)
-      [1, 2, 3].each.with_index.to_h { |k, v| [k.to_sym, v] }
-    RUBY
-  end
-
-  it 'does not flag `_.to_h{...}` when its receiver is `zip`' do
-    expect_no_offenses(<<~RUBY)
-      %i[a b c].zip([1, 2, 3]).to_h { |k, v| [k.to_sym, v] }
-    RUBY
+  context 'below Ruby 2.6', :ruby25 do
+    it 'does not flag _.to_h{...}' do
+      expect_no_offenses(<<~RUBY)
+        x.to_h {|k, v| [k.to_sym, v]}
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/style/hash_transform_values_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_values_spec.rb
@@ -218,66 +218,76 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
     RUBY
   end
 
-  it 'flags _.to_h{...} when transform_values could be used' do
-    expect_offense(<<~RUBY)
-      x.to_h {|k, v| [k, foo(v)]}
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
-    RUBY
+  context 'when using Ruby 2.6 or newer', :ruby26 do
+    it 'flags _.to_h{...} when transform_values could be used' do
+      expect_offense(<<~RUBY)
+        x.to_h {|k, v| [k, foo(v)]}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      x.transform_values {|v| foo(v)}
-    RUBY
+      expect_correction(<<~RUBY)
+        x.transform_values {|v| foo(v)}
+      RUBY
+    end
+
+    it 'register and corrects an offense _.to_h{...} when value is a hash literal and is enclosed in braces' do
+      expect_offense(<<~RUBY)
+        {a: 1, b: 2}.to_h { |key, val| [key, { value: val }] }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        {a: 1, b: 2}.transform_values { |val| { value: val } }
+      RUBY
+    end
+
+    it 'register and corrects an offense _.to_h{...} when value is a hash literal and is not enclosed in braces' do
+      expect_offense(<<~RUBY)
+        {a: 1, b: 2}.to_h { |key, val| [key, value: val] }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        {a: 1, b: 2}.transform_values { |val| { value: val } }
+      RUBY
+    end
+
+    it 'does not flag `_.to_h{...}` when both key & value are transformed' do
+      expect_no_offenses(<<~RUBY)
+        x.to_h { |k, v| [k.to_sym, foo(v)] }
+      RUBY
+    end
+
+    it 'does not flag `_.to_h{...}` when its receiver is an array literal' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].to_h { |k, v| [k, foo(v)] }
+      RUBY
+    end
+
+    it 'does not flag `_.to_h{...}` when its receiver is `each_with_index`' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].each_with_index.to_h { |k, v| [k, foo(v)] }
+      RUBY
+    end
+
+    it 'does not flag `_.to_h{...}` when its receiver is `with_index`' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].each.with_index.to_h { |k, v| [k, foo(v)] }
+      RUBY
+    end
+
+    it 'does not flag `_.to_h{...}` when its receiver is `zip`' do
+      expect_no_offenses(<<~RUBY)
+        %i[a b c].zip([1, 2, 3]).to_h { |k, v| [k, foo(v)] }
+      RUBY
+    end
   end
 
-  it 'register and corrects an offense _.to_h{...} when value is a hash literal and is enclosed in braces' do
-    expect_offense(<<~RUBY)
-      {a: 1, b: 2}.to_h { |key, val| [key, { value: val }] }
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      {a: 1, b: 2}.transform_values { |val| { value: val } }
-    RUBY
-  end
-
-  it 'register and corrects an offense _.to_h{...} when value is a hash literal and is not enclosed in braces' do
-    expect_offense(<<~RUBY)
-      {a: 1, b: 2}.to_h { |key, val| [key, value: val] }
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      {a: 1, b: 2}.transform_values { |val| { value: val } }
-    RUBY
-  end
-
-  it 'does not flag `_.to_h{...}` when both key & value are transformed' do
-    expect_no_offenses(<<~RUBY)
-      x.to_h { |k, v| [k.to_sym, foo(v)] }
-    RUBY
-  end
-
-  it 'does not flag `_.to_h{...}` when its receiver is an array literal' do
-    expect_no_offenses(<<~RUBY)
-      [1, 2, 3].to_h { |k, v| [k, foo(v)] }
-    RUBY
-  end
-
-  it 'does not flag `_.to_h{...}` when its receiver is `each_with_index`' do
-    expect_no_offenses(<<~RUBY)
-      [1, 2, 3].each_with_index.to_h { |k, v| [k, foo(v)] }
-    RUBY
-  end
-
-  it 'does not flag `_.to_h{...}` when its receiver is `with_index`' do
-    expect_no_offenses(<<~RUBY)
-      [1, 2, 3].each.with_index.to_h { |k, v| [k, foo(v)] }
-    RUBY
-  end
-
-  it 'does not flag `_.to_h{...}` when its receiver is `zip`' do
-    expect_no_offenses(<<~RUBY)
-      %i[a b c].zip([1, 2, 3]).to_h { |k, v| [k, foo(v)] }
-    RUBY
+  context 'below Ruby 2.6', :ruby25 do
+    it 'does not flag _.to_h{...}' do
+      expect_no_offenses(<<~RUBY)
+        x.to_h {|k, v| [k, foo(v)]}
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/style/map_to_hash_spec.rb
+++ b/spec/rubocop/cop/style/map_to_hash_spec.rb
@@ -1,106 +1,108 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MapToHash, :config do
-  %i[map collect].each do |method|
-    context "for `#{method}.to_h` with block arity 1" do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~RUBY, method: method)
-          foo.#{method} { |x| [x, x * 2] }.to_h
-              ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
-        RUBY
+  context '>= Ruby 2.6', :ruby26 do
+    %i[map collect].each do |method|
+      context "for `#{method}.to_h` with block arity 1" do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            foo.#{method} { |x| [x, x * 2] }.to_h
+                ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+          RUBY
 
-        expect_correction(<<~RUBY)
-          foo.to_h { |x| [x, x * 2] }
-        RUBY
+          expect_correction(<<~RUBY)
+            foo.to_h { |x| [x, x * 2] }
+          RUBY
+        end
       end
-    end
 
-    context "for `#{method}.to_h` with block arity 2" do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~RUBY, method: method)
-          foo.#{method} { |x, y| [x.to_s, y.to_i] }.to_h
-              ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
-        RUBY
+      context "for `#{method}.to_h` with block arity 2" do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            foo.#{method} { |x, y| [x.to_s, y.to_i] }.to_h
+                ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+          RUBY
 
-        expect_correction(<<~RUBY)
-          foo.to_h { |x, y| [x.to_s, y.to_i] }
-        RUBY
+          expect_correction(<<~RUBY)
+            foo.to_h { |x, y| [x.to_s, y.to_i] }
+          RUBY
+        end
       end
-    end
 
-    context 'when the receiver is an array' do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~RUBY, method: method)
-          [1, 2, 3].#{method} { |x| [x, x * 2] }.to_h
-                    ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
-        RUBY
+      context 'when the receiver is an array' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            [1, 2, 3].#{method} { |x| [x, x * 2] }.to_h
+                      ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+          RUBY
 
-        expect_correction(<<~RUBY)
-          [1, 2, 3].to_h { |x| [x, x * 2] }
-        RUBY
+          expect_correction(<<~RUBY)
+            [1, 2, 3].to_h { |x| [x, x * 2] }
+          RUBY
+        end
       end
-    end
 
-    context 'when the receiver is an hash' do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~RUBY, method: method)
-          { foo: :bar }.#{method} { |x, y| [x.to_s, y.to_s] }.to_h
-                        ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
-        RUBY
+      context 'when the receiver is an hash' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            { foo: :bar }.#{method} { |x, y| [x.to_s, y.to_s] }.to_h
+                          ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+          RUBY
 
-        expect_correction(<<~RUBY)
-          { foo: :bar }.to_h { |x, y| [x.to_s, y.to_s] }
-        RUBY
+          expect_correction(<<~RUBY)
+            { foo: :bar }.to_h { |x, y| [x.to_s, y.to_s] }
+          RUBY
+        end
       end
-    end
 
-    context 'when chained further' do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~RUBY, method: method)
-          foo.#{method} { |x| x * 2 }.to_h.bar
-              ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
-        RUBY
+      context 'when chained further' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            foo.#{method} { |x| x * 2 }.to_h.bar
+                ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+          RUBY
 
-        expect_correction(<<~RUBY)
-          foo.to_h { |x| x * 2 }.bar
-        RUBY
+          expect_correction(<<~RUBY)
+            foo.to_h { |x| x * 2 }.bar
+          RUBY
+        end
       end
-    end
 
-    context "`#{method}` without `to_h`" do
-      it 'does not register an offense' do
-        expect_no_offenses(<<~RUBY, method: method)
-          foo.#{method} { |x| x * 2 }
-        RUBY
+      context "`#{method}` without `to_h`" do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY, method: method)
+            foo.#{method} { |x| x * 2 }
+          RUBY
+        end
       end
-    end
 
-    context "`#{method}.to_h` with a block on `to_h`" do
-      it 'registers an offense but does not correct' do
-        expect_offense(<<~RUBY, method: method)
-          foo.#{method} { |x| x * 2 }.to_h { |x| [x.to_s, x] }
-              ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
-        RUBY
+      context "`#{method}.to_h` with a block on `to_h`" do
+        it 'registers an offense but does not correct' do
+          expect_offense(<<~RUBY, method: method)
+            foo.#{method} { |x| x * 2 }.to_h { |x| [x.to_s, x] }
+                ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+          RUBY
 
-        expect_no_corrections
+          expect_no_corrections
+        end
       end
-    end
 
-    context "`map` and `#{method}.to_h` with newlines" do
-      it 'registers an offense and corrects with newline removal' do
-        expect_offense(<<~RUBY, method: method)
-          {foo: bar}
-            .#{method} { |k, v| [k.to_s, v.do_something] }
-             ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
-            .to_h
-            .freeze
-        RUBY
+      context "`map` and `#{method}.to_h` with newlines" do
+        it 'registers an offense and corrects with newline removal' do
+          expect_offense(<<~RUBY, method: method)
+            {foo: bar}
+              .#{method} { |k, v| [k.to_s, v.do_something] }
+               ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+              .to_h
+              .freeze
+          RUBY
 
-        expect_correction(<<~RUBY)
-          {foo: bar}
-            .to_h { |k, v| [k.to_s, v.do_something] }
-            .freeze
-        RUBY
+          expect_correction(<<~RUBY)
+            {foo: bar}
+              .to_h { |k, v| [k.to_s, v.do_something] }
+              .freeze
+          RUBY
+        end
       end
     end
   end

--- a/spec/rubocop/cop/style/sample_spec.rb
+++ b/spec/rubocop/cop/style/sample_spec.rb
@@ -69,8 +69,10 @@ RSpec.describe RuboCop::Cop::Style::Sample, :config do
   it_behaves_like('accepts', 'shuffle[2..3]')           # empty if coll.size < 3
   it_behaves_like('accepts', 'shuffle[2..-3]')          # can't compute range size
   it_behaves_like('accepts', 'shuffle[foo..3]')         # can't compute range size
-  it_behaves_like('accepts', 'shuffle[3..]')            # can't compute range size
-  it_behaves_like('accepts', 'shuffle[3...]')           # can't compute range size
+  context 'Ruby >= 2.6', :ruby26 do
+    it_behaves_like('accepts', 'shuffle[3..]')          # can't compute range size
+    it_behaves_like('accepts', 'shuffle[3...]')         # can't compute range size
+  end
 
   it_behaves_like('accepts', 'shuffle[-4..-3]')         # nil if coll.size < 3
   it_behaves_like('accepts', 'shuffle[foo]')            # foo could be a Range

--- a/spec/rubocop/cop/style/slicing_with_range_spec.rb
+++ b/spec/rubocop/cop/style/slicing_with_range_spec.rb
@@ -1,44 +1,54 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::SlicingWithRange, :config do
-  it 'reports an offense for slicing to ..-1' do
-    expect_offense(<<~RUBY)
-      ary[1..-1]
-          ^^^^^ Prefer ary[n..] over ary[n..-1].
-    RUBY
-
-    expect_correction(<<~RUBY)
-      ary[1..]
-    RUBY
+  context '<= Ruby 2.5', :ruby25 do
+    it 'reports no offense for array slicing with -1' do
+      expect_no_offenses(<<~RUBY)
+        ary[1..-1]
+      RUBY
+    end
   end
 
-  it 'reports an offense for slicing from expression to ..-1' do
-    expect_offense(<<~RUBY)
-      ary[fetch_start(true).first..-1]
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer ary[n..] over ary[n..-1].
-    RUBY
+  context '>= Ruby 2.6', :ruby26 do
+    it 'reports an offense for slicing to ..-1' do
+      expect_offense(<<~RUBY)
+        ary[1..-1]
+            ^^^^^ Prefer ary[n..] over ary[n..-1].
+      RUBY
 
-    expect_correction(<<~RUBY)
-      ary[fetch_start(true).first..]
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        ary[1..]
+      RUBY
+    end
 
-  it 'reports no offense for excluding end' do
-    expect_no_offenses(<<~RUBY)
-      ary[1...-1]
-    RUBY
-  end
+    it 'reports an offense for slicing from expression to ..-1' do
+      expect_offense(<<~RUBY)
+        ary[fetch_start(true).first..-1]
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer ary[n..] over ary[n..-1].
+      RUBY
 
-  it 'reports no offense for other methods' do
-    expect_no_offenses(<<~RUBY)
-      ary.push(1..-1)
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        ary[fetch_start(true).first..]
+      RUBY
+    end
 
-  it 'reports no offense for array with range inside' do
-    expect_no_offenses(<<~RUBY)
-      ranges = [1..-1]
-    RUBY
+    it 'reports no offense for excluding end' do
+      expect_no_offenses(<<~RUBY)
+        ary[1...-1]
+      RUBY
+    end
+
+    it 'reports no offense for other methods' do
+      expect_no_offenses(<<~RUBY)
+        ary.push(1..-1)
+      RUBY
+    end
+
+    it 'reports no offense for array with range inside' do
+      expect_no_offenses(<<~RUBY)
+        ranges = [1..-1]
+      RUBY
+    end
   end
 
   context '>= Ruby 2.7', :ruby27 do


### PR DESCRIPTION
Fixes #10625 and reverts part of #10577.

Only the Ruby version (2.5) to runtime should have been dropped, not code analysis.
This PR the specification to `TargetRubyVersion: 2.5` So, this keeps it compatible with `TargetRubyVersion` up to 1.28.2.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
