### PR TITLE
Follow-up clean-up of Ruby < 2.6

### DIFF
--- a/lib/rubocop/cop/lint/redundant_require_statement.rb
+++ b/lib/rubocop/cop/lint/redundant_require_statement.rb
@@ -12,8 +12,6 @@ module RuboCop
       #   ruby 2.2.8p477 (2017-09-14 revision 59906) [x86_64-darwin13]
       #   ["enumerator.so", "rational.so", "complex.so", "thread.rb"]
       #
-      # This cop targets Ruby 2.2 or higher containing these 4 features.
-      #
       # @example
       #   # bad
       #   require 'unloaded_feature'
@@ -24,9 +22,6 @@ module RuboCop
       class RedundantRequireStatement < Base
         include RangeHelp
         extend AutoCorrector
-        extend TargetRubyVersion
-
-        minimum_target_ruby_version 2.2
 
         MSG = 'Remove unnecessary `require` statement.'
         RESTRICT_ON_SEND = %i[require].freeze

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -25,9 +25,6 @@ module RuboCop
       #   x&.foo || bar
       class SafeNavigationChain < Base
         include NilMethods
-        extend TargetRubyVersion
-
-        minimum_target_ruby_version 2.3
 
         MSG = 'Do not chain ordinary method call after safe navigation operator.'
 

--- a/lib/rubocop/cop/lint/unified_integer.rb
+++ b/lib/rubocop/cop/lint/unified_integer.rb
@@ -33,8 +33,6 @@ module RuboCop
           return unless klass
 
           add_offense(node, message: format(MSG, klass: klass)) do |corrector|
-            next if target_ruby_version <= 2.3
-
             corrector.replace(node.loc.name, 'Integer')
           end
         end

--- a/lib/rubocop/cop/style/dir.rb
+++ b/lib/rubocop/cop/style/dir.rb
@@ -18,9 +18,6 @@ module RuboCop
       #   path = __dir__
       class Dir < Base
         extend AutoCorrector
-        extend TargetRubyVersion
-
-        minimum_target_ruby_version 2.0
 
         MSG = "Use `__dir__` to get an absolute path to the current file's directory."
         RESTRICT_ON_SEND = %i[expand_path dirname].freeze

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -86,9 +86,6 @@ module RuboCop
         include FrozenStringLiteral
         include RangeHelp
         extend AutoCorrector
-        extend TargetRubyVersion
-
-        minimum_target_ruby_version 2.3
 
         MSG_MISSING_TRUE = 'Missing magic comment `# frozen_string_literal: true`.'
         MSG_MISSING = 'Missing frozen string literal comment.'

--- a/lib/rubocop/cop/style/hash_transform_keys.rb
+++ b/lib/rubocop/cop/style/hash_transform_keys.rb
@@ -7,8 +7,6 @@ module RuboCop
       # `_.map {...}.to_h`, and `Hash[_.map {...}]` that are actually just
       # transforming the keys of a hash, and tries to use a simpler & faster
       # call to `transform_keys` instead.
-      # It should only be enabled on Ruby version 2.5 or newer.
-      # (`transform_keys` was added in Ruby 2.5.)
       #
       # @safety
       #   This cop is unsafe, as it can produce false positives if we are
@@ -28,9 +26,6 @@ module RuboCop
       class HashTransformKeys < Base
         include HashTransformMethod
         extend AutoCorrector
-        extend TargetRubyVersion
-
-        minimum_target_ruby_version 2.5
 
         # @!method on_bad_each_with_object(node)
         def_node_matcher :on_bad_each_with_object, <<~PATTERN

--- a/lib/rubocop/cop/style/hash_transform_values.rb
+++ b/lib/rubocop/cop/style/hash_transform_values.rb
@@ -26,9 +26,6 @@ module RuboCop
       class HashTransformValues < Base
         include HashTransformMethod
         extend AutoCorrector
-        extend TargetRubyVersion
-
-        minimum_target_ruby_version 2.4
 
         # @!method on_bad_each_with_object(node)
         def_node_matcher :on_bad_each_with_object, <<~PATTERN

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -82,7 +82,7 @@ module RuboCop
               predicate(node)
             end
 
-          return unless numeric && operator && replacement_supported?(operator)
+          return unless numeric && operator
 
           [numeric, replacement(numeric, operator)]
         end
@@ -105,14 +105,6 @@ module RuboCop
 
         def require_parentheses?(node)
           node.send_type? && node.binary_operation? && !node.parenthesized?
-        end
-
-        def replacement_supported?(operator)
-          if %i[> <].include?(operator)
-            target_ruby_version >= 2.3
-          else
-            true
-          end
         end
 
         def invert

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -81,7 +81,6 @@ module RuboCop
         alias on_defs on_def
 
         def on_block(node)
-          return if target_ruby_version < 2.5
           return if node.send_node.lambda_literal?
           return if node.braces?
           return unless node.body&.kwbegin_type?

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -80,13 +80,10 @@ module RuboCop
         include NilMethods
         include RangeHelp
         extend AutoCorrector
-        extend TargetRubyVersion
 
         MSG = 'Use safe navigation (`&.`) instead of checking if an object ' \
               'exists before calling the method.'
         LOGIC_JUMP_KEYWORDS = %i[break fail next raise return throw yield].freeze
-
-        minimum_target_ruby_version 2.3
 
         # if format: (if checked_variable body nil)
         # unless format: (if checked_variable nil body)

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -34,9 +34,6 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include PercentArray
         extend AutoCorrector
-        extend TargetRubyVersion
-
-        minimum_target_ruby_version 2.0
 
         PERCENT_MSG = 'Use `%i` or `%I` for an array of symbols.'
         ARRAY_MSG = 'Use %<prefer>s for an array of symbols.'

--- a/lib/rubocop/cop/style/unpack_first.rb
+++ b/lib/rubocop/cop/style/unpack_first.rb
@@ -19,9 +19,6 @@ module RuboCop
       #
       class UnpackFirst < Base
         extend AutoCorrector
-        extend TargetRubyVersion
-
-        minimum_target_ruby_version 2.4
 
         MSG = 'Use `%<receiver>s.unpack1(%<format>s)` instead of ' \
               '`%<receiver>s.unpack(%<format>s)%<method>s`.'

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -159,7 +159,7 @@ module RuboCop
       private
 
       def compatible_external_encoding_for?(src)
-        src = src.dup if RUBY_VERSION < '2.3' || RUBY_ENGINE == 'jruby'
+        src = src.dup if RUBY_ENGINE == 'jruby'
         src.force_encoding(Encoding.default_external).valid_encoding?
       end
     end

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -116,10 +116,6 @@ RSpec.shared_context 'mock console output' do
   end
 end
 
-RSpec.shared_context 'ruby 2.1', :ruby21 do
-  let(:ruby_version) { 2.1 }
-end
-
 RSpec.shared_context 'ruby 2.2', :ruby22 do
   let(:ruby_version) { 2.2 }
 end

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -116,10 +116,6 @@ RSpec.shared_context 'mock console output' do
   end
 end
 
-RSpec.shared_context 'ruby 2.2', :ruby22 do
-  let(:ruby_version) { 2.2 }
-end
-
 RSpec.shared_context 'ruby 2.3', :ruby23 do
   let(:ruby_version) { 2.3 }
 end

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -116,10 +116,6 @@ RSpec.shared_context 'mock console output' do
   end
 end
 
-RSpec.shared_context 'ruby 2.0', :ruby20 do
-  let(:ruby_version) { 2.0 }
-end
-
 RSpec.shared_context 'ruby 2.1', :ruby21 do
   let(:ruby_version) { 2.1 }
 end

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -116,10 +116,6 @@ RSpec.shared_context 'mock console output' do
   end
 end
 
-RSpec.shared_context 'ruby 2.4', :ruby24 do
-  let(:ruby_version) { 2.4 }
-end
-
 RSpec.shared_context 'ruby 2.5', :ruby25 do
   let(:ruby_version) { 2.5 }
 end

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -116,10 +116,6 @@ RSpec.shared_context 'mock console output' do
   end
 end
 
-RSpec.shared_context 'ruby 2.5', :ruby25 do
-  let(:ruby_version) { 2.5 }
-end
-
 RSpec.shared_context 'ruby 2.6', :ruby26 do
   let(:ruby_version) { 2.6 }
 end

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -116,10 +116,6 @@ RSpec.shared_context 'mock console output' do
   end
 end
 
-RSpec.shared_context 'ruby 2.3', :ruby23 do
-  let(:ruby_version) { 2.3 }
-end
-
 RSpec.shared_context 'ruby 2.4', :ruby24 do
   let(:ruby_version) { 2.4 }
 end

--- a/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
+++ b/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
@@ -72,24 +72,22 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
     end
   end
 
-  context 'target ruby version > 2.6', :ruby26 do
-    it 'registers an offense when `required_ruby_version` is specified with >= and is higher than `TargetRubyVersion`' do
-      expect_offense(<<~RUBY, '/path/to/bar.gemspec')
-        Gem::Specification.new do |spec|
-          spec.required_ruby_version = '>= 2.7.0'
-                                       ^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (2.6, which may be specified in .rubocop.yml) should be equal.
-        end
-      RUBY
-    end
+  it 'registers an offense when `required_ruby_version` is specified with >= and is higher than `TargetRubyVersion`' do
+    expect_offense(<<~RUBY, '/path/to/bar.gemspec')
+      Gem::Specification.new do |spec|
+        spec.required_ruby_version = '>= 2.7.0'
+                                     ^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (2.6, which may be specified in .rubocop.yml) should be equal.
+      end
+    RUBY
+  end
 
-    it 'registers an offense when `required_ruby_version` is specified with ~> and is higher than `TargetRubyVersion`' do
-      expect_offense(<<~RUBY, '/path/to/bar.gemspec')
-        Gem::Specification.new do |spec|
-          spec.required_ruby_version = '~> 2.7.0'
-                                       ^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (2.6, which may be specified in .rubocop.yml) should be equal.
-        end
-      RUBY
-    end
+  it 'registers an offense when `required_ruby_version` is specified with ~> and is higher than `TargetRubyVersion`' do
+    expect_offense(<<~RUBY, '/path/to/bar.gemspec')
+      Gem::Specification.new do |spec|
+        spec.required_ruby_version = '~> 2.7.0'
+                                     ^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (2.6, which may be specified in .rubocop.yml) should be equal.
+      end
+    RUBY
   end
 
   # rubocop:disable RSpec/RepeatedExampleGroupDescription

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
         }
       )
   end
-  let(:target_ruby_version) { 2.5 }
+  let(:target_ruby_version) { 2.6 }
   let(:hash_style) { 'key' }
   let(:allow_for_alignment) { true }
   let(:exponent_operator_style) { nil }

--- a/spec/rubocop/cop/lint/ambiguous_range_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_range_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRange, :config do
         RUBY
       end
 
-      it 'can handle an endless range', :ruby26 do
+      it 'can handle an endless range' do
         expect_offense(<<~RUBY)
           x || 1#{operator}
           ^^^^^^ Wrap complex range boundaries with parentheses to avoid ambiguity.

--- a/spec/rubocop/cop/lint/deprecated_constants_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_constants_spec.rb
@@ -51,25 +51,15 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedConstants, :config do
     RUBY
   end
 
-  context 'Ruby <= 2.5', :ruby25 do
-    it 'does not register an offense when using `Net::HTTPServerException`' do
-      expect_no_offenses(<<~RUBY)
-        Net::HTTPServerException
-      RUBY
-    end
-  end
+  it 'registers and corrects an offense when using `Net::HTTPServerException`' do
+    expect_offense(<<~RUBY)
+      Net::HTTPServerException
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Use `Net::HTTPClientException` instead of `Net::HTTPServerException`, deprecated since Ruby 2.6.
+    RUBY
 
-  context 'Ruby >= 2.6', :ruby26 do
-    it 'registers and corrects an offense when using `Net::HTTPServerException`' do
-      expect_offense(<<~RUBY)
-        Net::HTTPServerException
-        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `Net::HTTPClientException` instead of `Net::HTTPServerException`, deprecated since Ruby 2.6.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        Net::HTTPClientException
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      Net::HTTPClientException
+    RUBY
   end
 
   context 'Ruby <= 2.7', :ruby27 do

--- a/spec/rubocop/cop/lint/duplicate_hash_key_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_hash_key_spec.rb
@@ -63,9 +63,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateHashKey, :config do
   it_behaves_like 'duplicated literal key', 'false'
   it_behaves_like 'duplicated literal key', 'nil'
   it_behaves_like 'duplicated literal key', "'str'"
-  context 'target ruby version >= 2.6', :ruby26 do
-    it_behaves_like 'duplicated literal key', '(42..)'
-  end
+  it_behaves_like 'duplicated literal key', '(42..)'
 
   shared_examples 'duplicated non literal key' do |key|
     it "does not register an offense for duplicated `#{key}` hash keys" do

--- a/spec/rubocop/cop/lint/erb_new_arguments_spec.rb
+++ b/spec/rubocop/cop/lint/erb_new_arguments_spec.rb
@@ -1,111 +1,101 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::ErbNewArguments, :config do
-  context '<= Ruby 2.5', :ruby25 do
-    it 'does not register an offense when using `ERB.new` with non-keyword arguments' do
-      expect_no_offenses(<<~RUBY)
-        ERB.new(str, nil, '-', '@output_buffer')
-      RUBY
-    end
+  it 'registers an offense when using `ERB.new` with non-keyword 2nd argument' do
+    expect_offense(<<~RUBY)
+      ERB.new(str, nil)
+                   ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ERB.new(str)
+    RUBY
   end
 
-  context '>= Ruby 2.6', :ruby26 do
-    it 'registers an offense when using `ERB.new` with non-keyword 2nd argument' do
-      expect_offense(<<~RUBY)
-        ERB.new(str, nil)
-                     ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
-      RUBY
+  it 'registers an offense when using `ERB.new` with non-keyword 2nd and 3rd arguments' do
+    expect_offense(<<~RUBY)
+      ERB.new(str, nil, '-')
+                        ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
+                   ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
+    RUBY
 
-      expect_correction(<<~RUBY)
-        ERB.new(str)
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      ERB.new(str, trim_mode: '-')
+    RUBY
+  end
 
-    it 'registers an offense when using `ERB.new` with non-keyword 2nd and 3rd arguments' do
-      expect_offense(<<~RUBY)
-        ERB.new(str, nil, '-')
-                          ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
-                     ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
-      RUBY
+  it 'registers an offense when using `ERB.new` with non-keyword 2nd, 3rd and 4th arguments' do
+    expect_offense(<<~RUBY)
+      ERB.new(str, nil, '-', '@output_buffer')
+                             ^^^^^^^^^^^^^^^^ Passing eoutvar with the 4th argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, eoutvar: '@output_buffer')` instead.
+                        ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
+                   ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
+    RUBY
 
-      expect_correction(<<~RUBY)
-        ERB.new(str, trim_mode: '-')
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
+    RUBY
+  end
 
-    it 'registers an offense when using `ERB.new` with non-keyword 2nd, 3rd and 4th arguments' do
-      expect_offense(<<~RUBY)
-        ERB.new(str, nil, '-', '@output_buffer')
+  it 'registers an offense when using `ERB.new` ' \
+     'with non-keyword 2nd, 3rd and 4th arguments and' \
+     'keyword 5th argument' do
+    expect_offense(<<~RUBY)
+      ERB.new(str, nil, '-', '@output_buffer', trim_mode: '-', eoutvar: '@output_buffer')
+                             ^^^^^^^^^^^^^^^^ Passing eoutvar with the 4th argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, eoutvar: '@output_buffer')` instead.
+                        ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
+                   ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
+    RUBY
+  end
+
+  it 'registers an offense when using `ERB.new` ' \
+     'with non-keyword 2nd and 3rd arguments and' \
+     'keyword 4th argument' do
+    expect_offense(<<~RUBY)
+      ERB.new(str, nil, '-', trim_mode: '-', eoutvar: '@output_buffer')
+                        ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
+                   ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
+    RUBY
+  end
+
+  it 'registers an offense when using `::ERB.new` with non-keyword 2nd, 3rd and 4th arguments' do
+    expect_offense(<<~RUBY)
+      ::ERB.new(str, nil, '-', '@output_buffer')
                                ^^^^^^^^^^^^^^^^ Passing eoutvar with the 4th argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, eoutvar: '@output_buffer')` instead.
                           ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
                      ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
-      RUBY
+    RUBY
 
-      expect_correction(<<~RUBY)
-        ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      ::ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
+    RUBY
+  end
 
-    it 'registers an offense when using `ERB.new` ' \
-       'with non-keyword 2nd, 3rd and 4th arguments and' \
-       'keyword 5th argument' do
-      expect_offense(<<~RUBY)
-        ERB.new(str, nil, '-', '@output_buffer', trim_mode: '-', eoutvar: '@output_buffer')
-                               ^^^^^^^^^^^^^^^^ Passing eoutvar with the 4th argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, eoutvar: '@output_buffer')` instead.
-                          ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
-                     ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
-      RUBY
+  it 'does not register an offense when using `ERB.new` with keyword arguments' do
+    expect_no_offenses(<<~RUBY)
+      ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
+    RUBY
+  end
 
-      expect_correction(<<~RUBY)
-        ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
-      RUBY
-    end
+  it 'does not register an offense when using `ERB.new` without optional arguments' do
+    expect_no_offenses(<<~RUBY)
+      ERB.new(str)
+    RUBY
+  end
 
-    it 'registers an offense when using `ERB.new` ' \
-       'with non-keyword 2nd and 3rd arguments and' \
-       'keyword 4th argument' do
-      expect_offense(<<~RUBY)
-        ERB.new(str, nil, '-', trim_mode: '-', eoutvar: '@output_buffer')
-                          ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
-                     ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
-      RUBY
-    end
-
-    it 'registers an offense when using `::ERB.new` with non-keyword 2nd, 3rd and 4th arguments' do
-      expect_offense(<<~RUBY)
-        ::ERB.new(str, nil, '-', '@output_buffer')
-                                 ^^^^^^^^^^^^^^^^ Passing eoutvar with the 4th argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, eoutvar: '@output_buffer')` instead.
-                            ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
-                       ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        ::ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
-      RUBY
-    end
-
-    it 'does not register an offense when using `ERB.new` with keyword arguments' do
+  context 'when using `ActionView::Template::Handlers::ERB.new`' do
+    it 'does not register an offense when using `ERB.new` without arguments' do
       expect_no_offenses(<<~RUBY)
-        ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
+        ERB.new
       RUBY
-    end
-
-    it 'does not register an offense when using `ERB.new` without optional arguments' do
-      expect_no_offenses(<<~RUBY)
-        ERB.new(str)
-      RUBY
-    end
-
-    context 'when using `ActionView::Template::Handlers::ERB.new`' do
-      it 'does not register an offense when using `ERB.new` without arguments' do
-        expect_no_offenses(<<~RUBY)
-          ERB.new
-        RUBY
-      end
     end
   end
 end

--- a/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
@@ -1,25 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
-  context 'target ruby version < 2.2', :ruby21 do
-    it "does not registers an offense when using `require 'enumerator'`" do
-      expect_no_offenses(<<~RUBY)
-        require 'enumerator'
-      RUBY
-    end
-  end
+  it "registers an offense and corrects when using `require 'enumerator'`" do
+    expect_offense(<<~RUBY)
+      require 'enumerator'
+      ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+      require 'uri'
+    RUBY
 
-  context 'target ruby version >= 2.2', :ruby22 do
-    it "registers an offense and corrects when using `require 'enumerator'`" do
-      expect_offense(<<~RUBY)
-        require 'enumerator'
-        ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
-        require 'uri'
-      RUBY
-
-      expect_correction(<<~RUBY)
-        require 'uri'
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      require 'uri'
+    RUBY
   end
 end

--- a/spec/rubocop/cop/lint/require_range_parentheses_spec.rb
+++ b/spec/rubocop/cop/lint/require_range_parentheses_spec.rb
@@ -24,12 +24,10 @@ RSpec.describe RuboCop::Cop::Lint::RequireRangeParentheses, :config do
     RUBY
   end
 
-  context 'Ruby >= 2.6', :ruby26 do
-    it 'does not register an offense when using endless range only' do
-      expect_no_offenses(<<~RUBY)
-        42..
-      RUBY
-    end
+  it 'does not register an offense when using endless range only' do
+    expect_no_offenses(<<~RUBY)
+      42..
+    RUBY
   end
 
   context 'Ruby >= 2.7', :ruby27 do

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -7,49 +7,132 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
     end
   end
 
-  context 'TargetRubyVersion >= 2.3', :ruby23 do
-    [
-      ['ordinary method chain', 'x.foo.bar.baz'],
-      ['ordinary method chain with argument', 'x.foo(x).bar(y).baz(z)'],
-      ['method chain with safe navigation only', 'x&.foo&.bar&.baz'],
-      ['method chain with safe navigation only with argument',
-       'x&.foo(x)&.bar(y)&.baz(z)'],
-      ['safe navigation at last only', 'x.foo.bar&.baz'],
-      ['safe navigation at last only with argument', 'x.foo(x).bar(y)&.baz(z)'],
-      ['safe navigation with == operator', 'x&.foo == bar'],
-      ['safe navigation with === operator', 'x&.foo === bar'],
-      ['safe navigation with || operator', 'x&.foo || bar'],
-      ['safe navigation with && operator', 'x&.foo && bar'],
-      ['safe navigation with | operator', 'x&.foo | bar'],
-      ['safe navigation with & operator', 'x&.foo & bar'],
-      ['safe navigation with `nil?` method', 'x&.foo.nil?'],
-      ['safe navigation with `present?` method', 'x&.foo.present?'],
-      ['safe navigation with `blank?` method', 'x&.foo.blank?'],
-      ['safe navigation with `try` method', 'a&.b.try(:c)'],
-      ['safe navigation with assignment method', 'x&.foo = bar'],
-      ['safe navigation with self assignment method', 'x&.foo += bar'],
-      ['safe navigation with `to_d` method', 'x&.foo.to_d'],
-      ['safe navigation with `in?` method', 'x&.foo.in?([:baz, :qux])']
-    ].each do |name, code|
-      include_examples 'accepts', name, code
-    end
+  [
+    ['ordinary method chain', 'x.foo.bar.baz'],
+    ['ordinary method chain with argument', 'x.foo(x).bar(y).baz(z)'],
+    ['method chain with safe navigation only', 'x&.foo&.bar&.baz'],
+    ['method chain with safe navigation only with argument',
+     'x&.foo(x)&.bar(y)&.baz(z)'],
+    ['safe navigation at last only', 'x.foo.bar&.baz'],
+    ['safe navigation at last only with argument', 'x.foo(x).bar(y)&.baz(z)'],
+    ['safe navigation with == operator', 'x&.foo == bar'],
+    ['safe navigation with === operator', 'x&.foo === bar'],
+    ['safe navigation with || operator', 'x&.foo || bar'],
+    ['safe navigation with && operator', 'x&.foo && bar'],
+    ['safe navigation with | operator', 'x&.foo | bar'],
+    ['safe navigation with & operator', 'x&.foo & bar'],
+    ['safe navigation with `nil?` method', 'x&.foo.nil?'],
+    ['safe navigation with `present?` method', 'x&.foo.present?'],
+    ['safe navigation with `blank?` method', 'x&.foo.blank?'],
+    ['safe navigation with `try` method', 'a&.b.try(:c)'],
+    ['safe navigation with assignment method', 'x&.foo = bar'],
+    ['safe navigation with self assignment method', 'x&.foo += bar'],
+    ['safe navigation with `to_d` method', 'x&.foo.to_d'],
+    ['safe navigation with `in?` method', 'x&.foo.in?([:baz, :qux])']
+  ].each do |name, code|
+    include_examples 'accepts', name, code
+  end
 
-    it 'registers an offense for ordinary method call exists after safe navigation method call' do
-      expect_offense(<<~RUBY)
-        x&.foo.bar
-              ^^^^ Do not chain ordinary method call after safe navigation operator.
-      RUBY
-    end
+  it 'registers an offense for ordinary method call exists after safe navigation method call' do
+    expect_offense(<<~RUBY)
+      x&.foo.bar
+            ^^^^ Do not chain ordinary method call after safe navigation operator.
+    RUBY
+  end
 
-    it 'registers an offense for ordinary method call exists after ' \
-       'safe navigation method call with an argument' do
-      expect_offense(<<~RUBY)
-        x&.foo(x).bar(y)
-                 ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-      RUBY
-    end
+  it 'registers an offense for ordinary method call exists after ' \
+     'safe navigation method call with an argument' do
+    expect_offense(<<~RUBY)
+      x&.foo(x).bar(y)
+               ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+    RUBY
+  end
 
-    it 'registers an offense for ordinary method chain exists after safe navigation method call' do
+  it 'registers an offense for ordinary method chain exists after safe navigation method call' do
+    expect_offense(<<~RUBY)
+      something
+      x&.foo.bar.baz
+            ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+    RUBY
+  end
+
+  it 'registers an offense for ordinary method chain exists after ' \
+     'safe navigation method call with an argument' do
+    expect_offense(<<~RUBY)
+      x&.foo(x).bar(y).baz(z)
+               ^^^^^^^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+    RUBY
+  end
+
+  it 'registers an offense for ordinary method chain exists after ' \
+     'safe navigation method call with a block-pass' do
+    expect_offense(<<~RUBY)
+      something
+      x&.select(&:foo).bar
+                      ^^^^ Do not chain ordinary method call after safe navigation operator.
+    RUBY
+  end
+
+  it 'registers an offense for ordinary method chain exists after ' \
+     'safe navigation method call with a block' do
+    expect_offense(<<~RUBY)
+      something
+      x&.select { |x| foo(x) }.bar
+                              ^^^^ Do not chain ordinary method call after safe navigation operator.
+    RUBY
+  end
+
+  it 'registers an offense for safe navigation with < operator' do
+    expect_offense(<<~RUBY)
+      x&.foo < bar
+            ^^^^^^ Do not chain ordinary method call after safe navigation operator.
+    RUBY
+  end
+
+  it 'registers an offense for safe navigation with > operator' do
+    expect_offense(<<~RUBY)
+      x&.foo > bar
+            ^^^^^^ Do not chain ordinary method call after safe navigation operator.
+    RUBY
+  end
+
+  it 'registers an offense for safe navigation with <= operator' do
+    expect_offense(<<~RUBY)
+      x&.foo <= bar
+            ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+    RUBY
+  end
+
+  it 'registers an offense for safe navigation with >= operator' do
+    expect_offense(<<~RUBY)
+      x&.foo >= bar
+            ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+    RUBY
+  end
+
+  it 'registers an offense for safe navigation with + operator' do
+    expect_offense(<<~RUBY)
+      x&.foo + bar
+            ^^^^^^ Do not chain ordinary method call after safe navigation operator.
+    RUBY
+  end
+
+  it 'registers an offense for safe navigation with [] operator' do
+    expect_offense(<<~RUBY)
+      x&.foo[bar]
+            ^^^^^ Do not chain ordinary method call after safe navigation operator.
+    RUBY
+  end
+
+  it 'registers an offense for safe navigation with []= operator' do
+    expect_offense(<<~RUBY)
+      x&.foo[bar] = baz
+            ^^^^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+    RUBY
+  end
+
+  context 'proper highlighting' do
+    it 'when there are methods before' do
       expect_offense(<<~RUBY)
         something
         x&.foo.bar.baz
@@ -57,122 +140,37 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
       RUBY
     end
 
-    it 'registers an offense for ordinary method chain exists after ' \
-       'safe navigation method call with an argument' do
+    it 'when there are methods after' do
       expect_offense(<<~RUBY)
-        x&.foo(x).bar(y).baz(z)
-                 ^^^^^^^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-      RUBY
-    end
-
-    it 'registers an offense for ordinary method chain exists after ' \
-       'safe navigation method call with a block-pass' do
-      expect_offense(<<~RUBY)
+        x&.foo.bar.baz
+              ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
         something
-        x&.select(&:foo).bar
-                        ^^^^ Do not chain ordinary method call after safe navigation operator.
       RUBY
     end
 
-    it 'registers an offense for ordinary method chain exists after ' \
-       'safe navigation method call with a block' do
+    it 'when in a method' do
       expect_offense(<<~RUBY)
-        something
-        x&.select { |x| foo(x) }.bar
-                                ^^^^ Do not chain ordinary method call after safe navigation operator.
-      RUBY
-    end
-
-    it 'registers an offense for safe navigation with < operator' do
-      expect_offense(<<~RUBY)
-        x&.foo < bar
-              ^^^^^^ Do not chain ordinary method call after safe navigation operator.
-      RUBY
-    end
-
-    it 'registers an offense for safe navigation with > operator' do
-      expect_offense(<<~RUBY)
-        x&.foo > bar
-              ^^^^^^ Do not chain ordinary method call after safe navigation operator.
-      RUBY
-    end
-
-    it 'registers an offense for safe navigation with <= operator' do
-      expect_offense(<<~RUBY)
-        x&.foo <= bar
-              ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-      RUBY
-    end
-
-    it 'registers an offense for safe navigation with >= operator' do
-      expect_offense(<<~RUBY)
-        x&.foo >= bar
-              ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-      RUBY
-    end
-
-    it 'registers an offense for safe navigation with + operator' do
-      expect_offense(<<~RUBY)
-        x&.foo + bar
-              ^^^^^^ Do not chain ordinary method call after safe navigation operator.
-      RUBY
-    end
-
-    it 'registers an offense for safe navigation with [] operator' do
-      expect_offense(<<~RUBY)
-        x&.foo[bar]
-              ^^^^^ Do not chain ordinary method call after safe navigation operator.
-      RUBY
-    end
-
-    it 'registers an offense for safe navigation with []= operator' do
-      expect_offense(<<~RUBY)
-        x&.foo[bar] = baz
-              ^^^^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-      RUBY
-    end
-
-    context 'proper highlighting' do
-      it 'when there are methods before' do
-        expect_offense(<<~RUBY)
-          something
+        def something
           x&.foo.bar.baz
                 ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-        RUBY
-      end
+        end
+      RUBY
+    end
 
-      it 'when there are methods after' do
-        expect_offense(<<~RUBY)
+    it 'when in a begin' do
+      expect_offense(<<~RUBY)
+        begin
           x&.foo.bar.baz
                 ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-          something
-        RUBY
-      end
+        end
+      RUBY
+    end
 
-      it 'when in a method' do
-        expect_offense(<<~RUBY)
-          def something
-            x&.foo.bar.baz
-                  ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-          end
-        RUBY
-      end
-
-      it 'when in a begin' do
-        expect_offense(<<~RUBY)
-          begin
-            x&.foo.bar.baz
-                  ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-          end
-        RUBY
-      end
-
-      it 'when used with a modifier if' do
-        expect_offense(<<~RUBY)
-          x&.foo.bar.baz if something
-                ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
-        RUBY
-      end
+    it 'when used with a modifier if' do
+      expect_offense(<<~RUBY)
+        x&.foo.bar.baz if something
+              ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/lint/suppressed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/suppressed_exception_spec.rb
@@ -114,27 +114,25 @@ RSpec.describe RuboCop::Cop::Lint::SuppressedException, :config do
       end
     end
 
-    context 'Ruby 2.5 or higher', :ruby25 do
-      context 'when empty rescue for `do` block' do
-        it 'registers an offense for empty rescue without comment' do
-          expect_offense(<<~RUBY)
-            foo do
-              do_something
-            rescue
-            ^^^^^^ Do not suppress exceptions.
-            end
-          RUBY
-        end
+    context 'when empty rescue for `do` block' do
+      it 'registers an offense for empty rescue without comment' do
+        expect_offense(<<~RUBY)
+          foo do
+            do_something
+          rescue
+          ^^^^^^ Do not suppress exceptions.
+          end
+        RUBY
+      end
 
-        it 'registers an offense for empty rescue with comment' do
-          expect_offense(<<~RUBY)
-            foo do
-            rescue
-            ^^^^^^ Do not suppress exceptions.
-              # do nothing
-            end
-          RUBY
-        end
+      it 'registers an offense for empty rescue with comment' do
+        expect_offense(<<~RUBY)
+          foo do
+          rescue
+          ^^^^^^ Do not suppress exceptions.
+            # do nothing
+          end
+        RUBY
       end
     end
   end
@@ -197,26 +195,24 @@ RSpec.describe RuboCop::Cop::Lint::SuppressedException, :config do
       end
     end
 
-    context 'Ruby 2.5 or higher', :ruby25 do
-      context 'when empty rescue for `do` block' do
-        it 'registers an offense for empty rescue without comment' do
-          expect_offense(<<~RUBY)
-            foo do
-              do_something
-            rescue
-            ^^^^^^ Do not suppress exceptions.
-            end
-          RUBY
-        end
+    context 'when empty rescue for `do` block' do
+      it 'registers an offense for empty rescue without comment' do
+        expect_offense(<<~RUBY)
+          foo do
+            do_something
+          rescue
+          ^^^^^^ Do not suppress exceptions.
+          end
+        RUBY
+      end
 
-        it 'does not register an offense for empty rescue with comment' do
-          expect_no_offenses(<<~RUBY)
-            foo do
-            rescue
-              # do nothing
-            end
-          RUBY
-        end
+      it 'does not register an offense for empty rescue with comment' do
+        expect_no_offenses(<<~RUBY)
+          foo do
+          rescue
+            # do nothing
+          end
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/lint/unified_integer_spec.rb
+++ b/spec/rubocop/cop/lint/unified_integer_spec.rb
@@ -2,72 +2,36 @@
 
 RSpec.describe RuboCop::Cop::Lint::UnifiedInteger, :config do
   shared_examples 'registers an offense' do |klass|
-    context 'target ruby version < 2.4', :ruby23 do
-      context "when #{klass}" do
-        context 'without any decorations' do
-          it 'registers an offense and autocorrects' do
-            expect_offense(<<~RUBY, klass: klass)
-              1.is_a?(%{klass})
-                      ^{klass} Use `Integer` instead of `#{klass}`.
-            RUBY
+    context "when #{klass}" do
+      context 'without any decorations' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY, klass: klass)
+            1.is_a?(#{klass})
+                    ^{klass} Use `Integer` instead of `#{klass}`.
+          RUBY
 
-            expect_no_corrections
-          end
-        end
-
-        context 'when explicitly specified as toplevel constant' do
-          let(:source) { "1.is_a?(::#{klass})" }
-
-          it 'registers an offense' do
-            expect_offense(<<~RUBY, klass: klass)
-              1.is_a?(::%{klass})
-                      ^^^{klass} Use `Integer` instead of `#{klass}`.
-            RUBY
-
-            expect_no_corrections
-          end
-        end
-
-        context 'with MyNamespace' do
-          it 'does not register an offense' do
-            expect_no_offenses("1.is_a?(MyNamespace::#{klass})")
-          end
+          expect_correction(<<~RUBY)
+            1.is_a?(Integer)
+          RUBY
         end
       end
-    end
 
-    context 'target ruby version >= 2.4', :ruby24 do
-      context "when #{klass}" do
-        context 'without any decorations' do
-          it 'registers an offense' do
-            expect_offense(<<~RUBY, klass: klass)
-              1.is_a?(#{klass})
-                      ^{klass} Use `Integer` instead of `#{klass}`.
-            RUBY
+      context 'when explicitly specified as toplevel constant' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY, klass: klass)
+            1.is_a?(::#{klass})
+                    ^^^{klass} Use `Integer` instead of `#{klass}`.
+          RUBY
 
-            expect_correction(<<~RUBY)
-              1.is_a?(Integer)
-            RUBY
-          end
+          expect_correction(<<~RUBY)
+            1.is_a?(::Integer)
+          RUBY
         end
+      end
 
-        context 'when explicitly specified as toplevel constant' do
-          it 'registers an offense' do
-            expect_offense(<<~RUBY, klass: klass)
-              1.is_a?(::#{klass})
-                      ^^^{klass} Use `Integer` instead of `#{klass}`.
-            RUBY
-
-            expect_correction(<<~RUBY)
-              1.is_a?(::Integer)
-            RUBY
-          end
-        end
-
-        context 'with MyNamespace' do
-          it 'does not register an offense' do
-            expect_no_offenses("1.is_a?(MyNamespace::#{klass})")
-          end
+      context 'with MyNamespace' do
+        it 'does not register an offense' do
+          expect_no_offenses("1.is_a?(MyNamespace::#{klass})")
         end
       end
     end

--- a/spec/rubocop/cop/lint/useless_else_without_rescue_spec.rb
+++ b/spec/rubocop/cop/lint/useless_else_without_rescue_spec.rb
@@ -1,19 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::UselessElseWithoutRescue, :config do
-  context 'with `else` without `rescue`', :ruby25 do
-    it 'registers an offense' do
-      expect_offense(<<~RUBY)
-        begin
-          do_something
-        else
-        ^^^^ `else` without `rescue` is useless.
-          handle_unknown_errors
-        end
-      RUBY
-    end
-  end
-
   context 'with `else` with `rescue`' do
     it 'accepts' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
       end
     end
 
-    context 'when frozen string literals is enabled', :ruby23 do
+    context 'when frozen string literals is enabled' do
       it 'does not register an offense for String.new' do
         expect_no_offenses(<<~RUBY)
           # frozen_string_literal: true

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -522,7 +522,7 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
       RUBY
     end
 
-    context 'when using safe navigation operator', :ruby23 do
+    context 'when using safe navigation operator' do
       it 'does not break' do
         expect_no_offenses(<<~RUBY)
           def func

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -1042,22 +1042,4 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       RUBY
     end
   end
-
-  context 'target_ruby_version < 2.3', :ruby22 do
-    it 'accepts freezing a string' do
-      expect_no_offenses('"x".freeze')
-    end
-
-    it 'accepts calling << on a string' do
-      expect_no_offenses('"x" << "y"')
-    end
-
-    it 'accepts freezing a string with interpolation' do
-      expect_no_offenses('"#{foo}bar".freeze')
-    end
-
-    it 'accepts calling << on a string with interpolation' do
-      expect_no_offenses('"#{foo}bar" << "baz"')
-    end
-  end
 end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -68,12 +68,6 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         expect_no_offenses('{}')
       end
 
-      context 'ruby < 2.2', :ruby21 do
-        it 'accepts hash rockets when symbol keys have string in them' do
-          expect_no_offenses('x = { :"string" => 0 }')
-        end
-      end
-
       it 'registers an offense when symbol keys have strings in them' do
         expect_offense(<<~RUBY)
           x = { :"string" => 0 }
@@ -478,44 +472,6 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
-      context 'ruby < 2.2', :ruby21 do
-        it 'accepts hash rockets when keys have whitespaces in them' do
-          expect_no_offenses('x = { :"t o" => 0, :b => 1 }')
-        end
-
-        it 'registers an offense when keys have whitespaces and mix styles' do
-          expect_offense(<<~RUBY)
-            x = { :"t o" => 0, b: 1 }
-                               ^^ Don't mix styles in the same hash.
-          RUBY
-          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-        end
-
-        it 'accepts hash rockets when keys have special symbols in them' do
-          expect_no_offenses('x = { :"\\tab" => 1, :b => 1 }')
-        end
-
-        it 'registers an offense when keys have special symbols and mix styles' do
-          expect_offense(<<~RUBY)
-            x = { :"\tab" => 1, b: 1 }
-                               ^^ Don't mix styles in the same hash.
-          RUBY
-          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-        end
-
-        it 'accepts hash rockets when keys start with a digit' do
-          expect_no_offenses('x = { :"1" => 1, :b => 1 }')
-        end
-
-        it 'registers an offense when keys start with a digit and mix styles' do
-          expect_offense(<<~RUBY)
-            x = { :"1" => 1, b: 1 }
-                             ^^ Don't mix styles in the same hash.
-          RUBY
-          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-        end
-      end
-
       it 'registers an offense when keys have whitespaces in them' do
         expect_offense(<<~RUBY)
           x = { :"t o" => 0 }
@@ -656,44 +612,6 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         expect_correction(<<~RUBY)
           x = { :a => 0, "b" => 1 }
         RUBY
-      end
-
-      context 'ruby < 2.2', :ruby21 do
-        it 'accepts hash rockets when keys have whitespaces in them' do
-          expect_no_offenses('x = { :"t o" => 0, :b => 1 }')
-        end
-
-        it 'registers an offense when keys have whitespaces and mix styles' do
-          expect_offense(<<~RUBY)
-            x = { :"t o" => 0, b: 1 }
-                               ^^ Don't mix styles in the same hash.
-          RUBY
-          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-        end
-
-        it 'accepts hash rockets when keys have special symbols in them' do
-          expect_no_offenses('x = { :"\\tab" => 1, :b => 1 }')
-        end
-
-        it 'registers an offense when keys have special symbols and mix styles' do
-          expect_offense(<<~RUBY)
-            x = { :"\tab" => 1, b: 1 }
-                               ^^ Don't mix styles in the same hash.
-          RUBY
-          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-        end
-
-        it 'accepts hash rockets when keys start with a digit' do
-          expect_no_offenses('x = { :"1" => 1, :b => 1 }')
-        end
-
-        it 'registers an offense when keys start with a digit and mix styles' do
-          expect_offense(<<~RUBY)
-            x = { :"1" => 1, b: 1 }
-                             ^^ Don't mix styles in the same hash.
-          RUBY
-          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-        end
       end
 
       it 'registers an offense when keys have whitespaces in them' do

--- a/spec/rubocop/cop/style/hash_transform_keys_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_keys_spec.rb
@@ -250,12 +250,6 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
     end
   end
 
-  context 'below Ruby 2.5', :ruby24 do
-    it 'does not flag even if transform_keys could be used' do
-      expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[foo(k)] = v}')
-    end
-  end
-
   context 'when using Ruby 2.6 or newer', :ruby26 do
     it 'flags _.to_h{...} when transform_keys could be used' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/hash_transform_keys_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_keys_spec.rb
@@ -1,303 +1,291 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
-  context 'when using Ruby 2.5 or newer', :ruby25 do
-    context 'with inline block' do
-      it 'flags each_with_object when transform_keys could be used' do
-        expect_offense(<<~RUBY)
-          x.each_with_object({}) {|(k, v), h| h[foo(k)] = v}
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `each_with_object`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          x.transform_keys {|k| foo(k)}
-        RUBY
-      end
-    end
-
-    context 'with multiline block' do
-      it 'flags each_with_object when transform_keys could be used' do
-        expect_offense(<<~RUBY)
-          some_hash.each_with_object({}) do |(key, val), memo|
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `each_with_object`.
-            memo[key.to_sym] = val
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          some_hash.transform_keys do |key|
-            key.to_sym
-          end
-        RUBY
-      end
-    end
-
-    context 'with safe navigation operator' do
-      it 'flags each_with_object when transform_keys could be used' do
-        expect_offense(<<~RUBY)
-          x&.each_with_object({}) {|(k, v), h| h[foo(k)] = v}
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `each_with_object`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          x&.transform_keys {|k| foo(k)}
-        RUBY
-      end
-    end
-
-    it 'does not flag each_with_object when both key & value are transformed' do
-      expect_no_offenses(<<~RUBY)
-        x.each_with_object({}) {|(k, v), h| h[k.to_sym] = foo(v)}
-      RUBY
-    end
-
-    it 'does not flag each_with_object when key transformation uses value' do
-      expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[foo(v)] = v}')
-    end
-
-    it 'does not flag each_with_object when no transformation occurs' do
-      expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[k] = v}')
-    end
-
-    it 'does not flag each_with_object when its argument is not modified' do
-      expect_no_offenses(<<~RUBY)
-        x.each_with_object({}) {|(k, v), h| other_h[k.to_sym] = v}
-      RUBY
-    end
-
-    it 'does not flag `each_with_object` when its argument is used in the key' do
-      expect_no_offenses(<<~RUBY)
-        x.each_with_object({}) { |(k, v), h| h[h[k.to_sym]] = v }
-      RUBY
-    end
-
-    it 'does not flag each_with_object when its receiver is array literal' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each_with_object({}) {|(k, v), h| h[foo(k)] = v}
-      RUBY
-    end
-
-    it 'does not flag `each_with_object` when its receiver is `each_with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each_with_index.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
-      RUBY
-    end
-
-    it 'does not flag `each_with_object` when its receiver is `with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each.with_index.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
-      RUBY
-    end
-
-    it 'does not flag `each_with_object` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        %i[a b c].zip([1, 2, 3]).each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
-      RUBY
-    end
-
-    it 'flags _.map{...}.to_h when transform_keys could be used' do
+  context 'with inline block' do
+    it 'flags each_with_object when transform_keys could be used' do
       expect_offense(<<~RUBY)
-        x.map {|k, v| [k.to_sym, v]}.to_h
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
+        x.each_with_object({}) {|(k, v), h| h[foo(k)] = v}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `each_with_object`.
       RUBY
 
       expect_correction(<<~RUBY)
-        x.transform_keys {|k| k.to_sym}
+        x.transform_keys {|k| foo(k)}
       RUBY
     end
+  end
 
-    it 'flags _.map{...}.to_h when transform_keys could be used when line break before `to_h`' do
+  context 'with multiline block' do
+    it 'flags each_with_object when transform_keys could be used' do
       expect_offense(<<~RUBY)
-        x.map {|k, v| [k.to_sym, v]}.
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
-          to_h
-      RUBY
-
-      expect_correction(<<~RUBY)
-        x.transform_keys {|k| k.to_sym}
-      RUBY
-    end
-
-    it 'flags _.map {...}.to_h when transform_keys could be used when wrapped in another block' do
-      expect_offense(<<~RUBY)
-        wrapping do
-          x.map do |k, v|
-          ^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
-            [k.to_sym, v]
-          end.to_h
+        some_hash.each_with_object({}) do |(key, val), memo|
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `each_with_object`.
+          memo[key.to_sym] = val
         end
       RUBY
 
       expect_correction(<<~RUBY)
-        wrapping do
-          x.transform_keys do |k|
-            k.to_sym
-          end
+        some_hash.transform_keys do |key|
+          key.to_sym
         end
       RUBY
     end
+  end
 
-    it 'does not flag _.map{...}.to_h when both key & value are transformed' do
-      expect_no_offenses('x.map {|k, v| [k.to_sym, foo(v)]}.to_h')
-    end
-
-    it 'flags Hash[_.map{...}] when transform_keys could be used' do
+  context 'with safe navigation operator' do
+    it 'flags each_with_object when transform_keys could be used' do
       expect_offense(<<~RUBY)
-        Hash[x.map {|k, v| [k.to_sym, v]}]
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `Hash[_.map {...}]`.
+        x&.each_with_object({}) {|(k, v), h| h[foo(k)] = v}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `each_with_object`.
       RUBY
 
       expect_correction(<<~RUBY)
-        x.transform_keys {|k| k.to_sym}
+        x&.transform_keys {|k| foo(k)}
       RUBY
     end
+  end
 
-    it 'does not flag Hash[_.map{...}] when both key & value are transformed' do
-      expect_no_offenses('Hash[x.map {|k, v| [k.to_sym, foo(v)]}]')
-    end
+  it 'does not flag each_with_object when both key & value are transformed' do
+    expect_no_offenses(<<~RUBY)
+      x.each_with_object({}) {|(k, v), h| h[k.to_sym] = foo(v)}
+    RUBY
+  end
 
-    it 'does not flag key transformation in the absence of to_h' do
-      expect_no_offenses('x.map {|k, v| [k.to_sym, v]}')
-    end
+  it 'does not flag each_with_object when key transformation uses value' do
+    expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[foo(v)] = v}')
+  end
 
-    it 'does not flag key transformation when receiver is array literal' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].map {|k, v| [k.to_sym, v]}.to_h
-      RUBY
-    end
+  it 'does not flag each_with_object when no transformation occurs' do
+    expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[k] = v}')
+  end
 
-    it 'does not flag `_.map{...}.to_h` when its receiver is `each_with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each_with_index.map { |k, v| [k.to_sym, v] }.to_h
-      RUBY
-    end
+  it 'does not flag each_with_object when its argument is not modified' do
+    expect_no_offenses(<<~RUBY)
+      x.each_with_object({}) {|(k, v), h| other_h[k.to_sym] = v}
+    RUBY
+  end
 
-    it 'does not flag `_.map{...}.to_h` when its receiver is `with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each.with_index.map { |k, v| [k.to_sym, v] }.to_h
-      RUBY
-    end
+  it 'does not flag `each_with_object` when its argument is used in the key' do
+    expect_no_offenses(<<~RUBY)
+      x.each_with_object({}) { |(k, v), h| h[h[k.to_sym]] = v }
+    RUBY
+  end
 
-    it 'does not flag `_.map{...}.to_h` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        %i[a b c].zip([1, 2, 3]).map { |k, v| [k.to_sym, v] }.to_h
-      RUBY
-    end
+  it 'does not flag each_with_object when its receiver is array literal' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].each_with_object({}) {|(k, v), h| h[foo(k)] = v}
+    RUBY
+  end
 
-    it 'correctly autocorrects _.map{...}.to_h without block' do
-      expect_offense(<<~RUBY)
-        {a: 1, b: 2}.map do |k, v|
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
-          [k.to_s, v]
+  it 'does not flag `each_with_object` when its receiver is `each_with_index`' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].each_with_index.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+    RUBY
+  end
+
+  it 'does not flag `each_with_object` when its receiver is `with_index`' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].each.with_index.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+    RUBY
+  end
+
+  it 'does not flag `each_with_object` when its receiver is `zip`' do
+    expect_no_offenses(<<~RUBY)
+      %i[a b c].zip([1, 2, 3]).each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+    RUBY
+  end
+
+  it 'flags _.map{...}.to_h when transform_keys could be used' do
+    expect_offense(<<~RUBY)
+      x.map {|k, v| [k.to_sym, v]}.to_h
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.transform_keys {|k| k.to_sym}
+    RUBY
+  end
+
+  it 'flags _.map{...}.to_h when transform_keys could be used when line break before `to_h`' do
+    expect_offense(<<~RUBY)
+      x.map {|k, v| [k.to_sym, v]}.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
+        to_h
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.transform_keys {|k| k.to_sym}
+    RUBY
+  end
+
+  it 'flags _.map {...}.to_h when transform_keys could be used when wrapped in another block' do
+    expect_offense(<<~RUBY)
+      wrapping do
+        x.map do |k, v|
+        ^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
+          [k.to_sym, v]
         end.to_h
-      RUBY
+      end
+    RUBY
 
-      expect_correction(<<~RUBY)
-        {a: 1, b: 2}.transform_keys do |k|
-          k.to_s
+    expect_correction(<<~RUBY)
+      wrapping do
+        x.transform_keys do |k|
+          k.to_sym
         end
-      RUBY
-    end
-
-    it 'correctly autocorrects _.map{...}.to_h with block' do
-      expect_offense(<<~RUBY)
-        {a: 1, b: 2}.map {|k, v| [k.to_s, v]}.to_h {|k, v| [v, k]}
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        {a: 1, b: 2}.transform_keys {|k| k.to_s}.to_h {|k, v| [v, k]}
-      RUBY
-    end
-
-    it 'correctly autocorrects Hash[_.map{...}]' do
-      expect_offense(<<~RUBY)
-        Hash[{a: 1, b: 2}.map do |k, v|
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `Hash[_.map {...}]`.
-          [k.to_s, v]
-        end]
-      RUBY
-
-      expect_correction(<<~RUBY)
-        {a: 1, b: 2}.transform_keys do |k|
-          k.to_s
-        end
-      RUBY
-    end
-
-    it 'does not flag `Hash[_.map{...}]` when its receiver is an array literal' do
-      expect_no_offenses(<<~RUBY)
-        Hash[[1, 2, 3].map { |k, v| [k.to_sym, v] }]
-      RUBY
-    end
-
-    it 'does not flag `Hash[_.map{...}]` when its receiver is `each_with_index`' do
-      expect_no_offenses(<<~RUBY)
-        Hash[[1, 2, 3].each_with_index.map { |k, v| [k.to_sym, v] }]
-      RUBY
-    end
-
-    it 'does not flag `Hash[_.map{...}]` when its receiver is `with_index`' do
-      expect_no_offenses(<<~RUBY)
-        Hash[[1, 2, 3].each.with_index.map { |k, v| [k.to_sym, v] }]
-      RUBY
-    end
-
-    it 'does not flag `Hash[_.map{...}]` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        Hash[%i[a b c].zip([1, 2, 3]).map { |k, v| [k.to_sym, v] }]
-      RUBY
-    end
+      end
+    RUBY
   end
 
-  context 'when using Ruby 2.6 or newer', :ruby26 do
-    it 'flags _.to_h{...} when transform_keys could be used' do
-      expect_offense(<<~RUBY)
-        x.to_h {|k, v| [k.to_sym, v]}
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `to_h {...}`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        x.transform_keys {|k| k.to_sym}
-      RUBY
-    end
-
-    it 'does not flag `_.to_h{...}` when both key & value are transformed' do
-      expect_no_offenses(<<~RUBY)
-        x.to_h { |k, v| [k.to_sym, foo(v)] }
-      RUBY
-    end
-
-    it 'does not flag `_.to_h{...}` when its receiver is an array literal' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].to_h { |k, v| [k.to_sym, v] }
-      RUBY
-    end
-
-    it 'does not flag `_.to_h{...}` when its receiver is `each_with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each_with_index.to_h { |k, v| [k.to_sym, v] }
-      RUBY
-    end
-
-    it 'does not flag `_.to_h{...}` when its receiver is `with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each.with_index.to_h { |k, v| [k.to_sym, v] }
-      RUBY
-    end
-
-    it 'does not flag `_.to_h{...}` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        %i[a b c].zip([1, 2, 3]).to_h { |k, v| [k.to_sym, v] }
-      RUBY
-    end
+  it 'does not flag _.map{...}.to_h when both key & value are transformed' do
+    expect_no_offenses('x.map {|k, v| [k.to_sym, foo(v)]}.to_h')
   end
 
-  context 'below Ruby 2.6', :ruby25 do
-    it 'does not flag _.to_h{...}' do
-      expect_no_offenses(<<~RUBY)
-        x.to_h {|k, v| [k.to_sym, v]}
-      RUBY
-    end
+  it 'flags Hash[_.map{...}] when transform_keys could be used' do
+    expect_offense(<<~RUBY)
+      Hash[x.map {|k, v| [k.to_sym, v]}]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `Hash[_.map {...}]`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.transform_keys {|k| k.to_sym}
+    RUBY
+  end
+
+  it 'does not flag Hash[_.map{...}] when both key & value are transformed' do
+    expect_no_offenses('Hash[x.map {|k, v| [k.to_sym, foo(v)]}]')
+  end
+
+  it 'does not flag key transformation in the absence of to_h' do
+    expect_no_offenses('x.map {|k, v| [k.to_sym, v]}')
+  end
+
+  it 'does not flag key transformation when receiver is array literal' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].map {|k, v| [k.to_sym, v]}.to_h
+    RUBY
+  end
+
+  it 'does not flag `_.map{...}.to_h` when its receiver is `each_with_index`' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].each_with_index.map { |k, v| [k.to_sym, v] }.to_h
+    RUBY
+  end
+
+  it 'does not flag `_.map{...}.to_h` when its receiver is `with_index`' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].each.with_index.map { |k, v| [k.to_sym, v] }.to_h
+    RUBY
+  end
+
+  it 'does not flag `_.map{...}.to_h` when its receiver is `zip`' do
+    expect_no_offenses(<<~RUBY)
+      %i[a b c].zip([1, 2, 3]).map { |k, v| [k.to_sym, v] }.to_h
+    RUBY
+  end
+
+  it 'correctly autocorrects _.map{...}.to_h without block' do
+    expect_offense(<<~RUBY)
+      {a: 1, b: 2}.map do |k, v|
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
+        [k.to_s, v]
+      end.to_h
+    RUBY
+
+    expect_correction(<<~RUBY)
+      {a: 1, b: 2}.transform_keys do |k|
+        k.to_s
+      end
+    RUBY
+  end
+
+  it 'correctly autocorrects _.map{...}.to_h with block' do
+    expect_offense(<<~RUBY)
+      {a: 1, b: 2}.map {|k, v| [k.to_s, v]}.to_h {|k, v| [v, k]}
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      {a: 1, b: 2}.transform_keys {|k| k.to_s}.to_h {|k, v| [v, k]}
+    RUBY
+  end
+
+  it 'correctly autocorrects Hash[_.map{...}]' do
+    expect_offense(<<~RUBY)
+      Hash[{a: 1, b: 2}.map do |k, v|
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `Hash[_.map {...}]`.
+        [k.to_s, v]
+      end]
+    RUBY
+
+    expect_correction(<<~RUBY)
+      {a: 1, b: 2}.transform_keys do |k|
+        k.to_s
+      end
+    RUBY
+  end
+
+  it 'does not flag `Hash[_.map{...}]` when its receiver is an array literal' do
+    expect_no_offenses(<<~RUBY)
+      Hash[[1, 2, 3].map { |k, v| [k.to_sym, v] }]
+    RUBY
+  end
+
+  it 'does not flag `Hash[_.map{...}]` when its receiver is `each_with_index`' do
+    expect_no_offenses(<<~RUBY)
+      Hash[[1, 2, 3].each_with_index.map { |k, v| [k.to_sym, v] }]
+    RUBY
+  end
+
+  it 'does not flag `Hash[_.map{...}]` when its receiver is `with_index`' do
+    expect_no_offenses(<<~RUBY)
+      Hash[[1, 2, 3].each.with_index.map { |k, v| [k.to_sym, v] }]
+    RUBY
+  end
+
+  it 'does not flag `Hash[_.map{...}]` when its receiver is `zip`' do
+    expect_no_offenses(<<~RUBY)
+      Hash[%i[a b c].zip([1, 2, 3]).map { |k, v| [k.to_sym, v] }]
+    RUBY
+  end
+
+  it 'flags _.to_h{...} when transform_keys could be used' do
+    expect_offense(<<~RUBY)
+      x.to_h {|k, v| [k.to_sym, v]}
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `to_h {...}`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.transform_keys {|k| k.to_sym}
+    RUBY
+  end
+
+  it 'does not flag `_.to_h{...}` when both key & value are transformed' do
+    expect_no_offenses(<<~RUBY)
+      x.to_h { |k, v| [k.to_sym, foo(v)] }
+    RUBY
+  end
+
+  it 'does not flag `_.to_h{...}` when its receiver is an array literal' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].to_h { |k, v| [k.to_sym, v] }
+    RUBY
+  end
+
+  it 'does not flag `_.to_h{...}` when its receiver is `each_with_index`' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].each_with_index.to_h { |k, v| [k.to_sym, v] }
+    RUBY
+  end
+
+  it 'does not flag `_.to_h{...}` when its receiver is `with_index`' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].each.with_index.to_h { |k, v| [k.to_sym, v] }
+    RUBY
+  end
+
+  it 'does not flag `_.to_h{...}` when its receiver is `zip`' do
+    expect_no_offenses(<<~RUBY)
+      %i[a b c].zip([1, 2, 3]).to_h { |k, v| [k.to_sym, v] }
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/hash_transform_values_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_values_spec.rb
@@ -218,76 +218,66 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
     RUBY
   end
 
-  context 'when using Ruby 2.6 or newer', :ruby26 do
-    it 'flags _.to_h{...} when transform_values could be used' do
-      expect_offense(<<~RUBY)
-        x.to_h {|k, v| [k, foo(v)]}
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
-      RUBY
+  it 'flags _.to_h{...} when transform_values could be used' do
+    expect_offense(<<~RUBY)
+      x.to_h {|k, v| [k, foo(v)]}
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
+    RUBY
 
-      expect_correction(<<~RUBY)
-        x.transform_values {|v| foo(v)}
-      RUBY
-    end
-
-    it 'register and corrects an offense _.to_h{...} when value is a hash literal and is enclosed in braces' do
-      expect_offense(<<~RUBY)
-        {a: 1, b: 2}.to_h { |key, val| [key, { value: val }] }
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        {a: 1, b: 2}.transform_values { |val| { value: val } }
-      RUBY
-    end
-
-    it 'register and corrects an offense _.to_h{...} when value is a hash literal and is not enclosed in braces' do
-      expect_offense(<<~RUBY)
-        {a: 1, b: 2}.to_h { |key, val| [key, value: val] }
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        {a: 1, b: 2}.transform_values { |val| { value: val } }
-      RUBY
-    end
-
-    it 'does not flag `_.to_h{...}` when both key & value are transformed' do
-      expect_no_offenses(<<~RUBY)
-        x.to_h { |k, v| [k.to_sym, foo(v)] }
-      RUBY
-    end
-
-    it 'does not flag `_.to_h{...}` when its receiver is an array literal' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].to_h { |k, v| [k, foo(v)] }
-      RUBY
-    end
-
-    it 'does not flag `_.to_h{...}` when its receiver is `each_with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each_with_index.to_h { |k, v| [k, foo(v)] }
-      RUBY
-    end
-
-    it 'does not flag `_.to_h{...}` when its receiver is `with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each.with_index.to_h { |k, v| [k, foo(v)] }
-      RUBY
-    end
-
-    it 'does not flag `_.to_h{...}` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        %i[a b c].zip([1, 2, 3]).to_h { |k, v| [k, foo(v)] }
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      x.transform_values {|v| foo(v)}
+    RUBY
   end
 
-  context 'below Ruby 2.6', :ruby25 do
-    it 'does not flag _.to_h{...}' do
-      expect_no_offenses(<<~RUBY)
-        x.to_h {|k, v| [k, foo(v)]}
-      RUBY
-    end
+  it 'register and corrects an offense _.to_h{...} when value is a hash literal and is enclosed in braces' do
+    expect_offense(<<~RUBY)
+      {a: 1, b: 2}.to_h { |key, val| [key, { value: val }] }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      {a: 1, b: 2}.transform_values { |val| { value: val } }
+    RUBY
+  end
+
+  it 'register and corrects an offense _.to_h{...} when value is a hash literal and is not enclosed in braces' do
+    expect_offense(<<~RUBY)
+      {a: 1, b: 2}.to_h { |key, val| [key, value: val] }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      {a: 1, b: 2}.transform_values { |val| { value: val } }
+    RUBY
+  end
+
+  it 'does not flag `_.to_h{...}` when both key & value are transformed' do
+    expect_no_offenses(<<~RUBY)
+      x.to_h { |k, v| [k.to_sym, foo(v)] }
+    RUBY
+  end
+
+  it 'does not flag `_.to_h{...}` when its receiver is an array literal' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].to_h { |k, v| [k, foo(v)] }
+    RUBY
+  end
+
+  it 'does not flag `_.to_h{...}` when its receiver is `each_with_index`' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].each_with_index.to_h { |k, v| [k, foo(v)] }
+    RUBY
+  end
+
+  it 'does not flag `_.to_h{...}` when its receiver is `with_index`' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].each.with_index.to_h { |k, v| [k, foo(v)] }
+    RUBY
+  end
+
+  it 'does not flag `_.to_h{...}` when its receiver is `zip`' do
+    expect_no_offenses(<<~RUBY)
+      %i[a b c].zip([1, 2, 3]).to_h { |k, v| [k, foo(v)] }
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/hash_transform_values_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_values_spec.rb
@@ -1,223 +1,221 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
-  context 'when using Ruby 2.4 or newer', :ruby24 do
-    context 'with inline block' do
-      it 'flags each_with_object when transform_values could be used' do
-        expect_offense(<<~RUBY)
-          x.each_with_object({}) {|(k, v), h| h[k] = foo(v)}
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          x.transform_values {|v| foo(v)}
-        RUBY
-      end
-    end
-
-    context 'with multiline block' do
-      it 'flags each_with_object when transform_values could be used' do
-        expect_offense(<<~RUBY)
-          some_hash.each_with_object({}) do |(key, val), memo|
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
-            memo[key] = val * val
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          some_hash.transform_values do |val|
-            val * val
-          end
-        RUBY
-      end
-    end
-
-    context 'with safe navigation operator' do
-      it 'flags each_with_object when transform_values could be used' do
-        expect_offense(<<~RUBY)
-          x&.each_with_object({}) {|(k, v), h| h[k] = foo(v)}
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          x&.transform_values {|v| foo(v)}
-        RUBY
-      end
-    end
-
-    it 'does not flag each_with_object when both key & value are transformed' do
-      expect_no_offenses(<<~RUBY)
-        x.each_with_object({}) {|(k, v), h| h[k.to_sym] = foo(v)}
-      RUBY
-    end
-
-    it 'does not flag each_with_object when value transformation uses key' do
-      expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[k] = k.to_s}')
-    end
-
-    it 'does not flag each_with_object when no transformation occurs' do
-      expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[k] = v}')
-    end
-
-    it 'does not flag each_with_object when its argument is not modified' do
-      expect_no_offenses(<<~RUBY)
-        x.each_with_object({}) {|(k, v), h| other_h[k] = v * v}
-      RUBY
-    end
-
-    it 'does not flag `each_with_object` when its argument is used in the value' do
-      expect_no_offenses(<<~RUBY)
-        x.each_with_object({}) { |(k, v), h| h[k] = h.count }
-      RUBY
-    end
-
-    it 'does not flag each_with_object when receiver is array literal' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each_with_object({}) {|(k, v), h| h[k] = foo(v)}
-      RUBY
-    end
-
-    it 'does not flag `each_with_object` when its receiver is `each_with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each_with_index.each_with_object({}) { |(k, v), h| h[k] = foo(v) }
-      RUBY
-    end
-
-    it 'does not flag `each_with_object` when its receiver is `with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each.with_index.each_with_object({}) { |(k, v), h| h[k] = foo(v) }
-      RUBY
-    end
-
-    it 'does not flag `each_with_object` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        %i[a b c].zip([1, 2, 3]).each_with_object({}) { |(k, v), h| h[k] = foo(v) }
-      RUBY
-    end
-
-    it 'flags _.map {...}.to_h when transform_values could be used' do
+  context 'with inline block' do
+    it 'flags each_with_object when transform_values could be used' do
       expect_offense(<<~RUBY)
-        x.map {|k, v| [k, foo(v)]}.to_h
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
+        x.each_with_object({}) {|(k, v), h| h[k] = foo(v)}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
       RUBY
 
       expect_correction(<<~RUBY)
         x.transform_values {|v| foo(v)}
       RUBY
     end
+  end
 
-    it 'flags _.map {...}.to_h when transform_values could be used when line break before `to_h`' do
+  context 'with multiline block' do
+    it 'flags each_with_object when transform_values could be used' do
       expect_offense(<<~RUBY)
-        x.map {|k, v| [k, foo(v)]}.
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
-          to_h
-      RUBY
-
-      expect_correction(<<~RUBY)
-        x.transform_values {|v| foo(v)}
-      RUBY
-    end
-
-    it 'flags _.map {...}.to_h when transform_values could be used when wrapped in another block' do
-      expect_offense(<<~RUBY)
-        wrapping do
-          x.map do |k, v|
-          ^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
-            [k, v.to_s]
-          end.to_h
+        some_hash.each_with_object({}) do |(key, val), memo|
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
+          memo[key] = val * val
         end
       RUBY
 
       expect_correction(<<~RUBY)
-        wrapping do
-          x.transform_values do |v|
-            v.to_s
-          end
+        some_hash.transform_values do |val|
+          val * val
         end
       RUBY
     end
+  end
 
-    it 'does not flag _.map{...}.to_h when both key & value are transformed' do
-      expect_no_offenses('x.map {|k, v| [k.to_sym, foo(v)]}.to_h')
-    end
-
-    it 'flags Hash[_.map{...}] when transform_values could be used' do
+  context 'with safe navigation operator' do
+    it 'flags each_with_object when transform_values could be used' do
       expect_offense(<<~RUBY)
-        Hash[x.map {|k, v| [k, foo(v)]}]
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `Hash[_.map {...}]`.
+        x&.each_with_object({}) {|(k, v), h| h[k] = foo(v)}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
       RUBY
 
       expect_correction(<<~RUBY)
-        x.transform_values {|v| foo(v)}
+        x&.transform_values {|v| foo(v)}
       RUBY
     end
+  end
 
-    it 'does not flag Hash[_.map{...}] when both key & value are transformed' do
-      expect_no_offenses('Hash[x.map {|k, v| [k.to_sym, foo(v)]}]')
-    end
+  it 'does not flag each_with_object when both key & value are transformed' do
+    expect_no_offenses(<<~RUBY)
+      x.each_with_object({}) {|(k, v), h| h[k.to_sym] = foo(v)}
+    RUBY
+  end
 
-    it 'does not flag value transformation in the absence of to_h' do
-      expect_no_offenses('x.map {|k, v| [k, foo(v)]}')
-    end
+  it 'does not flag each_with_object when value transformation uses key' do
+    expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[k] = k.to_s}')
+  end
 
-    it 'does not flag value transformation when receiver is array literal' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].map {|k, v| [k, foo(v)]}.to_h
-      RUBY
-    end
+  it 'does not flag each_with_object when no transformation occurs' do
+    expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[k] = v}')
+  end
 
-    it 'does not flag `_.map{...}.to_h` when its receiver is `each_with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each_with_index.map { |k, v| [k, foo(v)] }.to_h
-      RUBY
-    end
+  it 'does not flag each_with_object when its argument is not modified' do
+    expect_no_offenses(<<~RUBY)
+      x.each_with_object({}) {|(k, v), h| other_h[k] = v * v}
+    RUBY
+  end
 
-    it 'does not flag `_.map{...}.to_h` when its receiver is `with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each.with_index.map { |k, v| [k, foo(v)] }.to_h
-      RUBY
-    end
+  it 'does not flag `each_with_object` when its argument is used in the value' do
+    expect_no_offenses(<<~RUBY)
+      x.each_with_object({}) { |(k, v), h| h[k] = h.count }
+    RUBY
+  end
 
-    it 'does not flag `_.map{...}.to_h` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        %i[a b c].zip([1, 2, 3]).map { |k, v| [k, foo(v)] }.to_h
-      RUBY
-    end
+  it 'does not flag each_with_object when receiver is array literal' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].each_with_object({}) {|(k, v), h| h[k] = foo(v)}
+    RUBY
+  end
 
-    it 'correctly autocorrects _.map{...}.to_h with block' do
-      expect_offense(<<~RUBY)
-        {a: 1, b: 2}.map {|k, v| [k, foo(v)]}.to_h {|k, v| [v, k]}
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
-      RUBY
+  it 'does not flag `each_with_object` when its receiver is `each_with_index`' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].each_with_index.each_with_object({}) { |(k, v), h| h[k] = foo(v) }
+    RUBY
+  end
 
-      expect_correction(<<~RUBY)
-        {a: 1, b: 2}.transform_values {|v| foo(v)}.to_h {|k, v| [v, k]}
-      RUBY
-    end
+  it 'does not flag `each_with_object` when its receiver is `with_index`' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].each.with_index.each_with_object({}) { |(k, v), h| h[k] = foo(v) }
+    RUBY
+  end
 
-    it 'does not flag `Hash[_.map{...}]` when its receiver is an array literal' do
-      expect_no_offenses(<<~RUBY)
-        Hash[[1, 2, 3].map { |k, v| [k, foo(v)] }]
-      RUBY
-    end
+  it 'does not flag `each_with_object` when its receiver is `zip`' do
+    expect_no_offenses(<<~RUBY)
+      %i[a b c].zip([1, 2, 3]).each_with_object({}) { |(k, v), h| h[k] = foo(v) }
+    RUBY
+  end
 
-    it 'does not flag `Hash[_.map{...}]` when its receiver is `each_with_index`' do
-      expect_no_offenses(<<~RUBY)
-        Hash[[1, 2, 3].each_with_index.map { |k, v| [k, foo(v)] }]
-      RUBY
-    end
+  it 'flags _.map {...}.to_h when transform_values could be used' do
+    expect_offense(<<~RUBY)
+      x.map {|k, v| [k, foo(v)]}.to_h
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
+    RUBY
 
-    it 'does not flag `Hash[_.map{...}]` when its receiver is `with_index`' do
-      expect_no_offenses(<<~RUBY)
-        Hash[[1, 2, 3].each.with_index.map { |k, v| [k, foo(v)] }]
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      x.transform_values {|v| foo(v)}
+    RUBY
+  end
 
-    it 'does not flag `Hash[_.map{...}]` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        Hash[%i[a b c].zip([1, 2, 3]).map { |k, v| [k, foo(v)] }]
-      RUBY
-    end
+  it 'flags _.map {...}.to_h when transform_values could be used when line break before `to_h`' do
+    expect_offense(<<~RUBY)
+      x.map {|k, v| [k, foo(v)]}.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
+        to_h
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.transform_values {|v| foo(v)}
+    RUBY
+  end
+
+  it 'flags _.map {...}.to_h when transform_values could be used when wrapped in another block' do
+    expect_offense(<<~RUBY)
+      wrapping do
+        x.map do |k, v|
+        ^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
+          [k, v.to_s]
+        end.to_h
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      wrapping do
+        x.transform_values do |v|
+          v.to_s
+        end
+      end
+    RUBY
+  end
+
+  it 'does not flag _.map{...}.to_h when both key & value are transformed' do
+    expect_no_offenses('x.map {|k, v| [k.to_sym, foo(v)]}.to_h')
+  end
+
+  it 'flags Hash[_.map{...}] when transform_values could be used' do
+    expect_offense(<<~RUBY)
+      Hash[x.map {|k, v| [k, foo(v)]}]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `Hash[_.map {...}]`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.transform_values {|v| foo(v)}
+    RUBY
+  end
+
+  it 'does not flag Hash[_.map{...}] when both key & value are transformed' do
+    expect_no_offenses('Hash[x.map {|k, v| [k.to_sym, foo(v)]}]')
+  end
+
+  it 'does not flag value transformation in the absence of to_h' do
+    expect_no_offenses('x.map {|k, v| [k, foo(v)]}')
+  end
+
+  it 'does not flag value transformation when receiver is array literal' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].map {|k, v| [k, foo(v)]}.to_h
+    RUBY
+  end
+
+  it 'does not flag `_.map{...}.to_h` when its receiver is `each_with_index`' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].each_with_index.map { |k, v| [k, foo(v)] }.to_h
+    RUBY
+  end
+
+  it 'does not flag `_.map{...}.to_h` when its receiver is `with_index`' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].each.with_index.map { |k, v| [k, foo(v)] }.to_h
+    RUBY
+  end
+
+  it 'does not flag `_.map{...}.to_h` when its receiver is `zip`' do
+    expect_no_offenses(<<~RUBY)
+      %i[a b c].zip([1, 2, 3]).map { |k, v| [k, foo(v)] }.to_h
+    RUBY
+  end
+
+  it 'correctly autocorrects _.map{...}.to_h with block' do
+    expect_offense(<<~RUBY)
+      {a: 1, b: 2}.map {|k, v| [k, foo(v)]}.to_h {|k, v| [v, k]}
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      {a: 1, b: 2}.transform_values {|v| foo(v)}.to_h {|k, v| [v, k]}
+    RUBY
+  end
+
+  it 'does not flag `Hash[_.map{...}]` when its receiver is an array literal' do
+    expect_no_offenses(<<~RUBY)
+      Hash[[1, 2, 3].map { |k, v| [k, foo(v)] }]
+    RUBY
+  end
+
+  it 'does not flag `Hash[_.map{...}]` when its receiver is `each_with_index`' do
+    expect_no_offenses(<<~RUBY)
+      Hash[[1, 2, 3].each_with_index.map { |k, v| [k, foo(v)] }]
+    RUBY
+  end
+
+  it 'does not flag `Hash[_.map{...}]` when its receiver is `with_index`' do
+    expect_no_offenses(<<~RUBY)
+      Hash[[1, 2, 3].each.with_index.map { |k, v| [k, foo(v)] }]
+    RUBY
+  end
+
+  it 'does not flag `Hash[_.map{...}]` when its receiver is `zip`' do
+    expect_no_offenses(<<~RUBY)
+      Hash[%i[a b c].zip([1, 2, 3]).map { |k, v| [k, foo(v)] }]
+    RUBY
   end
 
   context 'when using Ruby 2.6 or newer', :ruby26 do

--- a/spec/rubocop/cop/style/hash_transform_values_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_values_spec.rb
@@ -285,12 +285,6 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
     end
   end
 
-  context 'below Ruby 2.4', :ruby23 do
-    it 'does not flag even if transform_values could be used' do
-      expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[k] = foo(v)}')
-    end
-  end
-
   context 'below Ruby 2.6', :ruby25 do
     it 'does not flag _.to_h{...}' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -513,7 +513,7 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
     end
   end
 
-  context 'when using safe navigation operator', :ruby23 do
+  context 'when using safe navigation operator' do
     it 'does not break' do
       expect_no_offenses(<<~RUBY)
         foo&.bar do |_|

--- a/spec/rubocop/cop/style/map_to_hash_spec.rb
+++ b/spec/rubocop/cop/style/map_to_hash_spec.rb
@@ -1,108 +1,106 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MapToHash, :config do
-  context '>= Ruby 2.6', :ruby26 do
-    %i[map collect].each do |method|
-      context "for `#{method}.to_h` with block arity 1" do
-        it 'registers an offense and corrects' do
-          expect_offense(<<~RUBY, method: method)
-            foo.#{method} { |x| [x, x * 2] }.to_h
-                ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
-          RUBY
+  %i[map collect].each do |method|
+    context "for `#{method}.to_h` with block arity 1" do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY, method: method)
+          foo.#{method} { |x| [x, x * 2] }.to_h
+              ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+        RUBY
 
-          expect_correction(<<~RUBY)
-            foo.to_h { |x| [x, x * 2] }
-          RUBY
-        end
+        expect_correction(<<~RUBY)
+          foo.to_h { |x| [x, x * 2] }
+        RUBY
       end
+    end
 
-      context "for `#{method}.to_h` with block arity 2" do
-        it 'registers an offense and corrects' do
-          expect_offense(<<~RUBY, method: method)
-            foo.#{method} { |x, y| [x.to_s, y.to_i] }.to_h
-                ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
-          RUBY
+    context "for `#{method}.to_h` with block arity 2" do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY, method: method)
+          foo.#{method} { |x, y| [x.to_s, y.to_i] }.to_h
+              ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+        RUBY
 
-          expect_correction(<<~RUBY)
-            foo.to_h { |x, y| [x.to_s, y.to_i] }
-          RUBY
-        end
+        expect_correction(<<~RUBY)
+          foo.to_h { |x, y| [x.to_s, y.to_i] }
+        RUBY
       end
+    end
 
-      context 'when the receiver is an array' do
-        it 'registers an offense and corrects' do
-          expect_offense(<<~RUBY, method: method)
-            [1, 2, 3].#{method} { |x| [x, x * 2] }.to_h
-                      ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
-          RUBY
+    context 'when the receiver is an array' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY, method: method)
+          [1, 2, 3].#{method} { |x| [x, x * 2] }.to_h
+                    ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+        RUBY
 
-          expect_correction(<<~RUBY)
-            [1, 2, 3].to_h { |x| [x, x * 2] }
-          RUBY
-        end
+        expect_correction(<<~RUBY)
+          [1, 2, 3].to_h { |x| [x, x * 2] }
+        RUBY
       end
+    end
 
-      context 'when the receiver is an hash' do
-        it 'registers an offense and corrects' do
-          expect_offense(<<~RUBY, method: method)
-            { foo: :bar }.#{method} { |x, y| [x.to_s, y.to_s] }.to_h
-                          ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
-          RUBY
+    context 'when the receiver is an hash' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY, method: method)
+          { foo: :bar }.#{method} { |x, y| [x.to_s, y.to_s] }.to_h
+                        ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+        RUBY
 
-          expect_correction(<<~RUBY)
-            { foo: :bar }.to_h { |x, y| [x.to_s, y.to_s] }
-          RUBY
-        end
+        expect_correction(<<~RUBY)
+          { foo: :bar }.to_h { |x, y| [x.to_s, y.to_s] }
+        RUBY
       end
+    end
 
-      context 'when chained further' do
-        it 'registers an offense and corrects' do
-          expect_offense(<<~RUBY, method: method)
-            foo.#{method} { |x| x * 2 }.to_h.bar
-                ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
-          RUBY
+    context 'when chained further' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY, method: method)
+          foo.#{method} { |x| x * 2 }.to_h.bar
+              ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+        RUBY
 
-          expect_correction(<<~RUBY)
-            foo.to_h { |x| x * 2 }.bar
-          RUBY
-        end
+        expect_correction(<<~RUBY)
+          foo.to_h { |x| x * 2 }.bar
+        RUBY
       end
+    end
 
-      context "`#{method}` without `to_h`" do
-        it 'does not register an offense' do
-          expect_no_offenses(<<~RUBY, method: method)
-            foo.#{method} { |x| x * 2 }
-          RUBY
-        end
+    context "`#{method}` without `to_h`" do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY, method: method)
+          foo.#{method} { |x| x * 2 }
+        RUBY
       end
+    end
 
-      context "`#{method}.to_h` with a block on `to_h`" do
-        it 'registers an offense but does not correct' do
-          expect_offense(<<~RUBY, method: method)
-            foo.#{method} { |x| x * 2 }.to_h { |x| [x.to_s, x] }
-                ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
-          RUBY
+    context "`#{method}.to_h` with a block on `to_h`" do
+      it 'registers an offense but does not correct' do
+        expect_offense(<<~RUBY, method: method)
+          foo.#{method} { |x| x * 2 }.to_h { |x| [x.to_s, x] }
+              ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+        RUBY
 
-          expect_no_corrections
-        end
+        expect_no_corrections
       end
+    end
 
-      context "`map` and `#{method}.to_h` with newlines" do
-        it 'registers an offense and corrects with newline removal' do
-          expect_offense(<<~RUBY, method: method)
-            {foo: bar}
-              .#{method} { |k, v| [k.to_s, v.do_something] }
-               ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
-              .to_h
-              .freeze
-          RUBY
+    context "`map` and `#{method}.to_h` with newlines" do
+      it 'registers an offense and corrects with newline removal' do
+        expect_offense(<<~RUBY, method: method)
+          {foo: bar}
+            .#{method} { |k, v| [k.to_s, v.do_something] }
+             ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+            .to_h
+            .freeze
+        RUBY
 
-          expect_correction(<<~RUBY)
-            {foo: bar}
-              .to_h { |k, v| [k.to_s, v.do_something] }
-              .freeze
-          RUBY
-        end
+        expect_correction(<<~RUBY)
+          {foo: bar}
+            .to_h { |k, v| [k.to_s, v.do_something] }
+            .freeze
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -89,113 +89,97 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
     end
 
     context 'when checking if a number is positive' do
-      context 'when target ruby version is 2.3 or higher', :ruby23 do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          number > 0
+          ^^^^^^^^^^ Use `number.positive?` instead of `number > 0`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          number.positive?
+        RUBY
+      end
+
+      it 'registers an offense in yoda condition' do
+        expect_offense(<<~RUBY)
+          0 < number
+          ^^^^^^^^^^ Use `number.positive?` instead of `0 < number`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          number.positive?
+        RUBY
+      end
+
+      context 'with a complex expression' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
-            number > 0
-            ^^^^^^^^^^ Use `number.positive?` instead of `number > 0`.
+            foo - 1 > 0
+            ^^^^^^^^^^^ Use `(foo - 1).positive?` instead of `foo - 1 > 0`.
           RUBY
 
           expect_correction(<<~RUBY)
-            number.positive?
+            (foo - 1).positive?
           RUBY
         end
 
         it 'registers an offense in yoda condition' do
           expect_offense(<<~RUBY)
-            0 < number
-            ^^^^^^^^^^ Use `number.positive?` instead of `0 < number`.
+            0 < foo - 1
+            ^^^^^^^^^^^ Use `(foo - 1).positive?` instead of `0 < foo - 1`.
           RUBY
 
           expect_correction(<<~RUBY)
-            number.positive?
+            (foo - 1).positive?
           RUBY
-        end
-
-        context 'with a complex expression' do
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              foo - 1 > 0
-              ^^^^^^^^^^^ Use `(foo - 1).positive?` instead of `foo - 1 > 0`.
-            RUBY
-
-            expect_correction(<<~RUBY)
-              (foo - 1).positive?
-            RUBY
-          end
-
-          it 'registers an offense in yoda condition' do
-            expect_offense(<<~RUBY)
-              0 < foo - 1
-              ^^^^^^^^^^^ Use `(foo - 1).positive?` instead of `0 < foo - 1`.
-            RUBY
-
-            expect_correction(<<~RUBY)
-              (foo - 1).positive?
-            RUBY
-          end
-        end
-      end
-
-      context 'when target ruby version is 2.2 or lower', :ruby22 do
-        it 'does not register an offense' do
-          expect_no_offenses('number > 0')
         end
       end
     end
 
     context 'when checking if a number is negative' do
-      context 'when target ruby version is 2.3 or higher', :ruby23 do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          number < 0
+          ^^^^^^^^^^ Use `number.negative?` instead of `number < 0`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          number.negative?
+        RUBY
+      end
+
+      it 'registers an offense in yoda condition' do
+        expect_offense(<<~RUBY)
+          0 > number
+          ^^^^^^^^^^ Use `number.negative?` instead of `0 > number`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          number.negative?
+        RUBY
+      end
+
+      context 'with a complex expression' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
-            number < 0
-            ^^^^^^^^^^ Use `number.negative?` instead of `number < 0`.
+            foo - 1 < 0
+            ^^^^^^^^^^^ Use `(foo - 1).negative?` instead of `foo - 1 < 0`.
           RUBY
 
           expect_correction(<<~RUBY)
-            number.negative?
+            (foo - 1).negative?
           RUBY
         end
 
         it 'registers an offense in yoda condition' do
           expect_offense(<<~RUBY)
-            0 > number
-            ^^^^^^^^^^ Use `number.negative?` instead of `0 > number`.
+            0 > foo - 1
+            ^^^^^^^^^^^ Use `(foo - 1).negative?` instead of `0 > foo - 1`.
           RUBY
 
           expect_correction(<<~RUBY)
-            number.negative?
+            (foo - 1).negative?
           RUBY
-        end
-
-        context 'with a complex expression' do
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              foo - 1 < 0
-              ^^^^^^^^^^^ Use `(foo - 1).negative?` instead of `foo - 1 < 0`.
-            RUBY
-
-            expect_correction(<<~RUBY)
-              (foo - 1).negative?
-            RUBY
-          end
-
-          it 'registers an offense in yoda condition' do
-            expect_offense(<<~RUBY)
-              0 > foo - 1
-              ^^^^^^^^^^^ Use `(foo - 1).negative?` instead of `0 > foo - 1`.
-            RUBY
-
-            expect_correction(<<~RUBY)
-              (foo - 1).negative?
-            RUBY
-          end
-        end
-      end
-
-      context 'when target ruby version is 2.2 or lower', :ruby22 do
-        it 'does not register an offense' do
-          expect_no_offenses('number < 0')
         end
       end
     end
@@ -302,44 +286,28 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
 
       context 'not ignored method' do
         context 'when checking if a number is positive' do
-          context 'when target ruby version is 2.3 or higher', :ruby23 do
-            it 'registers an offense' do
-              expect_offense(<<~RUBY)
-                exclude(number > 0)
-                        ^^^^^^^^^^ Use `number.positive?` instead of `number > 0`.
-              RUBY
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              exclude(number > 0)
+                      ^^^^^^^^^^ Use `number.positive?` instead of `number > 0`.
+            RUBY
 
-              expect_correction(<<~RUBY)
-                exclude(number.positive?)
-              RUBY
-            end
-          end
-
-          context 'when target ruby version is 2.2 or lower', :ruby22 do
-            it 'does not register an offense' do
-              expect_no_offenses('exclude { number > 0 }')
-            end
+            expect_correction(<<~RUBY)
+              exclude(number.positive?)
+            RUBY
           end
         end
 
         context 'when checking if a number is negative' do
-          context 'when target ruby version is 2.3 or higher', :ruby23 do
-            it 'registers an offense' do
-              expect_offense(<<~RUBY)
-                exclude(number < 0)
-                        ^^^^^^^^^^ Use `number.negative?` instead of `number < 0`.
-              RUBY
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              exclude(number < 0)
+                      ^^^^^^^^^^ Use `number.negative?` instead of `number < 0`.
+            RUBY
 
-              expect_correction(<<~RUBY)
-                exclude(number.negative?)
-              RUBY
-            end
-          end
-
-          context 'when target ruby version is 2.2 or lower', :ruby22 do
-            it 'does not register an offense' do
-              expect_no_offenses('exclude { number > 0 }')
-            end
+            expect_correction(<<~RUBY)
+              exclude(number.negative?)
+            RUBY
           end
         end
       end

--- a/spec/rubocop/cop/style/optional_arguments_spec.rb
+++ b/spec/rubocop/cop/style/optional_arguments_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe RuboCop::Cop::Style::OptionalArguments, :config do
       end
     end
 
-    context 'required params', :ruby21 do
+    context 'required params' do
       it 'registers an offense for optional arguments that come before ' \
          'required arguments where there are name arguments' do
         expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -344,20 +344,6 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     RUBY
   end
 
-  context '< Ruby 2.5', :ruby24 do
-    it 'accepts a do-end block with a begin-end' do
-      expect_no_offenses(<<~RUBY)
-        do_something do
-          begin
-            foo
-          rescue => e
-            bar
-          end
-        end
-      RUBY
-    end
-  end
-
   context '>= ruby 2.5', :ruby25 do
     it 'registers an offense for a do-end block with redundant begin-end' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -344,78 +344,76 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     RUBY
   end
 
-  context '>= ruby 2.5', :ruby25 do
-    it 'registers an offense for a do-end block with redundant begin-end' do
-      expect_offense(<<~RUBY)
-        do_something do
-          begin
-          ^^^^^ Redundant `begin` block detected.
-            foo
-          rescue => e
-            bar
-          end
+  it 'registers an offense for a do-end block with redundant begin-end' do
+    expect_offense(<<~RUBY)
+      do_something do
+        begin
+        ^^^^^ Redundant `begin` block detected.
+          foo
+        rescue => e
+          bar
         end
-      RUBY
+      end
+    RUBY
 
-      expect_correction(<<~RUBY)
-        do_something do
-         #{trailing_whitespace}
-            foo
-          rescue => e
-            bar
-         #{trailing_whitespace}
+    expect_correction(<<~RUBY)
+      do_something do
+       #{trailing_whitespace}
+          foo
+        rescue => e
+          bar
+       #{trailing_whitespace}
+      end
+    RUBY
+  end
+
+  it 'accepts a {} block with a begin-end' do
+    expect_no_offenses(<<~RUBY)
+      do_something {
+        begin
+          foo
+        rescue => e
+          bar
         end
-      RUBY
-    end
+      }
+    RUBY
+  end
 
-    it 'accepts a {} block with a begin-end' do
-      expect_no_offenses(<<~RUBY)
-        do_something {
-          begin
-            foo
-          rescue => e
-            bar
-          end
-        }
-      RUBY
-    end
-
-    it 'accepts a block with a begin block after a statement' do
-      expect_no_offenses(<<~RUBY)
-        do_something do
-          something
-          begin
-            ala
-          rescue => e
-            bala
-          end
+  it 'accepts a block with a begin block after a statement' do
+    expect_no_offenses(<<~RUBY)
+      do_something do
+        something
+        begin
+          ala
+        rescue => e
+          bala
         end
-      RUBY
-    end
+      end
+    RUBY
+  end
 
-    it 'accepts a stabby lambda with a begin-end' do
-      expect_no_offenses(<<~RUBY)
-        -> do
-          begin
-            foo
-          rescue => e
-            bar
-          end
+  it 'accepts a stabby lambda with a begin-end' do
+    expect_no_offenses(<<~RUBY)
+      -> do
+        begin
+          foo
+        rescue => e
+          bar
         end
-      RUBY
-    end
+      end
+    RUBY
+  end
 
-    it 'accepts super with block' do
-      expect_no_offenses(<<~RUBY)
-        def a_method
-          super do |arg|
-            foo
-          rescue => e
-            bar
-          end
+  it 'accepts super with block' do
+    expect_no_offenses(<<~RUBY)
+      def a_method
+        super do |arg|
+          foo
+        rescue => e
+          bar
         end
-      RUBY
-    end
+      end
+    RUBY
   end
 
   it 'accepts when one-liner `begin` block has multiple statements with modifier condition' do

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -2,7 +2,6 @@
 
 RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
   let(:cop_config) { { 'ConvertCodeThatCanStartToReturnNil' => false } }
-  let(:target_ruby_version) { 2.3 }
 
   it 'allows calls to methods not safeguarded by respond_to' do
     expect_no_offenses('foo.bar')
@@ -917,7 +916,6 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
           context 'with Lint/SafeNavigationChain disabled' do
             let(:config) do
               RuboCop::Config.new(
-                'AllCops' => { 'TargetRubyVersion' => target_ruby_version },
                 'Lint/SafeNavigationChain' => { 'Enabled' => false },
                 'Style/SafeNavigation' => cop_config
               )
@@ -1147,12 +1145,6 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
 
     it 'allows enumerable accessor method calls safeguarded by a respond_to check' do
       expect_no_offenses('foo[0] if foo.respond_to?(:[])')
-    end
-  end
-
-  context 'when Ruby <= 2.2', :ruby22 do
-    it 'does not register an offense when a method call that nil responds to safe guarded by an object check' do
-      expect_no_offenses('foo.bar if foo')
     end
   end
 end

--- a/spec/rubocop/cop/style/sample_spec.rb
+++ b/spec/rubocop/cop/style/sample_spec.rb
@@ -69,10 +69,8 @@ RSpec.describe RuboCop::Cop::Style::Sample, :config do
   it_behaves_like('accepts', 'shuffle[2..3]')           # empty if coll.size < 3
   it_behaves_like('accepts', 'shuffle[2..-3]')          # can't compute range size
   it_behaves_like('accepts', 'shuffle[foo..3]')         # can't compute range size
-  context 'Ruby >= 2.6', :ruby26 do
-    it_behaves_like('accepts', 'shuffle[3..]')          # can't compute range size
-    it_behaves_like('accepts', 'shuffle[3...]')         # can't compute range size
-  end
+  it_behaves_like('accepts', 'shuffle[3..]')            # can't compute range size
+  it_behaves_like('accepts', 'shuffle[3...]')           # can't compute range size
 
   it_behaves_like('accepts', 'shuffle[-4..-3]')         # nil if coll.size < 3
   it_behaves_like('accepts', 'shuffle[foo]')            # foo could be a Range

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -130,52 +130,50 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
     RUBY
   end
 
-  context 'Ruby >= 2.6', :ruby26 do
-    it 'registers an offense for endless range with semicolon (irange only)' do
-      expect_offense(<<~RUBY)
+  it 'registers an offense for endless range with semicolon (irange only)' do
+    expect_offense(<<~RUBY)
+      42..;
+          ^ Do not use semicolons to terminate expressions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (42..)
+    RUBY
+  end
+
+  it 'registers an offense for endless range with semicolon (irange and erange)' do
+    expect_offense(<<~RUBY)
+      42..;
+          ^ Do not use semicolons to terminate expressions.
+      42...;
+           ^ Do not use semicolons to terminate expressions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (42..)
+      (42...)
+    RUBY
+  end
+
+  it 'registers an offense for endless range with semicolon in the method definition' do
+    expect_offense(<<~RUBY)
+      def foo
         42..;
             ^ Do not use semicolons to terminate expressions.
-      RUBY
+      end
+    RUBY
 
-      expect_correction(<<~RUBY)
+    expect_correction(<<~RUBY)
+      def foo
         (42..)
-      RUBY
-    end
+      end
+    RUBY
+  end
 
-    it 'registers an offense for endless range with semicolon (irange and erange)' do
-      expect_offense(<<~RUBY)
-        42..;
-            ^ Do not use semicolons to terminate expressions.
-        42...;
-             ^ Do not use semicolons to terminate expressions.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        (42..)
-        (42...)
-      RUBY
-    end
-
-    it 'registers an offense for endless range with semicolon in the method definition' do
-      expect_offense(<<~RUBY)
-        def foo
-          42..;
-              ^ Do not use semicolons to terminate expressions.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        def foo
-          (42..)
-        end
-      RUBY
-    end
-
-    it 'does not register an offense for endless range without semicolon' do
-      expect_no_offenses(<<~RUBY)
-        42..
-      RUBY
-    end
+  it 'does not register an offense for endless range without semicolon' do
+    expect_no_offenses(<<~RUBY)
+      42..
+    RUBY
   end
 
   context 'with a multi-expression line without a semicolon' do

--- a/spec/rubocop/cop/style/slicing_with_range_spec.rb
+++ b/spec/rubocop/cop/style/slicing_with_range_spec.rb
@@ -1,54 +1,44 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::SlicingWithRange, :config do
-  context '<= Ruby 2.5', :ruby25 do
-    it 'reports no offense for array slicing with -1' do
-      expect_no_offenses(<<~RUBY)
-        ary[1..-1]
-      RUBY
-    end
+  it 'reports an offense for slicing to ..-1' do
+    expect_offense(<<~RUBY)
+      ary[1..-1]
+          ^^^^^ Prefer ary[n..] over ary[n..-1].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ary[1..]
+    RUBY
   end
 
-  context '>= Ruby 2.6', :ruby26 do
-    it 'reports an offense for slicing to ..-1' do
-      expect_offense(<<~RUBY)
-        ary[1..-1]
-            ^^^^^ Prefer ary[n..] over ary[n..-1].
-      RUBY
+  it 'reports an offense for slicing from expression to ..-1' do
+    expect_offense(<<~RUBY)
+      ary[fetch_start(true).first..-1]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer ary[n..] over ary[n..-1].
+    RUBY
 
-      expect_correction(<<~RUBY)
-        ary[1..]
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      ary[fetch_start(true).first..]
+    RUBY
+  end
 
-    it 'reports an offense for slicing from expression to ..-1' do
-      expect_offense(<<~RUBY)
-        ary[fetch_start(true).first..-1]
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer ary[n..] over ary[n..-1].
-      RUBY
+  it 'reports no offense for excluding end' do
+    expect_no_offenses(<<~RUBY)
+      ary[1...-1]
+    RUBY
+  end
 
-      expect_correction(<<~RUBY)
-        ary[fetch_start(true).first..]
-      RUBY
-    end
+  it 'reports no offense for other methods' do
+    expect_no_offenses(<<~RUBY)
+      ary.push(1..-1)
+    RUBY
+  end
 
-    it 'reports no offense for excluding end' do
-      expect_no_offenses(<<~RUBY)
-        ary[1...-1]
-      RUBY
-    end
-
-    it 'reports no offense for other methods' do
-      expect_no_offenses(<<~RUBY)
-        ary.push(1..-1)
-      RUBY
-    end
-
-    it 'reports no offense for array with range inside' do
-      expect_no_offenses(<<~RUBY)
-        ranges = [1..-1]
-      RUBY
-    end
+  it 'reports no offense for array with range inside' do
+    expect_no_offenses(<<~RUBY)
+      ranges = [1..-1]
+    RUBY
   end
 
   context '>= Ruby 2.7', :ruby27 do

--- a/spec/rubocop/cop/style/unpack_first_spec.rb
+++ b/spec/rubocop/cop/style/unpack_first_spec.rb
@@ -1,76 +1,74 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::UnpackFirst, :config do
-  context 'ruby version >= 2.4', :ruby24 do
-    context 'registers offense' do
-      it 'when using `#unpack` with `#first`' do
-        expect_offense(<<~RUBY)
-          x.unpack('h*').first
-          ^^^^^^^^^^^^^^^^^^^^ Use `x.unpack1('h*')` instead of `x.unpack('h*').first`.
-        RUBY
+  context 'registers offense' do
+    it 'when using `#unpack` with `#first`' do
+      expect_offense(<<~RUBY)
+        x.unpack('h*').first
+        ^^^^^^^^^^^^^^^^^^^^ Use `x.unpack1('h*')` instead of `x.unpack('h*').first`.
+      RUBY
 
-        expect_correction(<<~RUBY)
-          x.unpack1('h*')
-        RUBY
-      end
-
-      it 'when using `#unpack` with square brackets' do
-        expect_offense(<<~RUBY)
-          ''.unpack(y)[0]
-          ^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y)[0]`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          ''.unpack1(y)
-        RUBY
-      end
-
-      it 'when using `#unpack` with dot and square brackets' do
-        expect_offense(<<~RUBY)
-          ''.unpack(y).[](0)
-          ^^^^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y).[](0)`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          ''.unpack1(y)
-        RUBY
-      end
-
-      it 'when using `#unpack` with `#slice`' do
-        expect_offense(<<~RUBY)
-          ''.unpack(y).slice(0)
-          ^^^^^^^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y).slice(0)`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          ''.unpack1(y)
-        RUBY
-      end
-
-      it 'when using `#unpack` with `#at`' do
-        expect_offense(<<~RUBY)
-          ''.unpack(y).at(0)
-          ^^^^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y).at(0)`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          ''.unpack1(y)
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        x.unpack1('h*')
+      RUBY
     end
 
-    context 'does not register offense' do
-      it 'when using `#unpack1`' do
-        expect_no_offenses(<<~RUBY)
-          x.unpack1(y)
-        RUBY
-      end
+    it 'when using `#unpack` with square brackets' do
+      expect_offense(<<~RUBY)
+        ''.unpack(y)[0]
+        ^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y)[0]`.
+      RUBY
 
-      it 'when using `#unpack` accessing second element' do
-        expect_no_offenses(<<~RUBY)
-          ''.unpack('h*')[1]
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        ''.unpack1(y)
+      RUBY
+    end
+
+    it 'when using `#unpack` with dot and square brackets' do
+      expect_offense(<<~RUBY)
+        ''.unpack(y).[](0)
+        ^^^^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y).[](0)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ''.unpack1(y)
+      RUBY
+    end
+
+    it 'when using `#unpack` with `#slice`' do
+      expect_offense(<<~RUBY)
+        ''.unpack(y).slice(0)
+        ^^^^^^^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y).slice(0)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ''.unpack1(y)
+      RUBY
+    end
+
+    it 'when using `#unpack` with `#at`' do
+      expect_offense(<<~RUBY)
+        ''.unpack(y).at(0)
+        ^^^^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y).at(0)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ''.unpack1(y)
+      RUBY
+    end
+  end
+
+  context 'does not register offense' do
+    it 'when using `#unpack1`' do
+      expect_no_offenses(<<~RUBY)
+        x.unpack1(y)
+      RUBY
+    end
+
+    it 'when using `#unpack` accessing second element' do
+      expect_no_offenses(<<~RUBY)
+        ''.unpack('h*')[1]
+      RUBY
     end
   end
 end


### PR DESCRIPTION
This complements #10577, considering #10625 an #10697.

As we don't run specs on CI for Ruby < 2.5, those specs that would only run on those Ruby versions are now useless.

Spec changes are better viewed [without whitespace](https://github.com/rubocop/rubocop/pull/10805/files?diff=split&w=1).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/