### PR TITLE
[Fix #10899] Fix an error for `Lint/ShadowingOuterLocalVariable`

### DIFF
--- a/changelog/fix_an_error_for_lint_shadowing_outer_local_variable.md
+++ b/changelog/fix_an_error_for_lint_shadowing_outer_local_variable.md
@@ -1,0 +1,1 @@
+* [#10899](https://github.com/rubocop/rubocop/issues/10899): Fix an error for `Lint/ShadowingOuterLocalVariable` when the same variable name as a block variable is used in return value assignment of `if`. ([@koic][])

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -69,6 +69,7 @@ module RuboCop
 
           outer_local_variable_node =
             find_conditional_node_from_ascendant(outer_local_variable.declaration_node)
+          return true unless outer_local_variable_node
 
           outer_local_variable_node.conditional? && variable_node == outer_local_variable_node
         end

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -251,6 +251,18 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
     end
   end
 
+  context 'when the same variable name as a block variable is used in return value assignment of `if`' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        def some_method
+          foo = if condition
+                  bar { |foo| baz(foo) }
+                end
+        end
+      RUBY
+    end
+  end
+
   context 'when multiple block arguments have same name "_"' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #10899.

This PR fixes an error for `Lint/ShadowingOuterLocalVariable` when the same variable name as a block variable is used in return value assignment of `if`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
