### PR TITLE
Fix an obsolete option configuration values are duplicated when generating `.rubocop_todo.yml`

### DIFF
--- a/changelog/fix_fix_an_obsolete_option_configuration.md
+++ b/changelog/fix_fix_an_obsolete_option_configuration.md
@@ -1,0 +1,1 @@
+* [#10875](https://github.com/rubocop/rubocop/pull/10875): Fix an obsolete option configuration values are duplicated when generating `.rubocop_todo.yml`. ([@ydah][])

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -161,7 +161,7 @@ module RuboCop
           next unless value.is_a?(Array)
           next if value.empty?
 
-          output_buffer.puts "# #{param}: #{value.join(', ')}"
+          output_buffer.puts "# #{param}: #{value.uniq.join(', ')}"
         end
       end
 


### PR DESCRIPTION
Create two files with the following code:
```ruby
def fooBar; end
```

Set the following in .rubocop.yml:
```yml
Style/MethodName:
  IgnoredPatterns:
    - pattern1
    - pattern2
```

Run `rubocop --auto-gen-config`
Then duplicate configuration values are enumerated in `.rubocop_todo.yml` as follows:
```yml
# Offense count: 2
# Configuration parameters: EnforcedStyle, AllowedPatterns, IgnoredPatterns.
# SupportedStyles: snake_case, camelCase
# AllowedPatterns: pattern1, pattern2, pattern1, pattern2, pattern1, pattern2, pattern1, pattern2, pattern1, pattern2, pattern1, pattern2, pattern1, pattern2, pattern1, pattern2, pattern1, pattern2, pattern1, pattern2, pattern1, pattern2, pattern1, pattern2, pattern1, pattern2, pattern1, pattern2, pattern1, pattern2, pattern1, pattern2, pattern1, pattern2
Naming/MethodName:
  Exclude:
    - 'test1.rb'
    - 'test2.rb'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
