### PR TITLE
Fix: rubocop-performance SafeMode deprecation version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1992,7 +1992,7 @@
 * [#5265](https://github.com/rubocop/rubocop/issues/5265): Improved `Layout/ExtraSpacing` cop to handle nested consecutive assignments. ([@jfelchner][])
 * [#7215](https://github.com/rubocop/rubocop/issues/7215): Make it clear what's wrong in the message from `Style/GuardClause`. ([@jonas054][])
 * [#7245](https://github.com/rubocop/rubocop/pull/7245): Make cops detect string interpolations in more contexts: inside of backticks, regular expressions, and symbols. ([@buehmann][])
-* Deprecate the `SafeMode` option. Users will need to upgrade `rubocop-performance` to 1.15.0+ before the `SafeMode` module is removed. ([@rrosenblum][])
+* Deprecate the `SafeMode` option. Users will need to upgrade `rubocop-performance` to 1.5.0+ before the `SafeMode` module is removed. ([@rrosenblum][])
 
 ## 0.73.0 (2019-07-16)
 


### PR DESCRIPTION
Rubocop v0.74.0 [changelog](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#0740-2019-07-31) says:
```
Deprecate the SafeMode option. Users will need to upgrade rubocop-performance to 1.15.0+ before the SafeMode module is removed. ([@rrosenblum](https://github.com/rrosenblum))
```

But rubocop-performance version 1.15.0 does not exist. This was introduced in this [PR](https://github.com/rubocop/rubocop/pull/7249/files) 
It should say 1.5.0 instead of 1.15.0. 

According to [rubocop-performance releases](https://github.com/rubocop/rubocop-performance/releases/tag/v1.5.0), SafeMode was removed in version 1.5.0
