### PR TITLE
Change command for the rake task with arguments to a style that can also be used in zsh

### DIFF
--- a/tasks/new_cop.rake
+++ b/tasks/new_cop.rake
@@ -5,7 +5,7 @@ require 'rubocop'
 desc 'Generate a new cop template'
 task :new_cop, [:cop] do |_task, args|
   cop_name = args.fetch(:cop) do
-    warn 'usage: bundle exec rake new_cop[Department/Name]'
+    warn "usage: bundle exec rake 'new_cop[Department/Name]'"
     exit!
   end
 

--- a/tasks/prof.rake
+++ b/tasks/prof.rake
@@ -31,7 +31,7 @@ namespace :prof do
   desc 'Check a particular method by walking through the callstack'
   task :walk, [:method] => :run_if_needed do |_task, args|
     method = args.fetch(:method) do
-      warn 'usage: bundle exec rake walk[Class#method]'
+      warn "usage: bundle exec rake 'walk[Class#method]'"
       exit!
     end
     cmd = "stackprof #{dump_path} --walk --method '#{method}'"


### PR DESCRIPTION
If you try to add a new cop and use the wrong command in the rake task, you will get the following warning.

```console
❯ bundle exec rake new_cop                                     
usage: bundle exec rake new_cop[Department/Name]
```

If you try to execute it as is, you will face the following error.

```console
❯ bundle exec rake new_cop[Department/Name]
zsh: no matches found: new_cop[Department/Name]
```

https://github.com/rubocop/rubocop/pull/10695#issuecomment-1147019057

As noted in the documentation, it should be in a format that can be executed by zsh by enclosing it in single quotation marks.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
