### PR TITLE
Fix an error when using `changed_parameters` by external library

### DIFF
--- a/changelog/fix_an_error_when_using_changed_parameters_by_external_library.md
+++ b/changelog/fix_an_error_when_using_changed_parameters_by_external_library.md
@@ -1,0 +1,1 @@
+* [#10831](https://github.com/rubocop/rubocop/pull/10831): Fix an error when using `changed_parameters` in obsoletion.yml by external library. ([@koic][])

--- a/lib/rubocop/config_obsoletion.rb
+++ b/lib/rubocop/config_obsoletion.rb
@@ -47,10 +47,15 @@ module RuboCop
 
     # Default rules for obsoletions are in config/obsoletion.yml
     # Additional rules files can be added with `RuboCop::ConfigObsoletion.files << filename`
-    def load_rules
+    def load_rules # rubocop:disable Metrics/AbcSize
       rules = self.class.files.each_with_object({}) do |filename, hash|
         hash.merge!(YAML.safe_load(File.read(filename))) do |_key, first, second|
-          first.merge(second)
+          case first
+          when Hash
+            first.merge(second)
+          when Array
+            first.concat(second)
+          end
         end
       end
 

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -573,5 +573,28 @@ RSpec.describe RuboCop::ConfigObsoletion do
         expect { config_obsoletion.reject_obsolete! }.not_to raise_error
       end
     end
+
+    context 'when using `changed_parameters` by an external library' do
+      after { described_class.files = [described_class::DEFAULT_RULES_FILE] }
+
+      let(:hash) { {} }
+      let(:external_obsoletions) do
+        create_file('external/obsoletions.yml', <<~YAML)
+          changed_parameters:
+            - cops: Rails/FindEach
+              parameters: IgnoredMethods
+              alternatives:
+                - AllowedMethods
+                - AllowedPatterns
+              severity: warning
+        YAML
+      end
+
+      it 'allows the extracted cops' do
+        described_class.files << external_obsoletions
+
+        expect { config_obsoletion.reject_obsolete! }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the following error when using `changed_parameters` in obsoletion.yml by external library.

```console
NoMethodError: undefined method `merge' for
[{"cops"=>["Layout/SpaceAroundOperators", "Style/SpaceAroundOperators"],
"parameters"=>"MultiSpaceAllowedForOperators", "reason"=>"If your
intention was to allow extra spaces for alignment, please use `AllowFoy

          first.merge(second)
               ^^^^^^
/Users/koic/src/github.com/rubocop/rubocop-rails/lib/rubocop/rails/inject.rb:11:in `new'
/Users/koic/src/github.com/rubocop/rubocop-rails/lib/rubocop/rails/inject.rb:11:in `defaults!'
/Users/koic/src/github.com/rubocop/rubocop-rails/lib/rubocop-rails.rb:13:in `<top (required)>'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
