### PR TITLE
Break long method definitions when auto-correcting

### DIFF
--- a/changelog/new_autocorrect_wraps_method_definitions.md
+++ b/changelog/new_autocorrect_wraps_method_definitions.md
@@ -1,0 +1,1 @@
+* [#10692](https://github.com/rubocop/rubocop/pull/10692): Break long method definitions when auto-correcting. ([@Korri][])

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -80,6 +80,7 @@ module RuboCop
         alias on_array on_potential_breakable_node
         alias on_hash on_potential_breakable_node
         alias on_send on_potential_breakable_node
+        alias on_def on_potential_breakable_node
 
         def on_new_investigation
           check_for_breakable_semicolons(processed_source)

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -46,6 +46,8 @@ module RuboCop
         if node.send_type?
           args = process_args(node.arguments)
           return extract_breakable_node_from_elements(node, args, max)
+        elsif node.def_type?
+          return extract_breakable_node_from_elements(node, node.arguments, max)
         elsif node.array_type? || node.hash_type?
           return extract_breakable_node_from_elements(node, node.children, max)
         end
@@ -216,6 +218,8 @@ module RuboCop
 
       # @api private
       def already_on_multiple_lines?(node)
+        return node.first_line != node.arguments.last.last_line if node.def_type?
+
         node.first_line != node.last_line
       end
     end

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -597,6 +597,32 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       end
     end
 
+    context 'method definition' do
+      context 'when under limit' do
+        it 'does not add any offenses' do
+          expect_no_offenses(<<~RUBY)
+            def foo(foo: 1, bar: "2"); end
+          RUBY
+        end
+      end
+
+      context 'when over limit' do
+        it 'adds an offense and autocorrects it' do
+          expect_offense(<<~RUBY)
+            def foo(abc: "100000", def: "100000", ghi: "100000", jkl: "100000", mno: "100000")
+                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [82/40]
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def foo(abc: "100000", def: "100000",#{trailing_whitespace}
+            ghi: "100000", jkl: "100000", mno: "100000")
+            end
+          RUBY
+        end
+      end
+    end
+
     context 'method call' do
       context 'when under limit' do
         it 'does not add any offenses' do


### PR DESCRIPTION
Add autocorrect capabilities to `Layout/LineLength`, by wrapping method definitions on multiple lines.

```ruby
# bad
def foo(abc: "100000", def: "100000", ghi: "100000", jkl: "100000", mno: "100000")
end

# good (autocorrect)
def foo(abc: "100000", def: "100000", 
  ghi: "100000", jkl: "100000", mno: "100000")
end
```

Combined with https://github.com/rubocop/rubocop/pull/10691 it allows for some nice autocorrect.

This was split from the larger WIP pull request here: https://github.com/rubocop/rubocop/pull/10681

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
