### PR TITLE
[Fix #10737] Fix crash in `Style/ConditionalAssignment` with `EnforcedStyle: assign_inside_condition` when op-assigning a variable inside a `resbody`

### DIFF
--- a/changelog/fix_fix_crash_in_styleconditionalassignment.md
+++ b/changelog/fix_fix_crash_in_styleconditionalassignment.md
@@ -1,0 +1,1 @@
+* [#10737](https://github.com/rubocop/rubocop/issues/10737): Fix crash in `Style/ConditionalAssignment` with `EnforcedStyle: assign_inside_condition` when op-assigning a variable inside a `resbody`. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -237,6 +237,7 @@ module RuboCop
         ASSIGNMENT_TYPES.each do |type|
           define_method "on_#{type}" do |node|
             return if part_of_ignored_node?(node)
+            return if node.parent&.shorthand_asgn?
 
             check_assignment_to_condition(node)
           end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -242,6 +242,16 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
         end
       RUBY
     end
+
+    it 'does not crash when used inside rescue' do
+      expect_no_offenses(<<~RUBY)
+        begin
+          bar #{assignment} 2
+        rescue
+          bar #{assignment} 1
+        end
+      RUBY
+    end
   end
 
   shared_examples 'multiline all variable types offense' do |variable|


### PR DESCRIPTION
Because this cop adds node handlers for all the assignment types, but an `op-asgn` node contains an `lvasgn`, the `assignment_node` method was crashing with:

```
undefined method `begin_type?' for :bar:Symbol

          assignment, = *assignment if assignment.begin_type? && assignment.children.one?
                                                 ^^^^^^^^^^^^
```

This change ignores assignments inside `op-asgn`, `or_asgn` and `and_asgn` nodes, as they will have already been covered by the relevant `on_*` method.

Fixes #10737.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
