### PR TITLE
Fix a suggestions for safer conversions for `Lint/NonAtomicFileOperation`

### DIFF
--- a/changelog/fix_a_suggestions_for_safer_conversions_non_atomic_file_operation.md
+++ b/changelog/fix_a_suggestions_for_safer_conversions_non_atomic_file_operation.md
@@ -1,0 +1,1 @@
+* [#10781](https://github.com/rubocop/rubocop/pull/10781): Fix a suggestions for safer conversions for `Lint/NonAtomicFileOperation`. ([@ydah][])


### PR DESCRIPTION
This PR is fix a suggestions for safer conversions for `Lint/NonAtomicFileOperation`.

Change the uniform conversion to `rm_rf` or `mkdir_p` to a safe change proposal as follows.

For non-recurrent file deletions
```ruby
# bad
if File.exist?(path)
  File.remove(path)
end

# good
FileUtils.rm_f(path)
```

For cases that do not require replacement
```ruby
# bad
if File.exist?(path)
  FileUtils.makedirs(path)
end

# good
FileUtils.makedirs(path)
```


In addition, when replacing a non-atomic file operation with a forced file creation or deletion, an offense message has been added as follows.

```ruby
if FileTest.exist?(path)
   ^^^^^^^^^^^^^^^^^^^^^^^^ Remove an unnecessary existence checks `FileTest.exist?`.
  FileUtils.remove(path)
  ^^^^^^^^^^^^^^^^ Use atomic file operation method `FileUtils.rm_f`.
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
