### PR TITLE
[Fix #10633] Fix infinite autocorrection loop in `Style/AccessorGrouping` when combining multiple of the same accessor

### DIFF
--- a/changelog/fix_fix_infinite_autocorrection_loop_in.md
+++ b/changelog/fix_fix_infinite_autocorrection_loop_in.md
@@ -1,0 +1,1 @@
+* [#10633](https://github.com/rubocop/rubocop/issues/10633): Fix infinite autocorrection loop in `Style/AccessorGrouping` when combining multiple of the same accessor. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/accessor_grouping.rb
+++ b/lib/rubocop/cop/style/accessor_grouping.rb
@@ -122,14 +122,14 @@ module RuboCop
         def preferred_accessors(node)
           if grouped_style?
             accessors = sibling_accessors(node)
-            group_accessors(node, accessors) if node == accessors.first
+            group_accessors(node, accessors) if node.loc == accessors.first.loc
           else
             separate_accessors(node)
           end
         end
 
         def group_accessors(node, accessors)
-          accessor_names = accessors.flat_map { |accessor| accessor.arguments.map(&:source) }
+          accessor_names = accessors.flat_map { |accessor| accessor.arguments.map(&:source) }.uniq
 
           "#{node.method_name} #{accessor_names.join(', ')}"
         end

--- a/spec/rubocop/cop/style/accessor_grouping_spec.rb
+++ b/spec/rubocop/cop/style/accessor_grouping_spec.rb
@@ -152,6 +152,33 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
         end
       RUBY
     end
+
+    it 'registers an offense and correct if the same accessor is listed twice' do
+      expect_offense(<<~RUBY)
+        class Foo
+          attr_reader :one
+          ^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes.
+          attr_reader :two
+          ^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes.
+          attr_reader :one
+          ^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          attr_reader :one, :two
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the same accessor is given more than once in the same statement' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          attr_reader :one, :one
+        end
+      RUBY
+    end
   end
 
   context 'when EnforcedStyle is separated' do
@@ -269,6 +296,33 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
         class Foo
           # Some comment
           attr_reader :one, :two
+        end
+      RUBY
+    end
+
+    it 'does not register an offense if the same accessor is listed twice' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          attr_reader :one
+          attr_reader :two
+          attr_reader :one
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when the same accessor is given more than once in the same statement' do
+      expect_offense(<<~RUBY)
+        class Foo
+          attr_reader :one, :two, :one
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use one attribute per `attr_reader`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          attr_reader :one
+          attr_reader :two
+        attr_reader :one
         end
       RUBY
     end


### PR DESCRIPTION
Previously when the same accessor was listed more than once, the autocorrection would continually add it to the grouped accessor. This fixes it to ensure that the accessor will only show up once.

Fixes #10633.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
