### PR TITLE
Make Layout/LineContinuationLeadingSpace configurable

### DIFF
--- a/changelog/change_add_leading_style_to_LineContinuationLeadingSpace.md
+++ b/changelog/change_add_leading_style_to_LineContinuationLeadingSpace.md
@@ -1,0 +1,1 @@
+* Add EnforcedStyle (leading/trailing) configuration to `Layout::LineContinuationLeadingSpace`. ([@bquorning][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -977,6 +977,11 @@ Layout/LineContinuationLeadingSpace:
   AutoCorrect: false
   SafeAutoCorrect: false
   VersionAdded: '1.31'
+  VersionChanged: '<<next>>'
+  EnforcedStyle: trailing
+  SupportedStyles:
+    - leading
+    - trailing
 
 Layout/LineContinuationSpacing:
   Description: 'Checks the spacing in front of backslash in line continuations.'

--- a/lib/rubocop/cop/layout/line_continuation_leading_space.rb
+++ b/lib/rubocop/cop/layout/line_continuation_leading_space.rb
@@ -4,9 +4,10 @@ module RuboCop
   module Cop
     module Layout
       # Checks that strings broken over multiple lines (by a backslash) contain
-      # trailing spaces instead of leading spaces.
+      # trailing spaces instead of leading spaces (default) or leading spaces
+      # instead of trailing spaces.
       #
-      # @example
+      # @example EnforcedStyle: trailing (default)
       #   # bad
       #   'this text contains a lot of' \
       #   '               spaces'
@@ -23,18 +24,38 @@ module RuboCop
       #   'this text is too ' \
       #   'long'
       #
+      # @example EnforcedStyle: leading
+      #   # bad
+      #   'this text contains a lot of               ' \
+      #   'spaces'
+      #
+      #   # good
+      #   'this text contains a lot of' \
+      #   '               spaces'
+      #
+      #   # bad
+      #   'this text is too ' \
+      #   'long'
+      #
+      #   # good
+      #   'this text is too' \
+      #   ' long'
       class LineContinuationLeadingSpace < Base
         include RangeHelp
 
-        MSG = 'Move leading spaces to the end of previous line.'
-
         def on_dstr(node)
-          range_start = node.loc.expression.begin_pos - node.loc.expression.column
+          end_of_first_line = node.loc.expression.begin_pos - node.loc.expression.column
 
           raw_lines(node).each_cons(2) do |raw_line_one, raw_line_two|
-            range_start += raw_line_one.length
+            end_of_first_line += raw_line_one.length
 
-            investigate(raw_line_one, raw_line_two, range_start)
+            next unless continuation?(raw_line_one)
+
+            if enforced_style_leading?
+              investigate_leading_style(raw_line_one, end_of_first_line)
+            else
+              investigate_trailing_style(raw_line_two, end_of_first_line)
+            end
           end
         end
 
@@ -44,23 +65,46 @@ module RuboCop
           processed_source.raw_source.lines[node.first_line - 1, line_range(node).size]
         end
 
-        def investigate(first_line, second_line, range_start)
-          return unless continuation?(first_line)
-
-          matches = second_line.match(/\A(?<indent>\s*['"])(?<leading_spaces>\s+)/)
+        def investigate_leading_style(first_line, end_of_first_line)
+          matches = first_line.match(/(?<trailing_spaces>\s+)(?<ending>['"]\s*\\\n)/)
           return if matches.nil?
 
-          add_offense(offense_range(range_start, matches))
+          add_offense(leading_offense_range(end_of_first_line, matches))
+        end
+
+        def investigate_trailing_style(second_line, end_of_first_line)
+          matches = second_line.match(/\A(?<beginning>\s*['"])(?<leading_spaces>\s+)/)
+          return if matches.nil?
+
+          add_offense(trailing_offense_range(end_of_first_line, matches))
         end
 
         def continuation?(line)
           line.end_with?("\\\n")
         end
 
-        def offense_range(range_start, matches)
-          begin_pos = range_start + matches[:indent].length
+        def leading_offense_range(end_of_first_line, matches)
+          end_pos = end_of_first_line - matches[:ending].length
+          begin_pos = end_pos - matches[:trailing_spaces].length
+          range_between(begin_pos, end_pos)
+        end
+
+        def trailing_offense_range(end_of_first_line, matches)
+          begin_pos = end_of_first_line + matches[:beginning].length
           end_pos = begin_pos + matches[:leading_spaces].length
           range_between(begin_pos, end_pos)
+        end
+
+        def message(_range)
+          if enforced_style_leading?
+            'Move trailing spaces to the start of next line.'
+          else
+            'Move leading spaces to the end of previous line.'
+          end
+        end
+
+        def enforced_style_leading?
+          cop_config['EnforcedStyle'] == 'leading'
         end
       end
     end

--- a/spec/rubocop/cop/layout/line_continuation_leading_space_spec.rb
+++ b/spec/rubocop/cop/layout/line_continuation_leading_space_spec.rb
@@ -1,117 +1,241 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
-  it 'registers an offense when 2nd line has one leading space' do
-    expect_offense(<<~'RUBY')
-      'this text is too' \
-      ' long'
-       ^ Move leading spaces to the end of previous line.
-    RUBY
-  end
+  context 'EnforcedStyle: trailing' do
+    let(:cop_config) { { 'EnforcedStyle' => 'trailing' } }
 
-  it 'puts the offense message in correct position also on indented line' do
-    expect_offense(<<~'RUBY')
-      'this text is too' \
-        ' long'
-         ^ Move leading spaces to the end of previous line.
-    RUBY
-  end
-
-  it 'registers an offense when 2nd line has multiple leading spaces' do
-    expect_offense(<<~'RUBY')
-      'this text contains a lot of' \
-      '               spaces'
-       ^^^^^^^^^^^^^^^ Move leading spaces to the end of previous line.
-    RUBY
-  end
-
-  it 'registers offenses when 2nd and 3rd line has leading spaces' do
-    expect_offense(<<~'RUBY')
-      'this text is too' \
-      ' long' \
-       ^ Move leading spaces to the end of previous line.
-      '  long long'
-       ^^ Move leading spaces to the end of previous line.
-    RUBY
-  end
-
-  it 'registers offense in the right location when 1st line is not the string' do
-    expect_offense(<<~'RUBY')
-      something_unrelated_to_the_line_continuation_below
-      'this text is too' \
-      ' long'
-       ^ Move leading spaces to the end of previous line.
-    RUBY
-  end
-
-  it 'marks the correct range when string is a block method argument' do
-    expect_offense(<<~'RUBY')
-      long_method_name 'this text is too' \
-        ' long' do
-         ^ Move leading spaces to the end of previous line.
-      end
-    RUBY
-  end
-
-  it 'marks the correct range when string is a positional method argument' do
-    expect_offense(<<~'RUBY')
-      long_method_name(
+    it 'registers an offense when 2nd line has one leading space' do
+      expect_offense(<<~'RUBY')
         'this text is too' \
         ' long'
          ^ Move leading spaces to the end of previous line.
-      )
-    RUBY
-  end
-
-  describe 'interpolated strings' do
-    it 'registers no offense on interpolated string alone' do
-      expect_no_offenses(<<~'RUBY')
-        "foo #{bar}"
       RUBY
     end
 
-    it 'registers no offense on doubly interpolated string alone' do
-      expect_no_offenses(<<~'RUBY')
-        "foo #{bar} baz #{qux}"
-      RUBY
-    end
-
-    it 'registers offenses when 2nd line has leading spaces and 1st line is interpolated' do
+    it 'puts the offense message in correct position also on indented line' do
       expect_offense(<<~'RUBY')
-        "foo #{bar}" \
+        'this text is too' \
+          ' long'
+           ^ Move leading spaces to the end of previous line.
+      RUBY
+    end
+
+    it 'registers an offense when 2nd line has multiple leading spaces' do
+      expect_offense(<<~'RUBY')
+        'this text contains a lot of' \
+        '               spaces'
+         ^^^^^^^^^^^^^^^ Move leading spaces to the end of previous line.
+      RUBY
+    end
+
+    it 'registers offenses when 2nd and 3rd line has leading spaces' do
+      expect_offense(<<~'RUBY')
+        'this text is too' \
+        ' long' \
+         ^ Move leading spaces to the end of previous line.
+        '  long long'
+         ^^ Move leading spaces to the end of previous line.
+      RUBY
+    end
+
+    it 'registers offense in the right location when 1st line is not the string' do
+      expect_offense(<<~'RUBY')
+        something_unrelated_to_the_line_continuation_below
+        'this text is too' \
         ' long'
          ^ Move leading spaces to the end of previous line.
       RUBY
     end
 
-    it 'registers offenses when 2nd line has leading spaces and 2nd line is interpolated' do
+    it 'marks the correct range when string is a block method argument' do
       expect_offense(<<~'RUBY')
-        'this line is' \
-        " #{foo}"
-         ^ Move leading spaces to the end of previous line.
-      RUBY
-    end
-
-    it 'registers no offense for correctly formatted multiline interpolation' do
-      expect_no_offenses(<<~'RUBY')
-        "five is #{2 + \
-          3}"
-      RUBY
-    end
-
-    it 'registers no offense for correctly formatted multiline interpolated string' do
-      expect_no_offenses(<<~'RUBY')
-        "foo #{'bar ' \
-          'baz'}"
-      RUBY
-    end
-
-    it 'registers an offense for incorrectly formatted multiline interpolated string' do
-      expect_offense(<<~'RUBY')
-        "foo #{'bar' \
-          ' baz'}"
+        long_method_name 'this text is too' \
+          ' long' do
            ^ Move leading spaces to the end of previous line.
+        end
       RUBY
+    end
+
+    it 'marks the correct range when string is a positional method argument' do
+      expect_offense(<<~'RUBY')
+        long_method_name(
+          'this text is too' \
+          ' long'
+           ^ Move leading spaces to the end of previous line.
+        )
+      RUBY
+    end
+
+    describe 'interpolated strings' do
+      it 'registers no offense on interpolated string alone' do
+        expect_no_offenses(<<~'RUBY')
+          "foo #{bar}"
+        RUBY
+      end
+
+      it 'registers no offense on doubly interpolated string alone' do
+        expect_no_offenses(<<~'RUBY')
+          "foo #{bar} baz #{qux}"
+        RUBY
+      end
+
+      it 'registers offenses when 2nd line has leading spaces and 1st line is interpolated' do
+        expect_offense(<<~'RUBY')
+          "foo #{bar}" \
+          ' long'
+           ^ Move leading spaces to the end of previous line.
+        RUBY
+      end
+
+      it 'registers offenses when 2nd line has leading spaces and 2nd line is interpolated' do
+        expect_offense(<<~'RUBY')
+          'this line is' \
+          " #{foo}"
+           ^ Move leading spaces to the end of previous line.
+        RUBY
+      end
+
+      it 'registers no offense for correctly formatted multiline interpolation' do
+        expect_no_offenses(<<~'RUBY')
+          "five is #{2 + \
+            3}"
+        RUBY
+      end
+
+      it 'registers no offense for correctly formatted multiline interpolated string' do
+        expect_no_offenses(<<~'RUBY')
+          "foo #{'bar ' \
+            'baz'}"
+        RUBY
+      end
+
+      it 'registers an offense for incorrectly formatted multiline interpolated string' do
+        expect_offense(<<~'RUBY')
+          "foo #{'bar' \
+            ' baz'}"
+             ^ Move leading spaces to the end of previous line.
+        RUBY
+      end
+    end
+  end
+
+  context 'EnforcedStyle: leading' do
+    let(:cop_config) { { 'EnforcedStyle' => 'leading' } }
+
+    it 'registers an offense when 1st line has one trailing space' do
+      expect_offense(<<~'RUBY')
+        'this text is too ' \
+                         ^ Move trailing spaces to the start of next line.
+        'long'
+      RUBY
+    end
+
+    it 'puts the offense message in correct position also on indented line' do
+      expect_offense(<<~'RUBY')
+        'this text is too' \
+          ' very ' \
+                ^ Move trailing spaces to the start of next line.
+          'long'
+      RUBY
+    end
+
+    it 'registers an offense when 1st line has multiple trailing spaces' do
+      expect_offense(<<~'RUBY')
+        'this text contains a lot of               ' \
+                                    ^^^^^^^^^^^^^^^ Move trailing spaces to the start of next line.
+        'spaces'
+      RUBY
+    end
+
+    it 'registers offenses when 1st and 2nd line has trailing spaces' do
+      expect_offense(<<~'RUBY')
+        'this text is too ' \
+                         ^ Move trailing spaces to the start of next line.
+        'long  ' \
+             ^^ Move trailing spaces to the start of next line.
+        'long long'
+      RUBY
+    end
+
+    it 'registers offense in the right location when 1st line is not the string' do
+      expect_offense(<<~'RUBY')
+        something_unrelated_to_the_line_continuation_below
+        'this text is too ' \
+                         ^ Move trailing spaces to the start of next line.
+        'long'
+      RUBY
+    end
+
+    it 'marks the correct range when string is a block method argument' do
+      expect_offense(<<~'RUBY')
+        long_method_name 'this text is too' \
+          ' very ' \
+                ^ Move trailing spaces to the start of next line.
+          'long' do
+        end
+      RUBY
+    end
+
+    it 'marks the correct range when string is a positional method argument' do
+      expect_offense(<<~'RUBY')
+        long_method_name(
+          'this text is too ' \
+                           ^ Move trailing spaces to the start of next line.
+          'long'
+        )
+      RUBY
+    end
+
+    describe 'interpolated strings' do
+      it 'registers no offense on interpolated string alone' do
+        expect_no_offenses(<<~'RUBY')
+          "foo #{bar}"
+        RUBY
+      end
+
+      it 'registers no offense on doubly interpolated string alone' do
+        expect_no_offenses(<<~'RUBY')
+          "foo #{bar} baz #{qux}"
+        RUBY
+      end
+
+      it 'registers offenses when 1st line has trailing spaces and 2nd line is interpolated' do
+        expect_offense(<<~'RUBY')
+          'foo ' \
+              ^ Move trailing spaces to the start of next line.
+          "#{bar} long"
+        RUBY
+      end
+
+      it 'registers offenses when 1st line has leading spaces and 1st line is interpolated' do
+        expect_offense(<<~'RUBY')
+          "this #{foo} is " \
+                         ^ Move trailing spaces to the start of next line.
+          'long'
+        RUBY
+      end
+
+      it 'registers no offense for correctly formatted multiline interpolation' do
+        expect_no_offenses(<<~'RUBY')
+          "five is #{2 + \
+            3}"
+        RUBY
+      end
+
+      it 'registers no offense for correctly formatted multiline interpolated string' do
+        expect_no_offenses(<<~'RUBY')
+          "foo #{'bar' \
+            ' baz'}"
+        RUBY
+      end
+
+      it 'registers an offense for incorrectly formatted multiline interpolated string' do
+        expect_offense(<<~'RUBY')
+          "foo #{'bar ' \
+                     ^ Move trailing spaces to the start of next line.
+            'baz'}"
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
You can now choose between `EnforcedStyle: leading` and `EnforcedStyle: trailing`. `trailing` remains the default option.

Motivation:

- https://github.com/rubocop/rubocop/pull/10717#issuecomment-1168480753
- https://github.com/rubocop/rubocop/pull/10715#issuecomment-1160037386

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
