### PR TITLE
[Fix rubocop#10813] Fix recursive deletion to suppression in `Lint/NonAtomicFileOperation`

### DIFF
--- a/changelog/fix_recursive_deletions_to_suppression_in_non_atomic_file_operation.md
+++ b/changelog/fix_recursive_deletions_to_suppression_in_non_atomic_file_operation.md
@@ -1,0 +1,1 @@
+* [#10813](https://github.com/rubocop/rubocop/issues/10813): Fix recursive deletion to suppression in `Lint/NonAtomicFileOperation`. ([@ydah][])

--- a/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
+++ b/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
@@ -71,19 +71,11 @@ RSpec.describe RuboCop::Cop::Lint::NonAtomicFileOperation, :config do
   end
 
   %i[rm_r rmtree].each do |remove_method|
-    it 'registers an offense when use `FileTest.exist?` before remove recursive file' do
-      expect_offense(<<~RUBY, remove_method: remove_method)
+    it 'does not register an offense when use `FileTest.exist?` before remove recursive file' do
+      expect_no_offenses(<<~RUBY, remove_method: remove_method)
         if FileTest.exist?(path)
-        ^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary existence check `FileTest.exist?`.
           FileUtils.#{remove_method}(path)
-          ^^^^^^^^^^^{remove_method}^^^^^^ Use atomic file operation method `FileUtils.rm_rf`.
         end
-      RUBY
-
-      expect_correction(<<~RUBY)
-
-        #{trailing_whitespace}#{trailing_whitespace}FileUtils.rm_rf(path)
-
       RUBY
     end
   end


### PR DESCRIPTION
Fixes: rubocop#10813

This PR is suppress offense in case of
recursive deletion in `Lint/NonAtomicFileOperation`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
