### PR TITLE
[Fix #10651] Fix autocorrect for `Style/For` when using array with operator methods as collection

### DIFF
--- a/changelog/fix_autocorrect_for_stylefor_when_using_array_with_operator_method.md
+++ b/changelog/fix_autocorrect_for_stylefor_when_using_array_with_operator_method.md
@@ -1,0 +1,1 @@
+* [#10651](https://github.com/rubocop/rubocop/issues/10651): Fix autocorrect for `Style/For` when using array with operator methods as collection. ([@nobuyo][])

--- a/lib/rubocop/cop/correctors/for_to_each_corrector.rb
+++ b/lib/rubocop/cop/correctors/for_to_each_corrector.rb
@@ -35,7 +35,9 @@ module RuboCop
       end
 
       def requires_parentheses?
-        collection_node.range_type?
+        return true if collection_node.send_type? && collection_node.operator_method?
+
+        collection_node.range_type? || collection_node.or_type? || collection_node.and_type?
       end
 
       def end_position

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -180,6 +180,196 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
           end
         RUBY
       end
+
+      it 'corrects an array with `+` operator' do
+        expect_offense(<<~RUBY)
+          def func
+            a = [1, 2]
+            b = [3, 4]
+            c = [5]
+
+            for n in a + b + c
+            ^^^^^^^^^^^^^^^^^^ Prefer `each` over `for`.
+              puts n
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def func
+            a = [1, 2]
+            b = [3, 4]
+            c = [5]
+
+            (a + b + c).each do |n|
+              puts n
+            end
+          end
+        RUBY
+      end
+
+      it 'corrects an array with `-` operator' do
+        expect_offense(<<~RUBY)
+          def func
+            a = [1, 2, 3, 4]
+            b = [3]
+
+            for n in a - b
+            ^^^^^^^^^^^^^^ Prefer `each` over `for`.
+              puts n
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def func
+            a = [1, 2, 3, 4]
+            b = [3]
+
+            (a - b).each do |n|
+              puts n
+            end
+          end
+        RUBY
+      end
+
+      it 'corrects an array with `*` operator' do
+        expect_offense(<<~RUBY)
+          def func
+            for n in [1, 2, 3, 4] * 3
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `each` over `for`.
+              puts n
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def func
+            ([1, 2, 3, 4] * 3).each do |n|
+              puts n
+            end
+          end
+        RUBY
+      end
+
+      it 'corrects an array with `|` operator' do
+        expect_offense(<<~RUBY)
+          def func
+            a = [1, 2, 3, 4]
+            b = [4, 5]
+
+            for n in a | b
+            ^^^^^^^^^^^^^^ Prefer `each` over `for`.
+              puts n
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def func
+            a = [1, 2, 3, 4]
+            b = [4, 5]
+
+            (a | b).each do |n|
+              puts n
+            end
+          end
+        RUBY
+      end
+
+      it 'corrects an array with `&` operator' do
+        expect_offense(<<~RUBY)
+          def func
+            a = [1, 2, 3, 4]
+            b = [4, 5]
+
+            for n in a & b
+            ^^^^^^^^^^^^^^ Prefer `each` over `for`.
+              puts n
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def func
+            a = [1, 2, 3, 4]
+            b = [4, 5]
+
+            (a & b).each do |n|
+              puts n
+            end
+          end
+        RUBY
+      end
+
+      it 'corrects an array with `&&` operator' do
+        expect_offense(<<~RUBY)
+          def func
+            a = []
+            b = [1, 2, 3]
+
+            for n in a && b
+            ^^^^^^^^^^^^^^^ Prefer `each` over `for`.
+              puts n
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def func
+            a = []
+            b = [1, 2, 3]
+
+            (a && b).each do |n|
+              puts n
+            end
+          end
+        RUBY
+      end
+
+      it 'corrects an array with `||` operator' do
+        expect_offense(<<~RUBY)
+          def func
+            a = nil
+            b = [1, 2, 3]
+
+            for n in a || b
+            ^^^^^^^^^^^^^^^ Prefer `each` over `for`.
+              puts n
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def func
+            a = nil
+            b = [1, 2, 3]
+
+            (a || b).each do |n|
+              puts n
+            end
+          end
+        RUBY
+      end
+
+      it 'corrects to `each` without parenthesize collection if non-operator method called' do
+        expect_offense(<<~RUBY)
+          def func
+            for n in [1, 2, nil].compact
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `each` over `for`.
+              puts n
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def func
+            [1, 2, nil].compact.each do |n|
+              puts n
+            end
+          end
+        RUBY
+      end
     end
 
     it 'accepts multiline each' do


### PR DESCRIPTION
Fixes #10651.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
