### PR TITLE
[Fix #10864] Fix a false positive for `Style/SymbolProc`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_symbol_proc_when_using_hash_reject.md
+++ b/changelog/fix_a_false_positive_for_style_symbol_proc_when_using_hash_reject.md
@@ -1,0 +1,1 @@
+* [#10864](https://github.com/rubocop/rubocop/issues/10864): Fix a false positive for `Style/SymbolProc` when using `Hash#reject`. ([@koic][])


### PR DESCRIPTION
Fixes #10864.

This PR fixes a false positive for `Style/SymbolProc` when using `Hash#reject`.
The same is true for `Haash#select`.

```ruby
{foo: :bar}.reject { p _1 } # `_1` is `:foo`
{foo: :bar}.select { p _1 } # `_1` is `:foo`
{foo: :bar}.detect { p _1 } # `_1` is `[:foo, :bar]`
{foo: :bar}.map { p _1 }    # `_1` is `[:foo, :bar]`
```

It fixes `on_block` method because the same issue occurs in normal blocks.

```ruby
{foo: :bar}.select {|item| item.nil? } #=> no erros.
{foo: :bar}.select(&:nil?)             #=> wrong number of arguments (given 1, expected 0) (ArgumentError)
```

`Style/SymbolProc` is already marked as unsafe, but it avoids avoidable issues.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
