### PR TITLE
Fix `rake prof:slow_cops` to return correct results

### DIFF
--- a/tasks/prof.rake
+++ b/tasks/prof.rake
@@ -24,14 +24,11 @@ namespace :prof do
 
   desc 'List the slowest cops'
   task slow_cops: :run_if_needed do
-    method = 'RuboCop::Cop::Commissioner#trigger_responding_cops'
+    method = 'Kernel#public_send'
     cmd = "stackprof #{dump_path} --text --method '#{method}'"
     puts cmd
     output = `#{cmd}`
-    _header, list, _code = *output
-      .lines
-      .grep_v(/RuboCop::Cop::Commissioner/) # ignore internal calls
-      .slice_after { |line| line.match?(/callees.*:|code:/) }
+    list = output.lines.grep(/RuboCop::Cop::.+#on_\w+/)
     puts list.first(40)
   end
 


### PR DESCRIPTION
https://github.com/rubocop/rubocop/pull/8962 broke `rake prof:slow_cops`.

```
rake prof:slow_cops
```
**Before**
```
     182  (  100.0%)  Array#each
     181  (   99.5%)  Kernel#public_send
  code:
```
**After**
```
       9  (    4.9%)  RuboCop::Cop::Layout::RedundantLineBreak#on_send
       7  (    3.8%)  RuboCop::Cop::Layout::IndentationConsistency#on_begin
       6  (    3.3%)  RuboCop::Cop::Lint::DuplicateMethods#on_def
       6  (    3.3%)  RuboCop::Cop::MethodComplexity#on_def
       5  (    2.7%)  RuboCop::Cop::MultilineExpressionIndentation#on_send
... snip ...
```

cc @koic 