### PR TITLE
[Fix #10859] Fix `Lint/Debugger` to be able to handle method chains correctly

### DIFF
--- a/changelog/fix_fix_lintdebugger_to_be_able_to_handle.md
+++ b/changelog/fix_fix_lintdebugger_to_be_able_to_handle.md
@@ -1,0 +1,1 @@
+* [#10859](https://github.com/rubocop/rubocop/issues/10859): Fix `Lint/Debugger` to be able to handle method chains correctly. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1604,6 +1604,7 @@ Lint/Debugger:
     # a user's configuration, but are otherwise not significant.
     Kernel:
       - binding.irb
+      - Kernel.binding.irb
     Byebug:
       - byebug
       - remote_byebug
@@ -1621,6 +1622,9 @@ Lint/Debugger:
       - binding.pry
       - binding.remote_pry
       - binding.pry_remote
+      - Kernel.binding.pry
+      - Kernel.binding.remote_pry
+      - Kernel.binding.pry_remote
       - Pry.rescue
     Rails:
       - debugger

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -27,6 +27,39 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
         RUBY
       end
     end
+
+    context 'with a method chain' do
+      let(:cop_config) { { 'DebuggerMethods' => %w[debugger.foo.bar] } }
+
+      it 'registers an offense for a `debugger.foo.bar` call' do
+        expect_offense(<<~RUBY)
+          debugger.foo.bar
+          ^^^^^^^^^^^^^^^^ Remove debugger entry point `debugger.foo.bar`.
+        RUBY
+      end
+    end
+
+    context 'with a const chain' do
+      let(:cop_config) { { 'DebuggerMethods' => %w[Foo::Bar::Baz.debug] } }
+
+      it 'registers an offense for a `Foo::Bar::Baz.debug` call' do
+        expect_offense(<<~RUBY)
+          Foo::Bar::Baz.debug
+          ^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `Foo::Bar::Baz.debug`.
+        RUBY
+      end
+    end
+
+    context 'with a const chain and a method chain' do
+      let(:cop_config) { { 'DebuggerMethods' => %w[Foo::Bar::Baz.debug.this.code] } }
+
+      it 'registers an offense for a `Foo::Bar::Baz.debug.this.code` call' do
+        expect_offense(<<~RUBY)
+          Foo::Bar::Baz.debug.this.code
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `Foo::Bar::Baz.debug.this.code`.
+        RUBY
+      end
+    end
   end
 
   context 'built-in methods' do


### PR DESCRIPTION
`Lint/Debugger` was not handling method chains properly, so this fixes it. It also removes the implicit `Kernel` prefix and makes it explicit in the configuration (it wasn't working as expected anyways).

Fixes #10859.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
