### PR TITLE
[Fix #10893] Fix an error when running `rubocop` without `bundle exec`

### DIFF
--- a/changelog/fix_an_error_for_no_bundle_exec.md
+++ b/changelog/fix_an_error_for_no_bundle_exec.md
@@ -1,0 +1,1 @@
+* [#10893](https://github.com/rubocop/rubocop/issues/10893): Fix an error when running `rubocop` without `bundle exec`. ([@koic][])

--- a/lib/rubocop/feature_loader.rb
+++ b/lib/rubocop/feature_loader.rb
@@ -30,7 +30,9 @@ module RuboCop
     end
 
     def load
-      ::Kernel.require(target)
+      # Don't use `::Kernel.require(target)` to prevent the following error:
+      # https://github.com/rubocop/rubocop/issues/10893
+      require(target)
     rescue ::LoadError => e
       raise if e.path != target
 


### PR DESCRIPTION
Fixes #10893.

This PR fixes an error when running `rubocop` without `bundle exec`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
