### PR TITLE
Add new `InternalAffairs/CopDescription` cop

### DIFF
--- a/lib/rubocop/cop/bundler/gem_filename.rb
+++ b/lib/rubocop/cop/bundler/gem_filename.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Bundler
-      # This cop verifies that a project contains Gemfile or gems.rb file and correct
+      # Verifies that a project contains Gemfile or gems.rb file and correct
       # associated lock file based on the configuration.
       #
       # @example EnforcedStyle: Gemfile (default)

--- a/lib/rubocop/cop/gemspec/date_assignment.rb
+++ b/lib/rubocop/cop/gemspec/date_assignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Gemspec
-      # This cop checks that `date =` is not used in gemspec file.
+      # Checks that `date =` is not used in gemspec file.
       # It is set automatically when the gem is packaged.
       #
       # @example

--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'internal_affairs/cop_description'
 require_relative 'internal_affairs/empty_line_between_expect_offense_and_correction'
 require_relative 'internal_affairs/example_description'
 require_relative 'internal_affairs/inherit_deprecated_cop_class'

--- a/lib/rubocop/cop/internal_affairs/cop_description.rb
+++ b/lib/rubocop/cop/internal_affairs/cop_description.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # Enforces the cop description to start with a word such as verb.
+      #
+      # @example
+      #   # bad
+      #   # This cop checks ....
+      #   class SomeCop < Base
+      #     ....
+      #   end
+      #
+      #   # good
+      #   # Checks ...
+      #   class SomeCop < Base
+      #     ...
+      #   end
+      #
+      class CopDescription < Base
+        extend AutoCorrector
+
+        MSG = 'Description should be started with %<suggestion>s instead of `This cop ...`.'
+
+        SPECIAL_WORDS = %w[is can could should will would must may].freeze
+        COP_DESC_OFFENSE_REGEX = \
+          /^\s+# This cop (?<special>#{SPECIAL_WORDS.join('|')})?\s*(?<word>.+?) .*/.freeze
+        REPLACEMENT_REGEX = /^\s+# This cop (#{SPECIAL_WORDS.join('|')})?\s*(.+?) /.freeze
+
+        def on_class(node)
+          return unless (module_node = node.parent)
+
+          description_beginning = first_comment_line(module_node)
+          return unless description_beginning
+
+          start_with_subject = description_beginning.match(COP_DESC_OFFENSE_REGEX)
+          return unless start_with_subject
+
+          suggestion = start_with_subject['word']&.capitalize
+          range = range(module_node, description_beginning)
+          suggestion_for_message = suggestion_for_message(suggestion, start_with_subject)
+          message = format(MSG, suggestion: suggestion_for_message)
+
+          add_offense(range, message: message) do |corrector|
+            if suggestion && !start_with_subject['special']
+              replace_with_suggestion(corrector, range, suggestion, description_beginning)
+            end
+          end
+        end
+
+        private
+
+        def replace_with_suggestion(corrector, range, suggestion, description_beginning)
+          replacement = description_beginning.gsub(REPLACEMENT_REGEX, "#{suggestion} ")
+          corrector.replace(range, replacement)
+        end
+
+        def range(node, comment_line)
+          source_buffer = node.loc.expression.source_buffer
+
+          begin_pos = node.loc.expression.begin_pos
+          begin_pos += comment_index(node, comment_line)
+          end_pos = begin_pos + comment_body(comment_line).length
+
+          Parser::Source::Range.new(source_buffer, begin_pos, end_pos)
+        end
+
+        def suggestion_for_message(suggestion, match_data)
+          if suggestion && !match_data['special']
+            "`#{suggestion}`"
+          else
+            'a word such as verb'
+          end
+        end
+
+        def first_comment_line(node)
+          node.loc.expression.source.lines.find { |line| comment_line?(line) }
+        end
+
+        def comment_body(comment_line)
+          comment_line.gsub(/^\s*# /, '')
+        end
+
+        def comment_index(node, comment_line)
+          body = comment_body(comment_line)
+          node.loc.expression.source.index(body)
+        end
+
+        def relevant_file?(file)
+          file.match?(%r{/cop/.*\.rb\z})
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/internal_affairs/empty_line_between_expect_offense_and_correction.rb
+++ b/lib/rubocop/cop/internal_affairs/empty_line_between_expect_offense_and_correction.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module InternalAffairs
-      # This cop checks whether `expect_offense` and correction expectation methods
+      # Checks whether `expect_offense` and correction expectation methods
       # (i.e. `expect_correction` and `expect_no_corrections`) are separated by empty line.
       #
       # @example

--- a/lib/rubocop/cop/internal_affairs/location_line_equality_comparison.rb
+++ b/lib/rubocop/cop/internal_affairs/location_line_equality_comparison.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module InternalAffairs
-      # This cop enforces the use of `same_line?` instead of location line comparison for equality.
+      # Enforces the use of `same_line?` instead of location line comparison for equality.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/internal_affairs/method_name_end_with.rb
+++ b/lib/rubocop/cop/internal_affairs/method_name_end_with.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module InternalAffairs
-      # This cop checks potentially usage of method identifier predicates
+      # Checks potentially usage of method identifier predicates
       # defined in rubocop-ast instead of `method_name.end_with?`.
       #
       # @example

--- a/lib/rubocop/cop/internal_affairs/redundant_described_class_as_subject.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_described_class_as_subject.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module InternalAffairs
-      # This cop checks for redundant `subject(:cop) { described_class.new }`.
+      # Checks for redundant `subject(:cop) { described_class.new }`.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/internal_affairs/redundant_let_rubocop_config_new.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_let_rubocop_config_new.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module InternalAffairs
-      # This cop checks that `let` is `RuboCop::Config.new` with no arguments.
+      # Checks that `let` is `RuboCop::Config.new` with no arguments.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/layout/assignment_indentation.rb
+++ b/lib/rubocop/cop/layout/assignment_indentation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks the indentation of the first line of the
+      # Checks the indentation of the first line of the
       # right-hand-side of a multi-line assignment.
       #
       # @example

--- a/lib/rubocop/cop/layout/begin_end_alignment.rb
+++ b/lib/rubocop/cop/layout/begin_end_alignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks whether the end keyword of `begin` is aligned properly.
+      # Checks whether the end keyword of `begin` is aligned properly.
       #
       # Two modes are supported through the `EnforcedStyleAlignWith` configuration
       # parameter. If it's set to `start_of_line` (which is the default), the

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks whether the end keywords are aligned properly for do
+      # Checks whether the end keywords are aligned properly for do
       # end blocks.
       #
       # Three modes are supported through the `EnforcedStyleAlignWith`

--- a/lib/rubocop/cop/layout/block_end_newline.rb
+++ b/lib/rubocop/cop/layout/block_end_newline.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks whether the end statement of a do..end block
+      # Checks whether the end statement of a do..end block
       # is on its own line.
       #
       # @example

--- a/lib/rubocop/cop/layout/case_indentation.rb
+++ b/lib/rubocop/cop/layout/case_indentation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks how the `when` and ``in``s of a `case` expression
+      # Checks how the `when` and ``in``s of a `case` expression
       # are indented in relation to its `case` or `end` keyword.
       #
       # It will register a separate offense for each misaligned `when` and `in`.

--- a/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
+++ b/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks the indentation of hanging closing parentheses in
+      # Checks the indentation of hanging closing parentheses in
       # method calls, method definitions, and grouped expressions. A hanging
       # closing parenthesis means `)` preceded by a line break.
       #

--- a/lib/rubocop/cop/layout/comment_indentation.rb
+++ b/lib/rubocop/cop/layout/comment_indentation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks the indentation of comments.
+      # Checks the indentation of comments.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/layout/condition_position.rb
+++ b/lib/rubocop/cop/layout/condition_position.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for conditions that are not on the same line as
+      # Checks for conditions that are not on the same line as
       # if/while/until.
       #
       # @example

--- a/lib/rubocop/cop/layout/def_end_alignment.rb
+++ b/lib/rubocop/cop/layout/def_end_alignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks whether the end keywords of method definitions are
+      # Checks whether the end keywords of method definitions are
       # aligned properly.
       #
       # Two modes are supported through the EnforcedStyleAlignWith configuration

--- a/lib/rubocop/cop/layout/dot_position.rb
+++ b/lib/rubocop/cop/layout/dot_position.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks the . position in multi-line method calls.
+      # Checks the . position in multi-line method calls.
       #
       # @example EnforcedStyle: leading (default)
       #   # bad

--- a/lib/rubocop/cop/layout/else_alignment.rb
+++ b/lib/rubocop/cop/layout/else_alignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks the alignment of else keywords. Normally they should
+      # Checks the alignment of else keywords. Normally they should
       # be aligned with an if/unless/while/until/begin/def/rescue keyword, but there
       # are special cases when they should follow the same rules as the
       # alignment of end.

--- a/lib/rubocop/cop/layout/empty_comment.rb
+++ b/lib/rubocop/cop/layout/empty_comment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks empty comment.
+      # Checks empty comment.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop enforces empty line after guard clause
+      # Enforces empty line after guard clause
       #
       # @example
       #

--- a/lib/rubocop/cop/layout/empty_line_after_multiline_condition.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_multiline_condition.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop enforces empty line after multiline condition.
+      # Enforces empty line after multiline condition.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/layout/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/layout/empty_line_between_defs.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks whether class/module/method definitions are
+      # Checks whether class/module/method definitions are
       # separated by one or more empty lines.
       #
       # `NumberOfEmptyLines` can be an integer (default is 1) or

--- a/lib/rubocop/cop/layout/empty_lines.rb
+++ b/lib/rubocop/cop/layout/empty_lines.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for two or more consecutive blank lines.
+      # Checks for two or more consecutive blank lines.
       #
       # @example
       #

--- a/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks if empty lines exist around the arguments
+      # Checks if empty lines exist around the arguments
       # of a method invocation.
       #
       # @example

--- a/lib/rubocop/cop/layout/empty_lines_around_begin_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_begin_body.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks if empty lines exist around the bodies of begin-end
+      # Checks if empty lines exist around the bodies of begin-end
       # blocks.
       #
       # @example

--- a/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks if empty lines around the bodies of blocks match
+      # Checks if empty lines around the bodies of blocks match
       # the configuration.
       #
       # @example EnforcedStyle: empty_lines

--- a/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks if empty lines around the bodies of classes match
+      # Checks if empty lines around the bodies of classes match
       # the configuration.
       #
       # @example EnforcedStyle: empty_lines

--- a/lib/rubocop/cop/layout/empty_lines_around_exception_handling_keywords.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_exception_handling_keywords.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks if empty lines exist around the bodies of `begin`
+      # Checks if empty lines exist around the bodies of `begin`
       # sections. This cop doesn't check empty lines at `begin` body
       # beginning/end and around method definition body.
       # `Style/EmptyLinesAroundBeginBody` or `Style/EmptyLinesAroundMethodBody`

--- a/lib/rubocop/cop/layout/empty_lines_around_method_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_method_body.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks if empty lines exist around the bodies of methods.
+      # Checks if empty lines exist around the bodies of methods.
       #
       # @example
       #

--- a/lib/rubocop/cop/layout/empty_lines_around_module_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_module_body.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks if empty lines around the bodies of modules match
+      # Checks if empty lines around the bodies of modules match
       # the configuration.
       #
       # @example EnforcedStyle: empty_lines

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks whether the end keywords are aligned properly.
+      # Checks whether the end keywords are aligned properly.
       #
       # Three modes are supported through the `EnforcedStyleAlignWith`
       # configuration parameter:

--- a/lib/rubocop/cop/layout/end_of_line.rb
+++ b/lib/rubocop/cop/layout/end_of_line.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for Windows-style line endings in the source code.
+      # Checks for Windows-style line endings in the source code.
       #
       # @example EnforcedStyle: native (default)
       #   # The `native` style means that CR+LF (Carriage Return + Line Feed) is

--- a/lib/rubocop/cop/layout/extra_spacing.rb
+++ b/lib/rubocop/cop/layout/extra_spacing.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for extra/unnecessary whitespace.
+      # Checks for extra/unnecessary whitespace.
       #
       # @example
       #

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks the indentation of the first argument in a method call.
+      # Checks the indentation of the first argument in a method call.
       # Arguments after the first one are checked by `Layout/ArgumentAlignment`,
       # not by this cop.
       #

--- a/lib/rubocop/cop/layout/first_array_element_indentation.rb
+++ b/lib/rubocop/cop/layout/first_array_element_indentation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks the indentation of the first element in an array literal
+      # Checks the indentation of the first element in an array literal
       # where the opening bracket and the first element are on separate lines.
       # The other elements' indentations are handled by the ArrayAlignment cop.
       #

--- a/lib/rubocop/cop/layout/first_array_element_line_break.rb
+++ b/lib/rubocop/cop/layout/first_array_element_line_break.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for a line break before the first element in a
+      # Checks for a line break before the first element in a
       # multi-line array.
       #
       # @example

--- a/lib/rubocop/cop/layout/first_hash_element_indentation.rb
+++ b/lib/rubocop/cop/layout/first_hash_element_indentation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks the indentation of the first key in a hash literal
+      # Checks the indentation of the first key in a hash literal
       # where the opening brace and the first key are on separate lines. The
       # other keys' indentations are handled by the HashAlignment cop.
       #

--- a/lib/rubocop/cop/layout/first_hash_element_line_break.rb
+++ b/lib/rubocop/cop/layout/first_hash_element_line_break.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for a line break before the first element in a
+      # Checks for a line break before the first element in a
       # multi-line hash.
       #
       # @example

--- a/lib/rubocop/cop/layout/first_method_argument_line_break.rb
+++ b/lib/rubocop/cop/layout/first_method_argument_line_break.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for a line break before the first argument in a
+      # Checks for a line break before the first argument in a
       # multi-line method call.
       #
       # @example

--- a/lib/rubocop/cop/layout/first_method_parameter_line_break.rb
+++ b/lib/rubocop/cop/layout/first_method_parameter_line_break.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for a line break before the first parameter in a
+      # Checks for a line break before the first parameter in a
       # multi-line method parameter definition.
       #
       # @example

--- a/lib/rubocop/cop/layout/first_parameter_indentation.rb
+++ b/lib/rubocop/cop/layout/first_parameter_indentation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks the indentation of the first parameter in a method
+      # Checks the indentation of the first parameter in a method
       # definition. Parameters after the first one are checked by
       # Layout/ParameterAlignment, not by this cop.
       #

--- a/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
+++ b/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for the placement of the closing parenthesis
+      # Checks for the placement of the closing parenthesis
       # in a method call that passes a HEREDOC string as an argument.
       # It should be placed at the end of the line containing the
       # opening HEREDOC tag.

--- a/lib/rubocop/cop/layout/heredoc_indentation.rb
+++ b/lib/rubocop/cop/layout/heredoc_indentation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks the indentation of the here document bodies. The bodies
+      # Checks the indentation of the here document bodies. The bodies
       # are indented one step.
       #
       # Note: When ``Layout/LineLength``'s `AllowHeredoc` is false (not default),

--- a/lib/rubocop/cop/layout/indentation_consistency.rb
+++ b/lib/rubocop/cop/layout/indentation_consistency.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for inconsistent indentation.
+      # Checks for inconsistent indentation.
       #
       # The difference between `indented_internal_methods` and `normal` is
       # that the `indented_internal_methods` style prescribes that in

--- a/lib/rubocop/cop/layout/indentation_style.rb
+++ b/lib/rubocop/cop/layout/indentation_style.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks that the indentation method is consistent.
+      # Checks that the indentation method is consistent.
       # Either tabs only or spaces only are used for indentation.
       #
       # @example EnforcedStyle: spaces (default)

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for indentation that doesn't use the specified number
+      # Checks for indentation that doesn't use the specified number
       # of spaces.
       #
       # See also the IndentationConsistency cop which is the companion to this

--- a/lib/rubocop/cop/layout/initial_indentation.rb
+++ b/lib/rubocop/cop/layout/initial_indentation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for indentation of the first non-blank non-comment
+      # Checks for indentation of the first non-blank non-comment
       # line in a file.
       #
       # @example

--- a/lib/rubocop/cop/layout/leading_comment_space.rb
+++ b/lib/rubocop/cop/layout/leading_comment_space.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks whether comments have a leading space after the
+      # Checks whether comments have a leading space after the
       # `#` denoting the start of the comment. The leading space is not
       # required for some RDoc special syntax, like `#++`, `#--`,
       # `#:nodoc`, `=begin`- and `=end` comments, "shebang" directives,

--- a/lib/rubocop/cop/layout/leading_empty_lines.rb
+++ b/lib/rubocop/cop/layout/leading_empty_lines.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for unnecessary leading blank lines at the beginning
+      # Checks for unnecessary leading blank lines at the beginning
       # of a file.
       #
       # @example

--- a/lib/rubocop/cop/layout/line_end_string_concatenation_indentation.rb
+++ b/lib/rubocop/cop/layout/line_end_string_concatenation_indentation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks the indentation of the next line after a line that ends with a string
+      # Checks the indentation of the next line after a line that ends with a string
       # literal and a backslash.
       #
       # If `EnforcedStyle: aligned` is set, the concatenated string parts shall be aligned with the

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -5,7 +5,7 @@ require 'uri'
 module RuboCop
   module Cop
     module Layout
-      # This cop checks the length of lines in the source code.
+      # Checks the length of lines in the source code.
       # The maximum length is configurable.
       # The tab size is configured in the `IndentationWidth`
       # of the `Layout/IndentationStyle` cop.

--- a/lib/rubocop/cop/layout/multiline_array_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_array_brace_layout.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks that the closing brace in an array literal is either
+      # Checks that the closing brace in an array literal is either
       # on the same line as the last array element or on a new line.
       #
       # When using the `symmetrical` (default) style:

--- a/lib/rubocop/cop/layout/multiline_array_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_array_line_breaks.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop ensures that each item in a multi-line array
+      # Ensures that each item in a multi-line array
       # starts on a separate line.
       #
       # @example

--- a/lib/rubocop/cop/layout/multiline_assignment_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_assignment_layout.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks whether the multiline assignments have a newline
+      # Checks whether the multiline assignments have a newline
       # after the assignment operator.
       #
       # @example EnforcedStyle: new_line (default)

--- a/lib/rubocop/cop/layout/multiline_block_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_block_layout.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks whether the multiline do end blocks have a newline
+      # Checks whether the multiline do end blocks have a newline
       # after the start of the block. Additionally, it checks whether the block
       # arguments, if any, are on the same line as the start of the
       # block. Putting block arguments on separate lines, because the whole

--- a/lib/rubocop/cop/layout/multiline_hash_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_hash_brace_layout.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks that the closing brace in a hash literal is either
+      # Checks that the closing brace in a hash literal is either
       # on the same line as the last hash element, or a new line.
       #
       # When using the `symmetrical` (default) style:

--- a/lib/rubocop/cop/layout/multiline_hash_key_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_hash_key_line_breaks.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop ensures that each key in a multi-line hash
+      # Ensures that each key in a multi-line hash
       # starts on a separate line.
       #
       # @example

--- a/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop ensures that each argument in a multi-line method call
+      # Ensures that each argument in a multi-line method call
       # starts on a separate line.
       #
       # NOTE: this cop does not move the first argument, if you want that to

--- a/lib/rubocop/cop/layout/multiline_method_call_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_brace_layout.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks that the closing brace in a method call is either
+      # Checks that the closing brace in a method call is either
       # on the same line as the last method argument, or a new line.
       #
       # When using the `symmetrical` (default) style:

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks the indentation of the method name part in method calls
+      # Checks the indentation of the method name part in method calls
       # that span more than one line.
       #
       # @example EnforcedStyle: aligned (default)

--- a/lib/rubocop/cop/layout/multiline_method_definition_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_method_definition_brace_layout.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks that the closing brace in a method definition is either
+      # Checks that the closing brace in a method definition is either
       # on the same line as the last method parameter, or a new line.
       #
       # When using the `symmetrical` (default) style:

--- a/lib/rubocop/cop/layout/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_operation_indentation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks the indentation of the right hand side operand in binary operations that
+      # Checks the indentation of the right hand side operand in binary operations that
       # span more than one line.
       #
       # The `aligned` style checks that operators are aligned if they are part of an `if` or `while`

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks whether certain expressions, e.g. method calls, that could fit
+      # Checks whether certain expressions, e.g. method calls, that could fit
       # completely on a single line, are broken up into multiple lines unnecessarily.
       #
       # @example any configuration

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks whether the rescue and ensure keywords are aligned
+      # Checks whether the rescue and ensure keywords are aligned
       # properly.
       #
       # @example

--- a/lib/rubocop/cop/layout/single_line_block_chain.rb
+++ b/lib/rubocop/cop/layout/single_line_block_chain.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks if method calls are chained onto single line blocks. It considers that a
+      # Checks if method calls are chained onto single line blocks. It considers that a
       # line break before the dot improves the readability of the code.
       #
       # @example

--- a/lib/rubocop/cop/layout/space_after_not.rb
+++ b/lib/rubocop/cop/layout/space_after_not.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for space after `!`.
+      # Checks for space after `!`.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/layout/space_before_comment.rb
+++ b/lib/rubocop/cop/layout/space_before_comment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for missing space between a token and a comment on the
+      # Checks for missing space between a token and a comment on the
       # same line.
       #
       # @example

--- a/lib/rubocop/cop/layout/space_in_lambda_literal.rb
+++ b/lib/rubocop/cop/layout/space_in_lambda_literal.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for spaces between `->` and opening parameter
+      # Checks for spaces between `->` and opening parameter
       # parenthesis (`(`) in lambda literals.
       #
       # @example EnforcedStyle: require_no_space (default)

--- a/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
+++ b/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for whitespace within string interpolations.
+      # Checks for whitespace within string interpolations.
       #
       # @example EnforcedStyle: no_space (default)
       #   # bad

--- a/lib/rubocop/cop/layout/trailing_empty_lines.rb
+++ b/lib/rubocop/cop/layout/trailing_empty_lines.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop looks for trailing blank lines and a final newline in the
+      # Looks for trailing blank lines and a final newline in the
       # source code.
       #
       # @example EnforcedStyle: final_blank_line

--- a/lib/rubocop/cop/layout/trailing_whitespace.rb
+++ b/lib/rubocop/cop/layout/trailing_whitespace.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop looks for trailing whitespace in the source code.
+      # Looks for trailing whitespace in the source code.
       #
       # @example
       #   # The line in this example contains spaces after the 0.

--- a/lib/rubocop/cop/lint/ambiguous_assignment.rb
+++ b/lib/rubocop/cop/lint/ambiguous_assignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for mistyped shorthand assignments.
+      # Checks for mistyped shorthand assignments.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for ambiguous block association with method
+      # Checks for ambiguous block association with method
       # when param passed without parentheses.
       #
       # This cop can customize ignored methods with `IgnoredMethods`.

--- a/lib/rubocop/cop/lint/ambiguous_operator.rb
+++ b/lib/rubocop/cop/lint/ambiguous_operator.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for ambiguous operators in the first argument of a
+      # Checks for ambiguous operators in the first argument of a
       # method invocation without parentheses.
       #
       # @example

--- a/lib/rubocop/cop/lint/ambiguous_operator_precedence.rb
+++ b/lib/rubocop/cop/lint/ambiguous_operator_precedence.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop looks for expressions containing multiple binary operators
+      # Looks for expressions containing multiple binary operators
       # where precedence is ambiguous due to lack of parentheses. For example,
       # in `1 + 2 * 3`, the multiplication will happen before the addition, but
       # lexically it appears that the addition will happen first.

--- a/lib/rubocop/cop/lint/ambiguous_range.rb
+++ b/lib/rubocop/cop/lint/ambiguous_range.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for ambiguous ranges.
+      # Checks for ambiguous ranges.
       #
       # Ranges have quite low precedence, which leads to unexpected behavior when
       # using a range with other operators. This cop avoids that by making ranges

--- a/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
+++ b/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for ambiguous regexp literals in the first argument of
+      # Checks for ambiguous regexp literals in the first argument of
       # a method invocation without parentheses.
       #
       # @example

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for assignments in the conditions of
+      # Checks for assignments in the conditions of
       # if/while/until.
       #
       # `AllowSafeAssignment` option for safe assignment.

--- a/lib/rubocop/cop/lint/binary_operator_with_identical_operands.rb
+++ b/lib/rubocop/cop/lint/binary_operator_with_identical_operands.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for places where binary operator has identical operands.
+      # Checks for places where binary operator has identical operands.
       #
       # It covers arithmetic operators: `-`, `/`, `%`;
       # comparison operators: `==`, `===`, `=~`, `>`, `>=`, `<`, `<=`;

--- a/lib/rubocop/cop/lint/boolean_symbol.rb
+++ b/lib/rubocop/cop/lint/boolean_symbol.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for `:true` and `:false` symbols.
+      # Checks for `:true` and `:false` symbols.
       # In most cases it would be a typo.
       #
       # @safety

--- a/lib/rubocop/cop/lint/circular_argument_reference.rb
+++ b/lib/rubocop/cop/lint/circular_argument_reference.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for circular argument references in optional keyword
+      # Checks for circular argument references in optional keyword
       # arguments and optional ordinal arguments.
       #
       # This cop mirrors a warning produced by MRI since 2.2.

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for debug calls (such as `debugger` or `binding.pry`) that should
+      # Checks for debug calls (such as `debugger` or `binding.pry`) that should
       # not be kept for production code.
       #
       # The cop can be configured using `DebuggerMethods`. By default, a number of gems

--- a/lib/rubocop/cop/lint/deprecated_class_methods.rb
+++ b/lib/rubocop/cop/lint/deprecated_class_methods.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for uses of the deprecated class method usages.
+      # Checks for uses of the deprecated class method usages.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/deprecated_constants.rb
+++ b/lib/rubocop/cop/lint/deprecated_constants.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for deprecated constants.
+      # Checks for deprecated constants.
       #
       # It has `DeprecatedConstants` config. If there is an alternative method, you can set
       # alternative value as `Alternative`. And you can set the deprecated version as

--- a/lib/rubocop/cop/lint/disjunctive_assignment_in_constructor.rb
+++ b/lib/rubocop/cop/lint/disjunctive_assignment_in_constructor.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks constructors for disjunctive assignments (`||=`) that should
+      # Checks constructors for disjunctive assignments (`||=`) that should
       # be plain assignments.
       #
       # So far, this cop is only concerned with disjunctive assignment of

--- a/lib/rubocop/cop/lint/duplicate_branch.rb
+++ b/lib/rubocop/cop/lint/duplicate_branch.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks that there are no repeated bodies
+      # Checks that there are no repeated bodies
       # within `if/unless`, `case-when`, `case-in` and `rescue` constructs.
       #
       # With `IgnoreLiteralBranches: true`, branches are not registered

--- a/lib/rubocop/cop/lint/duplicate_case_condition.rb
+++ b/lib/rubocop/cop/lint/duplicate_case_condition.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks that there are no repeated conditions
+      # Checks that there are no repeated conditions
       # used in case 'when' expressions.
       #
       # @example

--- a/lib/rubocop/cop/lint/duplicate_elsif_condition.rb
+++ b/lib/rubocop/cop/lint/duplicate_elsif_condition.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks that there are no repeated conditions used in if 'elsif'.
+      # Checks that there are no repeated conditions used in if 'elsif'.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/duplicate_hash_key.rb
+++ b/lib/rubocop/cop/lint/duplicate_hash_key.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for duplicated keys in hash literals.
+      # Checks for duplicated keys in hash literals.
       #
       # This cop mirrors a warning in Ruby 2.2.
       #

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for duplicated instance (or singleton) method
+      # Checks for duplicated instance (or singleton) method
       # definitions.
       #
       # @example

--- a/lib/rubocop/cop/lint/duplicate_regexp_character_class_element.rb
+++ b/lib/rubocop/cop/lint/duplicate_regexp_character_class_element.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for duplicate elements in Regexp character classes.
+      # Checks for duplicate elements in Regexp character classes.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/duplicate_require.rb
+++ b/lib/rubocop/cop/lint/duplicate_require.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for duplicate `require`s and `require_relative`s.
+      # Checks for duplicate `require`s and `require_relative`s.
       #
       # @safety
       #   This cop's autocorrection is unsafe because it may break the dependency order

--- a/lib/rubocop/cop/lint/duplicate_rescue_exception.rb
+++ b/lib/rubocop/cop/lint/duplicate_rescue_exception.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks that there are no repeated exceptions
+      # Checks that there are no repeated exceptions
       # used in 'rescue' expressions.
       #
       # @example

--- a/lib/rubocop/cop/lint/each_with_object_argument.rb
+++ b/lib/rubocop/cop/lint/each_with_object_argument.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks if each_with_object is called with an immutable
+      # Checks if each_with_object is called with an immutable
       # argument. Since the argument is the object that the given block shall
       # make calls on to build something based on the enumerable that
       # each_with_object iterates over, an immutable argument makes no sense.

--- a/lib/rubocop/cop/lint/else_layout.rb
+++ b/lib/rubocop/cop/lint/else_layout.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for odd `else` block layout - like
+      # Checks for odd `else` block layout - like
       # having an expression on the same line as the `else` keyword,
       # which is usually a mistake.
       #

--- a/lib/rubocop/cop/lint/empty_block.rb
+++ b/lib/rubocop/cop/lint/empty_block.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for blocks without a body.
+      # Checks for blocks without a body.
       # Such empty blocks are typically an oversight or we should provide a comment
       # be clearer what we're aiming for.
       #

--- a/lib/rubocop/cop/lint/empty_class.rb
+++ b/lib/rubocop/cop/lint/empty_class.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for classes and metaclasses without a body.
+      # Checks for classes and metaclasses without a body.
       # Such empty classes and metaclasses are typically an oversight or we should provide a comment
       # to be clearer what we're aiming for.
       #

--- a/lib/rubocop/cop/lint/empty_conditional_body.rb
+++ b/lib/rubocop/cop/lint/empty_conditional_body.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for the presence of `if`, `elsif` and `unless` branches without a body.
+      # Checks for the presence of `if`, `elsif` and `unless` branches without a body.
       # @example
       #   # bad
       #   if condition

--- a/lib/rubocop/cop/lint/empty_ensure.rb
+++ b/lib/rubocop/cop/lint/empty_ensure.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for empty `ensure` blocks
+      # Checks for empty `ensure` blocks
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/empty_expression.rb
+++ b/lib/rubocop/cop/lint/empty_expression.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for the presence of empty expressions.
+      # Checks for the presence of empty expressions.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/empty_file.rb
+++ b/lib/rubocop/cop/lint/empty_file.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop enforces that Ruby source files are not empty.
+      # Enforces that Ruby source files are not empty.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/empty_in_pattern.rb
+++ b/lib/rubocop/cop/lint/empty_in_pattern.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for the presence of `in` pattern branches without a body.
+      # Checks for the presence of `in` pattern branches without a body.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/empty_interpolation.rb
+++ b/lib/rubocop/cop/lint/empty_interpolation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for empty interpolation.
+      # Checks for empty interpolation.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/empty_when.rb
+++ b/lib/rubocop/cop/lint/empty_when.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for the presence of `when` branches without a body.
+      # Checks for the presence of `when` branches without a body.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/ensure_return.rb
+++ b/lib/rubocop/cop/lint/ensure_return.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for `return` from an `ensure` block.
+      # Checks for `return` from an `ensure` block.
       # `return` from an ensure block is a dangerous code smell as it
       # will take precedence over any exception being raised,
       # and the exception will be silently thrown away as if it were rescued.

--- a/lib/rubocop/cop/lint/flip_flop.rb
+++ b/lib/rubocop/cop/lint/flip_flop.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop looks for uses of flip-flop operator
+      # Looks for uses of flip-flop operator
       # based on the Ruby Style Guide.
       #
       # Here is the history of flip-flops in Ruby.

--- a/lib/rubocop/cop/lint/float_comparison.rb
+++ b/lib/rubocop/cop/lint/float_comparison.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for the presence of precise comparison of floating point numbers.
+      # Checks for the presence of precise comparison of floating point numbers.
       #
       # Floating point values are inherently inaccurate, and comparing them for exact equality
       # is almost never the desired semantics. Comparison via the `==/!=` operators checks

--- a/lib/rubocop/cop/lint/float_out_of_range.rb
+++ b/lib/rubocop/cop/lint/float_out_of_range.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop identifies Float literals which are, like, really really really
+      # Identifies Float literals which are, like, really really really
       # really really really really really big. Too big. No-one needs Floats
       # that big. If you need a float that big, something is wrong with you.
       #

--- a/lib/rubocop/cop/lint/heredoc_method_call_position.rb
+++ b/lib/rubocop/cop/lint/heredoc_method_call_position.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for the ordering of a method call where
+      # Checks for the ordering of a method call where
       # the receiver of the call is a HEREDOC.
       #
       # @example

--- a/lib/rubocop/cop/lint/implicit_string_concatenation.rb
+++ b/lib/rubocop/cop/lint/implicit_string_concatenation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for implicit string concatenation of string literals
+      # Checks for implicit string concatenation of string literals
       # which are on the same line.
       #
       # @example

--- a/lib/rubocop/cop/lint/ineffective_access_modifier.rb
+++ b/lib/rubocop/cop/lint/ineffective_access_modifier.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for `private` or `protected` access modifiers which are
+      # Checks for `private` or `protected` access modifiers which are
       # applied to a singleton method. These access modifiers do not make
       # singleton methods private/protected. `private_class_method` can be
       # used for that.

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop looks for error classes inheriting from `Exception`.
+      # Looks for error classes inheriting from `Exception`.
       # It is configurable to suggest using either `StandardError` (default) or
       # `RuntimeError` instead.
       #

--- a/lib/rubocop/cop/lint/interpolation_check.rb
+++ b/lib/rubocop/cop/lint/interpolation_check.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for interpolation in a single quoted string.
+      # Checks for interpolation in a single quoted string.
       #
       # @safety
       #   This cop is generally safe, but is marked as unsafe because

--- a/lib/rubocop/cop/lint/lambda_without_literal_block.rb
+++ b/lib/rubocop/cop/lint/lambda_without_literal_block.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks uses of lambda without a literal block.
+      # Checks uses of lambda without a literal block.
       # It emulates the following warning in Ruby 3.0:
       #
       #   % ruby -vwe 'lambda(&proc {})'

--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for literals used as the conditions or as
+      # Checks for literals used as the conditions or as
       # operands in and/or expressions serving as the conditions of
       # if/while/until/case-when/case-in.
       #

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for interpolated literals.
+      # Checks for interpolated literals.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/loop.rb
+++ b/lib/rubocop/cop/lint/loop.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for uses of `begin...end while/until something`.
+      # Checks for uses of `begin...end while/until something`.
       #
       # @safety
       #   The cop is unsafe because behavior can change in some cases, including

--- a/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
@@ -4,7 +4,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks that there is an `# rubocop:enable ...` statement
+      # Checks that there is an `# rubocop:enable ...` statement
       # after a `# rubocop:disable ...` statement. This will prevent leaving
       # cop disables on wide ranges of code, that latter contributors to
       # a file wouldn't be aware of.

--- a/lib/rubocop/cop/lint/missing_super.rb
+++ b/lib/rubocop/cop/lint/missing_super.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for the presence of constructors and lifecycle callbacks
+      # Checks for the presence of constructors and lifecycle callbacks
       # without calls to `super`.
       #
       # This cop does not consider `method_missing` (and `respond_to_missing?`)

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for nested method definitions.
+      # Checks for nested method definitions.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/nested_percent_literal.rb
+++ b/lib/rubocop/cop/lint/nested_percent_literal.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for nested percent literals.
+      # Checks for nested percent literals.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
+++ b/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for non-local exits from iterators without a return
+      # Checks for non-local exits from iterators without a return
       # value. It registers an offense under these conditions:
       #
       # * No value is returned,

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop warns the usage of unsafe number conversions. Unsafe
+      # Warns the usage of unsafe number conversions. Unsafe
       # number conversion can cause unexpected error if auto type conversion
       # fails. Cop prefer parsing with number class instead.
       #

--- a/lib/rubocop/cop/lint/numbered_parameter_assignment.rb
+++ b/lib/rubocop/cop/lint/numbered_parameter_assignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for uses of numbered parameter assignment.
+      # Checks for uses of numbered parameter assignment.
       # It emulates the following warning in Ruby 2.7:
       #
       #   % ruby -ve '_1 = :value'

--- a/lib/rubocop/cop/lint/or_assignment_to_constant.rb
+++ b/lib/rubocop/cop/lint/or_assignment_to_constant.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for unintended or-assignment to a constant.
+      # Checks for unintended or-assignment to a constant.
       #
       # Constants should always be assigned in the same location. And its value
       # should always be the same. If constants are assigned in multiple

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for quotes and commas in %w, e.g. `%w('foo', "bar")`
+      # Checks for quotes and commas in %w, e.g. `%w('foo', "bar")`
       #
       # It is more likely that the additional characters are unintended (for
       # example, mistranslating an array of literals to percent string notation)

--- a/lib/rubocop/cop/lint/percent_symbol_array.rb
+++ b/lib/rubocop/cop/lint/percent_symbol_array.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for colons and commas in %i, e.g. `%i(:foo, :bar)`
+      # Checks for colons and commas in %i, e.g. `%i(:foo, :bar)`
       #
       # It is more likely that the additional characters are unintended (for
       # example, mistranslating an array of literals to percent string notation)

--- a/lib/rubocop/cop/lint/raise_exception.rb
+++ b/lib/rubocop/cop/lint/raise_exception.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for `raise` or `fail` statements which are
+      # Checks for `raise` or `fail` statements which are
       # raising `Exception` class.
       #
       # You can specify a module name that will be an implicit namespace

--- a/lib/rubocop/cop/lint/rand_one.rb
+++ b/lib/rubocop/cop/lint/rand_one.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for `rand(1)` calls.
+      # Checks for `rand(1)` calls.
       # Such calls always return `0`.
       #
       # @example

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -6,7 +6,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop detects instances of rubocop:disable comments that can be
+      # Detects instances of rubocop:disable comments that can be
       # removed without causing any offenses to be reported. It's implemented
       # as a cop in that it inherits from the Cop base class and calls
       # add_offense. The unusual part of its implementation is that it doesn't

--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -9,7 +9,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop detects instances of rubocop:enable comments that can be
+      # Detects instances of rubocop:enable comments that can be
       # removed.
       #
       # When comment enables all cops at once `rubocop:enable all`

--- a/lib/rubocop/cop/lint/redundant_safe_navigation.rb
+++ b/lib/rubocop/cop/lint/redundant_safe_navigation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for redundant safe navigation calls.
+      # Checks for redundant safe navigation calls.
       # `instance_of?`, `kind_of?`, `is_a?`, `eql?`, `respond_to?`, and `equal?` methods
       # are checked by default. These are customizable with `AllowedMethods` option.
       #

--- a/lib/rubocop/cop/lint/redundant_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/redundant_splat_expansion.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for unneeded usages of splat expansion
+      # Checks for unneeded usages of splat expansion
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/redundant_string_coercion.rb
+++ b/lib/rubocop/cop/lint/redundant_string_coercion.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for string conversion in string interpolation,
+      # Checks for string conversion in string interpolation,
       # which is redundant.
       #
       # @example

--- a/lib/rubocop/cop/lint/redundant_with_index.rb
+++ b/lib/rubocop/cop/lint/redundant_with_index.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for redundant `with_index`.
+      # Checks for redundant `with_index`.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/redundant_with_object.rb
+++ b/lib/rubocop/cop/lint/redundant_with_object.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for redundant `with_object`.
+      # Checks for redundant `with_object`.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/refinement_import_methods.rb
+++ b/lib/rubocop/cop/lint/refinement_import_methods.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks if `include` or `prepend` is called in `refine` block.
+      # Checks if `include` or `prepend` is called in `refine` block.
       # These methods are deprecated and should be replaced with `Refinement#import_methods`.
       #
       # It emulates deprecation warnings in Ruby 3.1.

--- a/lib/rubocop/cop/lint/regexp_as_condition.rb
+++ b/lib/rubocop/cop/lint/regexp_as_condition.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for regexp literals used as `match-current-line`.
+      # Checks for regexp literals used as `match-current-line`.
       # If a regexp literal is in condition, the regexp matches `$_` implicitly.
       #
       # @example

--- a/lib/rubocop/cop/lint/require_parentheses.rb
+++ b/lib/rubocop/cop/lint/require_parentheses.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for expressions where there is a call to a predicate
+      # Checks for expressions where there is a call to a predicate
       # method with at least one argument, where no parentheses are used around
       # the parameter list, and a boolean operator, && or ||, is used in the
       # last argument.

--- a/lib/rubocop/cop/lint/rescue_exception.rb
+++ b/lib/rubocop/cop/lint/rescue_exception.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for `rescue` blocks targeting the Exception class.
+      # Checks for `rescue` blocks targeting the Exception class.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/return_in_void_context.rb
+++ b/lib/rubocop/cop/lint/return_in_void_context.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for the use of a return with a value in a context
+      # Checks for the use of a return with a value in a context
       # where the value will be ignored. (initialize and setter methods)
       #
       # @example

--- a/lib/rubocop/cop/lint/safe_navigation_consistency.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_consistency.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop check to make sure that if safe navigation is used for a method
+      # Check to make sure that if safe navigation is used for a method
       # call in an `&&` or `||` condition that safe navigation is used for all
       # method calls on that same object.
       #

--- a/lib/rubocop/cop/lint/safe_navigation_with_empty.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_with_empty.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks to make sure safe navigation isn't used with `empty?` in
+      # Checks to make sure safe navigation isn't used with `empty?` in
       # a conditional.
       #
       # While the safe navigation operator is generally a good idea, when

--- a/lib/rubocop/cop/lint/script_permission.rb
+++ b/lib/rubocop/cop/lint/script_permission.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks if a file which has a shebang line as
+      # Checks if a file which has a shebang line as
       # its first line is granted execute permission.
       #
       # @example

--- a/lib/rubocop/cop/lint/self_assignment.rb
+++ b/lib/rubocop/cop/lint/self_assignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for self-assignments.
+      # Checks for self-assignments.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/shadowed_argument.rb
+++ b/lib/rubocop/cop/lint/shadowed_argument.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for shadowed arguments.
+      # Checks for shadowed arguments.
       #
       # This cop has `IgnoreImplicitReferences` configuration option.
       # It means argument shadowing is used in order to pass parameters

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for a rescued exception that get shadowed by a
+      # Checks for a rescued exception that get shadowed by a
       # less specific exception being rescued before a more specific
       # exception is rescued.
       #

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for the use of local variable names from an outer scope
+      # Checks for the use of local variable names from an outer scope
       # in block arguments or block-local variables. This mirrors the warning
       # given by `ruby -cw` prior to Ruby 2.6:
       # "shadowing outer local variable - foo".

--- a/lib/rubocop/cop/lint/struct_new_override.rb
+++ b/lib/rubocop/cop/lint/struct_new_override.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks unexpected overrides of the `Struct` built-in methods
+      # Checks unexpected overrides of the `Struct` built-in methods
       # via `Struct.new`.
       #
       # @example

--- a/lib/rubocop/cop/lint/suppressed_exception.rb
+++ b/lib/rubocop/cop/lint/suppressed_exception.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for `rescue` blocks with no body.
+      # Checks for `rescue` blocks with no body.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/symbol_conversion.rb
+++ b/lib/rubocop/cop/lint/symbol_conversion.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for uses of literal strings converted to
+      # Checks for uses of literal strings converted to
       # a symbol where a literal symbol could be used instead.
       #
       # There are two possible styles for this cop.

--- a/lib/rubocop/cop/lint/syntax.rb
+++ b/lib/rubocop/cop/lint/syntax.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop repacks Parser's diagnostics/errors
+      # Repacks Parser's diagnostics/errors
       # into RuboCop's offenses.
       class Syntax < Base
         def on_other_file

--- a/lib/rubocop/cop/lint/to_enum_arguments.rb
+++ b/lib/rubocop/cop/lint/to_enum_arguments.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop ensures that `to_enum`/`enum_for`, called for the current method,
+      # Ensures that `to_enum`/`enum_for`, called for the current method,
       # has correct arguments.
       #
       # @example

--- a/lib/rubocop/cop/lint/to_json.rb
+++ b/lib/rubocop/cop/lint/to_json.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks to make sure `#to_json` includes an optional argument.
+      # Checks to make sure `#to_json` includes an optional argument.
       # When overriding `#to_json`, callers may invoke JSON
       # generation via `JSON.generate(your_obj)`.  Since `JSON#generate` allows
       # for an optional argument, your method should too.

--- a/lib/rubocop/cop/lint/top_level_return_with_argument.rb
+++ b/lib/rubocop/cop/lint/top_level_return_with_argument.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for top level return with arguments. If there is a
+      # Checks for top level return with arguments. If there is a
       # top-level return statement with an argument, then the argument is
       # always ignored. This is detected automatically since Ruby 2.7.
       #

--- a/lib/rubocop/cop/lint/trailing_comma_in_attribute_declaration.rb
+++ b/lib/rubocop/cop/lint/trailing_comma_in_attribute_declaration.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for trailing commas in attribute declarations, such as
+      # Checks for trailing commas in attribute declarations, such as
       # `#attr_reader`. Leaving a trailing comma will nullify the next method
       # definition by overriding it with a getter method.
       #

--- a/lib/rubocop/cop/lint/triple_quotes.rb
+++ b/lib/rubocop/cop/lint/triple_quotes.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for "triple quotes" (strings delimited by any odd number
+      # Checks for "triple quotes" (strings delimited by any odd number
       # of quotes greater than 1).
       #
       # Ruby allows multiple strings to be implicitly concatenated by just

--- a/lib/rubocop/cop/lint/underscore_prefixed_variable_name.rb
+++ b/lib/rubocop/cop/lint/underscore_prefixed_variable_name.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for underscore-prefixed variables that are actually
+      # Checks for underscore-prefixed variables that are actually
       # used.
       #
       # Since block keyword arguments cannot be arbitrarily named at call

--- a/lib/rubocop/cop/lint/unexpected_block_arity.rb
+++ b/lib/rubocop/cop/lint/unexpected_block_arity.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for a block that is known to need more positional
+      # Checks for a block that is known to need more positional
       # block arguments than are given (by default this is configured for
       # `Enumerable` methods needing 2 arguments). Optional arguments are allowed,
       # although they don't generally make sense as the default value will

--- a/lib/rubocop/cop/lint/unified_integer.rb
+++ b/lib/rubocop/cop/lint/unified_integer.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for using Fixnum or Bignum constant.
+      # Checks for using Fixnum or Bignum constant.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for unreachable code.
+      # Checks for unreachable code.
       # The check are based on the presence of flow of control
       # statement in non-final position in `begin` (implicit) blocks.
       #

--- a/lib/rubocop/cop/lint/unreachable_loop.rb
+++ b/lib/rubocop/cop/lint/unreachable_loop.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for loops that will have at most one iteration.
+      # Checks for loops that will have at most one iteration.
       #
       # A loop that can never reach the second iteration is a possible error in the code.
       # In rare cases where only one iteration (or at most one iteration) is intended behavior,

--- a/lib/rubocop/cop/lint/unused_block_argument.rb
+++ b/lib/rubocop/cop/lint/unused_block_argument.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for unused block arguments.
+      # Checks for unused block arguments.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/unused_method_argument.rb
+++ b/lib/rubocop/cop/lint/unused_method_argument.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for unused method arguments.
+      # Checks for unused method arguments.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/uri_escape_unescape.rb
+++ b/lib/rubocop/cop/lint/uri_escape_unescape.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop identifies places where `URI.escape` can be replaced by
+      # Identifies places where `URI.escape` can be replaced by
       # `CGI.escape`, `URI.encode_www_form`, or `URI.encode_www_form_component`
       # depending on your specific use case.
       # Also this cop identifies places where `URI.unescape` can be replaced by

--- a/lib/rubocop/cop/lint/uri_regexp.rb
+++ b/lib/rubocop/cop/lint/uri_regexp.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop identifies places where `URI.regexp` is obsolete and should
+      # Identifies places where `URI.regexp` is obsolete and should
       # not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp`.
       #
       # @example

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for redundant access modifiers, including those with no
+      # Checks for redundant access modifiers, including those with no
       # code, those which are repeated, and leading `public` modifiers in a
       # class or module body. Conditionally-defined methods are considered as
       # always being defined, and thus access modifiers guarding such methods

--- a/lib/rubocop/cop/lint/useless_assignment.rb
+++ b/lib/rubocop/cop/lint/useless_assignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for every useless assignment to local variable in every
+      # Checks for every useless assignment to local variable in every
       # scope.
       # The basic idea for this cop was from the warning of `ruby -cw`:
       #

--- a/lib/rubocop/cop/lint/useless_method_definition.rb
+++ b/lib/rubocop/cop/lint/useless_method_definition.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for useless method definitions, specifically: empty constructors
+      # Checks for useless method definitions, specifically: empty constructors
       # and methods just delegating to `super`.
       #
       # @safety

--- a/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
+++ b/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop looks for `ruby2_keywords` calls for methods that do not need it.
+      # Looks for `ruby2_keywords` calls for methods that do not need it.
       #
       # `ruby2_keywords` should only be called on methods that accept an argument splat
       # (`*args`) but do not explicit keyword arguments (`k:` or `k: true`) or

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for setter call to local variable as the final
+      # Checks for setter call to local variable as the final
       # expression of a function definition.
       #
       # @safety

--- a/lib/rubocop/cop/lint/useless_times.rb
+++ b/lib/rubocop/cop/lint/useless_times.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for uses of `Integer#times` that will never yield
+      # Checks for uses of `Integer#times` that will never yield
       # (when the integer <= 0) or that will only ever yield once
       # (`1.times`).
       #

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for operators, variables, literals, and nonmutating
+      # Checks for operators, variables, literals, and nonmutating
       # methods used in void context.
       #
       # @example CheckForMethodsWithNoSideEffects: false (default)

--- a/lib/rubocop/cop/metrics/abc_size.rb
+++ b/lib/rubocop/cop/metrics/abc_size.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks that the ABC size of methods is not higher than the
+      # Checks that the ABC size of methods is not higher than the
       # configured maximum. The ABC size is based on assignments, branches
       # (method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric
       # and https://en.wikipedia.org/wiki/ABC_Software_Metric.

--- a/lib/rubocop/cop/metrics/block_length.rb
+++ b/lib/rubocop/cop/metrics/block_length.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks if the length of a block exceeds some maximum value.
+      # Checks if the length of a block exceeds some maximum value.
       # Comment lines can optionally be ignored.
       # The maximum allowed length is configurable.
       # The cop can be configured to ignore blocks passed to certain methods.

--- a/lib/rubocop/cop/metrics/block_nesting.rb
+++ b/lib/rubocop/cop/metrics/block_nesting.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks for excessive nesting of conditional and looping
+      # Checks for excessive nesting of conditional and looping
       # constructs.
       #
       # You can configure if blocks are considered using the `CountBlocks`

--- a/lib/rubocop/cop/metrics/class_length.rb
+++ b/lib/rubocop/cop/metrics/class_length.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks if the length a class exceeds some maximum value.
+      # Checks if the length a class exceeds some maximum value.
       # Comment lines can optionally be ignored.
       # The maximum allowed length is configurable.
       #

--- a/lib/rubocop/cop/metrics/cyclomatic_complexity.rb
+++ b/lib/rubocop/cop/metrics/cyclomatic_complexity.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks that the cyclomatic complexity of methods is not higher
+      # Checks that the cyclomatic complexity of methods is not higher
       # than the configured maximum. The cyclomatic complexity is the number of
       # linearly independent paths through a method. The algorithm counts
       # decision points and adds one.

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks if the length of a method exceeds some maximum value.
+      # Checks if the length of a method exceeds some maximum value.
       # Comment lines can optionally be ignored.
       # The maximum allowed length is configurable.
       #

--- a/lib/rubocop/cop/metrics/module_length.rb
+++ b/lib/rubocop/cop/metrics/module_length.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks if the length a module exceeds some maximum value.
+      # Checks if the length a module exceeds some maximum value.
       # Comment lines can optionally be ignored.
       # The maximum allowed length is configurable.
       #

--- a/lib/rubocop/cop/metrics/parameter_lists.rb
+++ b/lib/rubocop/cop/metrics/parameter_lists.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks for methods with too many parameters.
+      # Checks for methods with too many parameters.
       #
       # The maximum number of parameters is configurable.
       # Keyword arguments can optionally be excluded from the total count,

--- a/lib/rubocop/cop/metrics/perceived_complexity.rb
+++ b/lib/rubocop/cop/metrics/perceived_complexity.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop tries to produce a complexity score that's a measure of the
+      # Tries to produce a complexity score that's a measure of the
       # complexity the reader experiences when looking at a method. For that
       # reason it considers `when` nodes as something that doesn't add as much
       # complexity as an `if` or a `&&`. Except if it's one of those special

--- a/lib/rubocop/cop/naming/accessor_method_name.rb
+++ b/lib/rubocop/cop/naming/accessor_method_name.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop makes sure that accessor methods are named properly. Applies
+      # Makes sure that accessor methods are named properly. Applies
       # to both instance and class methods.
       #
       # NOTE: Offenses are only registered for methods with the expected

--- a/lib/rubocop/cop/naming/ascii_identifiers.rb
+++ b/lib/rubocop/cop/naming/ascii_identifiers.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop checks for non-ascii characters in identifier and constant names.
+      # Checks for non-ascii characters in identifier and constant names.
       # Identifiers are always checked and whether constants are checked
       # can be controlled using AsciiConstants config.
       #

--- a/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
+++ b/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop makes sure that certain binary operator methods have their
+      # Makes sure that certain binary operator methods have their
       # sole  parameter named `other`.
       #
       # @example

--- a/lib/rubocop/cop/naming/block_parameter_name.rb
+++ b/lib/rubocop/cop/naming/block_parameter_name.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop checks block parameter names for how descriptive they
+      # Checks block parameter names for how descriptive they
       # are. It is highly configurable.
       #
       # The `MinNameLength` config option takes an integer. It represents

--- a/lib/rubocop/cop/naming/class_and_module_camel_case.rb
+++ b/lib/rubocop/cop/naming/class_and_module_camel_case.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop checks for class and module names with
+      # Checks for class and module names with
       # an underscore in them.
       #
       # `AllowedNames` config takes an array of permitted names.

--- a/lib/rubocop/cop/naming/constant_name.rb
+++ b/lib/rubocop/cop/naming/constant_name.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop checks whether constant names are written using
+      # Checks whether constant names are written using
       # SCREAMING_SNAKE_CASE.
       #
       # To avoid false positives, it ignores cases in which we cannot know

--- a/lib/rubocop/cop/naming/file_name.rb
+++ b/lib/rubocop/cop/naming/file_name.rb
@@ -5,7 +5,7 @@ require 'pathname'
 module RuboCop
   module Cop
     module Naming
-      # This cop makes sure that Ruby source files have snake_case
+      # Makes sure that Ruby source files have snake_case
       # names. Ruby scripts (i.e. source files with a shebang in the
       # first line) are ignored.
       #

--- a/lib/rubocop/cop/naming/heredoc_delimiter_case.rb
+++ b/lib/rubocop/cop/naming/heredoc_delimiter_case.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop checks that your heredocs are using the configured case.
+      # Checks that your heredocs are using the configured case.
       # By default it is configured to enforce uppercase heredocs.
       #
       # @example EnforcedStyle: uppercase (default)

--- a/lib/rubocop/cop/naming/heredoc_delimiter_naming.rb
+++ b/lib/rubocop/cop/naming/heredoc_delimiter_naming.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop checks that your heredocs are using meaningful delimiters.
+      # Checks that your heredocs are using meaningful delimiters.
       # By default it disallows `END` and `EO*`, and can be configured through
       # forbidden listing additional delimiters.
       #

--- a/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
+++ b/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop checks for memoized methods whose instance variable name
+      # Checks for memoized methods whose instance variable name
       # does not match the method name. Applies to both regular methods
       # (defined with `def`) and dynamic methods (defined with
       # `define_method` or `define_singleton_method`).

--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop makes sure that all methods use the configured style,
+      # Makes sure that all methods use the configured style,
       # snake_case or camelCase, for their names.
       #
       # This cop has `AllowedPatterns` configuration option.

--- a/lib/rubocop/cop/naming/method_parameter_name.rb
+++ b/lib/rubocop/cop/naming/method_parameter_name.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop checks method parameter names for how descriptive they
+      # Checks method parameter names for how descriptive they
       # are. It is highly configurable.
       #
       # The `MinNameLength` config option takes an integer. It represents

--- a/lib/rubocop/cop/naming/predicate_name.rb
+++ b/lib/rubocop/cop/naming/predicate_name.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop makes sure that predicates are named properly.
+      # Makes sure that predicates are named properly.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop makes sure that rescued exceptions variables are named as
+      # Makes sure that rescued exceptions variables are named as
       # expected.
       #
       # The `PreferredName` config option takes a `String`. It represents

--- a/lib/rubocop/cop/naming/variable_name.rb
+++ b/lib/rubocop/cop/naming/variable_name.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop makes sure that all variables use the configured style,
+      # Makes sure that all variables use the configured style,
       # snake_case or camelCase, for their names.
       #
       # @example EnforcedStyle: snake_case (default)

--- a/lib/rubocop/cop/naming/variable_number.rb
+++ b/lib/rubocop/cop/naming/variable_number.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop makes sure that all numbered variables use the
+      # Makes sure that all numbered variables use the
       # configured style, snake_case, normalcase, or non_integer,
       # for their numbering.
       #

--- a/lib/rubocop/cop/security/compound_hash.rb
+++ b/lib/rubocop/cop/security/compound_hash.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Security
-      # This cop checks for implementations of the `hash` method which combine
+      # Checks for implementations of the `hash` method which combine
       # values using custom logic instead of delegating to `Array#hash`.
       #
       # Manually combining hashes is error prone and hard to follow, especially

--- a/lib/rubocop/cop/security/eval.rb
+++ b/lib/rubocop/cop/security/eval.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Security
-      # This cop checks for the use of `Kernel#eval` and `Binding#eval`.
+      # Checks for the use of `Kernel#eval` and `Binding#eval`.
       #
       # @example
       #

--- a/lib/rubocop/cop/security/json_load.rb
+++ b/lib/rubocop/cop/security/json_load.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Security
-      # This cop checks for the use of JSON class methods which have potential
+      # Checks for the use of JSON class methods which have potential
       # security issues.
       #
       # @safety

--- a/lib/rubocop/cop/security/marshal_load.rb
+++ b/lib/rubocop/cop/security/marshal_load.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Security
-      # This cop checks for the use of Marshal class methods which have
+      # Checks for the use of Marshal class methods which have
       # potential security issues leading to remote code execution when
       # loading from an untrusted source.
       #

--- a/lib/rubocop/cop/security/open.rb
+++ b/lib/rubocop/cop/security/open.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Security
-      # This cop checks for the use of `Kernel#open` and `URI.open` with dynamic
+      # Checks for the use of `Kernel#open` and `URI.open` with dynamic
       # data.
       #
       # `Kernel#open` and `URI.open` enable not only file access but also process

--- a/lib/rubocop/cop/security/yaml_load.rb
+++ b/lib/rubocop/cop/security/yaml_load.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Security
-      # This cop checks for the use of YAML class methods which have
+      # Checks for the use of YAML class methods which have
       # potential security issues leading to remote code execution when
       # loading from an untrusted source.
       #

--- a/lib/rubocop/cop/style/accessor_grouping.rb
+++ b/lib/rubocop/cop/style/accessor_grouping.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for grouping of accessors in `class` and `module` bodies.
+      # Checks for grouping of accessors in `class` and `module` bodies.
       # By default it enforces accessors to be placed in grouped declarations,
       # but it can be configured to enforce separating them in multiple declarations.
       #

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces the use of either `#alias` or `#alias_method`
+      # Enforces the use of either `#alias` or `#alias_method`
       # depending on configuration.
       # It also flags uses of `alias :symbol` rather than `alias bareword`.
       #

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of `and` and `or`, and suggests using `&&` and
+      # Checks for uses of `and` and `or`, and suggests using `&&` and
       # `||` instead. It can be configured to check only in conditions or in
       # all contexts.
       #

--- a/lib/rubocop/cop/style/array_coercion.rb
+++ b/lib/rubocop/cop/style/array_coercion.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces the use of `Array()` instead of explicit `Array` check or `[*var]`.
+      # Enforces the use of `Array()` instead of explicit `Array` check or `[*var]`.
       #
       # The cop is disabled by default due to safety concerns.
       #

--- a/lib/rubocop/cop/style/array_join.rb
+++ b/lib/rubocop/cop/style/array_join.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of "*" as a substitute for _join_.
+      # Checks for uses of "*" as a substitute for _join_.
       #
       # Not all cases can reliably checked, due to Ruby's dynamic
       # types, so we consider only cases when the first argument is an

--- a/lib/rubocop/cop/style/ascii_comments.rb
+++ b/lib/rubocop/cop/style/ascii_comments.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for non-ascii (non-English) characters
+      # Checks for non-ascii (non-English) characters
       # in comments. You could set an array of allowed non-ascii chars in
       # `AllowedChars` attribute (copyright notice "©" by default).
       #

--- a/lib/rubocop/cop/style/attr.rb
+++ b/lib/rubocop/cop/style/attr.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of Module#attr.
+      # Checks for uses of Module#attr.
       #
       # @example
       #   # bad - creates a single attribute accessor (deprecated in Ruby 1.9)

--- a/lib/rubocop/cop/style/auto_resource_cleanup.rb
+++ b/lib/rubocop/cop/style/auto_resource_cleanup.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for cases when you could use a block
+      # Checks for cases when you could use a block
       # accepting version of a method that does automatic
       # resource cleanup.
       #

--- a/lib/rubocop/cop/style/bare_percent_literals.rb
+++ b/lib/rubocop/cop/style/bare_percent_literals.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks if usage of %() or %Q() matches configuration.
+      # Checks if usage of %() or %Q() matches configuration.
       #
       # @example EnforcedStyle: bare_percent (default)
       #   # bad

--- a/lib/rubocop/cop/style/bisected_attr_accessor.rb
+++ b/lib/rubocop/cop/style/bisected_attr_accessor.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for places where `attr_reader` and `attr_writer`
+      # Checks for places where `attr_reader` and `attr_writer`
       # for the same method can be combined into single `attr_accessor`.
       #
       # @example

--- a/lib/rubocop/cop/style/block_comments.rb
+++ b/lib/rubocop/cop/style/block_comments.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop looks for uses of block comments (=begin...=end).
+      # Looks for uses of block comments (=begin...=end).
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/case_equality.rb
+++ b/lib/rubocop/cop/style/case_equality.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of the case equality operator(===).
+      # Checks for uses of the case equality operator(===).
       #
       # If `AllowOnConstant` option is enabled, the cop will ignore violations when the receiver of
       # the case equality operator is a constant.

--- a/lib/rubocop/cop/style/case_like_if.rb
+++ b/lib/rubocop/cop/style/case_like_if.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop identifies places where `if-elsif` constructions
+      # Identifies places where `if-elsif` constructions
       # can be replaced with `case-when`.
       #
       # @safety

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks the style of children definitions at classes and
+      # Checks the style of children definitions at classes and
       # modules. Basically there are two different styles:
       #
       # @safety

--- a/lib/rubocop/cop/style/class_check.rb
+++ b/lib/rubocop/cop/style/class_check.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces consistent use of `Object#is_a?` or `Object#kind_of?`.
+      # Enforces consistent use of `Object#is_a?` or `Object#kind_of?`.
       #
       # @example EnforcedStyle: is_a? (default)
       #   # bad

--- a/lib/rubocop/cop/style/class_equality_comparison.rb
+++ b/lib/rubocop/cop/style/class_equality_comparison.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces the use of `Object#instance_of?` instead of class comparison
+      # Enforces the use of `Object#instance_of?` instead of class comparison
       # for equality.
       #
       # @example

--- a/lib/rubocop/cop/style/class_methods.rb
+++ b/lib/rubocop/cop/style/class_methods.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of the class/module name instead of
+      # Checks for uses of the class/module name instead of
       # self, when defining class/module methods.
       #
       # @example

--- a/lib/rubocop/cop/style/class_methods_definitions.rb
+++ b/lib/rubocop/cop/style/class_methods_definitions.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces using `def self.method_name` or `class << self` to define class methods.
+      # Enforces using `def self.method_name` or `class << self` to define class methods.
       #
       # @example EnforcedStyle: def_self (default)
       #   # bad

--- a/lib/rubocop/cop/style/class_vars.rb
+++ b/lib/rubocop/cop/style/class_vars.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of class variables. Offenses
+      # Checks for uses of class variables. Offenses
       # are signaled only on assignment to class variables to
       # reduce the number of offenses that would be reported.
       #

--- a/lib/rubocop/cop/style/collection_compact.rb
+++ b/lib/rubocop/cop/style/collection_compact.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for places where custom logic on rejection nils from arrays
+      # Checks for places where custom logic on rejection nils from arrays
       # and hashes can be replaced with `{Array,Hash}#{compact,compact!}`.
       #
       # @safety

--- a/lib/rubocop/cop/style/collection_methods.rb
+++ b/lib/rubocop/cop/style/collection_methods.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces the use of consistent method names
+      # Enforces the use of consistent method names
       # from the Enumerable module.
       #
       # You can customize the mapping from undesired method to desired method.

--- a/lib/rubocop/cop/style/colon_method_call.rb
+++ b/lib/rubocop/cop/style/colon_method_call.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for methods invoked via the :: operator instead
+      # Checks for methods invoked via the :: operator instead
       # of the . operator (like FileUtils::rmdir instead of FileUtils.rmdir).
       #
       # @example

--- a/lib/rubocop/cop/style/colon_method_definition.rb
+++ b/lib/rubocop/cop/style/colon_method_definition.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for class methods that are defined using the `::`
+      # Checks for class methods that are defined using the `::`
       # operator instead of the `.` operator.
       #
       # @example

--- a/lib/rubocop/cop/style/combinable_loops.rb
+++ b/lib/rubocop/cop/style/combinable_loops.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for places where multiple consecutive loops over the same data
+      # Checks for places where multiple consecutive loops over the same data
       # can be combined into a single loop. It is very likely that combining them
       # will make the code more efficient and more concise.
       #

--- a/lib/rubocop/cop/style/command_literal.rb
+++ b/lib/rubocop/cop/style/command_literal.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces using `` or %x around command literals.
+      # Enforces using `` or %x around command literals.
       #
       # @example EnforcedStyle: backticks (default)
       #   # bad

--- a/lib/rubocop/cop/style/comment_annotation.rb
+++ b/lib/rubocop/cop/style/comment_annotation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks that comment annotation keywords are written according
+      # Checks that comment annotation keywords are written according
       # to guidelines.
       #
       # Annotation keywords can be specified by overriding the cop's `Keywords`

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for comments put on the same line as some keywords.
+      # Checks for comments put on the same line as some keywords.
       # These keywords are: `class`, `module`, `def`, `begin`, `end`.
       #
       # Note that some comments

--- a/lib/rubocop/cop/style/constant_visibility.rb
+++ b/lib/rubocop/cop/style/constant_visibility.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks that constants defined in classes and modules have
+      # Checks that constants defined in classes and modules have
       # an explicit visibility declaration. By default, Ruby makes all class-
       # and module constants public, which litters the public API of the
       # class or module. Explicitly declaring a visibility makes intent more

--- a/lib/rubocop/cop/style/date_time.rb
+++ b/lib/rubocop/cop/style/date_time.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for consistent usage of the `DateTime` class over the
+      # Checks for consistent usage of the `DateTime` class over the
       # `Time` class. This cop is disabled by default since these classes,
       # although highly overlapping, have particularities that make them not
       # replaceable in certain situations when dealing with multiple timezones

--- a/lib/rubocop/cop/style/def_with_parentheses.rb
+++ b/lib/rubocop/cop/style/def_with_parentheses.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for parentheses in the definition of a method,
+      # Checks for parentheses in the definition of a method,
       # that does not take any arguments. Both instance and
       # class/singleton methods are checked.
       #

--- a/lib/rubocop/cop/style/dir.rb
+++ b/lib/rubocop/cop/style/dir.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for places where the `#__dir__` method can replace more
+      # Checks for places where the `#__dir__` method can replace more
       # complex constructs to retrieve a canonicalized absolute path to the
       # current file.
       #

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for missing top-level documentation of classes and
+      # Checks for missing top-level documentation of classes and
       # modules. Classes with no body are exempt from the check and so are
       # namespace modules - modules that have nothing in their bodies except
       # classes, other modules, constant definitions or constant visibility

--- a/lib/rubocop/cop/style/documentation_method.rb
+++ b/lib/rubocop/cop/style/documentation_method.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for missing documentation comment for public methods.
+      # Checks for missing documentation comment for public methods.
       # It can optionally be configured to also require documentation for
       # non-public methods.
       #

--- a/lib/rubocop/cop/style/double_negation.rb
+++ b/lib/rubocop/cop/style/double_negation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of double negation (`!!`) to convert something to a boolean value.
+      # Checks for uses of double negation (`!!`) to convert something to a boolean value.
       #
       # When using `EnforcedStyle: allowed_in_returns`, allow double negation in contexts
       # that use boolean as a return value. When using `EnforcedStyle: forbidden`, double negation

--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for loops which iterate a constant number of times,
+      # Checks for loops which iterate a constant number of times,
       # using a Range literal and `#each`. This can be done more readably using
       # `Integer#times`.
       #

--- a/lib/rubocop/cop/style/each_with_object.rb
+++ b/lib/rubocop/cop/style/each_with_object.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop looks for inject / reduce calls where the passed in object is
+      # Looks for inject / reduce calls where the passed in object is
       # returned at the end and so could be replaced by each_with_object without
       # the need to return the object at the end.
       #

--- a/lib/rubocop/cop/style/empty_block_parameter.rb
+++ b/lib/rubocop/cop/style/empty_block_parameter.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for pipes for empty block parameters. Pipes for empty
+      # Checks for pipes for empty block parameters. Pipes for empty
       # block parameters do not cause syntax errors, but they are redundant.
       #
       # @example

--- a/lib/rubocop/cop/style/empty_case_condition.rb
+++ b/lib/rubocop/cop/style/empty_case_condition.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for case statements with an empty condition.
+      # Checks for case statements with an empty condition.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/empty_lambda_parameter.rb
+++ b/lib/rubocop/cop/style/empty_lambda_parameter.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for parentheses for empty lambda parameters. Parentheses
+      # Checks for parentheses for empty lambda parameters. Parentheses
       # for empty lambda parameters do not cause syntax errors, but they are
       # redundant.
       #

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for the use of a method, the result of which
+      # Checks for the use of a method, the result of which
       # would be a literal, like an empty array, hash, or string.
       #
       # @example

--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for the formatting of empty method definitions.
+      # Checks for the formatting of empty method definitions.
       # By default it enforces empty method definitions to go on a single
       # line (compact style), but it can be configured to enforce the `end`
       # to go on its own line (expanded style).

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks ensures source files have no utf-8 encoding comments.
+      # Checks ensures source files have no utf-8 encoding comments.
       # @example
       #   # bad
       #   # encoding: UTF-8

--- a/lib/rubocop/cop/style/end_block.rb
+++ b/lib/rubocop/cop/style/end_block.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for END blocks.
+      # Checks for END blocks.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for endless methods.
+      # Checks for endless methods.
       #
       # It can enforce either the use of endless methods definitions
       # for single-lined method bodies, or disallow endless methods.

--- a/lib/rubocop/cop/style/env_home.rb
+++ b/lib/rubocop/cop/style/env_home.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for consistent usage of `ENV['HOME']`. If `nil` is used as
+      # Checks for consistent usage of `ENV['HOME']`. If `nil` is used as
       # the second argument of `ENV.fetch`, it is treated as a bad case like `ENV[]`.
       #
       # @safety

--- a/lib/rubocop/cop/style/eval_with_location.rb
+++ b/lib/rubocop/cop/style/eval_with_location.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop ensures that eval methods (`eval`, `instance_eval`, `class_eval`
+      # Ensures that eval methods (`eval`, `instance_eval`, `class_eval`
       # and `module_eval`) are given filename and line number values (`__FILE__`
       # and `__LINE__`). This data is used to ensure that any errors raised
       # within the evaluated code will be given the correct identification

--- a/lib/rubocop/cop/style/even_odd.rb
+++ b/lib/rubocop/cop/style/even_odd.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for places where `Integer#even?` or `Integer#odd?`
+      # Checks for places where `Integer#even?` or `Integer#odd?`
       # can be used.
       #
       # @example

--- a/lib/rubocop/cop/style/expand_path_arguments.rb
+++ b/lib/rubocop/cop/style/expand_path_arguments.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for use of the `File.expand_path` arguments.
+      # Checks for use of the `File.expand_path` arguments.
       # Likewise, it also checks for the `Pathname.new` argument.
       #
       # Contrastive bad case and good case are alternately shown in

--- a/lib/rubocop/cop/style/explicit_block_argument.rb
+++ b/lib/rubocop/cop/style/explicit_block_argument.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces the use of explicit block argument to avoid writing
+      # Enforces the use of explicit block argument to avoid writing
       # block literal that just passes its arguments to another block.
       #
       # NOTE: This cop only registers an offense if the block args match the

--- a/lib/rubocop/cop/style/exponential_notation.rb
+++ b/lib/rubocop/cop/style/exponential_notation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces consistency when using exponential notation
+      # Enforces consistency when using exponential notation
       # for numbers in the code (eg 1.2e4). Different styles are supported:
       #
       # * `scientific` which enforces a mantissa between 1 (inclusive) and 10 (exclusive).

--- a/lib/rubocop/cop/style/fetch_env_var.rb
+++ b/lib/rubocop/cop/style/fetch_env_var.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop suggests `ENV.fetch` for the replacement of `ENV[]`.
+      # Suggests `ENV.fetch` for the replacement of `ENV[]`.
       # `ENV[]` silently fails and returns `nil` when the environment variable is unset,
       # which may cause unexpected behaviors when the developer forgets to set it.
       # On the other hand, `ENV.fetch` raises KeyError or returns the explicitly

--- a/lib/rubocop/cop/style/float_division.rb
+++ b/lib/rubocop/cop/style/float_division.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for division with integers coerced to floats.
+      # Checks for division with integers coerced to floats.
       # It is recommended to either always use `fdiv` or coerce one side only.
       # This cop also provides other options for code consistency.
       #

--- a/lib/rubocop/cop/style/for.rb
+++ b/lib/rubocop/cop/style/for.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop looks for uses of the `for` keyword or `each` method. The
+      # Looks for uses of the `for` keyword or `each` method. The
       # preferred alternative is set in the EnforcedStyle configuration
       # parameter. An `each` call with a block on a single line is always
       # allowed.

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces the use of a single string formatting utility.
+      # Enforces the use of a single string formatting utility.
       # Valid options include Kernel#format, Kernel#sprintf and String#%.
       #
       # The detection of String#% cannot be implemented in a reliable

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop is designed to help you transition from mutable string literals
+      # Helps you transition from mutable string literals
       # to frozen string literals.
       # It will add the `# frozen_string_literal: true` magic comment to the top
       # of files to enable frozen string literals. Frozen string literals may be

--- a/lib/rubocop/cop/style/global_std_stream.rb
+++ b/lib/rubocop/cop/style/global_std_stream.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces the use of `$stdout/$stderr/$stdin` instead of `STDOUT/STDERR/STDIN`.
+      # Enforces the use of `$stdout/$stderr/$stdin` instead of `STDOUT/STDERR/STDIN`.
       # `STDOUT/STDERR/STDIN` are constants, and while you can actually
       # reassign (possibly to redirect some stream) constants in Ruby, you'll get
       # an interpreter warning if you do so.

--- a/lib/rubocop/cop/style/global_vars.rb
+++ b/lib/rubocop/cop/style/global_vars.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop looks for uses of global variables.
+      # Looks for uses of global variables.
       # It does not report offenses for built-in global variables.
       # Built-in global variables are allowed by default. Additionally
       # users can allow additional variables via the AllowedVariables option.

--- a/lib/rubocop/cop/style/hash_conversion.rb
+++ b/lib/rubocop/cop/style/hash_conversion.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks the usage of pre-2.1 `Hash[args]` method of converting enumerables and
+      # Checks the usage of pre-2.1 `Hash[args]` method of converting enumerables and
       # sequences of values to hashes.
       #
       # Correction code from splat argument (`Hash[*ary]`) is not simply determined. For example,

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of `each_key` and `each_value` Hash methods.
+      # Checks for uses of `each_key` and `each_value` Hash methods.
       #
       # NOTE: If you have an array of two-element arrays, you can put
       #   parentheses around the block arguments to indicate that you're not

--- a/lib/rubocop/cop/style/hash_except.rb
+++ b/lib/rubocop/cop/style/hash_except.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for usages of `Hash#reject`, `Hash#select`, and `Hash#filter` methods
+      # Checks for usages of `Hash#reject`, `Hash#select`, and `Hash#filter` methods
       # that can be replaced with `Hash#except` method.
       #
       # This cop should only be enabled on Ruby version 3.0 or higher.

--- a/lib/rubocop/cop/style/hash_like_case.rb
+++ b/lib/rubocop/cop/style/hash_like_case.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for places where `case-when` represents a simple 1:1
+      # Checks for places where `case-when` represents a simple 1:1
       # mapping and can be replaced with a hash lookup.
       #
       # @example MinBranchesCount: 3 (default)

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks hash literal syntax.
+      # Checks hash literal syntax.
       #
       # It can enforce either the use of the class hash rocket syntax or
       # the use of the newer Ruby 1.9 syntax (when applicable).

--- a/lib/rubocop/cop/style/hash_transform_keys.rb
+++ b/lib/rubocop/cop/style/hash_transform_keys.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop looks for uses of `_.each_with_object({}) {...}`,
+      # Looks for uses of `_.each_with_object({}) {...}`,
       # `_.map {...}.to_h`, and `Hash[_.map {...}]` that are actually just
       # transforming the keys of a hash, and tries to use a simpler & faster
       # call to `transform_keys` instead.

--- a/lib/rubocop/cop/style/hash_transform_values.rb
+++ b/lib/rubocop/cop/style/hash_transform_values.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop looks for uses of `_.each_with_object({}) {...}`,
+      # Looks for uses of `_.each_with_object({}) {...}`,
       # `_.map {...}.to_h`, and `Hash[_.map {...}]` that are actually just
       # transforming the values of a hash, and tries to use a simpler & faster
       # call to `transform_values` instead.

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for identical expressions at the beginning or end of
+      # Checks for identical expressions at the beginning or end of
       # each branch of a conditional expression. Such expressions should normally
       # be placed outside the conditional expression - before or after it.
       #

--- a/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
+++ b/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for redundant `if` with boolean literal branches.
+      # Checks for redundant `if` with boolean literal branches.
       # It checks only conditions to return boolean value (`true` or `false`) for safe detection.
       # The conditions to be checked are comparison methods, predicate methods, and double negative.
       #

--- a/lib/rubocop/cop/style/implicit_runtime_error.rb
+++ b/lib/rubocop/cop/style/implicit_runtime_error.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for `raise` or `fail` statements which do not specify an
+      # Checks for `raise` or `fail` statements which do not specify an
       # explicit exception class. (This raises a `RuntimeError`. Some projects
       # might prefer to use exception classes which more precisely identify the
       # nature of the error.)

--- a/lib/rubocop/cop/style/in_pattern_then.rb
+++ b/lib/rubocop/cop/style/in_pattern_then.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for `in;` uses in `case` expressions.
+      # Checks for `in;` uses in `case` expressions.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/inline_comment.rb
+++ b/lib/rubocop/cop/style/inline_comment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for trailing inline comments.
+      # Checks for trailing inline comments.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop check for usages of not (`not` or `!`) called on a method
+      # Check for usages of not (`not` or `!`) called on a method
       # when an inverse of that method can be used instead.
       #
       # Methods that can be inverted by a not (`not` or `!`) should be defined

--- a/lib/rubocop/cop/style/ip_addresses.rb
+++ b/lib/rubocop/cop/style/ip_addresses.rb
@@ -5,7 +5,7 @@ require 'resolv'
 module RuboCop
   module Cop
     module Style
-      # This cop checks for hardcoded IP addresses, which can make code
+      # Checks for hardcoded IP addresses, which can make code
       # brittle. IP addresses are likely to need to be changed when code
       # is deployed to a different server or environment, which may break
       # a deployment if forgotten. Prefer setting IP addresses in ENV or

--- a/lib/rubocop/cop/style/keyword_parameters_order.rb
+++ b/lib/rubocop/cop/style/keyword_parameters_order.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces that optional keyword parameters are placed at the
+      # Enforces that optional keyword parameters are placed at the
       # end of the parameters list.
       #
       # This improves readability, because when looking through the source,

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop (by default) checks for uses of the lambda literal syntax for
+      # (by default) checks for uses of the lambda literal syntax for
       # single line lambdas, and the method call syntax for multiline lambdas.
       # It is configurable to enforce one of the styles for both single line
       # and multiline lambdas as well.

--- a/lib/rubocop/cop/style/lambda_call.rb
+++ b/lib/rubocop/cop/style/lambda_call.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for use of the lambda.(args) syntax.
+      # Checks for use of the lambda.(args) syntax.
       #
       # @example EnforcedStyle: call (default)
       #  # bad

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for string literal concatenation at
+      # Checks for string literal concatenation at
       # the end of a line.
       #
       # @safety

--- a/lib/rubocop/cop/style/map_to_hash.rb
+++ b/lib/rubocop/cop/style/map_to_hash.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop looks for uses of `map.to_h` or `collect.to_h` that could be
+      # Looks for uses of `map.to_h` or `collect.to_h` that could be
       # written with just `to_h` in Ruby >= 2.6.
       #
       # NOTE: `Style/HashTransformKeys` and `Style/HashTransformValues` will

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces the presence (default) or absence of parentheses in
+      # Enforces the presence (default) or absence of parentheses in
       # method calls containing parameters.
       #
       # In the default style (require_parentheses), macro methods are ignored.

--- a/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for unwanted parentheses in parameterless method calls.
+      # Checks for unwanted parentheses in parameterless method calls.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/method_called_on_do_end_block.rb
+++ b/lib/rubocop/cop/style/method_called_on_do_end_block.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for methods called on a do...end block. The point of
+      # Checks for methods called on a do...end block. The point of
       # this check is that it's easy to miss the call tacked on to the block
       # when reading code.
       #

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for parentheses around the arguments in method
+      # Checks for parentheses around the arguments in method
       # definitions. Both instance and class/singleton methods are checked.
       #
       # Regardless of style, parentheses are necessary for:

--- a/lib/rubocop/cop/style/min_max.rb
+++ b/lib/rubocop/cop/style/min_max.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for potential uses of `Enumerable#minmax`.
+      # Checks for potential uses of `Enumerable#minmax`.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/missing_respond_to_missing.rb
+++ b/lib/rubocop/cop/style/missing_respond_to_missing.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for the presence of `method_missing` without also
+      # Checks for the presence of `method_missing` without also
       # defining `respond_to_missing?`.
       #
       # @example

--- a/lib/rubocop/cop/style/mixin_grouping.rb
+++ b/lib/rubocop/cop/style/mixin_grouping.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for grouping of mixins in `class` and `module` bodies.
+      # Checks for grouping of mixins in `class` and `module` bodies.
       # By default it enforces mixins to be placed in separate declarations,
       # but it can be configured to enforce grouping them in one declaration.
       #

--- a/lib/rubocop/cop/style/mixin_usage.rb
+++ b/lib/rubocop/cop/style/mixin_usage.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks that `include`, `extend` and `prepend` statements appear
+      # Checks that `include`, `extend` and `prepend` statements appear
       # inside classes and modules, not at the top level, so as to not affect
       # the behavior of `Object`.
       #

--- a/lib/rubocop/cop/style/module_function.rb
+++ b/lib/rubocop/cop/style/module_function.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for use of `extend self` or `module_function` in a
+      # Checks for use of `extend self` or `module_function` in a
       # module.
       #
       # Supported styles are: module_function, extend_self, forbidden. `forbidden`

--- a/lib/rubocop/cop/style/multiline_block_chain.rb
+++ b/lib/rubocop/cop/style/multiline_block_chain.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for chaining of a block after another block that spans
+      # Checks for chaining of a block after another block that spans
       # multiple lines.
       #
       # @example

--- a/lib/rubocop/cop/style/multiline_in_pattern_then.rb
+++ b/lib/rubocop/cop/style/multiline_in_pattern_then.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks uses of the `then` keyword in multi-line `in` statement.
+      # Checks uses of the `then` keyword in multi-line `in` statement.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/multiline_memoization.rb
+++ b/lib/rubocop/cop/style/multiline_memoization.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks expressions wrapping styles for multiline memoization.
+      # Checks expressions wrapping styles for multiline memoization.
       #
       # @example EnforcedStyle: keyword (default)
       #   # bad

--- a/lib/rubocop/cop/style/multiline_method_signature.rb
+++ b/lib/rubocop/cop/style/multiline_method_signature.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for method signatures that span multiple lines.
+      # Checks for method signatures that span multiple lines.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/multiline_ternary_operator.rb
+++ b/lib/rubocop/cop/style/multiline_ternary_operator.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for multi-line ternary op expressions.
+      # Checks for multi-line ternary op expressions.
       #
       # NOTE: `return if ... else ... end` is syntax error. If `return` is used before
       # multiline ternary operator expression, it will be autocorrected to single-line

--- a/lib/rubocop/cop/style/multiline_when_then.rb
+++ b/lib/rubocop/cop/style/multiline_when_then.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks uses of the `then` keyword
+      # Checks uses of the `then` keyword
       # in multi-line when statements.
       #
       # @example

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks against comparing a variable with multiple items, where
+      # Checks against comparing a variable with multiple items, where
       # `Array#include?`, `Set#include?` or a `case` could be used instead
       # to avoid code repetition.
       # It accepts comparisons of multiple method calls to avoid unnecessary method calls

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks whether some constant value isn't a
+      # Checks whether some constant value isn't a
       # mutable literal (e.g. array or hash).
       #
       # Strict mode can be used to freeze all constants, rather than

--- a/lib/rubocop/cop/style/negated_if_else_condition.rb
+++ b/lib/rubocop/cop/style/negated_if_else_condition.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of `if-else` and ternary operators with a negated condition
+      # Checks for uses of `if-else` and ternary operators with a negated condition
       # which can be simplified by inverting condition and swapping branches.
       #
       # @example

--- a/lib/rubocop/cop/style/nested_file_dirname.rb
+++ b/lib/rubocop/cop/style/nested_file_dirname.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for nested `File.dirname`.
+      # Checks for nested `File.dirname`.
       # It replaces nested `File.dirname` with the level argument introduced in Ruby 3.1.
       #
       # @example

--- a/lib/rubocop/cop/style/nested_modifier.rb
+++ b/lib/rubocop/cop/style/nested_modifier.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for nested use of if, unless, while and until in their
+      # Checks for nested use of if, unless, while and until in their
       # modifier form.
       #
       # @example

--- a/lib/rubocop/cop/style/nested_parenthesized_calls.rb
+++ b/lib/rubocop/cop/style/nested_parenthesized_calls.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for unparenthesized method calls in the argument list
+      # Checks for unparenthesized method calls in the argument list
       # of a parenthesized method call.
       #
       # @example

--- a/lib/rubocop/cop/style/nested_ternary_operator.rb
+++ b/lib/rubocop/cop/style/nested_ternary_operator.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for nested ternary op expressions.
+      # Checks for nested ternary op expressions.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for comparison of something with nil using `==` and
+      # Checks for comparison of something with nil using `==` and
       # `nil?`.
       #
       # Supported styles are: predicate, comparison.

--- a/lib/rubocop/cop/style/nil_lambda.rb
+++ b/lib/rubocop/cop/style/nil_lambda.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for lambdas and procs that always return nil,
+      # Checks for lambdas and procs that always return nil,
       # which can be replaced with an empty lambda or proc instead.
       #
       # @example

--- a/lib/rubocop/cop/style/non_nil_check.rb
+++ b/lib/rubocop/cop/style/non_nil_check.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for non-nil checks, which are usually redundant.
+      # Checks for non-nil checks, which are usually redundant.
       #
       # With `IncludeSemanticChanges` set to `false` by default, this cop
       # does not report offenses for `!x.nil?` and does no changes that might

--- a/lib/rubocop/cop/style/not.rb
+++ b/lib/rubocop/cop/style/not.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of the keyword `not` instead of `!`.
+      # Checks for uses of the keyword `not` instead of `!`.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/numbered_parameters.rb
+++ b/lib/rubocop/cop/style/numbered_parameters.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for numbered parameters.
+      # Checks for numbered parameters.
       #
       # It can either restrict the use of numbered parameters to
       # single-lined blocks, or disallow completely numbered parameters.

--- a/lib/rubocop/cop/style/numbered_parameters_limit.rb
+++ b/lib/rubocop/cop/style/numbered_parameters_limit.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop detects use of an excessive amount of numbered parameters in a
+      # Detects use of an excessive amount of numbered parameters in a
       # single block. Having too many numbered parameters can make code too
       # cryptic and hard to read.
       #

--- a/lib/rubocop/cop/style/numeric_literal_prefix.rb
+++ b/lib/rubocop/cop/style/numeric_literal_prefix.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for octal, hex, binary, and decimal literals using
+      # Checks for octal, hex, binary, and decimal literals using
       # uppercase prefixes and corrects them to lowercase prefix
       # or no prefix (in case of decimals).
       #

--- a/lib/rubocop/cop/style/numeric_literals.rb
+++ b/lib/rubocop/cop/style/numeric_literals.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for big numeric literals without _ between groups
+      # Checks for big numeric literals without _ between groups
       # of digits in them.
       #
       # @example

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for usage of comparison operators (`==`,
+      # Checks for usage of comparison operators (`==`,
       # `>`, `<`) to test numbers as zero, positive, or negative.
       # These can be replaced by their respective predicate methods.
       # The cop can also be configured to do the reverse.

--- a/lib/rubocop/cop/style/object_then.rb
+++ b/lib/rubocop/cop/style/object_then.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces the use of consistent method names
+      # Enforces the use of consistent method names
       # `Object#yield_self` or `Object#then`.
       #
       # @example EnforcedStyle: then (default)

--- a/lib/rubocop/cop/style/open_struct_use.rb
+++ b/lib/rubocop/cop/style/open_struct_use.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop flags uses of OpenStruct, as it is now officially discouraged
+      # Flags uses of OpenStruct, as it is now officially discouraged
       # to be used for performance, version compatibility, and potential security issues.
       #
       # @safety

--- a/lib/rubocop/cop/style/option_hash.rb
+++ b/lib/rubocop/cop/style/option_hash.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for options hashes and discourages them if the
+      # Checks for options hashes and discourages them if the
       # current Ruby version supports keyword arguments.
       #
       # @example

--- a/lib/rubocop/cop/style/optional_arguments.rb
+++ b/lib/rubocop/cop/style/optional_arguments.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for optional arguments to methods
+      # Checks for optional arguments to methods
       # that do not come at the end of the argument list.
       #
       # @safety

--- a/lib/rubocop/cop/style/optional_boolean_parameter.rb
+++ b/lib/rubocop/cop/style/optional_boolean_parameter.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for places where keyword arguments can be used instead of
+      # Checks for places where keyword arguments can be used instead of
       # boolean arguments when defining methods. `respond_to_missing?` method is allowed by default.
       # These are customizable with `AllowedMethods` option.
       #

--- a/lib/rubocop/cop/style/or_assignment.rb
+++ b/lib/rubocop/cop/style/or_assignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for potential usage of the `||=` operator.
+      # Checks for potential usage of the `||=` operator.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/parentheses_around_condition.rb
+++ b/lib/rubocop/cop/style/parentheses_around_condition.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for the presence of superfluous parentheses around the
+      # Checks for the presence of superfluous parentheses around the
       # condition of if/unless/while/until.
       #
       # `AllowSafeAssignment` option for safe assignment.

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces the consistent usage of `%`-literal delimiters.
+      # Enforces the consistent usage of `%`-literal delimiters.
       #
       # Specify the 'default' key to set all preferred delimiters at once. You
       # can continue to specify individual preferred delimiters to override the

--- a/lib/rubocop/cop/style/percent_q_literals.rb
+++ b/lib/rubocop/cop/style/percent_q_literals.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for usage of the %Q() syntax when %q() would do.
+      # Checks for usage of the %Q() syntax when %q() would do.
       #
       # @example EnforcedStyle: lower_case_q (default)
       #   # The `lower_case_q` style prefers `%q` unless

--- a/lib/rubocop/cop/style/perl_backrefs.rb
+++ b/lib/rubocop/cop/style/perl_backrefs.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop looks for uses of Perl-style regexp match
+      # Looks for uses of Perl-style regexp match
       # backreferences and their English versions like
       # $1, $2, $&, &+, $MATCH, $PREMATCH, etc.
       #

--- a/lib/rubocop/cop/style/preferred_hash_methods.rb
+++ b/lib/rubocop/cop/style/preferred_hash_methods.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of methods `Hash#has_key?` and
+      # Checks for uses of methods `Hash#has_key?` and
       # `Hash#has_value?`, and suggests using `Hash#key?` and `Hash#value?` instead.
       #
       # It is configurable to enforce the verbose method names, by using the

--- a/lib/rubocop/cop/style/proc.rb
+++ b/lib/rubocop/cop/style/proc.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of Proc.new where Kernel#proc
+      # Checks for uses of Proc.new where Kernel#proc
       # would be more appropriate.
       #
       # @example

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks the args passed to `fail` and `raise`. For exploded
+      # Checks the args passed to `fail` and `raise`. For exploded
       # style (default), it recommends passing the exception class and message
       # to `raise`, rather than construct an instance of the error. It will
       # still allow passing just a message, or the construction of an error

--- a/lib/rubocop/cop/style/random_with_offset.rb
+++ b/lib/rubocop/cop/style/random_with_offset.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for the use of randomly generated numbers,
+      # Checks for the use of randomly generated numbers,
       # added/subtracted with integer literals, as well as those with
       # Integer#succ and Integer#pred methods. Prefer using ranges instead,
       # as it clearly states the intentions.

--- a/lib/rubocop/cop/style/redundant_argument.rb
+++ b/lib/rubocop/cop/style/redundant_argument.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for a redundant argument passed to certain methods.
+      # Checks for a redundant argument passed to certain methods.
       #
       # NOTE: This cop is limited to methods with single parameter.
       #

--- a/lib/rubocop/cop/style/redundant_assignment.rb
+++ b/lib/rubocop/cop/style/redundant_assignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for redundant assignment before returning.
+      # Checks for redundant assignment before returning.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for redundant `begin` blocks.
+      # Checks for redundant `begin` blocks.
       #
       # Currently it checks for code like this:
       #

--- a/lib/rubocop/cop/style/redundant_capital_w.rb
+++ b/lib/rubocop/cop/style/redundant_capital_w.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for usage of the %W() syntax when %w() would do.
+      # Checks for usage of the %W() syntax when %w() would do.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for unnecessary conditional expressions.
+      # Checks for unnecessary conditional expressions.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/redundant_conditional.rb
+++ b/lib/rubocop/cop/style/redundant_conditional.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for redundant returning of true/false in conditionals.
+      # Checks for redundant returning of true/false in conditionals.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/redundant_exception.rb
+++ b/lib/rubocop/cop/style/redundant_exception.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for RuntimeError as the argument of raise/fail.
+      # Checks for RuntimeError as the argument of raise/fail.
       #
       # It checks for code like this:
       #

--- a/lib/rubocop/cop/style/redundant_fetch_block.rb
+++ b/lib/rubocop/cop/style/redundant_fetch_block.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop identifies places where `fetch(key) { value }`
+      # Identifies places where `fetch(key) { value }`
       # can be replaced by `fetch(key, value)`.
       #
       # In such cases `fetch(key, value)` method is faster

--- a/lib/rubocop/cop/style/redundant_file_extension_in_require.rb
+++ b/lib/rubocop/cop/style/redundant_file_extension_in_require.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for the presence of superfluous `.rb` extension in
+      # Checks for the presence of superfluous `.rb` extension in
       # the filename provided to `require` and `require_relative`.
       #
       # Note: If the extension is omitted, Ruby tries adding '.rb', '.so',

--- a/lib/rubocop/cop/style/redundant_freeze.rb
+++ b/lib/rubocop/cop/style/redundant_freeze.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop check for uses of `Object#freeze` on immutable objects.
+      # Check for uses of `Object#freeze` on immutable objects.
       #
       # NOTE: Regexp and Range literals are frozen objects since Ruby 3.0.
       #

--- a/lib/rubocop/cop/style/redundant_interpolation.rb
+++ b/lib/rubocop/cop/style/redundant_interpolation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for strings that are just an interpolated expression.
+      # Checks for strings that are just an interpolated expression.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for redundant parentheses.
+      # Checks for redundant parentheses.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/redundant_percent_q.rb
+++ b/lib/rubocop/cop/style/redundant_percent_q.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for usage of the %q/%Q syntax when '' or "" would do.
+      # Checks for usage of the %q/%Q syntax when '' or "" would do.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/redundant_regexp_character_class.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_character_class.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for unnecessary single-element Regexp character classes.
+      # Checks for unnecessary single-element Regexp character classes.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for redundant escapes inside Regexp literals.
+      # Checks for redundant escapes inside Regexp literals.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for redundant `return` expressions.
+      # Checks for redundant `return` expressions.
       #
       # @example
       #   # These bad cases should be extended to handle methods whose body is

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for redundant uses of `self`.
+      # Checks for redundant uses of `self`.
       #
       # The usage of `self` is only needed when:
       #

--- a/lib/rubocop/cop/style/redundant_self_assignment.rb
+++ b/lib/rubocop/cop/style/redundant_self_assignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for places where redundant assignments are made for in place
+      # Checks for places where redundant assignments are made for in place
       # modification methods.
       #
       # @safety

--- a/lib/rubocop/cop/style/redundant_self_assignment_branch.rb
+++ b/lib/rubocop/cop/style/redundant_self_assignment_branch.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for places where conditional branch makes redundant self-assignment.
+      # Checks for places where conditional branch makes redundant self-assignment.
       #
       # It only detects local variable because it may replace state of instance variable,
       # class variable, and global variable that have state across methods with `nil`.

--- a/lib/rubocop/cop/style/redundant_sort.rb
+++ b/lib/rubocop/cop/style/redundant_sort.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop is used to identify instances of sorting and then
+      # Identifies instances of sorting and then
       # taking only the first or last element. The same behavior can
       # be accomplished without a relatively expensive sort by using
       # `Enumerable#min` instead of sorting and taking the first

--- a/lib/rubocop/cop/style/redundant_sort_by.rb
+++ b/lib/rubocop/cop/style/redundant_sort_by.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop identifies places where `sort_by { ... }` can be replaced by
+      # Identifies places where `sort_by { ... }` can be replaced by
       # `sort`.
       #
       # @example

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces using // or %r around regular expressions.
+      # Enforces using // or %r around regular expressions.
       #
       # @example EnforcedStyle: slashes (default)
       #   # bad

--- a/lib/rubocop/cop/style/rescue_modifier.rb
+++ b/lib/rubocop/cop/style/rescue_modifier.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of rescue in its modifier form.
+      # Checks for uses of rescue in its modifier form.
       #
       # The cop to check `rescue` in its modifier form is added for following
       # reasons:

--- a/lib/rubocop/cop/style/rescue_standard_error.rb
+++ b/lib/rubocop/cop/style/rescue_standard_error.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for rescuing `StandardError`. There are two supported
+      # Checks for rescuing `StandardError`. There are two supported
       # styles `implicit` and `explicit`. This cop will not register an offense
       # if any error other than `StandardError` is specified.
       #

--- a/lib/rubocop/cop/style/return_nil.rb
+++ b/lib/rubocop/cop/style/return_nil.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces consistency between 'return nil' and 'return'.
+      # Enforces consistency between 'return nil' and 'return'.
       #
       # Supported styles are: return, return_nil.
       #

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop transforms usages of a method call safeguarded by a non `nil`
+      # Transforms usages of a method call safeguarded by a non `nil`
       # check for the variable whose method is being called to
       # safe navigation (`&.`). If there is a method chain, all of the methods
       # in the chain need to be checked for safety, and all of the methods will

--- a/lib/rubocop/cop/style/sample.rb
+++ b/lib/rubocop/cop/style/sample.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop is used to identify usages of `shuffle.first`,
+      # Identifies usages of `shuffle.first`,
       # `shuffle.last`, and `shuffle[]` and change them to use
       # `sample` instead.
       #

--- a/lib/rubocop/cop/style/select_by_regexp.rb
+++ b/lib/rubocop/cop/style/select_by_regexp.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop looks for places where an subset of an Enumerable (array,
+      # Looks for places where an subset of an Enumerable (array,
       # range, set, etc.; see note below) is calculated based on a `Regexp`
       # match, and suggests `grep` or `grep_v` instead.
       #

--- a/lib/rubocop/cop/style/self_assignment.rb
+++ b/lib/rubocop/cop/style/self_assignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces the use the shorthand for self-assignment.
+      # Enforces the use the shorthand for self-assignment.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for multiple expressions placed on the same line.
+      # Checks for multiple expressions placed on the same line.
       # It also checks for lines terminated with a semicolon.
       #
       # This cop has `AllowAsExpressionSeparator` configuration option.

--- a/lib/rubocop/cop/style/send.rb
+++ b/lib/rubocop/cop/style/send.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for the use of the send method.
+      # Checks for the use of the send method.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/signal_exception.rb
+++ b/lib/rubocop/cop/style/signal_exception.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of `fail` and `raise`.
+      # Checks for uses of `fail` and `raise`.
       #
       # @example EnforcedStyle: only_raise (default)
       #   # The `only_raise` style enforces the sole use of `raise`.

--- a/lib/rubocop/cop/style/single_line_block_params.rb
+++ b/lib/rubocop/cop/style/single_line_block_params.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks whether the block parameters of a single-line
+      # Checks whether the block parameters of a single-line
       # method accepting a block match the names specified via configuration.
       #
       # For instance one can configure `reduce`(`inject`) to use |a, e| as

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for single-line method definitions that contain a body.
+      # Checks for single-line method definitions that contain a body.
       # It will accept single-line methods with no body.
       #
       # Endless methods added in Ruby 3.0 are also accepted by this cop.

--- a/lib/rubocop/cop/style/slicing_with_range.rb
+++ b/lib/rubocop/cop/style/slicing_with_range.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks that arrays are sliced with endless ranges instead of
+      # Checks that arrays are sliced with endless ranges instead of
       # `ary[start..-1]` on Ruby 2.6+.
       #
       # @safety

--- a/lib/rubocop/cop/style/static_class.rb
+++ b/lib/rubocop/cop/style/static_class.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for places where classes with only class methods can be
+      # Checks for places where classes with only class methods can be
       # replaced with a module. Classes should be used only when it makes sense to create
       # instances out of them.
       #

--- a/lib/rubocop/cop/style/stderr_puts.rb
+++ b/lib/rubocop/cop/style/stderr_puts.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop identifies places where `$stderr.puts` can be replaced by
+      # Identifies places where `$stderr.puts` can be replaced by
       # `warn`. The latter has the advantage of easily being disabled by,
       # the `-W0` interpreter flag or setting `$VERBOSE` to `nil`.
       #

--- a/lib/rubocop/cop/style/string_concatenation.rb
+++ b/lib/rubocop/cop/style/string_concatenation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for places where string concatenation
+      # Checks for places where string concatenation
       # can be replaced with string interpolation.
       #
       # The cop can autocorrect simple cases but will skip autocorrecting

--- a/lib/rubocop/cop/style/string_hash_keys.rb
+++ b/lib/rubocop/cop/style/string_hash_keys.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for the use of strings as keys in hashes. The use of
+      # Checks for the use of strings as keys in hashes. The use of
       # symbols is preferred instead.
       #
       # @safety

--- a/lib/rubocop/cop/style/string_literals_in_interpolation.rb
+++ b/lib/rubocop/cop/style/string_literals_in_interpolation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks that quotes inside the string interpolation
+      # Checks that quotes inside the string interpolation
       # match the configured preference.
       #
       # @example EnforcedStyle: single_quotes (default)

--- a/lib/rubocop/cop/style/string_methods.rb
+++ b/lib/rubocop/cop/style/string_methods.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces the use of consistent method names
+      # Enforces the use of consistent method names
       # from the String class.
       #
       # @example

--- a/lib/rubocop/cop/style/strip.rb
+++ b/lib/rubocop/cop/style/strip.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop identifies places where `lstrip.rstrip` can be replaced by
+      # Identifies places where `lstrip.rstrip` can be replaced by
       # `strip`.
       #
       # @example

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for inheritance from Struct.new.
+      # Checks for inheritance from Struct.new.
       #
       # @safety
       #   Autocorrection is unsafe because it will change the inheritance

--- a/lib/rubocop/cop/style/swap_values.rb
+++ b/lib/rubocop/cop/style/swap_values.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop enforces the use of shorthand-style swapping of 2 variables.
+      # Enforces the use of shorthand-style swapping of 2 variables.
       #
       # @safety
       #   Autocorrection is unsafe, because the temporary variable used to

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop can check for array literals made up of symbols that are not
+      # Checks for array literals made up of symbols that are not
       # using the %i() syntax.
       #
       # Alternatively, it checks for symbol arrays using the %i() syntax on

--- a/lib/rubocop/cop/style/symbol_literal.rb
+++ b/lib/rubocop/cop/style/symbol_literal.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks symbol literal syntax.
+      # Checks symbol literal syntax.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for the presence of parentheses around ternary
+      # Checks for the presence of parentheses around ternary
       # conditions. It is configurable to enforce inclusion or omission of
       # parentheses using `EnforcedStyle`. Omission is only enforced when
       # removing the parentheses won't cause a different behavior.

--- a/lib/rubocop/cop/style/trailing_body_on_class.rb
+++ b/lib/rubocop/cop/style/trailing_body_on_class.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for trailing code after the class definition.
+      # Checks for trailing code after the class definition.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
+++ b/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for trailing code after the method definition.
+      # Checks for trailing code after the method definition.
       #
       # NOTE: It always accepts endless method definitions that are basically on the same line.
       #

--- a/lib/rubocop/cop/style/trailing_body_on_module.rb
+++ b/lib/rubocop/cop/style/trailing_body_on_module.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for trailing code after the module definition.
+      # Checks for trailing code after the module definition.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for trailing comma in argument lists.
+      # Checks for trailing comma in argument lists.
       # The supported styles are:
       #
       # * `consistent_comma`: Requires a comma after the last argument,

--- a/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for trailing comma in array literals.
+      # Checks for trailing comma in array literals.
       # The configuration options are:
       #
       # * `consistent_comma`: Requires a comma after the

--- a/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks whether trailing commas in block arguments are
+      # Checks whether trailing commas in block arguments are
       # required. Blocks with only one argument and a trailing comma require
       # that comma to be present. Blocks with more than one argument never
       # require a trailing comma.

--- a/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for trailing comma in hash literals.
+      # Checks for trailing comma in hash literals.
       # The configuration options are:
       #
       # * `consistent_comma`: Requires a comma after the

--- a/lib/rubocop/cop/style/trailing_method_end_statement.rb
+++ b/lib/rubocop/cop/style/trailing_method_end_statement.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for trailing code after the method definition.
+      # Checks for trailing code after the method definition.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/trailing_underscore_variable.rb
+++ b/lib/rubocop/cop/style/trailing_underscore_variable.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for extra underscores in variable assignment.
+      # Checks for extra underscores in variable assignment.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop looks for trivial reader/writer methods, that could
+      # Looks for trivial reader/writer methods, that could
       # have been created with the attr_* family of functions automatically.
       #
       # @example

--- a/lib/rubocop/cop/style/unless_else.rb
+++ b/lib/rubocop/cop/style/unless_else.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop looks for `unless` expressions with `else` clauses.
+      # Looks for `unless` expressions with `else` clauses.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/unless_logical_operators.rb
+++ b/lib/rubocop/cop/style/unless_logical_operators.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for the use of logical operators in an `unless` condition.
+      # Checks for the use of logical operators in an `unless` condition.
       # It discourages such code, as the condition becomes more difficult
       # to read and understand.
       #

--- a/lib/rubocop/cop/style/unpack_first.rb
+++ b/lib/rubocop/cop/style/unpack_first.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for accessing the first element of `String#unpack`
+      # Checks for accessing the first element of `String#unpack`
       # which can be replaced with the shorter method `unpack1`.
       #
       # @example

--- a/lib/rubocop/cop/style/variable_interpolation.rb
+++ b/lib/rubocop/cop/style/variable_interpolation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for variable interpolation (like "#@ivar").
+      # Checks for variable interpolation (like "#@ivar").
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/when_then.rb
+++ b/lib/rubocop/cop/style/when_then.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for `when;` uses in `case` expressions.
+      # Checks for `when;` uses in `case` expressions.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop can check for array literals made up of word-like
+      # Checks for array literals made up of word-like
       # strings, that are not using the %w() syntax.
       #
       # Alternatively, it can check for uses of the %w() syntax, in projects

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop can either enforce or forbid Yoda conditions,
+      # Enforces or forbids Yoda conditions,
       # i.e. comparison operations where the order of expression is reversed.
       # eg. `5 == x`
       #

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for numeric comparisons that can be replaced
+      # Checks for numeric comparisons that can be replaced
       # by a predicate method, such as receiver.length == 0,
       # receiver.length > 0, receiver.length != 0,
       # receiver.length < 1 and receiver.size == 0 that can be

--- a/spec/rubocop/cop/internal_affairs/cop_description_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/cop_description_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::InternalAffairs::CopDescription, :config do
+  before do
+    allow_any_instance_of(described_class).to receive(:relevant_file?).and_return(true) # rubocop:disable RSpec/AnyInstance
+  end
+
+  context 'The description starts with `This cop ...`' do
+    it 'registers an offense and corrects if using just a verb' do
+      expect_offense(<<~RUBY)
+        module RuboCop
+          module Cop
+            module Lint
+              # This cop checks some offenses...
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description should be started with `Checks` instead of `This cop ...`.
+              #
+              # ...
+              class Foo < Base
+              end
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module RuboCop
+          module Cop
+            module Lint
+              # Checks some offenses...
+              #
+              # ...
+              class Foo < Base
+              end
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense if using an auxiliary verb' do
+      expect_offense(<<~RUBY)
+        module RuboCop
+          module Cop
+            module Lint
+              # This cop can check some offenses...
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description should be started with a word such as verb instead of `This cop ...`.
+              #
+              # ...
+              class Foo < Base
+              end
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense if the description like `This cop is ...`' do
+      expect_offense(<<~RUBY)
+        module RuboCop
+          module Cop
+            module Lint
+              # This cop is used to...
+                ^^^^^^^^^^^^^^^^^^^^^^ Description should be started with a word such as verb instead of `This cop ...`.
+              #
+              # ...
+              class Foo < Base
+              end
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'The description starts with a word such as verb' do
+    it 'does not register if the description like `Checks`' do
+      expect_no_offenses(<<~RUBY)
+        module RuboCop
+          module Cop
+            module Lint
+              # Checks some problem
+              #
+              # ...
+              class Foo < Base
+              end
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register if the description starts with non-verb word' do
+      expect_no_offenses(<<~RUBY)
+        module RuboCop
+          module Cop
+            module Lint
+              # Either foo or bar ...
+              #
+              # ...
+              class Foo < Base
+              end
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'There is no description comment' do
+    it 'does not register offense' do
+      expect_no_offenses(<<~RUBY)
+        module RuboCop
+          module Cop
+            module Lint
+              class Foo < Base
+              end
+            end
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Added new internal cop to unify the grammar of cop descriptions. And removed "This cop" from each cop file.
Mentioned in https://github.com/rubocop/rubocop/pull/10612#issuecomment-1120673490.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] ~Squashed related commits together.~
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
