### PR TITLE
Add `AllowOnSelfClass` option to `Style/CaseEquality`

### DIFF
--- a/changelog/new_add_allowonselfclass_option_to.md
+++ b/changelog/new_add_allowonselfclass_option_to.md
@@ -1,0 +1,1 @@
+* [#10931](https://github.com/rubocop/rubocop/pull/10931): Add `AllowOnSelfClass` option to `Style/CaseEquality`. ([@sambostock][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3186,6 +3186,15 @@ Style/CaseEquality:
   #   # good
   #   String === "string"
   AllowOnConstant: false
+  # If `AllowOnSelfClass` option is enabled, the cop will ignore violations when the receiver of
+  # the case equality operator is `self.class`.
+  #
+  #   # bad
+  #   some_class === object
+  #
+  #   # good
+  #   self.class === object
+  AllowOnSelfClass: false
 
 Style/CaseLikeIf:
   Description: 'Identifies places where `if-elsif` constructions can be replaced with `case-when`.'

--- a/spec/rubocop/cop/style/case_equality_spec.rb
+++ b/spec/rubocop/cop/style/case_equality_spec.rb
@@ -73,4 +73,42 @@ RSpec.describe RuboCop::Cop::Style::CaseEquality, :config do
 
     include_examples 'offenses'
   end
+
+  context 'when AllowOnSelfClass is false' do
+    let(:cop_config) { { 'AllowOnSelfClass' => false } }
+
+    it 'registers an offense and corrects for === when the receiver is self.class' do
+      expect_offense(<<~RUBY)
+        self.class === var
+                   ^^^ Avoid the use of the case equality operator `===`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var.is_a?(self.class)
+      RUBY
+    end
+
+    include_examples 'offenses'
+  end
+
+  context 'when AllowOnSelfClass is true' do
+    let(:cop_config) { { 'AllowOnSelfClass' => true } }
+
+    it 'does not register an offense for === when the receiver is self.class' do
+      expect_no_offenses(<<~RUBY)
+        self.class === var
+      RUBY
+    end
+
+    it 'registers an offense and corrects for === when the receiver is self.klass' do
+      expect_offense(<<~RUBY)
+        self.klass === var
+                   ^^^ Avoid the use of the case equality operator `===`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    include_examples 'offenses'
+  end
 end


### PR DESCRIPTION
`Style/CaseEquality`'s `AllowOnConstant` option allows the use of constants, to allow for case equality with classes and modules. `self.class` is a special case also referring to a class, and may be required in cases where the other object might be a `BasicObject`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
