### PR TITLE
[Fix #10791] Fix an incorrect autocorrect for `Style/Semicolon`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_semicolon.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_semicolon.md
@@ -1,0 +1,1 @@
+* [#10791](https://github.com/rubocop/rubocop/issues/10791): Fix an incorrect autocorrect for `Style/Semicolon` when using endless range before semicolon. ([@koic][])

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -108,6 +108,76 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
     expect_correction(" puts 1\n")
   end
 
+  it 'registers an offense for range (`1..42`) with semicolon' do
+    expect_offense(<<~RUBY)
+      1..42;
+           ^ Do not use semicolons to terminate expressions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      1..42
+    RUBY
+  end
+
+  it 'registers an offense for range (`1...42`) with semicolon' do
+    expect_offense(<<~RUBY)
+      1...42;
+            ^ Do not use semicolons to terminate expressions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      1...42
+    RUBY
+  end
+
+  context 'Ruby >= 2.6', :ruby26 do
+    it 'registers an offense for endless range with semicolon (irange only)' do
+      expect_offense(<<~RUBY)
+        42..;
+            ^ Do not use semicolons to terminate expressions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (42..)
+      RUBY
+    end
+
+    it 'registers an offense for endless range with semicolon (irange and erange)' do
+      expect_offense(<<~RUBY)
+        42..;
+            ^ Do not use semicolons to terminate expressions.
+        42...;
+             ^ Do not use semicolons to terminate expressions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (42..)
+        (42...)
+      RUBY
+    end
+
+    it 'registers an offense for endless range with semicolon in the method definition' do
+      expect_offense(<<~RUBY)
+        def foo
+          42..;
+              ^ Do not use semicolons to terminate expressions.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          (42..)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for endless range without semicolon' do
+      expect_no_offenses(<<~RUBY)
+        42..
+      RUBY
+    end
+  end
+
   context 'with a multi-expression line without a semicolon' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #10791.

This PR fixes an incorrect autocorrect for `Style/Semicolon` when using endless range before semicolon.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
