### PR TITLE
Restore docs for Lint/UselessElseWithoutRescue

### DIFF
--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -313,6 +313,7 @@ In the following section you find all available cops:
 * xref:cops_lint.adoc#linturiregexp[Lint/UriRegexp]
 * xref:cops_lint.adoc#lintuselessaccessmodifier[Lint/UselessAccessModifier]
 * xref:cops_lint.adoc#lintuselessassignment[Lint/UselessAssignment]
+* xref:cops_lint.adoc#lintuselesselsewithoutrescue[Lint/UselessElseWithoutRescue]
 * xref:cops_lint.adoc#lintuselessmethoddefinition[Lint/UselessMethodDefinition]
 * xref:cops_lint.adoc#lintuselessruby2keywords[Lint/UselessRuby2Keywords]
 * xref:cops_lint.adoc#lintuselesssettercall[Lint/UselessSetterCall]

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -6446,6 +6446,48 @@ end
 
 * https://rubystyle.guide#underscore-unused-vars
 
+== Lint/UselessElseWithoutRescue
+
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+| Enabled
+| Yes
+| No
+| 0.17
+| <<next>>
+|===
+
+Checks for useless `else` in `begin..end` without `rescue`.
+
+NOTE: This syntax is no longer valid on Ruby 2.6 or higher.
+
+=== Examples
+
+[source,ruby]
+----
+# bad
+
+begin
+  do_something
+else
+  do_something_else # This will never be run.
+end
+----
+
+[source,ruby]
+----
+# good
+
+begin
+  do_something
+rescue
+  handle_errors
+else
+  do_something_else
+end
+----
+
 == Lint/UselessMethodDefinition
 
 |===


### PR DESCRIPTION
When running `rake update_cops_documentation`, this cop's docs keep being added.

The cop was removed in #10577, and after a fix for Ruby code parsing in RuboCop 1.29.1, was restored in #10697
But the docs were left out.

Please pardon my ignorance if the missing docs are filled in during the new version release process. I'm scratching my itch of getting rid of unrelated changes when I run `rake update_cops_documentation` when developing on a branch branched off of `master`.
Please don't hesitate to close this PR, as I can definitely live with `git checkout --patch`, and this is a temporary hiccup.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/