### PR TITLE
Reduce unused `require_relative` for formatters

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -668,30 +668,7 @@ require_relative 'rubocop/cop/security/open'
 require_relative 'rubocop/cop/security/yaml_load'
 
 require_relative 'rubocop/cop/team'
-
-require_relative 'rubocop/formatter/base_formatter'
-require_relative 'rubocop/formatter/simple_text_formatter'
-# relies on simple text
-require_relative 'rubocop/formatter/clang_style_formatter'
-require_relative 'rubocop/formatter/disabled_config_formatter'
-require_relative 'rubocop/formatter/emacs_style_formatter'
-require_relative 'rubocop/formatter/file_list_formatter'
-require_relative 'rubocop/formatter/fuubar_style_formatter'
-require_relative 'rubocop/formatter/git_hub_actions_formatter'
-require_relative 'rubocop/formatter/html_formatter'
-require_relative 'rubocop/formatter/json_formatter'
-require_relative 'rubocop/formatter/junit_formatter'
-require_relative 'rubocop/formatter/markdown_formatter'
-require_relative 'rubocop/formatter/offense_count_formatter'
-require_relative 'rubocop/formatter/progress_formatter'
-require_relative 'rubocop/formatter/quiet_formatter'
-require_relative 'rubocop/formatter/tap_formatter'
-require_relative 'rubocop/formatter/worst_offenders_formatter'
-require_relative 'rubocop/formatter/pacman_formatter'
-# relies on progress formatter
-require_relative 'rubocop/formatter/auto_gen_config_formatter'
-
-require_relative 'rubocop/formatter/formatter_set'
+require_relative 'rubocop/formatter'
 
 require_relative 'rubocop/cached_data'
 require_relative 'rubocop/config'

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'erb'
 require 'yaml'
 require 'pathname'
 

--- a/lib/rubocop/formatter.rb
+++ b/lib/rubocop/formatter.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Formatter
+    autoload :BaseFormatter, 'rubocop/formatter/base_formatter'
+    autoload :SimpleTextFormatter, 'rubocop/formatter/simple_text_formatter'
+    # relies on simple text
+    autoload :ClangStyleFormatter, 'rubocop/formatter/clang_style_formatter'
+    autoload :DisabledConfigFormatter, 'rubocop/formatter/disabled_config_formatter'
+    autoload :EmacsStyleFormatter, 'rubocop/formatter/emacs_style_formatter'
+    autoload :FileListFormatter, 'rubocop/formatter/file_list_formatter'
+    autoload :FuubarStyleFormatter, 'rubocop/formatter/fuubar_style_formatter'
+    autoload :GitHubActionsFormatter, 'rubocop/formatter/git_hub_actions_formatter'
+    autoload :HTMLFormatter, 'rubocop/formatter/html_formatter'
+    autoload :JSONFormatter, 'rubocop/formatter/json_formatter'
+    autoload :JUnitFormatter, 'rubocop/formatter/junit_formatter'
+    autoload :MarkdownFormatter, 'rubocop/formatter/markdown_formatter'
+    autoload :OffenseCountFormatter, 'rubocop/formatter/offense_count_formatter'
+    autoload :ProgressFormatter, 'rubocop/formatter/progress_formatter'
+    autoload :QuietFormatter, 'rubocop/formatter/quiet_formatter'
+    autoload :TapFormatter, 'rubocop/formatter/tap_formatter'
+    autoload :WorstOffendersFormatter, 'rubocop/formatter/worst_offenders_formatter'
+    autoload :PacmanFormatter, 'rubocop/formatter/pacman_formatter'
+    # relies on progress formatter
+    autoload :AutoGenConfigFormatter, 'rubocop/formatter/auto_gen_config_formatter'
+    autoload :Colorizable, 'rubocop/formatter/colorizable'
+
+    require_relative 'formatter/formatter_set'
+    require_relative 'formatter/text_util'
+  end
+end

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -9,23 +9,23 @@ module RuboCop
     # which invoke same method of each formatters.
     class FormatterSet < Array
       BUILTIN_FORMATTERS_FOR_KEYS = {
-        '[a]utogenconf' => AutoGenConfigFormatter,
-        '[c]lang'       => ClangStyleFormatter,
-        '[e]macs'       => EmacsStyleFormatter,
-        '[fi]les'       => FileListFormatter,
-        '[fu]ubar'      => FuubarStyleFormatter,
-        '[g]ithub'      => GitHubActionsFormatter,
-        '[h]tml'        => HTMLFormatter,
-        '[j]son'        => JSONFormatter,
-        '[ju]nit'       => JUnitFormatter,
-        '[m]arkdown'    => MarkdownFormatter,
-        '[o]ffenses'    => OffenseCountFormatter,
-        '[pa]cman'      => PacmanFormatter,
-        '[p]rogress'    => ProgressFormatter,
-        '[q]uiet'       => QuietFormatter,
-        '[s]imple'      => SimpleTextFormatter,
-        '[t]ap'         => TapFormatter,
-        '[w]orst'       => WorstOffendersFormatter
+        '[a]utogenconf' => 'AutoGenConfigFormatter',
+        '[c]lang'       => 'ClangStyleFormatter',
+        '[e]macs'       => 'EmacsStyleFormatter',
+        '[fi]les'       => 'FileListFormatter',
+        '[fu]ubar'      => 'FuubarStyleFormatter',
+        '[g]ithub'      => 'GitHubActionsFormatter',
+        '[h]tml'        => 'HTMLFormatter',
+        '[j]son'        => 'JSONFormatter',
+        '[ju]nit'       => 'JUnitFormatter',
+        '[m]arkdown'    => 'MarkdownFormatter',
+        '[o]ffenses'    => 'OffenseCountFormatter',
+        '[pa]cman'      => 'PacmanFormatter',
+        '[p]rogress'    => 'ProgressFormatter',
+        '[q]uiet'       => 'QuietFormatter',
+        '[s]imple'      => 'SimpleTextFormatter',
+        '[t]ap'         => 'TapFormatter',
+        '[w]orst'       => 'WorstOffendersFormatter'
       }.freeze
 
       FORMATTER_APIS = %i[started finished].freeze
@@ -92,7 +92,8 @@ module RuboCop
 
         raise %(Cannot determine formatter for "#{specified_key}") if matching_keys.size > 1
 
-        BUILTIN_FORMATTERS_FOR_KEYS[matching_keys.first]
+        formatter_name = BUILTIN_FORMATTERS_FOR_KEYS[matching_keys.first]
+        RuboCop::Formatter.const_get(formatter_name)
       end
 
       def custom_formatter_class(specified_class_name)

--- a/lib/rubocop/formatter/html_formatter.rb
+++ b/lib/rubocop/formatter/html_formatter.rb
@@ -4,7 +4,6 @@ require 'cgi'
 require 'erb'
 require 'ostruct'
 require 'base64'
-require_relative 'text_util'
 
 module RuboCop
   module Formatter

--- a/lib/rubocop/formatter/offense_count_formatter.rb
+++ b/lib/rubocop/formatter/offense_count_formatter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ruby-progressbar'
+
 module RuboCop
   module Formatter
     # This formatter displays the list of offended cops with a count of how

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'colorizable'
-require_relative 'text_util'
-
 module RuboCop
   module Formatter
     # A basic formatter that displays only files with offenses.


### PR DESCRIPTION
Normally, only one formatter is used at the `rubocop` run time,  so not all  formatters need to be required.
No dramatic performance improvements have been made, but waste can be reduced.

`rubocop/formatter/formatter_set` is not a selective module, it keeps using `require_relative`.
Also `rubocop/formatter/text_util` is used as a common util, it uses `require_relative`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
