### PR TITLE
[Docs] Fix Gemspec/RequireMFA example code spacing

### DIFF
--- a/lib/rubocop/cop/gemspec/require_mfa.rb
+++ b/lib/rubocop/cop/gemspec/require_mfa.rb
@@ -36,29 +36,29 @@ module RuboCop
       #     spec.metadata['rubygems_mfa_required'] = 'true'
       #   end
       #
-      #  # bad
-      #  Gem::Specification.new do |spec|
-      #    spec.metadata = {
-      #      'rubygems_mfa_required' => 'false'
-      #    }
-      #  end
+      #   # bad
+      #   Gem::Specification.new do |spec|
+      #     spec.metadata = {
+      #       'rubygems_mfa_required' => 'false'
+      #     }
+      #   end
       #
-      #  # good
-      #  Gem::Specification.new do |spec|
-      #    spec.metadata = {
-      #      'rubygems_mfa_required' => 'true'
-      #    }
-      #  end
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.metadata = {
+      #       'rubygems_mfa_required' => 'true'
+      #     }
+      #   end
       #
-      #  # bad
-      #  Gem::Specification.new do |spec|
-      #    spec.metadata['rubygems_mfa_required'] = 'false'
-      #  end
+      #   # bad
+      #   Gem::Specification.new do |spec|
+      #     spec.metadata['rubygems_mfa_required'] = 'false'
+      #   end
       #
-      #  # good
-      #  Gem::Specification.new do |spec|
-      #    spec.metadata['rubygems_mfa_required'] = 'true'
-      #  end
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.metadata['rubygems_mfa_required'] = 'true'
+      #   end
       #
       class RequireMFA < Base
         include GemspecHelp


### PR DESCRIPTION
- Fix the indentation of the example code docs for Gemspec/RequireMFA.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists). (N/A)
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests. (N/A)
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
