### PR TITLE
[Fixes #9227] Corrected the misleading example for `Style/GuardClause`

### DIFF
--- a/changelog/fix_add_return_statement_to_guard_clause.md
+++ b/changelog/fix_add_return_statement_to_guard_clause.md
@@ -1,0 +1,1 @@
+* [#9227](https://github.com/rubocop/rubocop/issues/9227): Add return statement to guard clause example to make it more correct. ([@v1nayv][])

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -1637,7 +1637,7 @@ items.include?
 
 | PreferredMethods
 | `{"collect"=>"map", "collect!"=>"map!", "inject"=>"reduce", "detect"=>"find", "find_all"=>"select", "member?"=>"include?"}`
-| 
+|
 
 | MethodsAcceptingSymbol
 | `inject`, `reduce`
@@ -4789,7 +4789,7 @@ else
 end
 
 # good
-foo || raise('exception') if something
+return (foo || raise('exception')) if something
 ok
 ----
 
@@ -5971,11 +5971,11 @@ end
 
 | InverseMethods
 | `{:any?=>:none?, :even?=>:odd?, :===>:!=, :=~=>:!~, :<=>:>=, :>=>:<=}`
-| 
+|
 
 | InverseBlocks
 | `{:select=>:reject, :select!=>:reject!}`
-| 
+|
 |===
 
 == Style/IpAddresses
@@ -9460,7 +9460,7 @@ default.
 
 | PreferredDelimiters
 | `{"default"=>"()", "%i"=>"[]", "%I"=>"[]", "%r"=>"{}", "%w"=>"[]", "%W"=>"[]"}`
-| 
+|
 |===
 
 === References
@@ -9897,7 +9897,7 @@ A.foo
 
 | Methods
 | `{"join"=>"", "split"=>" ", "chomp"=>"\n", "chomp!"=>"\n"}`
-| 
+|
 |===
 
 == Style/RedundantAssignment
@@ -12647,7 +12647,7 @@ from the String class.
 
 | PreferredMethods
 | `{"intern"=>"to_sym"}`
-| 
+|
 |===
 
 == Style/Strip
@@ -14352,7 +14352,7 @@ array of 2 or fewer elements.
 
 | WordRegex
 | `(?-mix:\A(?:\p{Word}|\p{Word}-\p{Word}|\n|\t)+\z)`
-| 
+|
 |===
 
 === References


### PR DESCRIPTION
Corrected the misleading example for Stlye/GuardClause reported in #9227
Added the return statement to be more correct with the bad example.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
