### PR TITLE
[Fix #10763] Fix a false positive for `Layout/LineContinuationSpacing`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_line_continuation_spacing.md
+++ b/changelog/fix_a_false_positive_for_layout_line_continuation_spacing.md
@@ -1,0 +1,1 @@
+* [#10763](https://github.com/rubocop/rubocop/issues/10763): Fix a false positive for `Layout/LineContinuationSpacing` when using continuation keyword `\` after `__END__`. ([@koic][])

--- a/lib/rubocop/cop/layout/line_continuation_spacing.rb
+++ b/lib/rubocop/cop/layout/line_continuation_spacing.rb
@@ -32,10 +32,14 @@ module RuboCop
         extend AutoCorrector
 
         def on_new_investigation
+          last_line = last_line(processed_source)
+
           @ignored_ranges = string_literal_ranges(processed_source.ast) +
                             comment_ranges(processed_source.comments)
 
           processed_source.raw_source.lines.each_with_index do |line, index|
+            break if index >= last_line
+
             line_number = index + 1
             investigate(line, line_number)
           end
@@ -101,6 +105,12 @@ module RuboCop
 
         def comment_ranges(comments)
           comments.map(&:loc).map(&:expression)
+        end
+
+        def last_line(processed_source)
+          last_token = processed_source.tokens.last
+
+          last_token ? last_token.line : processed_source.lines.length
         end
 
         def ignore_range?(backtick_range)

--- a/spec/rubocop/cop/layout/line_continuation_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/line_continuation_spacing_spec.rb
@@ -79,6 +79,20 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationSpacing, :config do
         X
       RUBY
     end
+
+    it 'ignores when too much space in front of backslash after `__END__`' do
+      expect_no_offenses(<<~'RUBY')
+        foo
+        bar
+        __END__
+        baz    \
+        qux
+      RUBY
+    end
+
+    it 'ignores empty code' do
+      expect_no_offenses('')
+    end
   end
 
   context 'EnforcedStyle: no_space' do
@@ -158,6 +172,20 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationSpacing, :config do
           ok
         X
       RUBY
+    end
+
+    it 'ignores when too much space in front of backslash after `__END__`' do
+      expect_no_offenses(<<~'RUBY')
+        foo
+        bar
+        __END__
+        baz    \
+        qux
+      RUBY
+    end
+
+    it 'ignores empty code' do
+      expect_no_offenses('')
     end
   end
 end


### PR DESCRIPTION
Fixes #10763.

This PR fixes a false positive for `Layout/LineContinuationSpacing` when using continuation keyword `\` after `__END__`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
