### PR TITLE
[Fix #10913] Make `Style/ArgumentsForwarding` aware of anonymous block argument

### DIFF
--- a/changelog/fix_make_style_arguments_forwarding_aware_of_anonymous_block_argument.md
+++ b/changelog/fix_make_style_arguments_forwarding_aware_of_anonymous_block_argument.md
@@ -1,0 +1,1 @@
+* [#10913](https://github.com/rubocop/rubocop/issues/10913): Make `Style/ArgumentsForwarding` aware of anonymous block argument. ([@koic][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -73,11 +73,11 @@ module RuboCop
           {
             (send _ _
               (splat (lvar %1))
-              (block-pass (lvar %2)))
+              (block-pass {(lvar %2) nil?}))
             (send _ _
               (splat (lvar %1))
               (hash (kwsplat (lvar %3)))
-              (block-pass (lvar %2)))
+              (block-pass {(lvar %2) nil?}))
           }
         PATTERN
 

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -250,4 +250,38 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       end
     end
   end
+
+  context 'TargetRubyVersion >= 3.1', :ruby31 do
+    it 'registers an offense when using restarg and anonymous block arg' do
+      expect_offense(<<~RUBY)
+        def foo(*args, &)
+                ^^^^^^^^ Use arguments forwarding.
+          bar(*args, &)
+              ^^^^^^^^ Use arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(...)
+          bar(...)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using restarg, kwargs, and anonymous block arg' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs, &)
+                ^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+          bar(*args, **kwargs, &)
+              ^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(...)
+          bar(...)
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #10913.

This PR makes `Style/ArgumentsForwarding` aware of anonymous block argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
