### PR TITLE
[Fix #10939] Fix an error for `Style/Next`

### DIFF
--- a/changelog/fix_an_error_for_style_next.md
+++ b/changelog/fix_an_error_for_style_next.md
@@ -1,0 +1,1 @@
+* [#10939](https://github.com/rubocop/rubocop/issues/10939): Fix an error for `Style/Next` when line break before condition. ([@koic][])

--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -225,11 +225,7 @@ module RuboCop
           adjustment = delta + @reindented_lines[lineno]
           @reindented_lines[lineno] = adjustment
 
-          if adjustment.positive?
-            corrector.remove_leading(buffer.line_range(lineno), adjustment)
-          elsif adjustment.negative?
-            corrector.insert_before(buffer.line_range(lineno), ' ' * -adjustment)
-          end
+          corrector.remove_leading(buffer.line_range(lineno), adjustment) if adjustment.positive?
         end
       end
     end

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -315,6 +315,27 @@ RSpec.describe RuboCop::Cop::Style::Next, :config do
       RUBY
     end
 
+    it 'registers an offense when line break before condition' do
+      expect_offense(<<~RUBY)
+        array.each do |item|
+          if
+          ^^ Use `next` to skip iteration.
+             condition
+            next if item.zero?
+            do_something
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.each do |item|
+          next unless condition
+            next if item.zero?
+            do_something
+        end
+      RUBY
+    end
+
     it 'allows loops with conditional break' do
       expect_no_offenses(<<~RUBY)
         loop do


### PR DESCRIPTION
Fixes #10939.

This PR fixes an error for `Style/Next` when line break before condition. The removed indentation logic can be delegated to `Layout/IndentationConsistency`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
