### PR TITLE
Use GitHub Actions instead of CircleCI for JRuby matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,6 @@
 # Please keep /.mergify.yml synced!
 version: 2
 
-jruby_env: &jruby_env
-  # By default we have 2 CPUs and 4GB ram available
-  # https://circleci.com/docs/2.0/configuration-reference/#resource_class
-  JRUBY_OPTS: "--debug -J-Xmn1024m -J-Xms2048m -J-Xmx2048m"
-
 common_env: &common_env
   # CircleCI container has two cores, but Ruby can see 32 cores. So we
   # configure test-queue.
@@ -161,32 +156,6 @@ jobs:
     steps:
       *rubocop_steps
 
-  # JRuby 9.3
-  jruby-9.3-spec:
-    docker:
-      - image: circleci/jruby:9.3
-    environment:
-      <<: *common_env
-      <<: *jruby_env
-    steps:
-      *spec_steps
-  jruby-9.3-ascii_spec:
-    docker:
-      - image: circleci/jruby:9.3
-    environment:
-      <<: *common_env
-      <<: *jruby_env
-    steps:
-      *ascii_spec_steps
-  jruby-9.3-rubocop:
-    docker:
-      - image: circleci/jruby:9.3
-    environment:
-      <<: *common_env
-      <<: *jruby_env
-    steps:
-      *rubocop_steps
-
   # Job for downloading the Code Climate test reporter
   cc-setup:
     docker:
@@ -221,7 +190,7 @@ jobs:
       - run:
           name: Upload coverage results to Code Climate
           command: |
-            ./tmp/cc-test-reporter sum-coverage tmp/codeclimate.*.json --parts 5 --output tmp/codeclimate.total.json
+            ./tmp/cc-test-reporter sum-coverage tmp/codeclimate.*.json --parts 4 --output tmp/codeclimate.total.json
             ./tmp/cc-test-reporter upload-coverage --input tmp/codeclimate.total.json
 
   # Miscellaneous tasks
@@ -272,11 +241,6 @@ workflows:
             - cc-setup
       - ruby-head-ascii_spec
       - ruby-head-rubocop
-      - jruby-9.3-spec:
-          requires:
-            - cc-setup
-      - jruby-9.3-ascii_spec
-      - jruby-9.3-rubocop
 
       - cc-upload-coverage:
           requires:
@@ -284,4 +248,3 @@ workflows:
             - ruby-2.7-spec
             - ruby-3.0-spec
             - ruby-3.1-spec
-            - jruby-9.3-spec

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -53,6 +53,26 @@ jobs:
       - name: internal_investigation
         run: bundle exec rake internal_investigation
 
+  jruby:
+    name: JRuby 9.3
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: jruby-9.3
+
+      - name: install dependencies
+        run: bundle install --jobs 3 --retry 3
+      - name: spec
+        run: bundle exec rake spec
+      - name: ascii_spec
+        run: bundle exec rake ascii_spec
+      - name: internal_investigation
+        run: bundle exec rake internal_investigation
+
   rspec4:
     runs-on: ubuntu-latest
     name: RSpec 4

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,9 +58,7 @@ RSpec.configure do |config|
     config.filter_run_excluding broken_on: :ruby_head
   end
 
-  if %w[jruby-9.3-ascii_spec jruby-9.3-spec].include? ENV.fetch('CIRCLE_JOB', nil)
-    config.filter_run_excluding broken_on: :jruby
-  end
+  config.filter_run_excluding broken_on: :jruby if ENV.fetch('GITHUB_JOB', nil) == 'jruby'
 end
 
 module ::RSpec


### PR DESCRIPTION
This is an update similar to #10326.
https://hub.docker.com/r/circleci/jruby hasn't been updated in a while.

This PR migrates the JRuby CI matrix from CircleCI to GitHub Actions to keep up with the latest JRuby version.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
