### PR TITLE
Support --server with JRuby

### DIFF
--- a/changelog/new_server_under_jruby.md
+++ b/changelog/new_server_under_jruby.md
@@ -1,0 +1,1 @@
+* --server option is now supported under JRuby. ([@ccutrer][])

--- a/docs/modules/ROOT/pages/usage/server.adoc
+++ b/docs/modules/ROOT/pages/usage/server.adoc
@@ -13,7 +13,11 @@ Normally RuboCop starts somewhat slowly because it needs to `require` a ton of f
 slow. With the RuboCop server we sidestep this nasty issue and make it much more pleasant to
 interact with RuboCop from text editors and IDEs.
 
-NOTE: The feature cannot be used on JRuby and Windows, as they do not support the `fork` system call.
+NOTE: As JRuby and Windows do not support the `fork` system call, they have a
+slightly different implementation that spawns a new process. This means the
+startup time for a new instance of the background server is even longer than
+just running RuboCop directly, but once booted they still experience
+significant improvements for subsequent runs.
 
 == Run with Server
 
@@ -48,6 +52,8 @@ $ ps aux | grep 'rubocop --server'
 user             16060   0.0  0.0  5078568   2264   ??  S     7:54AM   0:00.00 rubocop --server /Users/user/src/github.com/rubocop/rubocop
 user             16337   0.0  0.0  5331560   2396   ??  S    23:51PM   0:00.00 rubocop --server /Users/user/src/github.com/rubocop/rubocop-rails
 ```
+
+NOTE: For JRuby and Windows, it might be `rubocop --start-server`.
 
 When you update and run `rubocop`, the server process will restart automatically.
 

--- a/lib/rubocop/server/cli.rb
+++ b/lib/rubocop/server/cli.rb
@@ -31,12 +31,6 @@ module RuboCop
       end
 
       def run(argv = ARGV)
-        unless Server.support_server?
-          return error('RuboCop server is not supported by this Ruby.') if use_server_option?(argv)
-
-          return STATUS_SUCCESS
-        end
-
         deleted_server_arguments = delete_server_argument_from(argv)
 
         if deleted_server_arguments.size >= 2
@@ -87,10 +81,6 @@ module RuboCop
         SERVER_OPTIONS.each_with_object([]) do |server_option, server_arguments|
           server_arguments << all_arguments.delete(server_option)
         end.compact
-      end
-
-      def use_server_option?(argv)
-        (argv & SERVER_OPTIONS).any?
       end
 
       def error(message)

--- a/lib/rubocop/server/client_command/base.rb
+++ b/lib/rubocop/server/client_command/base.rb
@@ -34,7 +34,7 @@ module RuboCop
         end
 
         def check_running_server
-          Server.running?.tap do |running|
+          (Server.running? && Server.listening?).tap do |running|
             warn 'RuboCop server is not running.' unless running
           end
         end

--- a/lib/rubocop/server/client_command/stop.rb
+++ b/lib/rubocop/server/client_command/stop.rb
@@ -18,12 +18,8 @@ module RuboCop
         def run
           return unless check_running_server
 
-          pid = fork do
-            send_request(command: 'stop')
-            Server.wait_for_running_status!(false)
-          end
-
-          Process.waitpid(pid)
+          send_request(command: 'stop')
+          Server.wait_for_status! { !Server.running? }
         end
       end
     end

--- a/spec/rubocop/server/cli_spec.rb
+++ b/spec/rubocop/server/cli_spec.rb
@@ -5,154 +5,143 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
 
   include_context 'cli spec behavior'
 
-  if RuboCop::Server.support_server?
-    before do
-      allow_any_instance_of(RuboCop::Server::Core).to receive(:server_mode?).and_return(false) # rubocop:disable RSpec/AnyInstance
+  before do
+    allow_any_instance_of(RuboCop::Server::Core).to receive(:server_mode?).and_return(false) # rubocop:disable RSpec/AnyInstance
+  end
+
+  after do
+    RuboCop::Server::ClientCommand::Stop.new.run
+  end
+
+  context 'when using `--server` option' do
+    it 'returns exit status 0 and display an information message' do
+      create_file('example.rb', <<~RUBY)
+        # frozen_string_literal: true
+
+        x = 0
+        puts x
+      RUBY
+      expect(cli.run(['--server', '--format', 'simple', 'example.rb'])).to eq(0)
+      expect(cli.exit?).to be(false)
+      expect($stdout.string).to start_with 'RuboCop server starting on '
+      expect($stderr.string).to eq ''
     end
+  end
 
-    after do
-      RuboCop::Server::ClientCommand::Stop.new.run
+  context 'when using `--no-server` option' do
+    it 'returns exit status 0' do
+      create_file('example.rb', <<~RUBY)
+        # frozen_string_literal: true
+
+        x = 0
+        puts x
+      RUBY
+      expect(cli.run(['--no-server', '--format', 'simple', 'example.rb'])).to eq(0)
+      expect(cli.exit?).to be(false)
+      expect($stdout.string).to eq ''
+      expect($stderr.string).to eq ''
     end
+  end
 
-    context 'when using `--server` option' do
-      it 'returns exit status 0 and display an information message' do
-        create_file('example.rb', <<~RUBY)
-          # frozen_string_literal: true
-
-          x = 0
-          puts x
-        RUBY
-        expect(cli.run(['--server', '--format', 'simple', 'example.rb'])).to eq(0)
-        expect(cli.exit?).to be(false)
-        expect($stdout.string).to start_with 'RuboCop server starting on '
-        expect($stderr.string).to eq ''
-      end
+  context 'when using `--start-server` option' do
+    it 'returns exit status 0 and display an information message' do
+      expect(cli.run(['--start-server'])).to eq(0)
+      expect(cli.exit?).to be(true)
+      expect($stdout.string).to start_with 'RuboCop server starting on '
+      expect($stderr.string).to eq ''
     end
+  end
 
-    context 'when using `--no-server` option' do
-      it 'returns exit status 0' do
-        create_file('example.rb', <<~RUBY)
-          # frozen_string_literal: true
-
-          x = 0
-          puts x
-        RUBY
-        expect(cli.run(['--no-server', '--format', 'simple', 'example.rb'])).to eq(0)
-        expect(cli.exit?).to be(false)
-        expect($stdout.string).to eq ''
-        expect($stderr.string).to eq ''
-      end
+  context 'when using `--stop-server` option' do
+    it 'returns exit status 0 and display a warning message' do
+      expect(cli.run(['--stop-server'])).to eq(0)
+      expect(cli.exit?).to be(true)
+      expect($stdout.string).to eq ''
+      expect($stderr.string).to eq "RuboCop server is not running.\n"
     end
+  end
 
-    context 'when using `--start-server` option' do
-      it 'returns exit status 0 and display an information message' do
-        expect(cli.run(['--start-server'])).to eq(0)
-        expect(cli.exit?).to be(true)
-        expect($stdout.string).to start_with 'RuboCop server starting on '
-        expect($stderr.string).to eq ''
-      end
+  context 'when using `--restart-server` option' do
+    it 'returns exit status 0 and display an information and a warning messages' do
+      expect(cli.run(['--restart-server'])).to eq(0)
+      expect(cli.exit?).to be(true)
+      expect($stdout.string).to start_with 'RuboCop server starting on '
+      expect($stderr.string).to eq "RuboCop server is not running.\n"
     end
+  end
 
-    context 'when using `--stop-server` option' do
-      it 'returns exit status 0 and display a warning message' do
-        expect(cli.run(['--stop-server'])).to eq(0)
-        expect(cli.exit?).to be(true)
-        expect($stdout.string).to eq ''
-        expect($stderr.string).to eq "RuboCop server is not running.\n"
-      end
+  context 'when using `--server-status` option' do
+    it 'returns exit status 0 and display an information message' do
+      expect(cli.run(['--server-status'])).to eq(0)
+      expect(cli.exit?).to be(true)
+      expect($stdout.string).to eq "RuboCop server is not running.\n"
+      expect($stderr.string).to eq ''
     end
+  end
 
-    context 'when using `--restart-server` option' do
-      it 'returns exit status 0 and display an information and a warning messages' do
-        expect(cli.run(['--restart-server'])).to eq(0)
-        expect(cli.exit?).to be(true)
-        expect($stdout.string).to start_with 'RuboCop server starting on '
-        expect($stderr.string).to eq "RuboCop server is not running.\n"
-      end
+  context 'when not using any server options' do
+    it 'returns exit status 0' do
+      create_file('example.rb', <<~RUBY)
+        # frozen_string_literal: true
+
+        x = 0
+        puts x
+      RUBY
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(0)
+      expect(cli.exit?).to be(false)
+      expect($stdout.string.blank?).to be(true)
+      expect($stderr.string.blank?).to be(true)
     end
+  end
 
-    context 'when using `--server-status` option' do
-      it 'returns exit status 0 and display an information message' do
-        expect(cli.run(['--server-status'])).to eq(0)
-        expect(cli.exit?).to be(true)
-        expect($stdout.string).to eq "RuboCop server is not running.\n"
-        expect($stderr.string).to eq ''
-      end
+  context 'when using multiple server options' do
+    it 'returns exit status 2 and display an error message' do
+      create_file('example.rb', <<~RUBY)
+        # frozen_string_literal: true
+
+        x = 0
+        puts x
+      RUBY
+      expect(cli.run(['--server', '--no-server', '--format', 'simple', 'example.rb'])).to eq(2)
+      expect(cli.exit?).to be(true)
+      expect($stdout.string).to eq ''
+      expect($stderr.string).to eq "--server, --no-server cannot be specified together.\n"
     end
+  end
 
-    context 'when not using any server options' do
-      it 'returns exit status 0' do
-        create_file('example.rb', <<~RUBY)
-          # frozen_string_literal: true
-
-          x = 0
-          puts x
-        RUBY
-        expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(0)
-        expect(cli.exit?).to be(false)
-        expect($stdout.string.blank?).to be(true)
-        expect($stderr.string.blank?).to be(true)
-      end
+  context 'when using exclusive `--restart-server` option' do
+    it 'returns exit status 2 and display an error message' do
+      expect(cli.run(['--restart-server', '--format', 'simple'])).to eq(2)
+      expect(cli.exit?).to be(true)
+      expect($stdout.string).to eq ''
+      expect($stderr.string).to eq "--restart-server cannot be combined with other options.\n"
     end
+  end
 
-    context 'when using multiple server options' do
-      it 'returns exit status 2 and display an error message' do
-        create_file('example.rb', <<~RUBY)
-          # frozen_string_literal: true
-
-          x = 0
-          puts x
-        RUBY
-        expect(cli.run(['--server', '--no-server', '--format', 'simple', 'example.rb'])).to eq(2)
-        expect(cli.exit?).to be(true)
-        expect($stdout.string).to eq ''
-        expect($stderr.string).to eq "--server, --no-server cannot be specified together.\n"
-      end
+  context 'when using exclusive `--start-server` option' do
+    it 'returns exit status 2 and display an error message' do
+      expect(cli.run(['--start-server', '--format', 'simple'])).to eq(2)
+      expect(cli.exit?).to be(true)
+      expect($stdout.string).to eq ''
+      expect($stderr.string).to eq "--start-server cannot be combined with other options.\n"
     end
+  end
 
-    context 'when using exclusive `--restart-server` option' do
-      it 'returns exit status 2 and display an error message' do
-        expect(cli.run(['--restart-server', '--format', 'simple'])).to eq(2)
-        expect(cli.exit?).to be(true)
-        expect($stdout.string).to eq ''
-        expect($stderr.string).to eq "--restart-server cannot be combined with other options.\n"
-      end
+  context 'when using exclusive `--stop-server` option' do
+    it 'returns exit status 2 and display an error message' do
+      expect(cli.run(['--stop-server', '--format', 'simple'])).to eq(2)
+      expect(cli.exit?).to be(true)
+      expect($stdout.string).to eq ''
+      expect($stderr.string).to eq "--stop-server cannot be combined with other options.\n"
     end
+  end
 
-    context 'when using exclusive `--start-server` option' do
-      it 'returns exit status 2 and display an error message' do
-        expect(cli.run(['--start-server', '--format', 'simple'])).to eq(2)
-        expect(cli.exit?).to be(true)
-        expect($stdout.string).to eq ''
-        expect($stderr.string).to eq "--start-server cannot be combined with other options.\n"
-      end
-    end
-
-    context 'when using exclusive `--stop-server` option' do
-      it 'returns exit status 2 and display an error message' do
-        expect(cli.run(['--stop-server', '--format', 'simple'])).to eq(2)
-        expect(cli.exit?).to be(true)
-        expect($stdout.string).to eq ''
-        expect($stderr.string).to eq "--stop-server cannot be combined with other options.\n"
-      end
-    end
-
-    context 'when using exclusive `--server-status` option' do
-      it 'returns exit status 2 and display an error message' do
-        expect(cli.run(['--server-status', '--format', 'simple'])).to eq(2)
-        expect(cli.exit?).to be(true)
-        expect($stdout.string).to eq ''
-        expect($stderr.string).to eq "--server-status cannot be combined with other options.\n"
-      end
-    end
-  else
-    context 'when using `--server` option' do
-      it 'returns exit status 2 and display an error message' do
-        expect(cli.run(['--server', '--format', 'simple'])).to eq(2)
-        expect(cli.exit?).to be(true)
-        expect($stdout.string).to eq ''
-        expect($stderr.string).to eq "RuboCop server is not supported by this Ruby.\n"
-      end
+  context 'when using exclusive `--server-status` option' do
+    it 'returns exit status 2 and display an error message' do
+      expect(cli.run(['--server-status', '--format', 'simple'])).to eq(2)
+      expect(cli.exit?).to be(true)
+      expect($stdout.string).to eq ''
+      expect($stderr.string).to eq "--server-status cannot be combined with other options.\n"
     end
   end
 end

--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -5,33 +5,31 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
 
   include_context 'cli spec behavior'
 
-  if RuboCop::Server.support_server?
-    context 'when using `--server` option after updating RuboCop' do
-      before do
-        options = '--server --only Style/FrozenStringLiteralComment,Style/StringLiterals'
-        `ruby -I . "#{rubocop}" #{options}`
+  context 'when using `--server` option after updating RuboCop' do
+    before do
+      options = '--server --only Style/FrozenStringLiteralComment,Style/StringLiterals'
+      backticks(%(ruby -I . "#{rubocop}" #{options}))
 
-        # Emulating RuboCop updates. `0.99.9` is a version value for testing that
-        # will never be used in the real world RuboCop version.
-        RuboCop::Server::Cache.write_version_file('0.99.9')
-      end
+      # Emulating RuboCop updates. `0.99.9` is a version value for testing that
+      # will never be used in the real world RuboCop version.
+      RuboCop::Server::Cache.write_version_file('0.99.9')
+    end
 
-      after do
-        `ruby -I . "#{rubocop}" --stop-server`
-      end
+    after do
+      backticks(%(ruby -I . "#{rubocop}" --stop-server))
+    end
 
-      it 'displays a restart information message' do
-        create_file('example.rb', <<~RUBY)
-          # frozen_string_literal: true
+    it 'displays a restart information message' do
+      create_file('example.rb', <<~RUBY)
+        # frozen_string_literal: true
 
-          x = 0
-          puts x
-        RUBY
-        options = '--server --only Style/FrozenStringLiteralComment,Style/StringLiterals'
-        expect(`ruby -I . "#{rubocop}" #{options}`).to start_with(
-          'RuboCop version incompatibility found, RuboCop server restarting...'
-        )
-      end
+        x = 0
+        puts x
+      RUBY
+      options = '--server --only Style/FrozenStringLiteralComment,Style/StringLiterals'
+      expect(backticks(%(ruby -I . "#{rubocop}" #{options}))).to start_with(
+        'RuboCop version incompatibility found, RuboCop server restarting...'
+      )
     end
   end
 end


### PR DESCRIPTION
by using spawn instead of fork when fork is unavailable. it's a bit
slower to startup since it has to clean-start a new jruby process,
but subsequent runs still get massive benefits.