### PR TITLE
[Fix #10648] Allow `Style/TernaryParentheses` to take priority over `Style/RedundantParentheses` for requiring parentheses

### DIFF
--- a/changelog/change_allow_styleternaryparentheses_to_take.md
+++ b/changelog/change_allow_styleternaryparentheses_to_take.md
@@ -1,0 +1,1 @@
+* [#10648](https://github.com/rubocop/rubocop/issues/10648): Allow `Style/TernaryParentheses` to take priority over `Style/RedundantParentheses` when parentheses are enforced. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -58,7 +58,8 @@ module RuboCop
           allowed_ancestor?(node) ||
             allowed_method_call?(node) ||
             allowed_array_or_hash_element?(node) ||
-            allowed_multiple_expression?(node)
+            allowed_multiple_expression?(node) ||
+            allowed_ternary?(node)
         end
 
         def allowed_ancestor?(node)
@@ -78,6 +79,19 @@ module RuboCop
           return false unless ancestor
 
           !ancestor.begin_type? && !ancestor.def_type? && !ancestor.block_type?
+        end
+
+        def allowed_ternary?(node)
+          return unless node&.parent&.if_type?
+
+          node.parent.ternary? && ternary_parentheses_required?
+        end
+
+        def ternary_parentheses_required?
+          config = @config.for_cop('Style/TernaryParentheses')
+          allowed_styles = %w[require_parentheses require_parentheses_when_complex]
+
+          config.fetch('Enabled') && allowed_styles.include?(config['EnforcedStyle'])
         end
 
         def like_method_argument_parentheses?(node)

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -71,7 +71,7 @@ module RuboCop
 
           return if only_closing_parenthesis_is_last_line?(condition)
           return if condition_as_parenthesized_one_line_pattern_matching?(condition)
-          return unless node.ternary? && !infinite_loop? && offense?(node)
+          return unless node.ternary? && offense?(node)
 
           message = message(node)
 
@@ -166,20 +166,8 @@ module RuboCop
           style == :require_parentheses_when_complex
         end
 
-        def redundant_parentheses_enabled?
-          @config.for_cop('Style/RedundantParentheses').fetch('Enabled')
-        end
-
         def parenthesized?(node)
           node.begin_type?
-        end
-
-        # When this cop is configured to enforce parentheses and the
-        # `RedundantParentheses` cop is enabled, it will cause an infinite loop
-        # as they compete to add and remove the parentheses respectively.
-        def infinite_loop?
-          (require_parentheses? || require_parentheses_when_complex?) &&
-            redundant_parentheses_enabled?
         end
 
         def unsafe_autocorrect?(condition)

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2640,4 +2640,30 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
            ]
     RUBY
   end
+
+  it 'properly autocorrects when `Style/TernaryParentheses` requires parentheses ' \
+     'that `Style/RedundantParentheses` would otherwise remove' do
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~RUBY)
+      foo ? bar : baz
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Style/TernaryParentheses:
+        EnforcedStyle: require_parentheses
+      Style/RedundantParentheses:
+        Enabled: true
+    YAML
+
+    status = cli.run(
+      %w[--autocorrect-all --only] << %w[
+        Style/TernaryParentheses
+        Style/RedundantParentheses
+      ].join(',')
+    )
+    expect(status).to eq(0)
+    expect(source_file.read).to eq(<<~RUBY)
+      (foo) ? bar : baz
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -57,18 +57,65 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   it_behaves_like 'redundant', '(retry)', 'retry', 'a keyword'
   it_behaves_like 'redundant', '(self)', 'self', 'a keyword'
 
-  it 'registers an offense for parens around constant ternary condition' do
-    expect_offense(<<~RUBY)
-      (X) ? Y : N
-      ^^^ Don't use parentheses around a constant.
-      (X)? Y : N
-      ^^^ Don't use parentheses around a constant.
-    RUBY
+  context 'ternaries' do
+    let(:other_cops) do
+      {
+        'Style/TernaryParentheses' => {
+          'Enabled' => ternary_parentheses_enabled,
+          'EnforcedStyle' => ternary_parentheses_enforced_style
+        }
+      }
+    end
+    let(:ternary_parentheses_enabled) { true }
+    let(:ternary_parentheses_enforced_style) { nil }
 
-    expect_correction(<<~RUBY)
-      X ? Y : N
-      X ? Y : N
-    RUBY
+    context 'when Style/TernaryParentheses is not enabled' do
+      let(:ternary_parentheses_enabled) { false }
+
+      it 'registers an offense for parens around constant ternary condition' do
+        expect_offense(<<~RUBY)
+          (X) ? Y : N
+          ^^^ Don't use parentheses around a constant.
+          (X)? Y : N
+          ^^^ Don't use parentheses around a constant.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          X ? Y : N
+          X ? Y : N
+        RUBY
+      end
+    end
+
+    context 'when Style/TernaryParentheses has EnforcedStyle: require_no_parentheses' do
+      let(:ternary_parentheses_enforced_style) { 'require_no_parentheses' }
+
+      it 'registers an offense for parens around ternary condition' do
+        expect_offense(<<~RUBY)
+          (X) ? Y : N
+          ^^^ Don't use parentheses around a constant.
+          (X)? Y : N
+          ^^^ Don't use parentheses around a constant.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          X ? Y : N
+          X ? Y : N
+        RUBY
+      end
+    end
+
+    context 'when Style/TernaryParentheses has EnforcedStyle: require_parentheses' do
+      let(:ternary_parentheses_enforced_style) { 'require_parentheses' }
+
+      it_behaves_like 'plausible', '(X) ? Y : N'
+    end
+
+    context 'when Style/TernaryParentheses has EnforcedStyle: require_parentheses_when_complex' do
+      let(:ternary_parentheses_enforced_style) { 'require_parentheses_when_complex' }
+
+      it_behaves_like 'plausible', '(X) ? Y : N'
+    end
   end
 
   it_behaves_like 'keyword with return value', 'break'

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -2,11 +2,6 @@
 
 RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
   let(:redundant_parens_enabled) { false }
-  let(:other_cops) do
-    {
-      'Style/RedundantParentheses' => { 'Enabled' => redundant_parens_enabled }
-    }
-  end
 
   shared_examples 'safe assignment disabled' do |style, message|
     let(:cop_config) { { 'EnforcedStyle' => style, 'AllowSafeAssignment' => false } }
@@ -895,26 +890,6 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
 
       it 'accepts safe assignment' do
         expect_no_offenses('foo = (bar = baz == 1) ? a : b')
-      end
-    end
-  end
-
-  context 'when `RedundantParenthesis` would cause an infinite loop' do
-    let(:redundant_parens_enabled) { true }
-
-    context 'when `EnforcedStyle: require_parentheses`' do
-      let(:cop_config) { { 'EnforcedStyle' => 'require_parentheses' } }
-
-      it 'accepts' do
-        expect_no_offenses('foo = bar? ? a : b')
-      end
-    end
-
-    context 'when `EnforcedStyle: require_parentheses_when_complex`' do
-      let(:cop_config) { { 'EnforcedStyle' => 'require_parentheses_when_complex' } }
-
-      it 'accepts' do
-        expect_no_offenses('!condition.nil? ? foo : bar')
       end
     end
   end


### PR DESCRIPTION
`Style/TernaryParentheses` allows RuboCop to require ternary conditions are wrapped in parentheses, but this behaviour doesn't take effect when `Style/RedundantParentheses` is also enabled, in order to prevent an infinite loop.

However, it makes more sense for `TernaryParentheses` to take priority here and have `RedudantParentheses` allow the parentheses instead of creating an infinite autocorrection loop.

This change moves the infinite loop protection into `RedundantParentheses` instead.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
