### PR TITLE
Fix an autocorrect for `Style/RedundantSort` with logical operator

### DIFF
--- a/changelog/fix_an_autocorrect_for_style_redundant_sort.md
+++ b/changelog/fix_an_autocorrect_for_style_redundant_sort.md
@@ -1,0 +1,1 @@
+* [#10853](https://github.com/rubocop/rubocop/pull/10853): Fix an autocorrect for `Style/RedundantSort` with logical operator. ([@ydah][])

--- a/spec/rubocop/cop/style/redundant_sort_spec.rb
+++ b/spec/rubocop/cop/style/redundant_sort_spec.rb
@@ -56,6 +56,81 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort, :config do
     RUBY
   end
 
+  it 'registers an offense when first is called on sort_by with line breaks' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3]
+        .sort_by { |x| x.length }
+         ^^^^^^^^^^^^^^^^^^^^^^^^ Use `min_by` instead of `sort_by...first`.
+        .first
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3]
+        .min_by { |x| x.length }
+      #{'  '}
+    RUBY
+  end
+
+  it 'registers an offense when first is called on sort_by with line breaks and `||` operator' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3]
+        .sort_by { |x| x.length }
+         ^^^^^^^^^^^^^^^^^^^^^^^^ Use `min_by` instead of `sort_by...first`.
+        .first || []
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3]
+        .min_by { |x| x.length } ||
+          []
+    RUBY
+  end
+
+  it 'registers an offense when first is called on sort_by with line breaks and `&&` operator' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3]
+        .sort_by { |x| x.length }
+         ^^^^^^^^^^^^^^^^^^^^^^^^ Use `min_by` instead of `sort_by...first`.
+        .first && []
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3]
+        .min_by { |x| x.length } &&
+          []
+    RUBY
+  end
+
+  it 'registers an offense when first is called on sort_by with line breaks and `or` operator' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3]
+        .sort_by { |x| x.length }
+         ^^^^^^^^^^^^^^^^^^^^^^^^ Use `min_by` instead of `sort_by...first`.
+        .first or []
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3]
+        .min_by { |x| x.length } or
+          []
+    RUBY
+  end
+
+  it 'registers an offense when first is called on sort_by with line breaks and `and` operator' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3]
+        .sort_by { |x| x.length }
+         ^^^^^^^^^^^^^^^^^^^^^^^^ Use `min_by` instead of `sort_by...first`.
+        .first and []
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3]
+        .min_by { |x| x.length } and
+          []
+    RUBY
+  end
+
   it 'registers an offense when first is called on sort_by no block' do
     expect_offense(<<~RUBY)
       [1, 2].sort_by(&:something).first


### PR DESCRIPTION
This PR is fix an autocorrect for `Style/RedundantSort` with logical operator

If you have a code like the following:
```ruby
[1, 2, 3]
  .sort_by { |x| x.length }
  .first || []
```

After autocorrection it will look like this:
```ruby
[1, 2, 3]
  .sort_by { |x| x.length }
  || []
```

This is a syntax error.
```
Error: : eval:3: syntax error, unexpected '|', expecting end-of-input
  || []
  ^
 (SyntaxError)
 ```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
