### PR TITLE
[Fix #10095] Preserve line breaks when generating bracketed arrays in `Style/SymbolArray` & `Style/WordArray`

### DIFF
--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -230,6 +230,40 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
         [:"#{foo}", :"#{foo}bar", :"foo#{bar}", :foo]
       RUBY
     end
+
+    it 'preserves line breaks when autocorrecting a multiline array' do
+      expect_offense(<<~RUBY)
+        %i(
+        ^^^ Use `[:foo,\\n:bar,\\n:baz]` for an array of symbols.
+        foo
+        bar
+        baz
+        )
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [
+        :foo,
+        :bar,
+        :baz
+        ]
+      RUBY
+    end
+
+    it 'preserves whitespace when autocorrecting an array using partial newlines' do
+      expect_offense(<<~RUBY)
+        %i(foo bar baz
+        ^^^^^^^^^^^^^^ Use `[:foo, :bar, :baz,\\n:boz, :buz,\\n:biz]` for an array of symbols.
+        boz buz
+        biz)
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [:foo, :bar, :baz,
+        :boz, :buz,
+        :biz]
+      RUBY
+    end
   end
 
   context 'with non-default MinSize' do

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -459,6 +459,40 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
         ["あ"]   # Valid as UTF-8
       RUBY
     end
+
+    it 'preserves line breaks when autocorrecting a multiline array' do
+      expect_offense(<<~RUBY)
+        %w(
+        ^^^ Use `['foo',\\n'bar',\\n'baz']` for an array of words.
+        foo
+        bar
+        baz
+        )
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [
+        'foo',
+        'bar',
+        'baz'
+        ]
+      RUBY
+    end
+
+    it 'preserves whitespace when autocorrecting an array using partial newlines' do
+      expect_offense(<<~RUBY)
+        %w(foo bar baz
+        ^^^^^^^^^^^^^^ Use `['foo', 'bar', 'baz',\\n'boz', 'buz',\\n'biz']` for an array of words.
+        boz buz
+        biz)
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ['foo', 'bar', 'baz',
+        'boz', 'buz',
+        'biz']
+      RUBY
+    end
   end
 
   context 'with a custom WordRegex configuration' do


### PR DESCRIPTION
**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
