### PR TITLE
[Fix #10631] Fix autocorrect for `Style/RedundantBegin`

### DIFF
--- a/changelog/fix_fix_autocorrect_for_styleredundantbegin.md
+++ b/changelog/fix_fix_autocorrect_for_styleredundantbegin.md
@@ -1,0 +1,1 @@
+* [#10631](https://github.com/rubocop/rubocop/issues/10631): Fix autocorrect for `Style/RedundantBegin`. ([@johnny-miyake][])

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -481,6 +481,23 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
 
   it 'reports an offense when assigning nested `begin` blocks' do
     expect_offense(<<~RUBY)
+      @foo ||= begin
+        @bar ||= begin
+                 ^^^^^ Redundant `begin` block detected.
+          baz
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      @foo ||= @bar ||= baz
+      #{trailing_whitespace * 2}
+
+    RUBY
+  end
+
+  it 'reports an offense when assigning nested blocks which contain `begin` blocks' do
+    expect_offense(<<~RUBY)
       var = do_something do
         begin
         ^^^^^ Redundant `begin` block detected.


### PR DESCRIPTION
Fixes #10631

This PR fixes autocorrect for `Style/RedundantBegin` to avoid the `swallowed_insertions_conflict` clobbering error against nested offensive begin blocks.

The autocorrect currently causes a clobbering error when correcting this code
```ruby
@foo ||= begin
  @bar ||= begin
    baz
  end
end
```

```
$ exe/rubocop --only=Style/RedundantBegin -a -d test.rb
...
Parser::Source::TreeRewriter detected clobbering
```

With this fix, the code is properly corrected without any errors.
```ruby
@foo ||= @bar ||= baz
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
