### PR TITLE
Add RSpec 4 prerelease CI job and make the test suite compatible with it

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -51,3 +51,26 @@ jobs:
         run: bundle exec rake ascii_spec
       - name: internal_investigation
         run: bundle exec rake internal_investigation
+
+  rspec4:
+    runs-on: ubuntu-latest
+    name: RSpec 4
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use latest RSpec 4 from `4-0-dev` branch
+        run: |
+          sed -e "/'rspec', '~> 3/d" -i Gemfile
+          cat << EOF > Gemfile.local
+            gem 'rspec', github: 'rspec/rspec', branch: '4-0-dev'
+            gem 'rspec-core', github: 'rspec/rspec-core', branch: '4-0-dev'
+            gem 'rspec-expectations', github: 'rspec/rspec-expectations', branch: '4-0-dev'
+            gem 'rspec-mocks', github: 'rspec/rspec-mocks', branch: '4-0-dev'
+            gem 'rspec-support', github: 'rspec/rspec-support', branch: '4-0-dev'
+          EOF
+      - name: set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: spec
+        run: bundle exec rspec

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
---color
 --require spec_helper

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -2,7 +2,7 @@
 
 require 'tmpdir'
 
-RSpec.shared_context 'isolated environment', :isolated_environment do
+RSpec.shared_context 'isolated environment' do
   around do |example|
     Dir.mktmpdir do |tmpdir|
       original_home = Dir.home
@@ -38,7 +38,7 @@ RSpec.shared_context 'isolated environment', :isolated_environment do
   end
 end
 
-RSpec.shared_context 'maintain registry', :restore_registry do
+RSpec.shared_context 'maintain registry' do
   around(:each) { |example| RuboCop::Cop::Registry.with_temporary_global { example.run } }
 
   def stub_cop_class(name, inherit: RuboCop::Cop::Base, &block)
@@ -49,7 +49,7 @@ RSpec.shared_context 'maintain registry', :restore_registry do
 end
 
 # This context assumes nothing and defines `cop`, among others.
-RSpec.shared_context 'config', :config do # rubocop:disable Metrics/BlockLength
+RSpec.shared_context 'config' do # rubocop:disable Metrics/BlockLength
   ### Meant to be overridden at will
 
   let(:cop_class) do
@@ -116,46 +116,46 @@ RSpec.shared_context 'mock console output' do
   end
 end
 
-RSpec.shared_context 'ruby 2.0', :ruby20 do
+RSpec.shared_context 'ruby 2.0' do
   let(:ruby_version) { 2.0 }
 end
 
-RSpec.shared_context 'ruby 2.1', :ruby21 do
+RSpec.shared_context 'ruby 2.1' do
   let(:ruby_version) { 2.1 }
 end
 
-RSpec.shared_context 'ruby 2.2', :ruby22 do
+RSpec.shared_context 'ruby 2.2' do
   let(:ruby_version) { 2.2 }
 end
 
-RSpec.shared_context 'ruby 2.3', :ruby23 do
+RSpec.shared_context 'ruby 2.3' do
   let(:ruby_version) { 2.3 }
 end
 
-RSpec.shared_context 'ruby 2.4', :ruby24 do
+RSpec.shared_context 'ruby 2.4' do
   let(:ruby_version) { 2.4 }
 end
 
-RSpec.shared_context 'ruby 2.5', :ruby25 do
+RSpec.shared_context 'ruby 2.5' do
   let(:ruby_version) { 2.5 }
 end
 
-RSpec.shared_context 'ruby 2.6', :ruby26 do
+RSpec.shared_context 'ruby 2.6' do
   let(:ruby_version) { 2.6 }
 end
 
-RSpec.shared_context 'ruby 2.7', :ruby27 do
+RSpec.shared_context 'ruby 2.7' do
   let(:ruby_version) { 2.7 }
 end
 
-RSpec.shared_context 'ruby 3.0', :ruby30 do
+RSpec.shared_context 'ruby 3.0' do
   let(:ruby_version) { 3.0 }
 end
 
-RSpec.shared_context 'ruby 3.1', :ruby31 do
+RSpec.shared_context 'ruby 3.1' do
   let(:ruby_version) { 3.1 }
 end
 
-RSpec.shared_context 'ruby 3.2', :ruby32 do
+RSpec.shared_context 'ruby 3.2' do
   let(:ruby_version) { 3.2 }
 end

--- a/lib/rubocop/rspec/support.rb
+++ b/lib/rubocop/rspec/support.rb
@@ -11,4 +11,18 @@ require_relative 'parallel_formatter'
 RSpec.configure do |config|
   config.include CopHelper
   config.include HostEnvironmentSimulatorHelper
+  config.include_context 'config', :config
+  config.include_context 'isolated environment', :isolated_environment
+  config.include_context 'maintain registry', :restore_registry
+  config.include_context 'ruby 2.0', :ruby20
+  config.include_context 'ruby 2.1', :ruby21
+  config.include_context 'ruby 2.2', :ruby22
+  config.include_context 'ruby 2.3', :ruby23
+  config.include_context 'ruby 2.4', :ruby24
+  config.include_context 'ruby 2.5', :ruby25
+  config.include_context 'ruby 2.6', :ruby26
+  config.include_context 'ruby 2.7', :ruby27
+  config.include_context 'ruby 3.0', :ruby30
+  config.include_context 'ruby 3.1', :ruby31
+  config.include_context 'ruby 3.2', :ruby32
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,41 +26,24 @@ require 'rubocop/rspec/support'
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
-  # This config option will be enabled by default on RSpec 4,
-  # but for reasons of backwards compatibility, you have to
-  # set it on RSpec 3.
-  #
-  # It causes the host group and examples to inherit metadata
-  # from the shared context.
-  config.shared_context_metadata_behavior = :apply_to_host_groups
-
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
   unless defined?(::TestQueue)
     # See. https://github.com/tmm1/test-queue/issues/60#issuecomment-281948929
-    config.filter_run :focus
-    config.run_all_when_everything_filtered = true
+    config.filter_run_when_matching :focus
   end
 
   config.example_status_persistence_file_path = 'spec/examples.txt'
-  config.disable_monkey_patching!
 
   config.include RuboCop::RSpec::ExpectOffense
 
   config.order = :random
   Kernel.srand config.seed
 
-  config.expect_with :rspec do |expectations|
-    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
-    expectations.syntax = :expect # Disable `should`
-  end
-
-  config.mock_with :rspec do |mocks|
-    mocks.syntax = :expect # Disable `should_receive` and `stub`
-    mocks.verify_partial_doubles = true
-  end
+  config.expect_with :rspec
+  config.mock_with :rspec
 
   config.before(:suite) do
     RuboCop::Cop::Registry.global.freeze

--- a/spec/support/alignment_examples.rb
+++ b/spec/support/alignment_examples.rb
@@ -2,7 +2,7 @@
 
 # `cop` and `source` must be declared with #let.
 
-shared_examples_for 'misaligned' do |annotated_source, used_style|
+RSpec.shared_examples_for 'misaligned' do |annotated_source, used_style|
   config_to_allow_offenses = if used_style
                                { 'EnforcedStyleAlignWith' => used_style.to_s }
                              else
@@ -29,7 +29,7 @@ shared_examples_for 'misaligned' do |annotated_source, used_style|
   end
 end
 
-shared_examples_for 'aligned' do |alignment_base, arg, end_kw, name|
+RSpec.shared_examples_for 'aligned' do |alignment_base, arg, end_kw, name|
   name ||= alignment_base
   name = name.gsub(/\n/, ' <newline>')
   it "accepts matching #{name} ... end" do

--- a/spec/support/empty_lines_around_body_shared_examples.rb
+++ b/spec/support/empty_lines_around_body_shared_examples.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
+RSpec.shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
   context 'when EnforcedStyle is empty_lines_special' do
     let(:cop_config) { { 'EnforcedStyle' => 'empty_lines_special' } }
 

--- a/spec/support/multiline_literal_brace_layout_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_examples.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples_for 'multiline literal brace layout' do
+RSpec.shared_examples_for 'multiline literal brace layout' do
   include MultilineLiteralBraceHelper
 
   let(:prefix) { '' } # A prefix before the opening brace.

--- a/spec/support/multiline_literal_brace_layout_method_argument_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_method_argument_examples.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples_for 'multiline literal brace layout method argument' do
+RSpec.shared_examples_for 'multiline literal brace layout method argument' do
   include MultilineLiteralBraceHelper
 
   context 'when arguments to a method' do

--- a/spec/support/multiline_literal_brace_layout_trailing_comma_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_trailing_comma_examples.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples_for 'multiline literal brace layout trailing comma' do
+RSpec.shared_examples_for 'multiline literal brace layout trailing comma' do
   let(:prefix) { '' } # A prefix before the opening brace.
   let(:suffix) { '' } # A suffix for the line after the closing brace.
   let(:open) { nil } # The opening brace.


### PR DESCRIPTION
See RSpec 4 changes in https://github.com/rspec/rspec-metagem/issues/61

[Sibling PR for `rubocop-rspec`](https://github.com/rubocop/rubocop-rspec/pull/1322).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/