### PR TITLE
Fix displaying version information for known extensions

### DIFF
--- a/changelog/fix_displaying_extension_versions.md
+++ b/changelog/fix_displaying_extension_versions.md
@@ -1,0 +1,1 @@
+* Fix `rubocop -V` not displaying the version information for rubocop-graphql, rubocop-md and rubocop-thread_safety. ([@Darhazer][])

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -9,7 +9,9 @@ module RuboCop
           'rubocop-ast %<rubocop_ast_version>s, ' \
           'running on %<ruby_engine>s %<ruby_version>s %<ruby_platform>s)'
 
-    CANONICAL_FEATURE_NAMES = { 'Rspec' => 'RSpec' }.freeze
+    CANONICAL_FEATURE_NAMES = { 'Rspec' => 'RSpec', 'Graphql' => 'GraphQL', 'Md' => 'Markdown',
+                                'Thread_safety' => 'ThreadSafety' }.freeze
+    EXTENSION_PATH_NAMES = { 'rubocop-md' => 'markdown' }.freeze
 
     # @api private
     def self.version(debug: false, env: nil)
@@ -43,16 +45,21 @@ module RuboCop
       features.map do |loaded_feature|
         next unless (match = loaded_feature.match(/rubocop-(?<feature>.*)/))
 
-        feature = match[:feature]
+        # Get the expected name of the folder containing the extension code.
+        # Usually it would be the same as the extension name. but sometimes authors
+        # can choose slightly different name for their gems, e.g. rubocop-md instead of
+        # rubocop-markdown.
+        feature = EXTENSION_PATH_NAMES.fetch(loaded_feature, match[:feature])
+
         begin
           require "rubocop/#{feature}/version"
         rescue LoadError
           # Not worth mentioning libs that are not installed
-        else
-          next unless (feature_version = feature_version(feature))
-
-          "  - #{loaded_feature} #{feature_version}"
         end
+
+        next unless (feature_version = feature_version(feature))
+
+        "  - #{loaded_feature} #{feature_version}"
       end.compact
     end
 

--- a/spec/rubocop/version_spec.rb
+++ b/spec/rubocop/version_spec.rb
@@ -104,5 +104,38 @@ RSpec.describe RuboCop::Version do
         end.not_to raise_error
       end
     end
+
+    context 'with all known mappings' do
+      let(:config) { instance_double(RuboCop::Config) }
+
+      let(:known_features) do
+        %w[
+          rubocop-performance
+          rubocop-rspec
+          rubocop-graphql
+          rubocop-md
+          rubocop-thread_safety
+        ]
+      end
+
+      before do
+        allow(config).to receive(:loaded_features).and_return(known_features)
+        allow(config_store).to receive(:for_dir).and_return(config)
+
+        stub_const('RuboCop::GraphQL::Version::STRING', '1.0.0')
+        stub_const('RuboCop::Markdown::Version::STRING', '1.0.0')
+        stub_const('RuboCop::ThreadSafety::Version::STRING', '1.0.0')
+      end
+
+      it 'returns the extensions' do
+        expect(extension_versions).to contain_exactly(
+          /- rubocop-performance \d+\.\d+\.\d+/,
+          /- rubocop-rspec \d+\.\d+\.\d+/,
+          /- rubocop-graphql \d+\.\d+\.\d+/,
+          /- rubocop-md \d+\.\d+\.\d+/,
+          /- rubocop-thread_safety \d+\.\d+\.\d+/
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
The rubocop extension namespaces not always match the gem name. We already had the mapping done for rubocop-rspec. This adds the mapping for rubocop-md, rubocop-thread_safety and rubocop-graphql.

Note that I also changed is so it would try to check the `RuboCop::<extension>::Version::STRING` constant if the load itself fails. This was needed in order to write the test, but since it also handles the constant not being defined gracefully, I decided there is no harm in the check still being performed.

rubocop-md was the worst offender, as the folder structure doesn't follow the gem name (the files are under `markdown` folder and not `md`). So it required one additional mapping - quite ugly at this point, but since it's the only exception, I hope it's acceptable 🙏 

Any suggestions for further improvement (or avoiding the degradation of the existing code) are welcome

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
