### PR TITLE
[Fix #10618] Fix `LineBreakCorrector` so that it won't remove a semicolon in the class/module body

### DIFF
--- a/changelog/fix_linebreakcorrector_so_that_it_wont_remove_semicolon_in_the_class_module_body.md
+++ b/changelog/fix_linebreakcorrector_so_that_it_wont_remove_semicolon_in_the_class_module_body.md
@@ -1,0 +1,1 @@
+* [#10618](https://github.com/rubocop/rubocop/issues/10618): Fix `LineBreakCorrector` so that it won't remove a semicolon in the class/module body. ([@johnny-miyake][])

--- a/lib/rubocop/cop/correctors/line_break_corrector.rb
+++ b/lib/rubocop/cop/correctors/line_break_corrector.rb
@@ -50,7 +50,13 @@ module RuboCop
 
         def semicolon(node)
           @semicolon ||= {}.compare_by_identity
-          @semicolon[node] ||= processed_source.tokens_within(node).find(&:semicolon?)
+          @semicolon[node] ||= processed_source.sorted_tokens.select(&:semicolon?).find do |token|
+            same_line?(token, node.body) && trailing_class_definition?(token, node.body)
+          end
+        end
+
+        def trailing_class_definition?(token, body)
+          token.column < body.loc.column
         end
       end
     end

--- a/spec/rubocop/cop/style/trailing_body_on_class_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_class_spec.rb
@@ -8,14 +8,26 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnClass, :config do
       class Foo; body
                  ^^^^ Place the first line of class body on its own line.
       end
+      class Foo body
+                ^^^^ Place the first line of class body on its own line.
+      end
       class Bar; def bar; end
                  ^^^^^^^^^^^^ Place the first line of class body on its own line.
+      end
+      class Bar def bar; end
+                ^^^^^^^^^^^^ Place the first line of class body on its own line.
       end
     RUBY
 
     expect_correction(<<~RUBY)
       class Foo#{trailing_whitespace}
         body
+      end
+      class Foo#{trailing_whitespace}
+        body
+      end
+      class Bar#{trailing_whitespace}
+        def bar; end
       end
       class Bar#{trailing_whitespace}
         def bar; end

--- a/spec/rubocop/cop/style/trailing_body_on_module_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_module_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnModule, :config do
       module Bar extend self
                  ^^^^^^^^^^^ Place the first line of module body on its own line.
       end
+      module Bar; def bar; end
+                  ^^^^^^^^^^^^ Place the first line of module body on its own line.
+      end
+      module Bar def bar; end
+                 ^^^^^^^^^^^^ Place the first line of module body on its own line.
+      end
     RUBY
 
     expect_correction(<<~RUBY)
@@ -19,6 +25,12 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnModule, :config do
       end
       module Bar#{trailing_whitespace}
         extend self
+      end
+      module Bar#{trailing_whitespace}
+        def bar; end
+      end
+      module Bar#{trailing_whitespace}
+        def bar; end
       end
     RUBY
   end


### PR DESCRIPTION
Fixes #10618

This PR fixes `LineBreakCorrector` (used by `Style/TrailingBodyOnClass` and `Style/TrailingBodyOnModule`).
It currently breaks the code by removing a semicolon in the class/module body when the class body is trailing class/module definition without a semicolon after the class/module name.

For example,
```ruby
class Foo def bar; end
end
class Foo bar
  a; b
end
```
is wrongly corrected into
```ruby
class Foo 
  def bar end # Unexpected correction
end
class Foo 
  bar
  a b # Unexpected correction
end
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
