### PR TITLE
Fix trivial typo

### DIFF
--- a/spec/rubocop/cop/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cop/style/trivial_accessors_spec.rb
@@ -317,7 +317,7 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
     RUBY
   end
 
-  it 'accepts reader nested within an instance_eval calll' do
+  it 'accepts reader nested within an instance_eval call' do
     expect_no_offenses(<<~RUBY)
       something.instance_eval do
         begin


### PR DESCRIPTION
Just fixed trivial typo `calll`-> `call`

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
