### PR TITLE
[Fix #10755] Fix a false positive for `Lint/LiteralAsCondition`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_literal_as_condition.md
+++ b/changelog/fix_a_false_positive_for_lint_literal_as_condition.md
@@ -1,0 +1,1 @@
+* [#10755](https://github.com/rubocop/rubocop/issues/10755): Fix a false positive for `Lint/LiteralAsCondition` when using a literal in `case-in` condition where the match variable is used in `in` are accepted as a pattern matching. ([@koic][])

--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -7,6 +7,9 @@ module RuboCop
       # operands in and/or expressions serving as the conditions of
       # if/while/until/case-when/case-in.
       #
+      # NOTE: Literals in `case-in` condition where the match variable is used in
+      # `in` are accepted as a pattern matching.
+      #
       # @example
       #
       #   # bad
@@ -69,6 +72,8 @@ module RuboCop
 
         def on_case_match(case_match_node)
           if case_match_node.condition
+            return if case_match_node.descendants.any?(&:match_var_type?)
+
             check_case(case_match_node)
           else
             case_match_node.each_in_pattern do |in_pattern_node|

--- a/spec/rubocop/cop/lint/literal_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_as_condition_spec.rb
@@ -75,11 +75,19 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
     end
 
     context '>= Ruby 2.7', :ruby27 do
-      it "registers an offense for literal #{lit} in case match" do
+      it "accepts an offense for literal #{lit} in case match with a match var" do
+        expect_no_offenses(<<~RUBY, lit: lit)
+          case %{lit}
+          in x then top
+          end
+        RUBY
+      end
+
+      it "registers an offense for literal #{lit} in case match without a match var" do
         expect_offense(<<~RUBY, lit: lit)
           case %{lit}
                ^{lit} Literal `#{lit}` appeared as a condition.
-          in x then top
+          in CONST then top
           end
         RUBY
       end
@@ -215,6 +223,14 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
         case [1, 2, [3, 4]]
              ^^^^^^^^^^^^^^ Literal `[1, 2, [3, 4]]` appeared as a condition.
         in [1, 2, 5] then top
+        end
+      RUBY
+    end
+
+    it 'accepts an offense for case match with a match var' do
+      expect_no_offenses(<<~RUBY)
+        case { a: 1, b: 2, c: 3 }
+        in a: Integer => m
         end
       RUBY
     end


### PR DESCRIPTION
Fixes #10755.

This PR fixes a false positive for `Lint/LiteralAsCondition` when using a literal in `case-in` condition where the match variable is used in `in` are accepted as a pattern matching.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
