### PR TITLE
[Fix #10613] Allow parallel inspection for autocorrect

### DIFF
--- a/changelog/change_allow_parallel_autocorrect.md
+++ b/changelog/change_allow_parallel_autocorrect.md
@@ -1,0 +1,1 @@
+* [#10613](https://github.com/rubocop/rubocop/issues/10613): Allow autocorrecting with -P/--parallel and make it the default. ([@jonas054][])

--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -237,8 +237,8 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | `-o/--out`
 | Write output to a file instead of STDOUT.
 
-| `--parallel`
-| Use available CPUs to execute inspection in parallel.
+| `--[no-]parallel`
+| Use available CPUs to execute inspection in parallel. Default is parallel.
 
 | `-r/--require`
 | Require Ruby file (see xref:extensions.adoc#loading-extensions[Loading Extensions]).

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -12,6 +12,7 @@ module RuboCop
       color debug display_style_guide display_time display_only_fail_level_offenses
       display_only_failed except extra_details fail_level fix_layout format
       ignore_disable_comments lint only only_guide_cops require safe
+      autocorrect safe_autocorrect autocorrect_all
     ].freeze
 
     class Finished < StandardError; end

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -421,12 +421,9 @@ module RuboCop
     end
 
     def invalid_arguments_for_parallel
-      [('--auto-gen-config'    if @options.key?(:auto_gen_config)),
-       ('-F/--fail-fast'       if @options.key?(:fail_fast)),
-       ('-x/--fix-layout'      if @options.key?(:fix_layout)),
-       ('-a/--autocorrect'     if @options.key?(:safe_autocorrect)),
-       ('-A/--autocorrect-all' if @options.key?(:autocorrect_all)),
-       ('--cache false'        if @options > { cache: 'false' })].compact
+      [('--auto-gen-config' if @options.key?(:auto_gen_config)),
+       ('-F/--fail-fast'    if @options.key?(:fail_fast)),
+       ('--cache false'     if @options > { cache: 'false' })].compact
     end
 
     def only_includes_redundant_disable?

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -63,8 +63,12 @@ module RuboCop
     # Warms up the RuboCop cache by forking a suitable number of RuboCop
     # instances that each inspects its allotted group of files.
     def warm_cache(target_files)
+      saved_options = @options.dup
       puts 'Running parallel inspection' if @options[:debug]
+      %i[autocorrect safe_autocorrect].each { |opt| @options[opt] = false }
       Parallel.each(target_files) { |target_file| file_offenses(target_file) }
+    ensure
+      @options = saved_options
     end
 
     def find_target_files(paths)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -213,16 +213,20 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         end
       end
 
-      # NOTE: Cannot be autocorrected with `parallel`.
       context 'when specifying `--debug` and `-a` options`' do
-        it 'fails with an error message' do
+        it 'uses parallel inspection when correcting the file' do
           create_file('example1.rb', <<~RUBY)
+            # frozen_string_literal: true
+
+            puts "hello"
+          RUBY
+          expect(cli.run(['--debug', '-a'])).to eq(0)
+          expect($stdout.string).to include('Use parallel by default.')
+          expect(File.read('example1.rb')).to eq(<<~RUBY)
             # frozen_string_literal: true
 
             puts 'hello'
           RUBY
-          expect(cli.run(['--debug', '-a'])).to eq(0)
-          expect($stdout.string).not_to include('Use parallel by default.')
         end
       end
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -260,29 +260,26 @@ RSpec.describe RuboCop::Options, :isolated_environment do
 
       context 'combined with an autocorrect argument' do
         context 'combined with --fix-layout' do
-          it 'ignores --parallel' do
+          it 'allows --parallel' do
             options.parse %w[--parallel --fix-layout]
-            expect($stdout.string).to include('-P/--parallel is being ignored because it is not ' \
-                                              'compatible with -x/--fix-layout')
-            expect(options.instance_variable_get(:@options).keys).not_to include(:parallel)
+            expect($stdout.string).not_to include('-P/--parallel is being ignored')
+            expect(options.instance_variable_get(:@options).keys).to include(:parallel)
           end
         end
 
         context 'combined with --autocorrect' do
-          it 'ignores --parallel' do
+          it 'allows --parallel' do
             options.parse %w[--parallel --autocorrect]
-            expect($stdout.string).to include('-P/--parallel is being ignored because it is not ' \
-                                              'compatible with -a/--autocorrect')
-            expect(options.instance_variable_get(:@options).keys).not_to include(:parallel)
+            expect($stdout.string).not_to include('-P/--parallel is being ignored')
+            expect(options.instance_variable_get(:@options).keys).to include(:parallel)
           end
         end
 
         context 'combined with --autocorrect-all' do
-          it 'ignores --parallel' do
+          it 'allows --parallel' do
             options.parse %w[--parallel --autocorrect-all]
-            expect($stdout.string).to include('-P/--parallel is being ignored because it is not ' \
-                                              'compatible with -A/--autocorrect-all')
-            expect(options.instance_variable_get(:@options).keys).not_to include(:parallel)
+            expect($stdout.string).not_to include('-P/--parallel is being ignored')
+            expect(options.instance_variable_get(:@options).keys).to include(:parallel)
           end
         end
       end
@@ -309,7 +306,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
         it 'ignores --parallel and lists both incompatible arguments' do
           options.parse %w[--parallel --fail-fast --autocorrect]
           expect($stdout.string).to include('-P/--parallel is being ignored because it is not ' \
-                                            'compatible with -F/--fail-fast, -a/--autocorrect')
+                                            'compatible with -F/--fail-fast')
           expect(options.instance_variable_get(:@options).keys).not_to include(:parallel)
         end
       end


### PR DESCRIPTION
Allow the `-P`/`--parallel` flag together with the autocorrection flags `--[safe-]auto-correct`/`-a` `--auto-correct-all`/`-A` and  `--fix-layout`/`-x`. Also make this the default, so that `--no-parallel` has to be given for a single core run.

The algorithm for normal parallel inspection is followed, so that a cache warm-up phase is run first. This phase only does caching of inspection results. It doesn't update any files. Then it does a single core run that takes advantage of the cached results and does the corrections. The speed gain from this approach is probably smaller than writing files in parallel, but it's a pretty small change that still outputs correction results in the same way as before.

Also fix the documentation for `--parallel`, which did not mention `--no-parallel`.