### PR TITLE
Recover Ruby 2.0 code analysis using `TargetRubyVersion: 2.0`

### DIFF
--- a/changelog/fix_recover_ruby_20_code_analysis.md
+++ b/changelog/fix_recover_ruby_20_code_analysis.md
@@ -1,0 +1,1 @@
+* [#10668](https://github.com/rubocop/rubocop/pull/10668): Recover Ruby 2.0 code analysis using `TargetRubyVersion: 2.0`. ([@koic][])

--- a/lib/rubocop/cop/style/dir.rb
+++ b/lib/rubocop/cop/style/dir.rb
@@ -18,6 +18,9 @@ module RuboCop
       #   path = __dir__
       class Dir < Base
         extend AutoCorrector
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.0
 
         MSG = "Use `__dir__` to get an absolute path to the current file's directory."
         RESTRICT_ON_SEND = %i[expand_path dirname].freeze

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -7,7 +7,8 @@ module RuboCop
       # using the %i() syntax.
       #
       # Alternatively, it checks for symbol arrays using the %i() syntax on
-      # projects which do not want to use that syntax.
+      # projects which do not want to use that syntax, perhaps because they
+      # support a version of Ruby lower than 2.0.
       #
       # Configuration option: MinSize
       # If set, arrays with fewer elements than this value will not trigger the
@@ -33,6 +34,9 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include PercentArray
         extend AutoCorrector
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.0
 
         PERCENT_MSG = 'Use `%i` or `%I` for an array of symbols.'
         ARRAY_MSG = 'Use `%<prefer>s` for an array of symbols.'

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -116,6 +116,10 @@ RSpec.shared_context 'mock console output' do
   end
 end
 
+RSpec.shared_context 'ruby 2.0', :ruby20 do
+  let(:ruby_version) { 2.0 }
+end
+
 RSpec.shared_context 'ruby 2.1', :ruby21 do
   let(:ruby_version) { 2.1 }
 end

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -4,7 +4,7 @@ module RuboCop
   # The kind of Ruby that code inspected by RuboCop is written in.
   # @api private
   class TargetRuby
-    KNOWN_RUBIES = [2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2].freeze
+    KNOWN_RUBIES = [2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2].freeze
     DEFAULT_VERSION = 2.6
 
     OBSOLETE_RUBIES = {

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1724,7 +1724,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           'Error: RuboCop found unknown Ruby version 4.0 in `TargetRubyVersion`'
         )
         expect($stderr.string.strip).to match(
-          /Supported versions: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2/
+          /Supported versions: 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2/
         )
       end
     end
@@ -1733,20 +1733,20 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       it 'fails with an error message' do
         create_file('.rubocop.yml', <<~YAML)
           AllCops:
-            TargetRubyVersion: 2.0
+            TargetRubyVersion: 1.9
         YAML
 
         expect(cli.run([])).to eq(2)
         expect($stderr.string.strip).to start_with(
-          'Error: RuboCop found unsupported Ruby version 2.0 in '\
+          'Error: RuboCop found unsupported Ruby version 1.9 in '\
           '`TargetRubyVersion`'
         )
 
         expect($stderr.string.strip).to match(
-          /2\.0-compatible analysis was dropped after version 0\.50/
+          /1\.9-compatible analysis was dropped after version 0\.41/
         )
 
-        expect($stderr.string.strip).to match(/Supported versions: 2.1/)
+        expect($stderr.string.strip).to match(/Supported versions: 2.0/)
       end
     end
   end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1188,7 +1188,7 @@ RSpec.describe RuboCop::ConfigLoader do
       end
 
       context 'when the specified version is obsolete' do
-        let(:inherited_version) { '2.0' }
+        let(:inherited_version) { '1.9' }
 
         context 'and it is not overridden' do
           before do
@@ -1199,7 +1199,7 @@ RSpec.describe RuboCop::ConfigLoader do
 
           it 'raises a validation error' do
             expect { configuration_from_file }.to raise_error(RuboCop::ValidationError) do |error|
-              expect(error.message).to start_with('RuboCop found unsupported Ruby version 2.0')
+              expect(error.message).to start_with('RuboCop found unsupported Ruby version 1.9')
             end
           end
         end

--- a/spec/rubocop/cop/style/optional_arguments_spec.rb
+++ b/spec/rubocop/cop/style/optional_arguments_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe RuboCop::Cop::Style::OptionalArguments, :config do
       end
     end
 
-    context 'required params' do
+    context 'required params', :ruby21 do
       it 'registers an offense for optional arguments that come before ' \
          'required arguments where there are name arguments' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10632#issuecomment-1125909580.

Reverts part of https://github.com/rubocop/rubocop/pull/4787.

Only the Ruby version (2.0) to runtime should have been dropped, not code analysis.
This PR makes Ruby 2.0 code analysis with `TargetRubyVersion: 2.0`.
It aims to solve essentially the same problem as #10626, #10632, #10640, #10644, and #10662.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
