### PR TITLE
Fix an incorrect autocorrect for `Style/MultilineTernaryOperator`  when contains a comment

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_multiline_ternary_operator.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_multiline_ternary_operator.md
@@ -1,0 +1,1 @@
+* [#10910](https://github.com/rubocop/rubocop/pull/10910): Fix an incorrect autocorrect for `Style/MultilineTernaryOperator`  when contains a comment. ([@ydah][])

--- a/lib/rubocop/cop/mixin/comments_help.rb
+++ b/lib/rubocop/cop/mixin/comments_help.rb
@@ -62,10 +62,12 @@ module RuboCop
       # Returns the end line of a node, which might be a comment and not part of the AST
       # End line is considered either the line at which another node starts, or
       # the line at which the parent node ends.
-      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def find_end_line(node)
-        if node.if_type? && node.loc.else
+        if node.if_type? && node.else?
           node.loc.else.line
+        elsif node.if_type? && node.ternary?
+          node.else_branch.loc.line
         elsif (next_sibling = node.right_sibling)
           next_sibling.loc.line
         elsif (parent = node.parent)
@@ -74,7 +76,7 @@ module RuboCop
           node.loc.end.line
         end
       end
-      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     end
   end
 end

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -179,4 +179,68 @@ RSpec.describe RuboCop::Cop::Style::MultilineTernaryOperator, :config do
   it 'accepts a single line ternary operator expression' do
     expect_no_offenses('a = cond ? b : c')
   end
+
+  it 'registers an offense and corrects when the if branch and the else branch are ' \
+     'on a separate line from the condition and not contains a comment' do
+    expect_offense(<<~RUBY)
+      # comment a
+      a = cond ?
+          ^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
+        b : c # comment b
+      # comment c
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # comment a
+      a = if cond
+        b
+      else
+        c
+      end # comment b
+      # comment c
+    RUBY
+  end
+
+  it 'registers an offense and corrects when if branch and the else branch are ' \
+     'on a separate line from the condition and contains a comment' do
+    expect_offense(<<~RUBY)
+      a = cond ? # comment a
+          ^^^^^^^^^^^^^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
+        # comment b
+        b : c
+
+      a = cond ?
+          ^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
+        b : # comment
+        c
+
+      a = cond ? b : # comment
+          ^^^^^^^^^^^^^^^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
+        c
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # comment a
+      # comment b
+      a = if cond
+        b
+      else
+        c
+      end
+
+      # comment
+      a = if cond
+        b
+      else
+        c
+      end
+
+      # comment
+      a = if cond
+        b
+      else
+        c
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fix an incorrect autocorrect for `Style/MultilineTernaryOperator`  when contains a comment

This PR is fix an incorrect autocorrect for `Style/MultilineTernaryOperator`  when contains a comment.

For example, we have the following code
```ruby
foo = condition? ?
        (do_something rescue rescued) : # rubocop:todo Style/RescueModifier
        other_something
```

When we run `bundle exec rubocop -A --only Style/MultilineTernaryOperator`, the comment disappears as follows
```ruby
foo = if condition?
  (do_something rescue rescued)
else
  other_something
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
