### PR TITLE
[Fix #10871] Restore `RuboCop::ConfigLoader.project_root` as deprecated

### DIFF
--- a/changelog/fix_restore_rubocop_config_loader_project_root.md
+++ b/changelog/fix_restore_rubocop_config_loader_project_root.md
@@ -1,0 +1,1 @@
+* [#10871](https://github.com/rubocop/rubocop/issues/10871): Restore `RuboCop::ConfigLoader.project_root` as deprecated. ([@koic][])

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -137,6 +137,18 @@ module RuboCop
         end
       end
 
+      # Returns the path RuboCop inferred as the root of the project. No file
+      # searches will go past this directory.
+      # @deprecated Use `RuboCop::ConfigFinder.project_root` instead.
+      def project_root
+        warn Rainbow(<<~WARNING).yellow
+          `RuboCop::ConfigLoader.project_root` is deprecated and will be removed in RuboCop 2.0. \
+          Use `RuboCop::ConfigFinder.project_root` instead.
+        WARNING
+
+        ConfigFinder.project_root
+      end
+
       PENDING_BANNER = <<~BANNER
         The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.
 


### PR DESCRIPTION
Fixes #10871 and https://github.com/utkarsh2102/rubocop-packaging/issues/44.

This PR restores `RuboCop::ConfigLoader.project_root` as deprecated.

It fixes the following build error.

```console
% cd path/to/github.com/utkarsh2102/rubocop-packaging
% bundle update && bundle exec rake
(snip)

Failures:

  1) RuboCop::Cop::Packaging::BundlerSetupInTests when `require
  bundler/setup` is used in a Rakefile does not register an offense
     Failure/Error: let(:project_root) {
  RuboCop::ConfigLoader.project_root }

     NoMethodError:
       undefined method `project_root' for RuboCop::ConfigLoader:Class
     # ./spec/rubocop/cop/packaging/bundler_setup_in_tests_spec.rb:6:in
       `block (2 levels) in <top (required)>'
     # ./spec/rubocop/cop/packaging/bundler_setup_in_tests_spec.rb:39:in
       `block (3 levels) in <top (required)>'
     # ./spec/rubocop/cop/packaging/bundler_setup_in_tests_spec.rb:43:in
       `block (3 levels) in <top (required)>'
```

I considered a soft deprecation, but decided to issue a warning as it is probably of limited use.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
