### PR TITLE
[Fix #10843] Fix a false positive for `Style/HashExcept`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_hash_except.md
+++ b/changelog/fix_a_false_positive_for_style_hash_except.md
@@ -1,0 +1,1 @@
+* [#10843](https://github.com/rubocop/rubocop/issues/10843): Fix a false positive for `Style/HashExcept` when using `reject` and calling `include?` method with symbol array and second block value. ([@koic][])

--- a/lib/rubocop/cop/style/hash_except.rb
+++ b/lib/rubocop/cop/style/hash_except.rb
@@ -159,10 +159,6 @@ module RuboCop
           key_argument = node.argument_list.first.source
           body = extract_body_if_nagated(node.body)
           lhs, _method_name, rhs = *body
-
-          return lhs if body.method?('include?')
-          return lhs if body.method?('exclude?')
-          return rhs if body.method?('in?')
           return if [lhs, rhs].map(&:source).none?(key_argument)
 
           [lhs, rhs].find { |operand| operand.source != key_argument }

--- a/spec/rubocop/cop/style/hash_except_spec.rb
+++ b/spec/rubocop/cop/style/hash_except_spec.rb
@@ -166,6 +166,12 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
           {foo: 1, bar: 2, baz: 3}.except(*array)
         RUBY
       end
+
+      it 'does not register an offense when using `reject` and calling `include?` method with symbol array and second block value' do
+        expect_no_offenses(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.reject { |k, v| ![1, 2].include?(v) }
+        RUBY
+      end
     end
 
     context 'using `exclude?`' do
@@ -364,6 +370,12 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
             {foo: 1, bar: 2, baz: 3}.except(*array)
           RUBY
         end
+
+        it 'does not register an offense when using `reject` and calling `in?` method with symbol array and second block value' do
+          expect_no_offenses(<<~RUBY)
+            {foo: 1, bar: 2, baz: 3}.reject { |k, v| v.in?([1, 2]) }
+          RUBY
+        end
       end
 
       context 'using `include?`' do
@@ -524,6 +536,12 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
 
           expect_correction(<<~RUBY)
             {foo: 1, bar: 2, baz: 3}.except(*array)
+          RUBY
+        end
+
+        it 'does not register an offense when using `reject` and calling `exclude?` method with symbol array and second block value' do
+          expect_no_offenses(<<~RUBY)
+            {foo: 1, bar: 2, baz: 3}.reject { |k, v| ![1, 2].exclude?(v) }
           RUBY
         end
       end


### PR DESCRIPTION
Fixes #10843.

This PR fix a false positive for `Style/HashExcept` when using `reject` and calling `include?` method with symbol array and
second block value.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
