### PR TITLE
[Fix #10754] Fix an incorrect autocorrect for `Style/HashExcept`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_hash_except.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_hash_except.md
@@ -1,0 +1,1 @@
+* [#10754](https://github.com/rubocop/rubocop/issues/10754): Fix an incorrect autocorrect for `Style/HashExcept` when using a non-literal collection receiver for `include?`. ([@koic][])

--- a/lib/rubocop/cop/style/hash_except.rb
+++ b/lib/rubocop/cop/style/hash_except.rb
@@ -144,7 +144,7 @@ module RuboCop
             return key.join(', ')
           end
 
-          key.source
+          key.literal? ? key.source : "*#{key.source}"
         end
 
         def decorate_source(value)

--- a/spec/rubocop/cop/style/hash_except_spec.rb
+++ b/spec/rubocop/cop/style/hash_except_spec.rb
@@ -142,6 +142,30 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
           {foo: 1, bar: 2, baz: 3}.except("\#{foo}", 'bar')
         RUBY
       end
+
+      it 'registers and corrects an offense when using `reject` and calling `include?` method with variable' do
+        expect_offense(<<~RUBY)
+          array = [:foo, :bar]
+          {foo: 1, bar: 2, baz: 3}.reject { |k, v| !array.include?(k) }
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `except(*array)` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array = [:foo, :bar]
+          {foo: 1, bar: 2, baz: 3}.except(*array)
+        RUBY
+      end
+
+      it 'registers and corrects an offense when using `reject` and calling `include?` method with method call' do
+        expect_offense(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.reject { |k, v| !array.include?(k) }
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `except(*array)` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.except(*array)
+        RUBY
+      end
     end
 
     context 'using `exclude?`' do
@@ -316,6 +340,30 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
             {foo: 1, bar: 2, baz: 3}.except("\#{foo}", 'bar')
           RUBY
         end
+
+        it 'registers and corrects an offense when using `reject` and calling `key.in?` method with variable' do
+          expect_offense(<<~RUBY)
+            array = %i[foo bar]
+            {foo: 1, bar: 2, baz: 3}.reject { |k, v| k.in?(array) }
+                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `except(*array)` instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            array = %i[foo bar]
+            {foo: 1, bar: 2, baz: 3}.except(*array)
+          RUBY
+        end
+
+        it 'registers and corrects an offense when using `reject` and calling `key.in?` method with method call' do
+          expect_offense(<<~RUBY)
+            {foo: 1, bar: 2, baz: 3}.reject { |k, v| k.in?(array) }
+                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `except(*array)` instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            {foo: 1, bar: 2, baz: 3}.except(*array)
+          RUBY
+        end
       end
 
       context 'using `include?`' do
@@ -373,6 +421,30 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
             {foo: 1, bar: 2, baz: 3}.except("\#{foo}", 'bar')
           RUBY
         end
+
+        it 'registers and corrects an offense when using `reject` and calling `include?` method with variable' do
+          expect_offense(<<~RUBY)
+            array = %i[foo bar]
+            {foo: 1, bar: 2, baz: 3}.reject { |k, v| !array.include?(k) }
+                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `except(*array)` instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            array = %i[foo bar]
+            {foo: 1, bar: 2, baz: 3}.except(*array)
+          RUBY
+        end
+
+        it 'registers and corrects an offense when using `reject` and calling `include?` method with method call' do
+          expect_offense(<<~RUBY)
+            {foo: 1, bar: 2, baz: 3}.reject { |k, v| !array.include?(k) }
+                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `except(*array)` instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            {foo: 1, bar: 2, baz: 3}.except(*array)
+          RUBY
+        end
       end
 
       context 'using `exclude?`' do
@@ -428,6 +500,30 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
 
           expect_correction(<<~RUBY)
             {foo: 1, bar: 2, baz: 3}.except("\#{foo}", 'bar')
+          RUBY
+        end
+
+        it 'registers and corrects an offense when using `reject` and calling `!exclude?` method with variable' do
+          expect_offense(<<~RUBY)
+            array = %i[foo bar]
+            {foo: 1, bar: 2, baz: 3}.reject { |k, v| !array.exclude?(k) }
+                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `except(*array)` instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            array = %i[foo bar]
+            {foo: 1, bar: 2, baz: 3}.except(*array)
+          RUBY
+        end
+
+        it 'registers and corrects an offense when using `reject` and calling `!exclude?` method with method call' do
+          expect_offense(<<~RUBY)
+            {foo: 1, bar: 2, baz: 3}.reject { |k, v| !array.exclude?(k) }
+                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `except(*array)` instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            {foo: 1, bar: 2, baz: 3}.except(*array)
           RUBY
         end
       end


### PR DESCRIPTION
Fixes #10754.

This PR fixes an incorrect autocorrect for `Style/HashExcept` when using a non-literal collection receiver for `include?`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
