### PR TITLE
[#9760] Phase 1: Deprecate passing `range` as a kwarg in RangeHelp#range_with_surrounding_space

### DIFF
--- a/changelog/change_range_help_range_with_surrounding_space_to_warn_on_kwarg_range.md
+++ b/changelog/change_range_help_range_with_surrounding_space_to_warn_on_kwarg_range.md
@@ -1,0 +1,1 @@
+* [#9760](https://github.com/rubocop/rubocop/issues/9760): (Deprecation) Change RangeHelp#range_with_surrounding_space to output a deprecation warning when passing the range as a kwarg. ([@pirj][])

--- a/lib/rubocop/cop/correctors/multiline_literal_brace_corrector.rb
+++ b/lib/rubocop/cop/correctors/multiline_literal_brace_corrector.rb
@@ -41,7 +41,7 @@ module RuboCop
       end
 
       def correct_next_line_brace(corrector)
-        corrector.remove(range_with_surrounding_space(range: node.loc.end, side: :left))
+        corrector.remove(range_with_surrounding_space(node.loc.end, side: :left))
 
         corrector.insert_before(
           last_element_range_with_trailing_comma(node).end,
@@ -51,7 +51,7 @@ module RuboCop
 
       def content_if_comment_present(corrector, node)
         range = range_with_surrounding_space(
-          range: children(node).last.source_range,
+          children(node).last.source_range,
           side: :right
         ).end.resize(1)
         if range.source == '#'
@@ -86,7 +86,7 @@ module RuboCop
 
       def last_element_trailing_comma_range(node)
         range = range_with_surrounding_space(
-          range: children(node).last.source_range,
+          children(node).last.source_range,
           side: :right
         ).end.resize(1)
 

--- a/lib/rubocop/cop/correctors/unused_arg_corrector.rb
+++ b/lib/rubocop/cop/correctors/unused_arg_corrector.rb
@@ -29,7 +29,7 @@ module RuboCop
         end
 
         def correct_for_blockarg_type(corrector, node)
-          range = range_with_surrounding_space(range: node.source_range, side: :left)
+          range = range_with_surrounding_space(node.source_range, side: :left)
           range = range_with_surrounding_comma(range, :left)
 
           corrector.remove(range)

--- a/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
+++ b/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
@@ -99,11 +99,7 @@ module RuboCop
           # If the pattern matcher uses arguments (`%1`, `%2`, etc.), include them in the directive
           arguments = pattern_arguments(node.arguments[1].source)
 
-          range = range_with_surrounding_space(
-            range: node.loc.expression,
-            side: :left,
-            newlines: false
-          )
+          range = range_with_surrounding_space(node.loc.expression, side: :left, newlines: false)
           indentation = range.source.match(/^\s*/)[0]
           directive = "#{indentation}# @!method #{actual_name}(#{arguments.join(', ')})\n"
           directive = "\n#{directive}" if add_newline?(node)

--- a/lib/rubocop/cop/internal_affairs/redundant_location_argument.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_location_argument.rb
@@ -43,7 +43,7 @@ module RuboCop
         private
 
         def offending_range(node)
-          with_space = range_with_surrounding_space(range: node.loc.expression)
+          with_space = range_with_surrounding_space(node.loc.expression)
 
           range_with_surrounding_comma(with_space, :left)
         end

--- a/lib/rubocop/cop/internal_affairs/redundant_message_argument.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_message_argument.rb
@@ -56,7 +56,7 @@ module RuboCop
         private
 
         def offending_range(node)
-          with_space = range_with_surrounding_space(range: node.loc.expression)
+          with_space = range_with_surrounding_space(node.loc.expression)
 
           range_with_surrounding_comma(with_space, :left)
         end

--- a/lib/rubocop/cop/layout/empty_comment.rb
+++ b/lib/rubocop/cop/layout/empty_comment.rb
@@ -97,7 +97,7 @@ module RuboCop
         def autocorrect(corrector, node)
           previous_token = previous_token(node)
           range = if previous_token && same_line?(node, previous_token)
-                    range_with_surrounding_space(range: node.loc.expression, newlines: false)
+                    range_with_surrounding_space(node.loc.expression, newlines: false)
                   else
                     range_by_whole_lines(node.loc.expression, include_final_newline: true)
                   end

--- a/lib/rubocop/cop/layout/initial_indentation.rb
+++ b/lib/rubocop/cop/layout/initial_indentation.rb
@@ -41,7 +41,7 @@ module RuboCop
           return unless token
           return if token.column.zero?
 
-          space_range = range_with_surrounding_space(range: token.pos, side: :left, newlines: false)
+          space_range = range_with_surrounding_space(token.pos, side: :left, newlines: false)
           # If the file starts with a byte order mark (BOM), the column can be
           # non-zero, but then we find out here if there's no space to the left
           # of the first token.

--- a/lib/rubocop/cop/layout/multiline_block_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_block_layout.rb
@@ -117,7 +117,7 @@ module RuboCop
 
         def autocorrect_arguments(corrector, node)
           end_pos = range_with_surrounding_space(
-            range: node.arguments.source_range,
+            node.arguments.source_range,
             side: :right,
             newlines: false
           ).end_pos

--- a/lib/rubocop/cop/layout/space_around_block_parameters.rb
+++ b/lib/rubocop/cop/layout/space_around_block_parameters.rb
@@ -127,7 +127,7 @@ module RuboCop
 
           expr = arg.source_range
           check_no_space(
-            range_with_surrounding_space(range: expr, side: :left).begin_pos,
+            range_with_surrounding_space(expr, side: :left).begin_pos,
             expr.begin_pos - 1,
             'Extra space before'
           )

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -161,7 +161,7 @@ module RuboCop
         end
 
         def check_operator(type, operator, right_operand)
-          with_space = range_with_surrounding_space(range: operator)
+          with_space = range_with_surrounding_space(operator)
           return if with_space.source.start_with?("\n")
 
           offense(type, operator, with_space, right_operand) do |msg|

--- a/lib/rubocop/cop/layout/space_before_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_before_block_braces.rb
@@ -65,7 +65,7 @@ module RuboCop
           return if conflict_with_block_delimiters?(node)
 
           left_brace = node.loc.begin
-          space_plus_brace = range_with_surrounding_space(range: left_brace)
+          space_plus_brace = range_with_surrounding_space(left_brace)
           used_style =
             space_plus_brace.source.start_with?('{') ? :no_space : :space
 

--- a/lib/rubocop/cop/layout/space_before_first_arg.rb
+++ b/lib/rubocop/cop/layout/space_before_first_arg.rb
@@ -36,7 +36,7 @@ module RuboCop
           return unless regular_method_call_with_arguments?(node)
 
           first_arg = node.first_argument.source_range
-          first_arg_with_space = range_with_surrounding_space(range: first_arg, side: :left)
+          first_arg_with_space = range_with_surrounding_space(first_arg, side: :left)
           space = range_between(first_arg_with_space.begin_pos, first_arg.begin_pos)
           return if space.length == 1
           return unless expect_params_after_method_name?(node)

--- a/lib/rubocop/cop/layout/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_block_braces.rb
@@ -185,7 +185,7 @@ module RuboCop
                       'Space between { and | detected.')
             end
           else
-            brace_with_space = range_with_surrounding_space(range: left_brace, side: :right)
+            brace_with_space = range_with_surrounding_space(left_brace, side: :right)
             space(brace_with_space.begin_pos + 1, brace_with_space.end_pos,
                   'Space inside { detected.')
           end
@@ -196,7 +196,7 @@ module RuboCop
         end
 
         def space_inside_right_brace(right_brace)
-          brace_with_space = range_with_surrounding_space(range: right_brace, side: :left)
+          brace_with_space = range_with_surrounding_space(right_brace, side: :left)
           space(brace_with_space.begin_pos, brace_with_space.end_pos - 1,
                 'Space inside } detected.')
         end

--- a/lib/rubocop/cop/layout/trailing_whitespace.rb
+++ b/lib/rubocop/cop/layout/trailing_whitespace.rb
@@ -89,7 +89,7 @@ module RuboCop
         end
 
         def whitespace_only?(range)
-          source = range_with_surrounding_space(range: range).source
+          source = range_with_surrounding_space(range).source
           source.start_with?("\n") && source.end_with?("\n")
         end
 

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -71,16 +71,16 @@ module RuboCop
              processed_source.comment_config.comment_only_line?(directive_comment_range.line) &&
              directive_comment_range.begin_pos == line_comment_range.begin_pos
             # When the previous line is blank, it should be retained
-            range_with_surrounding_space(range: directive_comment_range, side: :right)
+            range_with_surrounding_space(directive_comment_range, side: :right)
           else
             # Eat the entire comment, the preceding space, and the preceding
             # newline if there is one.
             original_begin = directive_comment_range.begin_pos
             range = range_with_surrounding_space(
-              range: directive_comment_range, side: :left, newlines: true
+              directive_comment_range, side: :left, newlines: true
             )
 
-            range_with_surrounding_space(range: range,
+            range_with_surrounding_space(range,
                                          side: :right,
                                          # Special for a comment that
                                          # begins the file: remove
@@ -94,13 +94,13 @@ module RuboCop
           # is NOT being removed?
           if ends_its_line?(ranges.last) && trailing_range?(ranges, range)
             # Eat the comma on the left.
-            range = range_with_surrounding_space(range: range, side: :left)
+            range = range_with_surrounding_space(range, side: :left)
             range = range_with_surrounding_comma(range, :left)
           end
 
           range = range_with_surrounding_comma(range, :right)
           # Eat following spaces up to EOL, but not the newline itself.
-          range_with_surrounding_space(range: range, side: :right, newlines: false)
+          range_with_surrounding_space(range, side: :right, newlines: false)
         end
 
         def each_redundant_disable(&block)

--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -60,7 +60,7 @@ module RuboCop
               message: format(MSG, cop: all_or_name(name))
             ) do |corrector|
               if directive.match?(cop_names)
-                corrector.remove(range_with_surrounding_space(range: directive.range, side: :right))
+                corrector.remove(range_with_surrounding_space(directive.range, side: :right))
               else
                 corrector.remove(range_with_comma(comment, name))
               end

--- a/lib/rubocop/cop/lint/redundant_require_statement.rb
+++ b/lib/rubocop/cop/lint/redundant_require_statement.rb
@@ -41,7 +41,7 @@ module RuboCop
           return unless unnecessary_require_statement?(node)
 
           add_offense(node) do |corrector|
-            range = range_with_surrounding_space(range: node.loc.expression, side: :right)
+            range = range_with_surrounding_space(node.loc.expression, side: :right)
 
             corrector.remove(range)
           end

--- a/lib/rubocop/cop/lint/trailing_comma_in_attribute_declaration.rb
+++ b/lib/rubocop/cop/lint/trailing_comma_in_attribute_declaration.rb
@@ -45,7 +45,7 @@ module RuboCop
 
         def trailing_comma_range(node)
           range_with_surrounding_space(
-            range: node.arguments[-2].source_range,
+            node.arguments[-2].source_range,
             side: :right
           ).end.resize(1)
         end

--- a/lib/rubocop/cop/mixin/range_help.rb
+++ b/lib/rubocop/cop/mixin/range_help.rb
@@ -51,9 +51,18 @@ module RuboCop
         Parser::Source::Range.new(buffer, begin_pos, end_pos)
       end
 
-      def range_with_surrounding_space(range:, side: :both,
-                                       newlines: true, whitespace: false,
-                                       continuations: false)
+      NOT_GIVEN = Module.new
+      def range_with_surrounding_space(range_positional = NOT_GIVEN, # rubocop:disable Metrics/ParameterLists
+                                       range: NOT_GIVEN, side: :both, newlines: true,
+                                       whitespace: false, continuations: false)
+        unless range == NOT_GIVEN
+          warn <<~WARNING
+            Passing `range` as a keyword argument is deprecated, and will be removed in RuboCop 2.0. Pass the range as the first positional argument instead.
+          WARNING
+        end
+
+        range = range_positional unless range_positional == NOT_GIVEN
+
         buffer = @processed_source.buffer
         src = buffer.source
 

--- a/lib/rubocop/cop/style/accessor_grouping.rb
+++ b/lib/rubocop/cop/style/accessor_grouping.rb
@@ -72,7 +72,7 @@ module RuboCop
           if (preferred_accessors = preferred_accessors(node))
             corrector.replace(node, preferred_accessors)
           else
-            range = range_with_surrounding_space(range: node.loc.expression, side: :left)
+            range = range_with_surrounding_space(node.loc.expression, side: :left)
             corrector.remove(range)
           end
         end

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -133,7 +133,7 @@ module RuboCop
         def register_offense_to_method_definition_arguments(method_definition)
           add_offense(arguments_range(method_definition)) do |corrector|
             arguments_range = range_with_surrounding_space(
-              range: method_definition.arguments.source_range, side: :left
+              method_definition.arguments.source_range, side: :left
             )
             corrector.replace(arguments_range, '(...)')
           end

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -281,7 +281,7 @@ module RuboCop
         def move_comment_before_block(corrector, comment, block_node, closing_brace)
           range = block_node.chained? ? end_of_chain(block_node.parent).source_range : closing_brace
           comment_range = range_between(range.end_pos, comment.loc.expression.end_pos)
-          corrector.remove(range_with_surrounding_space(range: comment_range, side: :right))
+          corrector.remove(range_with_surrounding_space(comment_range, side: :right))
           corrector.insert_after(range, "\n")
 
           corrector.insert_before(block_node, "#{comment.text}\n")

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -66,7 +66,7 @@ module RuboCop
 
         def register_offense(comment, matched_keyword)
           add_offense(comment, message: format(MSG, keyword: matched_keyword)) do |corrector|
-            range = range_with_surrounding_space(range: comment.loc.expression, newlines: false)
+            range = range_with_surrounding_space(comment.loc.expression, newlines: false)
             corrector.remove(range)
 
             unless matched_keyword == 'end'

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -51,7 +51,7 @@ module RuboCop
             text = comment.without(:encoding)
 
             if text.blank?
-              corrector.remove(range_with_surrounding_space(range: range, side: :right))
+              corrector.remove(range_with_surrounding_space(range, side: :right))
             else
               corrector.replace(range, text)
             end

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -182,7 +182,7 @@ module RuboCop
         end
 
         def remove_comment(corrector, node)
-          corrector.remove(range_with_surrounding_space(range: node.pos, side: :right))
+          corrector.remove(range_with_surrounding_space(node.pos, side: :right))
         end
 
         def enable_comment(corrector)

--- a/lib/rubocop/cop/style/hash_as_last_array_item.rb
+++ b/lib/rubocop/cop/style/hash_as_last_array_item.rb
@@ -87,7 +87,7 @@ module RuboCop
 
         def remove_last_element_trailing_comma(corrector, node)
           range = range_with_surrounding_space(
-            range: node.children.last.source_range,
+            node.children.last.source_range,
             side: :right
           ).end.resize(1)
 

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -223,7 +223,7 @@ module RuboCop
           operator = pair_node.loc.operator
 
           range = key.join(operator)
-          range_with_surrounding_space(range: range, side: :right)
+          range_with_surrounding_space(range, side: :right)
         end
 
         def argument_without_space?(node)
@@ -235,7 +235,7 @@ module RuboCop
 
           key_with_hash_rocket = ":#{pair_node.key.source}#{pair_node.inverse_delimiter(true)}"
           corrector.replace(pair_node.key, key_with_hash_rocket)
-          corrector.remove(range_with_surrounding_space(range: op))
+          corrector.remove(range_with_surrounding_space(op))
         end
 
         def autocorrect_no_mixed_keys(corrector, pair_node)

--- a/lib/rubocop/cop/style/keyword_parameters_order.rb
+++ b/lib/rubocop/cop/style/keyword_parameters_order.rb
@@ -65,7 +65,7 @@ module RuboCop
 
         def remove_kwargs(kwarg_nodes, corrector)
           kwarg_nodes.each do |kwarg|
-            with_space = range_with_surrounding_space(range: kwarg.source_range)
+            with_space = range_with_surrounding_space(kwarg.source_range)
             corrector.remove(range_with_surrounding_comma(with_space, :left))
           end
         end

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -70,7 +70,7 @@ module RuboCop
 
         def autocorrect(corrector, operator_range)
           # Include any trailing whitespace so we don't create a syntax error.
-          operator_range = range_with_surrounding_space(range: operator_range,
+          operator_range = range_with_surrounding_space(operator_range,
                                                         side: :right,
                                                         newlines: false)
           one_more_char = operator_range.resize(operator_range.size + 1)

--- a/lib/rubocop/cop/style/map_to_hash.rb
+++ b/lib/rubocop/cop/style/map_to_hash.rb
@@ -59,7 +59,7 @@ module RuboCop
         def autocorrect(corrector, to_h, map)
           removal_range = range_between(to_h.loc.dot.begin_pos, to_h.loc.selector.end_pos)
 
-          corrector.remove(range_with_surrounding_space(range: removal_range, side: :left))
+          corrector.remove(range_with_surrounding_space(removal_range, side: :left))
           corrector.replace(map.loc.selector, 'to_h')
         end
       end

--- a/lib/rubocop/cop/style/multiline_if_then.rb
+++ b/lib/rubocop/cop/style/multiline_if_then.rb
@@ -29,7 +29,7 @@ module RuboCop
           return unless non_modifier_then?(node)
 
           add_offense(node.loc.begin, message: format(MSG, keyword: node.keyword)) do |corrector|
-            corrector.remove(range_with_surrounding_space(range: node.loc.begin, side: :left))
+            corrector.remove(range_with_surrounding_space(node.loc.begin, side: :left))
           end
         end
 

--- a/lib/rubocop/cop/style/multiline_in_pattern_then.rb
+++ b/lib/rubocop/cop/style/multiline_in_pattern_then.rb
@@ -41,9 +41,7 @@ module RuboCop
 
           range = node.loc.begin
           add_offense(range) do |corrector|
-            corrector.remove(
-              range_with_surrounding_space(range: range, side: :left, newlines: false)
-            )
+            corrector.remove(range_with_surrounding_space(range, side: :left, newlines: false))
           end
         end
 

--- a/lib/rubocop/cop/style/multiline_method_signature.rb
+++ b/lib/rubocop/cop/style/multiline_method_signature.rb
@@ -59,7 +59,7 @@ module RuboCop
             node.first_argument.source_range.begin_pos, node.last_argument.source_range.end_pos
           )
 
-          range_with_surrounding_space(range: range, side: :left)
+          range_with_surrounding_space(range, side: :left)
         end
 
         def opening_line(node)

--- a/lib/rubocop/cop/style/multiline_when_then.rb
+++ b/lib/rubocop/cop/style/multiline_when_then.rb
@@ -39,9 +39,7 @@ module RuboCop
 
           range = node.loc.begin
           add_offense(range) do |corrector|
-            corrector.remove(
-              range_with_surrounding_space(range: range, side: :left, newlines: false)
-            )
+            corrector.remove(range_with_surrounding_space(range, side: :left, newlines: false))
           end
         end
 

--- a/lib/rubocop/cop/style/nested_parenthesized_calls.rb
+++ b/lib/rubocop/cop/style/nested_parenthesized_calls.rb
@@ -44,7 +44,7 @@ module RuboCop
           last_arg = nested.last_argument.source_range
 
           leading_space =
-            range_with_surrounding_space(range: first_arg.begin,
+            range_with_surrounding_space(first_arg.begin,
                                          side: :left,
                                          whitespace: true,
                                          continuations: true)

--- a/lib/rubocop/cop/style/nil_lambda.rb
+++ b/lib/rubocop/cop/style/nil_lambda.rb
@@ -57,7 +57,7 @@ module RuboCop
 
         def autocorrect(corrector, node)
           range = if node.single_line?
-                    range_with_surrounding_space(range: node.body.loc.expression)
+                    range_with_surrounding_space(node.body.loc.expression)
                   else
                     range_by_whole_lines(node.body.loc.expression, include_final_newline: true)
                   end

--- a/lib/rubocop/cop/style/not.rb
+++ b/lib/rubocop/cop/style/not.rb
@@ -33,7 +33,7 @@ module RuboCop
           return unless node.prefix_not?
 
           add_offense(node.loc.selector) do |corrector|
-            range = range_with_surrounding_space(range: node.loc.selector, side: :right)
+            range = range_with_surrounding_space(node.loc.selector, side: :right)
 
             if opposite_method?(node.receiver)
               correct_opposite_method(corrector, range, node.receiver)

--- a/lib/rubocop/cop/style/redundant_argument.rb
+++ b/lib/rubocop/cop/style/redundant_argument.rb
@@ -86,7 +86,7 @@ module RuboCop
           if node.parenthesized?
             range_between(node.loc.begin.begin_pos, node.loc.end.end_pos)
           else
-            range_with_surrounding_space(range: node.first_argument.source_range, newlines: false)
+            range_with_surrounding_space(node.first_argument.source_range, newlines: false)
           end
         end
       end

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -76,7 +76,7 @@ module RuboCop
             corrector.replace(first_argument, first_argument.source.delete_prefix('*'))
           end
 
-          keyword = range_with_surrounding_space(range: return_node.loc.keyword, side: :right)
+          keyword = range_with_surrounding_space(return_node.loc.keyword, side: :right)
           corrector.remove(keyword)
         end
 

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -138,7 +138,7 @@ module RuboCop
           corrector.insert_after(outer_condition, "#{and_operator}#{replace_condition(condition)}")
 
           range = range_between(if_branch.loc.keyword.begin_pos, condition.source_range.end_pos)
-          corrector.remove(range_with_surrounding_space(range: range, newlines: false))
+          corrector.remove(range_with_surrounding_space(range, newlines: false))
           corrector.remove(if_branch.loc.keyword)
         end
 
@@ -157,7 +157,7 @@ module RuboCop
                                   "#{'!' if node.unless?}#{replace_condition(node.condition)} && ")
 
           corrector.remove(node.condition.loc.expression)
-          corrector.remove(range_with_surrounding_space(range: node.loc.keyword, newlines: false))
+          corrector.remove(range_with_surrounding_space(node.loc.keyword, newlines: false))
           corrector.replace(if_branch.loc.keyword, 'if')
         end
 

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -34,7 +34,7 @@ module RuboCop
           return unless struct_constructor?(node.parent_class)
 
           add_offense(node.parent_class.source_range) do |corrector|
-            corrector.remove(range_with_surrounding_space(range: node.loc.keyword, newlines: false))
+            corrector.remove(range_with_surrounding_space(node.loc.keyword, newlines: false))
             corrector.replace(node.loc.operator, '=')
 
             correct_parent(node.parent_class, corrector)
@@ -51,7 +51,7 @@ module RuboCop
 
         def correct_parent(parent, corrector)
           if parent.block_type?
-            corrector.remove(range_with_surrounding_space(range: parent.loc.end, newlines: false))
+            corrector.remove(range_with_surrounding_space(parent.loc.end, newlines: false))
           elsif (class_node = parent.parent).body.nil?
             corrector.remove(range_for_empty_class_body(class_node, parent))
           else

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -152,7 +152,7 @@ module RuboCop
 
         def block_range_with_space(node)
           block_range = range_between(begin_pos_for_replacement(node), node.loc.end.end_pos)
-          range_with_surrounding_space(range: block_range, side: :left)
+          range_with_surrounding_space(block_range, side: :left)
         end
 
         def begin_pos_for_replacement(node)

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -34,7 +34,7 @@ module RuboCop
       def add_parentheses(node, corrector)
         if node.args_type?
           arguments_range = node.source_range
-          args_with_space = range_with_surrounding_space(range: arguments_range, side: :left)
+          args_with_space = range_with_surrounding_space(arguments_range, side: :left)
           leading_space = range_between(args_with_space.begin_pos, arguments_range.begin_pos)
           corrector.replace(leading_space, '(')
           corrector.insert_after(arguments_range, ')')

--- a/spec/rubocop/cop/range_help_spec.rb
+++ b/spec/rubocop/cop/range_help_spec.rb
@@ -35,33 +35,65 @@ RSpec.describe RuboCop::Cop::RangeHelp do
   end
 
   describe 'source indicated by #range_with_surrounding_space' do
-    subject do
-      obj = TestRangeHelp.new
-      obj.instance_exec(processed_source) { |src| @processed_source = src }
-      r = obj.send(:range_with_surrounding_space, range: input_range, side: side)
-      processed_source.buffer.source[r.begin_pos...r.end_pos]
-    end
-
     let(:source) { 'f {  a(2) }' }
     let(:processed_source) { parse_source(source) }
     let(:input_range) { Parser::Source::Range.new(processed_source.buffer, 5, 9) }
+    let(:obj) { TestRangeHelp.new }
 
-    context 'when side is :both' do
-      let(:side) { :both }
-
-      it { is_expected.to eq('  a(2) ') }
+    before do
+      obj.instance_exec(processed_source) { |src| @processed_source = src }
     end
 
-    context 'when side is :left' do
-      let(:side) { :left }
+    shared_examples 'works with various `side`s' do
+      context 'when side is :both' do
+        let(:side) { :both }
 
-      it { is_expected.to eq('  a(2)') }
+        it { is_expected.to eq('  a(2) ') }
+      end
+
+      context 'when side is :left' do
+        let(:side) { :left }
+
+        it { is_expected.to eq('  a(2)') }
+      end
+
+      context 'when side is :right' do
+        let(:side) { :right }
+
+        it { is_expected.to eq('a(2) ') }
+      end
     end
 
-    context 'when side is :right' do
-      let(:side) { :right }
+    context 'when passing range as a kwarg' do
+      subject do
+        r = obj.send(:range_with_surrounding_space, range: input_range, side: side)
+        processed_source.buffer.source[r.begin_pos...r.end_pos]
+      end
 
-      it { is_expected.to eq('a(2) ') }
+      it 'outputs a deprecation message' do
+        expect { obj.__send__(:range_with_surrounding_space, range: input_range) }
+          .to output(/Passing `range` as a keyword argument is deprecated/).to_stderr
+      end
+
+      it_behaves_like 'works with various `side`s' do
+        require 'rspec/support/spec/with_isolated_stderr'
+        include RSpec::Support::WithIsolatedStdErr
+
+        around do |example|
+          with_isolated_stderr do
+            example.run
+          end
+        end
+      end
+    end
+
+    context 'when `range` is passed as a positional argument' do
+      subject do
+        r = obj.send(:range_with_surrounding_space, input_range, side: side)
+        processed_source.buffer.source[r.begin_pos...r.end_pos]
+      end
+
+      it_behaves_like 'works with various `side`s'
     end
   end
 


### PR DESCRIPTION
This is a prequel to #10727, deprecating passing the `range` as a kwarg with a deprecation message.
The method still accepts the range both as a kwarg and as the first positional argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/