### PR TITLE
[Fix #10646] Fix an incorrect autocorrect for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_sole_nested_conditional.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#10646](https://github.com/rubocop/rubocop/issues/10646): Fix an incorrect autocorrect for `Style/SoleNestedConditional` when using `unless` and `&&` without parens in the outer condition and nested modifier condition. ([@koic][])

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -280,6 +280,22 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `unless` and `&&` without parens in the outer condition' \
+     ' and nested modifier condition' do
+    expect_offense(<<~RUBY)
+      unless foo && bar && baz
+        do_something unless qux
+                     ^^^^^^ Consider merging nested conditions into outer `unless` conditions.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if !foo && !bar && !baz && !qux
+        do_something
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `unless` and method arguments without parentheses ' \
      'in the outer condition and nested modifier condition' do
     expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #10646.

This PR fixes an incorrect autocorrect for `Style/SoleNestedConditional` when using `unless` and `&&` without parens in the outer condition and nested modifier condition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
