### PR TITLE
[Fix #10877] Fix crash with `Layout/BlockEndNewline` heredoc detection.

### DIFF
--- a/changelog/fix_fix_crash_with_layoutblockendnewline.md
+++ b/changelog/fix_fix_crash_with_layoutblockendnewline.md
@@ -1,0 +1,1 @@
+* [#10877](https://github.com/rubocop/rubocop/issues/10877): Fix crash with `Layout/BlockEndNewline` heredoc detection. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/block_end_newline.rb
+++ b/lib/rubocop/cop/layout/block_end_newline.rb
@@ -60,9 +60,10 @@ module RuboCop
         end
 
         def last_heredoc_argument(node)
+          return unless node&.call_type?
           return unless (arguments = node&.arguments)
 
-          heredoc = arguments.reverse.detect(&:heredoc?)
+          heredoc = arguments.reverse.detect { |arg| arg.str_type? && arg.heredoc? }
           return heredoc if heredoc
 
           last_heredoc_argument(node.children.first)

--- a/spec/rubocop/cop/layout/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/layout/block_end_newline_spec.rb
@@ -154,4 +154,32 @@ RSpec.describe RuboCop::Cop::Layout::BlockEndNewline, :config do
       }
     RUBY
   end
+
+  it 'registers an offense and corrects when a multiline block ends with a hash' do
+    expect_offense(<<~RUBY)
+      foo {
+        { bar: :baz } }
+                      ^ Expression at 2, 17 should be on its own line.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo {
+        { bar: :baz }
+      }
+    RUBY
+  end
+
+  it 'registers an offense and corrects when a multiline block ends with a method call with hash arguments' do
+    expect_offense(<<~RUBY)
+      foo {
+        bar(baz: :quux) }
+                        ^ Expression at 2, 19 should be on its own line.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo {
+        bar(baz: :quux)
+      }
+    RUBY
+  end
 end


### PR DESCRIPTION
Autocorrection for `Layout/BlockEndNewline` tries to handle heredocs but now crashes in some cases where `heredoc?` is not defined.

Fixes #10877.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
