### PR TITLE
[Fix #10857] Add `AllowedPatterns` to `Style/NumericLiterals`.

### DIFF
--- a/changelog/change_add_allowedpatterns_to.md
+++ b/changelog/change_add_allowedpatterns_to.md
@@ -1,0 +1,1 @@
+* [#10857](https://github.com/rubocop/rubocop/issues/10857): Add `AllowedPatterns` to `Style/NumericLiterals`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4405,6 +4405,7 @@ Style/NumericLiterals:
   Strict: false
   # You can specify allowed numbers. (e.g. port number 3000, 8080, and etc)
   AllowedNumbers: []
+  AllowedPatterns: []
 
 Style/NumericPredicate:
   Description: >-

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -379,7 +379,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                 '',
                 '# Offense count: 1',
                 '# This cop supports safe autocorrection (--autocorrect).',
-                '# Configuration parameters: Strict, AllowedNumbers.',
+                '# Configuration parameters: Strict, AllowedNumbers, AllowedPatterns.',
                 'Style/NumericLiterals:',
                 '  MinDigits: 7',
                 '',

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -253,4 +253,42 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
       RUBY
     end
   end
+
+  context 'AllowedPatterns' do
+    let(:cop_config) { { 'AllowedPatterns' => [/\d{2}_\d{2}_\d{4}/] } }
+
+    it 'does not register an offense for numbers that exactly match the pattern' do
+      expect_no_offenses(<<~RUBY)
+        12_34_5678
+      RUBY
+    end
+
+    it 'registers an offense for numbers that do not exactly match the pattern' do
+      expect_offense(<<~RUBY)
+        1234_56_78_9012
+        ^^^^^^^^^^^^^^^ Use underscores(_) as thousands separator and separate every 3 digits with them.
+      RUBY
+    end
+
+    it 'corrects by inserting underscores every 3 digits' do
+      expect_offense(<<~RUBY)
+        12345678
+        ^^^^^^^^ Use underscores(_) as thousands separator and separate every 3 digits with them.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        12_345_678
+      RUBY
+    end
+
+    context 'AllowedPatterns with repetition' do
+      let(:cop_config) { { 'AllowedPatterns' => [/\d{4}(_\d{4})+/] } }
+
+      it 'does not register an offense for numbers that match the pattern' do
+        expect_no_offenses(<<~RUBY)
+          1234_5678_9012_3456
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Allows additional allowed patterns to be specified for `Style/NumericLiterals` so that special patterns will not register offenses. The patterns are forced to be anchored (so `\d{4}_\d{4}` will only match exactly that, and not substrings), and this does not affect autocorrection, which will continue to add underscores between groups of 3 digits.

Fixes #10857.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
