### PR TITLE
[Fix #10659] Fix automatically appended path for `inherit_from` by `auto-gen-config`

### DIFF
--- a/changelog/fix_path_for_inherit_from_is_incorrect.md
+++ b/changelog/fix_path_for_inherit_from_is_incorrect.md
@@ -1,0 +1,1 @@
+* [#10659](https://github.com/rubocop/rubocop/issues/10659): Fix automatically appended path for `inherit_from` by `auto-gen-config` is incorrect if specified config file in a subdirectory as an option. ([@nobuyo][])

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -422,13 +422,15 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
               - 'example1.rb'
         YAML
         expect(File.read('dir/cop_config.yml')).to eq(<<~YAML)
-          inherit_from: .rubocop_todo.yml
+          inherit_from: ../.rubocop_todo.yml
 
           Layout/TrailingWhitespace:
             Enabled: false
           Layout/LineLength:
             Max: 95
         YAML
+        # Checks that the command can be run again with config modified by itself.
+        expect(cli.run(%w[--auto-gen-config --config dir/cop_config.yml])).to eq(0)
       end
     end
 


### PR DESCRIPTION
… is incorrect if specified config file in a subdirectory as an option.

Fixes #10659.

Here is the example project using rubocop with custom config in a subdirectory.

```sh
.
├── example.rb
└── dir
   └── .another_rubocop.yml
```

Current behavior for `rubocop --auto-gen-config --config dir/.another_rubocop.yml` is:
  - Generates `.rubocop_todo.yml` in project root.
  - Appends `inherit_from .rubocop_todo.yml` to `dir/.another_rubocop.yml`.

After running the command, modified configuration causes an error `Configuration file not found` because `.rubocop_todo.yml` is not exists in same directory of `.another_rubocop.yml`. So, after the fix, the generated location of .rubocop_todo.yml will be kept as it is, and the relative path will be used to the config for `inherit_from`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
