### PR TITLE
[Fix #10636] Fix false positive in `Style/RedundantCondition` when the branches call the same method on different receivers

### DIFF
--- a/changelog/fix_fix_false_positive_in.md
+++ b/changelog/fix_fix_false_positive_in.md
@@ -1,0 +1,1 @@
+* [#10636](https://github.com/rubocop/rubocop/issues/10636): Fix false positive in `Style/RedundantCondition` when the branches call the same method on different receivers. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -46,7 +46,7 @@ module RuboCop
           add_offense(range_of_offense(node), message: message) do |corrector|
             if node.ternary? && !branches_have_method?(node)
               correct_ternary(corrector, node)
-            elsif redudant_condition?(node)
+            elsif redundant_condition?(node)
               corrector.replace(node, node.if_branch.source)
             else
               corrected = make_ternary_form(node)
@@ -59,7 +59,7 @@ module RuboCop
         private
 
         def message(node)
-          if redudant_condition?(node)
+          if redundant_condition?(node)
             REDUNDANT_CONDITION
           else
             MSG
@@ -82,7 +82,7 @@ module RuboCop
             (node.ternary? || !else_branch.instance_of?(AST::Node) || else_branch.single_line?)
         end
 
-        def redudant_condition?(node)
+        def redundant_condition?(node)
           node.modifier_form? || !node.else_branch
         end
 
@@ -147,7 +147,11 @@ module RuboCop
 
           if_branch.send_type? && if_branch.arguments.count == 1 &&
             else_branch.send_type? && else_branch.arguments.count == 1 &&
-            if_branch.method?(else_branch.method_name)
+            same_method?(if_branch, else_branch)
+        end
+
+        def same_method?(if_branch, else_branch)
+          if_branch.method?(else_branch.method_name) && if_branch.receiver == else_branch.receiver
         end
 
         def if_source(if_branch)

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -376,6 +376,31 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
           end
         RUBY
       end
+
+      it 'registers an offense and correct when the branches are the same with the same receivers' do
+        expect_offense(<<~RUBY)
+          if x
+          ^^^^ Use double pipes `||` instead.
+            X.find(x)
+          else
+            X.find(y)
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          X.find(x || y)
+        RUBY
+      end
+
+      it 'does not register an offense when the branches are the same with different receivers' do
+        expect_no_offenses(<<~RUBY)
+          if x
+            X.find(x)
+          else
+            Y.find(y)
+          end
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #10636.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
