### PR TITLE
Fix `Lint/ErbNewArguments` code snippet formatting

### DIFF
--- a/lib/rubocop/cop/lint/erb_new_arguments.rb
+++ b/lib/rubocop/cop/lint/erb_new_arguments.rb
@@ -6,18 +6,18 @@ module RuboCop
       #
       # This cop emulates the following Ruby warnings in Ruby 2.6.
       #
+      # [source,console]
+      # ----
       # % cat example.rb
       # ERB.new('hi', nil, '-', '@output_buffer')
       # % ruby -rerb example.rb
-      # example.rb:1: warning: Passing safe_level with the 2nd argument of
-      # ERB.new is deprecated. Do not use it, and specify other arguments as
-      # keyword arguments.
-      # example.rb:1: warning: Passing trim_mode with the 3rd argument of
-      # ERB.new is deprecated. Use keyword argument like
-      # ERB.new(str, trim_mode:...) instead.
-      # example.rb:1: warning: Passing eoutvar with the 4th argument of ERB.new
-      # is deprecated. Use keyword argument like ERB.new(str, eoutvar: ...)
-      # instead.
+      # example.rb:1: warning: Passing safe_level with the 2nd argument of ERB.new is
+      # deprecated. Do not use it, and specify other arguments as keyword arguments.
+      # example.rb:1: warning: Passing trim_mode with the 3rd argument of ERB.new is
+      # deprecated. Use keyword argument like ERB.new(str, trim_mode:...) instead.
+      # example.rb:1: warning: Passing eoutvar with the 4th argument of ERB.new is
+      # deprecated. Use keyword argument like ERB.new(str, eoutvar: ...) instead.
+      # ----
       #
       # Now non-keyword arguments other than first one are softly deprecated
       # and will be removed when Ruby 2.5 becomes EOL.


### PR DESCRIPTION
The documentation code snippet does not render as code, but as plaintext.

Indenting it causes it to be interpreted as a block of code.
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* ~Added tests.~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
