### PR TITLE
Add ArrayAlignment to list of recommended Layout cops for LineLength

### DIFF
--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -22,6 +22,7 @@ module RuboCop
       # (Many of these are enabled by default.)
       #
       # * ArgumentAlignment
+      # * ArrayAlignment
       # * BlockAlignment
       # * BlockDelimiters
       # * BlockEndNewline


### PR DESCRIPTION
Both ArgumentAlignment and HashAlignment are listed so it looks like
ArrayAlignment should also be included.
