### PR TITLE
[Fix #10786] Fix a false positive for `Lint/NonAtomicFileOperation`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_non_atomic_file_operation.md
+++ b/changelog/fix_a_false_positive_for_lint_non_atomic_file_operation.md
@@ -1,0 +1,1 @@
+* [#10786](https://github.com/rubocop/rubocop/issues/10786): Fix a false positive for `Lint/NonAtomicFileOperation` when using complex conditional. ([@koic][])

--- a/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
+++ b/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
@@ -183,4 +183,20 @@ RSpec.describe RuboCop::Cop::Lint::NonAtomicFileOperation, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense when using complex conditional with `&&`' do
+    expect_no_offenses(<<~RUBY)
+      if FileTest.exist?(path) && File.stat(path).socket?
+        FileUtils.mkdir(path)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using complex conditional with `||`' do
+    expect_no_offenses(<<~RUBY)
+      if FileTest.exist?(path) || condition
+        FileUtils.mkdir(path)
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #10786.

This PR fixes a false positive for `Lint/NonAtomicFileOperation` when using complex conditional.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
