### PR TITLE
Fix a false negative for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_a_false_negative_for_style_redundant_parentheses.md
+++ b/changelog/fix_a_false_negative_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#10785](https://github.com/rubocop/rubocop/pull/10785): Fix a false negative for `Style/RedundantParentheses` when parens around a receiver of a method call with an argument. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -81,7 +81,8 @@ module RuboCop
         end
 
         def like_method_argument_parentheses?(node)
-          node.send_type? && node.arguments.size == 1 && !node.arithmetic_operation?
+          node.send_type? && node.arguments.one? &&
+            !node.arithmetic_operation? && node.first_argument.begin_type?
         end
 
         def empty_parentheses?(node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -125,6 +125,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   it_behaves_like 'plausible', '+(1.foo.bar)'
   it_behaves_like 'plausible', '()'
 
+  it 'registers an offense for parens around a receiver of a method call with an argument' do
+    expect_offense(<<~RUBY)
+      (x).y(z)
+      ^^^ Don't use parentheses around a method call.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.y(z)
+    RUBY
+  end
+
   it 'registers an offense for parens around an interpolated expression' do
     expect_offense(<<~RUBY)
       "\#{(foo)}"


### PR DESCRIPTION
This PR fixes a false negative for `Style/RedundantParentheses` when parens around a receiver of a method call with an argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
