### PR TITLE
Refactor `Style/FetchEnvVar` cop

### DIFF
--- a/lib/rubocop/cop/style/fetch_env_var.rb
+++ b/lib/rubocop/cop/style/fetch_env_var.rb
@@ -75,12 +75,12 @@ module RuboCop
 
             if operand_of_or?(node)
               target_node = offensive_nodes(or_chain_root(node)).to_a.last
-              name_node = env_with_bracket?(target_node)
+              target_name_node = env_with_bracket?(target_node)
 
               if default_to_rhs?(target_node)
-                default_rhs(target_node, name_node)
+                default_rhs(target_node, target_name_node)
               else
-                default_nil(target_node, name_node)
+                default_nil(target_node, target_name_node)
               end
             else
               default_nil(node, name_node)


### PR DESCRIPTION
This PR refactors `Style/FetchEnvVar` cop.
- Reduced the code for finding the correction target node.
- Renamed variables to improve readability.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
