### PR TITLE
Single file skip parallel

### DIFF
--- a/changelog/fix_speed_up_single_file_inspection.md
+++ b/changelog/fix_speed_up_single_file_inspection.md
@@ -1,0 +1,1 @@
+* [#10903](https://github.com/rubocop/rubocop/pull/10903): Skip forking off extra processes for parallel inspection when only a single file needs to be inspected. ([@wjwh][])

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -64,6 +64,10 @@ module RuboCop
     # instances that each inspects its allotted group of files.
     def warm_cache(target_files)
       saved_options = @options.dup
+      if target_files.length <= 1
+        puts 'Skipping parallel inspection: only a single file needs inspection' if @options[:debug]
+        return
+      end
       puts 'Running parallel inspection' if @options[:debug]
       %i[autocorrect safe_autocorrect].each { |opt| @options[opt] = false }
       Parallel.each(target_files) { |target_file| file_offenses(target_file) }

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
   describe '--parallel' do
     if RuboCop::Platform.windows?
       context 'on Windows' do
+        before do
+          create_file('test_1.rb', ['puts "hello world"'])
+          create_file('test_2.rb', ['puts "what a lovely day"'])
+        end
+
         it 'prints a warning' do
           cli.run ['-P']
           expect($stderr.string).to include('Process.fork is not supported by this Ruby')
@@ -35,7 +40,9 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       context 'on Unix-like systems' do
         it 'prints a message if --debug is specified' do
           cli.run ['--parallel', '--debug']
-          expect($stdout.string).to match(/Running parallel inspection/)
+          expect($stdout.string).to match(
+            /Skipping parallel inspection: only a single file needs inspection/
+          )
         end
 
         it 'does not print a message if --debug is not specified' do


### PR DESCRIPTION
This MR makes it so that if there is only a single file to be inspected, we do not split off extra worker processes to do the work. This is because doing the work in a separate process can never be faster than doing it inline. I benchmarked this change on my dev machine (with 6 physical cores) and it saves 40-50 ms per run (only if only a single file is inspected of course, otherwise it will take as long as before).

I did not know what to update the test with, so I just made it expect the new text. Let me know if this should be different.

(This is a fixed version of https://github.com/rubocop/rubocop/pull/10889, where I had messed up the rebasing)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Updated tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/