### PR TITLE
[Fix #10656] Mark `Style/RedundantInterpolation` as unsafe autocorrection

### DIFF
--- a/changelog/change_mark_unsafe_autocorrection_for_style_redundant_interpolation.md
+++ b/changelog/change_mark_unsafe_autocorrection_for_style_redundant_interpolation.md
@@ -1,0 +1,1 @@
+* [#10656](https://github.com/rubocop/rubocop/issues/10656): Mark `Style/RedundantInterpolation` as unsafe autocorrection. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4599,7 +4599,9 @@ Style/RedundantInitialize:
 Style/RedundantInterpolation:
   Description: 'Checks for strings that are just an interpolated expression.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.76'
+  VersionChanged: '<<next>>'
 
 Style/RedundantParentheses:
   Description: "Checks for parentheses that seem not to serve any purpose."

--- a/lib/rubocop/cop/style/redundant_interpolation.rb
+++ b/lib/rubocop/cop/style/redundant_interpolation.rb
@@ -5,6 +5,27 @@ module RuboCop
     module Style
       # Checks for strings that are just an interpolated expression.
       #
+      # @safety
+      #   Autocorrection is unsafe because when calling a destructive method to string,
+      #   the resulting string may have different behavior or raise `FrozenError`.
+      #
+      #   [source,ruby]
+      #   ----
+      #   x = 'a'
+      #   y = "#{x}"
+      #   y << 'b'   # return 'ab'
+      #   x          # return 'a'
+      #   y = x.to_s
+      #   y << 'b'   # return 'ab'
+      #   x          # return 'ab'
+      #
+      #   x = 'a'.freeze
+      #   y = "#{x}"
+      #   y << 'b'   # return 'ab'.
+      #   y = x.to_s
+      #   y << 'b'   # raise `FrozenError`.
+      #   ----
+      #
       # @example
       #
       #   # bad


### PR DESCRIPTION
Fixes #10656.

This PR marks `Style/RedundantInterpolation` as unsafe autocorrection because when calling a destructive method to string, the resulting string may have different behavior or raise `FrozenError`.

```ruby
x = 'a'
y = "#{x}"
y << 'b'   # return 'ab'
x          # return 'a'
y = x.to_s
y << 'b'   # return 'ab'
x          # return 'ab'

x = 'a'.freeze
y = "#{x}"
y << 'b'   # return 'ab'.
y = x.to_s
y << 'b'   # raise `FrozenError`.
```

Updating the auto-corrected code from `'a'.to_s` to `'a'.to_s.dup` will get safe, but it will make `dup` redundant when unneeded. And This would go against the cop's name "redundant". That means replacing it with a different redundancy that cannot be removed by static analysis. So I decided to mark it as unsafe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
