### PR TITLE
[Fix #10719] Fix a false positive for `Lint/ParenthesesAsGroupedExpression`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_parentheses_as_grouped_expression.md
+++ b/changelog/fix_a_false_positive_for_lint_parentheses_as_grouped_expression.md
@@ -1,0 +1,1 @@
+* [#10719](https://github.com/rubocop/rubocop/issues/10719): Fix a false positive for `Lint/ParenthesesAsGroupedExpression` when using safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
+++ b/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
@@ -55,7 +55,7 @@ module RuboCop
 
         def chained_calls?(node)
           first_argument = node.first_argument
-          first_argument.send_type? && (node.children.last&.children&.count || 0) > 1
+          first_argument.call_type? && (node.children.last&.children&.count || 0) > 1
         end
 
         def ternary_expression?(node)

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression, :config do
     RUBY
   end
 
+  it 'does not register an offense for expression followed by chained expression with safe navigation operator' do
+    expect_no_offenses(<<~RUBY)
+      func (x).func.func.func.func&.func
+    RUBY
+  end
+
   it 'does not register an offense for math expression' do
     expect_no_offenses(<<~RUBY)
       puts (2 + 3) * 4


### PR DESCRIPTION
Fixes #10719 and follow up #8039.

This PR fixes a false positive for `Lint/ParenthesesAsGroupedExpression` when using safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
