### PR TITLE
Change output timing of GitHubActionsFormatter

### DIFF
--- a/changelog/change_change_output_timing_of.md
+++ b/changelog/change_change_output_timing_of.md
@@ -1,0 +1,1 @@
+* [#10730](https://github.com/rubocop/rubocop/pull/10730): Change output timing of GitHubActionsFormatter. ([@r7kamura][])

--- a/spec/rubocop/formatter/git_hub_actions_formatter_spec.rb
+++ b/spec/rubocop/formatter/git_hub_actions_formatter_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Formatter::GitHubActionsFormatter, :config do
   let(:cop_class) { RuboCop::Cop::Cop }
   let(:output) { StringIO.new }
 
-  describe '#file_finished' do
+  describe '#finished' do
     let(:file) { '/path/to/file' }
     let(:message) { 'This is a message.' }
     let(:status) { :uncorrected }
@@ -22,7 +22,11 @@ RSpec.describe RuboCop::Formatter::GitHubActionsFormatter, :config do
 
     let(:location) { source_range(0...1) }
 
-    before { formatter.file_finished(file, offenses) }
+    before do
+      formatter.started([file])
+      formatter.file_finished(file, offenses)
+      formatter.finished([file])
+    end
 
     context 'when offenses are detected' do
       it 'reports offenses as errors' do
@@ -43,7 +47,7 @@ RSpec.describe RuboCop::Formatter::GitHubActionsFormatter, :config do
       let(:offenses) { [] }
 
       it 'does not print anything' do
-        expect(output.string).to eq ''
+        expect(output.string).to eq "\n"
       end
     end
 


### PR DESCRIPTION
This pull request changes the output timing of GitHubActionsFormatter from `#file_finished` to `#finished`.

When workflow commands are used, file path and line number are hidden in the GitHub Action log. So, if we want to use github formatter and still be able to identify the problematic file info from the log, we need to use it with another formatter like `--format progress --format github`.

However, the output timing of the current github formatter is a bit inconveninent when used with the progress formatter like this:

```
$ bundle exec rubocop --format progress --format github
Inspecting 2 files
C
Error: Bundler/OrderedGems: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem `paper_trail` should appear before `foo`.
Error: Layout/TrailingEmptyLines: 1 trailing blank lines detected.
C
Error: Layout/LeadingCommentSpace: Missing space after `#`.
Error: Layout/TrailingEmptyLines: 1 trailing blank lines detected.
Offenses:
Gemfile:77:1: C: [Correctable] Bundler/OrderedGems: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem bar should appear before foo.
gem 'bar'
^^^^^^^^^
Gemfile:234:1: C: [Correctable] Layout/TrailingEmptyLines: 1 trailing blank lines detected.
config/application.rb:24:5: C: [Correctable] Layout/LeadingCommentSpace: Missing space after #.
    #FIXME: baz
    ^^^^^^^^^^^
config/application.rb:85:1: C: [Correctable] Layout/TrailingEmptyLines: 1 trailing blank lines detected.
```

After this pull request's change, the output will be:

```
$ docker-compose run --rm web bundle exec rubocop Gemfile config/application.rb  --format progress --format github
Starting builderpadjp_elasticsearch_1 ... done
Creating builderpadjp_web_run         ... done
Inspecting 2 files
CC

Offenses:

Gemfile:77:1: C: [Correctable] Bundler/OrderedGems: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem bar should appear before foo.
gem 'bar'
^^^^^^^^^
Gemfile:234:1: C: [Correctable] Layout/TrailingEmptyLines: 1 trailing blank lines detected.
config/application.rb:24:5: C: [Correctable] Layout/LeadingCommentSpace: Missing space after #.
    #FIXME: baz
    ^^^^^^^^^^^
config/application.rb:85:1: C: [Correctable] Layout/TrailingEmptyLines: 1 trailing blank lines detected.

2 files inspected, 4 offenses detected, 4 offenses autocorrectable

::error file=Gemfile,line=77,col=1::Bundler/OrderedGems: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem `bar` should appear before `foo`.
::error file=Gemfile,line=234,col=1::Layout/TrailingEmptyLines: 1 trailing blank lines detected.
::error file=config/application.rb,line=24,col=5::Layout/LeadingCommentSpace: Missing space after `#`.
::error file=config/application.rb,line=85,col=1::Layout/TrailingEmptyLines: 1 trailing blank lines detected.
ERROR: 1
```

Since github formatter is mainly for machine use, I think it won't matter if the output timing changes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
