### PR TITLE
[Fix #10833] Fix an incorrect autocorrect for `Style/RedundantCondition`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_condition.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_condition.md
@@ -1,0 +1,1 @@
+* [#10833](https://github.com/rubocop/rubocop/issues/10833): Fix an incorrect autocorrect for `Style/RedundantCondition` when branches contains arithmetic operation. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -277,6 +277,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects when the branches contains arithmetic operation' do
+        expect_offense(<<~RUBY)
+          if foo
+          ^^^^^^ Use double pipes `||` instead.
+            @value - foo
+          else
+            @value - 'bar'
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          @value - (foo || 'bar')
+        RUBY
+      end
+
       it 'registers an offense and corrects when the branches contains method call' do
         expect_offense(<<~RUBY)
           if foo


### PR DESCRIPTION
Fixes #10833.

This PR fixes an incorrect autocorrect for `Style/RedundantCondition` when branches contains arithmetic operation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
