### PR TITLE
Recover 7x slow running `rubocop`

### DIFF
--- a/changelog/fix_recover_slow_running_rubocop.md
+++ b/changelog/fix_recover_slow_running_rubocop.md
@@ -1,0 +1,1 @@
+* [#10750](https://github.com/rubocop/rubocop/pull/10750): Recover 7x slow running `rubocop`. ([@koic][])

--- a/lib/rubocop/formatter.rb
+++ b/lib/rubocop/formatter.rb
@@ -2,30 +2,30 @@
 
 module RuboCop
   module Formatter
-    autoload :BaseFormatter, 'rubocop/formatter/base_formatter'
-    autoload :SimpleTextFormatter, 'rubocop/formatter/simple_text_formatter'
+    require_relative 'formatter/text_util'
+
+    require_relative 'formatter/base_formatter'
+    require_relative 'formatter/simple_text_formatter'
     # relies on simple text
-    autoload :ClangStyleFormatter, 'rubocop/formatter/clang_style_formatter'
-    autoload :DisabledConfigFormatter, 'rubocop/formatter/disabled_config_formatter'
-    autoload :EmacsStyleFormatter, 'rubocop/formatter/emacs_style_formatter'
-    autoload :FileListFormatter, 'rubocop/formatter/file_list_formatter'
-    autoload :FuubarStyleFormatter, 'rubocop/formatter/fuubar_style_formatter'
-    autoload :GitHubActionsFormatter, 'rubocop/formatter/git_hub_actions_formatter'
-    autoload :HTMLFormatter, 'rubocop/formatter/html_formatter'
-    autoload :JSONFormatter, 'rubocop/formatter/json_formatter'
-    autoload :JUnitFormatter, 'rubocop/formatter/junit_formatter'
-    autoload :MarkdownFormatter, 'rubocop/formatter/markdown_formatter'
-    autoload :OffenseCountFormatter, 'rubocop/formatter/offense_count_formatter'
-    autoload :ProgressFormatter, 'rubocop/formatter/progress_formatter'
-    autoload :QuietFormatter, 'rubocop/formatter/quiet_formatter'
-    autoload :TapFormatter, 'rubocop/formatter/tap_formatter'
-    autoload :WorstOffendersFormatter, 'rubocop/formatter/worst_offenders_formatter'
-    autoload :PacmanFormatter, 'rubocop/formatter/pacman_formatter'
+    require_relative 'formatter/clang_style_formatter'
+    require_relative 'formatter/disabled_config_formatter'
+    require_relative 'formatter/emacs_style_formatter'
+    require_relative 'formatter/file_list_formatter'
+    require_relative 'formatter/fuubar_style_formatter'
+    require_relative 'formatter/git_hub_actions_formatter'
+    require_relative 'formatter/html_formatter'
+    require_relative 'formatter/json_formatter'
+    require_relative 'formatter/junit_formatter'
+    require_relative 'formatter/markdown_formatter'
+    require_relative 'formatter/offense_count_formatter'
+    require_relative 'formatter/progress_formatter'
+    require_relative 'formatter/quiet_formatter'
+    require_relative 'formatter/tap_formatter'
+    require_relative 'formatter/worst_offenders_formatter'
+    require_relative 'formatter/pacman_formatter'
     # relies on progress formatter
-    autoload :AutoGenConfigFormatter, 'rubocop/formatter/auto_gen_config_formatter'
-    autoload :Colorizable, 'rubocop/formatter/colorizable'
+    require_relative 'formatter/auto_gen_config_formatter'
 
     require_relative 'formatter/formatter_set'
-    require_relative 'formatter/text_util'
   end
 end

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'colorizable'
+
 module RuboCop
   module Formatter
     # A basic formatter that displays only files with offenses.


### PR DESCRIPTION
Recovers #10735 regression.

This PR recovers 7x slower running `rubocop`.

## v1.30.1

Originally it was about 12 seconds:

```console
% git chceckout v1.30.1
% bundle exec rubocop --display-time
Inspecting 1366 files
(snip)

1366 files inspected, no offenses detected
Finished in 12.27936500031501 seconds
```

## master (v1.31.0 / after #10735)

7x slower in my local environment:

```console
% bundle exec rubocop --display-time
Inspecting 1393 files
(snip)

1393 files inspected, no offenses detected
Finished in 88.82363200001419 seconds
```

## This patch

It recovers to the same speed as v1.30.1:

```console
% bundle exec rubocop --display-time
Inspecting 1393 files
(snip)

1393 files inspected, no offenses detected
Finished in 12.322518999688327 seconds
```

The cause has not been clarified yet, but it seems that it was caused by changing `require_relative` to `autoload` in #10735.
This PR change to `require_relative` to resolve the cause of the delay.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
