### PR TITLE
Allow asking to avoid mixing hash shorthand styles in single hashes

### DIFF
--- a/changelog/new_allow_asking_to_avoid_mixing_hash.md
+++ b/changelog/new_allow_asking_to_avoid_mixing_hash.md
@@ -1,0 +1,1 @@
+* [#10776](https://github.com/rubocop/rubocop/pull/10776): New option (`consistent`) for `EnforcedShorthandSyntax` in `Style/HashSyntax` to avoid mixing shorthand and non-shorthand hash keys in ruby 3.1. ([@h-lame][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3839,6 +3839,8 @@ Style/HashSyntax:
     - never
     # accepts both shorthand and explicit use of hash literal value.
     - either
+    # like "always", but will avoid mixing styles in a single hash
+    - consistent
   # Force hashes that have a symbol value to use hash rockets
   UseHashRocketsWithSymbolValues: false
   # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -5,7 +5,7 @@ module RuboCop
     # This module checks for Ruby 3.1's hash value omission syntax.
     module HashShorthandSyntax
       OMIT_HASH_VALUE_MSG = 'Omit the hash value.'
-      EXPLICIT_HASH_VALUE_MSG = 'Explicit the hash value.'
+      EXPLICIT_HASH_VALUE_MSG = 'Include the hash value.'
 
       def on_pair(node)
         return if ignore_hash_shorthand_syntax?(node)

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -6,6 +6,21 @@ module RuboCop
     module HashShorthandSyntax
       OMIT_HASH_VALUE_MSG = 'Omit the hash value.'
       EXPLICIT_HASH_VALUE_MSG = 'Include the hash value.'
+      DO_NOT_MIX_MSG_PREFIX = 'Do not mix explicit and implicit hash values.'
+      DO_NOT_MIX_OMIT_VALUE_MSG = "#{DO_NOT_MIX_MSG_PREFIX} #{OMIT_HASH_VALUE_MSG}"
+      DO_NOT_MIX_EXPLICIT_VALUE_MSG = "#{DO_NOT_MIX_MSG_PREFIX} #{EXPLICIT_HASH_VALUE_MSG}"
+
+      def on_hash_for_mixed_shorthand(hash_node)
+        return if ignore_mixed_hash_shorthand_syntax?(hash_node)
+
+        hash_value_type_breakdown = breakdown_value_types_of_hash(hash_node)
+
+        if hash_with_mixed_shorthand_syntax?(hash_value_type_breakdown)
+          mixed_shorthand_syntax_check(hash_value_type_breakdown)
+        else
+          no_mixed_shorthand_syntax_check(hash_value_type_breakdown)
+        end
+      end
 
       def on_pair(node)
         return if ignore_hash_shorthand_syntax?(node)
@@ -36,8 +51,14 @@ module RuboCop
         end
       end
 
+      def ignore_mixed_hash_shorthand_syntax?(hash_node)
+        target_ruby_version <= 3.0 || enforced_shorthand_syntax != 'consistent' ||
+          !hash_node.hash_type?
+      end
+
       def ignore_hash_shorthand_syntax?(pair_node)
         target_ruby_version <= 3.0 || enforced_shorthand_syntax == 'either' ||
+          enforced_shorthand_syntax == 'consistent' ||
           !pair_node.parent.hash_type?
       end
 
@@ -80,6 +101,60 @@ module RuboCop
         return false unless right_sibling
 
         ancestor.respond_to?(:parenthesized?) && !ancestor.parenthesized? && !!right_sibling
+      end
+
+      def breakdown_value_types_of_hash(hash_node)
+        hash_node.pairs.group_by do |pair_node|
+          if pair_node.value_omission?
+            :value_omitted
+          elsif require_hash_value?(pair_node.key.source, pair_node)
+            :value_needed
+          else
+            :value_omittable
+          end
+        end
+      end
+
+      def hash_with_mixed_shorthand_syntax?(hash_value_type_breakdown)
+        hash_value_type_breakdown.keys.size > 1
+      end
+
+      def hash_with_values_that_cant_be_omitted?(hash_value_type_breakdown)
+        hash_value_type_breakdown[:value_needed]&.any?
+      end
+
+      def each_omitted_value_pair(hash_value_type_breakdown, &block)
+        hash_value_type_breakdown[:value_omitted]&.each(&block)
+      end
+
+      def each_omittable_value_pair(hash_value_type_breakdown, &block)
+        hash_value_type_breakdown[:value_omittable]&.each(&block)
+      end
+
+      def mixed_shorthand_syntax_check(hash_value_type_breakdown)
+        if hash_with_values_that_cant_be_omitted?(hash_value_type_breakdown)
+          each_omitted_value_pair(hash_value_type_breakdown) do |pair_node|
+            hash_key_source = pair_node.key.source
+            replacement = "#{hash_key_source}: #{hash_key_source}"
+            register_offense(pair_node, DO_NOT_MIX_EXPLICIT_VALUE_MSG, replacement)
+          end
+        else
+          each_omittable_value_pair(hash_value_type_breakdown) do |pair_node|
+            hash_key_source = pair_node.key.source
+            replacement = "#{hash_key_source}:"
+            register_offense(pair_node, DO_NOT_MIX_OMIT_VALUE_MSG, replacement)
+          end
+        end
+      end
+
+      def no_mixed_shorthand_syntax_check(hash_value_type_breakdown)
+        return if hash_with_values_that_cant_be_omitted?(hash_value_type_breakdown)
+
+        each_omittable_value_pair(hash_value_type_breakdown) do |pair_node|
+          hash_key_source = pair_node.key.source
+          replacement = "#{hash_key_source}:"
+          register_offense(pair_node, OMIT_HASH_VALUE_MSG, replacement)
+        end
       end
     end
   end

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -28,6 +28,7 @@ module RuboCop
       # * always - forces use of the 3.1 syntax (e.g. {foo:})
       # * never - forces use of explicit hash literal value
       # * either - accepts both shorthand and explicit use of hash literal value
+      # * consistent - like "always", but will avoid mixing styles in a single hash
       #
       # @example EnforcedStyle: ruby19 (default)
       #   # bad
@@ -89,6 +90,20 @@ module RuboCop
       #   # good
       #   {foo:, bar:}
       #
+      # @example EnforcedShorthandSyntax: consistent
+      #
+      #   # bad
+      #   {foo: , bar: bar}
+      #
+      #   # good
+      #   {foo:, bar:}
+      #
+      #   # bad
+      #   {foo: , bar: baz}
+      #
+      #   # good
+      #   {foo: foo, bar: baz}
+      #
       class HashSyntax < Base
         include ConfigurableEnforcedStyle
         include HashShorthandSyntax
@@ -103,6 +118,8 @@ module RuboCop
           pairs = node.pairs
 
           return if pairs.empty?
+
+          on_hash_for_mixed_shorthand(node)
 
           if style == :hash_rockets || force_hash_rockets?(pairs)
             hash_rockets_check(pairs)

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -1311,7 +1311,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         .to eq(<<~YAML)
           # Configuration parameters: EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
           # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-          # SupportedShorthandSyntax: always, never, either
+          # SupportedShorthandSyntax: always, never, either, consistent
           Style/HashSyntax:
             EnforcedStyle: hash_rockets
         YAML
@@ -1325,7 +1325,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         .to eq(<<~YAML)
           # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
           # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-          # SupportedShorthandSyntax: always, never, either
+          # SupportedShorthandSyntax: always, never, either, consistent
           Style/HashSyntax:
             Exclude:
               - 'example1.rb'
@@ -1346,7 +1346,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           .to eq(<<~YAML)
             # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
             # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-            # SupportedShorthandSyntax: always, never, either
+            # SupportedShorthandSyntax: always, never, either, consistent
             Style/HashSyntax:
               Exclude:
                 - 'example1.rb'

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1183,8 +1183,8 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       it 'registers and corrects an offense when hash values are omitted' do
         expect_offense(<<~RUBY)
           {foo:, bar:}
-           ^^^ Explicit the hash value.
-                 ^^^ Explicit the hash value.
+           ^^^ Include the hash value.
+                 ^^^ Include the hash value.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -1195,7 +1195,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       it 'registers and corrects an offense when hash key and hash value are partially the same' do
         expect_offense(<<~RUBY)
           {foo:, bar: bar, baz: qux}
-           ^^^ Explicit the hash value.
+           ^^^ Include the hash value.
         RUBY
 
         expect_correction(<<~RUBY)


### PR DESCRIPTION
For those who want to use hash shorthand style, but don't want to mix shorthand and explicit styles in the same hash we provide a new option for `EnforcedShorthandSyntax` called `consistent` that raises an offence if we've mixed styles.

E.g.

    # bad
    {foo: , bar: bar}

    # good
    {foo:, bar:}

    # bad
    {foo: , bar: baz}

    # good
    {foo: foo, bar: baz}

# Requesting help 🙋 

I don't particularly like the implementation.  Prior to this commit `HashSyntax` mixed in `HashShorthandSyntax` but was otherwise unaware of it.  With this change I've had to make `HashSyntax` aware of `HashShorthandSyntax` so it can call `on_hash_for_mixed_shorthand` in `on_hash`.  I don't think there's a way to enforce a no mixing style at the pair level meaning we can't do this in `on_pair` already present in `HashShorthandSyntax` and have to use `on_hash` to look at the whole hash in one go.  Would love some advice on this.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists). (n/a)
* [x] Feature branch is up-to-date with `master` (if not - rebase it). (current rebase against - 0984886d4aacb9b1a6de5c35d5984fac7500d9d0)
* [x] Squashed related commits together. (n/a - single commit)
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
