### PR TITLE
Fix default target Ruby version from 2.5 to 2.6

### DIFF
--- a/changelog/fix_default_target_ruby_version.md
+++ b/changelog/fix_default_target_ruby_version.md
@@ -1,0 +1,1 @@
+* [#10629](https://github.com/rubocop/rubocop/pull/10629): Fix default Ruby version from 2.5 to 2.6. ([@koic][])

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -5,7 +5,7 @@ module RuboCop
   # @api private
   class TargetRuby
     KNOWN_RUBIES = [2.5, 2.6, 2.7, 3.0, 3.1, 3.2].freeze
-    DEFAULT_VERSION = KNOWN_RUBIES.first
+    DEFAULT_VERSION = 2.6
 
     OBSOLETE_RUBIES = {
       1.9 => '0.41',
@@ -172,7 +172,7 @@ module RuboCop
         right_hand_side = version_from_gemspec_file(file)
         return if right_hand_side.nil?
 
-        find_minimal_known_ruby(right_hand_side)
+        find_default_minimal_known_ruby(right_hand_side)
       end
 
       def gemspec_filename
@@ -206,11 +206,13 @@ module RuboCop
         array.children.map(&:value)
       end
 
-      def find_minimal_known_ruby(right_hand_side)
+      def find_default_minimal_known_ruby(right_hand_side)
         version = version_from_right_hand_side(right_hand_side)
         requirement = Gem::Requirement.new(version)
 
-        KNOWN_RUBIES.detect { |v| requirement.satisfied_by?(Gem::Version.new("#{v}.99")) }
+        KNOWN_RUBIES.detect do |v|
+          v >= DEFAULT_VERSION && requirement.satisfied_by?(Gem::Version.new("#{v}.99"))
+        end
       end
     end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect($stderr.string).to eq ''
     expect($stdout.string)
       .to eq(["#{abs('example.rb')}:3:1: E: Lint/Syntax: unexpected " \
-              'token $end (Using Ruby 2.5 parser; configure using ' \
+              'token $end (Using Ruby 2.6 parser; configure using ' \
               '`TargetRubyVersion` parameter, under `AllCops`)',
               ''].join("\n"))
   end


### PR DESCRIPTION
This PR fixes default Ruby version from 2.5 to 2.6.

In #10626 (RuboCop 1.29.1) , the default target Ruby version is 2.5. This is an unexpected regression behavior and the default target Ruby version is expected to be 2.6.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
