### PR TITLE
[Fix #10825] Fix an incorrect autocorrect for `Style/ClassAndModuleChildren`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_class_and_module_children.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_class_and_module_children.md
@@ -1,0 +1,1 @@
+* [#10825](https://github.com/rubocop/rubocop/issues/10825): Fix an incorrect autocorrect for `Style/ClassAndModuleChildren` when using nested one-liner class. ([@koic][])

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -117,10 +117,10 @@ module RuboCop
         end
 
         def remove_end(corrector, body)
-          range = range_between(
-            body.loc.end.begin_pos - leading_spaces(body).size,
-            body.loc.end.end_pos + 1
-          )
+          remove_begin_pos = body.loc.end.begin_pos - leading_spaces(body).size
+          adjustment = processed_source.raw_source[remove_begin_pos] == ';' ? 0 : 1
+          range = range_between(remove_begin_pos, body.loc.end.end_pos + adjustment)
+
           corrector.remove(range)
         end
 

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -367,6 +367,20 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       RUBY
     end
 
+    it 'registers a offense for classes with nested one-liner children' do
+      expect_offense(<<~RUBY)
+        class FooClass
+              ^^^^^^^^ Use compact module/class definition instead of nested style.
+          class BarClass; end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class FooClass::BarClass
+        end
+      RUBY
+    end
+
     it 'accepts class/module with single method' do
       expect_no_offenses(<<~RUBY)
         class FooClass


### PR DESCRIPTION
Fixes #10825.

This PR fixes an incorrect autocorrect for `Style/ClassAndModuleChildren` when using nested one-liner class.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
