### PR TITLE
[Fix #10657] Fix `AutoGenerateConfig` command ignores specified config file by option

### DIFF
--- a/changelog/fix_autogenerateconfig_command_ignores_config.md
+++ b/changelog/fix_autogenerateconfig_command_ignores_config.md
@@ -1,0 +1,1 @@
+* [#10657](https://github.com/rubocop/rubocop/issues/10657): Fix `--auto-gen-config` command option ignores specified config file by option. ([@nobuyo][])

--- a/lib/rubocop/cli/command/auto_genenerate_config.rb
+++ b/lib/rubocop/cli/command/auto_genenerate_config.rb
@@ -66,6 +66,7 @@ module RuboCop
           execute_runner
           @options.delete(:only)
           @config_store = ConfigStore.new
+          @config_store.options_config = @options[:config] if @options[:config]
           # Save the todo configuration of the LineLength cop.
           File.read(AUTO_GENERATED_FILE).lines.drop_while { |line| line.start_with?('#') }.join
         end


### PR DESCRIPTION
Fixes #10657.

This PR fixes a bug that caused config files specified by `--config` options to be unintentionally ignored in `AutoGenerateConfig` command.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
