### PR TITLE
Enhanced documentation for "IgnoredMethods" option

### DIFF
--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -7,6 +7,7 @@ module RuboCop
       # when param passed without parentheses.
       #
       # This cop can customize ignored methods with `IgnoredMethods`.
+      # By default, there are no methods to ignored.
       #
       # @example
       #
@@ -29,10 +30,16 @@ module RuboCop
       #   # Lambda arguments require no disambiguation
       #   foo = ->(bar) { bar.baz }
       #
+      # @example IgnoredMethods: [] (default)
+      #
+      #   # bad
+      #   expect { do_something }.to change { object.attribute }
+      #
       # @example IgnoredMethods: [change]
       #
       #   # good
       #   expect { do_something }.to change { object.attribute }
+      #
       class AmbiguousBlockAssociation < Base
         include IgnoredMethods
 

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -16,7 +16,8 @@ module RuboCop
       # NOTE: Some values cannot be converted properly using one of the `Kernel`
       # method (for instance, `Time` and `DateTime` values are allowed by this
       # cop by default). Similarly, Rails' duration methods do not work well
-      # with `Integer()` and can be ignored with `IgnoredMethods`.
+      # with `Integer()` and can be ignored with `IgnoredMethods`. By default,
+      # there are no methods to ignored.
       #
       # @safety
       #   Autocorrection is unsafe because it is not guaranteed that the
@@ -44,6 +45,11 @@ module RuboCop
       #   ['1', '2', '3'].map { |i| Integer(i, 10) }
       #   foo.try { |i| Float(i) }
       #   bar.send { |i| Complex(i) }
+      #
+      # @example IgnoredMethods: [] (default)
+      #
+      #   # bad
+      #   10.minutes.to_i
       #
       # @example IgnoredMethods: [minutes]
       #

--- a/lib/rubocop/cop/metrics/block_length.rb
+++ b/lib/rubocop/cop/metrics/block_length.rb
@@ -15,6 +15,7 @@ module RuboCop
       #
       # NOTE: The `ExcludedMethods` configuration is deprecated and only kept
       # for backwards compatibility. Please use `IgnoredMethods` instead.
+      # By default, there are no methods to ignored.
       #
       # @example CountAsOne: ['array', 'heredoc']
       #

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -13,6 +13,7 @@ module RuboCop
       #
       # NOTE: The `ExcludedMethods` configuration is deprecated and only kept
       # for backwards compatibility. Please use `IgnoredMethods` instead.
+      # By default, there are no methods to ignored.
       #
       # @example CountAsOne: ['array', 'heredoc']
       #

--- a/lib/rubocop/cop/style/class_equality_comparison.rb
+++ b/lib/rubocop/cop/style/class_equality_comparison.rb
@@ -5,6 +5,8 @@ module RuboCop
     module Style
       # Enforces the use of `Object#instance_of?` instead of class comparison
       # for equality.
+      # `==`, `equal?`, and `eql?` methods are ignored by default.
+      # These are customizable with `IgnoredMethods` option.
       #
       # @example
       #   # bad
@@ -15,6 +17,26 @@ module RuboCop
       #
       #   # good
       #   var.instance_of?(Date)
+      #
+      # @example IgnoreMethods: [] (default)
+      #   # good
+      #   var.instance_of?(Date)
+      #
+      #   # bad
+      #   var.class == Date
+      #   var.class.equal?(Date)
+      #   var.class.eql?(Date)
+      #   var.class.name == 'Date'
+      #
+      # @example IgnoreMethods: [`==`]
+      #   # good
+      #   var.instance_of?(Date)
+      #   var.class == Date
+      #   var.class.name == 'Date'
+      #
+      #   # bad
+      #   var.class.equal?(Date)
+      #   var.class.eql?(Date)
       #
       class ClassEqualityComparison < Base
         include RangeHelp

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -12,6 +12,7 @@ module RuboCop
       # to encoded URLs or Date/Time formatting strings.
       #
       # This cop can be customized ignored methods with `IgnoredMethods`.
+      # By default, there are no methods to ignored.
       #
       # @example EnforcedStyle: annotated (default)
       #
@@ -60,6 +61,11 @@ module RuboCop
       #
       #   # good
       #   format('%06d', 10)
+      #
+      # @example IgnoredMethods: [] (default)
+      #
+      #   # bad
+      #   redirect('foo/%{bar_id}')
       #
       # @example IgnoredMethods: [redirect]
       #

--- a/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
@@ -5,12 +5,24 @@ module RuboCop
     module Style
       # Checks for unwanted parentheses in parameterless method calls.
       #
+      # This cop can be customized ignored methods with `IgnoredMethods`.
+      # By default, there are no methods to ignored.
+      #
       # @example
       #   # bad
       #   object.some_method()
       #
       #   # good
       #   object.some_method
+      #
+      # @example IgnoredMethods: [] (default)
+      #   # bad
+      #   object.foo()
+      #
+      # @example IgnoredMethods: [foo]
+      #   # good
+      #   object.foo()
+      #
       class MethodCallWithoutArgsParentheses < Base
         include IgnoredMethods
         extend AutoCorrector

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -6,13 +6,16 @@ module RuboCop
       # Checks for usage of comparison operators (`==`,
       # `>`, `<`) to test numbers as zero, positive, or negative.
       # These can be replaced by their respective predicate methods.
-      # The cop can also be configured to do the reverse.
+      # This cop can also be configured to do the reverse.
       #
-      # The cop disregards `#nonzero?` as its value is truthy or falsey,
+      # This cop can be customized ignored methods with `IgnoredMethods`.
+      # By default, there are no methods to ignored.
+      #
+      # This cop disregards `#nonzero?` as its value is truthy or falsey,
       # but not `true` and `false`, and thus not always interchangeable with
       # `!= 0`.
       #
-      # The cop ignores comparisons to global variables, since they are often
+      # This cop ignores comparisons to global variables, since they are often
       # populated with objects which can be compared with integers, but are
       # not themselves `Integer` polymorphic.
       #
@@ -23,29 +26,40 @@ module RuboCop
       #
       # @example EnforcedStyle: predicate (default)
       #   # bad
-      #
       #   foo == 0
       #   0 > foo
       #   bar.baz > 0
       #
       #   # good
-      #
       #   foo.zero?
       #   foo.negative?
       #   bar.baz.positive?
       #
       # @example EnforcedStyle: comparison
       #   # bad
-      #
       #   foo.zero?
       #   foo.negative?
       #   bar.baz.positive?
       #
       #   # good
-      #
       #   foo == 0
       #   0 > foo
       #   bar.baz > 0
+      #
+      # @example IgnoredMethods: [] (default) with EnforcedStyle: predicate
+      #   # bad
+      #   foo == 0
+      #   0 > foo
+      #   bar.baz > 0
+      #
+      # @example IgnoredMethods: [==] with EnforcedStyle: predicate
+      #   # good
+      #   foo == 0
+      #
+      #   # bad
+      #   0 > foo
+      #   bar.baz > 0
+      #
       class NumericPredicate < Base
         include ConfigurableEnforcedStyle
         include IgnoredMethods

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -7,6 +7,8 @@ module RuboCop
       #
       # If you prefer a style that allows block for method with arguments,
       # please set `true` to `AllowMethodsWithArguments`.
+      # respond_to , and `define_method?` methods are ignored by default.
+      # These are customizable with `IgnoredMethods` option.
       #
       # @safety
       #   This cop is unsafe because `proc`s and blocks work differently
@@ -68,6 +70,12 @@ module RuboCop
       #     s.upcase # some comment
       #     # some comment
       #   end
+      #
+      # @example IgnoredMethods: [respond_to, define_method] (default)
+      #   # good
+      #   respond_to { |foo| foo.bar }
+      #   define_method(:foo) { |foo| foo.bar }
+      #
       class SymbolProc < Base
         include CommentsHelp
         include RangeHelp


### PR DESCRIPTION
This PR is documentation was added according to the following policy for "IgnoredMethods" option

- Add code examples for cop that don't have code examples
- Add default values for cop that don't have default values

The code example also clearly shows the difference in behavior from the default when the default for "IgnoredMethods" is an empty array.

I thought We could flag "IgnoredMethods" as obsolete and merge it into "AllowedMethods".
Refs (case of "AllowedPatterns") : https://github.com/rubocop/rubocop/pull/10555

In the future, if it looks like it would be better to merge them, I would like to handle it other PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
