### PR TITLE
[Fix #10745] Fix an error when using old JSON gem

### DIFF
--- a/changelog/fix_an_error_when_using_old_json_gem.md
+++ b/changelog/fix_an_error_when_using_old_json_gem.md
@@ -1,0 +1,1 @@
+* [#10745](https://github.com/rubocop/rubocop/issues/10745): Require JSON 2.3 or higher to fix an incompatible JSON API error. ([@koic][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
+  s.add_runtime_dependency('json', '~> 2.3')
   s.add_runtime_dependency('parallel', '~> 1.10')
   s.add_runtime_dependency('parser', '>= 3.1.0.0')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')


### PR DESCRIPTION
Fixes #10745.

This PR fixes the following incompatible API error when using JSON 2.2 or lower.

```console
% bunlde exec rspec  ./spec/rubocop/result_cache_spec.rb:45
Run options: include {:focus=>true,
:locations=>{"./spec/rubocop/result_cache_spec.rb"=>[45]}}

Randomized with seed 40926
FF

Failures:

  1) RuboCop::ResultCache cached result that was saved with no command
  line option when no option is given is valid and can be loaded
     Failure/Error: deserialize_offenses(JSON.parse(text))

     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     Shared Example Group: "valid" called from
       ./spec/rubocop/result_cache_spec.rb:121
     # ./lib/rubocop/cached_data.rb:14:in `from_json'
     # ./lib/rubocop/result_cache.rb:119:in `load'
     # ./spec/rubocop/result_cache_spec.rb:45:in `block (4 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `block (4 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `block (3 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:7:in `block (2 levels) in
       <top (required)>'

  2) RuboCop::ResultCache cached result that was saved with no command
  line option when --format is given is valid and can be loaded
     Failure/Error: deserialize_offenses(JSON.parse(text))

     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     Shared Example Group: "valid" called from
       ./spec/rubocop/result_cache_spec.rb:242
     # ./lib/rubocop/cached_data.rb:14:in `from_json'
     # ./lib/rubocop/result_cache.rb:119:in `load'
     # ./spec/rubocop/result_cache_spec.rb:45:in `block (4 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `block (4 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:30:in `block (3 levels) in
       <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:7:in `block (2 levels) in
       <top (required)>'

Finished in 0.2064 seconds (files took 1.04 seconds to load)
2 examples, 2 failures
```

It resolves the error by requiring JSON 2.3 or higher.

NOTE: It's been a few years since JSON 2.3 was released. It's maybe widespread to some extent, so it's not expected to have a big impact.
https://rubygems.org/gems/json/versions/2.3.0

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
