### PR TITLE
[Fix #10926] Make `Style/SafeNavigation` aware of a redundant nil check

### DIFF
--- a/changelog/fix_make_style_safe_navigation_aware_of_a_redundant_nil_check.md
+++ b/changelog/fix_make_style_safe_navigation_aware_of_a_redundant_nil_check.md
@@ -1,0 +1,1 @@
+* [#10926](https://github.com/rubocop/rubocop/issues/10926): Make `Style/SafeNavigation` aware of a redundant nil check. ([@koic][])

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -123,7 +123,7 @@ module RuboCop
           return unless receiver == checked_variable
           return if use_var_only_in_unless_modifier?(node, checked_variable)
           return if chain_length(method_chain, method) > max_chain_length
-          return if unsafe_method_used?(method_chain, method)
+          return if unsafe_method_used?(method_chain, method) && !method.safe_navigation?
           return if method_chain.method?(:empty?)
 
           add_offense(node) { |corrector| autocorrect(corrector, node) }
@@ -141,7 +141,7 @@ module RuboCop
 
           corrector.remove(begin_range(node, body))
           corrector.remove(end_range(node, body))
-          corrector.insert_before(method_call.loc.dot, '&')
+          corrector.insert_before(method_call.loc.dot, '&') unless method_call.safe_navigation?
           handle_comments(corrector, node, method_call)
 
           add_safe_nav_to_all_methods_in_chain(corrector, method_call, body)

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -205,6 +205,17 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
         RUBY
       end
 
+      it 'registers an offense when safe guard check and safe navigation method call are connected with `&&` condition' do
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable} && %{variable}&.do_something
+          ^{variable}^^^^^{variable}^^^^^^^^^^^^^^ Use safe navigation (`&.`) instead of checking if an object exists before calling the method.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.do_something
+        RUBY
+      end
+
       it 'registers an offense for a method call on an accessor ' \
          'safeguarded by a check for the accessed variable' do
         expect_offense(<<~RUBY, variable: variable)


### PR DESCRIPTION
Fixes #10926.

This PR makes `Style/SafeNavigation` aware of a redundant nil check.

IMHO, the context of this patch is a minimal update. OTOH, a new cop like `Style/RedundantNilCheck` cop may be implemented if it is not suitable for this `Style/SafeNavigation` cop. (But I'm not sure if it's the best.)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
