### PR TITLE
[Fix #10639] Fix `Style/HashSyntax` to exclude files that violate it with `EnforceHashShorthandSyntax` when running `auto-gen-config`

### DIFF
--- a/changelog/fix_stylehashsyntax_not_adding_config_when_auto_gen_config.md
+++ b/changelog/fix_stylehashsyntax_not_adding_config_when_auto_gen_config.md
@@ -1,0 +1,1 @@
+* [#10639](https://github.com/rubocop/rubocop/issues/10639): Fix `Style/HashSyntax` to exclude files that violate it with `EnforceHashShorthandSyntax` when running `auto-gen-config`. ([@nobuyo][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -17,6 +17,7 @@ module RuboCop
 
           message = OMIT_HASH_VALUE_MSG
           replacement = "#{hash_key_source}:"
+          self.config_to_allow_offenses = { 'Enabled' => false }
         else
           return unless node.value_omission?
 
@@ -24,12 +25,16 @@ module RuboCop
           replacement = "#{hash_key_source}: #{hash_key_source}"
         end
 
+        register_offense(node, message, replacement)
+      end
+
+      private
+
+      def register_offense(node, message, replacement)
         add_offense(node.value, message: message) do |corrector|
           corrector.replace(node, replacement)
         end
       end
-
-      private
 
       def ignore_hash_shorthand_syntax?(pair_node)
         target_ruby_version <= 3.0 || enforced_shorthand_syntax == 'either' ||

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -1260,6 +1260,28 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         YAML
     end
 
+    context 'when hash value omission enabled', :ruby31 do
+      it 'generates Exclude if it solves all offenses' do
+        create_file('.rubocop.yml', <<~YAML)
+          AllCops:
+            NewCops: enable
+            TargetRubyVersion: 3.1
+        YAML
+        create_file('example1.rb', ['# frozen_string_literal: true', '', '{ a: a }'])
+
+        expect(cli.run(['--auto-gen-config'])).to eq(0)
+        expect(File.readlines('.rubocop_todo.yml')[10..].join)
+          .to eq(<<~YAML)
+            # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
+            # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
+            # SupportedShorthandSyntax: always, never, either
+            Style/HashSyntax:
+              Exclude:
+                - 'example1.rb'
+          YAML
+      end
+    end
+
     it 'can be called when there are no files to inspection' do
       expect(cli.run(['--auto-gen-config'])).to eq(0)
     end


### PR DESCRIPTION
Fixes #10639.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
