### PR TITLE
Fix a false positive for `Style/FetchEnvVar` in the body with assignment method

### DIFF
--- a/changelog/fix_false_positive_for_fetch_env_var.md
+++ b/changelog/fix_false_positive_for_fetch_env_var.md
@@ -1,0 +1,1 @@
+* [#10670](https://github.com/rubocop/rubocop/pull/10670): Fix a false positive for `Style/FetchEnvVar` in the body with assignment method. ([@ydah][])

--- a/lib/rubocop/cop/style/fetch_env_var.rb
+++ b/lib/rubocop/cop/style/fetch_env_var.rb
@@ -112,11 +112,18 @@ module RuboCop
         end
 
         def used_in_condition?(node, condition)
-          if condition.send_type? && (!condition.comparison_method? && !condition.predicate_method?)
-            return false
+          if condition.send_type?
+            return true if condition.assignment_method? && partial_matched?(node, condition)
+            return false if !condition.comparison_method? && !condition.predicate_method?
           end
 
           condition.child_nodes.any?(node)
+        end
+
+        # Avoid offending in the following cases:
+        # `ENV['key'] if ENV['key'] = x`
+        def partial_matched?(node, condition)
+          node.child_nodes == node.child_nodes & condition.child_nodes
         end
 
         def offensive?(node)

--- a/spec/rubocop/cop/style/fetch_env_var_spec.rb
+++ b/spec/rubocop/cop/style/fetch_env_var_spec.rb
@@ -364,6 +364,29 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
         end
       RUBY
     end
+
+    it 'registers no offenses when using the same `ENV` var as `if` condition in the body with assignment method' do
+      expect_no_offenses(<<~RUBY)
+        if ENV['X'] = x
+          puts ENV['X']
+        end
+      RUBY
+    end
+
+    it 'registers an offense with using an `ENV` var as `if` condition in the body with assignment method' do
+      expect_offense(<<~RUBY)
+        if ENV['X'] = x
+          puts ENV['Y']
+               ^^^^^^^^ Use `ENV.fetch('Y')` or `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if ENV['X'] = x
+          puts ENV.fetch('Y', nil)
+        end
+      RUBY
+    end
   end
 
   it 'registers an offense when using `ENV && x` that is different from `if` condition in the body' do


### PR DESCRIPTION
Follow up: https://github.com/rubocop/rubocop/pull/10653#issuecomment-1135884969

```ruby
if ENV['X'] = x
  puts ENV['X']
end

# The above is corrected into,

if ENV['X'] = x
  puts ENV.fetch('X', nil)
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
~* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
