### PR TITLE
Change yard `--markup` option from `markdown` to `asciidoc`

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,3 @@
---markup markdown
+--markup asciidoc
 --hide-void-return
 --tag safety:"Cop Safety Information"

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'asciidoctor'
 gem 'bump', require: false
 gem 'memory_profiler', platform: :mri
 gem 'rake', '~> 13.0'


### PR DESCRIPTION
I found some YARD documentation pages are wrongly rendered in HTML.

Currently `--markup markdown` is specified, but many comments appear to use AsciiDoc notation. Perhaps it should be `--markup asciidoc`?

## Example

For example, see the difference of `RuboCop::Cop::Style::RedundantArgument` doc page:

### Before

![yard-before](https://user-images.githubusercontent.com/111689/184062705-9de47296-ea0c-47f6-be19-0edecde264ca.png)

### After

![yard-after](https://user-images.githubusercontent.com/111689/184062715-ad7b0e3b-f78d-49b7-8d8a-4c0c26ec4405.png)

To reproduce this, run thw following command,

```
bundle install
bundle exec rake yard
```

then open `./doc/RuboCop/Cop/Style/RedundantArgument.html`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
