### PR TITLE
Support auto-restart RuboCop server

### DIFF
--- a/docs/modules/ROOT/pages/usage/server.adoc
+++ b/docs/modules/ROOT/pages/usage/server.adoc
@@ -49,6 +49,14 @@ user             16060   0.0  0.0  5078568   2264   ??  S     7:54AM   0:00.00 r
 user             16337   0.0  0.0  5331560   2396   ??  S    23:51PM   0:00.00 rubocop --server /Users/user/src/github.com/rubocop/rubocop-rails
 ```
 
+When you update and run `rubocop`, the server process will restart automatically.
+
+```console
+% rubocop --server
+RuboCop version incompatibility found, RuboCop server restarting...
+RuboCop server starting on 127.0.0.1:60665.
+```
+
 == Restart Server
 
 The started server does not reload the configuration file.

--- a/lib/rubocop/server/cache.rb
+++ b/lib/rubocop/server/cache.rb
@@ -64,6 +64,10 @@ module RuboCop
           dir.join('status')
         end
 
+        def version_path
+          dir.join('version')
+        end
+
         def pid_running?
           Process.kill(0, pid_path.read.to_i) == 1
         rescue Errno::ESRCH
@@ -94,6 +98,10 @@ module RuboCop
 
         def write_status_file(status)
           status_path.write(status)
+        end
+
+        def write_version_file(version)
+          version_path.write(version)
         end
       end
     end

--- a/lib/rubocop/server/client_command.rb
+++ b/lib/rubocop/server/client_command.rb
@@ -10,6 +10,8 @@
 # https://github.com/fohte/rubocop-daemon/blob/master/LICENSE.txt
 #
 module RuboCop
+  autoload :Version, 'rubocop/version'
+
   module Server
     # @api private
     module ClientCommand

--- a/lib/rubocop/server/client_command/base.rb
+++ b/lib/rubocop/server/client_command/base.rb
@@ -38,12 +38,6 @@ module RuboCop
             warn 'RuboCop server is not running.' unless running
           end
         end
-
-        def ensure_server!
-          return if check_running_server
-
-          ClientCommand::Start.new([]).run
-        end
       end
     end
   end

--- a/lib/rubocop/server/client_command/exec.rb
+++ b/lib/rubocop/server/client_command/exec.rb
@@ -28,6 +28,21 @@ module RuboCop
 
         private
 
+        def ensure_server!
+          if incompatible_version?
+            puts 'RuboCop version incompatibility found, RuboCop server restarting...'
+            ClientCommand::Stop.new.run
+          elsif check_running_server
+            return
+          end
+
+          ClientCommand::Start.new.run
+        end
+
+        def incompatible_version?
+          RuboCop::Version::STRING != Cache.version_path.read
+        end
+
         def status
           unless Cache.status_path.file?
             raise "RuboCop server: Could not find status file at: #{Cache.status_path}"

--- a/lib/rubocop/server/client_command/start.rb
+++ b/lib/rubocop/server/client_command/start.rb
@@ -29,10 +29,12 @@ module RuboCop
               exit 0
             end
 
-            Server::Core.new.start(
-              ENV.fetch('RUBOCOP_SERVER_HOST', '127.0.0.1'),
-              ENV.fetch('RUBOCOP_SERVER_PORT', 0)
-            )
+            Cache.write_version_file(RuboCop::Version::STRING)
+
+            host = ENV.fetch('RUBOCOP_SERVER_HOST', '127.0.0.1')
+            port = ENV.fetch('RUBOCOP_SERVER_PORT', 0)
+
+            Server::Core.new.start(host, port)
           end
         end
       end

--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RSpec/DescribeClass
+  let(:rubocop) { "#{RuboCop::ConfigLoader::RUBOCOP_HOME}/exe/rubocop" }
+
+  include_context 'cli spec behavior'
+
+  if RuboCop::Server.support_server?
+    context 'when using `--server` option after updating RuboCop' do
+      before do
+        options = '--server --only Style/FrozenStringLiteralComment,Style/StringLiterals'
+        `ruby -I . "#{rubocop}" #{options}`
+
+        # Emulating RuboCop updates. `0.99.9` is a version value for testing that
+        # will never be used in the real world RuboCop version.
+        RuboCop::Server::Cache.write_version_file('0.99.9')
+      end
+
+      after do
+        `ruby -I . "#{rubocop}" --stop-server`
+      end
+
+      it 'displays a restart information message' do
+        create_file('example.rb', <<~RUBY)
+          # frozen_string_literal: true
+
+          x = 0
+          puts x
+        RUBY
+        options = '--server --only Style/FrozenStringLiteralComment,Style/StringLiterals'
+        expect(`ruby -I . "#{rubocop}" #{options}`).to start_with(
+          'RuboCop version incompatibility found, RuboCop server restarting...'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR supports auto-restart RuboCop server when updating RuboCop.

First, cache RuboCop version when the RuboCop server starts.
And, auto-restarts when the runtime (client) RuboCop version does not match the cached RuboCop version.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
