### PR TITLE
Support `csend` on `Style/SymbolProc`

### DIFF
--- a/changelog/change_support_csend_on_stylesymbolproc.md
+++ b/changelog/change_support_csend_on_stylesymbolproc.md
@@ -1,0 +1,1 @@
+* [#10810](https://github.com/rubocop/rubocop/pull/10810): Support `csend` on `Style/SymbolProc`. ([@r7kamura][])

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -81,7 +81,7 @@ module RuboCop
         def_node_matcher :proc_node?, '(send (const {nil? cbase} :Proc) :new)'
 
         # @!method symbol_proc_receiver?(node)
-        def_node_matcher :symbol_proc_receiver?, '{(send ...) (super ...) zsuper}'
+        def_node_matcher :symbol_proc_receiver?, '{({csend | send} ...) (super ...) zsuper}'
 
         # @!method symbol_proc?(node)
         def_node_matcher :symbol_proc?, <<~PATTERN

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
     RUBY
   end
 
+  it 'registers an offense for csend' do
+    expect_offense(<<~RUBY)
+      coll&.map { |e| e.upcase }
+                ^^^^^^^^^^^^^^^^ Pass `&:upcase` as an argument to `map` instead of a block.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      coll&.map(&:upcase)
+    RUBY
+  end
+
   it 'registers an offense for a block when method in body is unary -/+' do
     expect_offense(<<~RUBY)
       something.map { |x| -x }


### PR DESCRIPTION
I think the following bad side code should also be treated as an offense:

```ruby
# bad
array&.map { |element| element.upcase }

# good
array&.map(&:upcase)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
    * There doesn't seem to be an existing issue on this
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
