### PR TITLE
[Fix #10893] Fix loading behavior on running without `bundle exec`

### DIFF
--- a/changelog/fix_fix_loading_behavior_on_running_without.md
+++ b/changelog/fix_fix_loading_behavior_on_running_without.md
@@ -1,0 +1,1 @@
+* [#10909](https://github.com/rubocop/rubocop/pull/10909): Fix loading behavior on running without `bundle exec`. ([@r7kamura][])

--- a/lib/rubocop/feature_loader.rb
+++ b/lib/rubocop/feature_loader.rb
@@ -37,7 +37,9 @@ module RuboCop
       raise if e.path != target
 
       begin
-        ::Kernel.require(namespaced_target)
+        # Don't use `::Kernel.require(target)` to prevent the following error:
+        # https://github.com/rubocop/rubocop/issues/10893
+        require(namespaced_target)
       rescue ::LoadError => error_for_namespaced_target
         raise e if error_for_namespaced_target.path == namespaced_target
 

--- a/spec/rubocop/feature_loader_spec.rb
+++ b/spec/rubocop/feature_loader_spec.rb
@@ -14,20 +14,28 @@ RSpec.describe RuboCop::FeatureLoader do
       'feature'
     end
 
+    let(:allow_feature_loader) do
+      allow_any_instance_of(described_class) # rubocop:disable RSpec/AnyInstance
+    end
+
+    let(:expect_feature_loader) do
+      expect_any_instance_of(described_class) # rubocop:disable RSpec/AnyInstance
+    end
+
     context 'with normally lodable feature' do
       before do
-        allow(Kernel).to receive(:require)
+        allow_feature_loader.to receive(:require)
       end
 
       it 'loads it normally' do
-        expect(Kernel).to receive(:require).with('feature')
+        expect_feature_loader.to receive(:require).with('feature')
         load
       end
     end
 
     context 'with dot-prefixed lodable feature' do
       before do
-        allow(Kernel).to receive(:require)
+        allow_feature_loader.to receive(:require)
       end
 
       let(:feature) do
@@ -35,15 +43,15 @@ RSpec.describe RuboCop::FeatureLoader do
       end
 
       it 'loads it as relative path' do
-        expect(Kernel).to receive(:require).with('path-to-config/./path/to/feature')
+        expect_feature_loader.to receive(:require).with('path-to-config/./path/to/feature')
         load
       end
     end
 
     context 'with namespaced feature' do
       before do
-        allow(Kernel).to receive(:require).with('feature-foo').and_call_original
-        allow(Kernel).to receive(:require).with('feature/foo')
+        allow_feature_loader.to receive(:require).with('feature-foo').and_call_original
+        allow_feature_loader.to receive(:require).with('feature/foo')
       end
 
       let(:feature) do
@@ -51,15 +59,16 @@ RSpec.describe RuboCop::FeatureLoader do
       end
 
       it 'loads it as namespaced feature' do
-        expect(Kernel).to receive(:require).with('feature/foo')
+        expect_feature_loader.to receive(:require).with('feature/foo')
         load
       end
     end
 
     context 'with dot-prefixed namespaced feature' do
       before do
-        allow(Kernel).to receive(:require).with('path-to-config/./feature-foo').and_call_original
-        allow(Kernel).to receive(:require).with('path-to-config/./feature/foo')
+        allow_feature_loader.to receive(:require).with('path-to-config/./feature-foo')
+                                                 .and_call_original
+        allow_feature_loader.to receive(:require).with('path-to-config/./feature/foo')
       end
 
       let(:feature) do
@@ -67,14 +76,14 @@ RSpec.describe RuboCop::FeatureLoader do
       end
 
       it 'loads it as namespaced feature' do
-        expect(Kernel).to receive(:require).with('path-to-config/./feature/foo')
+        expect_feature_loader.to receive(:require).with('path-to-config/./feature/foo')
         load
       end
     end
 
     context 'with unexpected LoadError from require' do
       before do
-        allow(Kernel).to receive(:require).and_raise(LoadError)
+        allow_feature_loader.to receive(:require).and_raise(LoadError)
       end
 
       it 'raises LoadError' do


### PR DESCRIPTION
This is an additional fix for #10893 and #10894.

The error in normal usage was fixed at #10894, but there is one more `Kernel.require` so there is a possible error in the case where users try to use the new feature.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
