### PR TITLE
[Fix #10693] Add ignore case for `Style/EmptyLinesAroundAttributeAccessor` when there is a comment line on the next line.

### DIFF
--- a/changelog/change_add_ignore_case_for_empty_lines_around_attribute_accessor.md
+++ b/changelog/change_add_ignore_case_for_empty_lines_around_attribute_accessor.md
@@ -1,0 +1,1 @@
+* [#10693](https://github.com/rubocop/rubocop/issues/10693): Add ignore case for `Style/EmptyLinesAroundAttributeAccessor` when there is a comment line on the next line. ([@ydah][])

--- a/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb
@@ -33,9 +33,144 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAttributeAccessor, :config 
     RUBY
   end
 
-  it 'accepts code that separates a attribute accessor from the code with a newline' do
+  it 'registers an offense and corrects for an attribute accessor and comment line' do
+    expect_offense(<<~RUBY)
+      attr_accessor :foo
+      ^^^^^^^^^^^^^^^^^^ Add an empty line after attribute accessor.
+      # comment
+      def do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      attr_accessor :foo
+
+      # comment
+      def do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects for some attribute accessors and comment line' do
+    expect_offense(<<~RUBY)
+      attr_accessor :foo
+      attr_reader :bar
+      attr_writer :baz
+      ^^^^^^^^^^^^^^^^ Add an empty line after attribute accessor.
+      # comment
+      def do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      attr_accessor :foo
+      attr_reader :bar
+      attr_writer :baz
+
+      # comment
+      def do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects for an attribute accessor and some comment line' do
+    expect_offense(<<~RUBY)
+      attr_accessor :foo
+      ^^^^^^^^^^^^^^^^^^ Add an empty line after attribute accessor.
+      # comment
+      # comment
+      def do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      attr_accessor :foo
+
+      # comment
+      # comment
+      def do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects for an attribute accessor and `rubocop:disable` ' \
+     'comment line' do
+    expect_offense(<<~RUBY)
+      attr_accessor :foo
+      ^^^^^^^^^^^^^^^^^^ Add an empty line after attribute accessor.
+      # rubocop:disable Department/Cop
+      def do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      attr_accessor :foo
+
+      # rubocop:disable Department/Cop
+      def do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects for an attribute accessor and `rubocop:enable` ' \
+     'comment line' do
+    expect_offense(<<~RUBY)
+      # rubocop:disable Department/Cop
+      attr_accessor :foo
+      ^^^^^^^^^^^^^^^^^^ Add an empty line after attribute accessor.
+      # rubocop:enable Department/Cop
+      def do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # rubocop:disable Department/Cop
+      attr_accessor :foo
+      # rubocop:enable Department/Cop
+
+      def do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects for an attribute accessor and `rubocop:enable` ' \
+     'comment line and other comment' do
+    expect_offense(<<~RUBY)
+      # rubocop:disable Department/Cop
+      attr_accessor :foo
+      ^^^^^^^^^^^^^^^^^^ Add an empty line after attribute accessor.
+      # rubocop:enable Department/Cop
+      # comment
+      def do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # rubocop:disable Department/Cop
+      attr_accessor :foo
+      # rubocop:enable Department/Cop
+
+      # comment
+      def do_something
+      end
+    RUBY
+  end
+
+  it 'accepts code that separates an attribute accessor from the code with a newline' do
     expect_no_offenses(<<~RUBY)
       attr_accessor :foo
+
+      def do_something
+      end
+    RUBY
+  end
+
+  it 'accepts code that separates an attribute accessor from the code and `rubocop:enable` ' \
+     'comment line with a newline' do
+    expect_no_offenses(<<~RUBY)
+      # rubocop:disable Department/Cop
+      attr_accessor :foo
+      # rubocop:enable Department/Cop
 
       def do_something
       end
@@ -52,6 +187,18 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAttributeAccessor, :config 
       attr_reader :bar
       attr_writer :baz
 
+      def do_something
+      end
+    RUBY
+  end
+
+  it 'accepts code that separates attribute accessors from the code and comment line with a newline' do
+    expect_no_offenses(<<~RUBY)
+      attr_accessor :foo
+      attr_reader :bar
+      attr_writer :baz
+
+      # comment
       def do_something
       end
     RUBY


### PR DESCRIPTION
Resolve: https://github.com/rubocop/rubocop/issues/10693

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
