### PR TITLE
[Fix #10944] Fix an incorrect autocorrect for `Lint/LiteralInInterpolation`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_literal_in_interpolation.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_literal_in_interpolation.md
@@ -1,0 +1,1 @@
+* [#10944](https://github.com/rubocop/rubocop/issues/10944): Fix an incorrect autocorrect for `Lint/LiteralInInterpolation` when using `"#{nil}"`. ([@koic][])

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -58,6 +58,7 @@ module RuboCop
           (node.str_type? && !node.loc.respond_to?(:begin)) || node.source_range.is?('__LINE__')
         end
 
+        # rubocop:disable Metrics/MethodLength
         def autocorrected_value(node)
           case node.type
           when :int
@@ -70,10 +71,13 @@ module RuboCop
             autocorrected_value_for_symbol(node)
           when :array
             autocorrected_value_for_array(node)
+          when :nil
+            ''
           else
             node.source.gsub('"', '\"')
           end
         end
+        # rubocop:enable Metrics/MethodLength
 
         def autocorrected_value_for_string(node)
           if node.source.start_with?("'", '%q')

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation, :config do
   it_behaves_like('literal interpolation', '{"a" => "b"}', '{\"a\" => \"b\"}')
   it_behaves_like('literal interpolation', true)
   it_behaves_like('literal interpolation', false)
-  it_behaves_like('literal interpolation', 'nil')
+  it_behaves_like('literal interpolation', 'nil', '')
   it_behaves_like('literal interpolation', ':symbol', 'symbol')
   it_behaves_like('literal interpolation', ':"symbol"', 'symbol')
   it_behaves_like('literal interpolation', 1..2)


### PR DESCRIPTION
Fixes #10944.

This PR fixes an incorrect autocorrect for `Lint/LiteralInInterpolation` when using `"#{nil}"`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
