### PR TITLE
[Fix #10881] Fix `Style/SoleNestedConditional` to properly wrap `block` and `csend` nodes when necessary

### DIFF
--- a/changelog/fix_fix_stylesolenestedconditional_to.md
+++ b/changelog/fix_fix_stylesolenestedconditional_to.md
@@ -1,0 +1,1 @@
+* [#10881](https://github.com/rubocop/rubocop/issues/10881): Fix `Style/SoleNestedConditional` to properly wrap `block` and `csend` nodes when necessary. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -663,6 +663,46 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
             end
         RUBY
       end
+
+      context 'with a `csend` node' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            if foo
+              if bar&.baz quux
+              ^^ Consider merging nested conditions into outer `if` conditions.
+                do_something
+              end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            if foo && (bar&.baz quux)
+                do_something
+              end
+          RUBY
+        end
+      end
+
+      context 'with a block' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            if foo
+              if ok? bar do
+              ^^ Consider merging nested conditions into outer `if` conditions.
+                  do_something
+                end
+              end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            if foo && (ok? bar do
+                  do_something
+                end)
+              end
+          RUBY
+        end
+      end
     end
   end
 


### PR DESCRIPTION
`Style/SoleNestedConditional` adds parentheses around `send` nodes that have unparenthesized arguments, but this wasn't being done for `csend` or `block` nodes, so this change fixes that.

Fixes #10881.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
