### PR TITLE
Preserve multiline semantics on `Style/SymbolArray` and `Style/WordArray`

### DIFF
--- a/changelog/change_preserve_multiline_on_stylesymbolarray.md
+++ b/changelog/change_preserve_multiline_on_stylesymbolarray.md
@@ -1,0 +1,1 @@
+* [#10784](https://github.com/rubocop/rubocop/pull/10784): Preserve multiline semantics on `Style/SymbolArray` and `Style/WordArray`. ([@r7kamura][])

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -39,7 +39,7 @@ module RuboCop
         minimum_target_ruby_version 2.0
 
         PERCENT_MSG = 'Use `%i` or `%I` for an array of symbols.'
-        ARRAY_MSG = 'Use `%<prefer>s` for an array of symbols.'
+        ARRAY_MSG = 'Use %<prefer>s for an array of symbols.'
 
         class << self
           attr_accessor :largest_brackets
@@ -74,8 +74,7 @@ module RuboCop
               to_symbol_literal(c.value.to_s)
             end
           end
-
-          "[#{syms.join(', ')}]"
+          build_bracketed_array_with_appropriate_whitespace(elements: syms, node: node)
         end
 
         def to_symbol_literal(string)

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -44,7 +44,7 @@ module RuboCop
         extend AutoCorrector
 
         PERCENT_MSG = 'Use `%w` or `%W` for an array of words.'
-        ARRAY_MSG = 'Use `%<prefer>s` for an array of words.'
+        ARRAY_MSG = 'Use %<prefer>s for an array of words.'
 
         class << self
           attr_accessor :largest_brackets
@@ -92,8 +92,7 @@ module RuboCop
               to_string_literal(word.children[0])
             end
           end
-
-          "[#{words.join(', ')}]"
+          build_bracketed_array_with_appropriate_whitespace(elements: words, node: node)
         end
       end
     end

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -220,6 +220,25 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
       RUBY
     end
 
+    it 'autocorrects multiline %i array' do
+      expect_offense(<<~RUBY)
+        %i(
+        ^^^ Use an array literal `[...]` for an array of symbols.
+          one
+          two
+          three
+        )
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [
+          :one,
+          :two,
+          :three
+        ]
+      RUBY
+    end
+
     it 'autocorrects an array has interpolations' do
       expect_offense(<<~'RUBY')
         %I(#{foo} #{foo}bar foo#{bar} foo)

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -416,6 +416,23 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       RUBY
     end
 
+    it 'autocorrects multiline %w() array' do
+      expect_offense(<<~'RUBY')
+        %w(
+        ^^^ Use an array literal `[...]` for an array of words.
+          foo
+          bar
+        )
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        [
+          'foo',
+          'bar'
+        ]
+      RUBY
+    end
+
     it 'autocorrects a %W() array which uses string with hyphen' do
       expect_offense(<<~'RUBY')
         %W(foo bar #{foo}-bar)


### PR DESCRIPTION
To fix https://github.com/rubocop/rubocop/issues/10455.

Example:

```diff
# Before
-%w(
- foo
- bar
- baz
-)
+["foo", "bar", "baz"]

# After
-%w(
- foo
- bar
- baz
-)
+[
+  "foo",
+  "bar",
+  "baz"
+]
```


To mimic the original whitespace semantics, I decided to extract three types of whitespace and reuse them in autocorrection.

```ruby
# Before
"%w[\n  foo\n  bar\n  baz\n]\n"
#   ^^^^   ^^^^          ^^
#   |      |             `-- whitespace_trailing
#   |      `-- whitespace_between
#   `-- whitespace_leading

# After
"[\n  'foo',\n  'bar',\n  'baz'\n]\n"
# ^^^^      ^^^^      ^^^^     ^^
# |         |         |        `-- whitespace_trailing
# |         `------------ whitespace_between
# `-- whitespace_leading
```

Note that this commit also changes the offense message like this (on multiline case):

```ruby
# Before
%w(
^^^ Use `[
  'foo',
  'bar'
]` for an array of words.
  foo
  bar
)

# After
%w(
^^^ Use an array literal `[...]` for an array of words.
  foo
  bar
)
```

This means that the auto-corrected code no longer appears in the offense message (on multiline case). I think this is a reasonable change because this format is already used for percent styles: 

> 'Use `%w` or `%W` for an array of words.'`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
