### PR TITLE
[Fix #10026] Fix inherit_mode resolution for parent and default config

### DIFF
--- a/changelog/fix_inherit_mode_resolution.md
+++ b/changelog/fix_inherit_mode_resolution.md
@@ -1,0 +1,1 @@
+* [#10026](https://github.com/rubocop/rubocop/issues/10026): Fix merging of array parameters in either parent of default config. ([@jonas054][])

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -179,7 +179,7 @@ module RuboCop
 
     def determine_inherit_mode(hash, key)
       cop_cfg = hash[key]
-      local_inherit = cop_cfg.delete('inherit_mode') if cop_cfg.is_a?(Hash)
+      local_inherit = cop_cfg['inherit_mode'] if cop_cfg.is_a?(Hash)
       local_inherit || hash['inherit_mode'] || {}
     end
 


### PR DESCRIPTION
The problem was that we deleted the `inherit_mode` entry in the configuration hash while processing the resolution of inheritance from base configurations (`inherit_from`, etc.). When the merging of default configuration and user configuration was done at a later stage, the `inherit_mode` parameter was gone.

By not deleting `inherit_mode`, we fix the problem. I don't think it has any unwanted side effects, but `inherit_mode` does show up in the output from `--show-cops` now. This should be OK.