### PR TITLE
Don't hash shared libraries for cache key

### DIFF
--- a/changelog/change_dont_hash_shared_libraries_for_cache_key.md
+++ b/changelog/change_dont_hash_shared_libraries_for_cache_key.md
@@ -1,0 +1,1 @@
+* [#10841](https://github.com/rubocop/rubocop/pull/10841): Don't hash shared libraries for cache key. ([@ChrisBr][])


### PR DESCRIPTION
Shared libraries often contain timestamps of when they were compiled and other non-stable data
hence would often produce different hashes on different machines. This happens often in our CI.

Related to https://github.com/rubocop/rubocop/pull/8633

cc @casperisfine

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
