### PR TITLE
Add more autocorrect support on `Style/EachForSimpleLoop`

### DIFF
--- a/changelog/change_autocorrect_0origin_range_with_block.md
+++ b/changelog/change_autocorrect_0origin_range_with_block.md
@@ -1,0 +1,1 @@
+* [#10928](https://github.com/rubocop/rubocop/pull/10928): Add more autocorrect support on `Style/EachForSimpleLoop`. ([@r7kamura][])

--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -9,15 +9,32 @@ RSpec.describe RuboCop::Cop::Style::EachForSimpleLoop, :config do
     expect_no_offenses('(0..b).each {}')
   end
 
-  it 'does not register offense for inline block with parameters' do
-    expect_no_offenses('(0..10).each { |n| puts n }')
+  context 'with inline block with parameters' do
+    it 'autocorrects an offense' do
+      expect_offense(<<~RUBY)
+        (0...10).each { |n| }
+        ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        10.times { |n| }
+      RUBY
+    end
   end
 
-  it 'does not register offense for multiline block with parameters' do
-    expect_no_offenses(<<~RUBY)
-      (0..10).each do |n|
-      end
-    RUBY
+  context 'with multiline block with parameters' do
+    it 'autocorrects an offense' do
+      expect_offense(<<~RUBY)
+        (0...10).each do |n|
+        ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        10.times do |n|
+        end
+      RUBY
+    end
   end
 
   it 'does not register offense for character range' do


### PR DESCRIPTION
If there is a block argument, it should be autocorrectable when the starting point of the range is 0.

```ruby
# bad
(0...10).each do |i|
  puts i
end

# good
10.times do |i|
  puts i
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
