### PR TITLE
Add autocorrection to `Lint/EmptyConditionalBody`

### DIFF
--- a/changelog/change_add_autocorrection_to.md
+++ b/changelog/change_add_autocorrection_to.md
@@ -1,0 +1,1 @@
+* [#10862](https://github.com/rubocop/rubocop/pull/10862): Add autocorrection to `Lint/EmptyConditionalBody`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1755,6 +1755,7 @@ Lint/EmptyConditionalBody:
   Enabled: true
   AllowComments: true
   VersionAdded: '0.89'
+  VersionChanged: '<<next>>'
 
 Lint/EmptyEnsure:
   Description: 'Checks for empty ensure block.'

--- a/lib/rubocop/cop/mixin/comments_help.rb
+++ b/lib/rubocop/cop/mixin/comments_help.rb
@@ -12,10 +12,14 @@ module RuboCop
       end
 
       def contains_comments?(node)
+        comments_in_range(node).any?
+      end
+
+      def comments_in_range(node)
         start_line = node.source_range.line
         end_line = find_end_line(node)
 
-        processed_source.each_comment_in_lines(start_line...end_line).any?
+        processed_source.each_comment_in_lines(start_line...end_line)
       end
 
       private

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       ^^^^^^^^^^^^ Avoid `if` branches without a body.
       end
     RUBY
+
+    expect_correction('')
   end
 
   it 'does not register an offense for missing `if` body with a comment' do
@@ -25,6 +27,64 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
         do_something
       elsif other_condition
       ^^^^^^^^^^^^^^^^^^^^^ Avoid `elsif` branches without a body.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if condition
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense for missing `if` body with `else`' do
+    expect_offense(<<~RUBY)
+      if condition
+      ^^^^^^^^^^^^ Avoid `if` branches without a body.
+      else
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      unless condition
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense for missing `unless` body with `else`' do
+    expect_offense(<<~RUBY)
+      unless condition
+      ^^^^^^^^^^^^^^^^ Avoid `unless` branches without a body.
+      else
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if condition
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense for missing `if` body with `elsif`' do
+    expect_offense(<<~RUBY)
+      if condition
+      ^^^^^^^^^^^^ Avoid `if` branches without a body.
+      elsif other_condition
+        do_something
+      elsif another_condition
+        do_something_else
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if other_condition
+        do_something
+      elsif another_condition
+        do_something_else
       end
     RUBY
   end
@@ -45,6 +105,14 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
         do_something
       elsif other_condition
       ^^^^^^^^^^^^^^^^^^^^^ Avoid `elsif` branches without a body.
+      else
+        # noop
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if condition
+        do_something
       else
         # noop
       end
@@ -72,6 +140,14 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       ^^^^^^^^^ Avoid `elsif` branches without a body.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      if foo
+        do_foo
+      elsif bar
+        do_bar
+      end
+    RUBY
   end
 
   it 'registers an offense for missing `unless` body' do
@@ -80,12 +156,30 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       ^^^^^^^^^^^^^^^^ Avoid `unless` branches without a body.
       end
     RUBY
+
+    expect_correction('')
   end
 
   it 'does not register an offense for missing `unless` body with a comment' do
     expect_no_offenses(<<~RUBY)
       unless condition
         # noop
+      end
+    RUBY
+  end
+
+  it 'autocorrects properly when the if is assigned to a variable' do
+    expect_offense(<<~RUBY)
+      x = if foo
+          ^^^^^^ Avoid `if` branches without a body.
+      elsif bar
+        5
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x = if bar
+        5
       end
     RUBY
   end
@@ -100,6 +194,8 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
           # noop
         end
       RUBY
+
+      expect_correction('')
     end
 
     it 'registers an offense for missing `elsif` body with a comment' do
@@ -111,6 +207,12 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
           # noop
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        if condition
+          do_something
+        end
+      RUBY
     end
 
     it 'registers an offense for missing `unless` body with a comment' do
@@ -120,6 +222,8 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
           # noop
         end
       RUBY
+
+      expect_correction('')
     end
   end
 end


### PR DESCRIPTION
I noticed in https://github.com/rubocop/rubocop/issues/10858#issuecomment-1204175590 that `Lint/EmptyConditionalBody` does not have autocorrection, so I added it. It does the following:

* Removes the empty branch, including any comments if `AllowComments` is false.
* Handles subsequent branches, including changing `elsif` to `if` and `else` to `if`/`unless` appropriately, if the topmost branch is the one being removed.
* Can handle the `if` statement being preceded by another node.

I believe I've covered the edge cases here but if there's one you can think of let me know and I'll add it in. I also was unsure if we should mark this as `SafeAutoCorrect: false` but am happy to do so.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
