### PR TITLE
fix "--auto-correct is deprecated; use --autocorrect"

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,4 @@
   entry: rubocop
   language: ruby
   types: ['ruby']
-  args: ['--auto-correct', '--force-exclusion']
+  args: ['--autocorrect', '--force-exclusion']


### PR DESCRIPTION
this silences a warning when used with `pre-commit`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists). (**N/A**)
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests. (**N/A**)
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code. (**N/A**)
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details. (**N/A**: hoping this is minor enough to not require a changelog entry)

[1]: https://chris.beams.io/posts/git-commit/
