### PR TITLE
Fix an error when .rubocop.yml is empty

### DIFF
--- a/changelog/fix_an_error_when_dot_rubocop_yml_is_empty.md
+++ b/changelog/fix_an_error_when_dot_rubocop_yml_is_empty.md
@@ -1,0 +1,1 @@
+* [#10916](https://github.com/rubocop/rubocop/pull/10916): Fix an error when .rubocop.yml is empty. ([@koic][])

--- a/lib/rubocop/server/cache.rb
+++ b/lib/rubocop/server/cache.rb
@@ -69,10 +69,12 @@ module RuboCop
             config_yaml = if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('4.0.0')
                             YAML.safe_load_file(config_path, permitted_classes: [Regexp, Symbol])
                           else
-                            YAML.load_file(config_path)
+                            config = YAML.load_file(config_path)
+
+                            config == false ? nil : config
                           end
 
-            config_yaml.dig('AllCops', 'CacheRootDirectory')
+            config_yaml&.dig('AllCops', 'CacheRootDirectory')
           end
         end
 

--- a/spec/rubocop/server/cache_spec.rb
+++ b/spec/rubocop/server/cache_spec.rb
@@ -205,5 +205,19 @@ RSpec.describe RuboCop::Server::Cache do
         end
       end
     end
+
+    context 'when .rubocop.yml is empty', :isolated_environment do
+      context 'when cache root path is not specified path' do
+        before do
+          cache_class.cache_root_path = nil
+        end
+
+        it 'does not raise an error' do
+          create_file('.rubocop.yml', '')
+
+          expect { cache_class.cache_path }.not_to raise_error
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the following error when .rubocop.yml is empty.

```console
% touch .rubocop.yml

% rubocop
/Users/koic/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.34.1/lib/rubocop/server/cache.rb:75:in
`block in cache_root_dir_from_config': undefined method `dig' for nil:NilClass (NoMethodError)

            config_yaml.dig('AllCops', 'CacheRootDirectory')
                       ^^^^
        from /Users/koic/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.34.1/lib/rubocop/cache_config.rb:9:in
                       `root_dir'
        from /Users/koic/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.34.1/lib/rubocop/server/cache.rb:61:in
                       `cache_root_dir_from_config'
        from /Users/koic/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.34.1/lib/rubocop/server/cache.rb:54:in
                       `cache_path'
        from /Users/koic/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.34.1/lib/rubocop/server/cache.rb:45:in
                       `dir'
        from /Users/koic/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.34.1/lib/rubocop/server.rb:36:in
                       `running?'
        from /Users/koic/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.34.1/exe/rubocop:11:in
                       `<top (required)>'
        from /Users/koic/.rbenv/versions/3.1.2/bin/rubocop:25:in `load'
        from /Users/koic/.rbenv/versions/3.1.2/bin/rubocop:25:in `<main>'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
