### PR TITLE
[Fix #10920] Fix an incorrect autocorrect for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_sole_nested_conditional.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#10920](https://github.com/rubocop/rubocop/issues/10920): Fix an incorrect autocorrect for `Style/SoleNestedConditional` when using nested conditional and branch contains a comment. ([@koic][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -173,8 +173,6 @@ module RuboCop
         end
 
         def correct_for_comment(corrector, node, if_branch)
-          return if config.for_cop('Style/IfUnlessModifier')['Enabled']
-
           comments = processed_source.ast_with_comments[if_branch]
           comment_text = comments.map(&:text).join("\n") << "\n"
 

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -382,6 +382,46 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using nested conditional and branch contains a comment' do
+    expect_offense(<<~RUBY)
+      if foo
+        # Comment.
+        if bar
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # Comment.
+      if foo && bar
+          do_something
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when there are outer and inline comments' do
+    expect_offense(<<~RUBY)
+      # Outer comment.
+      if foo
+        # Comment.
+        if bar # nested condition
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # Outer comment.
+      # Comment.
+      if foo && bar # nested condition
+          do_something
+        end
+    RUBY
+  end
+
   context 'when disabling `Style/IfUnlessModifier`' do
     let(:config) { RuboCop::Config.new('Style/IfUnlessModifier' => { 'Enabled' => false }) }
 


### PR DESCRIPTION
Fixes #10920.

This PR fixes an incorrect autocorrect for `Style/SoleNestedConditional` when using nested conditional and branch contains a comment.

It removes `return if config.for_cop('Style/IfUnlessModifier')['Enabled']` that introduced in #9195. That logic is now unnecessary due to https://github.com/rubocop/rubocop/commit/3fea162 change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
