### PR TITLE
[Fix #10679] Fix a false positive for `Style/SafeNavigation`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_safe_navigation.md
+++ b/changelog/fix_a_false_positive_for_style_safe_navigation.md
@@ -1,0 +1,1 @@
+* [#10679](https://github.com/rubocop/rubocop/issues/10679): Fix a false positive for `Style/SafeNavigation` when `TargetRubyVersion: 2.2` or lower. ([@koic][])

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -80,10 +80,13 @@ module RuboCop
         include NilMethods
         include RangeHelp
         extend AutoCorrector
+        extend TargetRubyVersion
 
         MSG = 'Use safe navigation (`&.`) instead of checking if an object ' \
               'exists before calling the method.'
         LOGIC_JUMP_KEYWORDS = %i[break fail next raise return throw yield].freeze
+
+        minimum_target_ruby_version 2.3
 
         # if format: (if checked_variable body nil)
         # unless format: (if checked_variable nil body)

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
   let(:cop_config) { { 'ConvertCodeThatCanStartToReturnNil' => false } }
+  let(:target_ruby_version) { 2.3 }
 
   it 'allows calls to methods not safeguarded by respond_to' do
     expect_no_offenses('foo.bar')
@@ -915,10 +916,11 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
 
           context 'with Lint/SafeNavigationChain disabled' do
             let(:config) do
-              RuboCop::Config.new('Lint/SafeNavigationChain' => {
-                                    'Enabled' => false
-                                  },
-                                  'Style/SafeNavigation' => cop_config)
+              RuboCop::Config.new(
+                'AllCops' => { 'TargetRubyVersion' => target_ruby_version },
+                'Lint/SafeNavigationChain' => { 'Enabled' => false },
+                'Style/SafeNavigation' => cop_config
+              )
             end
 
             it 'allows an object check followed by chained method calls' do
@@ -1145,6 +1147,12 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
 
     it 'allows enumerable accessor method calls safeguarded by a respond_to check' do
       expect_no_offenses('foo[0] if foo.respond_to?(:[])')
+    end
+  end
+
+  context 'when Ruby <= 2.2', :ruby22 do
+    it 'does not register an offense when a method call that nil responds to safe guarded by an object check' do
+      expect_no_offenses('foo.bar if foo')
     end
   end
 end


### PR DESCRIPTION
Fixes #10679.

Fix a false positive for `Style/SafeNavigation` when `TargetRubyVersion: 2.2` or lower.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
