### PR TITLE
[Fix #10895] Fix incorrect autocomplete in `Style/RedundantParentheses` when a heredoc is used in an array

### DIFF
--- a/changelog/fix_fix_incorrect_autocomplete_in.md
+++ b/changelog/fix_fix_incorrect_autocomplete_in.md
@@ -1,0 +1,1 @@
+* [#10895](https://github.com/rubocop/rubocop/issues/10895): Fix incorrect autocomplete in `Style/RedundantParentheses` when a heredoc is used in an array. ([@dvandersluis][])

--- a/lib/rubocop/cop/mixin/range_help.rb
+++ b/lib/rubocop/cop/mixin/range_help.rb
@@ -70,9 +70,8 @@ module RuboCop
         Parser::Source::Range.new(buffer, begin_pos, end_pos)
       end
 
-      def range_by_whole_lines(range, include_final_newline: false)
-        buffer = @processed_source.buffer
-
+      def range_by_whole_lines(range, include_final_newline: false,
+                               buffer: @processed_source.buffer)
         last_line = buffer.source_line(range.last_line)
         end_offset = last_line.length - range.last_column
         end_offset += 1 if include_final_newline

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -593,4 +593,37 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
       )
     RUBY
   end
+
+  it 'registers an offense and corrects an array of multiple heredocs' do
+    expect_offense(<<~RUBY)
+      [
+        (
+        ^ Don't use parentheses around a literal.
+        <<-STRING
+          foo
+        STRING
+        ) ,
+        (
+        ^ Don't use parentheses around a literal.
+        <<-STRING
+          bar
+        STRING
+        )
+      ]
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [
+      #{trailing_whitespace * 2}
+        <<-STRING,
+          foo
+        STRING
+      #{trailing_whitespace * 2}
+        <<-STRING
+          bar
+        STRING
+      #{trailing_whitespace * 2}
+      ]
+    RUBY
+  end
 end


### PR DESCRIPTION
Heredocs always causing problems :grin:

Fixes `Style/RedundantParentheses` to put the comma in the correct spot. Fixes #10895.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
