### PR TITLE
[Fix #10764] Fix performance issue for Layout/FirstHashElementIndentation and Layout/FirstArrayElementIndentation

### DIFF
--- a/changelog/fix_performance_issue_for_multiline_element_indentation.md
+++ b/changelog/fix_performance_issue_for_multiline_element_indentation.md
@@ -1,0 +1,1 @@
+* [#10764](https://github.com/rubocop/rubocop/issues/10764): Fix performance issue for Layout/FirstHashElementIndentation and Layout/FirstArrayElementIndentation. ([@j-miyake][])

--- a/lib/rubocop/cop/layout/first_array_element_indentation.rb
+++ b/lib/rubocop/cop/layout/first_array_element_indentation.rb
@@ -120,14 +120,15 @@ module RuboCop
             check_first(first_elem, left_bracket, left_parenthesis, 0)
           end
 
-          check_right_bracket(array_node.loc.end, left_bracket, left_parenthesis)
+          check_right_bracket(array_node.loc.end, first_elem, left_bracket, left_parenthesis)
         end
 
-        def check_right_bracket(right_bracket, left_bracket, left_parenthesis)
+        def check_right_bracket(right_bracket, first_elem, left_bracket, left_parenthesis)
           # if the right bracket is on the same line as the last value, accept
           return if /\S/.match?(right_bracket.source_line[0...right_bracket.column])
 
-          expected_column, indent_base_type = indent_base(left_bracket, left_parenthesis)
+          expected_column, indent_base_type = indent_base(left_bracket, first_elem,
+                                                          left_parenthesis)
           @column_delta = expected_column - right_bracket.column
           return if @column_delta.zero?
 

--- a/lib/rubocop/cop/layout/first_hash_element_indentation.rb
+++ b/lib/rubocop/cop/layout/first_hash_element_indentation.rb
@@ -158,14 +158,14 @@ module RuboCop
             end
           end
 
-          check_right_brace(hash_node.loc.end, left_brace, left_parenthesis)
+          check_right_brace(hash_node.loc.end, first_pair, left_brace, left_parenthesis)
         end
 
-        def check_right_brace(right_brace, left_brace, left_parenthesis)
+        def check_right_brace(right_brace, first_pair, left_brace, left_parenthesis)
           # if the right brace is on the same line as the last value, accept
           return if /\S/.match?(right_brace.source_line[0...right_brace.column])
 
-          expected_column, indent_base_type = indent_base(left_brace, left_parenthesis)
+          expected_column, indent_base_type = indent_base(left_brace, first_pair, left_parenthesis)
           @column_delta = expected_column - right_brace.column
           return if @column_delta.zero?
 


### PR DESCRIPTION
Fixes #10764.

In rubocop v1.31.0, `MultilineElementIndentation` that is used by `Layout/FirstHashElementIndentation` and `Layout/FirstArrayElementIndentation` walks all nodes through in the code to find a hash pair node where its value part begins with the given left-brace; That computation is expensive, so I made a change so that the hash pair is passed by each class that uses `MultilineElementIndentation`.

I ran rubocop by the following command to make sure the performance problem was fixed by this PR. The input file is the file provided in https://github.com/rubocop/rubocop/issues/10764#issuecomment-1170011469
```bash
$ time exe/rubocop --cache false test.rb
```

Result:

- With v1.30.1
```
exe/rubocop --cache false test.rb  1.51s user 0.33s system 41% cpu 4.410 total
```

- With v1.31.0
```
exe/rubocop --cache false test.rb  3.26s user 0.29s system 84% cpu 4.199 total
```

- With this PR
```
exe/rubocop --cache false test.rb  1.55s user 0.32s system 62% cpu 3.012 total
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
