### PR TITLE
Skip a flaky test for RSpec 4

### DIFF
--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
       end
 
       it 'displays a restart information message' do
+        # FIXME: Avoid flaky test for RSpec 4. It may be related that test-queue is not available.
+        # https://github.com/rubocop/rubocop/pull/10806#discussion_r918415067
+        skip if ENV['GITHUB_JOB'] == 'rspec4'
+
         create_file('example.rb', <<~RUBY)
           # frozen_string_literal: true
 


### PR DESCRIPTION
This PR skips the following flaky test for RSpec 4 GitHub Actions job.

```console
  1) rubocop --server when using `--server` option after updating
  RuboCop displays a restart information message
     Failure/Error:
       expect(`ruby -I . "#{rubocop}" #{options}`).to start_with(
         'RuboCop version incompatibility found, RuboCop server restarting...'
       )

       expected "RuboCop server starting on 127.0.0.1:36753.\nInspecting
       1 file\n\e[32m.\e[0m\n\n1 file inspected, \e[32mno offenses\e[0m
       detected\n" to start with "RuboCop version incompatibility found,
       RuboCop server restarting...
```

Unfortunately, the root cause is unknown yet. It may be related that test-queue is not available.
In any case, this test is run on a CI other than RSpec 4 (beta) job, so there's nothing I've overlooked.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
