### PR TITLE
Add server mode status to `-V` option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,7 +38,7 @@ output by `rubocop -V`, include them as well. Here's an example:
 
 ```
 $ [bundle exec] rubocop -V
-1.35.1 (using Parser 2.7.2.0, rubocop-ast 1.1.1, running on ruby 2.7.2 x86_64-linux)
+1.35.1 (using Parser 2.7.2.0, rubocop-ast 1.1.1, running on ruby 2.7.2) [x86_64-linux]
   - rubocop-performance 1.9.1
   - rubocop-rspec 2.0.0
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ do so.
 
 ```console
 $ rubocop -V
-1.35.1 (using Parser 2.7.2.0, rubocop-ast 1.1.1, running on ruby 2.7.2 x86_64-linux)
+1.35.1 (using Parser 2.7.2.0, rubocop-ast 1.1.1, running on ruby 2.7.2) [x86_64-linux]
   - rubocop-performance 1.9.1
   - rubocop-rspec 2.0.0
 ```

--- a/changelog/change_add_server_mode_to_version_option.md
+++ b/changelog/change_add_server_mode_to_version_option.md
@@ -1,0 +1,1 @@
+* [#10940](https://github.com/rubocop/rubocop/pull/10940): Add server mode status to `-V` option. ([@koic][])

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -7,7 +7,7 @@ module RuboCop
 
     MSG = '%<version>s (using Parser %<parser_version>s, ' \
           'rubocop-ast %<rubocop_ast_version>s, ' \
-          'running on %<ruby_engine>s %<ruby_version>s %<ruby_platform>s)'
+          'running on %<ruby_engine>s %<ruby_version>s)%<server>s [%<ruby_platform>s]'
 
     CANONICAL_FEATURE_NAMES = { 'Rspec' => 'RSpec', 'Graphql' => 'GraphQL', 'Md' => 'Markdown',
                                 'Thread_safety' => 'ThreadSafety' }.freeze
@@ -19,6 +19,7 @@ module RuboCop
         verbose_version = format(MSG, version: STRING, parser_version: Parser::VERSION,
                                       rubocop_ast_version: RuboCop::AST::Version::STRING,
                                       ruby_engine: RUBY_ENGINE, ruby_version: RUBY_VERSION,
+                                      server: Server.running? ? ' +server' : '',
                                       ruby_platform: RUBY_PLATFORM)
         return verbose_version unless env
 


### PR DESCRIPTION
When YJIT (disabled by default) is enabled in Ruby, it is displayed as follows.

```console
% ruby --yjit -ve 'RubyVM::YJIT.enabled?'
ruby 3.2.0dev (2022-08-18T08:09:08Z master b0b9f7201a) +YJIT [x86_64-darwin19]
```

`+YJIT` is added when YJIT is enabled.

This is a change inspired by it. Below is before and after `rubocop -V`.

## Before

```console
% rubocop -V
1.35.0 (using Parser 3.1.2.1, rubocop-ast 1.21.0, running on ruby 3.2.0 x86_64-darwin19)
  - rubocop-performance 1.14.3
  - rubocop-rake 0.6.0
  - rubocop-rspec 2.11.1
```

## After

It makes the `-V` format like `ruby --version`.

### No server mode

The platform (`x86_64-darwin19`) display will change slightly.

```console
% rubocop -V
1.35.0 (using Parser 3.1.2.1, rubocop-ast 1.21.0, running on ruby 3.2.0) [x86_64-darwin19]
  - rubocop-performance 1.14.3
  - rubocop-rake 0.6.0
  - rubocop-rspec 2.11.1
```

### Server mode

`+server` is added when server is enabled.

```console
% rubocop -V
1.35.0 (using Parser 3.1.2.1, rubocop-ast 1.21.0, running on ruby 3.2.0) +server [x86_64-darwin19]
  - rubocop-performance 1.14.3
  - rubocop-rake 0.6.0
  - rubocop-rspec 2.11.1
```

This change has the following benefits:

- Shorthand alternative to `rubocop --server-status`
- We can check the enable or disable of server mode in the bug report template

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
