### PR TITLE
[Fix #10685] Fix a false positive for `Style/StringConcatenation`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_string_concatenation.md
+++ b/changelog/fix_a_false_positive_for_style_string_concatenation.md
@@ -1,0 +1,1 @@
+* [#10685](https://github.com/rubocop/rubocop/issues/10685): Fix a false positive for `Style/StringConcatenation` when `Mode: conservative` and first operand is not string literal. ([@koic][])

--- a/lib/rubocop/cop/style/string_concatenation.rb
+++ b/lib/rubocop/cop/style/string_concatenation.rb
@@ -76,7 +76,7 @@ module RuboCop
 
           topmost_plus_node = find_topmost_plus_node(node)
           parts = collect_parts(topmost_plus_node)
-          return unless parts[0..-2].any? { |receiver_node| offensive_for_mode?(receiver_node) }
+          return if mode == :conservative && !parts.first.str_type?
 
           register_offense(topmost_plus_node, parts)
         end
@@ -93,11 +93,6 @@ module RuboCop
               @corrected_nodes.add(topmost_plus_node)
             end
           end
-        end
-
-        def offensive_for_mode?(receiver_node)
-          mode = cop_config['Mode'].to_sym
-          mode == :aggressive || (mode == :conservative && receiver_node.str_type?)
         end
 
         def line_end_concatenation?(node)
@@ -172,6 +167,10 @@ module RuboCop
 
         def single_quoted?(str_node)
           str_node.source.start_with?("'")
+        end
+
+        def mode
+          cop_config['Mode'].to_sym
         end
       end
     end

--- a/spec/rubocop/cop/style/string_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/string_concatenation_spec.rb
@@ -224,6 +224,7 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation, :config do
         expect_no_offenses(<<~RUBY)
           user.name + "!!"
           user.name + "<"
+          user.name + "<" + "user.email" + ">"
         RUBY
       end
     end
@@ -235,14 +236,11 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation, :config do
           ^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
           "Hello " + user.name + "!!"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
-          user.name + "<" + "user.email" + ">"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
         RUBY
 
         expect_correction(<<~RUBY)
           "Hello \#{user.name}"
           "Hello \#{user.name}!!"
-          "\#{user.name}<user.email>"
         RUBY
       end
     end


### PR DESCRIPTION
Fixes #10685.

This PR fixes a false positive for `Style/StringConcatenation` when `Mode: conservative` and first operand is not string literal. It also resolves the following feedback:
https://github.com/rubocop/rubocop/pull/9153#discussion_r616956347

`Mode: conservative` should be allowed considering the possibility that receiver is a `Pathname` object.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
