### PR TITLE
[Fix #10711] Fix an error for `Style/MultilineTernaryOperator`

### DIFF
--- a/changelog/fix_an_error_for_style_multiline_ternary_operator.md
+++ b/changelog/fix_an_error_for_style_multiline_ternary_operator.md
@@ -1,0 +1,1 @@
+* [#10711](https://github.com/rubocop/rubocop/issues/10711): Fix an error for `Style/MultilineTernaryOperator` when the false branch is on a separate line. ([@koic][])

--- a/lib/rubocop/cop/style/multiline_ternary_operator.rb
+++ b/lib/rubocop/cop/style/multiline_ternary_operator.rb
@@ -73,7 +73,7 @@ module RuboCop
         end
 
         def enforce_single_line_ternary_operator?(node)
-          SINGLE_LINE_TYPES.include?(node.parent.type) && !use_assignment_method?(node.parent)
+          SINGLE_LINE_TYPES.include?(node.parent&.type) && !use_assignment_method?(node.parent)
         end
 
         def use_assignment_method?(node)

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineTernaryOperator, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects when the false branch is on a separate line' do
+  it 'registers an offense and corrects when the false branch is on a separate line and assigning a return value' do
     expect_offense(<<~RUBY)
       a = cond ? b :
           ^^^^^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
@@ -27,6 +27,22 @@ RSpec.describe RuboCop::Cop::Style::MultilineTernaryOperator, :config do
 
     expect_correction(<<~RUBY)
       a = if cond
+        b
+      else
+        c
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when the false branch is on a separate line' do
+    expect_offense(<<~RUBY)
+      cond ? b :
+      ^^^^^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
+      c
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if cond
         b
       else
         c


### PR DESCRIPTION
Fixes #10711.

This PR fixes an error for `Style/MultilineTernaryOperator` when the false branch is on a separate line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
