### PR TITLE
[Fix #10760] Fix a false positive for `Lint/NonAtomicFileOperation`

### DIFF
--- a/changelog/fix_a_false_positive_for_non_atomic_file_operation.md
+++ b/changelog/fix_a_false_positive_for_non_atomic_file_operation.md
@@ -1,0 +1,1 @@
+* [#10760](https://github.com/rubocop/rubocop/issues/10760): Fix a false positive for `Lint/NonAtomicFileOperation` when using `FileTest.exist?` with `if` condition that has `else` branch. ([@koic][])

--- a/lib/rubocop/cop/lint/non_atomic_file_operation.rb
+++ b/lib/rubocop/cop/lint/non_atomic_file_operation.rb
@@ -72,6 +72,7 @@ module RuboCop
 
         def on_send(node)
           return unless node.parent&.if_type?
+          return if node.parent.else_branch
           return if explicit_not_force?(node)
           return unless (exist_node = send_exist_node(node.parent).first)
           return unless exist_node.first_argument == node.first_argument

--- a/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
+++ b/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
@@ -173,4 +173,14 @@ RSpec.describe RuboCop::Cop::Lint::NonAtomicFileOperation, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense when using `FileTest.exist?` with `if` condition that has `else` branch' do
+    expect_no_offenses(<<~RUBY)
+      if FileTest.exist?(path)
+        FileUtils.mkdir(path)
+      else
+        do_something
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #10760.

This PR fixes a false positive for `Lint/NonAtomicFileOperation` when using `FileTest.exist?` with `if` condition that has `else` branch.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
