### PR TITLE
[Fix #10734] Handle `ClobberingError` in `Style/NestedTernaryOperator` when there are multiple nested ternaries

### DIFF
--- a/changelog/fix_handle_clobberingerror_in.md
+++ b/changelog/fix_handle_clobberingerror_in.md
@@ -1,0 +1,1 @@
+* [#10734](https://github.com/rubocop/rubocop/issues/10734): Handle `ClobberingError` in `Style/NestedTernaryOperator` when there are multiple nested ternaries. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe RuboCop::Cop::Style::NestedTernaryOperator, :config do
 
     expect_correction(<<~RUBY)
       if a
-        b ? b1 : b2
+      b ? b1 : b2
       else
-        a2
+      a2
       end
     RUBY
   end
@@ -25,9 +25,9 @@ RSpec.describe RuboCop::Cop::Style::NestedTernaryOperator, :config do
 
     expect_correction(<<~RUBY)
       if cond
-        foo
+      foo
       else
-        bar(foo.a ? foo.b : foo) { |e, k| e.nil? ? nil : e[k] }
+      bar(foo.a ? foo.b : foo) { |e, k| e.nil? ? nil : e[k] }
       end
     RUBY
   end
@@ -40,9 +40,9 @@ RSpec.describe RuboCop::Cop::Style::NestedTernaryOperator, :config do
 
     expect_correction(<<~RUBY)
       if x
-        y + (z ? 1 : 0)
+      y + (z ? 1 : 0)
       else
-        nil
+      nil
       end
     RUBY
   end
@@ -53,6 +53,26 @@ RSpec.describe RuboCop::Cop::Style::NestedTernaryOperator, :config do
         cond ? b : c
       else
         d
+      end
+    RUBY
+  end
+
+  it 'can handle multiple nested ternaries' do
+    expect_offense(<<~RUBY)
+      a ? b : c ? d : e ? f : g
+                      ^^^^^^^^^ Ternary operators must not be nested. Prefer `if` or `else` constructs instead.
+              ^^^^^^^^^^^^^^^^^ Ternary operators must not be nested. Prefer `if` or `else` constructs instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if a
+      b
+      else
+      if c
+      d
+      else
+      e ? f : g
+      end
       end
     RUBY
   end


### PR DESCRIPTION
`Style/NestedTernaryOperator` was doing corrections by replacing the entire if node with a rewritten form. However, when there are multiple ternaries nested inside a single if, this caused a `ClobberingError` as subsequent rewrites would change the same range.

Instead, this takes a more surgical approach and edits by replacing the `?` and `:` symbols and then wrapping the node with `if`/`end`. The result is the same syntax, but layout is no longer handled (but will be picked up by other cops). 

Fixes #10734.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
