### PR TITLE
Recover Ruby 2.2 code analysis using `TargetRubyVersion: 2.2`

### DIFF
--- a/changelog/changelog/fix_recover_ruby_22_code_analysis.md
+++ b/changelog/changelog/fix_recover_ruby_22_code_analysis.md
@@ -1,0 +1,1 @@
+* [#10644](https://github.com/rubocop/rubocop/pull/10644): Recover Ruby 2.2 code analysis using `TargetRubyVersion: 2.2`. ([@koic][])

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -25,6 +25,9 @@ module RuboCop
       #   x&.foo || bar
       class SafeNavigationChain < Base
         include NilMethods
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.3
 
         MSG = 'Do not chain ordinary method call after safe navigation operator.'
 

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -8,7 +8,7 @@ module RuboCop
       # It will add the `# frozen_string_literal: true` magic comment to the top
       # of files to enable frozen string literals. Frozen string literals may be
       # default in future Ruby. The comment will be added below a shebang and
-      # encoding comment.
+      # encoding comment. The frozen string literal comment is only valid in Ruby 2.3+.
       #
       # Note that the cop will accept files where the comment exists but is set
       # to `false` instead of `true`.
@@ -86,6 +86,9 @@ module RuboCop
         include FrozenStringLiteral
         include RangeHelp
         extend AutoCorrector
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.3
 
         MSG_MISSING_TRUE = 'Missing magic comment `# frozen_string_literal: true`.'
         MSG_MISSING = 'Missing frozen string literal comment.'

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -82,7 +82,7 @@ module RuboCop
               predicate(node)
             end
 
-          return unless numeric && operator
+          return unless numeric && operator && replacement_supported?(operator)
 
           [numeric, replacement(numeric, operator)]
         end
@@ -105,6 +105,14 @@ module RuboCop
 
         def require_parentheses?(node)
           node.send_type? && node.binary_operation? && !node.parenthesized?
+        end
+
+        def replacement_supported?(operator)
+          if %i[> <].include?(operator)
+            target_ruby_version >= 2.3
+          else
+            true
+          end
         end
 
         def invert

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -159,7 +159,7 @@ module RuboCop
       private
 
       def compatible_external_encoding_for?(src)
-        src = src.dup if RUBY_ENGINE == 'jruby'
+        src = src.dup if RUBY_VERSION < '2.3' || RUBY_ENGINE == 'jruby'
         src.force_encoding(Encoding.default_external).valid_encoding?
       end
     end

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -116,6 +116,10 @@ RSpec.shared_context 'mock console output' do
   end
 end
 
+RSpec.shared_context 'ruby 2.2', :ruby22 do
+  let(:ruby_version) { 2.2 }
+end
+
 RSpec.shared_context 'ruby 2.3', :ruby23 do
   let(:ruby_version) { 2.3 }
 end

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -4,7 +4,7 @@ module RuboCop
   # The kind of Ruby that code inspected by RuboCop is written in.
   # @api private
   class TargetRuby
-    KNOWN_RUBIES = [2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2].freeze
+    KNOWN_RUBIES = [2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2].freeze
     DEFAULT_VERSION = 2.6
 
     OBSOLETE_RUBIES = {

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1724,7 +1724,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           'Error: RuboCop found unknown Ruby version 4.0 in `TargetRubyVersion`'
         )
         expect($stderr.string.strip).to match(
-          /Supported versions: 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2/
+          /Supported versions: 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2/
         )
       end
     end
@@ -1746,7 +1746,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           /2\.0-compatible analysis was dropped after version 0\.50/
         )
 
-        expect($stderr.string.strip).to match(/Supported versions: 2.3/)
+        expect($stderr.string.strip).to match(/Supported versions: 2.2/)
       end
     end
   end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1188,7 +1188,7 @@ RSpec.describe RuboCop::ConfigLoader do
       end
 
       context 'when the specified version is obsolete' do
-        let(:inherited_version) { '2.2' }
+        let(:inherited_version) { '2.1' }
 
         context 'and it is not overridden' do
           before do
@@ -1199,7 +1199,7 @@ RSpec.describe RuboCop::ConfigLoader do
 
           it 'raises a validation error' do
             expect { configuration_from_file }.to raise_error(RuboCop::ValidationError) do |error|
-              expect(error.message).to start_with('RuboCop found unsupported Ruby version 2.2')
+              expect(error.message).to start_with('RuboCop found unsupported Ruby version 2.1')
             end
           end
         end

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -7,79 +7,173 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
     end
   end
 
-  [
-    ['ordinary method chain', 'x.foo.bar.baz'],
-    ['ordinary method chain with argument', 'x.foo(x).bar(y).baz(z)'],
-    ['method chain with safe navigation only', 'x&.foo&.bar&.baz'],
-    ['method chain with safe navigation only with argument',
-     'x&.foo(x)&.bar(y)&.baz(z)'],
-    ['safe navigation at last only', 'x.foo.bar&.baz'],
-    ['safe navigation at last only with argument', 'x.foo(x).bar(y)&.baz(z)'],
-    ['safe navigation with == operator', 'x&.foo == bar'],
-    ['safe navigation with === operator', 'x&.foo === bar'],
-    ['safe navigation with || operator', 'x&.foo || bar'],
-    ['safe navigation with && operator', 'x&.foo && bar'],
-    ['safe navigation with | operator', 'x&.foo | bar'],
-    ['safe navigation with & operator', 'x&.foo & bar'],
-    ['safe navigation with `nil?` method', 'x&.foo.nil?'],
-    ['safe navigation with `present?` method', 'x&.foo.present?'],
-    ['safe navigation with `blank?` method', 'x&.foo.blank?'],
-    ['safe navigation with `try` method', 'a&.b.try(:c)'],
-    ['safe navigation with assignment method', 'x&.foo = bar'],
-    ['safe navigation with self assignment method', 'x&.foo += bar'],
-    ['safe navigation with `to_d` method', 'x&.foo.to_d'],
-    ['safe navigation with `in?` method', 'x&.foo.in?([:baz, :qux])']
-  ].each do |name, code|
-    include_examples 'accepts', name, code
-  end
+  context 'TargetRubyVersion >= 2.3', :ruby23 do
+    [
+      ['ordinary method chain', 'x.foo.bar.baz'],
+      ['ordinary method chain with argument', 'x.foo(x).bar(y).baz(z)'],
+      ['method chain with safe navigation only', 'x&.foo&.bar&.baz'],
+      ['method chain with safe navigation only with argument',
+       'x&.foo(x)&.bar(y)&.baz(z)'],
+      ['safe navigation at last only', 'x.foo.bar&.baz'],
+      ['safe navigation at last only with argument', 'x.foo(x).bar(y)&.baz(z)'],
+      ['safe navigation with == operator', 'x&.foo == bar'],
+      ['safe navigation with === operator', 'x&.foo === bar'],
+      ['safe navigation with || operator', 'x&.foo || bar'],
+      ['safe navigation with && operator', 'x&.foo && bar'],
+      ['safe navigation with | operator', 'x&.foo | bar'],
+      ['safe navigation with & operator', 'x&.foo & bar'],
+      ['safe navigation with `nil?` method', 'x&.foo.nil?'],
+      ['safe navigation with `present?` method', 'x&.foo.present?'],
+      ['safe navigation with `blank?` method', 'x&.foo.blank?'],
+      ['safe navigation with `try` method', 'a&.b.try(:c)'],
+      ['safe navigation with assignment method', 'x&.foo = bar'],
+      ['safe navigation with self assignment method', 'x&.foo += bar'],
+      ['safe navigation with `to_d` method', 'x&.foo.to_d'],
+      ['safe navigation with `in?` method', 'x&.foo.in?([:baz, :qux])']
+    ].each do |name, code|
+      include_examples 'accepts', name, code
+    end
 
-  it 'registers an offense for ordinary method call exists after safe navigation method call' do
-    expect_offense(<<~RUBY)
-      x&.foo.bar
-            ^^^^ Do not chain ordinary method call after safe navigation operator.
-    RUBY
-  end
+    it 'registers an offense for ordinary method call exists after safe navigation method call' do
+      expect_offense(<<~RUBY)
+        x&.foo.bar
+              ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
 
-  it 'registers an offense for ordinary method call exists after ' \
-     'safe navigation method call with an argument' do
-    expect_offense(<<~RUBY)
-      x&.foo(x).bar(y)
-               ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-    RUBY
-  end
+    it 'registers an offense for ordinary method call exists after ' \
+       'safe navigation method call with an argument' do
+      expect_offense(<<~RUBY)
+        x&.foo(x).bar(y)
+                 ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
 
-  it 'registers an offense for ordinary method chain exists after safe navigation method call' do
-    expect_offense(<<~RUBY)
-      something
-      x&.foo.bar.baz
-            ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-    RUBY
-  end
+    it 'registers an offense for ordinary method chain exists after safe navigation method call' do
+      expect_offense(<<~RUBY)
+        something
+        x&.foo.bar.baz
+              ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
 
-  it 'registers an offense for ordinary method chain exists after ' \
-     'safe navigation method call with an argument' do
-    expect_offense(<<~RUBY)
-      x&.foo(x).bar(y).baz(z)
-               ^^^^^^^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-    RUBY
-  end
+    it 'registers an offense for ordinary method chain exists after ' \
+       'safe navigation method call with an argument' do
+      expect_offense(<<~RUBY)
+        x&.foo(x).bar(y).baz(z)
+                 ^^^^^^^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
 
-  it 'registers an offense for ordinary method chain exists after ' \
-     'safe navigation method call with a block-pass' do
-    expect_offense(<<~RUBY)
-      something
-      x&.select(&:foo).bar
-                      ^^^^ Do not chain ordinary method call after safe navigation operator.
-    RUBY
-  end
+    it 'registers an offense for ordinary method chain exists after ' \
+       'safe navigation method call with a block-pass' do
+      expect_offense(<<~RUBY)
+        something
+        x&.select(&:foo).bar
+                        ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
 
-  it 'registers an offense for ordinary method chain exists after ' \
-     'safe navigation method call with a block' do
-    expect_offense(<<~RUBY)
-      something
-      x&.select { |x| foo(x) }.bar
-                              ^^^^ Do not chain ordinary method call after safe navigation operator.
-    RUBY
+    it 'registers an offense for ordinary method chain exists after ' \
+       'safe navigation method call with a block' do
+      expect_offense(<<~RUBY)
+        something
+        x&.select { |x| foo(x) }.bar
+                                ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with < operator' do
+      expect_offense(<<~RUBY)
+        x&.foo < bar
+              ^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with > operator' do
+      expect_offense(<<~RUBY)
+        x&.foo > bar
+              ^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with <= operator' do
+      expect_offense(<<~RUBY)
+        x&.foo <= bar
+              ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with >= operator' do
+      expect_offense(<<~RUBY)
+        x&.foo >= bar
+              ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with + operator' do
+      expect_offense(<<~RUBY)
+        x&.foo + bar
+              ^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with [] operator' do
+      expect_offense(<<~RUBY)
+        x&.foo[bar]
+              ^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with []= operator' do
+      expect_offense(<<~RUBY)
+        x&.foo[bar] = baz
+              ^^^^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    context 'proper highlighting' do
+      it 'when there are methods before' do
+        expect_offense(<<~RUBY)
+          something
+          x&.foo.bar.baz
+                ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+        RUBY
+      end
+
+      it 'when there are methods after' do
+        expect_offense(<<~RUBY)
+          x&.foo.bar.baz
+                ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+          something
+        RUBY
+      end
+
+      it 'when in a method' do
+        expect_offense(<<~RUBY)
+          def something
+            x&.foo.bar.baz
+                  ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+          end
+        RUBY
+      end
+
+      it 'when in a begin' do
+        expect_offense(<<~RUBY)
+          begin
+            x&.foo.bar.baz
+                  ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+          end
+        RUBY
+      end
+
+      it 'when used with a modifier if' do
+        expect_offense(<<~RUBY)
+          x&.foo.bar.baz if something
+                ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+        RUBY
+      end
+    end
   end
 
   context '>= Ruby 2.7', :ruby27 do
@@ -89,98 +183,6 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
         something
         x&.select { foo(_1) }.bar
                              ^^^^ Do not chain ordinary method call after safe navigation operator.
-      RUBY
-    end
-  end
-
-  it 'registers an offense for safe navigation with < operator' do
-    expect_offense(<<~RUBY)
-      x&.foo < bar
-            ^^^^^^ Do not chain ordinary method call after safe navigation operator.
-    RUBY
-  end
-
-  it 'registers an offense for safe navigation with > operator' do
-    expect_offense(<<~RUBY)
-      x&.foo > bar
-            ^^^^^^ Do not chain ordinary method call after safe navigation operator.
-    RUBY
-  end
-
-  it 'registers an offense for safe navigation with <= operator' do
-    expect_offense(<<~RUBY)
-      x&.foo <= bar
-            ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-    RUBY
-  end
-
-  it 'registers an offense for safe navigation with >= operator' do
-    expect_offense(<<~RUBY)
-      x&.foo >= bar
-            ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-    RUBY
-  end
-
-  it 'registers an offense for safe navigation with + operator' do
-    expect_offense(<<~RUBY)
-      x&.foo + bar
-            ^^^^^^ Do not chain ordinary method call after safe navigation operator.
-    RUBY
-  end
-
-  it 'registers an offense for safe navigation with [] operator' do
-    expect_offense(<<~RUBY)
-      x&.foo[bar]
-            ^^^^^ Do not chain ordinary method call after safe navigation operator.
-    RUBY
-  end
-
-  it 'registers an offense for safe navigation with []= operator' do
-    expect_offense(<<~RUBY)
-      x&.foo[bar] = baz
-            ^^^^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-    RUBY
-  end
-
-  context 'proper highlighting' do
-    it 'when there are methods before' do
-      expect_offense(<<~RUBY)
-        something
-        x&.foo.bar.baz
-              ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-      RUBY
-    end
-
-    it 'when there are methods after' do
-      expect_offense(<<~RUBY)
-        x&.foo.bar.baz
-              ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-        something
-      RUBY
-    end
-
-    it 'when in a method' do
-      expect_offense(<<~RUBY)
-        def something
-          x&.foo.bar.baz
-                ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-        end
-      RUBY
-    end
-
-    it 'when in a begin' do
-      expect_offense(<<~RUBY)
-        begin
-          x&.foo.bar.baz
-                ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-        end
-      RUBY
-    end
-
-    it 'when used with a modifier if' do
-      expect_offense(<<~RUBY)
-        x&.foo.bar.baz if something
-              ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
       RUBY
     end
   end

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
       end
     end
 
-    context 'when frozen string literals is enabled' do
+    context 'when frozen string literals is enabled', :ruby23 do
       it 'does not register an offense for String.new' do
         expect_no_offenses(<<~RUBY)
           # frozen_string_literal: true

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
       RUBY
     end
 
-    context 'when using safe navigation operator' do
+    context 'when using safe navigation operator', :ruby23 do
       it 'does not break' do
         expect_no_offenses(<<~RUBY)
           def func

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -1042,4 +1042,22 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       RUBY
     end
   end
+
+  context 'target_ruby_version < 2.3', :ruby22 do
+    it 'accepts freezing a string' do
+      expect_no_offenses('"x".freeze')
+    end
+
+    it 'accepts calling << on a string' do
+      expect_no_offenses('"x" << "y"')
+    end
+
+    it 'accepts freezing a string with interpolation' do
+      expect_no_offenses('"#{foo}bar".freeze')
+    end
+
+    it 'accepts calling << on a string with interpolation' do
+      expect_no_offenses('"#{foo}bar" << "baz"')
+    end
+  end
 end

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -513,7 +513,7 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
     end
   end
 
-  context 'when using safe navigation operator' do
+  context 'when using safe navigation operator', :ruby23 do
     it 'does not break' do
       expect_no_offenses(<<~RUBY)
         foo&.bar do |_|

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -89,97 +89,113 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
     end
 
     context 'when checking if a number is positive' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          number > 0
-          ^^^^^^^^^^ Use `number.positive?` instead of `number > 0`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          number.positive?
-        RUBY
-      end
-
-      it 'registers an offense in yoda condition' do
-        expect_offense(<<~RUBY)
-          0 < number
-          ^^^^^^^^^^ Use `number.positive?` instead of `0 < number`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          number.positive?
-        RUBY
-      end
-
-      context 'with a complex expression' do
+      context 'when target ruby version is 2.3 or higher', :ruby23 do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
-            foo - 1 > 0
-            ^^^^^^^^^^^ Use `(foo - 1).positive?` instead of `foo - 1 > 0`.
+            number > 0
+            ^^^^^^^^^^ Use `number.positive?` instead of `number > 0`.
           RUBY
 
           expect_correction(<<~RUBY)
-            (foo - 1).positive?
+            number.positive?
           RUBY
         end
 
         it 'registers an offense in yoda condition' do
           expect_offense(<<~RUBY)
-            0 < foo - 1
-            ^^^^^^^^^^^ Use `(foo - 1).positive?` instead of `0 < foo - 1`.
+            0 < number
+            ^^^^^^^^^^ Use `number.positive?` instead of `0 < number`.
           RUBY
 
           expect_correction(<<~RUBY)
-            (foo - 1).positive?
+            number.positive?
           RUBY
+        end
+
+        context 'with a complex expression' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              foo - 1 > 0
+              ^^^^^^^^^^^ Use `(foo - 1).positive?` instead of `foo - 1 > 0`.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              (foo - 1).positive?
+            RUBY
+          end
+
+          it 'registers an offense in yoda condition' do
+            expect_offense(<<~RUBY)
+              0 < foo - 1
+              ^^^^^^^^^^^ Use `(foo - 1).positive?` instead of `0 < foo - 1`.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              (foo - 1).positive?
+            RUBY
+          end
+        end
+      end
+
+      context 'when target ruby version is 2.2 or lower', :ruby22 do
+        it 'does not register an offense' do
+          expect_no_offenses('number > 0')
         end
       end
     end
 
     context 'when checking if a number is negative' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          number < 0
-          ^^^^^^^^^^ Use `number.negative?` instead of `number < 0`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          number.negative?
-        RUBY
-      end
-
-      it 'registers an offense in yoda condition' do
-        expect_offense(<<~RUBY)
-          0 > number
-          ^^^^^^^^^^ Use `number.negative?` instead of `0 > number`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          number.negative?
-        RUBY
-      end
-
-      context 'with a complex expression' do
+      context 'when target ruby version is 2.3 or higher', :ruby23 do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
-            foo - 1 < 0
-            ^^^^^^^^^^^ Use `(foo - 1).negative?` instead of `foo - 1 < 0`.
+            number < 0
+            ^^^^^^^^^^ Use `number.negative?` instead of `number < 0`.
           RUBY
 
           expect_correction(<<~RUBY)
-            (foo - 1).negative?
+            number.negative?
           RUBY
         end
 
         it 'registers an offense in yoda condition' do
           expect_offense(<<~RUBY)
-            0 > foo - 1
-            ^^^^^^^^^^^ Use `(foo - 1).negative?` instead of `0 > foo - 1`.
+            0 > number
+            ^^^^^^^^^^ Use `number.negative?` instead of `0 > number`.
           RUBY
 
           expect_correction(<<~RUBY)
-            (foo - 1).negative?
+            number.negative?
           RUBY
+        end
+
+        context 'with a complex expression' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              foo - 1 < 0
+              ^^^^^^^^^^^ Use `(foo - 1).negative?` instead of `foo - 1 < 0`.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              (foo - 1).negative?
+            RUBY
+          end
+
+          it 'registers an offense in yoda condition' do
+            expect_offense(<<~RUBY)
+              0 > foo - 1
+              ^^^^^^^^^^^ Use `(foo - 1).negative?` instead of `0 > foo - 1`.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              (foo - 1).negative?
+            RUBY
+          end
+        end
+      end
+
+      context 'when target ruby version is 2.2 or lower', :ruby22 do
+        it 'does not register an offense' do
+          expect_no_offenses('number < 0')
         end
       end
     end
@@ -285,26 +301,46 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
       end
 
       context 'not ignored method' do
-        it 'registers an offense for checking if a number is positive' do
-          expect_offense(<<~RUBY)
-            exclude(number > 0)
-                    ^^^^^^^^^^ Use `number.positive?` instead of `number > 0`.
-          RUBY
+        context 'when checking if a number is positive' do
+          context 'when target ruby version is 2.3 or higher', :ruby23 do
+            it 'registers an offense' do
+              expect_offense(<<~RUBY)
+                exclude(number > 0)
+                        ^^^^^^^^^^ Use `number.positive?` instead of `number > 0`.
+              RUBY
 
-          expect_correction(<<~RUBY)
-            exclude(number.positive?)
-          RUBY
+              expect_correction(<<~RUBY)
+                exclude(number.positive?)
+              RUBY
+            end
+          end
+
+          context 'when target ruby version is 2.2 or lower', :ruby22 do
+            it 'does not register an offense' do
+              expect_no_offenses('exclude { number > 0 }')
+            end
+          end
         end
 
-        it 'registers an offense for checking if a number is negative' do
-          expect_offense(<<~RUBY)
-            exclude(number < 0)
-                    ^^^^^^^^^^ Use `number.negative?` instead of `number < 0`.
-          RUBY
+        context 'when checking if a number is negative' do
+          context 'when target ruby version is 2.3 or higher', :ruby23 do
+            it 'registers an offense' do
+              expect_offense(<<~RUBY)
+                exclude(number < 0)
+                        ^^^^^^^^^^ Use `number.negative?` instead of `number < 0`.
+              RUBY
 
-          expect_correction(<<~RUBY)
-            exclude(number.negative?)
-          RUBY
+              expect_correction(<<~RUBY)
+                exclude(number.negative?)
+              RUBY
+            end
+          end
+
+          context 'when target ruby version is 2.2 or lower', :ruby22 do
+            it 'does not register an offense' do
+              expect_no_offenses('exclude { number > 0 }')
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10632#issuecomment-1125909580.

Reverts part of #6766, #7026, and #7030.

Only the Ruby version (2.2) to runtime should have been dropped, not code analysis.
This PR makes Ruby 2.2 code analysis with `TargetRubyVersion: 2.2`.
It aims to solve essentially the same problem as #10626, #10632, and #10640.

Previously, there was the following default enforced style `when_needed` for `Style/FrozenStringLiteralComment` cop.

```ruby
# @example EnforcedStyle: when_needed (default)
#   # The `when_needed` style will add the frozen string literal
#   # to files only when the `TargetRubyVersion` is set to 2.3+.
#   # bad
#   module Foo
#     # ...
#   end
#
#   # good
#   # frozen_string_literal: true
#
#   module Foo
#     # ...
#   end
```

This PR does not restore that option, but sets the `minimum_target_ruby_version 2.3` to make `always (default)` apply by default. It is a simple solution that does not handle frozen literal magic comment added in Ruby 2.3 when `TargetRubyVersion` is Ruby 2.2 or lower.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
