### PR TITLE
[Fix #10890] Fix an error for `Layout/BlockEndNewline` when multi-lineblocks with lambda literals

### DIFF
--- a/changelog/fix_fix_an_error_for_layout_block_end_new_line.md
+++ b/changelog/fix_fix_an_error_for_layout_block_end_new_line.md
@@ -1,0 +1,1 @@
+* [#10890](https://github.com/rubocop/rubocop/issue/10890): Fix an error for `Layout/BlockEndNewline` when multi-line blocks with lambda literals. ([@ydah][])

--- a/lib/rubocop/cop/layout/block_end_newline.rb
+++ b/lib/rubocop/cop/layout/block_end_newline.rb
@@ -60,7 +60,8 @@ module RuboCop
         end
 
         def last_heredoc_argument(node)
-          return unless (arguments = node&.arguments)
+          return unless node&.send_type?
+          return unless (arguments = node.arguments)
 
           heredoc = arguments.reverse.detect(&:heredoc?)
           return heredoc if heredoc

--- a/spec/rubocop/cop/layout/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/layout/block_end_newline_spec.rb
@@ -41,6 +41,22 @@ RSpec.describe RuboCop::Cop::Layout::BlockEndNewline, :config do
     RUBY
   end
 
+
+  it 'registers an offense and corrects when multiline block `}` is not on its own line' \
+    'with lambda literal `->`.' do
+    expect_offense(<<~RUBY)
+      -> {
+        nil }
+            ^ Expression at 2, 7 should be on its own line.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      -> {
+        nil
+      }
+    RUBY
+  end
+
   it 'registers an offense and corrects when `}` of multiline block ' \
      'without processing is not on its own line' do
     expect_offense(<<~RUBY)


### PR DESCRIPTION
Fix: #10890

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
