### PR TITLE
Fix `elif` (`elsif`) typo

### DIFF
--- a/spec/rubocop/cop/layout/line_end_string_concatenation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/line_end_string_concatenation_indentation_spec.rb
@@ -58,13 +58,13 @@ RSpec.describe RuboCop::Cop::Layout::LineEndStringConcatenationIndentation, :con
       RUBY
     end
 
-    it 'registers an offense for aligned strings in an if/elif/else statement' do
+    it 'registers an offense for aligned strings in an if/elsif/else statement' do
       expect_offense(<<~'RUBY')
         if cond1
           'a' \
           'b'
           ^^^ Indent the first part of a string concatenated with backslash.
-        elif cond2
+        elsif cond2
           'c' \
           'd'
           ^^^ Indent the first part of a string concatenated with backslash.
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::Layout::LineEndStringConcatenationIndentation, :con
         if cond1
           'a' \
             'b'
-        elif cond2
+        elsif cond2
           'c' \
             'd'
         else


### PR DESCRIPTION
- Resolves what seems to be an unintentional typo where `elif` (as a method call) is being use in place of the `elsif` keyword.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
