### PR TITLE
Fix Style/ClassAndModuleChildren compaction for oneliner children

### DIFF
--- a/changelog/fix_style_class_and_module_children.md
+++ b/changelog/fix_style_class_and_module_children.md
@@ -1,0 +1,1 @@
+* Fix Style/ClassAndModuleChildren compaction for oneliner children. ([@Morriar][])

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -117,11 +117,14 @@ module RuboCop
         end
 
         def remove_end(corrector, body)
-          range = range_between(
-            body.loc.end.begin_pos - leading_spaces(body).size,
-            body.loc.end.end_pos + 1
-          )
+          begin_pos = body.loc.end.begin_pos
+          begin_pos -= leading_spaces(body).size unless oneline?(body)
+          range = range_between(begin_pos, body.loc.end.end_pos + 1)
           corrector.remove(range)
+        end
+
+        def oneline?(node)
+          node.loc.name.line == node.loc.end.line
         end
 
         def configured_indentation_width

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -205,6 +205,24 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       RUBY
     end
 
+    it 'registers a offense for classes with nested oneline children' do
+      expect_offense(<<~RUBY)
+        class FooClass
+              ^^^^^^^^ Use compact module/class definition instead of nested style.
+          class BarClass end
+        end
+        class FooClass
+              ^^^^^^^^ Use compact module/class definition instead of nested style.
+          class BarClass; end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class FooClass::BarClass end
+        class FooClass::BarClass; end
+      RUBY
+    end
+
     it 'registers a offense for modules with nested children' do
       expect_offense(<<~RUBY)
         module FooModule
@@ -221,6 +239,24 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
           def method_example
           end
         end
+      RUBY
+    end
+
+    it 'registers a offense for modules with nested oneline children' do
+      expect_offense(<<~RUBY)
+        module FooModule
+               ^^^^^^^^^ Use compact module/class definition instead of nested style.
+          module BarModule end
+        end
+        module FooModule
+               ^^^^^^^^^ Use compact module/class definition instead of nested style.
+          module BarModule; end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module FooModule::BarModule end
+        module FooModule::BarModule; end
       RUBY
     end
 


### PR DESCRIPTION
`Style/ClassAndModuleChildren` with `EnforcedStyle: Compact` doesn't handle definitions on a single line properly.

Consider this example:

```rb
class Foo
  class Bar; end
end
```

Before this PR, the autocorrect was producing code with a syntax error:

```rb
class Foo::Barend
```

After this PR, the autocorrect is producing the correct code:

```rb
class Foo::Bar; end
```

This also fixes an error that was happening when autocorrecting this code:

```rb
class Foo
  class Bar end
end
```

Which was raising a `Parser::ClobberingError: Parser::Source::TreeRewriter detected clobbering` error.

After this PR, the autocorrect works properly:

```rb
class Foo::Bar end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
