### PR TITLE
add min and max to list of false positives for Style/SymbolProc

### DIFF
--- a/changelog/fix_add_min_and_max_to_list_of_false_positives_for_style_symbol_proc.md
+++ b/changelog/fix_add_min_and_max_to_list_of_false_positives_for_style_symbol_proc.md
@@ -1,0 +1,1 @@
+* [#10864](https://github.com/rubocop/rubocop/pull/10864): `min` and `max` results in false positives for `Style/SymbolProc` similarly to `select` and `reject`. ([@mollerhoj][])

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -121,6 +121,7 @@ module RuboCop
             # we should allow lambdas & procs
             return if proc_node?(dispatch_node)
             return if unsafe_hash_usage?(dispatch_node)
+            return if unsafe_array_usage?(dispatch_node)
             return if %i[lambda proc].include?(dispatch_node.method_name)
             return if allowed_method_name?(dispatch_node.method_name)
             return if allow_if_method_has_argument?(node.send_node)
@@ -142,6 +143,10 @@ module RuboCop
         # See: https://github.com/rubocop/rubocop/issues/10864
         def unsafe_hash_usage?(node)
           node.receiver&.hash_type? && %i[reject select].include?(node.method_name)
+        end
+
+        def unsafe_array_usage?(node)
+          node.receiver&.array_type? && %i[min max].include?(node.method_name)
         end
 
         def allowed_method_name?(name)

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -180,6 +180,25 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
     end
   end
 
+  %w[min max].each do |method|
+    it "registers an offense when receiver is a hash literal and using `#{method}` with a block" do
+      expect_offense(<<~RUBY, method: method)
+        {foo: 42}.%{method} {|item| item.foo }
+                  _{method} ^^^^^^^^^^^^^^^^^^ Pass `&:foo` as an argument to `#{method}` instead of a block.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        {foo: 42}.#{method}(&:foo)
+      RUBY
+    end
+
+    it "does not register an offense when receiver is a array literal and using `#{method}` with a block" do
+      expect_no_offenses(<<~RUBY, method: method)
+        [1, 2, 3].#{method} {|item| item.foo }
+      RUBY
+    end
+  end
+
   context 'when `AllowMethodsWithArguments: true`' do
     let(:cop_config) { { 'AllowMethodsWithArguments' => true } }
 
@@ -346,6 +365,25 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
       it "does not register an offense when receiver is a hash literal and using `#{method}` with a numblock" do
         expect_no_offenses(<<~RUBY, method: method)
           {foo: 42}.#{method} { _1.foo }
+        RUBY
+      end
+    end
+
+    %w[min max].each do |method|
+      it "registers an offense when receiver is an hash literal and using `#{method}` with a numblock" do
+        expect_offense(<<~RUBY, method: method)
+          {foo: 42}.%{method} { _1.foo }
+                    _{method} ^^^^^^^^^^ Pass `&:foo` as an argument to `#{method}` instead of a block.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {foo: 42}.#{method}(&:foo)
+        RUBY
+      end
+
+      it "does not register an offense when receiver is a array literal and using `#{method}` with a numblock" do
+        expect_no_offenses(<<~RUBY, method: method)
+          [1, 2, 3].#{method} { _1.foo }
         RUBY
       end
     end


### PR DESCRIPTION
This PR fixes a false positive for Style/SymbolProc when using Array#min and Array#max

The cop incorrectly assumes that the two invocations below are the same, and recommends the former:
```
> [1,2,3].min(&:to_i)
ArgumentError: wrong number of arguments (given 1, expected 0)
> [1,2,3].min { |x| x.to_i }
=> 1
```
Style/SymbolProc is already marked as unsafe, but it avoids avoidable issues.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
