### PR TITLE
Add a setting for "autocorrect" in `Naming/InclusiveLanguage`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,6 +100,12 @@ Naming/InclusiveLanguage:
   Enabled: true
   CheckStrings: true
   FlaggedTerms:
+    auto-correct:
+      Suggestions:
+        - autocorrect
+    auto_correct:
+      Suggestions:
+        - autocorrect
     behaviour:
       Suggestions:
         - behavior
@@ -108,6 +114,7 @@ Naming/InclusiveLanguage:
         - offense
   Exclude:
     - lib/rubocop/cop/naming/inclusive_language.rb
+    - lib/rubocop/cop/mixin/auto_corrector.rb
     - spec/rubocop/cop/naming/inclusive_language_spec.rb
 
 RSpec/FilePath:

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -63,7 +63,7 @@ require_relative 'rubocop/cop/mixin/alignment'
 require_relative 'rubocop/cop/mixin/allowed_identifiers'
 require_relative 'rubocop/cop/mixin/allowed_methods'
 require_relative 'rubocop/cop/mixin/allowed_pattern'
-require_relative 'rubocop/cop/mixin/auto_corrector'
+require_relative 'rubocop/cop/mixin/auto_corrector' # rubocop:todo Naming/InclusiveLanguage
 require_relative 'rubocop/cop/mixin/check_assignment'
 require_relative 'rubocop/cop/mixin/check_line_breakable'
 require_relative 'rubocop/cop/mixin/configurable_max'

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -25,12 +25,12 @@ module RuboCop
             return if allowed_string_interpolation_method_call?(node)
 
             add_offense(offense_range(node), message: OMIT_MSG) do |corrector|
-              auto_correct(corrector, node)
+              autocorrect(corrector, node)
             end
           end
           # rubocop:enable Metrics/PerceivedComplexity
 
-          def auto_correct(corrector, node)
+          def autocorrect(corrector, node)
             if parentheses_at_the_end_of_multiline_call?(node)
               corrector.replace(args_begin(node), ' \\')
             else

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -63,7 +63,7 @@ module RuboCop
                             rainbow,
                             # :safe_autocorrect is a derived option based on several command-line
                             # arguments - see Rubocop::Options#add_autocorrection_options
-                            safe_auto_correct: @options[:safe_autocorrect])
+                            safe_autocorrect: @options[:safe_autocorrect])
 
         output.puts
         output.puts report.summary
@@ -110,14 +110,14 @@ module RuboCop
         # rubocop:disable Metrics/ParameterLists
         def initialize(
           file_count, offense_count, correction_count, correctable_count, rainbow,
-          safe_auto_correct: false
+          safe_autocorrect: false
         )
           @file_count = file_count
           @offense_count = offense_count
           @correction_count = correction_count
           @correctable_count = correctable_count
           @rainbow = rainbow
-          @safe_auto_correct = safe_auto_correct
+          @safe_autocorrect = safe_autocorrect
         end
         # rubocop:enable Metrics/ParameterLists
 
@@ -159,7 +159,7 @@ module RuboCop
         end
 
         def correctable
-          if @safe_auto_correct
+          if @safe_autocorrect
             text = pluralize(@correctable_count, 'more offense')
             "#{colorize(text, :yellow)} can be corrected with `rubocop -A`"
           else

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -130,6 +130,7 @@ module RuboCop
       end
     end
 
+    # rubocop:todo Naming/InclusiveLanguage
     # the autocorrect command-line arguments map to the autocorrect @options values like so:
     #                            :fix_layout  :autocorrect  :safe_autocorrect  :autocorrect_all
     # -x, --fix-layout           true         true          -                  -
@@ -157,6 +158,7 @@ module RuboCop
         option(opts, '--disable-uncorrectable')
       end
     end
+    # rubocop:enable Naming/InclusiveLanguage
 
     def add_config_generation_options(opts)
       section(opts, 'Config Generation') do

--- a/lib/rubocop/rake_task.rb
+++ b/lib/rubocop/rake_task.rb
@@ -62,12 +62,14 @@ module RuboCop
 
     def setup_subtasks(name, *args, &task_block) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       namespace(name) do
+        # rubocop:todo Naming/InclusiveLanguage
         task(:auto_correct, *args) do
           warn Rainbow(
             'rubocop:auto_correct task is deprecated; use rubocop:autocorrect task instead.'
           ).yellow
           ::Rake::Task['rubocop:autocorrect'].invoke
         end
+        # rubocop:enable Naming/InclusiveLanguage
 
         desc 'Autocorrect RuboCop offenses'
         task(:autocorrect, *args) do |_, task_args|

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1073,7 +1073,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     create_file('example.rb', source)
 
     expect(cli.run([
-                     '--auto-correct-all',
+                     '--autocorrect-all',
                      '--only',
                      ['Layout/IndentationConsistency', 'Layout/IndentationWidth'].join(',')
                    ])).to eq(0)
@@ -2460,7 +2460,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     YAML
 
     status = cli.run(
-      %w[--auto-correct-all -d --only] << %w[
+      %w[--autocorrect-all -d --only] << %w[
         Layout/CaseIndentation Layout/ElseAlignment
       ].join(',')
     )

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
         rescue SystemExit # rubocop:disable Lint/SuppressedException
         end
 
+        # rubocop:todo Naming/InclusiveLanguage
         expected_help = <<~OUTPUT
           Usage: rubocop [options] [file1, file2, ...]
 
@@ -186,6 +187,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
               -v, --version                    Display version.
               -V, --verbose-version            Display verbose version.
         OUTPUT
+        # rubocop:enable Naming/InclusiveLanguage
 
         expect($stdout.string).to eq(expected_help)
       end
@@ -572,6 +574,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
     end
 
+    # rubocop:todo Naming/InclusiveLanguage
     describe 'deprecated options' do
       describe '--auto-correct' do
         it 'emits a warning and sets the correct options instead' do
@@ -601,6 +604,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
         end
       end
     end
+    # rubocop:enable Naming/InclusiveLanguage
 
     def expect_autocorrect_options_for_fix_layout
       options_keys = options.instance_variable_get(:@options).keys

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe RuboCop::RakeTask do
   after { Rake::Task.clear }
 
   describe 'defining tasks' do
+    # rubocop:todo Naming/InclusiveLanguage
     it 'creates a rubocop task and a rubocop auto_correct task' do
       described_class.new
 
@@ -24,6 +25,7 @@ RSpec.describe RuboCop::RakeTask do
       expect(Rake::Task.task_defined?(:lint_lib)).to be true
       expect(Rake::Task.task_defined?('lint_lib:auto_correct')).to be true
     end
+    # rubocop:enable Naming/InclusiveLanguage
 
     it 'creates a rubocop task and a rubocop autocorrect task' do
       described_class.new
@@ -148,7 +150,7 @@ RSpec.describe RuboCop::RakeTask do
 
         expect(cli).to receive(:run).with(options)
 
-        Rake::Task['rubocop:auto_correct'].execute
+        Rake::Task['rubocop:autocorrect'].execute
       end
 
       it 'runs with with the options that were passed to its parent task' do
@@ -166,7 +168,7 @@ RSpec.describe RuboCop::RakeTask do
 
         expect(cli).to receive(:run).with(options)
 
-        Rake::Task['rubocop:auto_correct'].execute
+        Rake::Task['rubocop:autocorrect'].execute
       end
     end
   end


### PR DESCRIPTION
In this PR, we have made the following word's suggestions
- auto-correct -> autocorrect
- auto_correct -> autocorrect

Also considered "AutoCorrect" but are hesitant to change the naming of the "RuboCop::Cop::AutoCorrector" module because of its large impact.

In addition, the "auto-correct" command, which is scheduled to be deprecated, is suppressed by including a comment to disable RuboCop in the section containing it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
