### PR TITLE
Fix a false positive for `Naming/AccessorMethodName` with type of the first argument is other than `arg`

### DIFF
--- a/changelog/fix_a_false_positive_accessor_method_name.md
+++ b/changelog/fix_a_false_positive_accessor_method_name.md
@@ -1,0 +1,1 @@
+* [#10674](https://github.com/rubocop/rubocop/issues/10674): Fix a false positive for `Naming/AccessorMethodName` with type of the first argument is other than `arg`. ([@ydah][])

--- a/lib/rubocop/cop/naming/accessor_method_name.rb
+++ b/lib/rubocop/cop/naming/accessor_method_name.rb
@@ -63,7 +63,9 @@ module RuboCop
         end
 
         def bad_writer_name?(node)
-          node.method_name.to_s.start_with?('set_') && node.arguments.one?
+          node.method_name.to_s.start_with?('set_') &&
+            node.arguments.one? &&
+            node.first_argument.arg_type?
         end
       end
     end

--- a/spec/rubocop/cop/naming/accessor_method_name_spec.rb
+++ b/spec/rubocop/cop/naming/accessor_method_name_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Naming::AccessorMethodName, :config do
-  it 'registers an offense for method get_... with no args' do
+  it 'registers an offense for method get_something with no args' do
     expect_offense(<<~RUBY)
-      def get_attr
-          ^^^^^^^^ Do not prefix reader method names with `get_`.
+      def get_something
+          ^^^^^^^^^^^^^ Do not prefix reader method names with `get_`.
         # ...
       end
     RUBY
   end
 
-  it 'registers an offense for singleton method get_... with no args' do
+  it 'registers an offense for singleton method get_something with no args' do
     expect_offense(<<~RUBY)
-      def self.get_attr
-               ^^^^^^^^ Do not prefix reader method names with `get_`.
+      def self.get_something
+               ^^^^^^^^^^^^^ Do not prefix reader method names with `get_`.
         # ...
       end
     RUBY
@@ -37,17 +37,75 @@ RSpec.describe RuboCop::Cop::Naming::AccessorMethodName, :config do
 
   it 'registers an offense for method set_something with one arg' do
     expect_offense(<<~RUBY)
-      def set_attr(arg)
-          ^^^^^^^^ Do not prefix writer method names with `set_`.
+      def set_something(arg)
+          ^^^^^^^^^^^^^ Do not prefix writer method names with `set_`.
         # ...
       end
     RUBY
   end
 
-  it 'registers an offense for singleton method set_... with one args' do
+  it 'accepts method set_something with optarg' do
+    expect_no_offenses(<<~RUBY)
+      def set_something(arg = :default)
+        # ...
+      end
+    RUBY
+  end
+
+  it 'accepts method set_something with restarg' do
+    expect_no_offenses(<<~RUBY)
+      def set_something(*args)
+        # ...
+      end
+    RUBY
+  end
+
+  it 'accepts method set_something with kwoptarg' do
+    expect_no_offenses(<<~RUBY)
+      def set_something(k: v)
+        # ...
+      end
+    RUBY
+  end
+
+  it 'accepts method set_something with kwarg' do
+    expect_no_offenses(<<~RUBY)
+      def set_something(k:)
+        # ...
+      end
+    RUBY
+  end
+
+  it 'accepts method set_something with kwrestarg' do
+    expect_no_offenses(<<~RUBY)
+      def set_something(**options)
+        # ...
+      end
+    RUBY
+  end
+
+  it 'accepts method set_something with blockarg' do
+    expect_no_offenses(<<~RUBY)
+      def set_something(&block)
+        # ...
+      end
+    RUBY
+  end
+
+  context '>= Ruby 2.7', :ruby27 do
+    it 'accepts method set_something with arguments forwarding' do
+      expect_no_offenses(<<~RUBY)
+        def set_something(...)
+          # ...
+        end
+      RUBY
+    end
+  end
+
+  it 'registers an offense for singleton method set_something with one args' do
     expect_offense(<<~RUBY)
-      def self.set_attr(arg)
-               ^^^^^^^^ Do not prefix writer method names with `set_`.
+      def self.set_something(arg)
+               ^^^^^^^^^^^^^ Do not prefix writer method names with `set_`.
         # ...
       end
     RUBY


### PR DESCRIPTION
This PR is fixed based on a similar problem: https://github.com/rubocop/rubocop/issues/10574

`Naming/AccessorMethodName` should only inform offense
if the type of the first argument is `arg`.

```ruby
# Bad
def set_something(arg)
  # ...
end

# Good
def set_something(arg = :default)
  # ...
end

def set_something(*args)
  # ...
end

def set_something(k: v)
  # ...
end

def set_something(k:)
  # ...
end

def set_something(**options)
  # ...
end

def set_something(&block)
  # ...
end

def set_something(...)
  # ...
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
~* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
