### PR TITLE
Support autocorrecton for `Style/CommentAnnotation` when note does not exist on the same line but exist on the next line

### DIFF
--- a/changelog/change_update_support_autocorrection_for_style_comment_annotation.md
+++ b/changelog/change_update_support_autocorrection_for_style_comment_annotation.md
@@ -1,0 +1,1 @@
+* [#10836](https://github.com/rubocop/rubocop/pull/10836): Support autocorrecton for `Style/CommentAnnotation` when note does not exist on the same line but exist on the next line. ([@ydah][])

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -82,6 +82,22 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
       end
     end
 
+    context 'upper case keyword with colon but no note is after line breaks' do
+      it 'registers an offense and autocorrection' do
+        expect_offense(<<~RUBY)
+          # HACK:
+            ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.
+          # this is a comment 1
+          # this is a comment 2
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # HACK: this is a comment 1
+          # this is a comment 2
+        RUBY
+      end
+    end
+
     context 'upper case keyword with space but no note' do
       it 'registers an offense without autocorrection' do
         expect_offense(<<~RUBY)
@@ -225,6 +241,22 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
         RUBY
 
         expect_no_corrections
+      end
+    end
+
+    context 'upper case keyword with colon but note is after line breaks' do
+      it 'registers an offense and autocorrection' do
+        expect_offense(<<~RUBY)
+          # HACK:
+            ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.
+          # this is a comment 1
+          # this is a comment 2
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # HACK this is a comment 1
+          # this is a comment 2
+        RUBY
       end
     end
 


### PR DESCRIPTION
This PR is support autocorrecton for `Style/CommentAnnotation` when note does not exist on the same line but exist on the next line

Even in cases where note does not exist on the same line, if there is a comment on the next line, it will be merged and automatically modified to the good case.

```ruby
# @example RequireColon: true (default)
# bad
# HACK:
# does not work

# good
# HACK: does not work

# @example RequireColon: false
# bad
# HACK
# does not work

# good
# HACK does not work
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
