### PR TITLE
Rename `Gemspec/TestFilesAssignment` to `Gemspec/DeprecatedAttributeAssignment`

### DIFF
--- a/changelog/new_add_new_gemspec_deprecated_attribute_assignments_cop.md
+++ b/changelog/new_add_new_gemspec_deprecated_attribute_assignments_cop.md
@@ -1,0 +1,1 @@
+* [#10065](https://github.com/rubocop/rubocop/issues/10065): Add new `Gemspec/DeprecatedAttributeAssignment` cop. ([@koic][])

--- a/changelog/new_add_new_gemspec_test_files_assignment_cop.md
+++ b/changelog/new_add_new_gemspec_test_files_assignment_cop.md
@@ -1,1 +1,0 @@
-* [#10065](https://github.com/rubocop/rubocop/issues/10065): Add new `Gemspec/TestFilesAssignment` cop. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -254,6 +254,13 @@ Gemspec/DependencyVersion:
     - '**/*.gemspec'
   AllowedGems: []
 
+Gemspec/DeprecatedAttributeAssignment:
+  Description: Checks that deprecated attribute assignments are not set in a gemspec file.
+  Enabled: pending
+  VersionAdded: '<<next>>'
+  Include:
+    - '**/*.gemspec'
+
 Gemspec/DuplicatedAssignment:
   Description: 'An attribute assignment method calls should be listed only once in a gemspec.'
   Enabled: true
@@ -295,13 +302,6 @@ Gemspec/RubyVersionGlobalsUsage:
   StyleGuide: '#no-ruby-version-in-the-gemspec'
   Enabled: true
   VersionAdded: '0.72'
-  Include:
-    - '**/*.gemspec'
-
-Gemspec/TestFilesAssignment:
-  Description: Checks that the `test_files` attribute is not set in a gemspec file.
-  Enabled: pending
-  VersionAdded: '<<next>>'
   Include:
     - '**/*.gemspec'
 

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -162,12 +162,12 @@ require_relative 'rubocop/cop/bundler/ordered_gems'
 
 require_relative 'rubocop/cop/gemspec/date_assignment'
 require_relative 'rubocop/cop/gemspec/dependency_version'
+require_relative 'rubocop/cop/gemspec/deprecated_attribute_assignment'
 require_relative 'rubocop/cop/gemspec/duplicated_assignment'
 require_relative 'rubocop/cop/gemspec/ordered_dependencies'
 require_relative 'rubocop/cop/gemspec/require_mfa'
 require_relative 'rubocop/cop/gemspec/required_ruby_version'
 require_relative 'rubocop/cop/gemspec/ruby_version_globals_usage'
-require_relative 'rubocop/cop/gemspec/test_files_assignment'
 
 require_relative 'rubocop/cop/layout/access_modifier_indentation'
 require_relative 'rubocop/cop/layout/argument_alignment'

--- a/lib/rubocop/cop/gemspec/deprecated_attribute_assignment.rb
+++ b/lib/rubocop/cop/gemspec/deprecated_attribute_assignment.rb
@@ -3,8 +3,8 @@
 module RuboCop
   module Cop
     module Gemspec
-      # Checks that the `test_files` attribute is not set in a gemspec file.
-      # Removing it allows the user to receive smaller packed gems.
+      # Checks that deprecated attribute attributes are not set in a gemspec file.
+      # Removing `test_files` allows the user to receive smaller packed gems.
       #
       # @example
       #
@@ -25,7 +25,7 @@ module RuboCop
       #     spec.name = 'your_cool_gem_name'
       #   end
       #
-      class TestFilesAssignment < Base
+      class DeprecatedAttributeAssignment < Base
         include RangeHelp
         extend AutoCorrector
 

--- a/spec/rubocop/cop/gemspec/deprecated_attribute_assignment_spec.rb
+++ b/spec/rubocop/cop/gemspec/deprecated_attribute_assignment_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Gemspec::TestFilesAssignment, :config do
+RSpec.describe RuboCop::Cop::Gemspec::DeprecatedAttributeAssignment, :config do
   it 'registers and corrects an offense when using `s.test_files =`' do
     expect_offense(<<~RUBY)
       Gem::Specification.new do |s|


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10105#issuecomment-924588815.

This PR renames `Gemspec/TestFilesAssignment` to `Gemspec/DeprecatedAttributeAssignment`.

The already released `Gemspec/DateAssignment` can be integrated in the future. However that integration is pending as breaking changes cannot be made in RuboCop 1.x.

Anyway, I think #10634 can be able to integrate into the cop of this name.

There is no changelog as this is an unreleased cop naming change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
