### PR TITLE
Tweak docs about target Ruby version

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,12 @@ You can read a lot more about RuboCop in its [official docs](https://docs.ruboco
 
 ## Compatibility
 
-RuboCop officially supports the following Ruby implementations:
+RuboCop officially supports the following runtime Ruby implementations:
 
 * MRI 2.6+
 * JRuby 9.3+
+
+Targets Ruby 2.0+ code analysis.
 
 See the [compatibility documentation](https://docs.rubocop.org/rubocop/compatibility.html) for further details.
 

--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -1,8 +1,8 @@
 = Compatibility
 
-RuboCop targets Ruby 2.6+.footnote:[As defined by its reference implementation MRI.]
+RuboCop targets Ruby 2.0+ code analysis.footnote:[As defined by its reference implementation MRI.]
 
-RuboCop officially supports MRI (a.k.a. CRuby) and JRuby.
+RuboCop officially runtime supports MRI (a.k.a. CRuby) and JRuby.
 
 - MRI 2.6+
 - JRuby 9.3+
@@ -16,10 +16,10 @@ NOTE: RuboCop might be working with other Ruby implementations as well, but it's
 RuboCop generally aims to follow MRI's own support policy - meaning RuboCop would support all officially supported MRI releases.footnote:[Typically the last 3 releases.] To give people extra time for a smooth transition, we've customarily provided support for about one year after EOL of MRI version.
 This means that if Ruby 2.6 reaches its EOL in Spring 2022, it would be supported by RuboCop (at least) until Spring 2023.footnote:[At the core team's discretion this policy might be waived aside for MRI releases causing significant maintenance overhead.]
 
-The following table is the support matrix.
+The following table is the runtime support matrix.
 
 |===
-| Supported target Ruby version | Last supported RuboCop version
+| Supported runtime Ruby version | Last supported RuboCop version
 
 | 1.9 | 0.41
 | 2.0 | 0.50
@@ -34,6 +34,8 @@ The following table is the support matrix.
 | 3.1 | -
 | 3.2 (experimental) | -
 |===
+
+Targets Ruby 2.0+ code analysis since RuboCop 1.30. It restored code analysis that was unsupported with EOL of runtime Ruby version.
 
 NOTE: The compatibility xref:configuration.adoc#setting-the-target-ruby-version[target Ruby version mentioned here] is about code analysis (what RuboCop can analyze), not runtime (is RuboCop capable of running on some Ruby or not).
 


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10632#issuecomment-1125893493.

RuboCop targets Ruby 2.0+ code analysis since RuboCop 1.30. This PR tweaks docs about target Ruby version.

NOTE: Ruby 1.9 code analysis is not restored because its some incompatibilities with Ruby 2.0+ cops. It may not be worth the maintenance cost.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
