### PR TITLE
Fix Layout/SpaceInsideBlockBraces for blocks with numbered arguments

### DIFF
--- a/changelog/fix_space_inside_block_braces_with_numbered_arguments.md
+++ b/changelog/fix_space_inside_block_braces_with_numbered_arguments.md
@@ -1,0 +1,1 @@
+* [#10736](https://github.com/rubocop/rubocop/pull/10736): Fix Layout/SpaceInsideBlockBraces for blocks with numbered arguments. ([@gsamokovarov][])

--- a/lib/rubocop/cop/layout/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_block_braces.rb
@@ -98,6 +98,8 @@ module RuboCop
           check_inside(node, left_brace, right_brace)
         end
 
+        alias on_numblock on_block
+
         private
 
         def check_inside(node, left_brace, right_brace)
@@ -126,7 +128,7 @@ module RuboCop
         end
 
         def braces_with_contents_inside(node, inner)
-          args_delimiter = node.arguments.loc.begin # Can be ( | or nil.
+          args_delimiter = node.arguments.loc.begin if node.block_type? # Can be ( | or nil.
 
           check_left_brace(inner, node.loc.begin, args_delimiter)
           check_right_brace(inner, node.loc.begin, node.loc.end, node.single_line?)

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -90,6 +90,20 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
   end
 
+  context 'Ruby >= 2.7', :ruby27 do
+    it 'registers an offense for numblocks without inner space' do
+      expect_offense(<<~RUBY)
+        [1, 2, 3].each {_1 * 2}
+                        ^ Space missing inside {.
+                              ^ Space missing inside }.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3].each { _1 * 2 }
+      RUBY
+    end
+  end
+
   it 'accepts braces surrounded by spaces' do
     expect_no_offenses('each { puts }')
   end


### PR DESCRIPTION
The `Layout/SpaceInsideBlockBraces` was not being applied for blocks with
numbered arguments as they have AST node type of `numblock` and the cop
only ran for `block` nodes.

At Dext we caught spacing errors during code review and wandered why the
cop didn't run at all. The piece of code was in the lines of:

```ruby
Tax.where(condition).partition {_1.by_something}
```

Not running `Layout/SpaceInsideBlockBraces` for `numblock` nodes was the
cause.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
