### PR TITLE
Update documentation for `Lint/Debugger`

### DIFF
--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -15,9 +15,19 @@ module RuboCop
       # [source,yaml]
       # ----
       # Lint/Debugger:
-      #   WebConsole: ~
+      #   DebuggerMethods:
+      #     WebConsole: ~
       # ----
       #
+      # You can also add your own methods by adding a new category:
+      #
+      # [source,yaml]
+      # ----
+      # Lint/Debugger:
+      #   DebuggerMethods:
+      #     MyDebugger:
+      #       MyDebugger.debug_this
+      # ----
       #
       # @example
       #


### PR DESCRIPTION
I noticed that the documentation for `Lint/Debugger` had a typo in it for the example for how to disable a category of debug statements. I also updated it to give an example of how to add additional debugger methods that are not covered by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
