### PR TITLE
Fix `Style/ClassMethodsDefinitions` for non-self receivers

### DIFF
--- a/changelog/fix_style_class_methods_definitions_for_non_self_receivers.md
+++ b/changelog/fix_style_class_methods_definitions_for_non_self_receivers.md
@@ -1,0 +1,1 @@
+* [#10911](https://github.com/rubocop/rubocop/pull/10911): Fix Style/ClassMethodsDefinitions for non-self receivers. ([@sambostock][])

--- a/lib/rubocop/cop/style/class_methods_definitions.rb
+++ b/lib/rubocop/cop/style/class_methods_definitions.rb
@@ -70,7 +70,7 @@ module RuboCop
 
         def on_sclass(node)
           return unless def_self_style?
-          return unless node.identifier.source == 'self'
+          return unless node.identifier.self_type?
           return unless all_methods_public?(node)
 
           add_offense(node, message: MSG_SCLASS) do |corrector|
@@ -80,6 +80,7 @@ module RuboCop
 
         def on_defs(node)
           return if def_self_style?
+          return unless node.receiver.self_type?
 
           message = format(MSG, preferred: 'class << self')
           add_offense(node, message: message)

--- a/spec/rubocop/cop/style/class_methods_definitions_spec.rb
+++ b/spec/rubocop/cop/style/class_methods_definitions_spec.rb
@@ -294,5 +294,13 @@ RSpec.describe RuboCop::Cop::Style::ClassMethodsDefinitions, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when defining singleton methods not on self' do
+      expect_no_offenses(<<~RUBY)
+        object = Object.new
+        def object.method
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
The `Style/ClassMethodsDefinitions` cop controls if class methods should be defined using

```ruby
class Klass
  class << self
    def method_name
```

or

```ruby
class Klass
  def self.method_name
```

Given the current error message, it should not apply to singleton methods defined on objects that aren't `self`:

```ruby
object = Object.new
def object.method_name
```

> **Note**
> We could potentially follow up with a config that allows controlling if this cop applies **only** to **`self`** or to **_any_ receiver**.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
