### PR TITLE
Add API for 3rd party template support

### DIFF
--- a/changelog/new_add_api_for_3rd_party_template.md
+++ b/changelog/new_add_api_for_3rd_party_template.md
@@ -1,0 +1,1 @@
+* [#10839](https://github.com/rubocop/rubocop/pull/10839): Add API for 3rd party template support. ([@r7kamura][])

--- a/docs/modules/ROOT/pages/extensions.adoc
+++ b/docs/modules/ROOT/pages/extensions.adoc
@@ -200,3 +200,43 @@ For example, when you have defined `MyCustomFormatter` in
 ----
 $ rubocop --require ./path/to/my_custom_formatter --format MyCustomFormatter
 ----
+
+== Template support
+
+RuboCop has API for extensions to support templates such as ERB, Haml, Slim, etc.
+
+Normally, RuboCop extracts one Ruby code from one Ruby file, however there are multiple embedded Ruby codes in one template file. To solve this problem, RuboCop has a mechanism called `Rubocop::Runner.ruby_extractors`, to which any Ruby extractor can be added on the extension side.
+
+Ruby extractor must be a callable object that takes a `RuboCop::ProcessedSource` and returns an `Array` of `Hash` that contains Ruby source codes and their offsets from original source code, or returns `nil` for unrelated file.
+
+[source,ruby]
+---
+ruby_extractor.call(processed_source)
+---
+
+An example returned value from a Ruby extractor would be as follows:
+
+[source]
+---
+[
+  {
+    offset: 2,
+    processed_source: #<RuboCop::ProcessedSource>
+  },
+  {
+    offset: 10,
+    processed_source: #<RuboCop::ProcessedSource>
+  },
+]
+---
+
+On the extension side, the code would be something like this:
+
+[source,ruby]
+---
+RuboCop::Runner.ruby_extractors.unshift(ruby_extractor)
+---
+
+`RuboCop::Runners.ruby_extractors` is processed from the beginning and ends when one of them returns a non-nil value. By default, there is a Ruby extractor that returns the given Ruby source code with offset 0, so you can unshift any Ruby extractor before it.
+
+NOTE: This is still an experimental feature and may change in the future.

--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -76,10 +76,10 @@ module RuboCop
       end
 
       # @return [InvestigationReport]
-      def investigate(processed_source)
+      def investigate(processed_source, offset: 0, original: processed_source)
         reset
 
-        @cops.each { |cop| cop.send :begin_investigation, processed_source }
+        begin_investigation(processed_source, offset: offset, original: original)
         if processed_source.valid_syntax?
           invoke(:on_new_investigation, @cops)
           invoke_with_argument(:investigate, @forces, processed_source)
@@ -94,6 +94,12 @@ module RuboCop
       end
 
       private
+
+      def begin_investigation(processed_source, offset:, original:)
+        @cops.each do |cop|
+          cop.begin_investigation(processed_source, offset: offset, original: original)
+        end
+      end
 
       def trigger_responding_cops(callback, node)
         @callbacks[callback]&.each do |cop|


### PR DESCRIPTION
## Background

As I discussed at the following thread, I would like to add 3rd party template language plugins support to RuboCop.

- https://github.com/rubocop/rubocop/discussions/10768

## Changes

To support template languages, I figured we need a new API to extract a set of Ruby code from one source code, so I added `RuboCop::Runner.ruby_extractors` in this pull request.

Ruby extractor is a callable object that takes a `RuboCop::ProcessedSource` and returns an `Array` of `Hash` (or returns nil for unrelated file) like this:

```ruby
ruby_extractor.call(processed_source)
```

```ruby
[
  {
    offset: 2,
    processed_source: #<RuboCop::ProcessedSource>
  },
  {
    offset: 10,
    processed_source: #<RuboCop::ProcessedSource>
  },
]
```

On the 3rd party plugin side, the following code would be written.

```ruby
# This is the newly added API.
RuboCop::Runner.ruby_extractors.unshift(
  ruby_extractor_for_some_template
)

# This is the same thing that other RuboCop extensions are doing.
RuboCop::ConfigLoader.instance_variable_set(
  :@default_configuration,
  default_config_for_some_template
)
```

## Examples

To demonstrate this change, I have prepared some 3rd party plugins:

- https://github.com/r7kamura/rubocop-erb
- https://github.com/r7kamura/rubocop-haml
- https://github.com/r7kamura/rubocop-slim
- https://github.com/r7kamura/rubocop-markdown

If you add these gems, `bundle exec rubocop` will automatically lint Ruby code in template files as well.

```
$ bundle exec rubocop
Inspecting 16 files
............WC..

Offenses:

ruby_offense_example.rb:1:1: W: Lint/Void: Literal "foo" used in void context.
"foo"
^^^^^
ruby_offense_example.rb:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
"foo"
^
ruby_offense_example.rb:1:1: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
"foo"
^^^^^
ruby_offense_example.rb:2:1: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
"baar"
^^^^^^
spec/fixtures/dummy.slim:1:3: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
- "a"
  ^^^
spec/fixtures/dummy.slim:3:5: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
| #{"c"}
    ^^^
spec/fixtures/dummy.slim:5:8: C: [Correctable] Style/ZeroLengthPredicate: Use !empty? instead of size > 0.
- a if array.size > 0
       ^^^^^^^^^^^^^^
spec/fixtures/dummy.slim:6:3: C: [Correctable] Style/NegatedIf: Favor unless over if for negative conditions.
- a if !b
  ^^^^^^^
spec/fixtures/dummy.slim:8:6: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
- if "a"
     ^^^

16 files inspected, 9 offenses detected, 8 offenses autocorrectable
```

## Related issues

I know there are some related Issues on the template language support:

- https://github.com/rubocop/rubocop/issues/1113
- https://github.com/rubocop/rubocop/issues/2077

## Drawbacks of the current ruby extractors implementation

I think there are limitations in the design of this ruby extractors pattern.

When one ruby extractor extracts code from a file, subsequent ruby extractors are not executed. This is a good mechanism to prevent the default ruby extractor from accidentally processing unrelated template files, for example, but on the other hand, it prevents multiple ruby extractors from running.

For example, if you try to create a rubocop-yard_example gem that inspects the code in the `@example` of a YARD comment, this will not work because the system does not allow multiple ruby extractors to be applied to a single file. If you use this gem, you will not be able to inspect normal Ruby code parts.

A mechanism such as the Rack middleware stack would allow plug-ins to choose whether or not to continue processing, but it would also increase the complexity of the design.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
