### PR TITLE
Fix false negatives when public method is defined after a private one

### DIFF
--- a/changelog/fix_false_negatives_in_documentation_comment.md
+++ b/changelog/fix_false_negatives_in_documentation_comment.md
@@ -1,0 +1,1 @@
+* [#10774](https://github.com/rubocop/rubocop/pull/10774): Fix false negatives in `Style/DocumentationMethod` when a public method is defined after a private one. ([@Darhazer][])

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -72,7 +72,6 @@ require_relative 'rubocop/cop/mixin/configurable_enforced_style'
 require_relative 'rubocop/cop/mixin/configurable_formatting'
 require_relative 'rubocop/cop/mixin/configurable_naming'
 require_relative 'rubocop/cop/mixin/configurable_numbering'
-require_relative 'rubocop/cop/mixin/def_node'
 require_relative 'rubocop/cop/mixin/documentation_comment'
 require_relative 'rubocop/cop/mixin/duplication'
 require_relative 'rubocop/cop/mixin/range_help'
@@ -130,6 +129,7 @@ require_relative 'rubocop/cop/mixin/uncommunicative_name'
 require_relative 'rubocop/cop/mixin/unused_argument'
 require_relative 'rubocop/cop/mixin/visibility_help'
 require_relative 'rubocop/cop/mixin/comments_help' # relies on visibility_help
+require_relative 'rubocop/cop/mixin/def_node' # relies on visibility_help
 
 require_relative 'rubocop/cop/utils/format_string'
 

--- a/lib/rubocop/cop/mixin/def_node.rb
+++ b/lib/rubocop/cop/mixin/def_node.rb
@@ -5,8 +5,7 @@ module RuboCop
     # Common functionality for checking def nodes.
     module DefNode
       extend NodePattern::Macros
-
-      NON_PUBLIC_MODIFIERS = %w[private protected].freeze
+      include VisibilityHelp
 
       private
 
@@ -15,11 +14,7 @@ module RuboCop
       end
 
       def preceding_non_public_modifier?(node)
-        stripped_source_upto(node.first_line).any? { |line| NON_PUBLIC_MODIFIERS.include?(line) }
-      end
-
-      def stripped_source_upto(index)
-        processed_source[0..index].map(&:strip)
+        node_visibility(node) != :public
       end
 
       # @!method non_public_modifier?(node)

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -32,6 +32,24 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
             ^^^^^^^^^^^^^^^ Missing method documentation comment.
           CODE
         end
+
+        it 'registers an offense when method is public, but there were private methods before' do
+          expect_offense(<<~CODE)
+            class Foo
+                private
+
+                def baz
+                end
+
+                public
+
+                def foo
+                ^^^^^^^ Missing method documentation comment.
+                  puts 'bar'
+                end
+            end
+          CODE
+        end
       end
 
       context 'when method is private' do


### PR DESCRIPTION
[Similar to Rails/Delegate](https://github.com/rubocop/rubocop-rails/pull/736) this cop was just checking the previous lines for a `private` declaration. This fails when there is a private method in a nested class, or as the added spec illustrates - when private methods are declared before the public ones

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
