### PR TITLE
Rewrite documentation for `Naming/PredicateName` to better clarify its configuration options

### DIFF
--- a/lib/rubocop/cop/naming/predicate_name.rb
+++ b/lib/rubocop/cop/naming/predicate_name.rb
@@ -3,9 +3,30 @@
 module RuboCop
   module Cop
     module Naming
-      # Makes sure that predicates are named properly.
-      # `is_a?` method is allowed by default.
-      # These are customizable with `AllowedMethods` option.
+      # Checks that predicate methods names end with a question mark and
+      # do not start with a forbidden prefix.
+      #
+      # A method is determined to be a predicate method if its name starts
+      # with one of the prefixes defined in the `NamePrefix` configuration.
+      # You can change what prefixes are considered by changing this option.
+      # Any method name that starts with one of these prefixes is required by
+      # the cop to end with a `?`. Other methods can be allowed by adding to
+      # the `AllowedMethods` configuration.
+      #
+      # NOTE: The `is_a?` method is allowed by default.
+      #
+      # If `ForbiddenPrefixes` is set, methods that start with the configured
+      # prefixes will not be allowed and will be removed by autocorrection.
+      #
+      # In other words, if `ForbiddenPrefixes` is empty, a method named `is_foo`
+      # will register an offense only due to the lack of question mark (and will be
+      # autocorrected to `is_foo?`). If `ForbiddenPrefixes` contains `is_`,
+      # `is_foo` will register an offense both because the ? is missing and because of
+      # the `is_` prefix, and will be corrected to `foo?`.
+      #
+      # NOTE: `ForbiddenPrefixes` is only applied to prefixes in `NamePrefix`;
+      # a prefix in the former but not the latter will not be considered by
+      # this cop.
       #
       # @example
       #   # bad


### PR DESCRIPTION
`Naming/PredicateName` did not have documentation in the guide about how to use the `NamePrefix` and `ForbiddenPrefixes` configuration options.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
