### PR TITLE
Change an option from `AllowedMethods` to `ForbiddenMethods` for `Lint/RedundantSafeNavigation` cop

### DIFF
--- a/changelog/change_change_an_option_from_allowedmethods_to.md
+++ b/changelog/change_change_an_option_from_allowedmethods_to.md
@@ -1,0 +1,1 @@
+* [#10876](https://github.com/rubocop/rubocop/pull/10876): Change an option from `AllowedMethods` to `ForbiddenMethods` for `Lint/RedundantSafeNavigation` cop. ([@ydah][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2097,13 +2097,15 @@ Lint/RedundantSafeNavigation:
   Description: 'Checks for redundant safe navigation calls.'
   Enabled: true
   VersionAdded: '0.93'
-  AllowedMethods:
+  VersionChanged: '<<next>>'
+  ForbiddenMethods:
     - instance_of?
     - kind_of?
     - is_a?
     - eql?
     - respond_to?
     - equal?
+  AllowedMethods: [] # deprecated
   Safe: false
 
 Lint/RedundantSplatExpansion:

--- a/config/obsoletion.yml
+++ b/config/obsoletion.yml
@@ -224,6 +224,11 @@ changed_parameters:
       - AllowedMethods
       - AllowedPatterns
     severity: warning
+  - cops:
+      - Lint/RedundantSafeNavigation
+    parameters: AllowedMethods
+    alternative: ForbiddenMethods
+    severity: warning
 
 # Enforced styles that have been removed or replaced
 changed_enforced_styles:

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -75,6 +75,7 @@ require_relative 'rubocop/cop/mixin/configurable_naming'
 require_relative 'rubocop/cop/mixin/configurable_numbering'
 require_relative 'rubocop/cop/mixin/documentation_comment'
 require_relative 'rubocop/cop/mixin/duplication'
+require_relative 'rubocop/cop/mixin/forbidden_methods'
 require_relative 'rubocop/cop/mixin/range_help'
 require_relative 'rubocop/cop/mixin/annotation_comment' # relies on range
 require_relative 'rubocop/cop/mixin/empty_lines_around_body' # relies on range

--- a/lib/rubocop/cop/lint/redundant_safe_navigation.rb
+++ b/lib/rubocop/cop/lint/redundant_safe_navigation.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Lint
       # Checks for redundant safe navigation calls.
       # `instance_of?`, `kind_of?`, `is_a?`, `eql?`, `respond_to?`, and `equal?` methods
-      # are checked by default. These are customizable with `AllowedMethods` option.
+      # are checked by default. These are customizable with `ForbiddenMethods` option.
       #
       # In the example below, the safe navigation operator (`&.`) is unnecessary
       # because `NilClass` has methods like `respond_to?` and `is_a?`.
@@ -35,7 +35,7 @@ module RuboCop
       #   # good - without `&.` this will always return `true`
       #   foo&.respond_to?(:to_a)
       #
-      # @example AllowedMethods: [foo?]
+      # @example ForbiddenMethods: [foo?]
       #   # bad
       #   do_something if attrs&.foo?(:[])
       #
@@ -43,7 +43,7 @@ module RuboCop
       #   do_something if attrs&.bar?(:[])
       #
       class RedundantSafeNavigation < Base
-        include AllowedMethods
+        include ForbiddenMethods
         include RangeHelp
         extend AutoCorrector
 
@@ -57,7 +57,7 @@ module RuboCop
         PATTERN
 
         def on_csend(node)
-          return unless check?(node) && allowed_method?(node.method_name)
+          return unless check?(node) && forbidden_method?(node.method_name)
           return if respond_to_nil_specific_method?(node)
 
           range = range_between(node.loc.dot.begin_pos, node.source_range.end_pos)
@@ -78,6 +78,10 @@ module RuboCop
 
         def condition?(parent, node)
           (parent.conditional? || parent.post_condition_loop?) && parent.condition == node
+        end
+
+        def cop_config_deprecated_values
+          Array(cop_config['AllowedMethods'])
         end
       end
     end

--- a/lib/rubocop/cop/mixin/forbidden_methods.rb
+++ b/lib/rubocop/cop/mixin/forbidden_methods.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # This module encapsulates the ability to forbid certain methods when
+    # parsing.
+    module ForbiddenMethods
+      private
+
+      def forbidden_method?(name)
+        forbidden_methods.include?(name.to_s)
+      end
+
+      def forbidden_methods
+        Array(cop_config['ForbiddenMethods']).concat(cop_config_deprecated_values)
+      end
+
+      def cop_config_deprecated_values
+        []
+      end
+    end
+  end
+end

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -332,6 +332,7 @@ RSpec.describe RuboCop::ConfigObsoletion do
           'Layout/EndAlignment' => { 'AlignWith' => 'end' },
           'Layout/DefEndAlignment' => { 'AlignWith' => 'end' },
           'Rails/UniqBeforePluck' => { 'EnforcedMode' => 'x' },
+          'Lint/RedundantSafeNavigation' => { 'AllowedMethods' => 'instance_of?' },
           # Moved cops with obsolete parameters
           'Lint/BlockAlignment' => { 'AlignWith' => 'end' },
           'Lint/EndAlignment' => { 'AlignWith' => 'end' },


### PR DESCRIPTION
The `AllowedMethods` indicates the method names that you want to allow in the bad case.
However, for `Lint/RedundantSafeNavigation`, it indicates the method names that should be considered as bad cases.

e.g.
- https://docs.rubocop.org/rubocop/cops_style.html#allowedmethods-lambda-proc-it-default
- https://docs.rubocop.org/rubocop/cops_style.html#allowedmethods-nonzero-default

Since the usage is different, we propose to change the option names.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
