### PR TITLE
Fix `Style/ClassEqualityComparison` autocorrection within module

### DIFF
--- a/changelog/fix_fix_styleclassequalitycomparison.md
+++ b/changelog/fix_fix_styleclassequalitycomparison.md
@@ -1,0 +1,1 @@
+* [#10850](https://github.com/rubocop/rubocop/pull/10850): Fix `Style/ClassEqualityComparison` autocorrection within module. ([@r7kamura][])

--- a/lib/rubocop/cop/style/class_equality_comparison.rb
+++ b/lib/rubocop/cop/style/class_equality_comparison.rb
@@ -97,7 +97,9 @@ module RuboCop
           if node.children.first.method?(:name)
             return class_node.receiver.source if class_node.receiver
 
-            class_node.source.delete('"').delete("'")
+            value = class_node.source.delete('"').delete("'")
+            value.prepend('::') if class_node.each_ancestor(:class, :module).any?
+            value
           else
             class_node.source
           end

--- a/spec/rubocop/cop/style/class_equality_comparison_spec.rb
+++ b/spec/rubocop/cop/style/class_equality_comparison_spec.rb
@@ -100,4 +100,31 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
       RUBY
     end
   end
+
+  context 'with String comparison in module' do
+    it 'registers and corrects an offense' do
+      expect_offense(<<~RUBY)
+        module Foo
+          def bar?(value)
+            bar.class.name == 'Bar'
+                ^^^^^^^^^^^^^^^^^^^ Use `instance_of?(::Bar)` instead of comparing classes.
+          end
+
+          class Bar
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Foo
+          def bar?(value)
+            bar.instance_of?(::Bar)
+          end
+
+          class Bar
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
In the situation where `Module.nesting` is not empty, `bar.class.name == 'Bar'` and `bar.instance_of?(Bar)` yield different results.

This is a simple example of the problematic case:
(In reality, it is more complicated because constant search is done by tracing back to ancestor inheritance tree)

```ruby
module Foo
  class << self
    def bar1?(value)
      value.instance_of?(Bar)
    end

    def bar2?(value)
      value.class.name == 'Bar'
    end
  end

  class Bar
  end
end

class Bar
end

p Foo.bar1?(Bar.new) #=> false
p Foo.bar1?(Foo::Bar.new) #=> true

p Foo.bar2?(Bar.new) #=> true
p Foo.bar2?(Foo::Bar.new) #=> false
```

So I changed it to prepend `::` in those situations.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
