### PR TITLE
[Fix #10751] Fix autocorrect for Layout/FirstHashElementIndentation

### DIFF
--- a/changelog/fix_autocorrect_for_first_hash_element_indentation.md
+++ b/changelog/fix_autocorrect_for_first_hash_element_indentation.md
@@ -1,0 +1,1 @@
+* [#10751](https://github.com/rubocop/rubocop/issues/10751): Fix autocorrect for Layout/FirstHashElementIndentation. ([@j-miyake][])

--- a/lib/rubocop/cop/mixin/multiline_element_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_element_indentation.rb
@@ -51,7 +51,8 @@ module RuboCop
         return [left_brace.column, :left_brace_or_bracket] if style == brace_alignment_style
 
         pair = hash_pair_where_value_beginning_with(left_brace)
-        if pair && key_and_value_begin_on_same_line?(pair) && pair.right_sibling
+        if pair && key_and_value_begin_on_same_line?(pair) &&
+           right_sibling_begins_on_subsequent_line?(pair)
           return [pair.loc.column, :parent_hash_key]
         end
 
@@ -77,6 +78,10 @@ module RuboCop
 
       def key_and_value_begin_on_same_line?(pair)
         same_line?(pair.key, pair.value)
+      end
+
+      def right_sibling_begins_on_subsequent_line?(pair)
+        pair.right_sibling && (pair.last_line < pair.right_sibling.first_line)
       end
 
       def detected_styles(actual_column, offset, left_parenthesis, left_brace)

--- a/spec/rubocop/cop/layout/first_array_element_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_array_element_indentation_spec.rb
@@ -301,6 +301,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation, :config do
           RUBY
         end
 
+        it 'accepts indent based on the preceding left parenthesis ' \
+           'when the right bracket and its following pair is on the same line' do
+          expect_no_offenses(<<~RUBY)
+            func(:x, y: [
+                   :a,
+                   :b
+                 ], z: [
+                   :c,
+                   :d
+                 ])
+          RUBY
+        end
+
         it 'accepts indent based on the left brace when the outer hash key and ' \
            'the left bracket is not on the same line' do
           expect_no_offenses(<<~RUBY)
@@ -403,6 +416,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation, :config do
           RUBY
         end
 
+        it 'accepts indent based on the start of the line where the left bracket is' \
+           'when the right bracket and its following pair is on the same line' do
+          expect_no_offenses(<<~RUBY)
+            func(:x, y: [
+              :a,
+              :b
+            ], z: [
+              :c,
+              :d
+            ])
+          RUBY
+        end
+
         it 'accepts indent based on the left brace when the outer hash key and ' \
            'the left bracket is not on the same line' do
           expect_no_offenses(<<~RUBY)
@@ -489,7 +515,20 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation, :config do
         RUBY
       end
 
-      it 'accepts indent based on the left brace when the outer hash key and ' \
+      it 'accepts indent based on the start of the line where the left bracket is' \
+         'when the right bracket and its following pair is on the same line' do
+        expect_no_offenses(<<~RUBY)
+          func :x, y: [
+            :a,
+            :b
+          ], z: [
+            :c,
+            :d
+          ]
+        RUBY
+      end
+
+      it 'accepts indent based on the left bracket when the outer hash key and ' \
          'the left bracket is not on the same line' do
         expect_no_offenses(<<~RUBY)
           func x:

--- a/spec/rubocop/cop/layout/first_hash_element_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_hash_element_indentation_spec.rb
@@ -385,6 +385,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation, :config do
           RUBY
         end
 
+        it 'accepts indent based on the preceding left parenthesis' \
+           'when the right brace and its following pair is on the same line' do
+          expect_no_offenses(<<~RUBY)
+            func(:x, y: {
+                   a: 1,
+                   b: 2
+                 }, z: {
+                   c: 1,
+                   d: 2
+                 })
+          RUBY
+        end
+
         it 'accepts indent based on the left brace when the outer hash key and ' \
            'the left brace is not on the same line' do
           expect_no_offenses(<<~RUBY)
@@ -487,6 +500,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation, :config do
           RUBY
         end
 
+        it 'accepts indent based on the start of the line where the left brace is' \
+           'when the right brace and its following pair is on the same line' do
+          expect_no_offenses(<<~RUBY)
+            func(:x, y: {
+              a: 1,
+              b: 2
+            }, z: {
+              c: 1,
+              d: 2
+            })
+          RUBY
+        end
+
         it 'accepts indent based on the left brace when the outer hash key and ' \
            'the left brace is not on the same line' do
           expect_no_offenses(<<~RUBY)
@@ -534,7 +560,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation, :config do
       end
 
       it 'registers an offense for the first inner hash member not based on the start of line ' \
-         'where the outer hash key is when no other outer hash members follow' do
+         'when the outer hash pair has no following siblings' do
         expect_offense(<<~RUBY)
           func x: :foo, y: {
                           a: 1, b: 2 }
@@ -571,6 +597,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation, :config do
                  c: 1,
                  d: 2
                }
+        RUBY
+      end
+
+      it 'accepts indent based on the start of the line where the left brace is' \
+         'when the right brace and its following pair is on the same line' do
+        expect_no_offenses(<<~RUBY)
+          func :x, y: {
+            a: 1,
+            b: 2
+          }, z: {
+            c: 1,
+            d: 2
+          }
         RUBY
       end
 


### PR DESCRIPTION
Fixes #10751

`Layout/FirstHashElementIndentation` should allow a hash where the content of the first pair is indented relative to the base column specified with configured cop style, and the second pair begins on the same line with the right brace of the first pair; because those two keys won't be aligned with each other by `Layout/HashAlignment`, not like the case of #10689.

With no parenthesis
```ruby
post :create, params: {
  foo: { bar: 'Baz' }
}, as: :json
```

With the parenthesis and `special_inside_parentheses` style
```ruby
post(:create, params: {
       foo: { bar: 'Baz' }
     }, as: :json)
```

With the parenthesis and `consistent` style
```ruby
post(:create, params: {
  foo: { bar: 'Baz' }
}, as: :json)
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
