### PR TITLE
Make `Style/GuardClause` a bit more lenient when the replacement would make the code more verbose

### DIFF
--- a/changelog/change_make_styleguardclause_a_bit_more_lenient.md
+++ b/changelog/change_make_styleguardclause_a_bit_more_lenient.md
@@ -1,0 +1,1 @@
+* [#10740](https://github.com/rubocop/rubocop/pull/10740): Make `Style/GuardClause` a bit more lenient when the replacement would make the code more verbose. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3703,7 +3703,7 @@ Style/GuardClause:
   StyleGuide: '#no-nested-conditionals'
   Enabled: true
   VersionAdded: '0.20'
-  VersionChanged: '1.28'
+  VersionChanged: '<<next>>'
   # `MinBodyLength` defines the number of lines of the a body of an `if` or `unless`
   # needs to have to trigger this cop
   MinBodyLength: 1

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -407,15 +407,47 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
   end
 
   context 'with Metrics/MaxLineLength enabled' do
-    it 'registers an offense with non-modifier example code if too long for single line' do
-      expect_offense(<<~RUBY)
-        def test
-          if something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line
-          ^^ Use a guard clause (`unless something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line; return; end`) instead of wrapping the code inside a conditional expression.
-            work
-          end
+    context 'when the correction is too long for a single line' do
+      context 'with a trivial body' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            def test
+              if something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line
+                work
+              end
+            end
+          RUBY
         end
-      RUBY
+      end
+
+      context 'with a nested `if` node' do
+        it 'does registers an offense' do
+          expect_offense(<<~RUBY)
+            def test
+              if something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line
+              ^^ Use a guard clause (`unless something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line; return; end`) instead of wrapping the code inside a conditional expression.
+                if something_else
+                  work
+                end
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'with a nested `begin` node' do
+        it 'does registers an offense' do
+          expect_offense(<<~RUBY)
+            def test
+              if something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line
+              ^^ Use a guard clause (`unless something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line; return; end`) instead of wrapping the code inside a conditional expression.
+                work
+                more_work
+              end
+            end
+          RUBY
+        end
+      end
     end
   end
 


### PR DESCRIPTION
We currently have an exception in `Style/GuardClause` when the suggested replacement would be too long.

```ruby
def test
  if something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line
    work
  end
end
```

RuboCop suggests replacing this with:

```ruby
def test
  unless something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line
    return
  end
  work
end
```

However, this makes the code more verbose (adds a line that doesn't really add any benefit) and harder to understand (since this only happens when the line is too long, it's a safe assumption that the condition is long, and flipping it with `unless` adds cognitive overhead).

This exception is not covered in the [style guide](https://rubystyle.guide/#no-nested-conditionals) either, so it should be "non-breaking".

My proposal here is that if the guard clause is too line but what is inside the `if` is trivial (a single statement, and not a nested if), it will not be registered as an offense.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
