### PR TITLE
Introduce new AllowMultilineFinalElement option for all __LineBreak(s) cops

### DIFF
--- a/changelog/new_allow_multiline_final_element_option_for_line_breaks_cops.md
+++ b/changelog/new_allow_multiline_final_element_option_for_line_breaks_cops.md
@@ -1,0 +1,1 @@
+* [#10812](https://github.com/rubocop/rubocop/pull/10812): New AllowMultilineFinalElement option for all LineBreaks cops. ([@Korri][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -762,6 +762,7 @@ Layout/FirstArrayElementLineBreak:
                  multi-line array.
   Enabled: false
   VersionAdded: '0.49'
+  AllowMultilineFinalElement: false
 
 Layout/FirstHashElementIndentation:
   Description: 'Checks the indentation of the first key in a hash literal.'
@@ -794,6 +795,7 @@ Layout/FirstHashElementLineBreak:
                  multi-line hash.
   Enabled: false
   VersionAdded: '0.49'
+  AllowMultilineFinalElement: false
 
 Layout/FirstMethodArgumentLineBreak:
   Description: >-
@@ -801,6 +803,7 @@ Layout/FirstMethodArgumentLineBreak:
                  multi-line method call.
   Enabled: false
   VersionAdded: '0.49'
+  AllowMultilineFinalElement: false
 
 Layout/FirstMethodParameterLineBreak:
   Description: >-
@@ -808,6 +811,7 @@ Layout/FirstMethodParameterLineBreak:
                  multi-line method parameter definition.
   Enabled: false
   VersionAdded: '0.49'
+  AllowMultilineFinalElement: false
 
 Layout/FirstParameterIndentation:
   Description: >-
@@ -1067,6 +1071,7 @@ Layout/MultilineArrayLineBreaks:
                  starts on a separate line.
   Enabled: false
   VersionAdded: '0.67'
+  AllowMultilineFinalElement: false
 
 Layout/MultilineAssignmentLayout:
   Description: 'Check for a newline after the assignment operator in multi-line assignments.'
@@ -1117,6 +1122,7 @@ Layout/MultilineHashKeyLineBreaks:
                  starts on a separate line.
   Enabled: false
   VersionAdded: '0.67'
+  AllowMultilineFinalElement: false
 
 Layout/MultilineMethodArgumentLineBreaks:
   Description: >-
@@ -1124,6 +1130,7 @@ Layout/MultilineMethodArgumentLineBreaks:
                  starts on a separate line.
   Enabled: false
   VersionAdded: '0.67'
+  AllowMultilineFinalElement: false
 
 Layout/MultilineMethodCallBraceLayout:
   Description: >-
@@ -1178,6 +1185,7 @@ Layout/MultilineMethodParameterLineBreaks:
                  starts on a separate line.
   Enabled: false
   VersionAdded: '1.32'
+  AllowMultilineFinalElement: false
 
 Layout/MultilineOperationIndentation:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -2914,7 +2914,7 @@ multi-line array.
 |===
 | Name | Default value | Configurable values
 
-| AllowMultilineFinalElement
+| xref:cops_layout.adoc#allowmultilinefinalelement[AllowMultilineFinalElement]
 | `false`
 | Boolean
 |===
@@ -3144,7 +3144,7 @@ multi-line hash.
 |===
 | Name | Default value | Configurable values
 
-| AllowMultilineFinalElement
+| xref:cops_layout.adoc#allowmultilinefinalelement[AllowMultilineFinalElement]
 | `false`
 | Boolean
 |===
@@ -3245,7 +3245,7 @@ method foo, bar,
 |===
 | Name | Default value | Configurable values
 
-| AllowMultilineFinalElement
+| xref:cops_layout.adoc#allowmultilinefinalelement[AllowMultilineFinalElement]
 | `false`
 | Boolean
 |===
@@ -3342,7 +3342,7 @@ end
 |===
 | Name | Default value | Configurable values
 
-| AllowMultilineFinalElement
+| xref:cops_layout.adoc#allowmultilinefinalelement[AllowMultilineFinalElement]
 | `false`
 | Boolean
 |===
@@ -4795,7 +4795,7 @@ starts on a separate line.
 |===
 | Name | Default value | Configurable values
 
-| AllowMultilineFinalElement
+| xref:cops_layout.adoc#allowmultilinefinalelement[AllowMultilineFinalElement]
 | `false`
 | Boolean
 |===
@@ -5165,7 +5165,7 @@ starts on a separate line.
 |===
 | Name | Default value | Configurable values
 
-| AllowMultilineFinalElement
+| xref:cops_layout.adoc#allowmultilinefinalelement[AllowMultilineFinalElement]
 | `false`
 | Boolean
 |===
@@ -5263,7 +5263,7 @@ foo(
 |===
 | Name | Default value | Configurable values
 
-| AllowMultilineFinalElement
+| xref:cops_layout.adoc#allowmultilinefinalelement[AllowMultilineFinalElement]
 | `false`
 | Boolean
 |===
@@ -5709,7 +5709,7 @@ end
 |===
 | Name | Default value | Configurable values
 
-| AllowMultilineFinalElement
+| xref:cops_layout.adoc#allowmultilinefinalelement[AllowMultilineFinalElement]
 | `false`
 | Boolean
 |===
@@ -7615,3 +7615,5 @@ RUBY
 === References
 
 * https://rubystyle.guide#no-trailing-whitespace
+
+include::../partials/cops_layout_footer.adoc[]

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -2859,6 +2859,36 @@ multi-line array.
 
 === Examples
 
+==== AllowMultilineFinalElement: false (default)
+
+[source,ruby]
+----
+# bad
+[ :a,
+  :b]
+
+# bad
+[ :a, {
+  :b => :c
+}]
+
+# good
+[:a, :b]
+
+# good
+[
+  :a,
+  :b]
+
+# good
+[
+  :a, {
+  :b => :c
+}]
+----
+
+==== AllowMultilineFinalElement: true
+
 [source,ruby]
 ----
 # bad
@@ -2866,10 +2896,28 @@ multi-line array.
   :b]
 
 # good
+[ :a, {
+  :b => :c
+}]
+
+# good
 [
   :a,
   :b]
+
+# good
+[:a, :b]
 ----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowMultilineFinalElement
+| `false`
+| Boolean
+|===
 
 == Layout/FirstHashElementIndentation
 
@@ -3035,17 +3083,71 @@ multi-line hash.
 
 === Examples
 
+==== AllowMultilineFinalElement: false (default)
+
 [source,ruby]
 ----
 # bad
 { a: 1,
   b: 2}
 
+# bad
+{ a: 1, b: {
+  c: 3
+}}
+
 # good
 {
   a: 1,
   b: 2 }
+
+# good
+{
+  a: 1, b: {
+  c: 3
+}}
 ----
+
+==== AllowMultilineFinalElement: true
+
+[source,ruby]
+----
+# bad
+{ a: 1,
+  b: 2}
+
+# bad
+{ a: 1,
+  b: {
+  c: 3
+}}
+
+# good
+{ a: 1, b: {
+  c: 3
+}}
+
+# good
+{
+  a: 1,
+  b: 2 }
+
+# good
+{
+  a: 1, b: {
+  c: 3
+}}
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowMultilineFinalElement
+| `false`
+| Boolean
+|===
 
 == Layout/FirstMethodArgumentLineBreak
 
@@ -3064,21 +3166,89 @@ multi-line method call.
 
 === Examples
 
+==== AllowMultilineFinalElement: false (default)
+
 [source,ruby]
 ----
 # bad
 method(foo, bar,
   baz)
 
+# bad
+method(foo, bar, {
+  baz: "a",
+  qux: "b",
+})
+
 # good
 method(
   foo, bar,
   baz)
 
+# good
+method(
+  foo, bar, {
+  baz: "a",
+  qux: "b",
+})
+
 # ignored
 method foo, bar,
   baz
 ----
+
+==== AllowMultilineFinalElement: true
+
+[source,ruby]
+----
+# bad
+method(foo, bar,
+  baz)
+
+# bad
+method(foo,
+  bar,
+  {
+    baz: "a",
+    qux: "b",
+  }
+)
+
+# good
+method(foo, bar, {
+  baz: "a",
+  qux: "b",
+})
+
+# good
+method(
+  foo, bar,
+  baz)
+
+# good
+method(
+  foo,
+  bar,
+  {
+    baz: "a",
+    qux: "b",
+  }
+)
+
+# ignored
+method foo, bar,
+  baz
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowMultilineFinalElement
+| `false`
+| Boolean
+|===
 
 == Layout/FirstMethodParameterLineBreak
 
@@ -3097,11 +3267,59 @@ multi-line method parameter definition.
 
 === Examples
 
+==== AllowMultilineFinalElement: false (default)
+
 [source,ruby]
 ----
 # bad
 def method(foo, bar,
     baz)
+  do_something
+end
+
+# bad
+def method(foo, bar, baz = {
+  :a => "b",
+})
+  do_something
+end
+
+# good
+def method(
+    foo, bar,
+    baz)
+  do_something
+end
+
+# good
+def method(
+  foo, bar, baz = {
+  :a => "b",
+})
+  do_something
+end
+
+# ignored
+def method foo,
+    bar
+  do_something
+end
+----
+
+==== AllowMultilineFinalElement: true
+
+[source,ruby]
+----
+# bad
+def method(foo, bar,
+    baz)
+  do_something
+end
+
+# good
+def method(foo, bar, baz = {
+  :a => "b",
+})
   do_something
 end
 
@@ -3118,6 +3336,16 @@ def method foo,
   do_something
 end
 ----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowMultilineFinalElement
+| `false`
+| Boolean
+|===
 
 == Layout/FirstParameterIndentation
 
@@ -4498,6 +4726,40 @@ starts on a separate line.
 
 === Examples
 
+==== AllowMultilineFinalElement: false (default)
+
+[source,ruby]
+----
+# bad
+[
+  a, b,
+  c
+]
+
+# bad
+[ a, b, foo(
+  bar
+)]
+
+# good
+[
+  a,
+  b,
+  c
+]
+
+# good
+[
+  a,
+  b,
+  foo(
+    bar
+  )
+]
+----
+
+==== AllowMultilineFinalElement: true
+
 [source,ruby]
 ----
 # bad
@@ -4507,12 +4769,36 @@ starts on a separate line.
 ]
 
 # good
+[ a, b, foo(
+  bar
+)]
+
+# good
 [
   a,
   b,
   c
 ]
+
+# good
+[
+  a,
+  b,
+  foo(
+    bar
+  )
+]
 ----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowMultilineFinalElement
+| `false`
+| Boolean
+|===
 
 == Layout/MultilineAssignmentLayout
 
@@ -4812,6 +5098,39 @@ starts on a separate line.
 
 === Examples
 
+==== AllowMultilineFinalElement: false (default)
+
+[source,ruby]
+----
+# bad
+{
+  a: 1, b: 2,
+  c: 3
+}
+
+# bad
+{ a: 1, b: {
+  c: 3,
+}}
+
+# good
+{
+  a: 1,
+  b: 2,
+  c: 3
+}
+
+# good
+{
+  a: 1,
+  b: {
+    c: 3,
+  }
+}
+----
+
+==== AllowMultilineFinalElement: true
+
 [source,ruby]
 ----
 # bad
@@ -4821,12 +5140,35 @@ starts on a separate line.
 }
 
 # good
+{ a: 1, b: {
+  c: 3,
+}}
+
+# good
 {
   a: 1,
   b: 2,
   c: 3
 }
+
+# good
+{
+  a: 1,
+  b: {
+    c: 3,
+  }
+}
 ----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowMultilineFinalElement
+| `false`
+| Boolean
+|===
 
 == Layout/MultilineMethodArgumentLineBreaks
 
@@ -4848,12 +5190,19 @@ be on a separate line, see `Layout/FirstMethodArgumentLineBreak`.
 
 === Examples
 
+==== AllowMultilineFinalElement: false (default)
+
 [source,ruby]
 ----
 # bad
 foo(a, b,
   c
 )
+
+# bad
+foo(a, b, {
+  foo: "bar",
+})
 
 # good
 foo(
@@ -4864,7 +5213,60 @@ foo(
 
 # good
 foo(a, b, c)
+
+# good
+foo(
+  a,
+  b,
+  {
+    foo: "bar",
+  }
+)
 ----
+
+==== AllowMultilineFinalElement: true
+
+[source,ruby]
+----
+# bad
+foo(a, b,
+  c
+)
+
+# good
+foo(a, b, {
+  foo: "bar",
+})
+
+# good
+foo(
+  a,
+  b,
+  c
+)
+
+# good
+foo(a, b, c)
+
+# good
+foo(
+  a,
+  b,
+  {
+    foo: "bar",
+  }
+)
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowMultilineFinalElement
+| `false`
+| Boolean
+|===
 
 == Layout/MultilineMethodCallBraceLayout
 
@@ -5226,12 +5628,20 @@ be on a separate line, see `Layout/FirstMethodParameterLineBreak`.
 
 === Examples
 
+==== AllowMultilineFinalElement: false (default)
+
 [source,ruby]
 ----
 # bad
 def foo(a, b,
   c
 )
+end
+
+# bad
+def foo(a, b = {
+  foo: "bar",
+})
 end
 
 # good
@@ -5243,9 +5653,66 @@ def foo(
 end
 
 # good
+def foo(
+  a,
+  b = {
+    foo: "bar",
+  }
+)
+end
+
+# good
 def foo(a, b, c)
 end
 ----
+
+==== AllowMultilineFinalElement: true
+
+[source,ruby]
+----
+# bad
+def foo(a, b,
+  c
+)
+end
+
+# good
+def foo(a, b = {
+  foo: "bar",
+})
+end
+
+# good
+def foo(
+  a,
+  b,
+  c
+)
+end
+
+# good
+def foo(
+  a,
+  b = {
+    foo: "bar",
+  }
+)
+end
+
+# good
+def foo(a, b, c)
+end
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowMultilineFinalElement
+| `false`
+| Boolean
+|===
 
 == Layout/MultilineOperationIndentation
 

--- a/docs/modules/ROOT/partials/cops_layout_footer.adoc
+++ b/docs/modules/ROOT/partials/cops_layout_footer.adoc
@@ -1,0 +1,101 @@
+
+== AllowMultilineFinalElement
+
+`AllowMultilineFinalElement` is a boolean option (`false` by default) that
+is available on the following Layout cops:
+
+  * FirstArrayElementLineBreak
+  * FirstHashElementLineBreak
+  * FirstMethodArgumentLineBreak
+  * FirstMethodParameterLineBreak
+  * MultilineArrayLineBreaks
+  * MultilineHashKeyLineBreaks
+  * MultilineMethodArgumentLineBreaks
+  * MultilineMethodParameterLineBreaks
+
+Those cops ignore their respective expressions if all or the elements of
+the expression are on the same line. If `AllowMultilineFinalElement` is
+set to `true`, the cop will also ignore multiline expressions if the last
+element starts on the same line, but ends on a different one.
+
+This works well with `Layout/LineLength` to present elements on
+individual lines when wrapping, while not affecting expressions
+that are already short enough, and only considered multiline
+because of their last element.
+
+Each cop can be configured independently allowing for more fine-grained
+control ovwer what is considered good ok in the codebase.
+
+=== Examples
+
+Here are some examples of real world expressions that get wrapped
+by their respective cops, but that are considered ok when setting
+`AllowMultilineFinalElement` to `true` on those same cops.
+
+[source,ruby]
+----
+# good
+
+# FirstArrayElementLineBreak and MultilineArrayLineBreaks
+
+  # Array of error containing a single error
+  errors = [{
+    error: "Something went wrong",
+    error_code: error_code,
+  }]
+
+  # Array of flags, with last flag computed
+  flags = [:a, :b, foo(
+    bar,
+    baz
+  )]
+
+# FirstHashElementLineBreak and MultilineHashKeyLineBreaks
+  hash = { foo: 1, bar: 2, baz: {
+    c: 1,
+    d: 2
+  }}
+
+# FirstMethodArgumentLineBreak and MultilineMethodArgumentLineBreaks
+  single_argument_hash_method_call({
+    a: 1,
+    b: 2,
+    c: 3
+  })
+
+  # Call some method, with a long last argument, that is a hash
+  write_log(:error,  {
+    "job_class" => job.class.name,
+    "resource" => resource.id,
+    "message" => "Something wrong happened here",
+  })
+
+  # Rails before action with long last argument
+  before_action :load_something, only: [
+    :show,
+    :list,
+    :some_other_long_action_name,
+  ]
+
+  # Rails validation with inline callback
+  validate :name, presence: true, on: [:create, :activate], if: -> {
+    active? && some_relationship.any?
+  }
+
+  # Rails after commit hook, with some Sorbet bindings
+  after_commit :geolocate, unless: -> {
+    T.bind(self, Address)
+    archived? || invalid?
+  }
+
+# FirstMethodParameterLineBreak and MultilineMethodParameterLineBreaks
+
+  # Method with a long last parameter default value
+  def foo(foo, bar, baz = {
+    a: 1,
+    b: 2,
+    c: 3
+  })
+    do_something
+  end
+----

--- a/lib/rubocop/cop/layout/first_array_element_line_break.rb
+++ b/lib/rubocop/cop/layout/first_array_element_line_break.rb
@@ -6,17 +6,49 @@ module RuboCop
       # Checks for a line break before the first element in a
       # multi-line array.
       #
-      # @example
+      # @example AllowMultilineFinalElement: false (default)
       #
       #     # bad
       #     [ :a,
       #       :b]
+      #
+      #     # bad
+      #     [ :a, {
+      #       :b => :c
+      #     }]
+      #
+      #     # good
+      #     [:a, :b]
       #
       #     # good
       #     [
       #       :a,
       #       :b]
       #
+      #     # good
+      #     [
+      #       :a, {
+      #       :b => :c
+      #     }]
+      #
+      # @example AllowMultilineFinalElement: true
+      #
+      #     # bad
+      #     [ :a,
+      #       :b]
+      #
+      #     # good
+      #     [ :a, {
+      #       :b => :c
+      #     }]
+      #
+      #     # good
+      #     [
+      #       :a,
+      #       :b]
+      #
+      #     # good
+      #     [:a, :b]
       class FirstArrayElementLineBreak < Base
         include FirstElementLineBreak
         extend AutoCorrector
@@ -26,7 +58,7 @@ module RuboCop
         def on_array(node)
           return if !node.loc.begin && !assignment_on_same_line?(node)
 
-          check_children_line_break(node, node.children)
+          check_children_line_break(node, node.children, ignore_last: ignore_last_element?)
         end
 
         private
@@ -34,6 +66,10 @@ module RuboCop
         def assignment_on_same_line?(node)
           source = node.source_range.source_line[0...node.loc.column]
           /\s*=\s*$/.match?(source)
+        end
+
+        def ignore_last_element?
+          !!cop_config['AllowMultilineFinalElement']
         end
       end
     end

--- a/lib/rubocop/cop/layout/first_hash_element_line_break.rb
+++ b/lib/rubocop/cop/layout/first_hash_element_line_break.rb
@@ -6,16 +6,55 @@ module RuboCop
       # Checks for a line break before the first element in a
       # multi-line hash.
       #
-      # @example
+      # @example AllowMultilineFinalElement: false (default)
       #
       #     # bad
       #     { a: 1,
       #       b: 2}
       #
+      #     # bad
+      #     { a: 1, b: {
+      #       c: 3
+      #     }}
+      #
       #     # good
       #     {
       #       a: 1,
       #       b: 2 }
+      #
+      #     # good
+      #     {
+      #       a: 1, b: {
+      #       c: 3
+      #     }}
+      #
+      # @example AllowMultilineFinalElement: true
+      #
+      #     # bad
+      #     { a: 1,
+      #       b: 2}
+      #
+      #     # bad
+      #     { a: 1,
+      #       b: {
+      #       c: 3
+      #     }}
+      #
+      #     # good
+      #     { a: 1, b: {
+      #       c: 3
+      #     }}
+      #
+      #     # good
+      #     {
+      #       a: 1,
+      #       b: 2 }
+      #
+      #     # good
+      #     {
+      #       a: 1, b: {
+      #       c: 3
+      #     }}
       class FirstHashElementLineBreak < Base
         include FirstElementLineBreak
         extend AutoCorrector
@@ -25,7 +64,15 @@ module RuboCop
         def on_hash(node)
           # node.loc.begin tells us whether the hash opens with a {
           # If it doesn't, Style/FirstMethodArgumentLineBreak will handle it
-          check_children_line_break(node, node.children) if node.loc.begin
+          return unless node.loc.begin
+
+          check_children_line_break(node, node.children, ignore_last: ignore_last_element?)
+        end
+
+        private
+
+        def ignore_last_element?
+          !!cop_config['AllowMultilineFinalElement']
         end
       end
     end

--- a/lib/rubocop/cop/layout/first_method_argument_line_break.rb
+++ b/lib/rubocop/cop/layout/first_method_argument_line_break.rb
@@ -6,16 +6,69 @@ module RuboCop
       # Checks for a line break before the first argument in a
       # multi-line method call.
       #
-      # @example
+      # @example AllowMultilineFinalElement: false (default)
       #
       #     # bad
       #     method(foo, bar,
       #       baz)
       #
+      #     # bad
+      #     method(foo, bar, {
+      #       baz: "a",
+      #       qux: "b",
+      #     })
+      #
       #     # good
       #     method(
       #       foo, bar,
       #       baz)
+      #
+      #     # good
+      #     method(
+      #       foo, bar, {
+      #       baz: "a",
+      #       qux: "b",
+      #     })
+      #
+      #     # ignored
+      #     method foo, bar,
+      #       baz
+      #
+      # @example AllowMultilineFinalElement: true
+      #
+      #     # bad
+      #     method(foo, bar,
+      #       baz)
+      #
+      #     # bad
+      #     method(foo,
+      #       bar,
+      #       {
+      #         baz: "a",
+      #         qux: "b",
+      #       }
+      #     )
+      #
+      #     # good
+      #     method(foo, bar, {
+      #       baz: "a",
+      #       qux: "b",
+      #     })
+      #
+      #     # good
+      #     method(
+      #       foo, bar,
+      #       baz)
+      #
+      #     # good
+      #     method(
+      #       foo,
+      #       bar,
+      #       {
+      #         baz: "a",
+      #         qux: "b",
+      #       }
+      #     )
       #
       #     # ignored
       #     method foo, bar,
@@ -38,10 +91,16 @@ module RuboCop
           last_arg = args.last
           args.concat(args.pop.children) if last_arg&.hash_type? && !last_arg&.braces?
 
-          check_method_line_break(node, args)
+          check_method_line_break(node, args, ignore_last: ignore_last_element?)
         end
         alias on_csend on_send
         alias on_super on_send
+
+        private
+
+        def ignore_last_element?
+          !!cop_config['AllowMultilineFinalElement']
+        end
       end
     end
   end

--- a/lib/rubocop/cop/layout/first_method_parameter_line_break.rb
+++ b/lib/rubocop/cop/layout/first_method_parameter_line_break.rb
@@ -6,11 +6,54 @@ module RuboCop
       # Checks for a line break before the first parameter in a
       # multi-line method parameter definition.
       #
-      # @example
+      # @example AllowMultilineFinalElement: false (default)
       #
       #     # bad
       #     def method(foo, bar,
       #         baz)
+      #       do_something
+      #     end
+      #
+      #     # bad
+      #     def method(foo, bar, baz = {
+      #       :a => "b",
+      #     })
+      #       do_something
+      #     end
+      #
+      #     # good
+      #     def method(
+      #         foo, bar,
+      #         baz)
+      #       do_something
+      #     end
+      #
+      #     # good
+      #     def method(
+      #       foo, bar, baz = {
+      #       :a => "b",
+      #     })
+      #       do_something
+      #     end
+      #
+      #     # ignored
+      #     def method foo,
+      #         bar
+      #       do_something
+      #     end
+      #
+      # @example AllowMultilineFinalElement: true
+      #
+      #     # bad
+      #     def method(foo, bar,
+      #         baz)
+      #       do_something
+      #     end
+      #
+      #     # good
+      #     def method(foo, bar, baz = {
+      #       :a => "b",
+      #     })
       #       do_something
       #     end
       #
@@ -26,6 +69,7 @@ module RuboCop
       #         bar
       #       do_something
       #     end
+      #
       class FirstMethodParameterLineBreak < Base
         include FirstElementLineBreak
         extend AutoCorrector
@@ -33,9 +77,15 @@ module RuboCop
         MSG = 'Add a line break before the first parameter of a multi-line method parameter list.'
 
         def on_def(node)
-          check_method_line_break(node, node.arguments)
+          check_method_line_break(node, node.arguments, ignore_last: ignore_last_element?)
         end
         alias on_defs on_def
+
+        private
+
+        def ignore_last_element?
+          !!cop_config['AllowMultilineFinalElement']
+        end
       end
     end
   end

--- a/lib/rubocop/cop/layout/multiline_array_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_array_line_breaks.rb
@@ -6,7 +6,36 @@ module RuboCop
       # Ensures that each item in a multi-line array
       # starts on a separate line.
       #
-      # @example
+      # @example AllowMultilineFinalElement: false (default)
+      #
+      #   # bad
+      #   [
+      #     a, b,
+      #     c
+      #   ]
+      #
+      #   # bad
+      #   [ a, b, foo(
+      #     bar
+      #   )]
+      #
+      #   # good
+      #   [
+      #     a,
+      #     b,
+      #     c
+      #   ]
+      #
+      #   # good
+      #   [
+      #     a,
+      #     b,
+      #     foo(
+      #       bar
+      #     )
+      #   ]
+      #
+      # @example AllowMultilineFinalElement: true
       #
       #   # bad
       #   [
@@ -15,10 +44,24 @@ module RuboCop
       #   ]
       #
       #   # good
+      #   [ a, b, foo(
+      #     bar
+      #   )]
+      #
+      #   # good
       #   [
       #     a,
       #     b,
       #     c
+      #   ]
+      #
+      #   # good
+      #   [
+      #     a,
+      #     b,
+      #     foo(
+      #       bar
+      #     )
       #   ]
       class MultilineArrayLineBreaks < Base
         include MultilineElementLineBreaks
@@ -27,7 +70,13 @@ module RuboCop
         MSG = 'Each item in a multi-line array must start on a separate line.'
 
         def on_array(node)
-          check_line_breaks(node, node.children)
+          check_line_breaks(node, node.children, ignore_last: ignore_last_element?)
+        end
+
+        private
+
+        def ignore_last_element?
+          !!cop_config['AllowMultilineFinalElement']
         end
       end
     end

--- a/lib/rubocop/cop/layout/multiline_hash_key_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_hash_key_line_breaks.rb
@@ -6,7 +6,35 @@ module RuboCop
       # Ensures that each key in a multi-line hash
       # starts on a separate line.
       #
-      # @example
+      # @example AllowMultilineFinalElement: false (default)
+      #
+      #   # bad
+      #   {
+      #     a: 1, b: 2,
+      #     c: 3
+      #   }
+      #
+      #   # bad
+      #   { a: 1, b: {
+      #     c: 3,
+      #   }}
+      #
+      #   # good
+      #   {
+      #     a: 1,
+      #     b: 2,
+      #     c: 3
+      #   }
+      #
+      #   # good
+      #   {
+      #     a: 1,
+      #     b: {
+      #       c: 3,
+      #     }
+      #   }
+      #
+      # @example AllowMultilineFinalElement: true
       #
       #   # bad
       #   {
@@ -15,10 +43,24 @@ module RuboCop
       #   }
       #
       #   # good
+      #   { a: 1, b: {
+      #     c: 3,
+      #   }}
+      #
+      #   # good
       #   {
       #     a: 1,
       #     b: 2,
       #     c: 3
+      #   }
+      #
+      #
+      #   # good
+      #   {
+      #     a: 1,
+      #     b: {
+      #       c: 3,
+      #     }
       #   }
       class MultilineHashKeyLineBreaks < Base
         include MultilineElementLineBreaks
@@ -31,14 +73,19 @@ module RuboCop
           # braces like {foo: 1}. That is, not a kwargs hashes.
           # Style/MultilineMethodArgumentLineBreaks handles those.
           return unless starts_with_curly_brace?(node)
+          return unless node.loc.begin
 
-          check_line_breaks(node, node.children) if node.loc.begin
+          check_line_breaks(node, node.children, ignore_last: ignore_last_element?)
         end
 
         private
 
         def starts_with_curly_brace?(node)
           node.loc.begin
+        end
+
+        def ignore_last_element?
+          !!cop_config['AllowMultilineFinalElement']
         end
       end
     end

--- a/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
@@ -9,12 +9,17 @@ module RuboCop
       # NOTE: This cop does not move the first argument, if you want that to
       # be on a separate line, see `Layout/FirstMethodArgumentLineBreak`.
       #
-      # @example
+      # @example AllowMultilineFinalElement: false (default)
       #
       #   # bad
       #   foo(a, b,
       #     c
       #   )
+      #
+      #   # bad
+      #   foo(a, b, {
+      #     foo: "bar",
+      #   })
       #
       #   # good
       #   foo(
@@ -25,6 +30,46 @@ module RuboCop
       #
       #   # good
       #   foo(a, b, c)
+      #
+      #   # good
+      #   foo(
+      #     a,
+      #     b,
+      #     {
+      #       foo: "bar",
+      #     }
+      #   )
+      #
+      # @example AllowMultilineFinalElement: true
+      #
+      #   # bad
+      #   foo(a, b,
+      #     c
+      #   )
+      #
+      #   # good
+      #   foo(a, b, {
+      #     foo: "bar",
+      #   })
+      #
+      #   # good
+      #   foo(
+      #     a,
+      #     b,
+      #     c
+      #   )
+      #
+      #   # good
+      #   foo(a, b, c)
+      #
+      #   # good
+      #   foo(
+      #     a,
+      #     b,
+      #     {
+      #       foo: "bar",
+      #     }
+      #   )
       class MultilineMethodArgumentLineBreaks < Base
         include MultilineElementLineBreaks
         extend AutoCorrector
@@ -45,7 +90,13 @@ module RuboCop
           last_arg = args.last
           args = args[0...-1] + last_arg.children if last_arg&.hash_type? && !last_arg&.braces?
 
-          check_line_breaks(node, args)
+          check_line_breaks(node, args, ignore_last: ignore_last_element?)
+        end
+
+        private
+
+        def ignore_last_element?
+          !!cop_config['AllowMultilineFinalElement']
         end
       end
     end

--- a/lib/rubocop/cop/layout/multiline_method_parameter_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_method_parameter_line_breaks.rb
@@ -9,7 +9,42 @@ module RuboCop
       # NOTE: This cop does not move the first argument, if you want that to
       # be on a separate line, see `Layout/FirstMethodParameterLineBreak`.
       #
-      # @example
+      # @example AllowMultilineFinalElement: false (default)
+      #
+      #   # bad
+      #   def foo(a, b,
+      #     c
+      #   )
+      #   end
+      #
+      #   # bad
+      #   def foo(a, b = {
+      #     foo: "bar",
+      #   })
+      #   end
+      #
+      #   # good
+      #   def foo(
+      #     a,
+      #     b,
+      #     c
+      #   )
+      #   end
+      #
+      #   # good
+      #   def foo(
+      #     a,
+      #     b = {
+      #       foo: "bar",
+      #     }
+      #   )
+      #   end
+      #
+      #   # good
+      #   def foo(a, b, c)
+      #   end
+      #
+      # @example AllowMultilineFinalElement: true
       #
       #   # bad
       #   def foo(a, b,
@@ -18,10 +53,25 @@ module RuboCop
       #   end
       #
       #   # good
+      #   def foo(a, b = {
+      #     foo: "bar",
+      #   })
+      #   end
+      #
+      #   # good
       #   def foo(
       #     a,
       #     b,
       #     c
+      #   )
+      #   end
+      #
+      #   # good
+      #   def foo(
+      #     a,
+      #     b = {
+      #       foo: "bar",
+      #     }
       #   )
       #   end
       #
@@ -37,7 +87,13 @@ module RuboCop
         def on_def(node)
           return if node.arguments.empty?
 
-          check_line_breaks(node, node.arguments)
+          check_line_breaks(node, node.arguments, ignore_last: ignore_last_element?)
+        end
+
+        private
+
+        def ignore_last_element?
+          !!cop_config['AllowMultilineFinalElement']
         end
       end
     end

--- a/lib/rubocop/cop/mixin/first_element_line_break.rb
+++ b/lib/rubocop/cop/mixin/first_element_line_break.rb
@@ -7,12 +7,12 @@ module RuboCop
     module FirstElementLineBreak
       private
 
-      def check_method_line_break(node, children)
+      def check_method_line_break(node, children, ignore_last: false)
         return if children.empty?
 
         return unless method_uses_parens?(node, children.first)
 
-        check_children_line_break(node, children)
+        check_children_line_break(node, children, ignore_last: ignore_last)
       end
 
       def method_uses_parens?(node, limit)
@@ -20,7 +20,7 @@ module RuboCop
         /\s*\(\s*$/.match?(source)
       end
 
-      def check_children_line_break(node, children, start = node)
+      def check_children_line_break(node, children, start = node, ignore_last: false)
         return if children.empty?
 
         line = start.first_line
@@ -28,8 +28,8 @@ module RuboCop
         min = first_by_line(children)
         return if line != min.first_line
 
-        max = last_by_line(children)
-        return if line == max.last_line
+        max_line = last_line(children, ignore_last: ignore_last)
+        return if line == max_line
 
         add_offense(min) { |corrector| EmptyLineCorrector.insert_before(corrector, min) }
       end
@@ -38,8 +38,12 @@ module RuboCop
         nodes.min_by(&:first_line)
       end
 
-      def last_by_line(nodes)
-        nodes.max_by(&:last_line)
+      def last_line(nodes, ignore_last:)
+        if ignore_last
+          nodes.map(&:first_line)
+        else
+          nodes.map(&:last_line)
+        end.max
       end
     end
   end

--- a/lib/rubocop/cop/mixin/multiline_element_line_breaks.rb
+++ b/lib/rubocop/cop/mixin/multiline_element_line_breaks.rb
@@ -10,8 +10,8 @@ module RuboCop
     module MultilineElementLineBreaks
       private
 
-      def check_line_breaks(_node, children)
-        return if all_on_same_line?(children)
+      def check_line_breaks(_node, children, ignore_last: false)
+        return if all_on_same_line?(children, ignore_last: ignore_last)
 
         last_seen_line = -1
         children.each do |child|
@@ -23,8 +23,10 @@ module RuboCop
         end
       end
 
-      def all_on_same_line?(nodes)
+      def all_on_same_line?(nodes, ignore_last: false)
         return true if nodes.empty?
+
+        return same_line?(nodes.first, nodes.last) if ignore_last
 
         nodes.first.first_line == nodes.last.last_line
       end

--- a/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
@@ -103,4 +103,54 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementLineBreak, :config do
         :b]
     RUBY
   end
+
+  context 'last element can be multiline' do
+    let(:cop_config) { { 'AllowMultilineFinalElement' => true } }
+
+    it 'ignores last argument that is a multine Hash' do
+      expect_no_offenses(<<~RUBY)
+        [a, b, {
+          c: d
+        }]
+      RUBY
+    end
+
+    it 'ignores single value that is a multiline hash' do
+      expect_no_offenses(<<~RUBY)
+        [{
+          a: b
+        }]
+      RUBY
+    end
+
+    it 'registers and corrects values that are multiline hashes and not the last value' do
+      expect_offense(<<~RUBY)
+        [a, {
+         ^ Add a line break before the first element of a multi-line array.
+          b: c
+        }, d]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [
+        a, {
+          b: c
+        }, d]
+      RUBY
+    end
+
+    it 'registers and corrects last value that starts on another line' do
+      expect_offense(<<~RUBY)
+        [a, b,
+         ^ Add a line break before the first element of a multi-line array.
+        c]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [
+        a, b,
+        c]
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
@@ -75,4 +75,54 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementLineBreak, :config do
         b: 2 }
     RUBY
   end
+
+  context 'last element can be multiline' do
+    let(:cop_config) { { 'AllowMultilineFinalElement' => true } }
+
+    it 'ignores last argument that is a multine Hash' do
+      expect_no_offenses(<<~RUBY)
+        h = {a: b, c: {
+          d: e
+        }}
+      RUBY
+    end
+
+    it 'ignores single value that is a multiline hash' do
+      expect_no_offenses(<<~RUBY)
+        h = {a: {
+          b: c
+        }}
+      RUBY
+    end
+
+    it 'registers and corrects values that are multiline hashes and not the last value' do
+      expect_offense(<<~RUBY)
+        h = {a: b, c: {
+             ^^^^ Add a line break before the first element of a multi-line hash.
+          d: e,
+        }, f: g}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        h = {
+        a: b, c: {
+          d: e,
+        }, f: g}
+      RUBY
+    end
+
+    it 'registers and corrects last value that starts on another line' do
+      expect_offense(<<~RUBY)
+        h = {a: b, c: d,
+             ^^^^ Add a line break before the first element of a multi-line hash.
+        e: f}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        h = {
+        a: b, c: d,
+        e: f}
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
@@ -91,4 +91,54 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak, :config do
   it 'ignores methods without arguments' do
     expect_no_offenses('foo')
   end
+
+  context 'last element can be multiline' do
+    let(:cop_config) { { 'AllowMultilineFinalElement' => true } }
+
+    it 'ignores last argument that is a multine Hash' do
+      expect_no_offenses(<<~RUBY)
+        foo(bar, {
+          a: b
+        })
+      RUBY
+    end
+
+    it 'ignores single argument that is a multiline hash' do
+      expect_no_offenses(<<~RUBY)
+        foo({
+          a: b
+        })
+      RUBY
+    end
+
+    it 'registers and corrects values that are multiline hashes and not the last value' do
+      expect_offense(<<~RUBY)
+        foo(bar, {
+            ^^^ Add a line break before the first argument of a multi-line method argument list.
+          a: b
+        }, baz)
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo(
+        bar, {
+          a: b
+        }, baz)
+      RUBY
+    end
+
+    it 'registers and corrects last argument that starts on another line' do
+      expect_offense(<<~RUBY)
+        foo(bar,
+            ^^^ Add a line break before the first argument of a multi-line method argument list.
+        baz)
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo(
+        bar,
+        baz)
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
@@ -83,4 +83,66 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak, :config do
       end
     RUBY
   end
+
+  context 'last element can be multiline' do
+    let(:cop_config) { { 'AllowMultilineFinalElement' => true } }
+
+    it 'ignores last argument that value is a multine Hash' do
+      expect_no_offenses(<<~RUBY)
+        def foo(bar, baz = {
+          a: b
+        })
+          do_something
+        end
+      RUBY
+    end
+
+    it 'ignores single argument that value is a multiline hash' do
+      expect_no_offenses(<<~RUBY)
+        def foo(bar = {
+          a: b
+        })
+          do_something
+        end
+      RUBY
+    end
+
+    it 'registers and corrects parameters that value is a multiline hashe and is not the last parameter' do
+      expect_offense(<<~RUBY)
+        def foo(bar, baz = {
+                ^^^ Add a line break before the first parameter of a multi-line method parameter list.
+          a: b
+        }, qux = false)
+          do_something
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(
+        bar, baz = {
+          a: b
+        }, qux = false)
+          do_something
+        end
+      RUBY
+    end
+
+    it 'registers and corrects last parameter that starts on another line' do
+      expect_offense(<<~RUBY)
+        def foo(bar, baz,
+                ^^^ Add a line break before the first parameter of a multi-line method parameter list.
+          qux = false)
+          do_something
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(
+        bar, baz,
+          qux = false)
+          do_something
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/multiline_array_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_array_line_breaks_spec.rb
@@ -50,4 +50,37 @@ RSpec.describe RuboCop::Cop::Layout::MultilineArrayLineBreaks, :config do
       RUBY
     end
   end
+
+  context 'ignore laste element' do
+    let(:cop_config) { { 'AllowMultilineFinalElement' => true } }
+
+    it 'ignores last value that is a multiline hash' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3, {
+          a: 1
+        }]
+      RUBY
+    end
+
+    it 'registers and corrects values that are multiline hashes and not the last value' do
+      expect_offense(<<~RUBY)
+        [1, 2, 3, {
+                  ^ Each item in a multi-line array must start on a separate line.
+               ^ Each item in a multi-line array must start on a separate line.
+            ^ Each item in a multi-line array must start on a separate line.
+          a: 1
+        }, 4]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1,#{trailing_whitespace}
+        2,#{trailing_whitespace}
+        3,#{trailing_whitespace}
+        {
+          a: 1
+        },#{trailing_whitespace}
+        4]
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/multiline_hash_key_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_hash_key_line_breaks_spec.rb
@@ -97,5 +97,48 @@ RSpec.describe RuboCop::Cop::Layout::MultilineHashKeyLineBreaks, :config do
         bar: "2"}
       RUBY
     end
+
+    context 'ignore last element' do
+      let(:cop_config) { { 'AllowMultilineFinalElement' => true } }
+
+      it 'ignores last value that is a multiline hash' do
+        expect_no_offenses(<<~RUBY)
+          {foo: 1, bar: {
+            a: 1
+          }}
+        RUBY
+      end
+
+      it 'registers and corrects values that are multiline hashes and not the last value' do
+        expect_offense(<<~RUBY)
+          {foo: 1, bar: {
+                   ^^^^^^ Each key in a multi-line hash must start on a separate line.
+            a: 1,
+          }, baz: 3}
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {foo: 1,#{trailing_whitespace}
+          bar: {
+            a: 1,
+          },#{trailing_whitespace}
+          baz: 3}
+        RUBY
+      end
+
+      it 'registers and corrects last value that is on a new line' do
+        expect_offense(<<~RUBY)
+          {foo: 1, bar: 2,
+                   ^^^^^^ Each key in a multi-line hash must start on a separate line.
+            baz: 3}
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {foo: 1,#{trailing_whitespace}
+          bar: 2,
+            baz: 3}
+        RUBY
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/layout/multiline_method_argument_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_argument_line_breaks_spec.rb
@@ -159,4 +159,53 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodArgumentLineBreaks, :config 
       RUBY
     end
   end
+
+  context 'ignore last element' do
+    let(:cop_config) { { 'AllowMultilineFinalElement' => true } }
+
+    it 'ignores last argument that is a multiline hash' do
+      expect_no_offenses(<<~RUBY)
+        foo(1, 2, 3, {
+          a: 1,
+        })
+      RUBY
+    end
+
+    it 'registers and corrects arguments that are multiline hashes and not the last argument' do
+      expect_offense(<<~RUBY)
+        foo(1, 2, 3, {
+                     ^ Each argument in a multi-line method call must start on a separate line.
+                  ^ Each argument in a multi-line method call must start on a separate line.
+               ^ Each argument in a multi-line method call must start on a separate line.
+          a: 1,
+        }, 4)
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo(1,#{trailing_whitespace}
+        2,#{trailing_whitespace}
+        3,#{trailing_whitespace}
+        {
+          a: 1,
+        },#{trailing_whitespace}
+        4)
+      RUBY
+    end
+
+    it 'registers and corrects last argument that starts on a new line' do
+      expect_offense(<<~RUBY)
+        foo(1, 2, 3,
+                  ^ Each argument in a multi-line method call must start on a separate line.
+               ^ Each argument in a multi-line method call must start on a separate line.
+        4)
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo(1,#{trailing_whitespace}
+        2,#{trailing_whitespace}
+        3,
+        4)
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/multiline_method_parameter_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_parameter_line_breaks_spec.rb
@@ -159,4 +159,56 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodParameterLineBreaks, :config
       RUBY
     end
   end
+
+  context 'ignore last element' do
+    let(:cop_config) { { 'AllowMultilineFinalElement' => true } }
+
+    it 'ignores last parameter that value is a multiline hash' do
+      expect_no_offenses(<<~RUBY)
+        def foo(abc, foo, bar = {
+          a: 1,
+        })
+        end
+      RUBY
+    end
+
+    it 'registers and corrects arguments that are multiline hashes and not the last argument' do
+      expect_offense(<<~RUBY)
+        def foo(abc, foo, bar = {
+                          ^^^^^^^ Each parameter in a multi-line method definition must start on a separate line.
+                     ^^^ Each parameter in a multi-line method definition must start on a separate line.
+          a: 1,
+        }, buz)
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(abc,#{trailing_whitespace}
+        foo,#{trailing_whitespace}
+        bar = {
+          a: 1,
+        },#{trailing_whitespace}
+        buz)
+        end
+      RUBY
+    end
+
+    it 'registers and corrects last argument that starts on a new line' do
+      expect_offense(<<~RUBY)
+        def foo(abc, foo, ghi,
+                          ^^^ Each parameter in a multi-line method definition must start on a separate line.
+                     ^^^ Each parameter in a multi-line method definition must start on a separate line.
+        jkl)
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(abc,#{trailing_whitespace}
+        foo,#{trailing_whitespace}
+        ghi,
+        jkl)
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This add a `AllowMultilineFinalElement` option, that when set to `true` allows the following cops to not consider a statement to be multiline even if the last (or only) element (value, argument or parameter) itself is multiline:

```
FirstArrayElementLineBreak
FirstHashElementLineBreak
FirstMethodArgumentLineBreak
FirstMethodParameterLineBreak
MultilineArrayLineBreaks
MultilineHashKeyLineBreaks
MultilineMethodArgumentLineBreaks
MultilineMethodParameterLineBreaks
```

The goal of this addition is to be able to use `Layout/LineLength` to format each elements on a new line, while not forcing some of the use cases that are considered "ok exceptions" by some people.

### Examples of exceptions that those changes make possible

```ruby
# Allow final element to be multiline

# good
foo(a, b, bar(
  c,
  d
))

# good
{ a: b, c: {
 foo: bar,
 baz: qux,
}}

# good
[ 1, 2, [
 foo,
 bar,
]]

# Single elements are ignored too

# good
foo({
 a: b,
})

# good
a = { foo: [
  bar,
  baz,
]}

# good
b = [{
  foo: bar
}]
```

### While still correcting the followings

```ruby
# bad
foo(bar, baz,
bat)

[1, 2
3]

# good
foo(
  bar,
  baz,
  bat,
)
[
  1,
  2,
  3,
]
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
