### PR TITLE
Split a custom rake task into `rubocop:autocorrect` and `rubocop:autocorrect_all`

### DIFF
--- a/changelog/change_rename_custom_rake_task_to_rubocop_autocorrect.md
+++ b/changelog/change_rename_custom_rake_task_to_rubocop_autocorrect.md
@@ -1,1 +1,1 @@
-* [#10709](https://github.com/rubocop/rubocop/pull/10709): Rename custom rake task from `rubocop:auto_correct` to `rubocop:autocorrect`. ([@koic][])
+* [#10709](https://github.com/rubocop/rubocop/pull/10709): Deprecate `rubocop:auto_correct` custom rake task and newly split `rubocop:autocorrect` and `rubocop:autocorrect-all` custom rake tasks. ([@koic][])

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -141,6 +141,18 @@ RSpec.describe RuboCop::RakeTask do
     end
 
     context 'autocorrect' do
+      it 'runs with --autocorrect' do
+        described_class.new
+
+        cli = instance_double(RuboCop::CLI, run: 0)
+        allow(RuboCop::CLI).to receive(:new).and_return(cli)
+        options = ['--autocorrect']
+
+        expect(cli).to receive(:run).with(options)
+
+        Rake::Task['rubocop:autocorrect'].execute
+      end
+
       it 'runs with --autocorrect-all' do
         described_class.new
 
@@ -150,7 +162,7 @@ RSpec.describe RuboCop::RakeTask do
 
         expect(cli).to receive(:run).with(options)
 
-        Rake::Task['rubocop:autocorrect'].execute
+        Rake::Task['rubocop:autocorrect_all'].execute
       end
 
       it 'runs with with the options that were passed to its parent task' do
@@ -168,7 +180,7 @@ RSpec.describe RuboCop::RakeTask do
 
         expect(cli).to receive(:run).with(options)
 
-        Rake::Task['rubocop:autocorrect'].execute
+        Rake::Task['rubocop:autocorrect_all'].execute
       end
     end
   end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10709#discussion_r905164287.

This PR splits deprecated `rubocop:auto_correct` custom rake task into `rubocop:autocorrect` and `rubocop:autocorrect_all`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
