### PR TITLE
Rename custom rake task to `rubocop:autocorrect`

### DIFF
--- a/changelog/change_rename_custom_rake_task_to_rubocop_autocorrect.md
+++ b/changelog/change_rename_custom_rake_task_to_rubocop_autocorrect.md
@@ -1,0 +1,1 @@
+* [#10709](https://github.com/rubocop/rubocop/pull/10709): Rename custom rake task from `rubocop:auto_correct` to `rubocop:autocorrect`. ([@koic][])

--- a/docs/modules/ROOT/pages/integration_with_other_tools.adoc
+++ b/docs/modules/ROOT/pages/integration_with_other_tools.adoc
@@ -157,8 +157,8 @@ If you run `rake -T`, the following two RuboCop tasks should show up:
 
 [source,sh]
 ----
-$ rake rubocop                                  # Run RuboCop
-$ rake rubocop:auto_correct                     # Autocorrect RuboCop offenses
+$ rake rubocop                                 # Run RuboCop
+$ rake rubocop:autocorrect                     # Autocorrect RuboCop offenses
 ----
 
 The above will use default values

--- a/lib/rubocop/rake_task.rb
+++ b/lib/rubocop/rake_task.rb
@@ -60,11 +60,17 @@ module RuboCop
       @formatters = []
     end
 
-    def setup_subtasks(name, *args, &task_block)
+    def setup_subtasks(name, *args, &task_block) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       namespace(name) do
-        desc 'Autocorrect RuboCop offenses'
+        task(:auto_correct, *args) do
+          warn Rainbow(
+            'rubocop:auto_correct task is deprecated; use rubocop:autocorrect task instead.'
+          ).yellow
+          ::Rake::Task['rubocop:autocorrect'].invoke
+        end
 
-        task(:auto_correct, *args) do |_, task_args|
+        desc 'Autocorrect RuboCop offenses'
+        task(:autocorrect, *args) do |_, task_args|
           RakeFileUtils.verbose(verbose) do
             yield(*[self, task_args].slice(0, task_block.arity)) if task_block
             options = full_options.unshift('--autocorrect-all')

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -24,6 +24,20 @@ RSpec.describe RuboCop::RakeTask do
       expect(Rake::Task.task_defined?(:lint_lib)).to be true
       expect(Rake::Task.task_defined?('lint_lib:auto_correct')).to be true
     end
+
+    it 'creates a rubocop task and a rubocop autocorrect task' do
+      described_class.new
+
+      expect(Rake::Task.task_defined?(:rubocop)).to be true
+      expect(Rake::Task.task_defined?('rubocop:autocorrect')).to be true
+    end
+
+    it 'creates a named task and a named autocorrect task' do
+      described_class.new(:lint_lib)
+
+      expect(Rake::Task.task_defined?(:lint_lib)).to be true
+      expect(Rake::Task.task_defined?('lint_lib:autocorrect')).to be true
+    end
   end
 
   describe 'running tasks' do


### PR DESCRIPTION
Follow up #10547.

This PR renames custom rake task from `rubocop:auto_correct` to `rubocop:autocorrect`.

## Before

```console
rake rubocop                              # Run RuboCop
rake rubocop:auto_correct                 # Autocorrect RuboCop offenses
```

## After

```console
rake rubocop                             # Run RuboCop
rake rubocop:autocorrect                 # Autocorrect RuboCop offenses
```

For compatibility, `rubocop:auto_correct` task is left, but the task is deprecated and does not display in `rake -T`.
When executed, the following warning will be displayed:

```console
% bundle exec rake rubocop:auto_correct
rubocop:auto_correct task is deprecated; use rubocop:autocorrect task instead.
Running RuboCop...
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
