### PR TITLE
[Fix #10700] Update `Style/EmptyMethod` to not correct if the correction would exceed the configuration for `Layout/LineLength`

### DIFF
--- a/changelog/fix_update_styleemptymethod_to_not_correct.md
+++ b/changelog/fix_update_styleemptymethod_to_not_correct.md
@@ -1,0 +1,1 @@
+* [#10700](https://github.com/rubocop/rubocop/issues/10700): Update `Style/EmptyMethod` to not correct if the correction would exceed the configuration for `Layout/LineLength`. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -51,7 +51,12 @@ module RuboCop
           return if node.body || comment_lines?(node)
           return if correct_style?(node)
 
-          add_offense(node) { |corrector| corrector.replace(node, corrected(node)) }
+          add_offense(node) do |corrector|
+            correction = corrected(node)
+            next if compact_style? && max_line_length && correction.size > max_line_length
+
+            corrector.replace(node, correction)
+          end
         end
         alias on_defs on_def
 
@@ -97,6 +102,12 @@ module RuboCop
 
         def expanded_style?
           style == :expanded
+        end
+
+        def max_line_length
+          return unless config.for_cop('Layout/LineLength')['Enabled']
+
+          config.for_cop('Layout/LineLength')['Max']
         end
       end
     end

--- a/spec/rubocop/cop/style/empty_method_spec.rb
+++ b/spec/rubocop/cop/style/empty_method_spec.rb
@@ -157,6 +157,46 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
         RUBY
       end
     end
+
+    context 'relation with Layout/LineLength' do
+      let(:other_cops) do
+        {
+          'Layout/LineLength' => {
+            'Enabled' => line_length_enabled,
+            'Max' => 20
+          }
+        }
+      end
+      let(:line_length_enabled) { true }
+
+      context 'when that cop is disabled' do
+        let(:line_length_enabled) { false }
+
+        it 'corrects to long lines' do
+          expect_offense(<<~RUBY)
+            def foo(abc: '10000', def: '20000', ghi: '30000')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Put empty method definitions on a single line.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def foo(abc: '10000', def: '20000', ghi: '30000'); end
+          RUBY
+        end
+      end
+
+      context 'when the correction would exceed the configured maximum' do
+        it 'reports an offense but does not correct' do
+          expect_offense(<<~RUBY)
+            def foo(abc: '10000', def: '20000', ghi: '30000')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Put empty method definitions on a single line.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+    end
   end
 
   context 'when configured with expanded style' do
@@ -277,6 +317,29 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
           class Foo
             def bar
             end
+          end
+        RUBY
+      end
+    end
+
+    context 'relation with Layout/LineLength' do
+      let(:other_cops) do
+        {
+          'Layout/LineLength' => {
+            'Enabled' => true,
+            'Max' => 20
+          }
+        }
+      end
+
+      it 'still corrects even if the method is longer than the configured Max' do
+        expect_offense(<<~RUBY)
+          def foo(abc: '10000', def: '20000', ghi: '30000'); end
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Put the `end` of empty method definitions on the next line.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(abc: '10000', def: '20000', ghi: '30000')
           end
         RUBY
       end


### PR DESCRIPTION
When an empty method definition is longer than the `Max` allowed by `Layout/LineLength`, autocorrection ends up in an infinite loop: `Layout/LineLength` splits the method onto two lines, and then `Style/EmptyMethod` puts it back onto one line.

This changes `Style/EmptyMethod` to not perform autocorrection with `EnforcedStyle: compact` if the resulting change will exceed the allowed line length. An offense will still be registered but it will be up to the user to determine how to resolve it, which will prevent the infinite loop.

NOTE: this makes an assumption that `Layout/LineLength` takes priority over `Style/EmptyMethod` for the purposes of correction.

Fixes #10700.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
