### PR TITLE
[Fix #10771] Make server mode aware of `--cache-root` command line option

### DIFF
--- a/changelog/fix_make_server_mode_aware_of_command_line_option
+++ b/changelog/fix_make_server_mode_aware_of_command_line_option
@@ -1,0 +1,1 @@
+* [#10771](https://github.com/rubocop/rubocop/issues/10771): Make server mode aware of `--cache-root` command line option. ([@koic][])

--- a/lib/rubocop/server/cache.rb
+++ b/lib/rubocop/server/cache.rb
@@ -19,6 +19,8 @@ module RuboCop
       GEMFILE_NAMES = %w[Gemfile gems.rb].freeze
 
       class << self
+        attr_accessor :cache_root_path
+
         # Searches for Gemfile or gems.rb in the current dir or any parent dirs
         def project_dir
           current_dir = Dir.pwd
@@ -38,10 +40,15 @@ module RuboCop
         end
 
         def dir
-          cache_path = File.expand_path('~/.cache/rubocop_cache/server')
           Pathname.new(File.join(cache_path, project_dir_cache_key)).tap do |d|
             d.mkpath unless d.exist?
           end
+        end
+
+        def cache_path
+          cache_root_dir = cache_root_path || File.join(Dir.home, '.cache')
+
+          File.expand_path(File.join(cache_root_dir, 'rubocop_cache', 'server'))
         end
 
         def port_path

--- a/lib/rubocop/server/cli.rb
+++ b/lib/rubocop/server/cli.rb
@@ -30,6 +30,7 @@ module RuboCop
         @exit = false
       end
 
+      # rubocop:disable Metrics/MethodLength
       def run(argv = ARGV)
         unless Server.support_server?
           return error('RuboCop server is not supported by this Ruby.') if use_server_option?(argv)
@@ -37,6 +38,7 @@ module RuboCop
           return STATUS_SUCCESS
         end
 
+        Cache.cache_root_path = fetch_cache_root_path_from(argv)
         deleted_server_arguments = delete_server_argument_from(argv)
 
         if deleted_server_arguments.size >= 2
@@ -45,7 +47,7 @@ module RuboCop
 
         server_command = deleted_server_arguments.first
 
-        if EXCLUSIVE_OPTIONS.include?(server_command) && argv.count >= 2
+        if EXCLUSIVE_OPTIONS.include?(server_command) && argv.count > allowed_option_count
           return error("#{server_command} cannot be combined with other options.")
         end
 
@@ -53,6 +55,7 @@ module RuboCop
 
         STATUS_SUCCESS
       end
+      # rubocop:enable Metrics/MethodLength
 
       def exit?
         @exit
@@ -83,6 +86,17 @@ module RuboCop
       end
       # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength:
 
+      def fetch_cache_root_path_from(arguments)
+        cache_root = arguments.detect { |argument| argument.start_with?('--cache-root') }
+        return unless cache_root
+
+        if cache_root.start_with?('--cache-root=')
+          cache_root.split('=')[1]
+        else
+          arguments[arguments.index(cache_root) + 1]
+        end
+      end
+
       def delete_server_argument_from(all_arguments)
         SERVER_OPTIONS.each_with_object([]) do |server_option, server_arguments|
           server_arguments << all_arguments.delete(server_option)
@@ -91,6 +105,10 @@ module RuboCop
 
       def use_server_option?(argv)
         (argv & SERVER_OPTIONS).any?
+      end
+
+      def allowed_option_count
+        Cache.cache_root_path ? 2 : 1
       end
 
       def error(message)

--- a/spec/rubocop/server/cache_spec.rb
+++ b/spec/rubocop/server/cache_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Server::Cache do
+  subject(:cache_class) { described_class }
+
+  describe '.cache_path' do
+    context 'when cache root path is not specified as default' do
+      before do
+        cache_class.cache_root_path = nil
+      end
+
+      it 'is the default path' do
+        expect(cache_class.cache_path).to eq("#{Dir.home}/.cache/rubocop_cache/server")
+      end
+    end
+
+    context 'when cache root path is specified path' do
+      before do
+        cache_class.cache_root_path = '/tmp'
+      end
+
+      it 'is the specified path' do
+        if RuboCop::Platform.windows?
+          expect(cache_class.cache_path).to eq('D:/tmp/rubocop_cache/server')
+        else
+          expect(cache_class.cache_path).to eq('/tmp/rubocop_cache/server')
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/server/cli_spec.rb
+++ b/spec/rubocop/server/cli_spec.rb
@@ -145,6 +145,24 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
         expect($stderr.string).to eq "--server-status cannot be combined with other options.\n"
       end
     end
+
+    context 'when using server option with `--cache-root path` option' do
+      it 'returns exit status 0 and display an error message' do
+        expect(cli.run(['--server-status', '--cache-root', '/tmp'])).to eq(0)
+        expect(cli.exit?).to be(true)
+        expect($stdout.string).to eq "RuboCop server is not running.\n"
+        expect($stderr.string).not_to eq "--server-status cannot be combined with other options.\n"
+      end
+    end
+
+    context 'when using server option with `--cache-root=path` option' do
+      it 'returns exit status 0 and display an information message' do
+        expect(cli.run(['--server-status', '--cache-root=/tmp'])).to eq(0)
+        expect(cli.exit?).to be(true)
+        expect($stdout.string).to eq "RuboCop server is not running.\n"
+        expect($stderr.string).not_to eq "--server-status cannot be combined with other options.\n"
+      end
+    end
   else
     context 'when using `--server` option' do
       it 'returns exit status 2 and display an error message' do


### PR DESCRIPTION
Fix #10771.

This PR makes server mode aware of `--cache-root` command line option.

The logic for getting `--cache-root` from command line option is original to make the implementation lighter. Because the client of server mode should be lightweight.
#10842 needs a different solution than `--cache-root` option. I'm working on it separately from solving this issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
