### PR TITLE
[Fix #3904] Automatically extract cop descriptions from cop code docs

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,4 @@
-# Common configuration.
-
+---
 AllCops:
   RubyInterpreters:
     - ruby
@@ -7,424 +6,339 @@ AllCops:
     - rake
     - jruby
     - rbx
-  # Include common Ruby source files.
   Include:
-    - '**/*.rb'
-    - '**/*.arb'
-    - '**/*.axlsx'
-    - '**/*.builder'
-    - '**/*.fcgi'
-    - '**/*.gemfile'
-    - '**/*.gemspec'
-    - '**/*.god'
-    - '**/*.jb'
-    - '**/*.jbuilder'
-    - '**/*.mspec'
-    - '**/*.opal'
-    - '**/*.pluginspec'
-    - '**/*.podspec'
-    - '**/*.rabl'
-    - '**/*.rake'
-    - '**/*.rbuild'
-    - '**/*.rbw'
-    - '**/*.rbx'
-    - '**/*.ru'
-    - '**/*.ruby'
-    - '**/*.spec'
-    - '**/*.thor'
-    - '**/*.watchr'
-    - '**/.irbrc'
-    - '**/.pryrc'
-    - '**/.simplecov'
-    - '**/buildfile'
-    - '**/Appraisals'
-    - '**/Berksfile'
-    - '**/Brewfile'
-    - '**/Buildfile'
-    - '**/Capfile'
-    - '**/Cheffile'
-    - '**/Dangerfile'
-    - '**/Deliverfile'
-    - '**/Fastfile'
-    - '**/*Fastfile'
-    - '**/Gemfile'
-    - '**/Guardfile'
-    - '**/Jarfile'
-    - '**/Mavenfile'
-    - '**/Podfile'
-    - '**/Puppetfile'
-    - '**/Rakefile'
-    - '**/rakefile'
-    - '**/Snapfile'
-    - '**/Steepfile'
-    - '**/Thorfile'
-    - '**/Vagabondfile'
-    - '**/Vagrantfile'
+    - "**/*.rb"
+    - "**/*.arb"
+    - "**/*.axlsx"
+    - "**/*.builder"
+    - "**/*.fcgi"
+    - "**/*.gemfile"
+    - "**/*.gemspec"
+    - "**/*.god"
+    - "**/*.jb"
+    - "**/*.jbuilder"
+    - "**/*.mspec"
+    - "**/*.opal"
+    - "**/*.pluginspec"
+    - "**/*.podspec"
+    - "**/*.rabl"
+    - "**/*.rake"
+    - "**/*.rbuild"
+    - "**/*.rbw"
+    - "**/*.rbx"
+    - "**/*.ru"
+    - "**/*.ruby"
+    - "**/*.spec"
+    - "**/*.thor"
+    - "**/*.watchr"
+    - "**/.irbrc"
+    - "**/.pryrc"
+    - "**/.simplecov"
+    - "**/buildfile"
+    - "**/Appraisals"
+    - "**/Berksfile"
+    - "**/Brewfile"
+    - "**/Buildfile"
+    - "**/Capfile"
+    - "**/Cheffile"
+    - "**/Dangerfile"
+    - "**/Deliverfile"
+    - "**/Fastfile"
+    - "**/*Fastfile"
+    - "**/Gemfile"
+    - "**/Guardfile"
+    - "**/Jarfile"
+    - "**/Mavenfile"
+    - "**/Podfile"
+    - "**/Puppetfile"
+    - "**/Rakefile"
+    - "**/rakefile"
+    - "**/Snapfile"
+    - "**/Steepfile"
+    - "**/Thorfile"
+    - "**/Vagabondfile"
+    - "**/Vagrantfile"
   Exclude:
-    - 'node_modules/**/*'
-    - 'tmp/**/*'
-    - 'vendor/**/*'
-    - '.git/**/*'
-  # Default formatter will be used if no `-f/--format` option is given.
+    - node_modules/**/*
+    - tmp/**/*
+    - vendor/**/*
+    - ".git/**/*"
   DefaultFormatter: progress
-  # Cop names are displayed in offense messages by default. Change behavior
-  # by overriding DisplayCopNames, or by giving the `--no-display-cop-names`
-  # option.
   DisplayCopNames: true
-  # Style guide URLs are not displayed in offense messages by default. Change
-  # behavior by overriding `DisplayStyleGuide`, or by giving the
-  # `-S/--display-style-guide` option.
   DisplayStyleGuide: false
-  # When specifying style guide URLs, any paths and/or fragments will be
-  # evaluated relative to the base URL.
   StyleGuideBaseURL: https://rubystyle.guide
-  # Documentation URLs will be constructed using the base URL.
   DocumentationBaseURL: https://docs.rubocop.org/rubocop
-  # Extra details are not displayed in offense messages by default. Change
-  # behavior by overriding ExtraDetails, or by giving the
-  # `-E/--extra-details` option.
   ExtraDetails: false
-  # Additional cops that do not reference a style guide rule may be enabled by
-  # default. Change behavior by overriding `StyleGuideCopsOnly`, or by giving
-  # the `--only-guide-cops` option.
   StyleGuideCopsOnly: false
-  # All cops except the ones configured `Enabled: false` in this file are enabled by default.
-  # Change this behavior by overriding either `DisabledByDefault` or `EnabledByDefault`.
-  # When `DisabledByDefault` is `true`, all cops in the default configuration
-  # are disabled, and only cops in user configuration are enabled. This makes
-  # cops opt-in instead of opt-out. Note that when `DisabledByDefault` is `true`,
-  # cops in user configuration will be enabled even if they don't set the
-  # Enabled parameter.
-  # When `EnabledByDefault` is `true`, all cops, even those configured `Enabled: false`
-  # in this file are enabled by default. Cops can still be disabled in user configuration.
-  # Note that it is invalid to set both EnabledByDefault and DisabledByDefault
-  # to true in the same configuration.
   EnabledByDefault: false
   DisabledByDefault: false
-  # New cops introduced between major versions are set to a special pending status
-  # and are not enabled by default with warning message.
-  # Change this behavior by overriding either `NewCops: enable` or `NewCops: disable`.
-  # When `NewCops` is `enable`, pending cops are enabled in bulk. Can be overridden by
-  # the `--enable-pending-cops` command-line option.
-  # When `NewCops` is `disable`, pending cops are disabled in bulk. Can be overridden by
-  # the `--disable-pending-cops` command-line option.
   NewCops: pending
-  # Enables the result cache if `true`. Can be overridden by the `--cache` command
-  # line option.
   UseCache: true
-  # Threshold for how many files can be stored in the result cache before some
-  # of the files are automatically removed.
   MaxFilesInCache: 20000
-  # The cache will be stored in "rubocop_cache" under this directory. If
-  # CacheRootDirectory is ~ (nil), which it is by default, the root will be
-  # taken from the environment variable `$XDG_CACHE_HOME` if it is set, or if
-  # `$XDG_CACHE_HOME` is not set, it will be `$HOME/.cache/`.
-  # The CacheRootDirectory can be overwritten by passing the `--cache-root` command
-  # line option or by setting `$RUBOCOP_CACHE_ROOT` environment variable.
-  CacheRootDirectory: ~
-  # It is possible for a malicious user to know the location of RuboCop's cache
-  # directory by looking at CacheRootDirectory, and create a symlink in its
-  # place that could cause RuboCop to overwrite unintended files, or read
-  # malicious input. If you are certain that your cache location is secure from
-  # this kind of attack, and wish to use a symlinked cache location, set this
-  # value to "true".
+  CacheRootDirectory:
   AllowSymlinksInCacheRootDirectory: false
-  # What MRI version of the Ruby interpreter is the inspected code intended to
-  # run on? (If there is more than one, set this to the lowest version.)
-  # If a value is specified for TargetRubyVersion then it is used. Acceptable
-  # values are specified as a float (i.e. 3.0); the teeny version of Ruby
-  # should not be included. If the project specifies a Ruby version in the
-  # .tool-versions or .ruby-version files, Gemfile or gems.rb file, RuboCop will
-  # try to determine the desired version of Ruby by inspecting the
-  # .tool-versions file first, then .ruby-version, followed by the Gemfile.lock
-  # or gems.locked file. (Although the Ruby version is specified in the Gemfile
-  # or gems.rb file, RuboCop reads the final value from the lock file.) If the
-  # Ruby version is still unresolved, RuboCop will use the oldest officially
-  # supported Ruby version (currently Ruby 2.6).
-  TargetRubyVersion: ~
-  # Determines if a notification for extension libraries should be shown when
-  # rubocop is run. Keys are the name of the extension, and values are an array
-  # of gems in the Gemfile that the extension is suggested for, if not already
-  # included.
+  TargetRubyVersion:
   SuggestExtensions:
-    rubocop-rails: [rails]
-    rubocop-rspec: [rspec, rspec-rails]
-    rubocop-minitest: [minitest]
-    rubocop-sequel: [sequel]
-    rubocop-rake: [rake]
-    rubocop-graphql: [graphql]
-
-#################### Bundler ###############################
-
+    rubocop-rails:
+      - rails
+    rubocop-rspec:
+      - rspec
+      - rspec-rails
+    rubocop-minitest:
+      - minitest
+    rubocop-sequel:
+      - sequel
+    rubocop-rake:
+      - rake
+    rubocop-graphql:
+      - graphql
 Bundler/DuplicatedGem:
-  Description: 'Checks for duplicate gem entries in Gemfile.'
+  Description: A Gem's requirements should be listed only once in a Gemfile.
   Enabled: true
   VersionAdded: '0.46'
   Include:
-    - '**/*.gemfile'
-    - '**/Gemfile'
-    - '**/gems.rb'
-
+    - "**/*.gemfile"
+    - "**/Gemfile"
+    - "**/gems.rb"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Bundler/DuplicatedGem
 Bundler/GemComment:
-  Description: 'Add a comment describing each gem.'
+  Description: |-
+    Each gem in the Gemfile should have a comment explaining
+    its purpose in the project, or the reason for its version
+    or source.
   Enabled: false
   VersionAdded: '0.59'
   VersionChanged: '0.85'
   Include:
-    - '**/*.gemfile'
-    - '**/Gemfile'
-    - '**/gems.rb'
+    - "**/*.gemfile"
+    - "**/Gemfile"
+    - "**/gems.rb"
   IgnoredGems: []
   OnlyFor: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Bundler/GemComment
 Bundler/GemFilename:
-  Description: 'Enforces the filename for managing gems.'
+  Description: |-
+    Verifies that a project contains Gemfile or gems.rb file and correct
+    associated lock file based on the configuration.
   Enabled: true
   VersionAdded: '1.20'
-  EnforcedStyle: 'Gemfile'
+  EnforcedStyle: Gemfile
   SupportedStyles:
-    - 'Gemfile'
-    - 'gems.rb'
+    - Gemfile
+    - gems.rb
   Include:
-    - '**/Gemfile'
-    - '**/gems.rb'
-    - '**/Gemfile.lock'
-    - '**/gems.locked'
-
+    - "**/Gemfile"
+    - "**/gems.rb"
+    - "**/Gemfile.lock"
+    - "**/gems.locked"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Bundler/GemFilename
 Bundler/GemVersion:
-  Description: 'Requires or forbids specifying gem versions.'
+  Description: |-
+    Enforce that Gem version specifications or a commit reference (branch,
+    ref, or tag) are either required or forbidden.
   Enabled: false
   VersionAdded: '1.14'
-  EnforcedStyle: 'required'
+  EnforcedStyle: required
   SupportedStyles:
-    - 'required'
-    - 'forbidden'
+    - required
+    - forbidden
   Include:
-    - '**/*.gemfile'
-    - '**/Gemfile'
-    - '**/gems.rb'
+    - "**/*.gemfile"
+    - "**/Gemfile"
+    - "**/gems.rb"
   AllowedGems: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Bundler/GemVersion
 Bundler/InsecureProtocolSource:
-  Description: >-
-                 The source `:gemcutter`, `:rubygems` and `:rubyforge` are deprecated
-                 because HTTP requests are insecure. Please change your source to
-                 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
+  Description: |-
+    Passing symbol arguments to `source` (e.g. `source :rubygems`) is
+    deprecated because they default to using HTTP requests. Instead, specify
+    `'https://rubygems.org'` if possible, or `'http://rubygems.org'` if not.
   Enabled: true
   VersionAdded: '0.50'
   AllowHttpProtocol: true
   Include:
-    - '**/*.gemfile'
-    - '**/Gemfile'
-    - '**/gems.rb'
-
+    - "**/*.gemfile"
+    - "**/Gemfile"
+    - "**/gems.rb"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Bundler/InsecureProtocolSource
 Bundler/OrderedGems:
-  Description: >-
-                 Gems within groups in the Gemfile should be alphabetically sorted.
+  Description: Gems should be alphabetically sorted within groups.
   Enabled: true
   VersionAdded: '0.46'
   VersionChanged: '0.47'
   TreatCommentsAsGroupSeparators: true
-  # By default, "-" and "_" are ignored for order purposes.
-  # This can be overridden by setting this parameter to true.
   ConsiderPunctuation: false
   Include:
-    - '**/*.gemfile'
-    - '**/Gemfile'
-    - '**/gems.rb'
-
-#################### Gemspec ###############################
-
+    - "**/*.gemfile"
+    - "**/Gemfile"
+    - "**/gems.rb"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Bundler/OrderedGems
 Gemspec/DateAssignment:
-  Description: 'Checks that `date =` is not used in gemspec file, it is set automatically when the gem is packaged.'
+  Description: |-
+    Checks that `date =` is not used in gemspec file.
+    It is set automatically when the gem is packaged.
   Enabled: pending
   VersionAdded: '1.10'
   Include:
-    - '**/*.gemspec'
-
+    - "**/*.gemspec"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Gemspec/DateAssignment
 Gemspec/DependencyVersion:
-  Description: 'Requires or forbids specifying gem dependency versions.'
+  Description: |-
+    Enforce that gem dependency version specifications or a commit reference (branch,
+    ref, or tag) are either required or forbidden.
   Enabled: false
   VersionAdded: '1.29'
-  EnforcedStyle: 'required'
+  EnforcedStyle: required
   SupportedStyles:
-    - 'required'
-    - 'forbidden'
+    - required
+    - forbidden
   Include:
-    - '**/*.gemspec'
+    - "**/*.gemspec"
   AllowedGems: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Gemspec/DependencyVersion
 Gemspec/DeprecatedAttributeAssignment:
-  Description: Checks that deprecated attribute assignments are not set in a gemspec file.
+  Description: |-
+    Checks that deprecated attribute attributes are not set in a gemspec file.
+    Removing `test_files` allows the user to receive smaller packed gems.
   Enabled: pending
   VersionAdded: '1.30'
   Include:
-    - '**/*.gemspec'
-
+    - "**/*.gemspec"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Gemspec/DeprecatedAttributeAssignment
 Gemspec/DuplicatedAssignment:
-  Description: 'An attribute assignment method calls should be listed only once in a gemspec.'
+  Description: |-
+    An attribute assignment method calls should be listed only once
+    in a gemspec.
   Enabled: true
   VersionAdded: '0.52'
   Include:
-    - '**/*.gemspec'
-
+    - "**/*.gemspec"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Gemspec/DuplicatedAssignment
 Gemspec/OrderedDependencies:
-  Description: >-
-                 Dependencies in the gemspec should be alphabetically sorted.
+  Description: Dependencies in the gemspec should be alphabetically sorted.
   Enabled: true
   VersionAdded: '0.51'
   TreatCommentsAsGroupSeparators: true
-  # By default, "-" and "_" are ignored for order purposes.
-  # This can be overridden by setting this parameter to true.
   ConsiderPunctuation: false
   Include:
-    - '**/*.gemspec'
-
+    - "**/*.gemspec"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Gemspec/OrderedDependencies
 Gemspec/RequireMFA:
-  Description: 'Checks that the gemspec has metadata to require Multi-Factor Authentication from RubyGems.'
+  Description: Requires a gemspec to have `rubygems_mfa_required` metadata set.
   Enabled: pending
   VersionAdded: '1.23'
-  Reference:
-    - https://guides.rubygems.org/mfa-requirement-opt-in/
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Gemspec/RequireMFA
   Include:
-    - '**/*.gemspec'
-
+    - "**/*.gemspec"
 Gemspec/RequiredRubyVersion:
-  Description: 'Checks that `required_ruby_version` of gemspec is specified and equal to `TargetRubyVersion` of .rubocop.yml.'
+  Description: |-
+    Checks that `required_ruby_version` in a gemspec file is set to a valid
+    value (non-blank) and matches `TargetRubyVersion` as set in RuboCop's
+    configuration for the gem.
   Enabled: true
   VersionAdded: '0.52'
   VersionChanged: '1.22'
   Include:
-    - '**/*.gemspec'
-
+    - "**/*.gemspec"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Gemspec/RequiredRubyVersion
 Gemspec/RubyVersionGlobalsUsage:
-  Description: Checks usage of RUBY_VERSION in gemspec.
-  StyleGuide: '#no-ruby-version-in-the-gemspec'
+  Description: |-
+    Checks that `RUBY_VERSION` constant is not used in gemspec.
+    Using `RUBY_VERSION` is dangerous because value of the
+    constant is determined by `rake release`.
+    It's possible to have dependency based on ruby version used
+    to execute `rake release` and not user's ruby version.
+  StyleGuide: "#no-ruby-version-in-the-gemspec"
   Enabled: true
   VersionAdded: '0.72'
   Include:
-    - '**/*.gemspec'
-
-#################### Layout ###########################
-
+    - "**/*.gemspec"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Gemspec/RubyVersionGlobalsUsage
 Layout/AccessModifierIndentation:
-  Description: Check indentation of private/protected visibility modifiers.
-  StyleGuide: '#indent-public-private-protected'
+  Description: |-
+    Bare access modifiers (those not applying to specific methods) should be
+    indented as deep as method definitions, or as deep as the class/module
+    keyword, depending on configuration.
+  StyleGuide: "#indent-public-private-protected"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: indent
   SupportedStyles:
     - outdent
     - indent
-  # By default the indentation width from `Layout/IndentationWidth` is used,
-  # but it can be overridden by setting this parameter.
-  IndentationWidth: ~
-
+  IndentationWidth:
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/AccessModifierIndentation
 Layout/ArgumentAlignment:
-  Description: >-
-                 Align the arguments of a method call if they span more
-                 than one line.
-  StyleGuide: '#no-double-indent'
+  Description: |-
+    Here we check if the arguments on a multi-line method
+    definition are aligned.
+  StyleGuide: "#no-double-indent"
   Enabled: true
   VersionAdded: '0.68'
   VersionChanged: '0.77'
-  # Alignment of arguments in multi-line method calls.
-  #
-  # The `with_first_argument` style aligns the following lines along the same
-  # column as the first parameter.
-  #
-  #     method_call(a,
-  #                 b)
-  #
-  # The `with_fixed_indentation` style aligns the following lines with one
-  # level of indentation relative to the start of the line with the method call.
-  #
-  #     method_call(a,
-  #       b)
   EnforcedStyle: with_first_argument
   SupportedStyles:
     - with_first_argument
     - with_fixed_indentation
-  # By default the indentation width from `Layout/IndentationWidth` is used,
-  # but it can be overridden by setting this parameter.
-  IndentationWidth: ~
-
+  IndentationWidth:
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/ArgumentAlignment
 Layout/ArrayAlignment:
-  Description: >-
-                 Align the elements of an array literal if they span more than
-                 one line.
-  StyleGuide: '#no-double-indent'
+  Description: |-
+    Here we check if the elements of a multi-line array literal are
+    aligned.
+  StyleGuide: "#no-double-indent"
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.77'
-  # Alignment of elements of a multi-line array.
-  #
-  # The `with_first_parameter` style aligns the following lines along the same
-  # column as the first element.
-  #
-  #     array = [1, 2, 3,
-  #              4, 5, 6]
-  #
-  # The `with_fixed_indentation` style aligns the following lines with one
-  # level of indentation relative to the start of the line with start of array.
-  #
-  #     array = [1, 2, 3,
-  #       4, 5, 6]
   EnforcedStyle: with_first_element
   SupportedStyles:
     - with_first_element
     - with_fixed_indentation
-  # By default the indentation width from `Layout/IndentationWidth` is used,
-  # but it can be overridden by setting this parameter.
-  IndentationWidth: ~
-
+  IndentationWidth:
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/ArrayAlignment
 Layout/AssignmentIndentation:
-  Description: >-
-                Checks the indentation of the first line of the
-                right-hand-side of a multi-line assignment.
+  Description: |-
+    Checks the indentation of the first line of the
+    right-hand-side of a multi-line assignment.
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.77'
-  # By default the indentation width from `Layout/IndentationWidth` is used,
-  # but it can be overridden by setting this parameter.
-  IndentationWidth: ~
-
+  IndentationWidth:
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/AssignmentIndentation
 Layout/BeginEndAlignment:
-  Description: 'Align ends corresponding to begins correctly.'
+  Description: Checks whether the end keyword of `begin` is aligned properly.
   Enabled: true
   VersionAdded: '0.91'
-  # The value `start_of_line` means that `end` should be aligned the start of the line
-  # where the `begin` keyword is.
-  # The value `begin` means that `end` should be aligned with the `begin` keyword.
   EnforcedStyleAlignWith: start_of_line
   SupportedStylesAlignWith:
     - start_of_line
     - begin
   Severity: warning
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/BeginEndAlignment
 Layout/BlockAlignment:
-  Description: 'Align block ends correctly.'
+  Description: |-
+    Checks whether the end keywords are aligned properly for do
+    end blocks.
   Enabled: true
   VersionAdded: '0.53'
-  # The value `start_of_block` means that the `end` should be aligned with line
-  # where the `do` keyword appears.
-  # The value `start_of_line` means it should be aligned with the whole
-  # expression's starting line.
-  # The value `either` means both are allowed.
   EnforcedStyleAlignWith: either
   SupportedStylesAlignWith:
     - either
     - start_of_block
     - start_of_line
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/BlockAlignment
 Layout/BlockEndNewline:
-  Description: 'Put end statement of multiline block on its own line.'
+  Description: |-
+    Checks whether the end statement of a do..end block
+    is on its own line.
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/BlockEndNewline
 Layout/CaseIndentation:
-  Description: 'Indentation of when in a case/(when|in)/[else/]end.'
-  StyleGuide: '#indent-when-to-case'
+  Description: |-
+    Checks how the `when` and ``in``s of a `case` expression
+    are indented in relation to its `case` or `end` keyword.
+  StyleGuide: "#indent-when-to-case"
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '1.16'
@@ -433,14 +347,11 @@ Layout/CaseIndentation:
     - case
     - end
   IndentOneStep: false
-  # By default the indentation width from `Layout/IndentationWidth` is used,
-  # but it can be overridden by setting this parameter.
-  # This only matters if `IndentOneStep` is `true`.
-  IndentationWidth: ~
-
+  IndentationWidth:
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/CaseIndentation
 Layout/ClassStructure:
-  Description: 'Enforces a configured order of definitions within a class body.'
-  StyleGuide: '#consistent-classes'
+  Description: 'Checks if the code style follows the ExpectedOrder configuration:'
+  StyleGuide: "#consistent-classes"
   Enabled: false
   VersionAdded: '0.52'
   Categories:
@@ -456,133 +367,134 @@ Layout/ClassStructure:
     - public_methods
     - protected_methods
     - private_methods
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/ClassStructure
 Layout/ClosingHeredocIndentation:
-  Description: 'Checks the indentation of here document closings.'
+  Description: Checks the indentation of here document closings.
   Enabled: true
   VersionAdded: '0.57'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/ClosingHeredocIndentation
 Layout/ClosingParenthesisIndentation:
-  Description: 'Checks the indentation of hanging closing parentheses.'
+  Description: |-
+    Checks the indentation of hanging closing parentheses in
+    method calls, method definitions, and grouped expressions. A hanging
+    closing parenthesis means `)` preceded by a line break.
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/ClosingParenthesisIndentation
 Layout/CommentIndentation:
-  Description: 'Indentation of comments.'
+  Description: Checks the indentation of comments.
   Enabled: true
-  # When true, allows comments to have extra indentation if that aligns them
-  # with a comment on the preceding line.
   AllowForAlignment: false
   VersionAdded: '0.49'
   VersionChanged: '1.24'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/CommentIndentation
 Layout/ConditionPosition:
-  Description: >-
-                 Checks for condition placed in a confusing position relative to
-                 the keyword.
-  StyleGuide: '#same-line-condition'
+  Description: |-
+    Checks for conditions that are not on the same line as
+    if/while/until.
+  StyleGuide: "#same-line-condition"
   Enabled: true
   VersionAdded: '0.53'
   VersionChanged: '0.83'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/ConditionPosition
 Layout/DefEndAlignment:
-  Description: 'Align ends corresponding to defs correctly.'
+  Description: |-
+    Checks whether the end keywords of method definitions are
+    aligned properly.
   Enabled: true
   VersionAdded: '0.53'
-  # The value `def` means that `end` should be aligned with the def keyword.
-  # The value `start_of_line` means that `end` should be aligned with method
-  # calls like `private`, `public`, etc, if present in front of the `def`
-  # keyword on the same line.
   EnforcedStyleAlignWith: start_of_line
   SupportedStylesAlignWith:
     - start_of_line
     - def
   Severity: warning
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/DefEndAlignment
 Layout/DotPosition:
-  Description: 'Checks the position of the dot in multi-line method calls.'
-  StyleGuide: '#consistent-multi-line-chains'
+  Description: Checks the . position in multi-line method calls.
+  StyleGuide: "#consistent-multi-line-chains"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: leading
   SupportedStyles:
     - leading
     - trailing
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/DotPosition
 Layout/ElseAlignment:
-  Description: 'Align elses and elsifs correctly.'
+  Description: |-
+    Checks the alignment of else keywords. Normally they should
+    be aligned with an if/unless/while/until/begin/def/rescue keyword, but there
+    are special cases when they should follow the same rules as the
+    alignment of end.
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/ElseAlignment
 Layout/EmptyComment:
-  Description: 'Checks empty comment.'
+  Description: Checks empty comment.
   Enabled: true
   VersionAdded: '0.53'
   AllowBorderComment: true
   AllowMarginComment: true
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyComment
 Layout/EmptyLineAfterGuardClause:
-  Description: 'Add empty line after guard clause.'
+  Description: Enforces empty line after guard clause
   Enabled: true
   VersionAdded: '0.56'
   VersionChanged: '0.59'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLineAfterGuardClause
 Layout/EmptyLineAfterMagicComment:
-  Description: 'Add an empty line after magic comments to separate them from code.'
-  StyleGuide: '#separate-magic-comments-from-code'
+  Description: Checks for a newline after the final magic comment.
+  StyleGuide: "#separate-magic-comments-from-code"
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLineAfterMagicComment
 Layout/EmptyLineAfterMultilineCondition:
-  Description: 'Enforces empty line after multiline condition.'
-  # This is disabled, because this style is not very common in practice.
+  Description: Enforces empty line after multiline condition.
   Enabled: false
   VersionAdded: '0.90'
-  Reference:
-    - https://github.com/airbnb/ruby#multiline-if-newline
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLineAfterMultilineCondition
 Layout/EmptyLineBetweenDefs:
-  Description: 'Use empty lines between class/module/method defs.'
-  StyleGuide: '#empty-lines-between-methods'
+  Description: |-
+    Checks whether class/module/method definitions are
+    separated by one or more empty lines.
+  StyleGuide: "#empty-lines-between-methods"
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '1.23'
   EmptyLineBetweenMethodDefs: true
   EmptyLineBetweenClassDefs: true
   EmptyLineBetweenModuleDefs: true
-  # `AllowAdjacentOneLineDefs` means that single line method definitions don't
-  # need an empty line between them. `true` by default.
   AllowAdjacentOneLineDefs: true
-  # Can be array to specify minimum and maximum number of empty lines, e.g. [1, 2]
   NumberOfEmptyLines: 1
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLineBetweenDefs
 Layout/EmptyLines:
-  Description: "Don't use several empty lines in a row."
-  StyleGuide: '#two-or-more-empty-lines'
+  Description: Checks for two or more consecutive blank lines.
+  StyleGuide: "#two-or-more-empty-lines"
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLines
 Layout/EmptyLinesAroundAccessModifier:
-  Description: "Keep blank lines around access modifiers."
-  StyleGuide: '#empty-lines-around-access-modifier'
+  Description: Access modifiers should be surrounded by blank lines.
+  StyleGuide: "#empty-lines-around-access-modifier"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: around
   SupportedStyles:
     - around
     - only_before
-  Reference:
-    # A reference to `EnforcedStyle: only_before`.
-    - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLinesAroundAccessModifier
 Layout/EmptyLinesAroundArguments:
-  Description: "Keeps track of empty lines around method arguments."
+  Description: |-
+    Checks if empty lines exist around the arguments
+    of a method invocation.
   Enabled: true
   VersionAdded: '0.52'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLinesAroundArguments
 Layout/EmptyLinesAroundAttributeAccessor:
-  Description: "Keep blank lines around attribute accessors."
-  StyleGuide: '#empty-lines-around-attribute-accessor'
+  Description: |-
+    Checks for a newline after an attribute accessor or a group of them.
+    `alias` syntax and `alias_method`, `public`, `protected`, and `private` methods are allowed
+    by default. These are customizable with `AllowAliasSyntax` and `AllowedMethods` options.
+  StyleGuide: "#empty-lines-around-attribute-accessor"
   Enabled: true
   VersionAdded: '0.83'
   VersionChanged: '0.84'
@@ -592,26 +504,32 @@ Layout/EmptyLinesAroundAttributeAccessor:
     - public
     - protected
     - private
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLinesAroundAttributeAccessor
 Layout/EmptyLinesAroundBeginBody:
-  Description: "Keeps track of empty lines around begin-end bodies."
-  StyleGuide: '#empty-lines-around-bodies'
+  Description: |-
+    Checks if empty lines exist around the bodies of begin-end
+    blocks.
+  StyleGuide: "#empty-lines-around-bodies"
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLinesAroundBeginBody
 Layout/EmptyLinesAroundBlockBody:
-  Description: "Keeps track of empty lines around block bodies."
-  StyleGuide: '#empty-lines-around-bodies'
+  Description: |-
+    Checks if empty lines around the bodies of blocks match
+    the configuration.
+  StyleGuide: "#empty-lines-around-bodies"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: no_empty_lines
   SupportedStyles:
     - empty_lines
     - no_empty_lines
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLinesAroundBlockBody
 Layout/EmptyLinesAroundClassBody:
-  Description: "Keeps track of empty lines around class bodies."
-  StyleGuide: '#empty-lines-around-bodies'
+  Description: |-
+    Checks if empty lines around the bodies of classes match
+    the configuration.
+  StyleGuide: "#empty-lines-around-bodies"
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.53'
@@ -623,22 +541,29 @@ Layout/EmptyLinesAroundClassBody:
     - no_empty_lines
     - beginning_only
     - ending_only
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLinesAroundClassBody
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
-  Description: "Keeps track of empty lines around exception handling keywords."
-  StyleGuide: '#empty-lines-around-bodies'
+  Description: |-
+    Checks if empty lines exist around the bodies of `begin`
+    sections. This cop doesn't check empty lines at `begin` body
+    beginning/end and around method definition body.
+    `Style/EmptyLinesAroundBeginBody` or `Style/EmptyLinesAroundMethodBody`
+    can be used for this purpose.
+  StyleGuide: "#empty-lines-around-bodies"
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLinesAroundExceptionHandlingKeywords
 Layout/EmptyLinesAroundMethodBody:
-  Description: "Keeps track of empty lines around method bodies."
-  StyleGuide: '#empty-lines-around-bodies'
+  Description: Checks if empty lines exist around the bodies of methods.
+  StyleGuide: "#empty-lines-around-bodies"
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLinesAroundMethodBody
 Layout/EmptyLinesAroundModuleBody:
-  Description: "Keeps track of empty lines around module bodies."
-  StyleGuide: '#empty-lines-around-bodies'
+  Description: |-
+    Checks if empty lines around the bodies of modules match
+    the configuration.
+  StyleGuide: "#empty-lines-around-bodies"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: no_empty_lines
@@ -647,163 +572,116 @@ Layout/EmptyLinesAroundModuleBody:
     - empty_lines_except_namespace
     - empty_lines_special
     - no_empty_lines
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLinesAroundModuleBody
 Layout/EndAlignment:
-  Description: 'Align ends correctly.'
+  Description: Checks whether the end keywords are aligned properly.
   Enabled: true
   VersionAdded: '0.53'
-  # The value `keyword` means that `end` should be aligned with the matching
-  # keyword (`if`, `while`, etc.).
-  # The value `variable` means that in assignments, `end` should be aligned
-  # with the start of the variable on the left hand side of `=`. In all other
-  # situations, `end` should still be aligned with the keyword.
-  # The value `start_of_line` means that `end` should be aligned with the start
-  # of the line which the matching keyword appears on.
   EnforcedStyleAlignWith: keyword
   SupportedStylesAlignWith:
     - keyword
     - variable
     - start_of_line
   Severity: warning
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EndAlignment
 Layout/EndOfLine:
-  Description: 'Use Unix-style line endings.'
-  StyleGuide: '#crlf'
+  Description: Checks for Windows-style line endings in the source code.
+  StyleGuide: "#crlf"
   Enabled: true
   VersionAdded: '0.49'
-  # The `native` style means that CR+LF (Carriage Return + Line Feed) is
-  # enforced on Windows, and LF is enforced on other platforms. The other styles
-  # mean LF and CR+LF, respectively.
   EnforcedStyle: native
   SupportedStyles:
     - native
     - lf
     - crlf
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EndOfLine
 Layout/ExtraSpacing:
-  Description: 'Do not use unnecessary spacing.'
+  Description: Checks for extra/unnecessary whitespace.
   Enabled: true
   VersionAdded: '0.49'
-  # When true, allows most uses of extra spacing if the intent is to align
-  # things with the previous or next line, not counting empty lines or comment
-  # lines.
   AllowForAlignment: true
-  # When true, allows things like 'obj.meth(arg)  # comment',
-  # rather than insisting on 'obj.meth(arg) # comment'.
-  # If done for alignment, either this OR AllowForAlignment will allow it.
   AllowBeforeTrailingComments: false
-  # When true, forces the alignment of `=` in assignments on consecutive lines.
   ForceEqualSignAlignment: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/ExtraSpacing
 Layout/FirstArgumentIndentation:
-  Description: 'Checks the indentation of the first argument in a method call.'
+  Description: |-
+    Checks the indentation of the first argument in a method call.
+    Arguments after the first one are checked by `Layout/ArgumentAlignment`,
+    not by this cop.
   Enabled: true
   VersionAdded: '0.68'
   VersionChanged: '0.77'
   EnforcedStyle: special_for_inner_method_call_in_parentheses
   SupportedStyles:
-    # The first parameter should always be indented one step more than the
-    # preceding line.
     - consistent
-    # The first parameter should always be indented one level relative to the
-    # parent that is receiving the parameter
     - consistent_relative_to_receiver
-    # The first parameter should normally be indented one step more than the
-    # preceding line, but if it's a parameter for a method call that is itself
-    # a parameter in a method call, then the inner parameter should be indented
-    # relative to the inner method.
     - special_for_inner_method_call
-    # Same as `special_for_inner_method_call` except that the special rule only
-    # applies if the outer method call encloses its arguments in parentheses.
     - special_for_inner_method_call_in_parentheses
-  # By default the indentation width from `Layout/IndentationWidth` is used,
-  # but it can be overridden by setting this parameter.
-  IndentationWidth: ~
-
+  IndentationWidth:
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/FirstArgumentIndentation
 Layout/FirstArrayElementIndentation:
-  Description: >-
-                 Checks the indentation of the first element in an array
-                 literal.
+  Description: |-
+    Checks the indentation of the first element in an array literal
+    where the opening bracket and the first element are on separate lines.
+    The other elements' indentations are handled by the ArrayAlignment cop.
   Enabled: true
   VersionAdded: '0.68'
   VersionChanged: '0.77'
-  # The value `special_inside_parentheses` means that array literals with
-  # brackets that have their opening bracket on the same line as a surrounding
-  # opening round parenthesis, shall have their first element indented relative
-  # to the first position inside the parenthesis.
-  #
-  # The value `consistent` means that the indentation of the first element shall
-  # always be relative to the first position of the line where the opening
-  # bracket is.
-  #
-  # The value `align_brackets` means that the indentation of the first element
-  # shall always be relative to the position of the opening bracket.
   EnforcedStyle: special_inside_parentheses
   SupportedStyles:
     - special_inside_parentheses
     - consistent
     - align_brackets
-  # By default the indentation width from `Layout/IndentationWidth` is used,
-  # but it can be overridden by setting this parameter.
-  IndentationWidth: ~
-
+  IndentationWidth:
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/FirstArrayElementIndentation
 Layout/FirstArrayElementLineBreak:
-  Description: >-
-                 Checks for a line break before the first element in a
-                 multi-line array.
+  Description: |-
+    Checks for a line break before the first element in a
+    multi-line array.
   Enabled: false
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/FirstArrayElementLineBreak
 Layout/FirstHashElementIndentation:
-  Description: 'Checks the indentation of the first key in a hash literal.'
+  Description: |-
+    Checks the indentation of the first key in a hash literal
+    where the opening brace and the first key are on separate lines. The
+    other keys' indentations are handled by the HashAlignment cop.
   Enabled: true
   VersionAdded: '0.68'
   VersionChanged: '0.77'
-  # The value `special_inside_parentheses` means that hash literals with braces
-  # that have their opening brace on the same line as a surrounding opening
-  # round parenthesis, shall have their first key indented relative to the
-  # first position inside the parenthesis.
-  #
-  # The value `consistent` means that the indentation of the first key shall
-  # always be relative to the first position of the line where the opening
-  # brace is.
-  #
-  # The value `align_braces` means that the indentation of the first key shall
-  # always be relative to the position of the opening brace.
   EnforcedStyle: special_inside_parentheses
   SupportedStyles:
     - special_inside_parentheses
     - consistent
     - align_braces
-  # By default the indentation width from `Layout/IndentationWidth` is used,
-  # but it can be overridden by setting this parameter.
-  IndentationWidth: ~
-
+  IndentationWidth:
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/FirstHashElementIndentation
 Layout/FirstHashElementLineBreak:
-  Description: >-
-                 Checks for a line break before the first element in a
-                 multi-line hash.
+  Description: |-
+    Checks for a line break before the first element in a
+    multi-line hash.
   Enabled: false
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/FirstHashElementLineBreak
 Layout/FirstMethodArgumentLineBreak:
-  Description: >-
-                 Checks for a line break before the first argument in a
-                 multi-line method call.
+  Description: |-
+    Checks for a line break before the first argument in a
+    multi-line method call.
   Enabled: false
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/FirstMethodArgumentLineBreak
 Layout/FirstMethodParameterLineBreak:
-  Description: >-
-                 Checks for a line break before the first parameter in a
-                 multi-line method parameter definition.
+  Description: |-
+    Checks for a line break before the first parameter in a
+    multi-line method parameter definition.
   Enabled: false
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/FirstMethodParameterLineBreak
 Layout/FirstParameterIndentation:
-  Description: >-
-                 Checks the indentation of the first parameter in a
-                 method definition.
+  Description: |-
+    Checks the indentation of the first parameter in a method
+    definition. Parameters after the first one are checked by
+    Layout/ParameterAlignment, not by this cop.
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.77'
@@ -811,235 +689,176 @@ Layout/FirstParameterIndentation:
   SupportedStyles:
     - consistent
     - align_parentheses
-  # By default the indentation width from `Layout/IndentationWidth` is used,
-  # but it can be overridden by setting this parameter.
-  IndentationWidth: ~
-
+  IndentationWidth:
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/FirstParameterIndentation
 Layout/HashAlignment:
-  Description: >-
-    Align the elements of a hash literal if they span more than
-    one line.
+  Description: |-
+    Check that the keys, separators, and values of a multi-line hash
+    literal are aligned according to configuration. The configuration
+    options are:
   Enabled: true
   AllowMultipleStyles: true
   VersionAdded: '0.49'
   VersionChanged: '1.16'
-  # Alignment of entries using hash rocket as separator. Valid values are:
-  #
-  # key - left alignment of keys
-  #   'a' => 2
-  #   'bb' => 3
-  # separator - alignment of hash rockets, keys are right aligned
-  #    'a' => 2
-  #   'bb' => 3
-  # table - left alignment of keys, hash rockets, and values
-  #   'a'  => 2
-  #   'bb' => 3
   EnforcedHashRocketStyle: key
   SupportedHashRocketStyles:
     - key
     - separator
     - table
-  # Alignment of entries using colon as separator. Valid values are:
-  #
-  # key - left alignment of keys
-  #   a: 0
-  #   bb: 1
-  # separator - alignment of colons, keys are right aligned
-  #    a: 0
-  #   bb: 1
-  # table - left alignment of keys and values
-  #   a:  0
-  #   bb: 1
   EnforcedColonStyle: key
   SupportedColonStyles:
     - key
     - separator
     - table
-  # Select whether hashes that are the last argument in a method call should be
-  # inspected? Valid values are:
-  #
-  # always_inspect - Inspect both implicit and explicit hashes.
-  #   Registers an offense for:
-  #     function(a: 1,
-  #       b: 2)
-  #   Registers an offense for:
-  #     function({a: 1,
-  #       b: 2})
-  # always_ignore - Ignore both implicit and explicit hashes.
-  #   Accepts:
-  #     function(a: 1,
-  #       b: 2)
-  #   Accepts:
-  #     function({a: 1,
-  #       b: 2})
-  # ignore_implicit - Ignore only implicit hashes.
-  #   Accepts:
-  #     function(a: 1,
-  #       b: 2)
-  #   Registers an offense for:
-  #     function({a: 1,
-  #       b: 2})
-  # ignore_explicit - Ignore only explicit hashes.
-  #   Accepts:
-  #     function({a: 1,
-  #       b: 2})
-  #   Registers an offense for:
-  #     function(a: 1,
-  #       b: 2)
   EnforcedLastArgumentHashStyle: always_inspect
   SupportedLastArgumentHashStyles:
     - always_inspect
     - always_ignore
     - ignore_implicit
     - ignore_explicit
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/HashAlignment
 Layout/HeredocArgumentClosingParenthesis:
-  Description: >-
-                 Checks for the placement of the closing parenthesis in a
-                 method call that passes a HEREDOC string as an argument.
+  Description: |-
+    Checks for the placement of the closing parenthesis
+    in a method call that passes a HEREDOC string as an argument.
+    It should be placed at the end of the line containing the
+    opening HEREDOC tag.
   Enabled: false
-  StyleGuide: '#heredoc-argument-closing-parentheses'
+  StyleGuide: "#heredoc-argument-closing-parentheses"
   VersionAdded: '0.68'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/HeredocArgumentClosingParenthesis
 Layout/HeredocIndentation:
-  Description: 'Checks the indentation of the here document bodies.'
-  StyleGuide: '#squiggly-heredocs'
+  Description: |-
+    Checks the indentation of the here document bodies. The bodies
+    are indented one step.
+  StyleGuide: "#squiggly-heredocs"
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.85'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/HeredocIndentation
 Layout/IndentationConsistency:
-  Description: 'Keep indentation straight.'
-  StyleGuide: '#spaces-indentation'
+  Description: Checks for inconsistent indentation.
+  StyleGuide: "#spaces-indentation"
   Enabled: true
   VersionAdded: '0.49'
-  # The difference between `indented` and `normal` is that the `indented_internal_methods`
-  # style prescribes that in classes and modules the `protected` and `private`
-  # modifier keywords shall be indented the same as public methods and that
-  # protected and private members shall be indented one step more than the
-  # modifiers. Other than that, both styles mean that entities on the same
-  # logical depth shall have the same indentation.
   EnforcedStyle: normal
   SupportedStyles:
     - normal
     - indented_internal_methods
-  Reference:
-    # A reference to `EnforcedStyle: indented_internal_methods`.
-    - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/IndentationConsistency
 Layout/IndentationStyle:
-  Description: 'Consistent indentation either with tabs only or spaces only.'
-  StyleGuide: '#spaces-indentation'
+  Description: |-
+    Checks that the indentation method is consistent.
+    Either tabs only or spaces only are used for indentation.
+  StyleGuide: "#spaces-indentation"
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.82'
-  # By default the indentation width from `Layout/IndentationWidth` is used,
-  # but it can be overridden by setting this parameter.
-  # It is used during autocorrection to determine how many spaces should
-  # replace each tab.
-  IndentationWidth: ~
+  IndentationWidth:
   EnforcedStyle: spaces
   SupportedStyles:
     - spaces
     - tabs
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/IndentationStyle
 Layout/IndentationWidth:
-  Description: 'Use 2 spaces for indentation.'
-  StyleGuide: '#spaces-indentation'
+  Description: |-
+    Checks for indentation that doesn't use the specified number
+    of spaces.
+  StyleGuide: "#spaces-indentation"
   Enabled: true
   VersionAdded: '0.49'
-  # Number of spaces for each indentation level.
   Width: 2
   AllowedPatterns: []
-  IgnoredPatterns: [] # deprecated
-
+  IgnoredPatterns: []
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/IndentationWidth
 Layout/InitialIndentation:
-  Description: >-
-    Checks the indentation of the first non-blank non-comment line in a file.
+  Description: |-
+    Checks for indentation of the first non-blank non-comment
+    line in a file.
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/InitialIndentation
 Layout/LeadingCommentSpace:
-  Description: 'Comments should start with a space.'
-  StyleGuide: '#hash-space'
+  Description: |-
+    Checks whether comments have a leading space after the
+    `#` denoting the start of the comment. The leading space is not
+    required for some RDoc special syntax, like `#++`, `#--`,
+    `#:nodoc`, `=begin`- and `=end` comments, "shebang" directives,
+    or rackup options.
+  StyleGuide: "#hash-space"
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.73'
   AllowDoxygenCommentStyle: false
   AllowGemfileRubyComment: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/LeadingCommentSpace
 Layout/LeadingEmptyLines:
-  Description: Check for unnecessary blank lines at the beginning of a file.
+  Description: |-
+    Checks for unnecessary leading blank lines at the beginning
+    of a file.
   Enabled: true
   VersionAdded: '0.57'
   VersionChanged: '0.77'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/LeadingEmptyLines
 Layout/LineEndStringConcatenationIndentation:
-  Description: >-
-                 Checks the indentation of the next line after a line that
-                 ends with a string literal and a backslash.
+  Description: |-
+    Checks the indentation of the next line after a line that ends with a string
+    literal and a backslash.
   Enabled: pending
   VersionAdded: '1.18'
   EnforcedStyle: aligned
   SupportedStyles:
     - aligned
     - indented
-  # By default the indentation width from `Layout/IndentationWidth` is used,
-  # but it can be overridden by setting this parameter.
-  IndentationWidth: ~
-
+  IndentationWidth:
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/LineEndStringConcatenationIndentation
 Layout/LineLength:
-  Description: 'Checks that line length does not exceed the configured limit.'
-  StyleGuide: '#max-line-length'
+  Description: |-
+    Checks the length of lines in the source code.
+    The maximum length is configurable.
+    The tab size is configured in the `IndentationWidth`
+    of the `Layout/IndentationStyle` cop.
+    It also ignores a shebang line by default.
+  StyleGuide: "#max-line-length"
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '1.4'
   Max: 120
-  # To make it possible to copy or click on URIs in the code, we allow lines
-  # containing a URI to be longer than Max.
   AllowHeredoc: true
   AllowURI: true
   URISchemes:
     - http
     - https
-  # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
-  # directives like '# rubocop: enable ...' when calculating a line's length.
   IgnoreCopDirectives: true
-  # The AllowedPatterns option is a list of !ruby/regexp and/or string
-  # elements. Strings will be converted to Regexp objects. A line that matches
-  # any regular expression listed in this option will be ignored by LineLength.
   AllowedPatterns: []
-  IgnoredPatterns: [] # deprecated
-
+  IgnoredPatterns: []
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/LineLength
 Layout/MultilineArrayBraceLayout:
-  Description: >-
-                 Checks that the closing brace in an array literal is
-                 either on the same line as the last array element, or
-                 a new line.
+  Description: |-
+    Checks that the closing brace in an array literal is either
+    on the same line as the last array element or on a new line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
   SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on the same line as last element
     - symmetrical
     - new_line
     - same_line
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineArrayBraceLayout
 Layout/MultilineArrayLineBreaks:
-  Description: >-
-                 Checks that each item in a multi-line array literal
-                 starts on a separate line.
+  Description: |-
+    Ensures that each item in a multi-line array
+    starts on a separate line.
   Enabled: false
   VersionAdded: '0.67'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineArrayLineBreaks
 Layout/MultilineAssignmentLayout:
-  Description: 'Check for a newline after the assignment operator in multi-line assignments.'
-  StyleGuide: '#indent-conditional-assignment'
+  Description: |-
+    Checks whether the multiline assignments have a newline
+    after the assignment operator.
+  StyleGuide: "#indent-conditional-assignment"
   Enabled: false
   VersionAdded: '0.49'
-  # The types of assignments which are subject to this rule.
   SupportedTypes:
     - block
     - case
@@ -1049,68 +868,61 @@ Layout/MultilineAssignmentLayout:
     - module
   EnforcedStyle: new_line
   SupportedStyles:
-    # Ensures that the assignment operator and the rhs are on the same line for
-    # the set of supported types.
     - same_line
-    # Ensures that the assignment operator and the rhs are on separate lines
-    # for the set of supported types.
     - new_line
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineAssignmentLayout
 Layout/MultilineBlockLayout:
-  Description: 'Ensures newlines after multiline block do statements.'
+  Description: |-
+    Checks whether the multiline do end blocks have a newline
+    after the start of the block. Additionally, it checks whether the block
+    arguments, if any, are on the same line as the start of the
+    block. Putting block arguments on separate lines, because the whole
+    line would otherwise be too long, is accepted.
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineBlockLayout
 Layout/MultilineHashBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a hash literal is
-                 either on the same line as the last hash element, or
-                 a new line.
+  Description: |-
+    Checks that the closing brace in a hash literal is either
+    on the same line as the last hash element, or a new line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
   SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on same line as last element
     - symmetrical
     - new_line
     - same_line
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineHashBraceLayout
 Layout/MultilineHashKeyLineBreaks:
-  Description: >-
-                 Checks that each item in a multi-line hash literal
-                 starts on a separate line.
+  Description: |-
+    Ensures that each key in a multi-line hash
+    starts on a separate line.
   Enabled: false
   VersionAdded: '0.67'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineHashKeyLineBreaks
 Layout/MultilineMethodArgumentLineBreaks:
-  Description: >-
-                 Checks that each argument in a multi-line method call
-                 starts on a separate line.
+  Description: |-
+    Ensures that each argument in a multi-line method call
+    starts on a separate line.
   Enabled: false
   VersionAdded: '0.67'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineMethodArgumentLineBreaks
 Layout/MultilineMethodCallBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a method call is
-                 either on the same line as the last method argument, or
-                 a new line.
+  Description: |-
+    Checks that the closing brace in a method call is either
+    on the same line as the last method argument, or a new line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
   SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on the same line as last argument
     - symmetrical
     - new_line
     - same_line
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineMethodCallBraceLayout
 Layout/MultilineMethodCallIndentation:
-  Description: >-
-                 Checks indentation of method calls with the dot operator
-                 that span more than one line.
+  Description: |-
+    Checks the indentation of the method name part in method calls
+    that span more than one line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: aligned
@@ -1118,169 +930,154 @@ Layout/MultilineMethodCallIndentation:
     - aligned
     - indented
     - indented_relative_to_receiver
-  # By default the indentation width from `Layout/IndentationWidth` is used,
-  # but it can be overridden by setting this parameter.
-  IndentationWidth: ~
-
+  IndentationWidth:
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineMethodCallIndentation
 Layout/MultilineMethodDefinitionBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a method definition is
-                 either on the same line as the last method parameter, or
-                 a new line.
+  Description: |-
+    Checks that the closing brace in a method definition is either
+    on the same line as the last method parameter, or a new line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
   SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on the same line as last parameter
     - symmetrical
     - new_line
     - same_line
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineMethodDefinitionBraceLayout
 Layout/MultilineOperationIndentation:
-  Description: >-
-                 Checks indentation of binary operations that span more than
-                 one line.
+  Description: |-
+    Checks the indentation of the right hand side operand in binary operations that
+    span more than one line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: aligned
   SupportedStyles:
     - aligned
     - indented
-  # By default the indentation width from `Layout/IndentationWidth` is used,
-  # but it can be overridden by setting this parameter.
-  IndentationWidth: ~
-
+  IndentationWidth:
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineOperationIndentation
 Layout/ParameterAlignment:
-  Description: >-
-                 Align the parameters of a method definition if they span more
-                 than one line.
-  StyleGuide: '#no-double-indent'
+  Description: |-
+    Here we check if the parameters on a multi-line method call or
+    definition are aligned.
+  StyleGuide: "#no-double-indent"
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.77'
-  # Alignment of parameters in multi-line method calls.
-  #
-  # The `with_first_parameter` style aligns the following lines along the same
-  # column as the first parameter.
-  #
-  #     def method_foo(a,
-  #                    b)
-  #
-  # The `with_fixed_indentation` style aligns the following lines with one
-  # level of indentation relative to the start of the line with the method call.
-  #
-  #     def method_foo(a,
-  #       b)
   EnforcedStyle: with_first_parameter
   SupportedStyles:
     - with_first_parameter
     - with_fixed_indentation
-  # By default the indentation width from `Layout/IndentationWidth` is used,
-  # but it can be overridden by setting this parameter.
-  IndentationWidth: ~
-
+  IndentationWidth:
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/ParameterAlignment
 Layout/RedundantLineBreak:
-  Description: >-
-                 Do not break up an expression into multiple lines when it fits
-                 on a single line.
+  Description: |-
+    Checks whether certain expressions, e.g. method calls, that could fit
+    completely on a single line, are broken up into multiple lines unnecessarily.
   Enabled: false
   InspectBlocks: false
   VersionAdded: '1.13'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/RedundantLineBreak
 Layout/RescueEnsureAlignment:
-  Description: 'Align rescues and ensures correctly.'
+  Description: |-
+    Checks whether the rescue and ensure keywords are aligned
+    properly.
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/RescueEnsureAlignment
 Layout/SingleLineBlockChain:
-  Description: 'Put method call on a separate line if chained to a single line block.'
+  Description: |-
+    Checks if method calls are chained onto single line blocks. It considers that a
+    line break before the dot improves the readability of the code.
   Enabled: false
   VersionAdded: '1.14'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SingleLineBlockChain
 Layout/SpaceAfterColon:
-  Description: 'Use spaces after colons.'
-  StyleGuide: '#spaces-operators'
+  Description: |-
+    Checks for colon (:) not followed by some kind of space.
+    N.B. this cop does not handle spaces after a ternary operator, which are
+    instead handled by Layout/SpaceAroundOperators.
+  StyleGuide: "#spaces-operators"
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceAfterColon
 Layout/SpaceAfterComma:
-  Description: 'Use spaces after commas.'
-  StyleGuide: '#spaces-operators'
+  Description: Checks for comma (,) not followed by some kind of space.
+  StyleGuide: "#spaces-operators"
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceAfterComma
 Layout/SpaceAfterMethodName:
-  Description: >-
-                 Do not put a space between a method name and the opening
-                 parenthesis in a method definition.
-  StyleGuide: '#parens-no-spaces'
+  Description: Checks for space between a method name and a left parenthesis in defs.
+  StyleGuide: "#parens-no-spaces"
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceAfterMethodName
 Layout/SpaceAfterNot:
-  Description: Tracks redundant space after the ! operator.
-  StyleGuide: '#no-space-bang'
+  Description: Checks for space after `!`.
+  StyleGuide: "#no-space-bang"
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceAfterNot
 Layout/SpaceAfterSemicolon:
-  Description: 'Use spaces after semicolons.'
-  StyleGuide: '#spaces-operators'
+  Description: Checks for semicolon (;) not followed by some kind of space.
+  StyleGuide: "#spaces-operators"
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceAfterSemicolon
 Layout/SpaceAroundBlockParameters:
-  Description: 'Checks the spacing inside and after block parameters pipes.'
+  Description: |-
+    Checks the spacing inside and after block parameters pipes. Line breaks
+    inside parameter pipes are checked by `Layout/MultilineBlockLayout` and
+    not by this cop.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyleInsidePipes: no_space
   SupportedStylesInsidePipes:
     - space
     - no_space
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceAroundBlockParameters
 Layout/SpaceAroundEqualsInParameterDefault:
-  Description: >-
-                 Checks that the equals signs in parameter default assignments
-                 have or don't have surrounding space depending on
-                 configuration.
-  StyleGuide: '#spaces-around-equals'
+  Description: |-
+    Checks that the equals signs in parameter default assignments
+    have or don't have surrounding space depending on configuration.
+  StyleGuide: "#spaces-around-equals"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: space
   SupportedStyles:
     - space
     - no_space
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceAroundEqualsInParameterDefault
 Layout/SpaceAroundKeyword:
-  Description: 'Use a space around keywords if appropriate.'
+  Description: Checks the spacing around the keywords.
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceAroundKeyword
 Layout/SpaceAroundMethodCallOperator:
-  Description: 'Checks method call operators to not have spaces around them.'
+  Description: Checks method call operators to not have spaces around them.
   Enabled: true
   VersionAdded: '0.82'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceAroundMethodCallOperator
 Layout/SpaceAroundOperators:
-  Description: 'Use a single space around operators.'
-  StyleGuide: '#spaces-operators'
+  Description: |-
+    Checks that operators have space around them, except for ** which
+    should or shouldn't have surrounding space depending on configuration.
+    It allows vertical alignment consisting of one or more whitespace
+    around operators.
+  StyleGuide: "#spaces-operators"
   Enabled: true
   VersionAdded: '0.49'
-  # When `true`, allows most uses of extra spacing if the intent is to align
-  # with an operator on the previous or next line, not counting empty lines
-  # or comment lines.
   AllowForAlignment: true
   EnforcedStyleForExponentOperator: no_space
   SupportedStylesForExponentOperator:
     - space
     - no_space
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceAroundOperators
 Layout/SpaceBeforeBlockBraces:
-  Description: >-
-                 Checks that the left block brace has or doesn't have space
-                 before it.
+  Description: |-
+    Checks that block braces have or don't have a space before the opening
+    brace depending on configuration.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: space
@@ -1292,76 +1089,80 @@ Layout/SpaceBeforeBlockBraces:
     - space
     - no_space
   VersionChanged: '0.52'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceBeforeBlockBraces
 Layout/SpaceBeforeBrackets:
-  Description: 'Checks for receiver with a space before the opening brackets.'
-  StyleGuide: '#space-in-brackets-access'
+  Description: |-
+    Checks for space between the name of a receiver and a left
+    brackets.
+  StyleGuide: "#space-in-brackets-access"
   Enabled: pending
   VersionAdded: '1.7'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceBeforeBrackets
 Layout/SpaceBeforeComma:
-  Description: 'No spaces before commas.'
+  Description: Checks for comma (,) preceded by space.
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceBeforeComma
 Layout/SpaceBeforeComment:
-  Description: >-
-                 Checks for missing space between code and a comment on the
-                 same line.
+  Description: |-
+    Checks for missing space between a token and a comment on the
+    same line.
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceBeforeComment
 Layout/SpaceBeforeFirstArg:
-  Description: >-
-                 Checks that exactly one space is used between a method name
-                 and the first argument for method calls without parentheses.
+  Description: |-
+    Checks that exactly one space is used between a method name and the
+    first argument for method calls without parentheses.
   Enabled: true
   VersionAdded: '0.49'
-  # When `true`, allows most uses of extra spacing if the intent is to align
-  # things with the previous or next line, not counting empty lines or comment
-  # lines.
   AllowForAlignment: true
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceBeforeFirstArg
 Layout/SpaceBeforeSemicolon:
-  Description: 'No spaces before semicolons.'
+  Description: Checks for semicolon (;) preceded by space.
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceBeforeSemicolon
 Layout/SpaceInLambdaLiteral:
-  Description: 'Checks for spaces in lambda literals.'
+  Description: |-
+    Checks for spaces between `->` and opening parameter
+    parenthesis (`(`) in lambda literals.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: require_no_space
   SupportedStyles:
     - require_no_space
     - require_space
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceInLambdaLiteral
 Layout/SpaceInsideArrayLiteralBrackets:
-  Description: 'Checks the spacing inside array literal brackets.'
+  Description: |-
+    Checks that brackets used for array literals have or don't have
+    surrounding space depending on configuration.
   Enabled: true
   VersionAdded: '0.52'
   EnforcedStyle: no_space
   SupportedStyles:
     - space
     - no_space
-    # 'compact' normally requires a space inside the brackets, with the exception
-    # that successive left brackets or right brackets are collapsed together
     - compact
   EnforcedStyleForEmptyBrackets: no_space
   SupportedStylesForEmptyBrackets:
     - space
     - no_space
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceInsideArrayLiteralBrackets
 Layout/SpaceInsideArrayPercentLiteral:
-  Description: 'No unnecessary additional spaces between elements in %i/%w literals.'
+  Description: |-
+    Checks for unnecessary additional spaces inside array percent literals
+    (i.e. %i/%w).
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceInsideArrayPercentLiteral
 Layout/SpaceInsideBlockBraces:
-  Description: >-
-                 Checks that block braces have or don't have surrounding space.
-                 For blocks taking parameters, checks that the left brace has
-                 or doesn't have trailing space.
+  Description: |-
+    Checks that block braces have or don't have surrounding space inside
+    them on configuration. For blocks taking parameters, it checks that the
+    left brace has or doesn't have trailing space depending on
+    configuration.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: space
@@ -1372,30 +1173,28 @@ Layout/SpaceInsideBlockBraces:
   SupportedStylesForEmptyBraces:
     - space
     - no_space
-  # Space between `{` and `|`. Overrides `EnforcedStyle` if there is a conflict.
   SpaceBeforeBlockParameters: true
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceInsideBlockBraces
 Layout/SpaceInsideHashLiteralBraces:
-  Description: "Use spaces inside hash literal braces - or don't."
-  StyleGuide: '#spaces-braces'
+  Description: |-
+    Checks that braces used for hash literals have or don't have
+    surrounding space depending on configuration.
+  StyleGuide: "#spaces-braces"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: space
   SupportedStyles:
     - space
     - no_space
-    # 'compact' normally requires a space inside hash braces, with the exception
-    # that successive left braces or right braces are collapsed together
     - compact
   EnforcedStyleForEmptyBraces: no_space
   SupportedStylesForEmptyBraces:
     - space
     - no_space
-
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceInsideHashLiteralBraces
 Layout/SpaceInsideParens:
-  Description: 'No spaces after ( or before ).'
-  StyleGuide: '#spaces-braces'
+  Description: Checks for spaces inside ordinary round parentheses.
+  StyleGuide: "#spaces-braces"
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '1.22'
@@ -1404,20 +1203,24 @@ Layout/SpaceInsideParens:
     - space
     - compact
     - no_space
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceInsideParens
 Layout/SpaceInsidePercentLiteralDelimiters:
-  Description: 'No unnecessary spaces inside delimiters of %i/%w/%x literals.'
+  Description: |-
+    Checks for unnecessary additional spaces inside the delimiters of
+    %i/%w/%x literals.
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceInsidePercentLiteralDelimiters
 Layout/SpaceInsideRangeLiteral:
-  Description: 'No spaces inside range literals.'
-  StyleGuide: '#no-space-inside-range-literals'
+  Description: Checks for spaces inside range literals.
+  StyleGuide: "#no-space-inside-range-literals"
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceInsideRangeLiteral
 Layout/SpaceInsideReferenceBrackets:
-  Description: 'Checks the spacing inside referential brackets.'
+  Description: |-
+    Checks that reference brackets have or don't have
+    surrounding space depending on configuration.
   Enabled: true
   VersionAdded: '0.52'
   VersionChanged: '0.53'
@@ -1429,20 +1232,22 @@ Layout/SpaceInsideReferenceBrackets:
   SupportedStylesForEmptyBrackets:
     - space
     - no_space
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceInsideReferenceBrackets
 Layout/SpaceInsideStringInterpolation:
-  Description: 'Checks for padding/surrounding spaces inside string interpolation.'
-  StyleGuide: '#string-interpolation'
+  Description: Checks for whitespace within string interpolations.
+  StyleGuide: "#string-interpolation"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: no_space
   SupportedStyles:
     - space
     - no_space
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceInsideStringInterpolation
 Layout/TrailingEmptyLines:
-  Description: 'Checks trailing blank lines and final newline.'
-  StyleGuide: '#newline-eof'
+  Description: |-
+    Looks for trailing blank lines and a final newline in the
+    source code.
+  StyleGuide: "#newline-eof"
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.77'
@@ -1450,124 +1255,130 @@ Layout/TrailingEmptyLines:
   SupportedStyles:
     - final_newline
     - final_blank_line
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/TrailingEmptyLines
 Layout/TrailingWhitespace:
-  Description: 'Avoid trailing whitespace.'
-  StyleGuide: '#no-trailing-whitespace'
+  Description: Looks for trailing whitespace in the source code.
+  StyleGuide: "#no-trailing-whitespace"
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '1.0'
   AllowInHeredoc: false
-
-#################### Lint ##################################
-### Warnings
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/TrailingWhitespace
 Lint/AmbiguousAssignment:
-  Description: 'Checks for mistyped shorthand assignments.'
+  Description: Checks for mistyped shorthand assignments.
   Enabled: pending
   VersionAdded: '1.7'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/AmbiguousAssignment
 Lint/AmbiguousBlockAssociation:
-  Description: >-
-                 Checks for ambiguous block association with method when param passed without
-                 parentheses.
-  StyleGuide: '#syntax'
+  Description: |-
+    Checks for ambiguous block association with method
+    when param passed without parentheses.
+  StyleGuide: "#syntax"
   Enabled: true
   VersionAdded: '0.48'
   VersionChanged: '1.13'
   IgnoredMethods: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/AmbiguousBlockAssociation
 Lint/AmbiguousOperator:
-  Description: >-
-                 Checks for ambiguous operators in the first argument of a
-                 method invocation without parentheses.
-  StyleGuide: '#method-invocation-parens'
+  Description: |-
+    Checks for ambiguous operators in the first argument of a
+    method invocation without parentheses.
+  StyleGuide: "#method-invocation-parens"
   Enabled: true
   VersionAdded: '0.17'
   VersionChanged: '0.83'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/AmbiguousOperator
 Lint/AmbiguousOperatorPrecedence:
-  Description: >-
-                 Checks for expressions containing multiple binary operations with
-                 ambiguous precedence.
+  Description: |-
+    Looks for expressions containing multiple binary operators
+    where precedence is ambiguous due to lack of parentheses. For example,
+    in `1 + 2 * 3`, the multiplication will happen before the addition, but
+    lexically it appears that the addition will happen first.
   Enabled: pending
   VersionAdded: '1.21'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/AmbiguousOperatorPrecedence
 Lint/AmbiguousRange:
-  Description: Checks for ranges with ambiguous boundaries.
+  Description: Checks for ambiguous ranges.
   Enabled: pending
   VersionAdded: '1.19'
   SafeAutoCorrect: false
   RequireParenthesesForMethodChains: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/AmbiguousRange
 Lint/AmbiguousRegexpLiteral:
-  Description: >-
-                 Checks for ambiguous regexp literals in the first argument of
-                 a method invocation without parentheses.
+  Description: |-
+    Checks for ambiguous regexp literals in the first argument of
+    a method invocation without parentheses.
   Enabled: true
   VersionAdded: '0.17'
   VersionChanged: '0.83'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/AmbiguousRegexpLiteral
 Lint/AssignmentInCondition:
-  Description: "Don't use assignment in conditions."
-  StyleGuide: '#safe-assignment-in-condition'
+  Description: |-
+    Checks for assignments in the conditions of
+    if/while/until.
+  StyleGuide: "#safe-assignment-in-condition"
   Enabled: true
   VersionAdded: '0.9'
   AllowSafeAssignment: true
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/AssignmentInCondition
 Lint/BigDecimalNew:
-  Description: '`BigDecimal.new()` is deprecated. Use `BigDecimal()` instead.'
+  Description: |-
+    `BigDecimal.new()` is deprecated since BigDecimal 1.3.3.
+    This cop identifies places where `BigDecimal.new()`
+    can be replaced by `BigDecimal()`.
   Enabled: true
   VersionAdded: '0.53'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/BigDecimalNew
 Lint/BinaryOperatorWithIdenticalOperands:
-  Description: 'Checks for places where binary operator has identical operands.'
+  Description: Checks for places where binary operator has identical operands.
   Enabled: true
   Safe: false
   VersionAdded: '0.89'
   VersionChanged: '1.7'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/BinaryOperatorWithIdenticalOperands
 Lint/BooleanSymbol:
-  Description: 'Check for `:true` and `:false` symbols.'
+  Description: |-
+    Checks for `:true` and `:false` symbols.
+    In most cases it would be a typo.
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.50'
   VersionChanged: '1.22'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/BooleanSymbol
 Lint/CircularArgumentReference:
-  Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."
+  Description: |-
+    Checks for circular argument references in optional keyword
+    arguments and optional ordinal arguments.
   Enabled: true
   VersionAdded: '0.33'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/CircularArgumentReference
 Lint/ConstantDefinitionInBlock:
-  Description: 'Do not define constants within a block.'
-  StyleGuide: '#no-constant-definition-in-block'
+  Description: |-
+    Do not define constants within a block, since the block's scope does not
+    isolate or namespace the constant in any way.
+  StyleGuide: "#no-constant-definition-in-block"
   Enabled: true
   VersionAdded: '0.91'
   VersionChanged: '1.3'
-  # `enums` for Typed Enums via T::Enum in Sorbet.
-  # https://sorbet.org/docs/tenum
   AllowedMethods:
     - enums
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/ConstantDefinitionInBlock
 Lint/ConstantResolution:
-  Description: 'Check that constants are fully qualified with `::`.'
+  Description: Check that certain constants are fully qualified.
   Enabled: false
   VersionAdded: '0.86'
-  # Restrict this cop to only looking at certain names
   Only: []
-  # Restrict this cop from only looking at certain names
   Ignore: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/ConstantResolution
 Lint/Debugger:
-  Description: 'Check for debugger calls.'
+  Description: |-
+    Checks for debug calls (such as `debugger` or `binding.pry`) that should
+    not be kept for production code.
   Enabled: true
   VersionAdded: '0.14'
   VersionChanged: '1.10'
-  DebuggerReceivers: [] # deprecated
+  DebuggerReceivers: []
   DebuggerMethods:
-    # Groups are available so that a specific group can be disabled in
-    # a user's configuration, but are otherwise not significant.
     Kernel:
       - binding.irb
     Byebug:
@@ -1595,30 +1406,20 @@ Lint/Debugger:
       - jard
     WebConsole:
       - binding.console
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/Debugger
 Lint/DeprecatedClassMethods:
-  Description: 'Check for deprecated class method calls.'
+  Description: Checks for uses of the deprecated class method usages.
   Enabled: true
   VersionAdded: '0.19'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/DeprecatedClassMethods
 Lint/DeprecatedConstants:
-  Description: 'Checks for deprecated constants.'
+  Description: Checks for deprecated constants.
   Enabled: pending
   VersionAdded: '1.8'
   VersionChanged: '1.22'
-  # You can configure deprecated constants.
-  # If there is an alternative method, you can set alternative value as `Alternative`.
-  # And you can set the deprecated version as `DeprecatedVersion`.
-  # These options can be omitted if they are not needed.
-  #
-  # DeprecatedConstants:
-  #   'DEPRECATED_CONSTANT':
-  #     Alternative: 'alternative_value'
-  #     DeprecatedVersion: 'deprecated_version'
-  #
   DeprecatedConstants:
-    'NIL':
-      Alternative: 'nil'
+    NIL:
+      Alternative: nil
       DeprecatedVersion: '2.4'
     'TRUE':
       Alternative: 'true'
@@ -1626,329 +1427,396 @@ Lint/DeprecatedConstants:
     'FALSE':
       Alternative: 'false'
       DeprecatedVersion: '2.4'
-    'Net::HTTPServerException':
-      Alternative: 'Net::HTTPClientException'
+    Net::HTTPServerException:
+      Alternative: Net::HTTPClientException
       DeprecatedVersion: '2.6'
-    'Random::DEFAULT':
-      Alternative: 'Random.new'
+    Random::DEFAULT:
+      Alternative: Random.new
       DeprecatedVersion: '3.0'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/DeprecatedConstants
 Lint/DeprecatedOpenSSLConstant:
-  Description: "Don't use algorithm constants for `OpenSSL::Cipher` and `OpenSSL::Digest`."
+  Description: |-
+    Algorithmic constants for `OpenSSL::Cipher` and `OpenSSL::Digest`
+    deprecated since OpenSSL version 2.2.0. Prefer passing a string
+    instead.
   Enabled: true
   VersionAdded: '0.84'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/DeprecatedOpenSSLConstant
 Lint/DisjunctiveAssignmentInConstructor:
-  Description: 'In constructor, plain assignment is preferred over disjunctive.'
+  Description: |-
+    Checks constructors for disjunctive assignments (`||=`) that should
+    be plain assignments.
   Enabled: true
   Safe: false
   VersionAdded: '0.62'
   VersionChanged: '0.88'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/DisjunctiveAssignmentInConstructor
 Lint/DuplicateBranch:
-  Description: Checks that there are no repeated bodies within `if/unless`, `case-when` and `rescue` constructs.
+  Description: |-
+    Checks that there are no repeated bodies
+    within `if/unless`, `case-when`, `case-in` and `rescue` constructs.
   Enabled: pending
   VersionAdded: '1.3'
   VersionChanged: '1.7'
   IgnoreLiteralBranches: false
   IgnoreConstantBranches: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/DuplicateBranch
 Lint/DuplicateCaseCondition:
-  Description: 'Do not repeat values in case conditionals.'
+  Description: |-
+    Checks that there are no repeated conditions
+    used in case 'when' expressions.
   Enabled: true
   VersionAdded: '0.45'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/DuplicateCaseCondition
 Lint/DuplicateElsifCondition:
-  Description: 'Do not repeat conditions used in if `elsif`.'
+  Description: Checks that there are no repeated conditions used in if 'elsif'.
   Enabled: true
   VersionAdded: '0.88'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/DuplicateElsifCondition
 Lint/DuplicateHashKey:
-  Description: 'Check for duplicate keys in hash literals.'
+  Description: Checks for duplicated keys in hash literals.
   Enabled: true
   VersionAdded: '0.34'
   VersionChanged: '0.77'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/DuplicateHashKey
 Lint/DuplicateMethods:
-  Description: 'Check for duplicate method definitions.'
+  Description: |-
+    Checks for duplicated instance (or singleton) method
+    definitions.
   Enabled: true
   VersionAdded: '0.29'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/DuplicateMethods
 Lint/DuplicateRegexpCharacterClassElement:
-  Description: 'Checks for duplicate elements in Regexp character classes.'
+  Description: Checks for duplicate elements in Regexp character classes.
   Enabled: pending
   VersionAdded: '1.1'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/DuplicateRegexpCharacterClassElement
 Lint/DuplicateRequire:
-  Description: 'Check for duplicate `require`s and `require_relative`s.'
+  Description: Checks for duplicate `require`s and `require_relative`s.
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.90'
   VersionChanged: '1.28'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/DuplicateRequire
 Lint/DuplicateRescueException:
-  Description: 'Checks that there are no repeated exceptions used in `rescue` expressions.'
+  Description: |-
+    Checks that there are no repeated exceptions
+    used in 'rescue' expressions.
   Enabled: true
   VersionAdded: '0.89'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/DuplicateRescueException
 Lint/EachWithObjectArgument:
-  Description: 'Check for immutable argument given to each_with_object.'
+  Description: |-
+    Checks if each_with_object is called with an immutable
+    argument. Since the argument is the object that the given block shall
+    make calls on to build something based on the enumerable that
+    each_with_object iterates over, an immutable argument makes no sense.
+    It's definitely a bug.
   Enabled: true
   VersionAdded: '0.31'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/EachWithObjectArgument
 Lint/ElseLayout:
-  Description: 'Check for odd code arrangement in an else block.'
+  Description: |-
+    Checks for odd `else` block layout - like
+    having an expression on the same line as the `else` keyword,
+    which is usually a mistake.
   Enabled: true
   VersionAdded: '0.17'
   VersionChanged: '1.2'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/ElseLayout
 Lint/EmptyBlock:
-  Description: 'Checks for blocks without a body.'
+  Description: |-
+    Checks for blocks without a body.
+    Such empty blocks are typically an oversight or we should provide a comment
+    be clearer what we're aiming for.
   Enabled: pending
   VersionAdded: '1.1'
   VersionChanged: '1.15'
   AllowComments: true
   AllowEmptyLambdas: true
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/EmptyBlock
 Lint/EmptyClass:
-  Description: 'Checks for classes and metaclasses without a body.'
+  Description: |-
+    Checks for classes and metaclasses without a body.
+    Such empty classes and metaclasses are typically an oversight or we should provide a comment
+    to be clearer what we're aiming for.
   Enabled: pending
   VersionAdded: '1.3'
   AllowComments: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/EmptyClass
 Lint/EmptyConditionalBody:
-  Description: 'Checks for the presence of `if`, `elsif` and `unless` branches without a body.'
+  Description: Checks for the presence of `if`, `elsif` and `unless` branches without
+    a body.
   Enabled: true
   AllowComments: true
   VersionAdded: '0.89'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/EmptyConditionalBody
 Lint/EmptyEnsure:
-  Description: 'Checks for empty ensure block.'
+  Description: Checks for empty `ensure` blocks
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '0.48'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/EmptyEnsure
 Lint/EmptyExpression:
-  Description: 'Checks for empty expressions.'
+  Description: Checks for the presence of empty expressions.
   Enabled: true
   VersionAdded: '0.45'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/EmptyExpression
 Lint/EmptyFile:
-  Description: 'Enforces that Ruby source files are not empty.'
+  Description: Enforces that Ruby source files are not empty.
   Enabled: true
   AllowComments: true
   VersionAdded: '0.90'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/EmptyFile
 Lint/EmptyInPattern:
-  Description: 'Checks for the presence of `in` pattern branches without a body.'
+  Description: Checks for the presence of `in` pattern branches without a body.
   Enabled: pending
   AllowComments: true
   VersionAdded: '1.16'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/EmptyInPattern
 Lint/EmptyInterpolation:
-  Description: 'Checks for empty string interpolation.'
+  Description: Checks for empty interpolation.
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.45'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/EmptyInterpolation
 Lint/EmptyWhen:
-  Description: 'Checks for `when` branches with empty bodies.'
+  Description: Checks for the presence of `when` branches without a body.
   Enabled: true
   AllowComments: true
   VersionAdded: '0.45'
   VersionChanged: '0.83'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/EmptyWhen
 Lint/EnsureReturn:
-  Description: 'Do not use return in an ensure block.'
-  StyleGuide: '#no-return-ensure'
+  Description: |-
+    Checks for `return` from an `ensure` block.
+    `return` from an ensure block is a dangerous code smell as it
+    will take precedence over any exception being raised,
+    and the exception will be silently thrown away as if it were rescued.
+  StyleGuide: "#no-return-ensure"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.83'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/EnsureReturn
 Lint/ErbNewArguments:
-  Description: 'Use `:trim_mode` and `:eoutvar` keyword arguments to `ERB.new`.'
+  Description: This cop emulates the following Ruby warnings in Ruby 2.6.
   Enabled: true
   VersionAdded: '0.56'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/ErbNewArguments
 Lint/FlipFlop:
-  Description: 'Checks for flip-flops.'
-  StyleGuide: '#no-flip-flops'
+  Description: |-
+    Looks for uses of flip-flop operator
+    based on the Ruby Style Guide.
+  StyleGuide: "#no-flip-flops"
   Enabled: true
   VersionAdded: '0.16'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/FlipFlop
 Lint/FloatComparison:
-  Description: 'Checks for the presence of precise comparison of floating point numbers.'
-  StyleGuide: '#float-comparison'
+  Description: Checks for the presence of precise comparison of floating point numbers.
+  StyleGuide: "#float-comparison"
   Enabled: true
   VersionAdded: '0.89'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/FloatComparison
 Lint/FloatOutOfRange:
-  Description: >-
-                 Catches floating-point literals too large or small for Ruby to
-                 represent.
+  Description: |-
+    Identifies Float literals which are, like, really really really
+    really really really really really big. Too big. No-one needs Floats
+    that big. If you need a float that big, something is wrong with you.
   Enabled: true
   VersionAdded: '0.36'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/FloatOutOfRange
 Lint/FormatParameterMismatch:
-  Description: 'The number of parameters to format/sprint must match the fields.'
+  Description: |-
+    This lint sees if there is a mismatch between the number of
+    expected fields for format/sprintf/#% and what is actually
+    passed as arguments.
   Enabled: true
   VersionAdded: '0.33'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/FormatParameterMismatch
 Lint/HashCompareByIdentity:
-  Description: 'Prefer using `Hash#compare_by_identity` than using `object_id` for keys.'
-  StyleGuide: '#identity-comparison'
+  Description: |-
+    Prefer using `Hash#compare_by_identity` rather than using `object_id`
+    for hash keys.
+  StyleGuide: "#identity-comparison"
   Enabled: true
   Safe: false
   VersionAdded: '0.93'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/HashCompareByIdentity
 Lint/HeredocMethodCallPosition:
-  Description: >-
-                 Checks for the ordering of a method call where
-                 the receiver of the call is a HEREDOC.
+  Description: |-
+    Checks for the ordering of a method call where
+    the receiver of the call is a HEREDOC.
   Enabled: false
-  StyleGuide: '#heredoc-method-calls'
+  StyleGuide: "#heredoc-method-calls"
   VersionAdded: '0.68'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/HeredocMethodCallPosition
 Lint/IdentityComparison:
-  Description: 'Prefer `equal?` over `==` when comparing `object_id`.'
+  Description: Prefer `equal?` over `==` when comparing `object_id`.
   Enabled: true
-  StyleGuide: '#identity-comparison'
+  StyleGuide: "#identity-comparison"
   VersionAdded: '0.91'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/IdentityComparison
 Lint/ImplicitStringConcatenation:
-  Description: >-
-                 Checks for adjacent string literals on the same line, which
-                 could better be represented as a single string literal.
+  Description: |-
+    Checks for implicit string concatenation of string literals
+    which are on the same line.
   Enabled: true
   VersionAdded: '0.36'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/ImplicitStringConcatenation
 Lint/IncompatibleIoSelectWithFiberScheduler:
-  Description: 'Checks for `IO.select` that is incompatible with Fiber Scheduler.'
+  Description: This cop checks for `IO.select` that is incompatible with Fiber Scheduler
+    since Ruby 3.0.
   Enabled: pending
   SafeAutoCorrect: false
   VersionAdded: '1.21'
   VersionChanged: '1.24'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/IncompatibleIoSelectWithFiberScheduler
 Lint/IneffectiveAccessModifier:
-  Description: >-
-                 Checks for attempts to use `private` or `protected` to set
-                 the visibility of a class method, which does not work.
+  Description: |-
+    Checks for `private` or `protected` access modifiers which are
+    applied to a singleton method. These access modifiers do not make
+    singleton methods private/protected. `private_class_method` can be
+    used for that.
   Enabled: true
   VersionAdded: '0.36'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/IneffectiveAccessModifier
 Lint/InheritException:
-  Description: 'Avoid inheriting from the `Exception` class.'
+  Description: |-
+    Looks for error classes inheriting from `Exception`.
+    It is configurable to suggest using either `StandardError` (default) or
+    `RuntimeError` instead.
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.41'
   VersionChanged: '1.26'
-  # The default base class in favour of `Exception`.
   EnforcedStyle: standard_error
   SupportedStyles:
     - standard_error
     - runtime_error
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/InheritException
 Lint/InterpolationCheck:
-  Description: 'Raise warning for interpolation in single q strs.'
+  Description: Checks for interpolation in a single quoted string.
   Enabled: true
   Safe: false
   VersionAdded: '0.50'
   VersionChanged: '0.87'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/InterpolationCheck
 Lint/LambdaWithoutLiteralBlock:
-  Description: 'Checks uses of lambda without a literal block.'
+  Description: |-
+    Checks uses of lambda without a literal block.
+    It emulates the following warning in Ruby 3.0:
   Enabled: pending
   VersionAdded: '1.8'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/LambdaWithoutLiteralBlock
 Lint/LiteralAsCondition:
-  Description: 'Checks of literals used in conditions.'
+  Description: |-
+    Checks for literals used as the conditions or as
+    operands in and/or expressions serving as the conditions of
+    if/while/until/case-when/case-in.
   Enabled: true
   VersionAdded: '0.51'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/LiteralAsCondition
 Lint/LiteralInInterpolation:
-  Description: 'Checks for literals used in interpolation.'
+  Description: Checks for interpolated literals.
   Enabled: true
   VersionAdded: '0.19'
   VersionChanged: '0.32'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/LiteralInInterpolation
 Lint/Loop:
-  Description: >-
-                 Use Kernel#loop with break rather than begin/end/until or
-                 begin/end/while for post-loop tests.
-  StyleGuide: '#loop-with-break'
+  Description: Checks for uses of `begin...end while/until something`.
+  StyleGuide: "#loop-with-break"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '1.3'
   Safe: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/Loop
 Lint/MissingCopEnableDirective:
-  Description: 'Checks for a `# rubocop:enable` after `# rubocop:disable`.'
+  Description: |-
+    Checks that there is an `# rubocop:enable ...` statement
+    after a `# rubocop:disable ...` statement. This will prevent leaving
+    cop disables on wide ranges of code, that latter contributors to
+    a file wouldn't be aware of.
   Enabled: true
   VersionAdded: '0.52'
-  # Maximum number of consecutive lines the cop can be disabled for.
-  # 0 allows only single-line disables
-  # 1 would mean the maximum allowed is the following:
-  #   # rubocop:disable SomeCop
-  #   a = 1
-  #   # rubocop:enable SomeCop
-  # .inf for any size
   MaximumRangeSize: .inf
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/MissingCopEnableDirective
 Lint/MissingSuper:
-  Description: >-
-                  Checks for the presence of constructors and lifecycle callbacks
-                  without calls to `super`.
+  Description: |-
+    Checks for the presence of constructors and lifecycle callbacks
+    without calls to `super`.
   Enabled: true
   VersionAdded: '0.89'
   VersionChanged: '1.4'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/MissingSuper
 Lint/MixedRegexpCaptureTypes:
-  Description: 'Do not mix named captures and numbered captures in a Regexp literal.'
+  Description: |-
+    Do not mix named captures and numbered captures in a Regexp literal
+    because numbered capture is ignored if they're mixed.
+    Replace numbered captures with non-capturing groupings or
+    named captures.
   Enabled: true
   VersionAdded: '0.85'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/MixedRegexpCaptureTypes
 Lint/MultipleComparison:
-  Description: "Use `&&` operator to compare multiple values."
+  Description: |-
+    In math and Python, we can use `x < y < z` style comparison to compare
+    multiple value. However, we can't use the comparison in Ruby. However,
+    the comparison is not syntax error. This cop checks the bad usage of
+    comparison operators.
   Enabled: true
   VersionAdded: '0.47'
   VersionChanged: '1.1'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/MultipleComparison
 Lint/NestedMethodDefinition:
-  Description: 'Do not use nested method definitions.'
-  StyleGuide: '#no-nested-methods'
+  Description: Checks for nested method definitions.
+  StyleGuide: "#no-nested-methods"
   Enabled: true
   VersionAdded: '0.32'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/NestedMethodDefinition
 Lint/NestedPercentLiteral:
-  Description: 'Checks for nested percent literals.'
+  Description: Checks for nested percent literals.
   Enabled: true
   VersionAdded: '0.52'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/NestedPercentLiteral
 Lint/NextWithoutAccumulator:
-  Description: >-
-                  Do not omit the accumulator when calling `next`
-                  in a `reduce`/`inject` block.
+  Description: Don't omit the accumulator when calling `next` in a `reduce` block.
   Enabled: true
   VersionAdded: '0.36'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/NextWithoutAccumulator
 Lint/NoReturnInBeginEndBlocks:
-  Description: 'Do not `return` inside `begin..end` blocks in assignment contexts.'
+  Description: |-
+    Checks for the presence of a `return` inside a `begin..end` block
+    in assignment contexts.
+    In this situation, the `return` will result in an exit from the current
+    method, possibly leading to unexpected behavior.
   Enabled: pending
   VersionAdded: '1.2'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/NoReturnInBeginEndBlocks
 Lint/NonDeterministicRequireOrder:
-  Description: 'Always sort arrays returned by Dir.glob when requiring files.'
+  Description: |-
+    `Dir[...]` and `Dir.glob(...)` do not make any guarantees about
+    the order in which files are returned. The final order is
+    determined by the operating system and file system.
+    This means that using them in cases where the order matters,
+    such as requiring files, can lead to intermittent failures
+    that are hard to debug. To ensure this doesn't happen,
+    always sort the list.
   Enabled: true
   VersionAdded: '0.78'
   Safe: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/NonDeterministicRequireOrder
 Lint/NonLocalExitFromIterator:
-  Description: 'Do not use return in iterator to cause non-local exit.'
+  Description: |-
+    Checks for non-local exits from iterators without a return
+    value. It registers an offense under these conditions:
   Enabled: true
   VersionAdded: '0.30'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/NonLocalExitFromIterator
 Lint/NumberConversion:
-  Description: 'Checks unsafe usage of number conversion methods.'
+  Description: |-
+    Warns the usage of unsafe number conversions. Unsafe
+    number conversion can cause unexpected error if auto type conversion
+    fails. Cop prefer parsing with number class instead.
   Enabled: false
   VersionAdded: '0.53'
   VersionChanged: '1.1'
@@ -1957,95 +1825,114 @@ Lint/NumberConversion:
   IgnoredClasses:
     - Time
     - DateTime
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/NumberConversion
 Lint/NumberedParameterAssignment:
-  Description: 'Checks for uses of numbered parameter assignment.'
+  Description: |-
+    Checks for uses of numbered parameter assignment.
+    It emulates the following warning in Ruby 2.7:
   Enabled: pending
   VersionAdded: '1.9'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/NumberedParameterAssignment
 Lint/OrAssignmentToConstant:
-  Description: 'Checks unintended or-assignment to constant.'
+  Description: Checks for unintended or-assignment to a constant.
   Enabled: pending
   Safe: false
   VersionAdded: '1.9'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/OrAssignmentToConstant
 Lint/OrderedMagicComments:
-  Description: 'Checks the proper ordering of magic comments and whether a magic comment is not placed before a shebang.'
+  Description: |-
+    Checks the proper ordering of magic comments and whether
+    a magic comment is not placed before a shebang.
   Enabled: true
   VersionAdded: '0.53'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/OrderedMagicComments
 Lint/OutOfRangeRegexpRef:
-  Description: 'Checks for out of range reference for Regexp because it always returns nil.'
+  Description: |-
+    This cops looks for references of Regexp captures that are out of range
+    and thus always returns nil.
   Enabled: true
   Safe: false
   VersionAdded: '0.89'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/OutOfRangeRegexpRef
 Lint/ParenthesesAsGroupedExpression:
-  Description: >-
-                 Checks for method calls with a space before the opening
-                 parenthesis.
-  StyleGuide: '#parens-no-spaces'
+  Description: |-
+    Checks for space between the name of a called method and a left
+    parenthesis.
+  StyleGuide: "#parens-no-spaces"
   Enabled: true
   VersionAdded: '0.12'
   VersionChanged: '0.83'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/ParenthesesAsGroupedExpression
 Lint/PercentStringArray:
-  Description: >-
-                 Checks for unwanted commas and quotes in %w/%W literals.
+  Description: Checks for quotes and commas in %w, e.g. `%w('foo', "bar")`
   Enabled: true
   Safe: false
   VersionAdded: '0.41'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/PercentStringArray
 Lint/PercentSymbolArray:
-  Description: >-
-                 Checks for unwanted commas and colons in %i/%I literals.
+  Description: Checks for colons and commas in %i, e.g. `%i(:foo, :bar)`
   Enabled: true
   VersionAdded: '0.41'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/PercentSymbolArray
 Lint/RaiseException:
-  Description: Checks for `raise` or `fail` statements which are raising `Exception` class.
-  StyleGuide: '#raise-exception'
+  Description: |-
+    Checks for `raise` or `fail` statements which are
+    raising `Exception` class.
+  StyleGuide: "#raise-exception"
   Enabled: true
   Safe: false
   VersionAdded: '0.81'
   VersionChanged: '0.86'
   AllowedImplicitNamespaces:
-    - 'Gem'
-
+    - Gem
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RaiseException
 Lint/RandOne:
-  Description: >-
-                 Checks for `rand(1)` calls. Such calls always return `0`
-                 and most likely a mistake.
+  Description: |-
+    Checks for `rand(1)` calls.
+    Such calls always return `0`.
   Enabled: true
   VersionAdded: '0.36'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RandOne
 Lint/RedundantCopDisableDirective:
-  Description: >-
-                 Checks for rubocop:disable comments that can be removed.
-                 Note: this cop is not disabled when disabling all cops.
-                 It must be explicitly disabled.
+  Description: |-
+    Detects instances of rubocop:disable comments that can be
+    removed without causing any offenses to be reported. It's implemented
+    as a cop in that it inherits from the Cop base class and calls
+    add_offense. The unusual part of its implementation is that it doesn't
+    have any on_* methods or an investigate method. This means that it
+    doesn't take part in the investigation phase when the other cops do
+    their work. Instead, it waits until it's called in a later stage of the
+    execution. The reason it can't be implemented as a normal cop is that
+    it depends on the results of all other cops to do its work.
   Enabled: true
   VersionAdded: '0.76'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RedundantCopDisableDirective
 Lint/RedundantCopEnableDirective:
-  Description: Checks for rubocop:enable comments that can be removed.
+  Description: |-
+    Detects instances of rubocop:enable comments that can be
+    removed.
   Enabled: true
   VersionAdded: '0.76'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RedundantCopEnableDirective
 Lint/RedundantDirGlobSort:
-  Description: 'Checks for redundant `sort` method to `Dir.glob` and `Dir[]`.'
+  Description: |-
+    Sort globbed results by default in Ruby 3.0.
+    This cop checks for redundant `sort` method to `Dir.glob` and `Dir[]`.
   Enabled: pending
   VersionAdded: '1.8'
   VersionChanged: '1.26'
   SafeAutoCorrect: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RedundantDirGlobSort
 Lint/RedundantRequireStatement:
-  Description: 'Checks for unnecessary `require` statement.'
+  Description: Checks for unnecessary `require` statement.
   Enabled: true
   VersionAdded: '0.76'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RedundantRequireStatement
 Lint/RedundantSafeNavigation:
-  Description: 'Checks for redundant safe navigation calls.'
+  Description: |-
+    Checks for redundant safe navigation calls.
+    `instance_of?`, `kind_of?`, `is_a?`, `eql?`, `respond_to?`, and `equal?` methods
+    are checked by default. These are customizable with `AllowedMethods` option.
   Enabled: true
   VersionAdded: '0.93'
   AllowedMethods:
@@ -2056,76 +1943,91 @@ Lint/RedundantSafeNavigation:
     - respond_to?
     - equal?
   Safe: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RedundantSafeNavigation
 Lint/RedundantSplatExpansion:
-  Description: 'Checks for splat unnecessarily being called on literals.'
+  Description: Checks for unneeded usages of splat expansion
   Enabled: true
   VersionAdded: '0.76'
   VersionChanged: '1.7'
   AllowPercentLiteralArrayArgument: true
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RedundantSplatExpansion
 Lint/RedundantStringCoercion:
-  Description: 'Checks for Object#to_s usage in string interpolation.'
-  StyleGuide: '#no-to-s'
+  Description: |-
+    Checks for string conversion in string interpolation,
+    which is redundant.
+  StyleGuide: "#no-to-s"
   Enabled: true
   VersionAdded: '0.19'
   VersionChanged: '0.77'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RedundantStringCoercion
 Lint/RedundantWithIndex:
-  Description: 'Checks for redundant `with_index`.'
+  Description: Checks for redundant `with_index`.
   Enabled: true
   VersionAdded: '0.50'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RedundantWithIndex
 Lint/RedundantWithObject:
-  Description: 'Checks for redundant `with_object`.'
+  Description: Checks for redundant `with_object`.
   Enabled: true
   VersionAdded: '0.51'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RedundantWithObject
 Lint/RefinementImportMethods:
-  Description: 'Use `Refinement#import_methods` when using `include` or `prepend` in `refine` block.'
+  Description: |-
+    Checks if `include` or `prepend` is called in `refine` block.
+    These methods are deprecated and should be replaced with `Refinement#import_methods`.
   Enabled: pending
   SafeAutoCorrect: false
   VersionAdded: '1.27'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RefinementImportMethods
 Lint/RegexpAsCondition:
-  Description: >-
-                 Do not use regexp literal as a condition.
-                 The regexp literal matches `$_` implicitly.
+  Description: |-
+    Checks for regexp literals used as `match-current-line`.
+    If a regexp literal is in condition, the regexp matches `$_` implicitly.
   Enabled: true
   VersionAdded: '0.51'
   VersionChanged: '0.86'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RegexpAsCondition
 Lint/RequireParentheses:
-  Description: >-
-                 Use parentheses in the method call to avoid confusion
-                 about precedence.
+  Description: |-
+    Checks for expressions where there is a call to a predicate
+    method with at least one argument, where no parentheses are used around
+    the parameter list, and a boolean operator, && or ||, is used in the
+    last argument.
   Enabled: true
   VersionAdded: '0.18'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RequireParentheses
 Lint/RequireRelativeSelfPath:
-  Description: 'Checks for uses a file requiring itself with `require_relative`.'
+  Description: Checks for uses a file requiring itself with `require_relative`.
   Enabled: pending
   VersionAdded: '1.22'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RequireRelativeSelfPath
 Lint/RescueException:
-  Description: 'Avoid rescuing the Exception class.'
-  StyleGuide: '#no-blind-rescues'
+  Description: Checks for `rescue` blocks targeting the Exception class.
+  StyleGuide: "#no-blind-rescues"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.27'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RescueException
 Lint/RescueType:
-  Description: 'Avoid rescuing from non constants that could result in a `TypeError`.'
+  Description: |-
+    Check for arguments to `rescue` that will result in a `TypeError`
+    if an exception is raised.
   Enabled: true
   VersionAdded: '0.49'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RescueType
 Lint/ReturnInVoidContext:
-  Description: 'Checks for return in void context.'
+  Description: |-
+    Checks for the use of a return with a value in a context
+    where the value will be ignored. (initialize and setter methods)
   Enabled: true
   VersionAdded: '0.50'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/ReturnInVoidContext
 Lint/SafeNavigationChain:
-  Description: 'Do not chain ordinary method call after safe navigation operator.'
+  Description: |-
+    The safe navigation operator returns nil if the receiver is
+    nil. If you chain an ordinary method call after a safe
+    navigation operator, it raises NoMethodError. We should use a
+    safe navigation operator after a safe navigation operator.
+    This cop checks for the problem outlined above.
   Enabled: true
   VersionAdded: '0.47'
   VersionChanged: '0.77'
@@ -2136,12 +2038,12 @@ Lint/SafeNavigationChain:
     - try
     - try!
     - in?
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/SafeNavigationChain
 Lint/SafeNavigationConsistency:
-  Description: >-
-                 Check to make sure that if safe navigation is used for a method
-                 call in an `&&` or `||` condition that safe navigation is used
-                 for all method calls on that same object.
+  Description: |-
+    Check to make sure that if safe navigation is used for a method
+    call in an `&&` or `||` condition that safe navigation is used for all
+    method calls on that same object.
   Enabled: true
   VersionAdded: '0.55'
   VersionChanged: '0.77'
@@ -2151,66 +2053,78 @@ Lint/SafeNavigationConsistency:
     - presence
     - try
     - try!
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/SafeNavigationConsistency
 Lint/SafeNavigationWithEmpty:
-  Description: 'Avoid `foo&.empty?` in conditionals.'
+  Description: |-
+    Checks to make sure safe navigation isn't used with `empty?` in
+    a conditional.
   Enabled: true
   VersionAdded: '0.62'
   VersionChanged: '0.87'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/SafeNavigationWithEmpty
 Lint/ScriptPermission:
-  Description: 'Grant script file execute permission.'
+  Description: |-
+    Checks if a file which has a shebang line as
+    its first line is granted execute permission.
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.50'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/ScriptPermission
 Lint/SelfAssignment:
-  Description: 'Checks for self-assignments.'
+  Description: Checks for self-assignments.
   Enabled: true
   VersionAdded: '0.89'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/SelfAssignment
 Lint/SendWithMixinArgument:
-  Description: 'Checks for `send` method when using mixin.'
+  Description: |-
+    This cop checks for `send`, `public_send`, and `__send__` methods
+    when using mix-in.
   Enabled: true
   VersionAdded: '0.75'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/SendWithMixinArgument
 Lint/ShadowedArgument:
-  Description: 'Avoid reassigning arguments before they were used.'
+  Description: Checks for shadowed arguments.
   Enabled: true
   VersionAdded: '0.52'
   IgnoreImplicitReferences: false
-
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/ShadowedArgument
 Lint/ShadowedException:
-  Description: >-
-                  Avoid rescuing a higher level exception
-                  before a lower level exception.
+  Description: |-
+    Checks for a rescued exception that get shadowed by a
+    less specific exception being rescued before a more specific
+    exception is rescued.
   Enabled: true
   VersionAdded: '0.41'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/ShadowedException
 Lint/ShadowingOuterLocalVariable:
-  Description: >-
-                 Do not use the same name as outer local variable
-                 for block arguments or block local variables.
+  Description: |-
+    Checks for the use of local variable names from an outer scope
+    in block arguments or block-local variables. This mirrors the warning
+    given by `ruby -cw` prior to Ruby 2.6:
+    "shadowing outer local variable - foo".
   Enabled: true
   VersionAdded: '0.9'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/ShadowingOuterLocalVariable
 Lint/StructNewOverride:
-  Description: 'Disallow overriding the `Struct` built-in methods via `Struct.new`.'
+  Description: |-
+    Checks unexpected overrides of the `Struct` built-in methods
+    via `Struct.new`.
   Enabled: true
   VersionAdded: '0.81'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/StructNewOverride
 Lint/SuppressedException:
-  Description: "Don't suppress exceptions."
-  StyleGuide: '#dont-hide-exceptions'
+  Description: Checks for `rescue` blocks with no body.
+  StyleGuide: "#dont-hide-exceptions"
   Enabled: true
   AllowComments: true
   AllowNil: true
   VersionAdded: '0.9'
   VersionChanged: '1.12'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/SuppressedException
 Lint/SymbolConversion:
-  Description: 'Checks for unnecessary symbol conversions.'
+  Description: |-
+    Checks for uses of literal strings converted to
+    a symbol where a literal symbol could be used instead.
   Enabled: pending
   VersionAdded: '1.9'
   VersionChanged: '1.16'
@@ -2218,45 +2132,69 @@ Lint/SymbolConversion:
   SupportedStyles:
     - strict
     - consistent
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/SymbolConversion
 Lint/Syntax:
-  Description: 'Checks for syntax errors.'
+  Description: |-
+    Repacks Parser's diagnostics/errors
+    into RuboCop's offenses.
   Enabled: true
   VersionAdded: '0.9'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/Syntax
 Lint/ToEnumArguments:
-  Description: 'Ensures that `to_enum`/`enum_for`, called for the current method, has correct arguments.'
+  Description: |-
+    Ensures that `to_enum`/`enum_for`, called for the current method,
+    has correct arguments.
   Enabled: pending
   VersionAdded: '1.1'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/ToEnumArguments
 Lint/ToJSON:
-  Description: 'Ensure #to_json includes an optional argument.'
+  Description: |-
+    Checks to make sure `#to_json` includes an optional argument.
+    When overriding `#to_json`, callers may invoke JSON
+    generation via `JSON.generate(your_obj)`.  Since `JSON#generate` allows
+    for an optional argument, your method should too.
   Enabled: true
   VersionAdded: '0.66'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/ToJSON
 Lint/TopLevelReturnWithArgument:
-  Description: 'Detects top level return statements with argument.'
+  Description: |-
+    Checks for top level return with arguments. If there is a
+    top-level return statement with an argument, then the argument is
+    always ignored. This is detected automatically since Ruby 2.7.
   Enabled: true
   VersionAdded: '0.89'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/TopLevelReturnWithArgument
 Lint/TrailingCommaInAttributeDeclaration:
-  Description: 'Checks for trailing commas in attribute declarations.'
+  Description: |-
+    Checks for trailing commas in attribute declarations, such as
+    `#attr_reader`. Leaving a trailing comma will nullify the next method
+    definition by overriding it with a getter method.
   Enabled: true
   VersionAdded: '0.90'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/TrailingCommaInAttributeDeclaration
 Lint/TripleQuotes:
-  Description: 'Checks for useless triple quote constructs.'
+  Description: |-
+    Checks for "triple quotes" (strings delimited by any odd number
+    of quotes greater than 1).
   Enabled: pending
   VersionAdded: '1.9'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/TripleQuotes
 Lint/UnderscorePrefixedVariableName:
-  Description: 'Do not use prefix `_` for a variable that is used.'
+  Description: |-
+    Checks for underscore-prefixed variables that are actually
+    used.
   Enabled: true
   VersionAdded: '0.21'
   AllowKeywordBlockArguments: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnderscorePrefixedVariableName
 Lint/UnexpectedBlockArity:
-  Description: 'Looks for blocks that have fewer arguments that the calling method expects.'
+  Description: |-
+    Checks for a block that is known to need more positional
+    block arguments than are given (by default this is configured for
+    `Enumerable` methods needing 2 arguments). Optional arguments are allowed,
+    although they don't generally make sense as the default value will
+    be used. Blocks that have no receiver, or take splatted arguments
+    (ie. `*args`) are always accepted.
   Enabled: pending
   Safe: false
   VersionAdded: '1.5'
@@ -2271,260 +2209,293 @@ Lint/UnexpectedBlockArity:
     reduce: 2
     slice_when: 2
     sort: 2
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnexpectedBlockArity
 Lint/UnifiedInteger:
-  Description: 'Use Integer instead of Fixnum or Bignum.'
+  Description: Checks for using Fixnum or Bignum constant.
   Enabled: true
   VersionAdded: '0.43'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnifiedInteger
 Lint/UnmodifiedReduceAccumulator:
-  Description: Checks for `reduce` or `inject` blocks that do not update the accumulator each iteration.
+  Description: |-
+    Looks for `reduce` or `inject` blocks where the value returned (implicitly or
+    explicitly) does not include the accumulator. A block is considered valid as
+    long as at least one return value includes the accumulator.
   Enabled: pending
   VersionAdded: '1.1'
   VersionChanged: '1.5'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnmodifiedReduceAccumulator
 Lint/UnreachableCode:
-  Description: 'Unreachable code.'
+  Description: |-
+    Checks for unreachable code.
+    The check are based on the presence of flow of control
+    statement in non-final position in `begin` (implicit) blocks.
   Enabled: true
   VersionAdded: '0.9'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnreachableCode
 Lint/UnreachableLoop:
-  Description: 'Checks for loops that will have at most one iteration.'
+  Description: Checks for loops that will have at most one iteration.
   Enabled: true
   VersionAdded: '0.89'
   VersionChanged: '1.7'
   AllowedPatterns:
-    # RSpec uses `times` in its message expectations
-    # eg. `exactly(2).times`
     - !ruby/regexp /(exactly|at_least|at_most)\(\d+\)\.times/
-  IgnoredPatterns: [] # deprecated
-
+  IgnoredPatterns: []
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnreachableLoop
 Lint/UnusedBlockArgument:
-  Description: 'Checks for unused block arguments.'
-  StyleGuide: '#underscore-unused-vars'
+  Description: Checks for unused block arguments.
+  StyleGuide: "#underscore-unused-vars"
   Enabled: true
   VersionAdded: '0.21'
   VersionChanged: '0.22'
   IgnoreEmptyBlocks: true
   AllowUnusedKeywordArguments: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnusedBlockArgument
 Lint/UnusedMethodArgument:
-  Description: 'Checks for unused method arguments.'
-  StyleGuide: '#underscore-unused-vars'
+  Description: Checks for unused method arguments.
+  StyleGuide: "#underscore-unused-vars"
   Enabled: true
   VersionAdded: '0.21'
   VersionChanged: '0.81'
   AllowUnusedKeywordArguments: false
   IgnoreEmptyMethods: true
   IgnoreNotImplementedMethods: true
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnusedMethodArgument
 Lint/UriEscapeUnescape:
-  Description: >-
-                 `URI.escape` method is obsolete and should not be used. Instead, use
-                 `CGI.escape`, `URI.encode_www_form` or `URI.encode_www_form_component`
-                 depending on your specific use case.
-                 Also `URI.unescape` method is obsolete and should not be used. Instead, use
-                 `CGI.unescape`, `URI.decode_www_form` or `URI.decode_www_form_component`
-                 depending on your specific use case.
+  Description: |-
+    Identifies places where `URI.escape` can be replaced by
+    `CGI.escape`, `URI.encode_www_form`, or `URI.encode_www_form_component`
+    depending on your specific use case.
+    Also this cop identifies places where `URI.unescape` can be replaced by
+    `CGI.unescape`, `URI.decode_www_form`,
+    or `URI.decode_www_form_component` depending on your specific use case.
   Enabled: true
   VersionAdded: '0.50'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UriEscapeUnescape
 Lint/UriRegexp:
-  Description: 'Use `URI::DEFAULT_PARSER.make_regexp` instead of `URI.regexp`.'
+  Description: |-
+    Identifies places where `URI.regexp` is obsolete and should
+    not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp`.
   Enabled: true
   VersionAdded: '0.50'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UriRegexp
 Lint/UselessAccessModifier:
-  Description: 'Checks for useless access modifiers.'
+  Description: |-
+    Checks for redundant access modifiers, including those with no
+    code, those which are repeated, and leading `public` modifiers in a
+    class or module body. Conditionally-defined methods are considered as
+    always being defined, and thus access modifiers guarding such methods
+    are not redundant.
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.83'
   ContextCreatingMethods: []
   MethodCreatingMethods: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UselessAccessModifier
 Lint/UselessAssignment:
-  Description: 'Checks for useless assignment to a local variable.'
-  StyleGuide: '#underscore-unused-vars'
+  Description: |-
+    Checks for every useless assignment to local variable in every
+    scope.
+    The basic idea for this cop was from the warning of `ruby -cw`:
+  StyleGuide: "#underscore-unused-vars"
   Enabled: true
   VersionAdded: '0.11'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UselessAssignment
 Lint/UselessElseWithoutRescue:
-  Description: 'Checks for useless `else` in `begin..end` without `rescue`.'
+  Description: Checks for useless `else` in `begin..end` without `rescue`.
   Enabled: true
   VersionAdded: '0.17'
-  VersionChanged: '<<next>>'
-
+  VersionChanged: "<<next>>"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UselessElseWithoutRescue
 Lint/UselessMethodDefinition:
-  Description: 'Checks for useless method definitions.'
+  Description: |-
+    Checks for useless method definitions, specifically: empty constructors
+    and methods just delegating to `super`.
   Enabled: true
   VersionAdded: '0.90'
   VersionChanged: '0.91'
   Safe: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UselessMethodDefinition
 Lint/UselessRuby2Keywords:
-  Description: 'Finds unnecessary uses of `ruby2_keywords`.'
+  Description: Looks for `ruby2_keywords` calls for methods that do not need it.
   Enabled: pending
   VersionAdded: '1.23'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UselessRuby2Keywords
 Lint/UselessSetterCall:
-  Description: 'Checks for useless setter call to a local variable.'
+  Description: |-
+    Checks for setter call to local variable as the final
+    expression of a function definition.
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.13'
   VersionChanged: '1.2'
   Safe: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UselessSetterCall
 Lint/UselessTimes:
-  Description: 'Checks for useless `Integer#times` calls.'
+  Description: |-
+    Checks for uses of `Integer#times` that will never yield
+    (when the integer <= 0) or that will only ever yield once
+    (`1.times`).
   Enabled: true
   VersionAdded: '0.91'
   Safe: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UselessTimes
 Lint/Void:
-  Description: 'Possible use of operator/literal/variable in void context.'
+  Description: |-
+    Checks for operators, variables, literals, and nonmutating
+    methods used in void context.
   Enabled: true
   VersionAdded: '0.9'
   CheckForMethodsWithNoSideEffects: false
-
-#################### Metrics ###############################
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/Void
 Metrics/AbcSize:
-  Description: >-
-                 A calculated magnitude based on number of assignments,
-                 branches, and conditions.
-  Reference:
-    - http://c2.com/cgi/wiki?AbcMetric
-    - https://en.wikipedia.org/wiki/ABC_Software_Metric
+  Description: |-
+    Checks that the ABC size of methods is not higher than the
+    configured maximum. The ABC size is based on assignments, branches
+    (method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric
+    and https://en.wikipedia.org/wiki/ABC_Software_Metric.
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/AbcSize
   Enabled: true
   VersionAdded: '0.27'
   VersionChanged: '1.5'
-  # The ABC size is a calculated magnitude, so this number can be an Integer or
-  # a Float.
   IgnoredMethods: []
   CountRepeatedAttributes: true
   Max: 17
-
 Metrics/BlockLength:
-  Description: 'Avoid long blocks with many lines.'
+  Description: |-
+    Checks if the length of a block exceeds some maximum value.
+    Comment lines can optionally be ignored.
+    The maximum allowed length is configurable.
+    The cop can be configured to ignore blocks passed to certain methods.
   Enabled: true
   VersionAdded: '0.44'
   VersionChanged: '1.5'
-  CountComments: false  # count full line comments?
+  CountComments: false
   Max: 25
   CountAsOne: []
-  ExcludedMethods: [] # deprecated, retained for backwards compatibility
+  ExcludedMethods: []
   IgnoredMethods:
-    # By default, exclude the `#refine` method, as it tends to have larger
-    # associated blocks.
     - refine
   Exclude:
-    - '**/*.gemspec'
-
+    - "**/*.gemspec"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/BlockLength
 Metrics/BlockNesting:
-  Description: 'Avoid excessive block nesting.'
-  StyleGuide: '#three-is-the-number-thou-shalt-count'
+  Description: |-
+    Checks for excessive nesting of conditional and looping
+    constructs.
+  StyleGuide: "#three-is-the-number-thou-shalt-count"
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '0.47'
   CountBlocks: false
   Max: 3
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/BlockNesting
 Metrics/ClassLength:
-  Description: 'Avoid classes longer than 100 lines of code.'
+  Description: |-
+    Checks if the length a class exceeds some maximum value.
+    Comment lines can optionally be ignored.
+    The maximum allowed length is configurable.
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '0.87'
-  CountComments: false  # count full line comments?
+  CountComments: false
   Max: 100
   CountAsOne: []
-
-# Avoid complex methods.
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/ClassLength
 Metrics/CyclomaticComplexity:
-  Description: >-
-                 A complexity metric that is strongly correlated to the number
-                 of test cases needed to validate a method.
+  Description: |-
+    Checks that the cyclomatic complexity of methods is not higher
+    than the configured maximum. The cyclomatic complexity is the number of
+    linearly independent paths through a method. The algorithm counts
+    decision points and adds one.
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '0.81'
   IgnoredMethods: []
   Max: 7
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/CyclomaticComplexity
 Metrics/MethodLength:
-  Description: 'Avoid methods longer than 10 lines of code.'
-  StyleGuide: '#short-methods'
+  Description: |-
+    Checks if the length of a method exceeds some maximum value.
+    Comment lines can optionally be ignored.
+    The maximum allowed length is configurable.
+  StyleGuide: "#short-methods"
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '1.5'
-  CountComments: false  # count full line comments?
+  CountComments: false
   Max: 10
   CountAsOne: []
-  ExcludedMethods: [] # deprecated, retained for backwards compatibility
+  ExcludedMethods: []
   IgnoredMethods: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/MethodLength
 Metrics/ModuleLength:
-  Description: 'Avoid modules longer than 100 lines of code.'
+  Description: |-
+    Checks if the length a module exceeds some maximum value.
+    Comment lines can optionally be ignored.
+    The maximum allowed length is configurable.
   Enabled: true
   VersionAdded: '0.31'
   VersionChanged: '0.87'
-  CountComments: false  # count full line comments?
+  CountComments: false
   Max: 100
   CountAsOne: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/ModuleLength
 Metrics/ParameterLists:
-  Description: 'Avoid parameter lists longer than three or four parameters.'
-  StyleGuide: '#too-many-params'
+  Description: Checks for methods with too many parameters.
+  StyleGuide: "#too-many-params"
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '1.5'
   Max: 5
   CountKeywordArgs: true
   MaxOptionalParameters: 3
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/ParameterLists
 Metrics/PerceivedComplexity:
-  Description: >-
-                 A complexity metric geared towards measuring complexity for a
-                 human reader.
+  Description: Checks the coplexity for the human reader.
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '0.81'
   IgnoredMethods: []
   Max: 8
-
-################## Migration #############################
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/PerceivedComplexity
 Migration/DepartmentName:
-  Description: >-
-                 Check that cop names in rubocop:disable (etc) comments are
-                 given with department name.
+  Description: |-
+    Check that cop names in rubocop:disable comments are given with
+    department name.
   Enabled: true
   VersionAdded: '0.75'
-
-#################### Naming ##############################
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Migration/DepartmentName
 Naming/AccessorMethodName:
-  Description: Check the naming of accessor methods for get_/set_.
-  StyleGuide: '#accessor_mutator_method_names'
+  Description: |-
+    Makes sure that accessor methods are named properly. Applies
+    to both instance and class methods.
+  StyleGuide: "#accessor_mutator_method_names"
   Enabled: true
   VersionAdded: '0.50'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/AccessorMethodName
 Naming/AsciiIdentifiers:
-  Description: 'Use only ascii symbols in identifiers and constants.'
-  StyleGuide: '#english-identifiers'
+  Description: |-
+    Checks for non-ascii characters in identifier and constant names.
+    Identifiers are always checked and whether constants are checked
+    can be controlled using AsciiConstants config.
+  StyleGuide: "#english-identifiers"
   Enabled: true
   VersionAdded: '0.50'
   VersionChanged: '0.87'
   AsciiConstants: true
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/AsciiIdentifiers
 Naming/BinaryOperatorParameterName:
-  Description: 'When defining binary operators, name the argument other.'
-  StyleGuide: '#other-arg'
+  Description: |-
+    Makes sure that certain binary operator methods have their
+    sole  parameter named `other`.
+  StyleGuide: "#other-arg"
   Enabled: true
   VersionAdded: '0.50'
   VersionChanged: '1.2'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/BinaryOperatorParameterName
 Naming/BlockForwarding:
-  Description: 'Use anonymous block forwarding.'
-  StyleGuide: '#block-forwarding'
+  Description: In Ruby 3.1, anonymous block forwarding has been added.
+  StyleGuide: "#block-forwarding"
   Enabled: pending
   VersionAdded: '1.24'
   EnforcedStyle: anonymous
@@ -2532,72 +2503,56 @@ Naming/BlockForwarding:
     - anonymous
     - explicit
   BlockForwardingName: block
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/BlockForwarding
 Naming/BlockParameterName:
-  Description: >-
-                 Checks for block parameter names that contain capital letters,
-                 end in numbers, or do not meet a minimal length.
+  Description: |-
+    Checks block parameter names for how descriptive they
+    are. It is highly configurable.
   Enabled: true
   VersionAdded: '0.53'
   VersionChanged: '0.77'
-  # Parameter names may be equal to or greater than this value
   MinNameLength: 1
   AllowNamesEndingInNumbers: true
-  # Allowed names that will not register an offense
   AllowedNames: []
-  # Forbidden names that will register an offense
   ForbiddenNames: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/BlockParameterName
 Naming/ClassAndModuleCamelCase:
-  Description: 'Use CamelCase for classes and modules.'
-  StyleGuide: '#camelcase-classes'
+  Description: |-
+    Checks for class and module names with
+    an underscore in them.
+  StyleGuide: "#camelcase-classes"
   Enabled: true
   VersionAdded: '0.50'
   VersionChanged: '0.85'
-  # Allowed class/module names can be specified here.
-  # These can be full or part of the name.
   AllowedNames:
     - module_parent
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/ClassAndModuleCamelCase
 Naming/ConstantName:
-  Description: 'Constants should use SCREAMING_SNAKE_CASE.'
-  StyleGuide: '#screaming-snake-case'
+  Description: |-
+    Checks whether constant names are written using
+    SCREAMING_SNAKE_CASE.
+  StyleGuide: "#screaming-snake-case"
   Enabled: true
   VersionAdded: '0.50'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/ConstantName
 Naming/FileName:
-  Description: 'Use snake_case for source file names.'
-  StyleGuide: '#snake-case-files'
+  Description: |-
+    Makes sure that Ruby source files have snake_case
+    names. Ruby scripts (i.e. source files with a shebang in the
+    first line) are ignored.
+  StyleGuide: "#snake-case-files"
   Enabled: true
   VersionAdded: '0.50'
   VersionChanged: '1.23'
-  # Camel case file names listed in `AllCops:Include` and all file names listed
-  # in `AllCops:Exclude` are excluded by default. Add extra excludes here.
   Exclude: []
-  # When `true`, requires that each source file should define a class or module
-  # with a name which matches the file name (converted to ... case).
-  # It further expects it to be nested inside modules which match the names
-  # of subdirectories in its path.
   ExpectMatchingDefinition: false
-  # When `false`, changes the behavior of ExpectMatchingDefinition to match only
-  # whether each source file's class or module name matches the file name --
-  # not whether the nested module hierarchy matches the subdirectory path.
   CheckDefinitionPathHierarchy: true
-  # paths that are considered root directories, for example "lib" in most ruby projects
-  # or "app/models" in rails projects
   CheckDefinitionPathHierarchyRoots:
     - lib
     - spec
     - test
     - src
-  # If non-`nil`, expect all source file names to match the following regex.
-  # Only the file name itself is matched, not the entire file path.
-  # Use anchors as necessary if you want to match the entire name rather than
-  # just a part of it.
-  Regex: ~
-  # With `IgnoreExecutableScripts` set to `true`, this cop does not
-  # report offending filenames for executable scripts (i.e. source
-  # files with a shebang in the first line).
+  Regex:
   IgnoreExecutableScripts: true
   AllowedAcronyms:
     - CLI
@@ -2640,10 +2595,12 @@ Naming/FileName:
     - XMPP
     - XSRF
     - XSS
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/FileName
 Naming/HeredocDelimiterCase:
-  Description: 'Use configured case for heredoc delimiters.'
-  StyleGuide: '#heredoc-delimiters'
+  Description: |-
+    Checks that your heredocs are using the configured case.
+    By default it is configured to enforce uppercase heredocs.
+  StyleGuide: "#heredoc-delimiters"
   Enabled: true
   VersionAdded: '0.50'
   VersionChanged: '1.2'
@@ -2651,17 +2608,31 @@ Naming/HeredocDelimiterCase:
   SupportedStyles:
     - lowercase
     - uppercase
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/HeredocDelimiterCase
 Naming/HeredocDelimiterNaming:
-  Description: 'Use descriptive heredoc delimiters.'
-  StyleGuide: '#heredoc-delimiters'
+  Description: |-
+    Checks that your heredocs are using meaningful delimiters.
+    By default it disallows `END` and `EO*`, and can be configured through
+    forbidden listing additional delimiters.
+  StyleGuide: "#heredoc-delimiters"
   Enabled: true
   VersionAdded: '0.50'
   ForbiddenDelimiters:
-    - !ruby/regexp '/(^|\s)(EO[A-Z]{1}|END)(\s|$)/'
-
+    - !ruby/regexp /(^|\s)(EO[A-Z]{1}|END)(\s|$)/
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/HeredocDelimiterNaming
 Naming/InclusiveLanguage:
-  Description: 'Recommend the use of inclusive language instead of problematic terms.'
+  Description: |-
+    This cops recommends the use of inclusive language instead of problematic terms.
+    The cop can check the following locations for offenses:
+      - identifiers
+      - constants
+      - variables
+      - strings
+      - symbols
+      - comments
+      - file paths
+    Each of these locations can be individually enabled/disabled via configuration,
+    for example CheckIdentifiers = true/false.
   Enabled: false
   VersionAdded: '1.18'
   VersionChanged: '1.21'
@@ -2674,22 +2645,28 @@ Naming/InclusiveLanguage:
   CheckFilepaths: true
   FlaggedTerms:
     whitelist:
-      Regex: !ruby/regexp '/white[-_\s]?list/'
+      Regex: !ruby/regexp /white[-_\s]?list/
       Suggestions:
         - allowlist
         - permit
     blacklist:
-      Regex: !ruby/regexp '/black[-_\s]?list/'
+      Regex: !ruby/regexp /black[-_\s]?list/
       Suggestions:
         - denylist
         - block
     slave:
       WholeWord: true
-      Suggestions: ['replica', 'secondary', 'follower']
-
+      Suggestions:
+        - replica
+        - secondary
+        - follower
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/InclusiveLanguage
 Naming/MemoizedInstanceVariableName:
-  Description: >-
-    Memoized method name should match memo instance variable name.
+  Description: |-
+    Checks for memoized methods whose instance variable name
+    does not match the method name. Applies to both regular methods
+    (defined with `def`) and dynamic methods (defined with
+    `define_method` or `define_singleton_method`).
   Enabled: true
   VersionAdded: '0.53'
   VersionChanged: '1.2'
@@ -2699,36 +2676,30 @@ Naming/MemoizedInstanceVariableName:
     - required
     - optional
   Safe: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/MemoizedInstanceVariableName
 Naming/MethodName:
-  Description: 'Use the configured style when naming methods.'
-  StyleGuide: '#snake-case-symbols-methods-vars'
+  Description: |-
+    Makes sure that all methods use the configured style,
+    snake_case or camelCase, for their names.
+  StyleGuide: "#snake-case-symbols-methods-vars"
   Enabled: true
   VersionAdded: '0.50'
   EnforcedStyle: snake_case
   SupportedStyles:
     - snake_case
     - camelCase
-  # Method names matching patterns are always allowed.
-  #
-  #   AllowedPatterns:
-  #     - '\A\s*onSelectionBulkChange\s*'
-  #     - '\A\s*onSelectionCleared\s*'
-  #
   AllowedPatterns: []
-  IgnoredPatterns: [] # deprecated
-
+  IgnoredPatterns: []
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/MethodName
 Naming/MethodParameterName:
-  Description: >-
-                 Checks for method parameter names that contain capital letters,
-                 end in numbers, or do not meet a minimal length.
+  Description: |-
+    Checks method parameter names for how descriptive they
+    are. It is highly configurable.
   Enabled: true
   VersionAdded: '0.53'
   VersionChanged: '0.77'
-  # Parameter names may be equal to or greater than this value
   MinNameLength: 3
   AllowNamesEndingInNumbers: true
-  # Allowed names that will not register an offense
   AllowedNames:
     - at
     - by
@@ -2742,48 +2713,44 @@ Naming/MethodParameterName:
     - os
     - pp
     - to
-  # Forbidden names that will register an offense
   ForbiddenNames: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/MethodParameterName
 Naming/PredicateName:
-  Description: 'Check the names of predicate methods.'
-  StyleGuide: '#bool-methods-qmark'
+  Description: Makes sure that predicates are named properly.
+  StyleGuide: "#bool-methods-qmark"
   Enabled: true
   VersionAdded: '0.50'
   VersionChanged: '0.77'
-  # Predicate name prefixes.
   NamePrefix:
     - is_
     - has_
     - have_
-  # Predicate name prefixes that should be removed.
   ForbiddenPrefixes:
     - is_
     - has_
     - have_
-  # Predicate names which, despite having a forbidden prefix, or no `?`,
-  # should still be accepted
   AllowedMethods:
     - is_a?
-  # Method definition macros for dynamically generated methods.
   MethodDefinitionMacros:
     - define_method
     - define_singleton_method
-  # Exclude Rspec specs because there is a strong convention to write spec
-  # helpers in the form of `have_something` or `be_something`.
   Exclude:
-    - 'spec/**/*'
-
+    - spec/**/*
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/PredicateName
 Naming/RescuedExceptionsVariableName:
-  Description: 'Use consistent rescued exceptions variables naming.'
+  Description: |-
+    Makes sure that rescued exceptions variables are named as
+    expected.
   Enabled: true
   VersionAdded: '0.67'
   VersionChanged: '0.68'
   PreferredName: e
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/RescuedExceptionsVariableName
 Naming/VariableName:
-  Description: 'Use the configured style when naming variables.'
-  StyleGuide: '#snake-case-symbols-methods-vars'
+  Description: |-
+    Makes sure that all variables use the configured style,
+    snake_case or camelCase, for their names.
+  StyleGuide: "#snake-case-symbols-methods-vars"
   Enabled: true
   VersionAdded: '0.50'
   VersionChanged: '1.8'
@@ -2793,10 +2760,13 @@ Naming/VariableName:
     - camelCase
   AllowedIdentifiers: []
   AllowedPatterns: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/VariableName
 Naming/VariableNumber:
-  Description: 'Use the configured style when numbering symbols, methods and variables.'
-  StyleGuide: '#snake-case-symbols-methods-vars-with-numbers'
+  Description: |-
+    Makes sure that all numbered variables use the
+    configured style, snake_case, normalcase, or non_integer,
+    for their numbering.
+  StyleGuide: "#snake-case-symbols-methods-vars-with-numbers"
   Enabled: true
   VersionAdded: '0.50'
   VersionChanged: '1.4'
@@ -2808,74 +2778,76 @@ Naming/VariableNumber:
   CheckMethodNames: true
   CheckSymbols: true
   AllowedIdentifiers:
-    - capture3     # Open3.capture3
-    - iso8601      # Time#iso8601
-    - rfc1123_date # CGI.rfc1123_date
-    - rfc822       # Time#rfc822
-    - rfc2822      # Time#rfc2822
-    - rfc3339      # DateTime.rfc3339
+    - capture3
+    - iso8601
+    - rfc1123_date
+    - rfc822
+    - rfc2822
+    - rfc3339
   AllowedPatterns: []
-
-#################### Security ##############################
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/VariableNumber
 Security/CompoundHash:
-  Description: 'When overwriting Object#hash to combine values, prefer delegating to Array#hash over writing a custom implementation.'
+  Description: |-
+    Checks for implementations of the `hash` method which combine
+    values using custom logic instead of delegating to `Array#hash`.
   Enabled: pending
   VersionAdded: '1.28'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Security/CompoundHash
 Security/Eval:
-  Description: 'The use of eval represents a serious security risk.'
+  Description: Checks for the use of `Kernel#eval` and `Binding#eval`.
   Enabled: true
   VersionAdded: '0.47'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Security/Eval
 Security/IoMethods:
-  Description: >-
-                 Checks for the first argument to `IO.read`, `IO.binread`, `IO.write`, `IO.binwrite`,
-                 `IO.foreach`, and `IO.readlines`.
+  Description: |-
+    Checks for the first argument to `IO.read`, `IO.binread`, `IO.write`, `IO.binwrite`,
+    `IO.foreach`, and `IO.readlines`.
   Enabled: pending
   Safe: false
   VersionAdded: '1.22'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Security/IoMethods
 Security/JSONLoad:
-  Description: >-
-                 Prefer usage of `JSON.parse` over `JSON.load` due to potential
-                 security issues. See reference for more information.
-  Reference: 'https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load'
+  Description: |-
+    Checks for the use of JSON class methods which have potential
+    security issues.
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Security/JSONLoad
   Enabled: true
   VersionAdded: '0.43'
   VersionChanged: '1.22'
-  # Autocorrect here will change to a method that may cause crashes depending
-  # on the value of the argument.
   SafeAutoCorrect: false
-
 Security/MarshalLoad:
-  Description: >-
-                 Avoid using of `Marshal.load` or `Marshal.restore` due to potential
-                 security issues. See reference for more information.
-  Reference: 'https://ruby-doc.org/core-2.7.0/Marshal.html#module-Marshal-label-Security+considerations'
+  Description: |-
+    Checks for the use of Marshal class methods which have
+    potential security issues leading to remote code execution when
+    loading from an untrusted source.
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Security/MarshalLoad
   Enabled: true
   VersionAdded: '0.47'
-
 Security/Open:
-  Description: 'The use of `Kernel#open` and `URI.open` represent a serious security risk.'
+  Description: |-
+    Checks for the use of `Kernel#open` and `URI.open` with dynamic
+    data.
   Enabled: true
   VersionAdded: '0.53'
   VersionChanged: '1.0'
   Safe: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Security/Open
 Security/YAMLLoad:
-  Description: >-
-                 Prefer usage of `YAML.safe_load` over `YAML.load` due to potential
-                 security issues. See reference for more information.
-  Reference: 'https://ruby-doc.org/stdlib-2.7.0/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security'
+  Description: |-
+    Checks for the use of YAML class methods which have
+    potential security issues leading to remote code execution when
+    loading from an untrusted source.
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Security/YAMLLoad
   Enabled: true
   VersionAdded: '0.47'
   SafeAutoCorrect: false
-
-#################### Style ###############################
-
 Style/AccessModifierDeclarations:
-  Description: 'Checks style of how access modifiers are used.'
+  Description: |-
+    Access modifiers should be declared to apply to a group of methods
+    or inline before each method, depending on configuration.
+    EnforcedStyle config covers only method definitions.
+    Applications of visibility methods to symbols can be controlled
+    using AllowModifiersOnSymbols config.
   Enabled: true
   VersionAdded: '0.57'
   VersionChanged: '0.81'
@@ -2884,21 +2856,25 @@ Style/AccessModifierDeclarations:
     - inline
     - group
   AllowModifiersOnSymbols: true
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/AccessModifierDeclarations
 Style/AccessorGrouping:
-  Description: 'Checks for grouping of accessors in `class` and `module` bodies.'
+  Description: |-
+    Checks for grouping of accessors in `class` and `module` bodies.
+    By default it enforces accessors to be placed in grouped declarations,
+    but it can be configured to enforce separating them in multiple declarations.
   Enabled: true
   VersionAdded: '0.87'
   EnforcedStyle: grouped
   SupportedStyles:
-    # separated: each accessor goes in a separate statement.
-    # grouped: accessors are grouped into a single statement.
     - separated
     - grouped
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/AccessorGrouping
 Style/Alias:
-  Description: 'Use alias instead of alias_method.'
-  StyleGuide: '#alias-method-lexically'
+  Description: |-
+    Enforces the use of either `#alias` or `#alias_method`
+    depending on configuration.
+    It also flags uses of `alias :symbol` rather than `alias bareword`.
+  StyleGuide: "#alias-method-lexically"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.36'
@@ -2906,137 +2882,116 @@ Style/Alias:
   SupportedStyles:
     - prefer_alias
     - prefer_alias_method
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Alias
 Style/AndOr:
-  Description: 'Use &&/|| instead of and/or.'
-  StyleGuide: '#no-and-or-or'
+  Description: |-
+    Checks for uses of `and` and `or`, and suggests using `&&` and
+    `||` instead. It can be configured to check only in conditions or in
+    all contexts.
+  StyleGuide: "#no-and-or-or"
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.9'
   VersionChanged: '1.21'
-  # Whether `and` and `or` are banned only in conditionals (conditionals)
-  # or completely (always).
   EnforcedStyle: conditionals
   SupportedStyles:
     - always
     - conditionals
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/AndOr
 Style/ArgumentsForwarding:
-  Description: 'Use arguments forwarding.'
-  StyleGuide: '#arguments-forwarding'
+  Description: In Ruby 2.7, arguments forwarding has been added.
+  StyleGuide: "#arguments-forwarding"
   Enabled: pending
   AllowOnlyRestArgument: true
   VersionAdded: '1.1'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ArgumentsForwarding
 Style/ArrayCoercion:
-  Description: >-
-                  Use Array() instead of explicit Array check or [*var], when dealing
-                  with a variable you want to treat as an Array, but you're not certain it's an array.
-  StyleGuide: '#array-coercion'
+  Description: Enforces the use of `Array()` instead of explicit `Array` check or
+    `[*var]`.
+  StyleGuide: "#array-coercion"
   Safe: false
   Enabled: false
   VersionAdded: '0.88'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ArrayCoercion
 Style/ArrayJoin:
-  Description: 'Use Array#join instead of Array#*.'
-  StyleGuide: '#array-join'
+  Description: Checks for uses of "*" as a substitute for _join_.
+  StyleGuide: "#array-join"
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.31'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ArrayJoin
 Style/AsciiComments:
-  Description: 'Use only ascii symbols in comments.'
-  StyleGuide: '#english-comments'
+  Description: |-
+    Checks for non-ascii (non-English) characters
+    in comments. You could set an array of allowed non-ascii chars in
+    `AllowedChars` attribute (copyright notice "©" by default).
+  StyleGuide: "#english-comments"
   Enabled: false
   VersionAdded: '0.9'
   VersionChanged: '1.21'
   AllowedChars:
-    - ©
-
+    - "©"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/AsciiComments
 Style/Attr:
-  Description: 'Checks for uses of Module#attr.'
-  StyleGuide: '#attr'
+  Description: Checks for uses of Module#attr.
+  StyleGuide: "#attr"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.12'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Attr
 Style/AutoResourceCleanup:
-  Description: 'Suggests the usage of an auto resource cleanup version of a method (if available).'
+  Description: |-
+    Checks for cases when you could use a block
+    accepting version of a method that does automatic
+    resource cleanup.
   Enabled: false
   VersionAdded: '0.30'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/AutoResourceCleanup
 Style/BarePercentLiterals:
-  Description: 'Checks if usage of %() or %Q() matches configuration.'
-  StyleGuide: '#percent-q-shorthand'
+  Description: Checks if usage of %() or %Q() matches configuration.
+  StyleGuide: "#percent-q-shorthand"
   Enabled: true
   VersionAdded: '0.25'
   EnforcedStyle: bare_percent
   SupportedStyles:
     - percent_q
     - bare_percent
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/BarePercentLiterals
 Style/BeginBlock:
-  Description: 'Avoid the use of BEGIN blocks.'
-  StyleGuide: '#no-BEGIN-blocks'
+  Description: This cop checks for BEGIN blocks.
+  StyleGuide: "#no-BEGIN-blocks"
   Enabled: true
   VersionAdded: '0.9'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/BeginBlock
 Style/BisectedAttrAccessor:
-  Description: >-
-                Checks for places where `attr_reader` and `attr_writer`
-                for the same method can be combined into single `attr_accessor`.
+  Description: |-
+    Checks for places where `attr_reader` and `attr_writer`
+    for the same method can be combined into single `attr_accessor`.
   Enabled: true
   VersionAdded: '0.87'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/BisectedAttrAccessor
 Style/BlockComments:
-  Description: 'Do not use block comments.'
-  StyleGuide: '#no-block-comments'
+  Description: Looks for uses of block comments (=begin...=end).
+  StyleGuide: "#no-block-comments"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.23'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/BlockComments
 Style/BlockDelimiters:
-  Description: >-
-                Avoid using {...} for multi-line blocks (multiline chaining is
-                always ugly).
-                Prefer {...} over do...end for single-line blocks.
-  StyleGuide: '#single-line-blocks'
+  Description: |-
+    Check for uses of braces or do/end around single line or
+    multi-line blocks.
+  StyleGuide: "#single-line-blocks"
   Enabled: true
   VersionAdded: '0.30'
   VersionChanged: '0.35'
   EnforcedStyle: line_count_based
   SupportedStyles:
-    # The `line_count_based` style enforces braces around single line blocks and
-    # do..end around multi-line blocks.
     - line_count_based
-    # The `semantic` style enforces braces around functional blocks, where the
-    # primary purpose of the block is to return a value and do..end for
-    # multi-line procedural blocks, where the primary purpose of the block is
-    # its side-effects. Single-line procedural blocks may only use do-end,
-    # unless AllowBracesOnProceduralOneLiners has a truthy value (see below).
-    #
-    # This looks at the usage of a block's method to determine its type (e.g. is
-    # the result of a `map` assigned to a variable or passed to another
-    # method) but exceptions are permitted in the `ProceduralMethods`,
-    # `FunctionalMethods` and `IgnoredMethods` sections below.
     - semantic
-    # The `braces_for_chaining` style enforces braces around single line blocks
-    # and do..end around multi-line blocks, except for multi-line blocks whose
-    # return value is being chained with another method (in which case braces
-    # are enforced).
     - braces_for_chaining
-    # The `always_braces` style always enforces braces.
     - always_braces
   ProceduralMethods:
-    # Methods that are known to be procedural in nature but look functional from
-    # their usage, e.g.
-    #
-    #   time = Benchmark.realtime do
-    #     foo.bar
-    #   end
-    #
-    # Here, the return value of the block is discarded but the return value of
-    # `Benchmark.realtime` is used.
     - benchmark
     - bm
     - bmbm
@@ -3048,242 +3003,179 @@ Style/BlockDelimiters:
     - tap
     - with_object
   FunctionalMethods:
-    # Methods that are known to be functional in nature but look procedural from
-    # their usage, e.g.
-    #
-    #   let(:foo) { Foo.new }
-    #
-    # Here, the return value of `Foo.new` is used to define a `foo` helper but
-    # doesn't appear to be used from the return value of `let`.
     - let
     - let!
     - subject
     - watch
   IgnoredMethods:
-    # Methods that can be either procedural or functional and cannot be
-    # categorised from their usage alone, e.g.
-    #
-    #   foo = lambda do |x|
-    #     puts "Hello, #{x}"
-    #   end
-    #
-    #   foo = lambda do |x|
-    #     x * 100
-    #   end
-    #
-    # Here, it is impossible to tell from the return value of `lambda` whether
-    # the inner block's return value is significant.
     - lambda
     - proc
     - it
-  # The AllowBracesOnProceduralOneLiners option is ignored unless the
-  # EnforcedStyle is set to `semantic`. If so:
-  #
-  # If AllowBracesOnProceduralOneLiners is unspecified, or set to any
-  # falsey value, then semantic purity is maintained, so one-line
-  # procedural blocks must use do-end, not braces.
-  #
-  #   # bad
-  #   collection.each { |element| puts element }
-  #
-  #   # good
-  #   collection.each do |element| puts element end
-  #
-  # If AllowBracesOnProceduralOneLiners is set to any truthy value,
-  # then one-line procedural blocks may use either style.
-  #
-  #   # good
-  #   collection.each { |element| puts element }
-  #
-  #   # also good
-  #   collection.each do |element| puts element end
   AllowBracesOnProceduralOneLiners: false
-  # The BracesRequiredMethods overrides all other configurations except
-  # IgnoredMethods. It can be used to enforce that all blocks for specific
-  # methods use braces. For example, you can use this to enforce Sorbet
-  # signatures use braces even when the rest of your codebase enforces
-  # the `line_count_based` style.
   BracesRequiredMethods: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/BlockDelimiters
 Style/CaseEquality:
-  Description: 'Avoid explicit use of the case equality operator(===).'
-  StyleGuide: '#no-case-equality'
+  Description: Checks for uses of the case equality operator(===).
+  StyleGuide: "#no-case-equality"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.89'
-  # If `AllowOnConstant` option is enabled, the cop will ignore violations when the receiver of
-  # the case equality operator is a constant.
-  #
-  #   # bad
-  #   /string/ === "string"
-  #
-  #   # good
-  #   String === "string"
   AllowOnConstant: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/CaseEquality
 Style/CaseLikeIf:
-  Description: 'Identifies places where `if-elsif` constructions can be replaced with `case-when`.'
-  StyleGuide: '#case-vs-if-else'
+  Description: |-
+    Identifies places where `if-elsif` constructions
+    can be replaced with `case-when`.
+  StyleGuide: "#case-vs-if-else"
   Enabled: true
   Safe: false
   VersionAdded: '0.88'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/CaseLikeIf
 Style/CharacterLiteral:
-  Description: 'Checks for uses of character literals.'
-  StyleGuide: '#no-character-literals'
+  Description: |-
+    Checks for uses of the character literal ?x.
+    Starting with Ruby 1.9 character literals are
+    essentially one-character strings, so this syntax
+    is mostly redundant at this point.
+  StyleGuide: "#no-character-literals"
   Enabled: true
   VersionAdded: '0.9'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/CharacterLiteral
 Style/ClassAndModuleChildren:
-  Description: 'Checks style of children classes and modules.'
-  StyleGuide: '#namespace-definition'
-  # Moving from compact to nested children requires knowledge of whether the
-  # outer parent is a module or a class. Moving from nested to compact requires
-  # verification that the outer parent is defined elsewhere. Rubocop does not
-  # have the knowledge to perform either operation safely and thus requires
-  # manual oversight.
+  Description: |-
+    Checks the style of children definitions at classes and
+    modules. Basically there are two different styles:
+  StyleGuide: "#namespace-definition"
   SafeAutoCorrect: false
   Enabled: true
   VersionAdded: '0.19'
-  #
-  # Basically there are two different styles:
-  #
-  # `nested` - have each child on a separate line
-  #   class Foo
-  #     class Bar
-  #     end
-  #   end
-  #
-  # `compact` - combine definitions as much as possible
-  #   class Foo::Bar
-  #   end
-  #
-  # The compact style is only forced, for classes or modules with one child.
   EnforcedStyle: nested
   SupportedStyles:
     - nested
     - compact
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ClassAndModuleChildren
 Style/ClassCheck:
-  Description: 'Enforces consistent use of `Object#is_a?` or `Object#kind_of?`.'
-  StyleGuide: '#is-a-vs-kind-of'
+  Description: Enforces consistent use of `Object#is_a?` or `Object#kind_of?`.
+  StyleGuide: "#is-a-vs-kind-of"
   Enabled: true
   VersionAdded: '0.24'
   EnforcedStyle: is_a?
   SupportedStyles:
     - is_a?
     - kind_of?
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ClassCheck
 Style/ClassEqualityComparison:
-  Description: 'Enforces the use of `Object#instance_of?` instead of class comparison for equality.'
-  StyleGuide: '#instance-of-vs-class-comparison'
+  Description: |-
+    Enforces the use of `Object#instance_of?` instead of class comparison
+    for equality.
+  StyleGuide: "#instance-of-vs-class-comparison"
   Enabled: true
   VersionAdded: '0.93'
   IgnoredMethods:
-    - ==
+    - "=="
     - equal?
     - eql?
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ClassEqualityComparison
 Style/ClassMethods:
-  Description: 'Use self when defining module/class methods.'
-  StyleGuide: '#def-self-class-methods'
+  Description: |-
+    Checks for uses of the class/module name instead of
+    self, when defining class/module methods.
+  StyleGuide: "#def-self-class-methods"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.20'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ClassMethods
 Style/ClassMethodsDefinitions:
-  Description: 'Enforces using `def self.method_name` or `class << self` to define class methods.'
-  StyleGuide: '#def-self-class-methods'
+  Description: Enforces using `def self.method_name` or `class << self` to define
+    class methods.
+  StyleGuide: "#def-self-class-methods"
   Enabled: false
   VersionAdded: '0.89'
   EnforcedStyle: def_self
   SupportedStyles:
     - def_self
     - self_class
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ClassMethodsDefinitions
 Style/ClassVars:
-  Description: 'Avoid the use of class variables.'
-  StyleGuide: '#no-class-vars'
+  Description: |-
+    Checks for uses of class variables. Offenses
+    are signaled only on assignment to class variables to
+    reduce the number of offenses that would be reported.
+  StyleGuide: "#no-class-vars"
   Enabled: true
   VersionAdded: '0.13'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ClassVars
 Style/CollectionCompact:
-  Description: 'Use `{Array,Hash}#{compact,compact!}` instead of custom logic to reject nils.'
+  Description: |-
+    Checks for places where custom logic on rejection nils from arrays
+    and hashes can be replaced with `{Array,Hash}#{compact,compact!}`.
   Enabled: pending
   Safe: false
   VersionAdded: '1.2'
   VersionChanged: '1.3'
-
-# Align with the style guide.
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/CollectionCompact
 Style/CollectionMethods:
-  Description: 'Preferred collection methods.'
-  StyleGuide: '#map-find-select-reduce-include-size'
+  Description: |-
+    Enforces the use of consistent method names
+    from the Enumerable module.
+  StyleGuide: "#map-find-select-reduce-include-size"
   Enabled: false
   VersionAdded: '0.9'
   VersionChanged: '1.7'
   Safe: false
-  # Mapping from undesired method to desired method
-  # e.g. to use `detect` over `find`:
-  #
-  # Style/CollectionMethods:
-  #   PreferredMethods:
-  #     find: detect
   PreferredMethods:
-    collect: 'map'
-    collect!: 'map!'
-    inject: 'reduce'
-    detect: 'find'
-    find_all: 'select'
-    member?: 'include?'
-  # Methods in this array accept a final symbol as an implicit block
-  # eg. `inject(:+)`
+    collect: map
+    collect!: map!
+    inject: reduce
+    detect: find
+    find_all: select
+    member?: include?
   MethodsAcceptingSymbol:
     - inject
     - reduce
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/CollectionMethods
 Style/ColonMethodCall:
-  Description: 'Do not use :: for method call.'
-  StyleGuide: '#double-colons'
+  Description: |-
+    Checks for methods invoked via the :: operator instead
+    of the . operator (like FileUtils::rmdir instead of FileUtils.rmdir).
+  StyleGuide: "#double-colons"
   Enabled: true
   VersionAdded: '0.9'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ColonMethodCall
 Style/ColonMethodDefinition:
-  Description: 'Do not use :: for defining class methods.'
-  StyleGuide: '#colon-method-definition'
+  Description: |-
+    Checks for class methods that are defined using the `::`
+    operator instead of the `.` operator.
+  StyleGuide: "#colon-method-definition"
   Enabled: true
   VersionAdded: '0.52'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ColonMethodDefinition
 Style/CombinableLoops:
-  Description: >-
-                  Checks for places where multiple consecutive loops over the same data
-                  can be combined into a single loop.
+  Description: |-
+    Checks for places where multiple consecutive loops over the same data
+    can be combined into a single loop. It is very likely that combining them
+    will make the code more efficient and more concise.
   Enabled: true
   Safe: false
   VersionAdded: '0.90'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/CombinableLoops
 Style/CommandLiteral:
-  Description: 'Use `` or %x around command literals.'
-  StyleGuide: '#percent-x'
+  Description: Enforces using `` or %x around command literals.
+  StyleGuide: "#percent-x"
   Enabled: true
   VersionAdded: '0.30'
   EnforcedStyle: backticks
-  # backticks: Always use backticks.
-  # percent_x: Always use `%x`.
-  # mixed: Use backticks on single-line commands, and `%x` on multi-line commands.
   SupportedStyles:
     - backticks
     - percent_x
     - mixed
-  # If `false`, the cop will always recommend using `%x` if one or more backticks
-  # are found in the command string.
   AllowInnerBackticks: false
-
-# Checks formatting of special comments
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/CommandLiteral
 Style/CommentAnnotation:
-  Description: >-
-                 Checks formatting of special comments
-                 (TODO, FIXME, OPTIMIZE, HACK, REVIEW, NOTE).
-  StyleGuide: '#annotate-keywords'
+  Description: |-
+    Checks that comment annotation keywords are written according
+    to guidelines.
+  StyleGuide: "#annotate-keywords"
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '1.20'
@@ -3295,19 +3187,21 @@ Style/CommentAnnotation:
     - REVIEW
     - NOTE
   RequireColon: true
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/CommentAnnotation
 Style/CommentedKeyword:
-  Description: 'Do not place comments on the same line as certain keywords.'
+  Description: |-
+    Checks for comments put on the same line as some keywords.
+    These keywords are: `class`, `module`, `def`, `begin`, `end`.
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.51'
   VersionChanged: '1.19'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/CommentedKeyword
 Style/ConditionalAssignment:
-  Description: >-
-                 Use the return value of `if` and `case` statements for
-                 assignment to a variable and variable comparison instead
-                 of assigning that variable inside of each branch.
+  Description: |-
+    Check for `if` and `case` statements where each branch is used for
+    assignment to the same variable when using the return of the
+    condition can be used instead.
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.47'
@@ -3315,115 +3209,116 @@ Style/ConditionalAssignment:
   SupportedStyles:
     - assign_to_condition
     - assign_inside_condition
-  # When configured to `assign_to_condition`, `SingleLineConditionsOnly`
-  # will only register an offense when all branches of a condition are
-  # a single line.
-  # When configured to `assign_inside_condition`, `SingleLineConditionsOnly`
-  # will only register an offense for assignment to a condition that has
-  # at least one multiline branch.
   SingleLineConditionsOnly: true
   IncludeTernaryExpressions: true
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ConditionalAssignment
 Style/ConstantVisibility:
-  Description: >-
-                 Check that class- and module constants have
-                 visibility declarations.
+  Description: |-
+    Checks that constants defined in classes and modules have
+    an explicit visibility declaration. By default, Ruby makes all class-
+    and module constants public, which litters the public API of the
+    class or module. Explicitly declaring a visibility makes intent more
+    clear, and prevents outside actors from touching private state.
   Enabled: false
   VersionAdded: '0.66'
   VersionChanged: '1.10'
   IgnoreModules: false
-
-# Checks that you have put a copyright in a comment before any code.
-#
-# You can override the default Notice in your .rubocop.yml file.
-#
-# In order to use autocorrect, you must supply a value for the
-# `AutocorrectNotice` key that matches the regexp Notice. A blank
-# `AutocorrectNotice` will cause an error during autocorrect.
-#
-# Autocorrect will add a copyright notice in a comment at the top
-# of the file immediately after any shebang or encoding comments.
-#
-# Example rubocop.yml:
-#
-# Style/Copyright:
-#   Enabled: true
-#   Notice: 'Copyright (\(c\) )?2015 Yahoo! Inc'
-#   AutocorrectNotice: '# Copyright (c) 2015 Yahoo! Inc.'
-#
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ConstantVisibility
 Style/Copyright:
-  Description: 'Include a copyright notice in each file before any code.'
+  Description: Check that a copyright notice was given in each source file.
   Enabled: false
   VersionAdded: '0.30'
-  Notice: '^Copyright (\(c\) )?2[0-9]{3} .+'
+  Notice: "^Copyright (\\(c\\) )?2[0-9]{3} .+"
   AutocorrectNotice: ''
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Copyright
 Style/DateTime:
-  Description: 'Use Time over DateTime.'
-  StyleGuide: '#date--time'
+  Description: |-
+    Checks for consistent usage of the `DateTime` class over the
+    `Time` class. This cop is disabled by default since these classes,
+    although highly overlapping, have particularities that make them not
+    replaceable in certain situations when dealing with multiple timezones
+    and/or DST.
+  StyleGuide: "#date--time"
   Enabled: false
   VersionAdded: '0.51'
   VersionChanged: '0.92'
   SafeAutoCorrect: false
   AllowCoercion: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/DateTime
 Style/DefWithParentheses:
-  Description: 'Use def with parentheses when there are arguments.'
-  StyleGuide: '#method-parens'
+  Description: |-
+    Checks for parentheses in the definition of a method,
+    that does not take any arguments. Both instance and
+    class/singleton methods are checked.
+  StyleGuide: "#method-parens"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.12'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/DefWithParentheses
 Style/Dir:
-  Description: >-
-                 Use the `__dir__` method to retrieve the canonicalized
-                 absolute path to the current file.
+  Description: |-
+    Checks for places where the `#__dir__` method can replace more
+    complex constructs to retrieve a canonicalized absolute path to the
+    current file.
   Enabled: true
   VersionAdded: '0.50'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Dir
 Style/DisableCopsWithinSourceCodeDirective:
-  Description: >-
-                 Forbids disabling/enabling cops within source code.
+  Description: |-
+    Detects comments to enable/disable RuboCop.
+    This is useful if want to make sure that every RuboCop error gets fixed
+    and not quickly disabled with a comment.
   Enabled: false
   VersionAdded: '0.82'
   VersionChanged: '1.9'
   AllowedCops: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/DisableCopsWithinSourceCodeDirective
 Style/DocumentDynamicEvalDefinition:
-  Description: >-
-                When using `class_eval` (or other `eval`) with string interpolation,
-                add a comment block showing its appearance if interpolated.
-  StyleGuide: '#eval-comment-docs'
+  Description: |-
+    When using `class_eval` (or other `eval`) with string interpolation,
+    add a comment block showing its appearance if interpolated (a practice used in Rails code).
+  StyleGuide: "#eval-comment-docs"
   Enabled: pending
   VersionAdded: '1.1'
   VersionChanged: '1.3'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/DocumentDynamicEvalDefinition
 Style/Documentation:
-  Description: 'Document classes and non-namespace modules.'
+  Description: |-
+    Checks for missing top-level documentation of classes and
+    modules. Classes with no body are exempt from the check and so are
+    namespace modules - modules that have nothing in their bodies except
+    classes, other modules, constant definitions or constant visibility
+    declarations.
   Enabled: true
   VersionAdded: '0.9'
   AllowedConstants: []
   Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
-
+    - spec/**/*
+    - test/**/*
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Documentation
 Style/DocumentationMethod:
-  Description: 'Checks for missing documentation comment for public methods.'
+  Description: |-
+    Checks for missing documentation comment for public methods.
+    It can optionally be configured to also require documentation for
+    non-public methods.
   Enabled: false
   VersionAdded: '0.43'
   Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
+    - spec/**/*
+    - test/**/*
   RequireForNonPublicMethods: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/DocumentationMethod
 Style/DoubleCopDisableDirective:
-  Description: 'Checks for double rubocop:disable comments on a single line.'
+  Description: |-
+    Detects double disable comments on one line. This is mostly to catch
+    automatically generated comments that need to be regenerated.
   Enabled: true
   VersionAdded: '0.73'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/DoubleCopDisableDirective
 Style/DoubleNegation:
-  Description: 'Checks for uses of double negation (!!).'
-  StyleGuide: '#no-bang-bang'
+  Description: Checks for uses of double negation (`!!`) to convert something to a
+    boolean value.
+  StyleGuide: "#no-bang-bang"
   Enabled: true
   VersionAdded: '0.19'
   VersionChanged: '1.2'
@@ -3432,83 +3327,97 @@ Style/DoubleNegation:
   SupportedStyles:
     - allowed_in_returns
     - forbidden
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/DoubleNegation
 Style/EachForSimpleLoop:
-  Description: >-
-                 Use `Integer#times` for a simple loop which iterates a fixed
-                 number of times.
+  Description: |-
+    Checks for loops which iterate a constant number of times,
+    using a Range literal and `#each`. This can be done more readably using
+    `Integer#times`.
   Enabled: true
   VersionAdded: '0.41'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EachForSimpleLoop
 Style/EachWithObject:
-  Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
+  Description: |-
+    Looks for inject / reduce calls where the passed in object is
+    returned at the end and so could be replaced by each_with_object without
+    the need to return the object at the end.
   Enabled: true
   VersionAdded: '0.22'
   VersionChanged: '0.42'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EachWithObject
 Style/EmptyBlockParameter:
-  Description: 'Omit pipes for empty block parameters.'
+  Description: |-
+    Checks for pipes for empty block parameters. Pipes for empty
+    block parameters do not cause syntax errors, but they are redundant.
   Enabled: true
   VersionAdded: '0.52'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EmptyBlockParameter
 Style/EmptyCaseCondition:
-  Description: 'Avoid empty condition in case statements.'
+  Description: Checks for case statements with an empty condition.
   Enabled: true
   VersionAdded: '0.40'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EmptyCaseCondition
 Style/EmptyElse:
-  Description: 'Avoid empty else-clauses.'
+  Description: |-
+    Checks for empty else-clauses, possibly including comments and/or an
+    explicit `nil` depending on the EnforcedStyle.
   Enabled: true
   VersionAdded: '0.28'
   VersionChanged: '0.32'
   EnforcedStyle: both
-  # empty - warn only on empty `else`
-  # nil - warn on `else` with nil in it
-  # both - warn on empty `else` and `else` with `nil` in it
   SupportedStyles:
     - empty
     - nil
     - both
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EmptyElse
 Style/EmptyLambdaParameter:
-  Description: 'Omit parens for empty lambda parameters.'
+  Description: |-
+    Checks for parentheses for empty lambda parameters. Parentheses
+    for empty lambda parameters do not cause syntax errors, but they are
+    redundant.
   Enabled: true
   VersionAdded: '0.52'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EmptyLambdaParameter
 Style/EmptyLiteral:
-  Description: 'Prefer literals to Array.new/Hash.new/String.new.'
-  StyleGuide: '#literal-array-hash'
+  Description: |-
+    Checks for the use of a method, the result of which
+    would be a literal, like an empty array, hash, or string.
+  StyleGuide: "#literal-array-hash"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.12'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EmptyLiteral
 Style/EmptyMethod:
-  Description: 'Checks the formatting of empty method definitions.'
-  StyleGuide: '#no-single-line-methods'
+  Description: |-
+    Checks for the formatting of empty method definitions.
+    By default it enforces empty method definitions to go on a single
+    line (compact style), but it can be configured to enforce the `end`
+    to go on its own line (expanded style).
+  StyleGuide: "#no-single-line-methods"
   Enabled: true
   VersionAdded: '0.46'
   EnforcedStyle: compact
   SupportedStyles:
     - compact
     - expanded
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EmptyMethod
 Style/Encoding:
-  Description: 'Use UTF-8 as the source file encoding.'
-  StyleGuide: '#utf-8'
+  Description: Checks ensures source files have no utf-8 encoding comments.
+  StyleGuide: "#utf-8"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.50'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Encoding
 Style/EndBlock:
-  Description: 'Avoid the use of END blocks.'
-  StyleGuide: '#no-END-blocks'
+  Description: Checks for END blocks.
+  StyleGuide: "#no-END-blocks"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.81'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EndBlock
 Style/EndlessMethod:
-  Description: 'Avoid the use of multi-lined endless method definitions.'
-  StyleGuide: '#endless-methods'
+  Description: Checks for endless methods.
+  StyleGuide: "#endless-methods"
   Enabled: pending
   VersionAdded: '1.8'
   EnforcedStyle: allow_single_line
@@ -3516,42 +3425,55 @@ Style/EndlessMethod:
     - allow_single_line
     - allow_always
     - disallow
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EndlessMethod
 Style/EnvHome:
-  Description: "Checks for consistent usage of `ENV['HOME']`."
+  Description: |-
+    Checks for consistent usage of `ENV['HOME']`. If `nil` is used as
+    the second argument of `ENV.fetch`, it is treated as a bad case like `ENV[]`.
   Enabled: pending
   Safe: false
   VersionAdded: '1.29'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EnvHome
 Style/EvalWithLocation:
-  Description: 'Pass `__FILE__` and `__LINE__` to `eval` method, as they are used by backtraces.'
+  Description: |-
+    Ensures that eval methods (`eval`, `instance_eval`, `class_eval`
+    and `module_eval`) are given filename and line number values (`__FILE__`
+    and `__LINE__`). This data is used to ensure that any errors raised
+    within the evaluated code will be given the correct identification
+    in a backtrace.
   Enabled: true
   VersionAdded: '0.52'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EvalWithLocation
 Style/EvenOdd:
-  Description: 'Favor the use of `Integer#even?` && `Integer#odd?`.'
-  StyleGuide: '#predicate-methods'
+  Description: |-
+    Checks for places where `Integer#even?` or `Integer#odd?`
+    can be used.
+  StyleGuide: "#predicate-methods"
   Enabled: true
   VersionAdded: '0.12'
   VersionChanged: '0.29'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EvenOdd
 Style/ExpandPathArguments:
-  Description: "Use `expand_path(__dir__)` instead of `expand_path('..', __FILE__)`."
+  Description: |-
+    Checks for use of the `File.expand_path` arguments.
+    Likewise, it also checks for the `Pathname.new` argument.
   Enabled: true
   VersionAdded: '0.53'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ExpandPathArguments
 Style/ExplicitBlockArgument:
-  Description: >-
-                  Consider using explicit block argument to avoid writing block literal
-                  that just passes its arguments to another block.
-  StyleGuide: '#block-argument'
+  Description: |-
+    Enforces the use of explicit block argument to avoid writing
+    block literal that just passes its arguments to another block.
+  StyleGuide: "#block-argument"
   Enabled: true
   VersionAdded: '0.89'
   VersionChanged: '1.8'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ExplicitBlockArgument
 Style/ExponentialNotation:
-  Description: 'When using exponential notation, favor a mantissa between 1 (inclusive) and 10 (exclusive).'
-  StyleGuide: '#exponential-notation'
+  Description: |-
+    Enforces consistency when using exponential notation
+    for numbers in the code (eg 1.2e4). Different styles are supported:
+  StyleGuide: "#exponential-notation"
   Enabled: true
   VersionAdded: '0.82'
   EnforcedStyle: scientific
@@ -3559,33 +3481,37 @@ Style/ExponentialNotation:
     - scientific
     - engineering
     - integral
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ExponentialNotation
 Style/FetchEnvVar:
-  Description: >-
-                 Suggests `ENV.fetch` for the replacement of `ENV[]`.
-  Reference:
-    - https://rubystyle.guide/#hash-fetch-defaults
+  Description: |-
+    Suggests `ENV.fetch` for the replacement of `ENV[]`.
+    `ENV[]` silently fails and returns `nil` when the environment variable is unset,
+    which may cause unexpected behaviors when the developer forgets to set it.
+    On the other hand, `ENV.fetch` raises KeyError or returns the explicitly
+    specified default value.
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FetchEnvVar
   Enabled: pending
   VersionAdded: '1.28'
-  # Environment variables to be excluded from the inspection.
   AllowedVars: []
-
 Style/FileRead:
-  Description: 'Favor `File.(bin)read` convenience methods.'
-  StyleGuide: '#file-read'
+  Description: Favor `File.(bin)read` convenience methods.
+  StyleGuide: "#file-read"
   Enabled: pending
   VersionAdded: '1.24'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FileRead
 Style/FileWrite:
-  Description: 'Favor `File.(bin)write` convenience methods.'
-  StyleGuide: '#file-write'
+  Description: Favor `File.(bin)write` convenience methods.
+  StyleGuide: "#file-write"
   Enabled: pending
   VersionAdded: '1.24'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FileWrite
 Style/FloatDivision:
-  Description: 'For performing float division, coerce one side only.'
-  StyleGuide: '#float-division'
-  Reference: 'https://blog.rubystyle.guide/ruby/2019/06/21/float-division.html'
+  Description: |-
+    Checks for division with integers coerced to floats.
+    It is recommended to either always use `fdiv` or coerce one side only.
+    This cop also provides other options for code consistency.
+  StyleGuide: "#float-division"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FloatDivision
   Enabled: true
   VersionAdded: '0.72'
   VersionChanged: '1.9'
@@ -3596,10 +3522,13 @@ Style/FloatDivision:
     - right_coerce
     - single_coerce
     - fdiv
-
 Style/For:
-  Description: 'Checks use of for or each in multiline loops.'
-  StyleGuide: '#no-for-loops'
+  Description: |-
+    Looks for uses of the `for` keyword or `each` method. The
+    preferred alternative is set in the EnforcedStyle configuration
+    parameter. An `each` call with a block on a single line is always
+    allowed.
+  StyleGuide: "#no-for-loops"
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.13'
@@ -3608,10 +3537,12 @@ Style/For:
   SupportedStyles:
     - each
     - for
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/For
 Style/FormatString:
-  Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
-  StyleGuide: '#sprintf'
+  Description: |-
+    Enforces the use of a single string formatting utility.
+    Valid options include Kernel#format, Kernel#sprintf and String#%.
+  StyleGuide: "#sprintf"
   Enabled: true
   VersionAdded: '0.19'
   VersionChanged: '0.49'
@@ -3620,253 +3551,252 @@ Style/FormatString:
     - format
     - sprintf
     - percent
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FormatString
 Style/FormatStringToken:
-  Description: 'Use a consistent style for format string tokens.'
+  Description: Use a consistent style for named format string tokens.
   Enabled: true
   EnforcedStyle: annotated
   SupportedStyles:
-    # Prefer tokens which contain a sprintf like type annotation like
-    # `%<name>s`, `%<age>d`, `%<score>f`
     - annotated
-    # Prefer simple looking "template" style tokens like `%{name}`, `%{age}`
     - template
     - unannotated
-  # `MaxUnannotatedPlaceholdersAllowed` defines the number of `unannotated`
-  # style token in a format string to be allowed when enforced style is not
-  # `unannotated`.
   MaxUnannotatedPlaceholdersAllowed: 1
   VersionAdded: '0.49'
   VersionChanged: '1.0'
   IgnoredMethods: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FormatStringToken
 Style/FrozenStringLiteralComment:
-  Description: >-
-                 Add the frozen_string_literal comment to the top of files
-                 to help transition to frozen string literals by default.
+  Description: |-
+    Helps you transition from mutable string literals
+    to frozen string literals.
+    It will add the `# frozen_string_literal: true` magic comment to the top
+    of files to enable frozen string literals. Frozen string literals may be
+    default in future Ruby. The comment will be added below a shebang and
+    encoding comment. The frozen string literal comment is only valid in Ruby 2.3+.
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.79'
   EnforcedStyle: always
   SupportedStyles:
-    # `always` will always add the frozen string literal comment to a file
-    # regardless of the Ruby version or if `freeze` or `<<` are called on a
-    # string literal. It is possible that this will create errors.
     - always
-    # `always_true` will add the frozen string literal comment to a file,
-    # similarly to the `always` style, but will also change any disabled
-    # comments (e.g. `# frozen_string_literal: false`) to be enabled.
     - always_true
-    # `never` will enforce that the frozen string literal comment does not
-    # exist in a file.
     - never
   SafeAutoCorrect: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FrozenStringLiteralComment
 Style/GlobalStdStream:
-  Description: 'Enforces the use of `$stdout/$stderr/$stdin` instead of `STDOUT/STDERR/STDIN`.'
-  StyleGuide: '#global-stdout'
+  Description: |-
+    Enforces the use of `$stdout/$stderr/$stdin` instead of `STDOUT/STDERR/STDIN`.
+    `STDOUT/STDERR/STDIN` are constants, and while you can actually
+    reassign (possibly to redirect some stream) constants in Ruby, you'll get
+    an interpreter warning if you do so.
+  StyleGuide: "#global-stdout"
   Enabled: true
   VersionAdded: '0.89'
   SafeAutoCorrect: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/GlobalStdStream
 Style/GlobalVars:
-  Description: 'Do not introduce global variables.'
-  StyleGuide: '#instance-vars'
-  Reference: 'https://www.zenspider.com/ruby/quickref.html'
+  Description: |-
+    Looks for uses of global variables.
+    It does not report offenses for built-in global variables.
+    Built-in global variables are allowed by default. Additionally
+    users can allow additional variables via the AllowedVariables option.
+  StyleGuide: "#instance-vars"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/GlobalVars
   Enabled: true
   VersionAdded: '0.13'
-  # Built-in global variables are allowed by default.
   AllowedVariables: []
-
 Style/GuardClause:
-  Description: 'Check for conditionals that can be replaced with guard clauses.'
-  StyleGuide: '#no-nested-conditionals'
+  Description: |-
+    Use a guard clause instead of wrapping the code inside a conditional
+    expression
+  StyleGuide: "#no-nested-conditionals"
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '1.28'
-  # `MinBodyLength` defines the number of lines of the a body of an `if` or `unless`
-  # needs to have to trigger this cop
   MinBodyLength: 1
   AllowConsecutiveConditionals: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/GuardClause
 Style/HashAsLastArrayItem:
-  Description: >-
-                 Checks for presence or absence of braces around hash literal as a last
-                 array item depending on configuration.
-  StyleGuide: '#hash-literal-as-last-array-item'
+  Description: |-
+    Checks for presence or absence of braces around hash literal as a last
+    array item depending on configuration.
+  StyleGuide: "#hash-literal-as-last-array-item"
   Enabled: true
   VersionAdded: '0.88'
   EnforcedStyle: braces
   SupportedStyles:
     - braces
     - no_braces
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashAsLastArrayItem
 Style/HashConversion:
-  Description: 'Avoid Hash[] in favor of ary.to_h or literal hashes.'
-  StyleGuide: '#avoid-hash-constructor'
+  Description: |-
+    Checks the usage of pre-2.1 `Hash[args]` method of converting enumerables and
+    sequences of values to hashes.
+  StyleGuide: "#avoid-hash-constructor"
   Enabled: pending
   VersionAdded: '1.10'
   VersionChanged: '1.11'
   AllowSplatArgument: true
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashConversion
 Style/HashEachMethods:
-  Description: 'Use Hash#each_key and Hash#each_value.'
-  StyleGuide: '#hash-each'
+  Description: Checks for uses of `each_key` and `each_value` Hash methods.
+  StyleGuide: "#hash-each"
   Enabled: true
   Safe: false
   VersionAdded: '0.80'
   VersionChanged: '1.16'
   AllowedReceivers: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashEachMethods
 Style/HashExcept:
-  Description: >-
-                 Checks for usages of `Hash#reject`, `Hash#select`, and `Hash#filter` methods
-                 that can be replaced with `Hash#except` method.
+  Description: |-
+    Checks for usages of `Hash#reject`, `Hash#select`, and `Hash#filter` methods
+    that can be replaced with `Hash#except` method.
   Enabled: pending
   VersionAdded: '1.7'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashExcept
 Style/HashLikeCase:
-  Description: >-
-                  Checks for places where `case-when` represents a simple 1:1
-                  mapping and can be replaced with a hash lookup.
+  Description: |-
+    Checks for places where `case-when` represents a simple 1:1
+    mapping and can be replaced with a hash lookup.
   Enabled: true
   VersionAdded: '0.88'
-  # `MinBranchesCount` defines the number of branches `case` needs to have
-  # to trigger this cop
   MinBranchesCount: 3
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashLikeCase
 Style/HashSyntax:
-  Description: >-
-                 Prefer Ruby 1.9 hash syntax { a: 1, b: 2 } over 1.8 syntax
-                 { :a => 1, :b => 2 }.
-  StyleGuide: '#hash-literals'
+  Description: Checks hash literal syntax.
+  StyleGuide: "#hash-literals"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '1.24'
   EnforcedStyle: ruby19
   SupportedStyles:
-    # checks for 1.9 syntax (e.g. {a: 1}) for all symbol keys
     - ruby19
-    # checks for hash rocket syntax for all hashes
     - hash_rockets
-    # forbids mixed key syntaxes (e.g. {a: 1, :b => 2})
     - no_mixed_keys
-    # enforces both ruby19 and no_mixed_keys styles
     - ruby19_no_mixed_keys
-  # Force hashes that have a hash value omission
   EnforcedShorthandSyntax: always
   SupportedShorthandSyntax:
-    # forces use of the 3.1 syntax (e.g. {foo:}) when the hash key and value are the same.
     - always
-    # forces use of explicit hash literal value.
     - never
-    # accepts both shorthand and explicit use of hash literal value.
     - either
-  # Force hashes that have a symbol value to use hash rockets
   UseHashRocketsWithSymbolValues: false
-  # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style
   PreferHashRocketsForNonAlnumEndingSymbols: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashSyntax
 Style/HashTransformKeys:
-  Description: 'Prefer `transform_keys` over `each_with_object`, `map`, or `to_h`.'
+  Description: |-
+    Looks for uses of `_.each_with_object({}) {...}`,
+    `_.map {...}.to_h`, and `Hash[_.map {...}]` that are actually just
+    transforming the keys of a hash, and tries to use a simpler & faster
+    call to `transform_keys` instead.
+    It should only be enabled on Ruby version 2.5 or newer.
+    (`transform_keys` was added in Ruby 2.5.)
   Enabled: true
   VersionAdded: '0.80'
   VersionChanged: '0.90'
   Safe: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashTransformKeys
 Style/HashTransformValues:
-  Description: 'Prefer `transform_values` over `each_with_object`, `map`, or `to_h`.'
+  Description: |-
+    Looks for uses of `_.each_with_object({}) {...}`,
+    `_.map {...}.to_h`, and `Hash[_.map {...}]` that are actually just
+    transforming the values of a hash, and tries to use a simpler & faster
+    call to `transform_values` instead.
   Enabled: true
   VersionAdded: '0.80'
   VersionChanged: '0.90'
   Safe: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashTransformValues
 Style/IdenticalConditionalBranches:
-  Description: >-
-                 Checks that conditional statements do not have an identical
-                 line at the end of each branch, which can validly be moved
-                 out of the conditional.
+  Description: |-
+    Checks for identical expressions at the beginning or end of
+    each branch of a conditional expression. Such expressions should normally
+    be placed outside the conditional expression - before or after it.
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.36'
   VersionChanged: '1.19'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/IdenticalConditionalBranches
 Style/IfInsideElse:
-  Description: 'Finds if nodes inside else, which can be converted to elsif.'
+  Description: |-
+    If the `else` branch of a conditional consists solely of an `if` node,
+    it can be combined with the `else` to become an `elsif`.
+    This helps to keep the nesting level from getting too deep.
   Enabled: true
   AllowIfModifier: false
   VersionAdded: '0.36'
   VersionChanged: '1.3'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/IfInsideElse
 Style/IfUnlessModifier:
-  Description: >-
-                 Favor modifier if/unless usage when you have a
-                 single-line body.
-  StyleGuide: '#if-as-a-modifier'
+  Description: |-
+    Checks for `if` and `unless` statements that would fit on one line if
+    written as modifier `if`/`unless`. The cop also checks for modifier
+    `if`/`unless` lines that exceed the maximum line length.
+  StyleGuide: "#if-as-a-modifier"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.30'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/IfUnlessModifier
 Style/IfUnlessModifierOfIfUnless:
-  Description: >-
-                 Avoid modifier if/unless usage on conditionals.
+  Description: |-
+    Checks for if and unless statements used as modifiers of other if or
+    unless statements.
   Enabled: true
   VersionAdded: '0.39'
   VersionChanged: '0.87'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/IfUnlessModifierOfIfUnless
 Style/IfWithBooleanLiteralBranches:
-  Description: 'Checks for redundant `if` with boolean literal branches.'
+  Description: |-
+    Checks for redundant `if` with boolean literal branches.
+    It checks only conditions to return boolean value (`true` or `false`) for safe detection.
+    The conditions to be checked are comparison methods, predicate methods, and double negative.
   Enabled: pending
   VersionAdded: '1.9'
   SafeAutoCorrect: false
   AllowedMethods:
     - nonzero?
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/IfWithBooleanLiteralBranches
 Style/IfWithSemicolon:
-  Description: 'Do not use if x; .... Use the ternary operator instead.'
-  StyleGuide: '#no-semicolon-ifs'
+  Description: Checks for uses of semicolon in if statements.
+  StyleGuide: "#no-semicolon-ifs"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.83'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/IfWithSemicolon
 Style/ImplicitRuntimeError:
-  Description: >-
-                 Use `raise` or `fail` with an explicit exception class and
-                 message, rather than just a message.
+  Description: |-
+    Checks for `raise` or `fail` statements which do not specify an
+    explicit exception class. (This raises a `RuntimeError`. Some projects
+    might prefer to use exception classes which more precisely identify the
+    nature of the error.)
   Enabled: false
   VersionAdded: '0.41'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ImplicitRuntimeError
 Style/InPatternThen:
-  Description: 'Checks for `in;` uses in `case` expressions.'
-  StyleGuide: '#no-in-pattern-semicolons'
+  Description: Checks for `in;` uses in `case` expressions.
+  StyleGuide: "#no-in-pattern-semicolons"
   Enabled: pending
   VersionAdded: '1.16'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/InPatternThen
 Style/InfiniteLoop:
-  Description: >-
-                 Use Kernel#loop for infinite loops.
-                 This cop is unsafe if the body may raise a `StopIteration` exception.
+  Description: Use `Kernel#loop` for infinite loops.
   Safe: false
-  StyleGuide: '#infinite-loop'
+  StyleGuide: "#infinite-loop"
   Enabled: true
   VersionAdded: '0.26'
   VersionChanged: '0.61'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/InfiniteLoop
 Style/InlineComment:
-  Description: 'Avoid trailing inline comments.'
+  Description: Checks for trailing inline comments.
   Enabled: false
   VersionAdded: '0.23'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/InlineComment
 Style/InverseMethods:
-  Description: >-
-                 Use the inverse method instead of `!.method`
-                 if an inverse method is defined.
+  Description: |-
+    Check for usages of not (`not` or `!`) called on a method
+    when an inverse of that method can be used instead.
   Enabled: true
   Safe: false
   VersionAdded: '0.48'
-  # `InverseMethods` are methods that can be inverted by a not (`not` or `!`)
-  # The relationship of inverse methods only needs to be defined in one direction.
-  # Keys and values both need to be defined as symbols.
   InverseMethods:
     :any?: :none?
     :even?: :odd?
@@ -3874,41 +3804,44 @@ Style/InverseMethods:
     :=~: :!~
     :<: :>=
     :>: :<=
-    # `ActiveSupport` defines some common inverse methods. They are listed below,
-    # and not enabled by default.
-    # :present?: :blank?,
-    # :include?: :exclude?
-  # `InverseBlocks` are methods that are inverted by inverting the return
-  # of the block that is passed to the method
   InverseBlocks:
     :select: :reject
     :select!: :reject!
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/InverseMethods
 Style/IpAddresses:
-  Description: "Don't include literal IP addresses in code."
+  Description: |-
+    Checks for hardcoded IP addresses, which can make code
+    brittle. IP addresses are likely to need to be changed when code
+    is deployed to a different server or environment, which may break
+    a deployment if forgotten. Prefer setting IP addresses in ENV or
+    other configuration.
   Enabled: false
   VersionAdded: '0.58'
   VersionChanged: '0.91'
-  # Allow addresses to be permitted
   AllowedAddresses:
     - "::"
-    # :: is a valid IPv6 address, but could potentially be legitimately in code
   Exclude:
-    - '**/*.gemfile'
-    - '**/Gemfile'
-    - '**/gems.rb'
-    - '**/*.gemspec'
-
+    - "**/*.gemfile"
+    - "**/Gemfile"
+    - "**/gems.rb"
+    - "**/*.gemspec"
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/IpAddresses
 Style/KeywordParametersOrder:
-  Description: 'Enforces that optional keyword parameters are placed at the end of the parameters list.'
-  StyleGuide: '#keyword-parameters-order'
+  Description: |-
+    Enforces that optional keyword parameters are placed at the
+    end of the parameters list.
+  StyleGuide: "#keyword-parameters-order"
   Enabled: true
   VersionAdded: '0.90'
   VersionChanged: '1.7'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/KeywordParametersOrder
 Style/Lambda:
-  Description: 'Use the new lambda literal syntax for single-line blocks.'
-  StyleGuide: '#lambda-multi-line'
+  Description: |-
+    (by default) checks for uses of the lambda literal syntax for
+    single line lambdas, and the method call syntax for multiline lambdas.
+    It is configurable to enforce one of the styles for both single line
+    and multiline lambdas as well.
+  StyleGuide: "#lambda-multi-line"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.40'
@@ -3917,10 +3850,10 @@ Style/Lambda:
     - line_count_dependent
     - lambda
     - literal
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Lambda
 Style/LambdaCall:
-  Description: 'Use lambda.call(...) instead of lambda.(...).'
-  StyleGuide: '#proc-call'
+  Description: Checks for use of the lambda.(args) syntax.
+  StyleGuide: "#proc-call"
   Enabled: true
   VersionAdded: '0.13'
   VersionChanged: '0.14'
@@ -3928,37 +3861,41 @@ Style/LambdaCall:
   SupportedStyles:
     - call
     - braces
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/LambdaCall
 Style/LineEndConcatenation:
-  Description: >-
-                 Use \ instead of + or << to concatenate two string literals at
-                 line end.
+  Description: |-
+    Checks for string literal concatenation at
+    the end of a line.
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.18'
   VersionChanged: '0.64'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/LineEndConcatenation
 Style/MapCompactWithConditionalBlock:
-  Description: 'Prefer `select` or `reject` over `map { ... }.compact`.'
+  Description: Prefer `select` or `reject` over `map { ... }.compact`.
   Enabled: pending
   VersionAdded: '1.30'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MapCompactWithConditionalBlock
 Style/MapToHash:
-  Description: 'Prefer `to_h` with a block over `map.to_h`.'
+  Description: |-
+    Looks for uses of `map.to_h` or `collect.to_h` that could be
+    written with just `to_h` in Ruby >= 2.6.
   Enabled: pending
   VersionAdded: '1.24'
   Safe: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MapToHash
 Style/MethodCallWithArgsParentheses:
-  Description: 'Use parentheses for method calls with arguments.'
-  StyleGuide: '#method-invocation-parens'
+  Description: |-
+    Enforces the presence (default) or absence of parentheses in
+    method calls containing parameters.
+  StyleGuide: "#method-invocation-parens"
   Enabled: false
   VersionAdded: '0.47'
   VersionChanged: '1.7'
   IgnoreMacros: true
   IgnoredMethods: []
   AllowedPatterns: []
-  IgnoredPatterns: [] # deprecated
+  IgnoredPatterns: []
   IncludedMacros: []
   AllowParenthesesInMultilineCall: false
   AllowParenthesesInChaining: false
@@ -3968,26 +3905,29 @@ Style/MethodCallWithArgsParentheses:
   SupportedStyles:
     - require_parentheses
     - omit_parentheses
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MethodCallWithArgsParentheses
 Style/MethodCallWithoutArgsParentheses:
-  Description: 'Do not use parentheses for method calls with no arguments.'
-  StyleGuide: '#method-invocation-parens'
+  Description: Checks for unwanted parentheses in parameterless method calls.
+  StyleGuide: "#method-invocation-parens"
   Enabled: true
   IgnoredMethods: []
   VersionAdded: '0.47'
   VersionChanged: '0.55'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MethodCallWithoutArgsParentheses
 Style/MethodCalledOnDoEndBlock:
-  Description: 'Avoid chaining a method call on a do...end block.'
-  StyleGuide: '#single-line-blocks'
+  Description: |-
+    Checks for methods called on a do...end block. The point of
+    this check is that it's easy to miss the call tacked on to the block
+    when reading code.
+  StyleGuide: "#single-line-blocks"
   Enabled: false
   VersionAdded: '0.14'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MethodCalledOnDoEndBlock
 Style/MethodDefParentheses:
-  Description: >-
-                 Checks if the method definitions have or don't have
-                 parentheses.
-  StyleGuide: '#method-parens'
+  Description: |-
+    Checks for parentheses around the arguments in method
+    definitions. Both instance and class/singleton methods are checked.
+  StyleGuide: "#method-parens"
   Enabled: true
   VersionAdded: '0.16'
   VersionChanged: '1.7'
@@ -3996,62 +3936,58 @@ Style/MethodDefParentheses:
     - require_parentheses
     - require_no_parentheses
     - require_no_parentheses_except_multiline
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MethodDefParentheses
 Style/MinMax:
-  Description: >-
-                 Use `Enumerable#minmax` instead of `Enumerable#min`
-                 and `Enumerable#max` in conjunction.
+  Description: Checks for potential uses of `Enumerable#minmax`.
   Enabled: true
   VersionAdded: '0.50'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MinMax
 Style/MissingElse:
-  Description: >-
-                Require if/case expressions to have an else branches.
-                If enabled, it is recommended that
-                Style/UnlessElse and Style/EmptyElse be enabled.
-                This will conflict with Style/EmptyElse if
-                Style/EmptyElse is configured to style "both".
+  Description: Checks for `if` expressions that do not have an `else` branch.
   Enabled: false
   VersionAdded: '0.30'
   VersionChanged: '0.38'
   EnforcedStyle: both
   SupportedStyles:
-    # if - warn when an if expression is missing an else branch
-    # case - warn when a case expression is missing an else branch
-    # both - warn when an if or case expression is missing an else branch
     - if
     - case
     - both
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MissingElse
 Style/MissingRespondToMissing:
-  Description: >-
-                  Checks if `method_missing` is implemented
-                  without implementing `respond_to_missing`.
-  StyleGuide: '#no-method-missing'
+  Description: |-
+    Checks for the presence of `method_missing` without also
+    defining `respond_to_missing?`.
+  StyleGuide: "#no-method-missing"
   Enabled: true
   VersionAdded: '0.56'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MissingRespondToMissing
 Style/MixinGrouping:
-  Description: 'Checks for grouping of mixins in `class` and `module` bodies.'
-  StyleGuide: '#mixin-grouping'
+  Description: |-
+    Checks for grouping of mixins in `class` and `module` bodies.
+    By default it enforces mixins to be placed in separate declarations,
+    but it can be configured to enforce grouping them in one declaration.
+  StyleGuide: "#mixin-grouping"
   Enabled: true
   VersionAdded: '0.48'
   VersionChanged: '0.49'
   EnforcedStyle: separated
   SupportedStyles:
-    # separated: each mixed in module goes in a separate statement.
-    # grouped: mixed in modules are grouped into a single statement.
     - separated
     - grouped
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MixinGrouping
 Style/MixinUsage:
-  Description: 'Checks that `include`, `extend` and `prepend` exists at the top level.'
+  Description: |-
+    Checks that `include`, `extend` and `prepend` statements appear
+    inside classes and modules, not at the top level, so as to not affect
+    the behavior of `Object`.
   Enabled: true
   VersionAdded: '0.51'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MixinUsage
 Style/ModuleFunction:
-  Description: 'Checks for usage of `extend self` in modules.'
-  StyleGuide: '#module-function'
+  Description: |-
+    Checks for use of `extend self` or `module_function` in a
+    module.
+  StyleGuide: "#module-function"
   Enabled: true
   VersionAdded: '0.11'
   VersionChanged: '0.65'
@@ -4062,34 +3998,36 @@ Style/ModuleFunction:
     - forbidden
   Autocorrect: false
   SafeAutoCorrect: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ModuleFunction
 Style/MultilineBlockChain:
-  Description: 'Avoid multi-line chains of blocks.'
-  StyleGuide: '#single-line-blocks'
+  Description: |-
+    Checks for chaining of a block after another block that spans
+    multiple lines.
+  StyleGuide: "#single-line-blocks"
   Enabled: true
   VersionAdded: '0.13'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MultilineBlockChain
 Style/MultilineIfModifier:
-  Description: 'Only use if/unless modifiers on single line statements.'
-  StyleGuide: '#no-multiline-if-modifiers'
+  Description: Checks for uses of if/unless modifiers with multiple-lines bodies.
+  StyleGuide: "#no-multiline-if-modifiers"
   Enabled: true
   VersionAdded: '0.45'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MultilineIfModifier
 Style/MultilineIfThen:
-  Description: 'Do not use then for multi-line if/unless.'
-  StyleGuide: '#no-then'
+  Description: Checks for uses of the `then` keyword in multi-line if statements.
+  StyleGuide: "#no-then"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.26'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MultilineIfThen
 Style/MultilineInPatternThen:
-  Description: 'Do not use `then` for multi-line `in` statement.'
-  StyleGuide: '#no-then'
+  Description: Checks uses of the `then` keyword in multi-line `in` statement.
+  StyleGuide: "#no-then"
   Enabled: pending
   VersionAdded: '1.16'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MultilineInPatternThen
 Style/MultilineMemoization:
-  Description: 'Wrap multiline memoizations in a `begin` and `end` block.'
+  Description: Checks expressions wrapping styles for multiline memoization.
   Enabled: true
   VersionAdded: '0.44'
   VersionChanged: '0.48'
@@ -4097,113 +4035,112 @@ Style/MultilineMemoization:
   SupportedStyles:
     - keyword
     - braces
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MultilineMemoization
 Style/MultilineMethodSignature:
-  Description: 'Avoid multi-line method signatures.'
+  Description: Checks for method signatures that span multiple lines.
   Enabled: false
   VersionAdded: '0.59'
   VersionChanged: '1.7'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MultilineMethodSignature
 Style/MultilineTernaryOperator:
-  Description: >-
-                 Avoid multi-line ?: (the ternary operator);
-                 use if/unless instead.
-  StyleGuide: '#no-multiline-ternary'
+  Description: Checks for multi-line ternary op expressions.
+  StyleGuide: "#no-multiline-ternary"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.86'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MultilineTernaryOperator
 Style/MultilineWhenThen:
-  Description: 'Do not use then for multi-line when statement.'
-  StyleGuide: '#no-then'
+  Description: |-
+    Checks uses of the `then` keyword
+    in multi-line when statements.
+  StyleGuide: "#no-then"
   Enabled: true
   VersionAdded: '0.73'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MultilineWhenThen
 Style/MultipleComparison:
-  Description: >-
-                 Avoid comparing a variable with multiple items in a conditional,
-                 use Array#include? instead.
+  Description: |-
+    Checks against comparing a variable with multiple items, where
+    `Array#include?`, `Set#include?` or a `case` could be used instead
+    to avoid code repetition.
+    It accepts comparisons of multiple method calls to avoid unnecessary method calls
+    by default. It can be configured by `AllowMethodComparison` option.
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '1.1'
   AllowMethodComparison: true
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MultipleComparison
 Style/MutableConstant:
-  Description: 'Do not assign mutable objects to constants.'
+  Description: |-
+    Checks whether some constant value isn't a
+    mutable literal (e.g. array or hash).
   Enabled: true
   VersionAdded: '0.34'
   VersionChanged: '1.8'
   SafeAutoCorrect: false
   EnforcedStyle: literals
   SupportedStyles:
-    # literals: freeze literals assigned to constants
-    # strict: freeze all constants
-    # Strict mode is considered an experimental feature. It has not been updated
-    # with an exhaustive list of all methods that will produce frozen objects so
-    # there is a decent chance of getting some false positives. Luckily, there is
-    # no harm in freezing an already frozen object.
     - literals
     - strict
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MutableConstant
 Style/NegatedIf:
-  Description: >-
-                 Favor unless over if for negative conditions
-                 (or control flow or).
-  StyleGuide: '#unless-for-negatives'
+  Description: |-
+    Checks for uses of if with a negated condition. Only ifs
+    without else are considered. There are three different styles:
+  StyleGuide: "#unless-for-negatives"
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.48'
   EnforcedStyle: both
   SupportedStyles:
-    # both: prefix and postfix negated `if` should both use `unless`
-    # prefix: only use `unless` for negated `if` statements positioned before the body of the statement
-    # postfix: only use `unless` for negated `if` statements positioned after the body of the statement
     - both
     - prefix
     - postfix
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NegatedIf
 Style/NegatedIfElseCondition:
-  Description: >-
-                Checks for uses of `if-else` and ternary operators with a negated condition
-                which can be simplified by inverting condition and swapping branches.
+  Description: |-
+    Checks for uses of `if-else` and ternary operators with a negated condition
+    which can be simplified by inverting condition and swapping branches.
   Enabled: pending
   VersionAdded: '1.2'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NegatedIfElseCondition
 Style/NegatedUnless:
-  Description: 'Favor if over unless for negative conditions.'
-  StyleGuide: '#if-for-negatives'
+  Description: |-
+    Checks for uses of unless with a negated condition. Only unless
+    without else are considered. There are three different styles:
+  StyleGuide: "#if-for-negatives"
   Enabled: true
   VersionAdded: '0.69'
   EnforcedStyle: both
   SupportedStyles:
-    # both: prefix and postfix negated `unless` should both use `if`
-    # prefix: only use `if` for negated `unless` statements positioned before the body of the statement
-    # postfix: only use `if` for negated `unless` statements positioned after the body of the statement
     - both
     - prefix
     - postfix
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NegatedUnless
 Style/NegatedWhile:
-  Description: 'Favor until over while for negative conditions.'
-  StyleGuide: '#until-for-negatives'
+  Description: Checks for uses of while with a negated condition.
+  StyleGuide: "#until-for-negatives"
   Enabled: true
   VersionAdded: '0.20'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NegatedWhile
 Style/NestedFileDirname:
-  Description: 'Checks for nested `File.dirname`.'
+  Description: |-
+    Checks for nested `File.dirname`.
+    It replaces nested `File.dirname` with the level argument introduced in Ruby 3.1.
   Enabled: pending
   VersionAdded: '1.26'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NestedFileDirname
 Style/NestedModifier:
-  Description: 'Avoid using nested modifiers.'
-  StyleGuide: '#no-nested-modifiers'
+  Description: |-
+    Checks for nested use of if, unless, while and until in their
+    modifier form.
+  StyleGuide: "#no-nested-modifiers"
   Enabled: true
   VersionAdded: '0.35'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NestedModifier
 Style/NestedParenthesizedCalls:
-  Description: >-
-                 Parenthesize method calls which are nested inside the
-                 argument list of another parenthesized method call.
+  Description: |-
+    Checks for unparenthesized method calls in the argument list
+    of a parenthesized method call.
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.77'
@@ -4225,34 +4162,31 @@ Style/NestedParenthesizedCalls:
     - raise_error
     - respond_to
     - start_with
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NestedParenthesizedCalls
 Style/NestedTernaryOperator:
-  Description: 'Use one expression per branch in a ternary operator.'
-  StyleGuide: '#no-nested-ternary'
+  Description: Checks for nested ternary op expressions.
+  StyleGuide: "#no-nested-ternary"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.86'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NestedTernaryOperator
 Style/Next:
-  Description: 'Use `next` to skip iteration instead of a condition at the end.'
-  StyleGuide: '#no-nested-conditionals'
+  Description: Use `next` to skip iteration instead of a condition at the end.
+  StyleGuide: "#no-nested-conditionals"
   Enabled: true
   VersionAdded: '0.22'
   VersionChanged: '0.35'
-  # With `always` all conditions at the end of an iteration needs to be
-  # replaced by next - with `skip_modifier_ifs` the modifier if like this one
-  # are ignored: [1, 2].each { |a| return 'yes' if a == 1 }
   EnforcedStyle: skip_modifier_ifs
-  # `MinBodyLength` defines the number of lines of the a body of an `if` or `unless`
-  # needs to have to trigger this cop
   MinBodyLength: 3
   SupportedStyles:
     - skip_modifier_ifs
     - always
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Next
 Style/NilComparison:
-  Description: 'Prefer x.nil? to x == nil.'
-  StyleGuide: '#predicate-methods'
+  Description: |-
+    Checks for comparison of something with nil using `==` and
+    `nil?`.
+  StyleGuide: "#predicate-methods"
   Enabled: true
   VersionAdded: '0.12'
   VersionChanged: '0.59'
@@ -4260,81 +4194,81 @@ Style/NilComparison:
   SupportedStyles:
     - predicate
     - comparison
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NilComparison
 Style/NilLambda:
-  Description: 'Prefer `-> {}` to `-> { nil }`.'
+  Description: |-
+    Checks for lambdas and procs that always return nil,
+    which can be replaced with an empty lambda or proc instead.
   Enabled: pending
   VersionAdded: '1.3'
   VersionChanged: '1.15'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NilLambda
 Style/NonNilCheck:
-  Description: 'Checks for redundant nil checks.'
-  StyleGuide: '#no-non-nil-checks'
+  Description: Checks for non-nil checks, which are usually redundant.
+  StyleGuide: "#no-non-nil-checks"
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.22'
-  # With `IncludeSemanticChanges` set to `true`, this cop reports offenses for
-  # `!x.nil?` and autocorrects that and `x != nil` to solely `x`, which is
-  # **usually** OK, but might change behavior.
-  #
-  # With `IncludeSemanticChanges` set to `false`, this cop does not report
-  # offenses for `!x.nil?` and does no changes that might change behavior.
   IncludeSemanticChanges: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NonNilCheck
 Style/Not:
-  Description: 'Use ! instead of not.'
-  StyleGuide: '#bang-not-not'
+  Description: Checks for uses of the keyword `not` instead of `!`.
+  StyleGuide: "#bang-not-not"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.20'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Not
 Style/NumberedParameters:
-  Description: 'Restrict the usage of numbered parameters.'
+  Description: Checks for numbered parameters.
   Enabled: pending
   VersionAdded: '1.22'
   EnforcedStyle: allow_single_line
   SupportedStyles:
     - allow_single_line
     - disallow
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NumberedParameters
 Style/NumberedParametersLimit:
-  Description: 'Avoid excessive numbered params in a single block.'
+  Description: |-
+    Detects use of an excessive amount of numbered parameters in a
+    single block. Having too many numbered parameters can make code too
+    cryptic and hard to read.
   Enabled: pending
   VersionAdded: '1.22'
   Max: 1
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NumberedParametersLimit
 Style/NumericLiteralPrefix:
-  Description: 'Use smallcase prefixes for numeric literals.'
-  StyleGuide: '#numeric-literal-prefixes'
+  Description: |-
+    Checks for octal, hex, binary, and decimal literals using
+    uppercase prefixes and corrects them to lowercase prefix
+    or no prefix (in case of decimals).
+  StyleGuide: "#numeric-literal-prefixes"
   Enabled: true
   VersionAdded: '0.41'
   EnforcedOctalStyle: zero_with_o
   SupportedOctalStyles:
     - zero_with_o
     - zero_only
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NumericLiteralPrefix
 Style/NumericLiterals:
-  Description: >-
-                 Add underscores to large numeric literals to improve their
-                 readability.
-  StyleGuide: '#underscores-in-numerics'
+  Description: |-
+    Checks for big numeric literals without _ between groups
+    of digits in them.
+  StyleGuide: "#underscores-in-numerics"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.48'
   MinDigits: 5
   Strict: false
-  # You can specify allowed numbers. (e.g. port number 3000, 8080, and etc)
   AllowedNumbers: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NumericLiterals
 Style/NumericPredicate:
-  Description: >-
-                 Checks for the use of predicate- or comparison methods for
-                 numeric comparisons.
-  StyleGuide: '#predicate-methods'
+  Description: |-
+    Checks for usage of comparison operators (`==`,
+    `>`, `<`) to test numbers as zero, positive, or negative.
+    These can be replaced by their respective predicate methods.
+    The cop can also be configured to do the reverse.
+  StyleGuide: "#predicate-methods"
   Safe: false
-  # This will change to a new method call which isn't guaranteed to be on the
-  # object. Switching these methods has to be done with knowledge of the types
-  # of the variables which rubocop doesn't have.
   SafeAutoCorrect: false
   Enabled: true
   VersionAdded: '0.42'
@@ -4344,50 +4278,47 @@ Style/NumericPredicate:
     - predicate
     - comparison
   IgnoredMethods: []
-  # Exclude RSpec specs because assertions like `expect(1).to be > 0` cause
-  # false positives.
   Exclude:
-    - 'spec/**/*'
-
+    - spec/**/*
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NumericPredicate
 Style/ObjectThen:
-  Description: 'Enforces the use of consistent method names `Object#yield_self` or `Object#then`.'
-  StyleGuide: '#object-yield-self-vs-object-then'
+  Description: |-
+    Enforces the use of consistent method names
+    `Object#yield_self` or `Object#then`.
+  StyleGuide: "#object-yield-self-vs-object-then"
   Enabled: pending
   VersionAdded: '1.28'
-  # Use `Object#yield_self` or `Object#then`?
-  # Prefer `Object#yield_self` to `Object#then` (yield_self)
-  # Prefer `Object#then` to `Object#yield_self` (then)
-  EnforcedStyle: 'then'
+  EnforcedStyle: then
   SupportedStyles:
     - then
     - yield_self
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ObjectThen
 Style/OneLineConditional:
-  Description: >-
-                 Favor the ternary operator (?:) or multi-line constructs over
-                 single-line if/then/else/end constructs.
-  StyleGuide: '#ternary-operator'
+  Description: |-
+    Checks for uses of if/then/else/end constructs on a single line.
+    AlwaysCorrectToMultiline config option can be set to true to auto-convert all offenses to
+    multi-line constructs. When AlwaysCorrectToMultiline is false (default case) the
+    autocorrect will first try converting them to ternary operators.
+  StyleGuide: "#ternary-operator"
   Enabled: true
   AlwaysCorrectToMultiline: false
   VersionAdded: '0.9'
   VersionChanged: '0.90'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/OneLineConditional
 Style/OpenStructUse:
-  Description: >-
-                 Avoid using OpenStruct. As of Ruby 3.0, use is officially discouraged due to performance,
-                 version compatibility, and potential security issues.
-  Reference:
-    - https://docs.ruby-lang.org/en/3.0.0/OpenStruct.html#class-OpenStruct-label-Caveats
-
+  Description: |-
+    Flags uses of OpenStruct, as it is now officially discouraged
+    to be used for performance, version compatibility, and potential security issues.
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/OpenStructUse
   Enabled: pending
   VersionAdded: '1.23'
-
 Style/OptionHash:
-  Description: "Don't use option hashes when you can use keyword arguments."
+  Description: |-
+    Checks for options hashes and discourages them if the
+    current Ruby version supports keyword arguments.
   Enabled: false
   VersionAdded: '0.33'
   VersionChanged: '0.34'
-  # A list of parameter names that will be flagged by this cop.
   SuspiciousParamNames:
     - options
     - opts
@@ -4395,87 +4326,92 @@ Style/OptionHash:
     - params
     - parameters
   Allowlist: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/OptionHash
 Style/OptionalArguments:
-  Description: >-
-                 Checks for optional arguments that do not appear at the end
-                 of the argument list.
-  StyleGuide: '#optional-arguments'
+  Description: |-
+    Checks for optional arguments to methods
+    that do not come at the end of the argument list.
+  StyleGuide: "#optional-arguments"
   Enabled: true
   Safe: false
   VersionAdded: '0.33'
   VersionChanged: '0.83'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/OptionalArguments
 Style/OptionalBooleanParameter:
-  Description: 'Use keyword arguments when defining method with boolean argument.'
-  StyleGuide: '#boolean-keyword-arguments'
+  Description: |-
+    Checks for places where keyword arguments can be used instead of
+    boolean arguments when defining methods. `respond_to_missing?` method is allowed by default.
+    These are customizable with `AllowedMethods` option.
+  StyleGuide: "#boolean-keyword-arguments"
   Enabled: true
   Safe: false
   VersionAdded: '0.89'
   AllowedMethods:
     - respond_to_missing?
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/OptionalBooleanParameter
 Style/OrAssignment:
-  Description: 'Recommend usage of double pipe equals (||=) where applicable.'
-  StyleGuide: '#double-pipe-for-uninit'
+  Description: Checks for potential usage of the `||=` operator.
+  StyleGuide: "#double-pipe-for-uninit"
   Enabled: true
   VersionAdded: '0.50'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/OrAssignment
 Style/ParallelAssignment:
-  Description: >-
-                  Check for simple usages of parallel assignment.
-                  It will only warn when the number of variables
-                  matches on both sides of the assignment.
-  StyleGuide: '#parallel-assignment'
+  Description: |-
+    Checks for simple usages of parallel assignment.
+    This will only complain when the number of variables
+    being assigned matched the number of assigning variables.
+  StyleGuide: "#parallel-assignment"
   Enabled: true
   VersionAdded: '0.32'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ParallelAssignment
 Style/ParenthesesAroundCondition:
-  Description: >-
-                 Don't use parentheses around the condition of an
-                 if/unless/while.
-  StyleGuide: '#no-parens-around-condition'
+  Description: |-
+    Checks for the presence of superfluous parentheses around the
+    condition of if/unless/while/until.
+  StyleGuide: "#no-parens-around-condition"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.56'
   AllowSafeAssignment: true
   AllowInMultilineConditions: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ParenthesesAroundCondition
 Style/PercentLiteralDelimiters:
-  Description: 'Use `%`-literal delimiters consistently.'
-  StyleGuide: '#percent-literal-braces'
+  Description: Enforces the consistent usage of `%`-literal delimiters.
+  StyleGuide: "#percent-literal-braces"
   Enabled: true
   VersionAdded: '0.19'
-  # Specify the default preferred delimiter for all types with the 'default' key
-  # Override individual delimiters (even with default specified) by specifying
-  # an individual key
   PreferredDelimiters:
-    default: ()
-    '%i': '[]'
-    '%I': '[]'
-    '%r': '{}'
-    '%w': '[]'
-    '%W': '[]'
+    default: "()"
+    "%i": "[]"
+    "%I": "[]"
+    "%r": "{}"
+    "%w": "[]"
+    "%W": "[]"
   VersionChanged: '0.48'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/PercentLiteralDelimiters
 Style/PercentQLiterals:
-  Description: 'Checks if uses of %Q/%q match the configured preference.'
+  Description: Checks for usage of the %Q() syntax when %q() would do.
   Enabled: true
   VersionAdded: '0.25'
   EnforcedStyle: lower_case_q
   SupportedStyles:
-    - lower_case_q # Use `%q` when possible, `%Q` when necessary
-    - upper_case_q # Always use `%Q`
-
+    - lower_case_q
+    - upper_case_q
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/PercentQLiterals
 Style/PerlBackrefs:
-  Description: 'Avoid Perl-style regex back references.'
-  StyleGuide: '#no-perl-regexp-last-matchers'
+  Description: |-
+    Looks for uses of Perl-style regexp match
+    backreferences and their English versions like
+    $1, $2, $&, &+, $MATCH, $PREMATCH, etc.
+  StyleGuide: "#no-perl-regexp-last-matchers"
   Enabled: true
   VersionAdded: '0.13'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/PerlBackrefs
 Style/PreferredHashMethods:
-  Description: 'Checks use of `has_key?` and `has_value?` Hash methods.'
-  StyleGuide: '#hash-key'
+  Description: |-
+    Checks for uses of methods `Hash#has_key?` and
+    `Hash#has_value?`, and suggests using `Hash#key?` and `Hash#value?` instead.
+  StyleGuide: "#hash-key"
   Enabled: true
   Safe: false
   VersionAdded: '0.41'
@@ -4484,16 +4420,21 @@ Style/PreferredHashMethods:
   SupportedStyles:
     - short
     - verbose
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/PreferredHashMethods
 Style/Proc:
-  Description: 'Use proc instead of Proc.new.'
-  StyleGuide: '#proc'
+  Description: |-
+    Checks for uses of Proc.new where Kernel#proc
+    would be more appropriate.
+  StyleGuide: "#proc"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.18'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Proc
 Style/QuotedSymbols:
-  Description: 'Use a consistent style for quoted symbols.'
+  Description: |-
+    Checks if the quotes used for quoted symbols match the configured defaults.
+    By default uses the same configuration as `Style/StringLiterals`; if that
+    cop is not enabled, the default `EnforcedStyle` is `single_quotes`.
   Enabled: pending
   VersionAdded: '1.16'
   EnforcedStyle: same_as_string_literals
@@ -4501,238 +4442,240 @@ Style/QuotedSymbols:
     - same_as_string_literals
     - single_quotes
     - double_quotes
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/QuotedSymbols
 Style/RaiseArgs:
-  Description: 'Checks the arguments passed to raise/fail.'
-  StyleGuide: '#exception-class-messages'
+  Description: |-
+    Checks the args passed to `fail` and `raise`. For exploded
+    style (default), it recommends passing the exception class and message
+    to `raise`, rather than construct an instance of the error. It will
+    still allow passing just a message, or the construction of an error
+    with more than one argument.
+  StyleGuide: "#exception-class-messages"
   Enabled: true
   VersionAdded: '0.14'
   VersionChanged: '1.2'
   EnforcedStyle: exploded
   SupportedStyles:
-    - compact # raise Exception.new(msg)
-    - exploded # raise Exception, msg
+    - compact
+    - exploded
   AllowedCompactTypes: []
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RaiseArgs
 Style/RandomWithOffset:
-  Description: >-
-                 Prefer to use ranges when generating random numbers instead of
-                 integers with offsets.
-  StyleGuide: '#random-numbers'
+  Description: |-
+    Checks for the use of randomly generated numbers,
+    added/subtracted with integer literals, as well as those with
+    Integer#succ and Integer#pred methods. Prefer using ranges instead,
+    as it clearly states the intentions.
+  StyleGuide: "#random-numbers"
   Enabled: true
   VersionAdded: '0.52'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RandomWithOffset
 Style/RedundantArgument:
-  Description: 'Check for a redundant argument passed to certain methods.'
+  Description: Checks for a redundant argument passed to certain methods.
   Enabled: pending
   Safe: false
   VersionAdded: '1.4'
   VersionChanged: '1.7'
   Methods:
-    # Array#join
     join: ''
-    # String#split
-    split: ' '
-    # String#chomp
+    split: " "
     chomp: "\n"
-    # String#chomp!
     chomp!: "\n"
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantArgument
 Style/RedundantAssignment:
-  Description: 'Checks for redundant assignment before returning.'
+  Description: Checks for redundant assignment before returning.
   Enabled: true
   VersionAdded: '0.87'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantAssignment
 Style/RedundantBegin:
-  Description: "Don't use begin blocks when they are not needed."
-  StyleGuide: '#begin-implicit'
+  Description: Checks for redundant `begin` blocks.
+  StyleGuide: "#begin-implicit"
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '0.21'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantBegin
 Style/RedundantCapitalW:
-  Description: 'Checks for %W when interpolation is not needed.'
+  Description: Checks for usage of the %W() syntax when %w() would do.
   Enabled: true
   VersionAdded: '0.76'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantCapitalW
 Style/RedundantCondition:
-  Description: 'Checks for unnecessary conditional expressions.'
+  Description: Checks for unnecessary conditional expressions.
   Enabled: true
   VersionAdded: '0.76'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantCondition
 Style/RedundantConditional:
-  Description: "Don't return true/false from a conditional."
+  Description: Checks for redundant returning of true/false in conditionals.
   Enabled: true
   VersionAdded: '0.50'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantConditional
 Style/RedundantException:
-  Description: "Checks for an obsolete RuntimeException argument in raise/fail."
-  StyleGuide: '#no-explicit-runtimeerror'
+  Description: Checks for RuntimeError as the argument of raise/fail.
+  StyleGuide: "#no-explicit-runtimeerror"
   Enabled: true
   VersionAdded: '0.14'
   VersionChanged: '0.29'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantException
 Style/RedundantFetchBlock:
-  Description: >-
-                  Use `fetch(key, value)` instead of `fetch(key) { value }`
-                  when value has Numeric, Rational, Complex, Symbol or String type, `false`, `true`, `nil` or is a constant.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#hashfetch-with-argument-vs-hashfetch--block-code'
+  Description: |-
+    Identifies places where `fetch(key) { value }`
+    can be replaced by `fetch(key, value)`.
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantFetchBlock
   Enabled: true
   Safe: false
-  # If enabled, this cop will autocorrect usages of
-  # `fetch` being called with block returning a constant.
-  # This can be dangerous since constants will not be defined at that moment.
   SafeForConstants: false
   VersionAdded: '0.86'
-
 Style/RedundantFileExtensionInRequire:
-  Description: >-
-                  Checks for the presence of superfluous `.rb` extension in
-                  the filename provided to `require` and `require_relative`.
-  StyleGuide: '#no-explicit-rb-to-require'
+  Description: |-
+    Checks for the presence of superfluous `.rb` extension in
+    the filename provided to `require` and `require_relative`.
+  StyleGuide: "#no-explicit-rb-to-require"
   Enabled: true
   VersionAdded: '0.88'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantFileExtensionInRequire
 Style/RedundantFreeze:
-  Description: "Checks usages of Object#freeze on immutable objects."
+  Description: Check for uses of `Object#freeze` on immutable objects.
   Enabled: true
   VersionAdded: '0.34'
   VersionChanged: '0.66'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantFreeze
 Style/RedundantInitialize:
-  Description: 'Checks for redundant `initialize` methods.'
+  Description: Checks for `initialize` methods that are redundant.
   Enabled: pending
   Safe: false
   AllowComments: true
   VersionAdded: '1.27'
   VersionChanged: '1.28'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantInitialize
 Style/RedundantInterpolation:
-  Description: 'Checks for strings that are just an interpolated expression.'
+  Description: Checks for strings that are just an interpolated expression.
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.76'
   VersionChanged: '1.30'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantInterpolation
 Style/RedundantParentheses:
-  Description: "Checks for parentheses that seem not to serve any purpose."
+  Description: Checks for redundant parentheses.
   Enabled: true
   VersionAdded: '0.36'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantParentheses
 Style/RedundantPercentQ:
-  Description: 'Checks for %q/%Q when single quotes or double quotes would do.'
-  StyleGuide: '#percent-q'
+  Description: Checks for usage of the %q/%Q syntax when '' or "" would do.
+  StyleGuide: "#percent-q"
   Enabled: true
   VersionAdded: '0.76'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantPercentQ
 Style/RedundantRegexpCharacterClass:
-  Description: 'Checks for unnecessary single-element Regexp character classes.'
+  Description: Checks for unnecessary single-element Regexp character classes.
   Enabled: true
   VersionAdded: '0.85'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantRegexpCharacterClass
 Style/RedundantRegexpEscape:
-  Description: 'Checks for redundant escapes in Regexps.'
+  Description: Checks for redundant escapes inside Regexp literals.
   Enabled: true
   VersionAdded: '0.85'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantRegexpEscape
 Style/RedundantReturn:
-  Description: "Don't use return where it's not required."
-  StyleGuide: '#no-explicit-return'
+  Description: Checks for redundant `return` expressions.
+  StyleGuide: "#no-explicit-return"
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '0.14'
-  # When `true` allows code like `return x, y`.
   AllowMultipleReturnValues: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantReturn
 Style/RedundantSelf:
-  Description: "Don't use self where it's not needed."
-  StyleGuide: '#no-self-unless-required'
+  Description: Checks for redundant uses of `self`.
+  StyleGuide: "#no-self-unless-required"
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '0.13'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantSelf
 Style/RedundantSelfAssignment:
-  Description: 'Checks for places where redundant assignments are made for in place modification methods.'
+  Description: |-
+    Checks for places where redundant assignments are made for in place
+    modification methods.
   Enabled: true
   Safe: false
   VersionAdded: '0.90'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantSelfAssignment
 Style/RedundantSelfAssignmentBranch:
-  Description: 'Checks for places where conditional branch makes redundant self-assignment.'
+  Description: Checks for places where conditional branch makes redundant self-assignment.
   Enabled: pending
   VersionAdded: '1.19'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantSelfAssignmentBranch
 Style/RedundantSort:
-  Description: >-
-                  Use `min` instead of `sort.first`,
-                  `max_by` instead of `sort_by...last`, etc.
+  Description: |-
+    Identifies instances of sorting and then
+    taking only the first or last element. The same behavior can
+    be accomplished without a relatively expensive sort by using
+    `Enumerable#min` instead of sorting and taking the first
+    element and `Enumerable#max` instead of sorting and taking the
+    last element. Similarly, `Enumerable#min_by` and
+    `Enumerable#max_by` can replace `Enumerable#sort_by` calls
+    after which only the first or last element is used.
   Enabled: true
   VersionAdded: '0.76'
   VersionChanged: '1.22'
   Safe: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantSort
 Style/RedundantSortBy:
-  Description: 'Use `sort` instead of `sort_by { |x| x }`.'
+  Description: |-
+    Identifies places where `sort_by { ... }` can be replaced by
+    `sort`.
   Enabled: true
   VersionAdded: '0.36'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantSortBy
 Style/RegexpLiteral:
-  Description: 'Use / or %r around regular expressions.'
-  StyleGuide: '#percent-r'
+  Description: Enforces using // or %r around regular expressions.
+  StyleGuide: "#percent-r"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.30'
   EnforcedStyle: slashes
-  # slashes: Always use slashes.
-  # percent_r: Always use `%r`.
-  # mixed: Use slashes on single-line regexes, and `%r` on multi-line regexes.
   SupportedStyles:
     - slashes
     - percent_r
     - mixed
-  # If `false`, the cop will always recommend using `%r` if one or more slashes
-  # are found in the regexp string.
   AllowInnerSlashes: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RegexpLiteral
 Style/RescueModifier:
-  Description: 'Avoid using rescue in its modifier form.'
-  StyleGuide: '#no-rescue-modifiers'
+  Description: Checks for uses of rescue in its modifier form.
+  StyleGuide: "#no-rescue-modifiers"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.34'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RescueModifier
 Style/RescueStandardError:
-  Description: 'Avoid rescuing without specifying an error class.'
+  Description: |-
+    Checks for rescuing `StandardError`. There are two supported
+    styles `implicit` and `explicit`. This cop will not register an offense
+    if any error other than `StandardError` is specified.
   Enabled: true
   VersionAdded: '0.52'
   EnforcedStyle: explicit
-  # implicit: Do not include the error class, `rescue`
-  # explicit: Require an error class `rescue StandardError`
   SupportedStyles:
     - implicit
     - explicit
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RescueStandardError
 Style/ReturnNil:
-  Description: 'Use return instead of return nil.'
+  Description: Enforces consistency between 'return nil' and 'return'.
   Enabled: false
   EnforcedStyle: return
   SupportedStyles:
     - return
     - return_nil
   VersionAdded: '0.50'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ReturnNil
 Style/SafeNavigation:
-  Description: >-
-                  Transforms usages of a method call safeguarded by
-                  a check for the existence of the object to
-                  safe navigation (`&.`).
-                  Autocorrection is unsafe as it assumes the object will
-                  be `nil` or truthy, but never `false`.
+  Description: |-
+    Transforms usages of a method call safeguarded by a non `nil`
+    check for the variable whose method is being called to
+    safe navigation (`&.`). If there is a method chain, all of the methods
+    in the chain need to be checked for safety, and all of the methods will
+    need to be changed to use safe navigation.
   Enabled: true
   VersionAdded: '0.43'
   VersionChanged: '1.27'
-  # Safe navigation may cause a statement to start returning `nil` in addition
-  # to whatever it used to return.
   ConvertCodeThatCanStartToReturnNil: false
   AllowedMethods:
     - present?
@@ -4741,50 +4684,51 @@ Style/SafeNavigation:
     - try
     - try!
   SafeAutoCorrect: false
-  # Maximum length of method chains for register an offense.
   MaxChainLength: 2
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SafeNavigation
 Style/Sample:
-  Description: >-
-                  Use `sample` instead of `shuffle.first`,
-                  `shuffle.last`, and `shuffle[Integer]`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
+  Description: |-
+    Identifies usages of `shuffle.first`,
+    `shuffle.last`, and `shuffle[]` and change them to use
+    `sample` instead.
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Sample
   Enabled: true
   VersionAdded: '0.30'
-
 Style/SelectByRegexp:
-  Description: 'Prefer grep/grep_v to select/reject with a regexp match.'
+  Description: |-
+    Looks for places where an subset of an Enumerable (array,
+    range, set, etc.; see note below) is calculated based on a `Regexp`
+    match, and suggests `grep` or `grep_v` instead.
   Enabled: pending
   SafeAutoCorrect: false
   VersionAdded: '1.22'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SelectByRegexp
 Style/SelfAssignment:
-  Description: >-
-                 Checks for places where self-assignment shorthand should have
-                 been used.
-  StyleGuide: '#self-assignment'
+  Description: Enforces the use the shorthand for self-assignment.
+  StyleGuide: "#self-assignment"
   Enabled: true
   VersionAdded: '0.19'
   VersionChanged: '0.29'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SelfAssignment
 Style/Semicolon:
-  Description: "Don't use semicolons to terminate expressions."
-  StyleGuide: '#no-semicolon'
+  Description: |-
+    Checks for multiple expressions placed on the same line.
+    It also checks for lines terminated with a semicolon.
+  StyleGuide: "#no-semicolon"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.19'
-  # Allow `;` to separate several expressions on the same line.
   AllowAsExpressionSeparator: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Semicolon
 Style/Send:
-  Description: 'Prefer `Object#__send__` or `Object#public_send` to `send`, as `send` may overlap with existing methods.'
-  StyleGuide: '#prefer-public-send'
+  Description: Checks for the use of the send method.
+  StyleGuide: "#prefer-public-send"
   Enabled: false
   VersionAdded: '0.33'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Send
 Style/SignalException:
-  Description: 'Checks for proper usage of fail and raise.'
-  StyleGuide: '#prefer-raise-over-fail'
+  Description: Checks for uses of `fail` and `raise`.
+  StyleGuide: "#prefer-raise-over-fail"
   Enabled: true
   VersionAdded: '0.11'
   VersionChanged: '0.37'
@@ -4793,52 +4737,65 @@ Style/SignalException:
     - only_raise
     - only_fail
     - semantic
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SignalException
 Style/SingleArgumentDig:
-  Description: 'Avoid using single argument dig method.'
+  Description: |-
+    Sometimes using dig method ends up with just a single
+    argument. In such cases, dig should be replaced with [].
   Enabled: true
   VersionAdded: '0.89'
   Safe: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SingleArgumentDig
 Style/SingleLineBlockParams:
-  Description: 'Enforces the names of some block params.'
+  Description: |-
+    Checks whether the block parameters of a single-line
+    method accepting a block match the names specified via configuration.
   Enabled: false
   VersionAdded: '0.16'
   VersionChanged: '1.6'
   Methods:
     - reduce:
-        - acc
-        - elem
+      - acc
+      - elem
     - inject:
-        - acc
-        - elem
-
+      - acc
+      - elem
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SingleLineBlockParams
 Style/SingleLineMethods:
-  Description: 'Avoid single-line methods.'
-  StyleGuide: '#no-single-line-methods'
+  Description: |-
+    Checks for single-line method definitions that contain a body.
+    It will accept single-line methods with no body.
+  StyleGuide: "#no-single-line-methods"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '1.8'
   AllowIfMethodIsEmpty: true
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SingleLineMethods
 Style/SlicingWithRange:
-  Description: 'Checks array slicing is done with endless ranges when suitable.'
+  Description: |-
+    Checks that arrays are sliced with endless ranges instead of
+    `ary[start..-1]` on Ruby 2.6+.
   Enabled: true
   VersionAdded: '0.83'
   Safe: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SlicingWithRange
 Style/SoleNestedConditional:
-  Description: >-
-                  Finds sole nested conditional nodes
-                  which can be merged into outer conditional node.
+  Description: |-
+    If the branch of a conditional consists solely of a conditional node,
+    its conditions can be combined with the conditions of the outer branch.
+    This helps to keep the nesting level from getting too deep.
   Enabled: true
   VersionAdded: '0.89'
   VersionChanged: '1.5'
   AllowModifier: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SoleNestedConditional
 Style/SpecialGlobalVars:
-  Description: 'Avoid Perl-style global variables.'
-  StyleGuide: '#no-cryptic-perlisms'
+  Description: |-
+    This cop looks for uses of Perl-style global variables.
+    Correcting to global variables in the 'English' library
+    will add a require statement to the top of the file if
+    enabled by RequireEnglish config.
+  StyleGuide: "#no-cryptic-perlisms"
   Enabled: true
   VersionAdded: '0.13'
   VersionChanged: '0.36'
@@ -4849,57 +4806,70 @@ Style/SpecialGlobalVars:
     - use_perl_names
     - use_english_names
     - use_builtin_english_names
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SpecialGlobalVars
 Style/StabbyLambdaParentheses:
-  Description: 'Check for the usage of parentheses around stabby lambda arguments.'
-  StyleGuide: '#stabby-lambda-with-args'
+  Description: |-
+    Check for parentheses around stabby lambda arguments.
+    There are two different styles. Defaults to `require_parentheses`.
+  StyleGuide: "#stabby-lambda-with-args"
   Enabled: true
   VersionAdded: '0.35'
   EnforcedStyle: require_parentheses
   SupportedStyles:
     - require_parentheses
     - require_no_parentheses
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StabbyLambdaParentheses
 Style/StaticClass:
-  Description: 'Prefer modules to classes with only class methods.'
-  StyleGuide: '#modules-vs-classes'
+  Description: |-
+    Checks for places where classes with only class methods can be
+    replaced with a module. Classes should be used only when it makes sense to create
+    instances out of them.
+  StyleGuide: "#modules-vs-classes"
   Enabled: false
   Safe: false
   VersionAdded: '1.3'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StaticClass
 Style/StderrPuts:
-  Description: 'Use `warn` instead of `$stderr.puts`.'
-  StyleGuide: '#warn'
+  Description: |-
+    Identifies places where `$stderr.puts` can be replaced by
+    `warn`. The latter has the advantage of easily being disabled by,
+    the `-W0` interpreter flag or setting `$VERBOSE` to `nil`.
+  StyleGuide: "#warn"
   Enabled: true
   VersionAdded: '0.51'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StderrPuts
 Style/StringChars:
-  Description: 'Checks for uses of `String#split` with empty string or regexp literal argument.'
-  StyleGuide: '#string-chars'
+  Description: Checks for uses of `String#split` with empty string or regexp literal
+    argument.
+  StyleGuide: "#string-chars"
   Enabled: pending
   Safe: false
   VersionAdded: '1.12'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StringChars
 Style/StringConcatenation:
-  Description: 'Checks for places where string concatenation can be replaced with string interpolation.'
-  StyleGuide: '#string-interpolation'
+  Description: |-
+    Checks for places where string concatenation
+    can be replaced with string interpolation.
+  StyleGuide: "#string-interpolation"
   Enabled: true
   Safe: false
   VersionAdded: '0.89'
   VersionChanged: '1.18'
   Mode: aggressive
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StringConcatenation
 Style/StringHashKeys:
-  Description: 'Prefer symbols instead of strings as hash keys.'
-  StyleGuide: '#symbols-as-keys'
+  Description: |-
+    Checks for the use of strings as keys in hashes. The use of
+    symbols is preferred instead.
+  StyleGuide: "#symbols-as-keys"
   Enabled: false
   VersionAdded: '0.52'
   VersionChanged: '0.75'
   Safe: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StringHashKeys
 Style/StringLiterals:
-  Description: 'Checks if uses of quotes match the configured preference.'
-  StyleGuide: '#consistent-string-literals'
+  Description: Checks if uses of quotes match the configured preference.
+  StyleGuide: "#consistent-string-literals"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.36'
@@ -4907,58 +4877,56 @@ Style/StringLiterals:
   SupportedStyles:
     - single_quotes
     - double_quotes
-  # If `true`, strings which span multiple lines using `\` for continuation must
-  # use the same type of quotes on each line.
   ConsistentQuotesInMultiline: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StringLiterals
 Style/StringLiteralsInInterpolation:
-  Description: >-
-                 Checks if uses of quotes inside expressions in interpolated
-                 strings match the configured preference.
+  Description: |-
+    Checks that quotes inside the string interpolation
+    match the configured preference.
   Enabled: true
   VersionAdded: '0.27'
   EnforcedStyle: single_quotes
   SupportedStyles:
     - single_quotes
     - double_quotes
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StringLiteralsInInterpolation
 Style/StringMethods:
-  Description: 'Checks if configured preferred methods are used over non-preferred.'
+  Description: |-
+    Enforces the use of consistent method names
+    from the String class.
   Enabled: false
   VersionAdded: '0.34'
   VersionChanged: '0.34'
-  # Mapping from undesired method to desired_method
-  # e.g. to use `to_sym` over `intern`:
-  #
-  # StringMethods:
-  #   PreferredMethods:
-  #     intern: to_sym
   PreferredMethods:
     intern: to_sym
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StringMethods
 Style/Strip:
-  Description: 'Use `strip` instead of `lstrip.rstrip`.'
+  Description: |-
+    Identifies places where `lstrip.rstrip` can be replaced by
+    `strip`.
   Enabled: true
   VersionAdded: '0.36'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Strip
 Style/StructInheritance:
-  Description: 'Checks for inheritance from Struct.new.'
-  StyleGuide: '#no-extend-struct-new'
+  Description: Checks for inheritance from Struct.new.
+  StyleGuide: "#no-extend-struct-new"
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.29'
   VersionChanged: '1.20'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StructInheritance
 Style/SwapValues:
-  Description: 'Enforces the use of shorthand-style swapping of 2 variables.'
-  StyleGuide: '#values-swapping'
+  Description: Enforces the use of shorthand-style swapping of 2 variables.
+  StyleGuide: "#values-swapping"
   Enabled: pending
   VersionAdded: '1.1'
   SafeAutoCorrect: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SwapValues
 Style/SymbolArray:
-  Description: 'Use %i or %I for arrays of symbols.'
-  StyleGuide: '#percent-i'
+  Description: |-
+    Checks for array literals made up of symbols that are not
+    using the %i() syntax.
+  StyleGuide: "#percent-i"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.49'
@@ -4967,28 +4935,30 @@ Style/SymbolArray:
   SupportedStyles:
     - percent
     - brackets
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SymbolArray
 Style/SymbolLiteral:
-  Description: 'Use plain symbols instead of string symbols when possible.'
+  Description: Checks symbol literal syntax.
   Enabled: true
   VersionAdded: '0.30'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SymbolLiteral
 Style/SymbolProc:
-  Description: 'Use symbols as procs instead of blocks when possible.'
+  Description: Use symbols as procs when possible.
   Enabled: true
   Safe: false
   VersionAdded: '0.26'
   VersionChanged: '1.28'
   AllowMethodsWithArguments: false
-  # A list of method names to be ignored by the check.
-  # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
   IgnoredMethods:
     - respond_to
     - define_method
   AllowComments: false
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SymbolProc
 Style/TernaryParentheses:
-  Description: 'Checks for use of parentheses around ternary conditions.'
+  Description: |-
+    Checks for the presence of parentheses around ternary
+    conditions. It is configurable to enforce inclusion or omission of
+    parentheses using `EnforcedStyle`. Omission is only enforced when
+    removing the parentheses won't cause a different behavior.
   Enabled: true
   VersionAdded: '0.42'
   VersionChanged: '0.46'
@@ -4998,118 +4968,101 @@ Style/TernaryParentheses:
     - require_no_parentheses
     - require_parentheses_when_complex
   AllowSafeAssignment: true
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TernaryParentheses
 Style/TopLevelMethodDefinition:
-  Description: 'Looks for top-level method definitions.'
-  StyleGuide: '#top-level-methods'
+  Description: |-
+    Newcomers to ruby applications may write top-level methods,
+    when ideally they should be organized in appropriate classes or modules.
+    This cop looks for definitions of top-level methods and warns about them.
+  StyleGuide: "#top-level-methods"
   Enabled: false
   VersionAdded: '1.15'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TopLevelMethodDefinition
 Style/TrailingBodyOnClass:
-  Description: 'Class body goes below class statement.'
+  Description: Checks for trailing code after the class definition.
   Enabled: true
   VersionAdded: '0.53'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingBodyOnClass
 Style/TrailingBodyOnMethodDefinition:
-  Description: 'Method body goes below definition.'
+  Description: Checks for trailing code after the method definition.
   Enabled: true
   VersionAdded: '0.52'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingBodyOnMethodDefinition
 Style/TrailingBodyOnModule:
-  Description: 'Module body goes below module statement.'
+  Description: Checks for trailing code after the module definition.
   Enabled: true
   VersionAdded: '0.53'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingBodyOnModule
 Style/TrailingCommaInArguments:
-  Description: 'Checks for trailing comma in argument lists.'
-  StyleGuide: '#no-trailing-params-comma'
+  Description: |-
+    Checks for trailing comma in argument lists.
+    The supported styles are:
+  StyleGuide: "#no-trailing-params-comma"
   Enabled: true
   VersionAdded: '0.36'
-  # If `comma`, the cop requires a comma after the last argument, but only for
-  # parenthesized method calls where each argument is on its own line.
-  # If `consistent_comma`, the cop requires a comma after the last argument,
-  # for all parenthesized method calls with arguments.
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInArguments
 Style/TrailingCommaInArrayLiteral:
-  Description: 'Checks for trailing comma in array literals.'
-  StyleGuide: '#no-trailing-array-commas'
+  Description: |-
+    Checks for trailing comma in array literals.
+    The configuration options are:
+  StyleGuide: "#no-trailing-array-commas"
   Enabled: true
   VersionAdded: '0.53'
-  # If `comma`, the cop requires a comma after the last item in an array,
-  # but only when each item is on its own line.
-  # If `consistent_comma`, the cop requires a comma after the last item of all
-  # non-empty, multiline array literals.
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInArrayLiteral
 Style/TrailingCommaInBlockArgs:
-  Description: 'Checks for useless trailing commas in block arguments.'
+  Description: |-
+    Checks whether trailing commas in block arguments are
+    required. Blocks with only one argument and a trailing comma require
+    that comma to be present. Blocks with more than one argument never
+    require a trailing comma.
   Enabled: false
   Safe: false
   VersionAdded: '0.81'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInBlockArgs
 Style/TrailingCommaInHashLiteral:
-  Description: 'Checks for trailing comma in hash literals.'
+  Description: |-
+    Checks for trailing comma in hash literals.
+    The configuration options are:
   Enabled: true
-  # If `comma`, the cop requires a comma after the last item in a hash,
-  # but only when each item is on its own line.
-  # If `consistent_comma`, the cop requires a comma after the last item of all
-  # non-empty, multiline hash literals.
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma
   VersionAdded: '0.53'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInHashLiteral
 Style/TrailingMethodEndStatement:
-  Description: 'Checks for trailing end statement on line of method body.'
+  Description: Checks for trailing code after the method definition.
   Enabled: true
   VersionAdded: '0.52'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingMethodEndStatement
 Style/TrailingUnderscoreVariable:
-  Description: >-
-                 Checks for the usage of unneeded trailing underscores at the
-                 end of parallel variable assignment.
+  Description: Checks for extra underscores in variable assignment.
   AllowNamedUnderscoreVariables: true
   Enabled: true
   VersionAdded: '0.31'
   VersionChanged: '0.35'
-
-# `TrivialAccessors` requires exact name matches and doesn't allow
-# predicated methods by default.
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingUnderscoreVariable
 Style/TrivialAccessors:
-  Description: 'Prefer attr_* methods to trivial readers/writers.'
-  StyleGuide: '#attr_family'
+  Description: |-
+    Looks for trivial reader/writer methods, that could
+    have been created with the attr_* family of functions automatically.
+  StyleGuide: "#attr_family"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '1.15'
-  # When set to `false` the cop will suggest the use of accessor methods
-  # in situations like:
-  #
-  # def name
-  #   @other_name
-  # end
-  #
-  # This way you can uncover "hidden" attributes in your code.
   ExactNameMatch: true
   AllowPredicates: true
-  # Allows trivial writers that don't end in an equal sign. e.g.
-  #
-  # def on_exception(action)
-  #   @on_exception=action
-  # end
-  # on_exception :restart
-  #
-  # Commonly used in DSLs
   AllowDSLWriters: true
   IgnoreClassMethods: false
   AllowedMethods:
@@ -5130,102 +5083,101 @@ Style/TrivialAccessors:
     - to_str
     - to_s
     - to_sym
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrivialAccessors
 Style/UnlessElse:
-  Description: >-
-                 Do not use unless with else. Rewrite these with the positive
-                 case first.
-  StyleGuide: '#no-else-with-unless'
+  Description: Looks for `unless` expressions with `else` clauses.
+  StyleGuide: "#no-else-with-unless"
   Enabled: true
   VersionAdded: '0.9'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/UnlessElse
 Style/UnlessLogicalOperators:
-  Description: >-
-                 Checks for use of logical operators in an unless condition.
+  Description: |-
+    Checks for the use of logical operators in an `unless` condition.
+    It discourages such code, as the condition becomes more difficult
+    to read and understand.
   Enabled: false
   VersionAdded: '1.11'
   EnforcedStyle: forbid_mixed_logical_operators
   SupportedStyles:
     - forbid_mixed_logical_operators
     - forbid_logical_operators
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/UnlessLogicalOperators
 Style/UnpackFirst:
-  Description: >-
-                 Checks for accessing the first element of `String#unpack`
-                 instead of using `unpack1`.
+  Description: |-
+    Checks for accessing the first element of `String#unpack`
+    which can be replaced with the shorter method `unpack1`.
   Enabled: true
   VersionAdded: '0.54'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/UnpackFirst
 Style/VariableInterpolation:
-  Description: >-
-                 Don't interpolate global, instance and class variables
-                 directly in strings.
-  StyleGuide: '#curlies-interpolate'
+  Description: Checks for variable interpolation (like "#@ivar").
+  StyleGuide: "#curlies-interpolate"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.20'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/VariableInterpolation
 Style/WhenThen:
-  Description: 'Use when x then ... for one-line cases.'
-  StyleGuide: '#no-when-semicolons'
+  Description: Checks for `when;` uses in `case` expressions.
+  StyleGuide: "#no-when-semicolons"
   Enabled: true
   VersionAdded: '0.9'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/WhenThen
 Style/WhileUntilDo:
-  Description: 'Checks for redundant do after while or until.'
-  StyleGuide: '#no-multiline-while-do'
+  Description: Checks for uses of `do` in multi-line `while/until` statements.
+  StyleGuide: "#no-multiline-while-do"
   Enabled: true
   VersionAdded: '0.9'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/WhileUntilDo
 Style/WhileUntilModifier:
-  Description: >-
-                 Favor modifier while/until usage when you have a
-                 single-line body.
-  StyleGuide: '#while-as-a-modifier'
+  Description: |-
+    Checks for while and until statements that would fit on one line
+    if written as a modifier while/until. The maximum line length is
+    configured in the `Layout/LineLength` cop.
+  StyleGuide: "#while-as-a-modifier"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.30'
-
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/WhileUntilModifier
 Style/WordArray:
-  Description: 'Use %w or %W for arrays of words.'
-  StyleGuide: '#percent-w'
+  Description: |-
+    Checks for array literals made up of word-like
+    strings, that are not using the %w() syntax.
+  StyleGuide: "#percent-w"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '1.19'
   EnforcedStyle: percent
   SupportedStyles:
-    # percent style: %w(word1 word2)
     - percent
-    # bracket style: ['word1', 'word2']
     - brackets
-  # The `MinSize` option causes the `WordArray` rule to be ignored for arrays
-  # smaller than a certain size. The rule is only applied to arrays
-  # whose element count is greater than or equal to `MinSize`.
   MinSize: 2
-  # The regular expression `WordRegex` decides what is considered a word.
-  WordRegex: !ruby/regexp '/\A(?:\p{Word}|\p{Word}-\p{Word}|\n|\t)+\z/'
-
+  WordRegex: !ruby/regexp /\A(?:\p{Word}|\p{Word}-\p{Word}|\n|\t)+\z/
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/WordArray
 Style/YodaCondition:
-  Description: 'Forbid or enforce yoda conditions.'
-  Reference: 'https://en.wikipedia.org/wiki/Yoda_conditions'
+  Description: |-
+    Enforces or forbids Yoda conditions,
+    i.e. comparison operations where the order of expression is reversed.
+    eg. `5 == x`
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/YodaCondition
   Enabled: true
   EnforcedStyle: forbid_for_all_comparison_operators
   SupportedStyles:
-    # check all comparison operators
     - forbid_for_all_comparison_operators
-    # check only equality operators: `!=` and `==`
     - forbid_for_equality_operators_only
-    # enforce yoda for all comparison operators
     - require_for_all_comparison_operators
-    # enforce yoda only for equality operators: `!=` and `==`
     - require_for_equality_operators_only
   Safe: false
   VersionAdded: '0.49'
   VersionChanged: '0.75'
-
 Style/ZeroLengthPredicate:
-  Description: 'Use #empty? when testing for objects of length 0.'
+  Description: |-
+    Checks for numeric comparisons that can be replaced
+    by a predicate method, such as receiver.length == 0,
+    receiver.length > 0, receiver.length != 0,
+    receiver.length < 1 and receiver.size == 0 that can be
+    replaced by receiver.empty? and !receiver.empty?.
   Enabled: true
   Safe: false
   VersionAdded: '0.37'
   VersionChanged: '0.39'
+  Reference: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ZeroLengthPredicate

--- a/lib/rubocop/config_formatter.rb
+++ b/lib/rubocop/config_formatter.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module RuboCop
+  # Builds a YAML config file from two config hashes
+  class ConfigFormatter
+    # SUBDEPARTMENTS = %(RSpec/Capybara RSpec/FactoryBot RSpec/Rails)
+    COP_DOC_BASE_URL = 'https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/'
+
+    def initialize(config, descriptions)
+      @config       = config
+      @descriptions = descriptions
+    end
+
+    def dump
+      YAML.dump(unified_config)
+        .gsub(/^(\s+)- /, '\1  - ')
+    end
+
+    private
+
+    def unified_config
+      cops.each_with_object(config.dup) do |cop, unified|
+        # next if SUBDEPARTMENTS.include?(cop)
+        # next if AMENDMENTS.include?(cop)
+        next if cop == 'AllCops'
+        next if cop == 'Cop/Base'
+
+        unified[cop].merge!(descriptions.fetch(cop)) rescue binding.pry
+        unified[cop]['Reference'] = COP_DOC_BASE_URL + cop
+      end
+    end
+
+    def cops
+      descriptions.keys | config.keys
+    end
+
+    attr_reader :config, :descriptions
+  end
+end

--- a/lib/rubocop/cop/metrics/perceived_complexity.rb
+++ b/lib/rubocop/cop/metrics/perceived_complexity.rb
@@ -3,6 +3,8 @@
 module RuboCop
   module Cop
     module Metrics
+      # Checks the coplexity for the human reader.
+      #
       # Tries to produce a complexity score that's a measure of the
       # complexity the reader experiences when looking at a method. For that
       # reason it considers `when` nodes as something that doesn't add as much

--- a/lib/rubocop/description_extractor.rb
+++ b/lib/rubocop/description_extractor.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # Extracts cop descriptions from YARD docstrings
+  class DescriptionExtractor
+    def initialize(yardocs)
+      @code_objects = yardocs.map(&CodeObject.public_method(:new))
+    end
+
+    def to_h
+      code_objects
+        .select(&:cop?)
+        .map(&:configuration)
+        .reduce(:merge)
+    end
+
+    private
+
+    attr_reader :code_objects
+
+    # Decorator of a YARD code object for working with documented cops
+    class CodeObject
+      COP_BASE_CLASS = RuboCop::Cop::Base
+      # RSPEC_NAMESPACE = 'RuboCop::Cop::RSpec'
+
+      def initialize(yardoc)
+        @yardoc = yardoc
+      end
+
+      # Test if the YARD code object documents a concrete cop class
+      #
+      # @return [Boolean]
+      def cop?
+          # rspec_cop_namespace? &&
+        class_documentation? &&
+          cop_subclass? &&
+          !abstract?
+      end
+
+      # Configuration for the documented cop that would live in default.yml
+      #
+      # @return [Hash]
+      def configuration
+        { cop_name => { 'Description' => description } }
+      end
+
+      private
+
+      def cop_class
+        Object.const_get(documented_constant)
+      end
+
+      def cop_name
+        cop_class.cop_name
+      end
+
+      def description
+        yardoc.docstring.split("\n\n").first.to_s
+      end
+
+      def class_documentation?
+        yardoc.type.equal?(:class)
+      end
+
+      def documented_constant
+        yardoc.path
+      end
+
+      def cop_subclass?
+        cop_class.ancestors.include?(COP_BASE_CLASS)
+      end
+
+      def abstract?
+        yardoc.tags.any? { |tag| tag.tag_name.eql?('abstract') }
+      end
+
+      attr_reader :yardoc
+    end
+  end
+end


### PR DESCRIPTION
Adapt the code from `rubocop-rspec` that does that.

fixes #3904

There is a huge problem with this approach. [LibYAML is not capable of parsing and emitting comments](https://github.com/yaml/libyaml/issues/42) for our `config/default.yml`, and we really have valuable comments there.

Unless someone is brave enough to submit a test case to [YAML test suite](https://github.com/yaml/libyaml/issues/42#issuecomment-269890440), implement this on LibYAML side, or suggest a better approach, I'll keep this as a draft.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/