### PR TITLE
Fix `--ignore-unrecognized-cops` option always showing empty warning even if there was no problem

### DIFF
--- a/changelog/fix_ignore_unrecognized_cops_option.md
+++ b/changelog/fix_ignore_unrecognized_cops_option.md
@@ -1,0 +1,1 @@
+* [#10676](https://github.com/rubocop/rubocop/pull/10676): Fix `--ignore-unrecognized-cops` option always showing empty warning even if there was no problem. ([@nobuyo][])

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -104,13 +104,17 @@ module RuboCop
     def alert_about_unrecognized_cops(invalid_cop_names)
       unknown_cops = list_unknown_cops(invalid_cop_names)
 
+      return if unknown_cops.empty?
+
       if ConfigLoader.ignore_unrecognized_cops
         warn Rainbow('The following cops or departments are not '\
                      'recognized and will be ignored:').yellow
         warn unknown_cops.join("\n")
-      elsif unknown_cops.any?
-        raise ValidationError, unknown_cops.join("\n")
+
+        return
       end
+
+      raise ValidationError, unknown_cops.join("\n")
     end
 
     def list_unknown_cops(invalid_cop_names)


### PR DESCRIPTION
The internal condition was wrong, and the message `The following cops or departments are ...` was always displayed with just the option is specified.

Reported at: https://github.com/rubocop/rubocop/pull/10630#issuecomment-1140263726

```rb
$ bundle exec rubocop --ignore-unrecognized-cops
The following cops or departments are not recognized and will be ignored: # <--- 👀 

Inspecting 2 files
.W

...
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
