### PR TITLE
[Fix #10936] Fix an error for `Lint/NonAtomicFileOperation`

### DIFF
--- a/changelog/fix_an_error_for_lint_non_atomic_file_operation.md
+++ b/changelog/fix_an_error_for_lint_non_atomic_file_operation.md
@@ -1,0 +1,1 @@
+* [#10936](https://github.com/rubocop/rubocop/issues/10936): Fix an error for `Lint/NonAtomicFileOperation` when using `FileTest.exist?` as a condition for `elsif`. ([@koic][])

--- a/lib/rubocop/cop/lint/non_atomic_file_operation.rb
+++ b/lib/rubocop/cop/lint/non_atomic_file_operation.rb
@@ -99,17 +99,17 @@ module RuboCop
         end
 
         def register_offense(node, exist_node)
-          unless force_method?(node)
-            add_offense(node,
-                        message: format(MSG_CHANGE_FORCE_METHOD,
-                                        method_name: replacement_method(node)))
-          end
+          add_offense(node, message: message_change_force_method(node)) unless force_method?(node)
 
           range = range_between(node.parent.loc.keyword.begin_pos,
                                 exist_node.loc.expression.end_pos)
           add_offense(range, message: message_remove_file_exist_check(exist_node)) do |corrector|
-            autocorrect(corrector, node, range)
+            autocorrect(corrector, node, range) unless node.parent.elsif?
           end
+        end
+
+        def message_change_force_method(node)
+          format(MSG_CHANGE_FORCE_METHOD, method_name: replacement_method(node))
         end
 
         def message_remove_file_exist_check(node)

--- a/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
+++ b/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
@@ -95,6 +95,19 @@ RSpec.describe RuboCop::Cop::Lint::NonAtomicFileOperation, :config do
     RUBY
   end
 
+  it 'registers an offense when using `FileTest.exist?` as a condition for `elsif`' do
+    expect_offense(<<~RUBY)
+      if condition
+        do_something
+      elsif FileTest.exist?(path)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary existence check `FileTest.exist?`.
+        FileUtils.rm_f path
+      end
+    RUBY
+
+    expect_no_corrections
+  end
+
   it 'does not register an offense when use `FileTest.exist?` before creating file with an option `force: false`' do
     expect_no_offenses(<<~RUBY)
       unless FileTest.exists?(path)


### PR DESCRIPTION
Fixes #10936.

This PR fixes an error for `Lint/NonAtomicFileOperation` when using `FileTest.exist?` as a condition for `elsif`.
Complex cases such as `if`/`elsif`/`else` don't autocorrect and respect user changes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
