### PR TITLE
Add a check for EnforcedStyle: (default) examples

### DIFF
--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -1945,6 +1945,17 @@ the configuration.
 
 === Examples
 
+==== EnforcedStyle: no_empty_lines (default)
+
+[source,ruby]
+----
+# good
+
+foo do |bar|
+  # ...
+end
+----
+
 ==== EnforcedStyle: empty_lines
 
 [source,ruby]
@@ -1955,17 +1966,6 @@ foo do |bar|
 
   # ...
 
-end
-----
-
-==== EnforcedStyle: no_empty_lines (default)
-
-[source,ruby]
-----
-# good
-
-foo do |bar|
-  # ...
 end
 ----
 
@@ -1999,6 +1999,19 @@ Checks if empty lines around the bodies of classes match
 the configuration.
 
 === Examples
+
+==== EnforcedStyle: no_empty_lines (default)
+
+[source,ruby]
+----
+# good
+
+class Foo
+  def bar
+    # ...
+  end
+end
+----
 
 ==== EnforcedStyle: empty_lines
 
@@ -2067,19 +2080,6 @@ class Foo
     # ...
   end
 
-end
-----
-
-==== EnforcedStyle: no_empty_lines (default)
-
-[source,ruby]
-----
-# good
-
-class Foo
-  def bar
-    # ...
-  end
 end
 ----
 
@@ -2226,6 +2226,19 @@ the configuration.
 
 === Examples
 
+==== EnforcedStyle: no_empty_lines (default)
+
+[source,ruby]
+----
+# good
+
+module Foo
+  def bar
+    # ...
+  end
+end
+----
+
 ==== EnforcedStyle: empty_lines
 
 [source,ruby]
@@ -2265,19 +2278,6 @@ module Foo
 
   def bar; end
 
-end
-----
-
-==== EnforcedStyle: no_empty_lines (default)
-
-[source,ruby]
-----
-# good
-
-module Foo
-  def bar
-    # ...
-  end
 end
 ----
 
@@ -2587,6 +2587,37 @@ nested_first_param),
 second_param
 ----
 
+==== EnforcedStyle: special_for_inner_method_call_in_parentheses (default)
+
+[source,ruby]
+----
+# Same as `special_for_inner_method_call` except that the special rule
+# only applies if the outer method call encloses its arguments in
+# parentheses.
+
+# good
+some_method(
+  first_param,
+second_param)
+
+foo = some_method(
+  first_param,
+second_param)
+
+foo = some_method(nested_call(
+                    nested_first_param),
+second_param)
+
+foo = some_method(
+  nested_call(
+    nested_first_param),
+second_param)
+
+some_method nested_call(
+  nested_first_param),
+second_param
+----
+
 ==== EnforcedStyle: consistent
 
 [source,ruby]
@@ -2676,37 +2707,6 @@ second_param)
 
 some_method nested_call(
               nested_first_param),
-second_param
-----
-
-==== EnforcedStyle: special_for_inner_method_call_in_parentheses (default)
-
-[source,ruby]
-----
-# Same as `special_for_inner_method_call` except that the special rule
-# only applies if the outer method call encloses its arguments in
-# parentheses.
-
-# good
-some_method(
-  first_param,
-second_param)
-
-foo = some_method(
-  first_param,
-second_param)
-
-foo = some_method(nested_call(
-                    nested_first_param),
-second_param)
-
-foo = some_method(
-  nested_call(
-    nested_first_param),
-second_param)
-
-some_method nested_call(
-  nested_first_param),
 second_param
 ----
 
@@ -6104,20 +6104,6 @@ surrounding space depending on configuration.
 
 === Examples
 
-==== EnforcedStyle: space
-
-[source,ruby]
-----
-# The `space` style enforces that array literals have
-# surrounding space.
-
-# bad
-array = [a, b, c, d]
-
-# good
-array = [ a, b, c, d ]
-----
-
 ==== EnforcedStyle: no_space (default)
 
 [source,ruby]
@@ -6130,6 +6116,20 @@ array = [ a, b, c, d ]
 
 # good
 array = [a, b, c, d]
+----
+
+==== EnforcedStyle: space
+
+[source,ruby]
+----
+# The `space` style enforces that array literals have
+# surrounding space.
+
+# bad
+array = [a, b, c, d]
+
+# good
+array = [ a, b, c, d ]
 ----
 
 ==== EnforcedStyle: compact
@@ -6780,6 +6780,25 @@ source code.
 
 === Examples
 
+==== EnforcedStyle: final_newline (default)
+
+[source,ruby]
+----
+# `final_newline` looks for one newline at the end of files.
+
+# bad
+class Foo; end
+
+# EOF
+
+# bad
+class Foo; end # EOF
+
+# good
+class Foo; end
+# EOF
+----
+
 ==== EnforcedStyle: final_blank_line
 
 [source,ruby]
@@ -6797,25 +6816,6 @@ class Foo; end # EOF
 # good
 class Foo; end
 
-# EOF
-----
-
-==== EnforcedStyle: final_newline (default)
-
-[source,ruby]
-----
-# `final_newline` looks for one newline at the end of files.
-
-# bad
-class Foo; end
-
-# EOF
-
-# bad
-class Foo; end # EOF
-
-# good
-class Foo; end
 # EOF
 ----
 

--- a/docs/modules/ROOT/pages/cops_naming.adoc
+++ b/docs/modules/ROOT/pages/cops_naming.adoc
@@ -1312,27 +1312,6 @@ Both are enabled by default.
 
 === Examples
 
-==== EnforcedStyle: snake_case
-
-[source,ruby]
-----
-# bad
-:some_sym1
-variable1 = 1
-
-def some_method1; end
-
-def some_method_1(arg1); end
-
-# good
-:some_sym_1
-variable_1 = 1
-
-def some_method_1; end
-
-def some_method_1(arg_1); end
-----
-
 ==== EnforcedStyle: normalcase (default)
 
 [source,ruby]
@@ -1352,6 +1331,27 @@ variable1 = 1
 def some_method1; end
 
 def some_method1(arg1); end
+----
+
+==== EnforcedStyle: snake_case
+
+[source,ruby]
+----
+# bad
+:some_sym1
+variable1 = 1
+
+def some_method1; end
+
+def some_method_1(arg1); end
+
+# good
+:some_sym_1
+variable_1 = 1
+
+def some_method_1; end
+
+def some_method_1(arg_1); end
 ----
 
 ==== EnforcedStyle: non_integer

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -247,25 +247,6 @@ and that might change the behavior.
 
 === Examples
 
-==== EnforcedStyle: always
-
-[source,ruby]
-----
-# bad
-foo.save and return
-
-# bad
-if foo and bar
-end
-
-# good
-foo.save && return
-
-# good
-if foo && bar
-end
-----
-
 ==== EnforcedStyle: conditionals (default)
 
 [source,ruby]
@@ -279,6 +260,25 @@ foo.save && return
 
 # good
 foo.save and return
+
+# good
+if foo && bar
+end
+----
+
+==== EnforcedStyle: always
+
+[source,ruby]
+----
+# bad
+foo.save and return
+
+# bad
+if foo and bar
+end
+
+# good
+foo.save && return
 
 # good
 if foo && bar
@@ -3051,6 +3051,38 @@ explicit `nil` depending on the EnforcedStyle.
 
 === Examples
 
+==== EnforcedStyle: both (default)
+
+[source,ruby]
+----
+# warn on empty else and else with nil in it
+
+# bad
+if condition
+  statement
+else
+  nil
+end
+
+# bad
+if condition
+  statement
+else
+end
+
+# good
+if condition
+  statement
+else
+  statement
+end
+
+# good
+if condition
+  statement
+end
+----
+
 ==== EnforcedStyle: empty
 
 [source,ruby]
@@ -3097,38 +3129,6 @@ else
 end
 
 # good
-if condition
-  statement
-else
-end
-
-# good
-if condition
-  statement
-else
-  statement
-end
-
-# good
-if condition
-  statement
-end
-----
-
-==== EnforcedStyle: both (default)
-
-[source,ruby]
-----
-# warn on empty else and else with nil in it
-
-# bad
-if condition
-  statement
-else
-  nil
-end
-
-# bad
 if condition
   statement
 else
@@ -6678,6 +6678,39 @@ Supported styles are: if, case, both.
 
 === Examples
 
+==== EnforcedStyle: both (default)
+
+[source,ruby]
+----
+# warn when an `if` or `case` expression is missing an `else` branch.
+
+# bad
+if condition
+  statement
+end
+
+# bad
+case var
+when condition
+  statement
+end
+
+# good
+if condition
+  statement
+else
+  # the content of `else` branch will be determined by Style/EmptyElse
+end
+
+# good
+case var
+when condition
+  statement
+else
+  # the content of `else` branch will be determined by Style/EmptyElse
+end
+----
+
 ==== EnforcedStyle: if
 
 [source,ruby]
@@ -6738,39 +6771,6 @@ end
 
 # good
 if condition
-  statement
-else
-  # the content of `else` branch will be determined by Style/EmptyElse
-end
-----
-
-==== EnforcedStyle: both (default)
-
-[source,ruby]
-----
-# warn when an `if` or `case` expression is missing an `else` branch.
-
-# bad
-if condition
-  statement
-end
-
-# bad
-case var
-when condition
-  statement
-end
-
-# good
-if condition
-  statement
-else
-  # the content of `else` branch will be determined by Style/EmptyElse
-end
-
-# good
-case var
-when condition
   statement
 else
   # the content of `else` branch will be determined by Style/EmptyElse
@@ -10868,42 +10868,6 @@ if any error other than `StandardError` is specified.
 
 === Examples
 
-==== EnforcedStyle: implicit
-
-[source,ruby]
-----
-# `implicit` will enforce using `rescue` instead of
-# `rescue StandardError`.
-
-# bad
-begin
-  foo
-rescue StandardError
-  bar
-end
-
-# good
-begin
-  foo
-rescue
-  bar
-end
-
-# good
-begin
-  foo
-rescue OtherError
-  bar
-end
-
-# good
-begin
-  foo
-rescue StandardError, SecurityError
-  bar
-end
-----
-
 ==== EnforcedStyle: explicit (default)
 
 [source,ruby]
@@ -10922,6 +10886,42 @@ end
 begin
   foo
 rescue StandardError
+  bar
+end
+
+# good
+begin
+  foo
+rescue OtherError
+  bar
+end
+
+# good
+begin
+  foo
+rescue StandardError, SecurityError
+  bar
+end
+----
+
+==== EnforcedStyle: implicit
+
+[source,ruby]
+----
+# `implicit` will enforce using `rescue` instead of
+# `rescue StandardError`.
+
+# bad
+begin
+  foo
+rescue StandardError
+  bar
+end
+
+# good
+begin
+  foo
+rescue
   bar
 end
 
@@ -11009,6 +11009,8 @@ end
 |===
 
 == Style/SafeNavigation
+
+NOTE: Required Ruby version: 2.3
 
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed

--- a/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
@@ -6,6 +6,13 @@ module RuboCop
       # Checks if empty lines around the bodies of blocks match
       # the configuration.
       #
+      # @example EnforcedStyle: no_empty_lines (default)
+      #   # good
+      #
+      #   foo do |bar|
+      #     # ...
+      #   end
+      #
       # @example EnforcedStyle: empty_lines
       #   # good
       #
@@ -13,13 +20,6 @@ module RuboCop
       #
       #     # ...
       #
-      #   end
-      #
-      # @example EnforcedStyle: no_empty_lines (default)
-      #   # good
-      #
-      #   foo do |bar|
-      #     # ...
       #   end
       class EmptyLinesAroundBlockBody < Base
         include EmptyLinesAroundBody

--- a/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
@@ -6,6 +6,15 @@ module RuboCop
       # Checks if empty lines around the bodies of classes match
       # the configuration.
       #
+      # @example EnforcedStyle: no_empty_lines (default)
+      #   # good
+      #
+      #   class Foo
+      #     def bar
+      #       # ...
+      #     end
+      #   end
+      #
       # @example EnforcedStyle: empty_lines
       #   # good
       #
@@ -54,15 +63,6 @@ module RuboCop
       #       # ...
       #     end
       #
-      #   end
-      #
-      # @example EnforcedStyle: no_empty_lines (default)
-      #   # good
-      #
-      #   class Foo
-      #     def bar
-      #       # ...
-      #     end
       #   end
       class EmptyLinesAroundClassBody < Base
         include EmptyLinesAroundBody

--- a/lib/rubocop/cop/layout/empty_lines_around_module_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_module_body.rb
@@ -6,6 +6,15 @@ module RuboCop
       # Checks if empty lines around the bodies of modules match
       # the configuration.
       #
+      # @example EnforcedStyle: no_empty_lines (default)
+      #   # good
+      #
+      #   module Foo
+      #     def bar
+      #       # ...
+      #     end
+      #   end
+      #
       # @example EnforcedStyle: empty_lines
       #   # good
       #
@@ -34,15 +43,6 @@ module RuboCop
       #
       #     def bar; end
       #
-      #   end
-      #
-      # @example EnforcedStyle: no_empty_lines (default)
-      #   # good
-      #
-      #   module Foo
-      #     def bar
-      #       # ...
-      #     end
       #   end
       class EmptyLinesAroundModuleBody < Base
         include EmptyLinesAroundBody

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -37,6 +37,33 @@ module RuboCop
       #   nested_first_param),
       #   second_param
       #
+      # @example EnforcedStyle: special_for_inner_method_call_in_parentheses (default)
+      #   # Same as `special_for_inner_method_call` except that the special rule
+      #   # only applies if the outer method call encloses its arguments in
+      #   # parentheses.
+      #
+      #   # good
+      #   some_method(
+      #     first_param,
+      #   second_param)
+      #
+      #   foo = some_method(
+      #     first_param,
+      #   second_param)
+      #
+      #   foo = some_method(nested_call(
+      #                       nested_first_param),
+      #   second_param)
+      #
+      #   foo = some_method(
+      #     nested_call(
+      #       nested_first_param),
+      #   second_param)
+      #
+      #   some_method nested_call(
+      #     nested_first_param),
+      #   second_param
+      #
       # @example EnforcedStyle: consistent
       #   # The first argument should always be indented one step more than the
       #   # preceding line.
@@ -115,33 +142,6 @@ module RuboCop
       #
       #   some_method nested_call(
       #                 nested_first_param),
-      #   second_param
-      #
-      # @example EnforcedStyle: special_for_inner_method_call_in_parentheses (default)
-      #   # Same as `special_for_inner_method_call` except that the special rule
-      #   # only applies if the outer method call encloses its arguments in
-      #   # parentheses.
-      #
-      #   # good
-      #   some_method(
-      #     first_param,
-      #   second_param)
-      #
-      #   foo = some_method(
-      #     first_param,
-      #   second_param)
-      #
-      #   foo = some_method(nested_call(
-      #                       nested_first_param),
-      #   second_param)
-      #
-      #   foo = some_method(
-      #     nested_call(
-      #       nested_first_param),
-      #   second_param)
-      #
-      #   some_method nested_call(
-      #     nested_first_param),
       #   second_param
       #
       class FirstArgumentIndentation < Base

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -6,16 +6,6 @@ module RuboCop
       # Checks that brackets used for array literals have or don't have
       # surrounding space depending on configuration.
       #
-      # @example EnforcedStyle: space
-      #   # The `space` style enforces that array literals have
-      #   # surrounding space.
-      #
-      #   # bad
-      #   array = [a, b, c, d]
-      #
-      #   # good
-      #   array = [ a, b, c, d ]
-      #
       # @example EnforcedStyle: no_space (default)
       #   # The `no_space` style enforces that array literals have
       #   # no surrounding space.
@@ -25,6 +15,16 @@ module RuboCop
       #
       #   # good
       #   array = [a, b, c, d]
+      #
+      # @example EnforcedStyle: space
+      #   # The `space` style enforces that array literals have
+      #   # surrounding space.
+      #
+      #   # bad
+      #   array = [a, b, c, d]
+      #
+      #   # good
+      #   array = [ a, b, c, d ]
       #
       # @example EnforcedStyle: compact
       #   # The `compact` style normally requires a space inside

--- a/lib/rubocop/cop/layout/trailing_empty_lines.rb
+++ b/lib/rubocop/cop/layout/trailing_empty_lines.rb
@@ -6,6 +6,21 @@ module RuboCop
       # Looks for trailing blank lines and a final newline in the
       # source code.
       #
+      # @example EnforcedStyle: final_newline (default)
+      #   # `final_newline` looks for one newline at the end of files.
+      #
+      #   # bad
+      #   class Foo; end
+      #
+      #   # EOF
+      #
+      #   # bad
+      #   class Foo; end # EOF
+      #
+      #   # good
+      #   class Foo; end
+      #   # EOF
+      #
       # @example EnforcedStyle: final_blank_line
       #   # `final_blank_line` looks for one blank line followed by a new line
       #   # at the end of files.
@@ -20,21 +35,6 @@ module RuboCop
       #   # good
       #   class Foo; end
       #
-      #   # EOF
-      #
-      # @example EnforcedStyle: final_newline (default)
-      #   # `final_newline` looks for one newline at the end of files.
-      #
-      #   # bad
-      #   class Foo; end
-      #
-      #   # EOF
-      #
-      #   # bad
-      #   class Foo; end # EOF
-      #
-      #   # good
-      #   class Foo; end
       #   # EOF
       #
       class TrailingEmptyLines < Base

--- a/lib/rubocop/cop/naming/variable_number.rb
+++ b/lib/rubocop/cop/naming/variable_number.rb
@@ -11,23 +11,6 @@ module RuboCop
       # can be used to specify whether method names and symbols should be checked.
       # Both are enabled by default.
       #
-      # @example EnforcedStyle: snake_case
-      #   # bad
-      #   :some_sym1
-      #   variable1 = 1
-      #
-      #   def some_method1; end
-      #
-      #   def some_method_1(arg1); end
-      #
-      #   # good
-      #   :some_sym_1
-      #   variable_1 = 1
-      #
-      #   def some_method_1; end
-      #
-      #   def some_method_1(arg_1); end
-      #
       # @example EnforcedStyle: normalcase (default)
       #   # bad
       #   :some_sym_1
@@ -44,6 +27,23 @@ module RuboCop
       #   def some_method1; end
       #
       #   def some_method1(arg1); end
+      #
+      # @example EnforcedStyle: snake_case
+      #   # bad
+      #   :some_sym1
+      #   variable1 = 1
+      #
+      #   def some_method1; end
+      #
+      #   def some_method_1(arg1); end
+      #
+      #   # good
+      #   :some_sym_1
+      #   variable_1 = 1
+      #
+      #   def some_method_1; end
+      #
+      #   def some_method_1(arg_1); end
       #
       # @example EnforcedStyle: non_integer
       #   # bad

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -12,21 +12,6 @@ module RuboCop
       #   between logical operators (`&&` and `||`) and semantic operators (`and` and `or`),
       #   and that might change the behavior.
       #
-      # @example EnforcedStyle: always
-      #   # bad
-      #   foo.save and return
-      #
-      #   # bad
-      #   if foo and bar
-      #   end
-      #
-      #   # good
-      #   foo.save && return
-      #
-      #   # good
-      #   if foo && bar
-      #   end
-      #
       # @example EnforcedStyle: conditionals (default)
       #   # bad
       #   if foo and bar
@@ -37,6 +22,21 @@ module RuboCop
       #
       #   # good
       #   foo.save and return
+      #
+      #   # good
+      #   if foo && bar
+      #   end
+      #
+      # @example EnforcedStyle: always
+      #   # bad
+      #   foo.save and return
+      #
+      #   # bad
+      #   if foo and bar
+      #   end
+      #
+      #   # good
+      #   foo.save && return
       #
       #   # good
       #   if foo && bar

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -6,6 +6,34 @@ module RuboCop
       # Checks for empty else-clauses, possibly including comments and/or an
       # explicit `nil` depending on the EnforcedStyle.
       #
+      # @example EnforcedStyle: both (default)
+      #   # warn on empty else and else with nil in it
+      #
+      #   # bad
+      #   if condition
+      #     statement
+      #   else
+      #     nil
+      #   end
+      #
+      #   # bad
+      #   if condition
+      #     statement
+      #   else
+      #   end
+      #
+      #   # good
+      #   if condition
+      #     statement
+      #   else
+      #     statement
+      #   end
+      #
+      #   # good
+      #   if condition
+      #     statement
+      #   end
+      #
       # @example EnforcedStyle: empty
       #   # warn only on empty else
       #
@@ -45,34 +73,6 @@ module RuboCop
       #   end
       #
       #   # good
-      #   if condition
-      #     statement
-      #   else
-      #   end
-      #
-      #   # good
-      #   if condition
-      #     statement
-      #   else
-      #     statement
-      #   end
-      #
-      #   # good
-      #   if condition
-      #     statement
-      #   end
-      #
-      # @example EnforcedStyle: both (default)
-      #   # warn on empty else and else with nil in it
-      #
-      #   # bad
-      #   if condition
-      #     statement
-      #   else
-      #     nil
-      #   end
-      #
-      #   # bad
       #   if condition
       #     statement
       #   else

--- a/lib/rubocop/cop/style/missing_else.rb
+++ b/lib/rubocop/cop/style/missing_else.rb
@@ -10,6 +10,35 @@ module RuboCop
       #
       # Supported styles are: if, case, both.
       #
+      # @example EnforcedStyle: both (default)
+      #   # warn when an `if` or `case` expression is missing an `else` branch.
+      #
+      #   # bad
+      #   if condition
+      #     statement
+      #   end
+      #
+      #   # bad
+      #   case var
+      #   when condition
+      #     statement
+      #   end
+      #
+      #   # good
+      #   if condition
+      #     statement
+      #   else
+      #     # the content of `else` branch will be determined by Style/EmptyElse
+      #   end
+      #
+      #   # good
+      #   case var
+      #   when condition
+      #     statement
+      #   else
+      #     # the content of `else` branch will be determined by Style/EmptyElse
+      #   end
+      #
       # @example EnforcedStyle: if
       #   # warn when an `if` expression is missing an `else` branch.
       #
@@ -63,35 +92,6 @@ module RuboCop
       #
       #   # good
       #   if condition
-      #     statement
-      #   else
-      #     # the content of `else` branch will be determined by Style/EmptyElse
-      #   end
-      #
-      # @example EnforcedStyle: both (default)
-      #   # warn when an `if` or `case` expression is missing an `else` branch.
-      #
-      #   # bad
-      #   if condition
-      #     statement
-      #   end
-      #
-      #   # bad
-      #   case var
-      #   when condition
-      #     statement
-      #   end
-      #
-      #   # good
-      #   if condition
-      #     statement
-      #   else
-      #     # the content of `else` branch will be determined by Style/EmptyElse
-      #   end
-      #
-      #   # good
-      #   case var
-      #   when condition
       #     statement
       #   else
       #     # the content of `else` branch will be determined by Style/EmptyElse

--- a/lib/rubocop/cop/style/rescue_standard_error.rb
+++ b/lib/rubocop/cop/style/rescue_standard_error.rb
@@ -7,21 +7,21 @@ module RuboCop
       # styles `implicit` and `explicit`. This cop will not register an offense
       # if any error other than `StandardError` is specified.
       #
-      # @example EnforcedStyle: implicit
-      #   # `implicit` will enforce using `rescue` instead of
-      #   # `rescue StandardError`.
+      # @example EnforcedStyle: explicit (default)
+      #   # `explicit` will enforce using `rescue StandardError`
+      #   # instead of `rescue`.
       #
       #   # bad
       #   begin
       #     foo
-      #   rescue StandardError
+      #   rescue
       #     bar
       #   end
       #
       #   # good
       #   begin
       #     foo
-      #   rescue
+      #   rescue StandardError
       #     bar
       #   end
       #
@@ -39,21 +39,21 @@ module RuboCop
       #     bar
       #   end
       #
-      # @example EnforcedStyle: explicit (default)
-      #   # `explicit` will enforce using `rescue StandardError`
-      #   # instead of `rescue`.
+      # @example EnforcedStyle: implicit
+      #   # `implicit` will enforce using `rescue` instead of
+      #   # `rescue StandardError`.
       #
       #   # bad
       #   begin
       #     foo
-      #   rescue
+      #   rescue StandardError
       #     bar
       #   end
       #
       #   # good
       #   begin
       #     foo
-      #   rescue StandardError
+      #   rescue
       #     bar
       #   end
       #


### PR DESCRIPTION
Previously, not all default enforced styles were at the top.

Known limitations:

1. only checks for `EnforcedStyle:`, not e.g.  `EnforcedStyleForMultiline:` (which is the **only**) enforced style type in `Style/TrailingCommaInArrayLiteral` cop.

2. only checks for `EnforcedStyle:` when other enforced style types are present, e.g. `EnforcedStyleForEmptyBrackets:` for `Layout/SpaceInsideArrayLiteralBrackets` (also has regular `EnforcedStyle:`).

3. No autocorrection 😄 

Follow-up to https://github.com/rubocop/rubocop-rspec/pull/1289, basing on [this discussion](https://github.com/rubocop/rubocop-rspec/pull/1279#discussion_r884678237).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/