### PR TITLE
Mark autocorrection for `Lint/EmptyConditionalBody` as unsafe

### DIFF
--- a/changelog/fix_mark_autocorrection_for.md
+++ b/changelog/fix_mark_autocorrection_for.md
@@ -1,0 +1,1 @@
+* [#10867](https://github.com/rubocop/rubocop/pull/10867): Mark autocorrection for `Lint/EmptyConditionalBody` as unsafe. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1753,9 +1753,10 @@ Lint/EmptyClass:
 Lint/EmptyConditionalBody:
   Description: 'Checks for the presence of `if`, `elsif` and `unless` branches without a body.'
   Enabled: true
+  SafeAutoCorrect: false
   AllowComments: true
   VersionAdded: '0.89'
-  VersionChanged: '1.33'
+  VersionChanged: '<<next>>'
 
 Lint/EmptyEnsure:
   Description: 'Checks for empty ensure block.'

--- a/lib/rubocop/cop/lint/empty_conditional_body.rb
+++ b/lib/rubocop/cop/lint/empty_conditional_body.rb
@@ -7,6 +7,11 @@ module RuboCop
       #
       # NOTE: empty `else` branches are handled by `Style/EmptyElse`.
       #
+      # @safety
+      #   Autocorrection for this cop is not safe. The conditions for empty branches that
+      #   the autocorrection removes may have side effects, or the logic in subsequent
+      #   branches may change due to the removal of a previous condition.
+      #
       # @example
       #   # bad
       #   if condition


### PR DESCRIPTION
There are cases I wasn't considering where the autocorrection added in #10862 can change the behaviour of the code, so as an immediate step, autocorrection is being marked as unsafe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
