### PR TITLE
[Fix #10627] Add command-line option `--ignore-unrecognized-cops`

### DIFF
--- a/changelog/new_add_commandline_option_ignore_unrecognized_cops.md
+++ b/changelog/new_add_commandline_option_ignore_unrecognized_cops.md
@@ -1,0 +1,1 @@
+* [#10627](https://github.com/rubocop/rubocop/issues/10627): Add command-line option `--ignore-unrecognized-cops` to ignore any unknown cops or departments in .rubocop.yml. ([@nobuyo][])

--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -210,6 +210,9 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | `--ignore-parent-exclusion`
 | Ignores all Exclude: settings from all .rubocop.yml files present in parent folders. This is useful when you are importing submodules when you want to test them without being affected by the parent module's rubocop settings.
 
+| `--ignore-unrecognized-cops`
+| Ignore unrecognized cops or departments in the config.
+
 | `--init`
 | Generate a .rubocop.yml file in the current directory.
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -124,6 +124,7 @@ module RuboCop
       ConfigLoader.disable_pending_cops = @options[:disable_pending_cops]
       ConfigLoader.enable_pending_cops = @options[:enable_pending_cops]
       ConfigLoader.ignore_parent_exclusion = @options[:ignore_parent_exclusion]
+      ConfigLoader.ignore_unrecognized_cops = @options[:ignore_unrecognized_cops]
     end
 
     def handle_exiting_options

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -22,7 +22,8 @@ module RuboCop
     class << self
       include FileFinder
 
-      attr_accessor :debug, :ignore_parent_exclusion, :disable_pending_cops, :enable_pending_cops
+      attr_accessor :debug, :ignore_parent_exclusion, :disable_pending_cops, :enable_pending_cops,
+                    :ignore_unrecognized_cops
       attr_writer :default_configuration, :project_root
       attr_reader :loaded_features
 

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -102,6 +102,18 @@ module RuboCop
     end
 
     def alert_about_unrecognized_cops(invalid_cop_names)
+      unknown_cops = list_unknown_cops(invalid_cop_names)
+
+      if ConfigLoader.ignore_unrecognized_cops
+        warn Rainbow('The following cops or departments are not '\
+                     'recognized and will be ignored:').yellow
+        warn unknown_cops.join("\n")
+      elsif unknown_cops.any?
+        raise ValidationError, unknown_cops.join("\n")
+      end
+    end
+
+    def list_unknown_cops(invalid_cop_names)
       unknown_cops = []
       invalid_cop_names.each do |name|
         # There could be a custom cop with this name. If so, don't warn
@@ -119,7 +131,8 @@ module RuboCop
 
         unknown_cops << message
       end
-      raise ValidationError, unknown_cops.join("\n") if unknown_cops.any?
+
+      unknown_cops
     end
 
     def suggestion(name)

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -93,6 +93,7 @@ module RuboCop
         option(opts, '--force-exclusion')
         option(opts, '--only-recognized-file-types')
         option(opts, '--ignore-parent-exclusion')
+        option(opts, '--ignore-unrecognized-cops')
         option(opts, '--force-default-config')
         option(opts, '-s', '--stdin FILE')
         option(opts, '-P', '--[no-]parallel')
@@ -496,6 +497,7 @@ module RuboCop
                                          'by a `rubocop:disable` directive.'],
       ignore_parent_exclusion:          ['Prevent from inheriting `AllCops/Exclude` from',
                                          'parent folders.'],
+      ignore_unrecognized_cops:         ['Ignore unrecognized cops or departments in the config.'],
       force_default_config:             ['Use default configuration even if configuration',
                                          'files are present in the directory tree.'],
       format:                           ['Choose an output formatter. This option',

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1479,6 +1479,36 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         OUTPUT
     end
 
+    it 'runs without errors for an unrecognized cop name in .rubocop.yml and `--ignore-unrecognized-cops` option is given' do
+      create_file('example/example1.rb', '# frozen_string_literal: true')
+
+      create_file('example/.rubocop.yml', <<~YAML)
+        Layout/LyneLenth:
+          Enabled: true
+          Max: 100
+        Linth:
+          Enabled: false
+        Lint/LiteralInCondition:
+          Enabled: true
+        Style/AlignHash:
+          Enabled: true
+      YAML
+
+      expect(cli.run(%w[--format simple example --ignore-unrecognized-cops])).to eq(0)
+      expect($stderr.string)
+        .to eq(<<~OUTPUT)
+          The following cops or departments are not recognized and will be ignored:
+          unrecognized cop or department Layout/LyneLenth found in example/.rubocop.yml
+          Did you mean `Layout/LineLength`?
+          unrecognized cop or department Linth found in example/.rubocop.yml
+          Did you mean `Lint`?
+          unrecognized cop or department Lint/LiteralInCondition found in example/.rubocop.yml
+          Did you mean `Lint/LiteralAsCondition`?
+          unrecognized cop or department Style/AlignHash found in example/.rubocop.yml
+          Did you mean `Style/Alias`, `Style/OptionHash`?
+        OUTPUT
+    end
+
     it 'prints a warning for an unrecognized configuration parameter' do
       create_file('example/example1.rb', '#' * 90)
 

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -36,6 +36,30 @@ RSpec.describe RuboCop::Config do
       end
     end
 
+    context 'when the configuration includes any unrecognized cop name and given `--ignore-unrecognized-cops` option' do
+      before do
+        create_file(configuration_path, <<~YAML)
+          LyneLenth:
+            Enabled: true
+            Max: 100
+        YAML
+        RuboCop::ConfigLoader.ignore_unrecognized_cops = true
+        $stderr = StringIO.new
+      end
+
+      after do
+        RuboCop::ConfigLoader.ignore_unrecognized_cops = nil
+        $stderr = STDERR
+      end
+
+      it 'raises an validation error' do
+        configuration
+        expect($stderr.string)
+          .to match('The following cops or departments are not recognized and will be ignored:\n'\
+                    'unrecognized cop or department LyneLenth found in .rubocop.yml')
+      end
+    end
+
     context 'when the configuration includes an empty section' do
       before { create_file(configuration_path, ['Layout/LineLength:']) }
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                of user configuration or default configuration.
                   --ignore-parent-exclusion    Prevent from inheriting `AllCops/Exclude` from
                                                parent folders.
+                  --ignore-unrecognized-cops   Ignore unrecognized cops or departments in the config.
                   --force-default-config       Use default configuration even if configuration
                                                files are present in the directory tree.
               -s, --stdin FILE                 Pipe source from STDIN, using FILE in offense


### PR DESCRIPTION
…to ignore any unknown cops or departments in .rubocop.yml.

Fixes #10627.

This PR implements new command-line option `--ignore-unrecognized-cops`.

```rb
# .rubocop.yml
AllCops:
  NewCops: enable

Foo:
  Enabled: true

Bar/Baz:
  Enabled: true
```

```sh
# run without option
$ rubocop
Error: unrecognized cop or department Foo found in .rubocop.yml
unrecognized cop or department Bar/Baz found in .rubocop.yml

# with option
$ bundle exec rubocop --ignore-unrecognized-cops
The following cops or departments are not recognized and will be ignored:
unrecognized cop or department Foo found in .rubocop.yml
unrecognized cop or department Bar/Baz found in .rubocop.yml
Inspecting 3 files
...

#...
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
