### PR TITLE
Fix a false negative for `Style/SymbolProc`

### DIFF
--- a/changelog/fix_false_negative_for_style_symbol_proc.md
+++ b/changelog/fix_false_negative_for_style_symbol_proc.md
@@ -1,0 +1,1 @@
+* [#10661](https://github.com/rubocop/rubocop/pull/10661): Fix a false negative for `Style/SymbolProc` when method has no arguments and `AllowMethodsWithArguments: true`. ([@koic][])

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -104,7 +104,7 @@ module RuboCop
             return if proc_node?(dispatch_node)
             return if %i[lambda proc].include?(dispatch_node.method_name)
             return if ignored_method?(dispatch_node.method_name)
-            return if allow_if_method_has_argument?(node)
+            return if allow_if_method_has_argument?(node.send_node)
             return if node.block_type? && destructuring_block_argument?(arguments_node)
             return if allow_comments? && contains_comments?(node)
 
@@ -165,8 +165,8 @@ module RuboCop
           end
         end
 
-        def allow_if_method_has_argument?(node)
-          !!cop_config.fetch('AllowMethodsWithArguments', false) && !node.arguments.count.zero?
+        def allow_if_method_has_argument?(send_node)
+          !!cop_config.fetch('AllowMethodsWithArguments', false) && !send_node.arguments.count.zero?
         end
 
         def allow_comments?

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -159,6 +159,15 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
         RUBY
       end
     end
+
+    context 'when method has no arguments' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          coll.map { |e| e.upcase }
+                   ^^^^^^^^^^^^^^^^ Pass `&:upcase` as an argument to `map` instead of a block.
+        RUBY
+      end
+    end
   end
 
   context 'when `AllowMethodsWithArguments: false`' do


### PR DESCRIPTION
This PR fixes a false negative for `Style/SymbolProc` when method has no arguments and `AllowMethodsWithArguments: true`.

The cause of the false negative was that they were counted using block arguments instead of method arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
