### PR TITLE
[Fix #10846] Fix a false negative for `Style/DoubleNegation` when there is a hash or an array at return location of method.

### DIFF
--- a/changelog/fix_fix_a_false_negative_for_double_negation.md
+++ b/changelog/fix_fix_a_false_negative_for_double_negation.md
@@ -1,0 +1,1 @@
+* [#10846](https://github.com/rubocop/rubocop/issues/10846): Fix a false negative for `Style/DoubleNegation` when there is a hash or an array at return location of method. ([@nobuyo][])

--- a/lib/rubocop/cop/style/double_negation.rb
+++ b/lib/rubocop/cop/style/double_negation.rb
@@ -93,6 +93,8 @@ module RuboCop
 
           if conditional_node
             double_negative_condition_return_value?(node, last_child, conditional_node)
+          elsif last_child.pair_type? || last_child.hash_type? || last_child.parent.array_type?
+            false
           else
             last_child.last_line <= node.last_line
           end

--- a/spec/rubocop/cop/style/double_negation_spec.rb
+++ b/spec/rubocop/cop/style/double_negation_spec.rb
@@ -291,6 +291,147 @@ RSpec.describe RuboCop::Cop::Style::DoubleNegation, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects for `!!` with multi-line array at return location' do
+      expect_offense(<<~RUBY)
+        def foo
+          [
+            foo1,
+            !!bar1,
+            ^ Avoid the use of double negation (`!!`).
+            !!baz1
+            ^ Avoid the use of double negation (`!!`).
+          ]
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          [
+            foo1,
+            !bar1.nil?,
+            !baz1.nil?
+          ]
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for `!!` with single-line array at return location' do
+      expect_offense(<<~RUBY)
+        def foo
+          [foo1, !!bar1, baz1]
+                 ^ Avoid the use of double negation (`!!`).
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          [foo1, !bar1.nil?, baz1]
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for `!!` with multi-line hash at return location' do
+      expect_offense(<<~RUBY)
+        def foo
+          {
+            foo: foo1,
+            bar: !!bar1,
+                 ^ Avoid the use of double negation (`!!`).
+            baz: !!baz1
+                 ^ Avoid the use of double negation (`!!`).
+          }
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          {
+            foo: foo1,
+            bar: !bar1.nil?,
+            baz: !baz1.nil?
+          }
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for `!!` with single-line hash at return location' do
+      expect_offense(<<~RUBY)
+        def foo
+          { foo: foo1, bar: !!bar1, baz: baz1 }
+                            ^ Avoid the use of double negation (`!!`).
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          { foo: foo1, bar: !bar1.nil?, baz: baz1 }
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for `!!` with nested hash at return location' do
+      expect_offense(<<~RUBY)
+        def foo
+          {
+            foo: foo1,
+            bar: { baz: !!quux }
+                        ^ Avoid the use of double negation (`!!`).
+          }
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          {
+            foo: foo1,
+            bar: { baz: !quux.nil? }
+          }
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for `!!` with nested array at return location' do
+      expect_offense(<<~RUBY)
+        def foo
+          [
+            foo1,
+            [baz, !!quux]
+                  ^ Avoid the use of double negation (`!!`).
+          ]
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          [
+            foo1,
+            [baz, !quux.nil?]
+          ]
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for `!!` with complex array at return location' do
+      expect_offense(<<~RUBY)
+        def foo
+          [
+            foo1,
+            { baz: !!quux }
+                   ^ Avoid the use of double negation (`!!`).
+          ]
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          [
+            foo1,
+            { baz: !quux.nil? }
+          ]
+        end
+      RUBY
+    end
+
     # rubocop:disable RSpec/RepeatedExampleGroupDescription
     context 'Ruby >= 2.7', :ruby27 do
       # rubocop:enable RSpec/RepeatedExampleGroupDescription


### PR DESCRIPTION
This PR fixes #10846.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
