### PR TITLE
Fix typo in some comments

### DIFF
--- a/changelog/fix_fix_typo_in_some_comments.md
+++ b/changelog/fix_fix_typo_in_some_comments.md
@@ -1,0 +1,1 @@
+* [#10847](https://github.com/rubocop/rubocop/pull/10847): Fix typo in some comments. ([@j-miyake][])

--- a/lib/rubocop/cop/metrics/utils/iterating_block.rb
+++ b/lib/rubocop/cop/metrics/utils/iterating_block.rb
@@ -43,7 +43,7 @@ module RuboCop
             end
           end
 
-          # Returns true iff name is a known iterating type (e.g. :each, :transform_values)
+          # Returns true if name is a known iterating type (e.g. :each, :transform_values)
           def iterating_method?(name)
             KNOWN_ITERATING_METHODS.include? name
           end

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation, :config do
                                               #         -2 is the last child, etc...
                                               #         This shift of 1 from standard Ruby indices is stored in DELTA
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Incorrect indentation detected (column 38 instead of 4).
-            @in_sync = false                  # `true` iff `@cur_child_var` and `@cur_index_var` correspond to `@cur_index`
+            @in_sync = false                  # `true` if `@cur_child_var` and `@cur_index_var` correspond to `@cur_index`
                                               # Must be true if `@cur_index` is `:variadic_mode`
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Incorrect indentation detected (column 38 instead of 4).
             compile_terms(seq)
@@ -284,7 +284,7 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation, :config do
                                               #   < 0 : when the index is known from the end, where -1 is *past the end*,
                                               #         -2 is the last child, etc...
                                               #         This shift of 1 from standard Ruby indices is stored in DELTA
-            @in_sync = false                  # `true` iff `@cur_child_var` and `@cur_index_var` correspond to `@cur_index`
+            @in_sync = false                  # `true` if `@cur_child_var` and `@cur_index_var` correspond to `@cur_index`
                                               # Must be true if `@cur_index` is `:variadic_mode`
             compile_terms(seq)
           end


### PR DESCRIPTION
Fixed `iff` into `if` in some comments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] ~Added tests.~ No need to add tests
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
