### PR TITLE
Fix wrong offense with `Style/TopLevelMethodDefinition` when just calling methods on top-level

### DIFF
--- a/lib/rubocop/cop/internal_affairs/useless_restrict_on_send.rb
+++ b/lib/rubocop/cop/internal_affairs/useless_restrict_on_send.rb
@@ -33,7 +33,13 @@ module RuboCop
         MSG = 'Useless `RESTRICT_ON_SEND` is defined.'
 
         # @!method defined_send_callback?(node)
-        def_node_search :defined_send_callback?, '(def {:on_send :after_send} ...)'
+        def_node_search :defined_send_callback?, <<~PATTERN
+          {
+            (def {:on_send :after_send} ...)
+            (alias (sym {:on_send :after_send}) _source ...)
+            (send nil? :alias_method {(sym {:on_send :after_send}) (str {"on_send" "after_send"})} _source ...)
+          }
+        PATTERN
 
         def on_casgn(node)
           return if !restrict_on_send?(node) || defined_send_callback?(node.parent)

--- a/lib/rubocop/cop/style/top_level_method_definition.rb
+++ b/lib/rubocop/cop/style/top_level_method_definition.rb
@@ -47,6 +47,8 @@ module RuboCop
       class TopLevelMethodDefinition < Base
         MSG = 'Do not define methods at the top-level.'
 
+        RESTRICT_ON_SEND = %i[define_method].freeze # rubocop:disable InternalAffairs/UselessRestrictOnSend
+
         def on_def(node)
           return unless top_level_method_definition?(node)
 

--- a/lib/rubocop/cop/style/top_level_method_definition.rb
+++ b/lib/rubocop/cop/style/top_level_method_definition.rb
@@ -47,7 +47,7 @@ module RuboCop
       class TopLevelMethodDefinition < Base
         MSG = 'Do not define methods at the top-level.'
 
-        RESTRICT_ON_SEND = %i[define_method].freeze # rubocop:disable InternalAffairs/UselessRestrictOnSend
+        RESTRICT_ON_SEND = %i[define_method].freeze
 
         def on_def(node)
           return unless top_level_method_definition?(node)

--- a/spec/rubocop/cop/internal_affairs/useless_restrict_on_send_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/useless_restrict_on_send_spec.rb
@@ -27,6 +27,30 @@ RSpec.describe RuboCop::Cop::InternalAffairs::UselessRestrictOnSend, :config do
     RUBY
   end
 
+  it 'does not register an offense when using `RESTRICT_ON_SEND` and defines `on_send` with alias' do
+    expect_no_offenses(<<~RUBY)
+      class FooCop
+        RESTRICT_ON_SEND = %i[bad_method].freeze
+        def on_def(node)
+          # ...
+        end
+        alias on_send on_def
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `RESTRICT_ON_SEND` and defines `on_send` with alias_method' do
+    expect_no_offenses(<<~RUBY)
+      class FooCop
+        RESTRICT_ON_SEND = %i[bad_method].freeze
+        def on_def(node)
+          # ...
+        end
+        alias_method :on_send, :on_def
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using `RESTRICT_ON_SEND` and defines `after_send`' do
     expect_no_offenses(<<~RUBY)
       class FooCop
@@ -34,6 +58,30 @@ RSpec.describe RuboCop::Cop::InternalAffairs::UselessRestrictOnSend, :config do
         def after_send(node)
           # ...
         end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `RESTRICT_ON_SEND` and defines `after_send` with alias' do
+    expect_no_offenses(<<~RUBY)
+      class FooCop
+        RESTRICT_ON_SEND = %i[bad_method].freeze
+        def after_send(node)
+          # ...
+        end
+        alias after_send any
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `RESTRICT_ON_SEND` and defines `after_send` with alias_method' do
+    expect_no_offenses(<<~RUBY)
+      class FooCop
+        RESTRICT_ON_SEND = %i[bad_method].freeze
+        def after_send(node)
+          # ...
+        end
+        self.alias_method "after_send", "any"
       end
     RUBY
   end

--- a/spec/rubocop/cop/style/top_level_method_definition_spec.rb
+++ b/spec/rubocop/cop/style/top_level_method_definition_spec.rb
@@ -97,4 +97,10 @@ RSpec.describe RuboCop::Cop::Style::TopLevelMethodDefinition, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense when just called method on top-level' do
+    expect_no_offenses(<<~RUBY)
+      require_relative 'foo'
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR updates #10743

Currently `1.31.2` looks all method callings on top-level are [falling](https://github.com/kachick/ruby-ulid/runs/7243055726?check_suite_focus=true) when enabled `Style/TopLevelMethodDefinition` even if `require_relative`.

```yaml
Style/TopLevelMethodDefinition:
  Enabled: true
```

Fixes #10799

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
