### PR TITLE
[Fix #10842] Make server mode aware of `CacheRootDirectory` and two env vars

### DIFF
--- a/changelog/fix_make_server_mode_aware_of_cache_root_directory.md
+++ b/changelog/fix_make_server_mode_aware_of_cache_root_directory.md
@@ -1,0 +1,1 @@
+* [#10842](https://github.com/rubocop/rubocop/issues/10842): Make server mode aware of `CacheRootDirectory` config option value, `RUBOCOP_CACHE_ROOT`, and `XDG_CACHE_HOME` environment variables. ([@koic][])

--- a/lib/rubocop/cache_config.rb
+++ b/lib/rubocop/cache_config.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # This class represents the cache config of the caching RuboCop runs.
+  # @api private
+  class CacheConfig
+    def self.root_dir
+      root = ENV.fetch('RUBOCOP_CACHE_ROOT', nil)
+      root ||= yield
+      root ||= if ENV.key?('XDG_CACHE_HOME')
+                 # Include user ID in the path to make sure the user has write
+                 # access.
+                 File.join(ENV.fetch('XDG_CACHE_HOME'), Process.uid.to_s)
+               else
+                 # On FreeBSD, the /home path is a symbolic link to /usr/home
+                 # and the $HOME environment variable returns the /home path.
+                 #
+                 # As $HOME is a built-in environment variable, FreeBSD users
+                 # always get a warning message.
+                 #
+                 # To avoid raising warn log messages on FreeBSD, we retrieve
+                 # the real path of the home folder.
+                 File.join(File.realpath(Dir.home), '.cache')
+               end
+
+      File.join(root, 'rubocop_cache')
+    end
+  end
+end

--- a/lib/rubocop/cli/command/auto_genenerate_config.rb
+++ b/lib/rubocop/cli/command/auto_genenerate_config.rb
@@ -98,7 +98,7 @@ module RuboCop
         def add_inheritance_from_auto_generated_file(config_file)
           file_string = " #{relative_path_to_todo_from_options_config}"
 
-          config_file ||= ConfigLoader::DOTFILE
+          config_file ||= ConfigFinder::DOTFILE
 
           if File.exist?(config_file)
             files = Array(ConfigLoader.load_yaml_configuration(config_file)['inherit_from'])
@@ -113,7 +113,7 @@ module RuboCop
           write_config_file(config_file, file_string, rubocop_yml_contents)
 
           puts "Added inheritance from `#{relative_path_to_todo_from_options_config}` " \
-               "in `#{ConfigLoader::DOTFILE}`."
+               "in `#{ConfigFinder::DOTFILE}`."
         end
 
         def existing_configuration(config_file)

--- a/lib/rubocop/cli/command/init_dotfile.rb
+++ b/lib/rubocop/cli/command/init_dotfile.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Generate a .rubocop.yml file in the current directory.
       # @api private
       class InitDotfile < Base
-        DOTFILE = ConfigLoader::DOTFILE
+        DOTFILE = ConfigFinder::DOTFILE
 
         self.command_name = :init
 

--- a/lib/rubocop/config_finder.rb
+++ b/lib/rubocop/config_finder.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative 'file_finder'
+
+module RuboCop
+  # This class has methods related to finding configuration path.
+  # @api private
+  class ConfigFinder
+    DOTFILE = '.rubocop.yml'
+    XDG_CONFIG = 'config.yml'
+    RUBOCOP_HOME = File.realpath(File.join(File.dirname(__FILE__), '..', '..'))
+    DEFAULT_FILE = File.join(RUBOCOP_HOME, 'config', 'default.yml')
+
+    class << self
+      include FileFinder
+
+      attr_writer :project_root
+
+      def find_config_path(target_dir)
+        find_project_dotfile(target_dir) || find_user_dotfile || find_user_xdg_config ||
+          DEFAULT_FILE
+      end
+
+      # Returns the path RuboCop inferred as the root of the project. No file
+      # searches will go past this directory.
+      def project_root
+        @project_root ||= find_project_root
+      end
+
+      private
+
+      def find_project_root
+        pwd = Dir.pwd
+        gems_file = find_last_file_upwards('Gemfile', pwd) || find_last_file_upwards('gems.rb', pwd)
+        return unless gems_file
+
+        File.dirname(gems_file)
+      end
+
+      def find_project_dotfile(target_dir)
+        find_file_upwards(DOTFILE, target_dir, project_root)
+      end
+
+      def find_user_dotfile
+        return unless ENV.key?('HOME')
+
+        file = File.join(Dir.home, DOTFILE)
+
+        return file if File.exist?(file)
+      end
+
+      def find_user_xdg_config
+        xdg_config_home = expand_path(ENV.fetch('XDG_CONFIG_HOME', '~/.config'))
+        xdg_config = File.join(xdg_config_home, 'rubocop', XDG_CONFIG)
+
+        return xdg_config if File.exist?(xdg_config)
+      end
+
+      def expand_path(path)
+        File.expand_path(path)
+      rescue ArgumentError
+        # Could happen because HOME or ID could not be determined. Fall back on
+        # using the path literally in that case.
+        path
+      end
+    end
+  end
+end

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -4,6 +4,7 @@ require 'digest/sha1'
 require 'find'
 require 'etc'
 require 'zlib'
+require_relative 'cache_config'
 
 module RuboCop
   # Provides functionality for caching RuboCop runs.
@@ -67,24 +68,9 @@ module RuboCop
     end
 
     def self.cache_root(config_store)
-      root = ENV.fetch('RUBOCOP_CACHE_ROOT', nil)
-      root ||= config_store.for_pwd.for_all_cops['CacheRootDirectory']
-      root ||= if ENV.key?('XDG_CACHE_HOME')
-                 # Include user ID in the path to make sure the user has write
-                 # access.
-                 File.join(ENV.fetch('XDG_CACHE_HOME'), Process.uid.to_s)
-               else
-                 # On FreeBSD, the /home path is a symbolic link to /usr/home
-                 # and the $HOME environment variable returns the /home path.
-                 #
-                 # As $HOME is a built-in environment variable, FreeBSD users
-                 # always get a warning message.
-                 #
-                 # To avoid raising warn log messages on FreeBSD, we retrieve
-                 # the real path of the home folder.
-                 File.join(File.realpath(Dir.home), '.cache')
-               end
-      File.join(root, 'rubocop_cache')
+      CacheConfig.root_dir do
+        config_store.for_pwd.for_all_cops['CacheRootDirectory']
+      end
     end
 
     def self.allow_symlinks_in_cache_location?(config_store)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -85,14 +85,14 @@ RSpec.describe RuboCop::ConfigLoader do
 
       before do
         # Force reload of project root
-        described_class.project_root = nil
+        RuboCop::ConfigFinder.project_root = nil
         create_empty_file('Gemfile')
         create_empty_file('../.rubocop.yml')
       end
 
       after do
         # Don't leak project root change
-        described_class.project_root = nil
+        RuboCop::ConfigFinder.project_root = nil
       end
 
       it 'ignores the spurious config and falls back to the provided default file if run from the project' do

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe RuboCop::Cop::Generator do
 
     let(:config) do
       config = RuboCop::ConfigStore.new
-      path = File.join(RuboCop::ConfigLoader::RUBOCOP_HOME, RuboCop::ConfigLoader::DOTFILE)
+      path = File.join(RuboCop::ConfigLoader::RUBOCOP_HOME, RuboCop::ConfigFinder::DOTFILE)
       config.options_config = path
       config
     end

--- a/spec/rubocop/server/cache_spec.rb
+++ b/spec/rubocop/server/cache_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe RuboCop::Server::Cache do
   subject(:cache_class) { described_class }
 
+  include_context 'cli spec behavior'
+
   describe '.cache_path' do
     context 'when cache root path is not specified as default' do
       before do
@@ -24,6 +26,182 @@ RSpec.describe RuboCop::Server::Cache do
           expect(cache_class.cache_path).to eq('D:/tmp/rubocop_cache/server')
         else
           expect(cache_class.cache_path).to eq('/tmp/rubocop_cache/server')
+        end
+      end
+    end
+
+    context 'when `CacheRootDirectory` configure value is set', :isolated_environment do
+      context 'when cache root path is not specified path' do
+        let(:cache_path) { File.join('/tmp/cache-root-directory', 'rubocop_cache', 'server') }
+
+        before do
+          cache_class.cache_root_path = nil
+        end
+
+        it 'contains the root from `CacheRootDirectory` configure value' do
+          create_file('.rubocop.yml', <<~YAML)
+            AllCops:
+              CacheRootDirectory: '/tmp/cache-root-directory'
+          YAML
+
+          if RuboCop::Platform.windows?
+            expect(cache_class.cache_path).to eq(cache_path.prepend('D:'))
+          else
+            expect(cache_class.cache_path).to eq(cache_path)
+          end
+        end
+      end
+
+      context 'when cache root path is not specified path and `XDG_CACHE_HOME` environment variable is spacified' do
+        let(:cache_path) { File.join('/tmp/cache-root-directory', 'rubocop_cache', 'server') }
+
+        around do |example|
+          cache_class.cache_root_path = nil
+
+          ENV['XDG_CACHE_HOME'] = '/tmp/cache-from-xdg-env'
+          begin
+            example.run
+          ensure
+            ENV.delete('XDG_CACHE_HOME')
+          end
+        end
+
+        it 'contains the root from `CacheRootDirectory` configure value' do
+          create_file('.rubocop.yml', <<~YAML)
+            AllCops:
+              CacheRootDirectory: '/tmp/cache-root-directory'
+          YAML
+
+          if RuboCop::Platform.windows?
+            expect(cache_class.cache_path).to eq(cache_path.prepend('D:'))
+          else
+            expect(cache_class.cache_path).to eq(cache_path)
+          end
+        end
+      end
+
+      context 'when cache root path is specified path' do
+        before do
+          cache_class.cache_root_path = '/tmp'
+        end
+
+        it 'contains the root from cache root path' do
+          create_file('.rubocop.yml', <<~YAML)
+            AllCops:
+              CacheRootDirectory: '/tmp/cache-root-directory'
+          YAML
+
+          if RuboCop::Platform.windows?
+            expect(cache_class.cache_path).to eq(File.join('D:/tmp', 'rubocop_cache', 'server'))
+          else
+            expect(cache_class.cache_path).to eq(File.join('/tmp', 'rubocop_cache', 'server'))
+          end
+        end
+      end
+    end
+
+    context 'when `RUBOCOP_CACHE_ROOT` environment variable is set' do
+      around do |example|
+        ENV['RUBOCOP_CACHE_ROOT'] = '/tmp/rubocop-cache-root-env'
+        begin
+          example.run
+        ensure
+          ENV.delete('RUBOCOP_CACHE_ROOT')
+        end
+      end
+
+      context 'when cache root path is not specified path' do
+        let(:cache_path) { File.join('/tmp/rubocop-cache-root-env', 'rubocop_cache', 'server') }
+
+        before do
+          cache_class.cache_root_path = nil
+        end
+
+        it 'contains the root from `RUBOCOP_CACHE_ROOT`' do
+          if RuboCop::Platform.windows?
+            expect(cache_class.cache_path).to eq(cache_path.prepend('D:'))
+          else
+            expect(cache_class.cache_path).to eq(cache_path)
+          end
+        end
+      end
+
+      context 'when cache root path is not specified path and `XDG_CACHE_HOME` environment variable is specified' do
+        let(:cache_path) { File.join('/tmp/rubocop-cache-root-env', 'rubocop_cache', 'server') }
+
+        around do |example|
+          cache_class.cache_root_path = nil
+
+          ENV['XDG_CACHE_HOME'] = '/tmp/cache-from-xdg-env'
+          begin
+            example.run
+          ensure
+            ENV.delete('XDG_CACHE_HOME')
+          end
+        end
+
+        it 'contains the root from `RUBOCOP_CACHE_ROOT`' do
+          if RuboCop::Platform.windows?
+            expect(cache_class.cache_path).to eq(cache_path.prepend('D:'))
+          else
+            expect(cache_class.cache_path).to eq(cache_path)
+          end
+        end
+      end
+
+      context 'when cache root path is specified path' do
+        before do
+          cache_class.cache_root_path = '/tmp'
+        end
+
+        it 'contains the root from cache root path' do
+          if RuboCop::Platform.windows?
+            expect(cache_class.cache_path).to eq(File.join('D:/tmp', 'rubocop_cache', 'server'))
+          else
+            expect(cache_class.cache_path).to eq(File.join('/tmp', 'rubocop_cache', 'server'))
+          end
+        end
+      end
+    end
+
+    context 'when `XDG_CACHE_HOME` environment variable is set' do
+      around do |example|
+        ENV['XDG_CACHE_HOME'] = '/tmp/cache-from-xdg-env'
+        begin
+          example.run
+        ensure
+          ENV.delete('XDG_CACHE_HOME')
+        end
+      end
+
+      context 'when cache root path is not specified path' do
+        let(:puid) { Process.uid.to_s }
+        let(:cache_path) { File.join('/tmp/cache-from-xdg-env', puid, 'rubocop_cache', 'server') }
+
+        before do
+          cache_class.cache_root_path = nil
+        end
+
+        it 'contains the root from `XDG_CACHE_HOME`' do
+          if RuboCop::Platform.windows?
+            expect(cache_class.cache_path).to eq(cache_path.prepend('D:'))
+          else
+            expect(cache_class.cache_path).to eq(cache_path)
+          end
+        end
+      end
+
+      context 'when cache root path is specified path' do
+        before do
+          cache_class.cache_root_path = '/tmp'
+        end
+
+        it 'contains the root from cache root path' do
+          if RuboCop::Platform.windows?
+            expect(cache_class.cache_path).to eq(File.join('D:/tmp', 'rubocop_cache', 'server'))
+          else
+            expect(cache_class.cache_path).to eq(File.join('/tmp', 'rubocop_cache', 'server'))
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #10842 and follow up #10849.

This PR makes server mode aware of `CacheRootDirectory` config option value, `RUBOCOP_CACHE_ROOT`, and `XDG_CACHE_HOME` environment variables.

`RuboCop::ConfigLoader` and `RuboCop::ResultCache` classes to get these values has many dependencies. So, it is not suitable for use in server mode where speed is required.

This solution is to extract `ConfigPathFinder` class from `ConfigLoader` class and `CacheRoot` class from `ResultCache` class. This allows server mode to depend on lightweight `ConfigPathFinder` and `CacheRoot` classes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
