### PR TITLE
Add note to `Style/EmptyMethod` documentation about autocorrection re: `Layout/LineLength`

### DIFF
--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -11,6 +11,10 @@ module RuboCop
       # NOTE: A method definition is not considered empty if it contains
       # comments.
       #
+      # NOTE: Autocorrection will not be applied for the `compact` style
+      # if the resulting code is longer than the `Max` configuration for
+      # `Layout/LineLength`, but an offense will still be registered.
+      #
       # @example EnforcedStyle: compact (default)
       #   # bad
       #   def foo(bar)


### PR DESCRIPTION
Adds a comment to the documentation as per @bbatsov's comment https://github.com/rubocop/rubocop/pull/10742#issuecomment-1165262149

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
