### PR TITLE
Fix `Style/SafeNavigation` for negated method call with a safe navigation

### DIFF
--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -123,7 +123,7 @@ module RuboCop
           return unless receiver == checked_variable
           return if use_var_only_in_unless_modifier?(node, checked_variable)
           return if chain_length(method_chain, method) > max_chain_length
-          return if unsafe_method_used?(method_chain, method) && !method.safe_navigation?
+          return if unsafe_method_used?(method_chain, method)
           return if method_chain.method?(:empty?)
 
           add_offense(node) { |corrector| autocorrect(corrector, node) }
@@ -250,7 +250,9 @@ module RuboCop
         end
 
         def unsafe_method?(send_node)
-          negated?(send_node) || send_node.assignment? || !send_node.dot?
+          negated?(send_node) ||
+            send_node.assignment? ||
+            (!send_node.dot? && !send_node.safe_navigation?)
         end
 
         def negated?(send_node)

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -116,6 +116,10 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
     expect_no_offenses('foo.baz = bar if foo')
   end
 
+  it 'allows an object check before a negated method call with a safe navigation' do
+    expect_no_offenses('obj && !obj&.do_something')
+  end
+
   it 'allows object checks in the condition of an elsif statement ' \
      'and a method call on that object in the body' do
     expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Running rubocop on
```ruby
link && !link&.persisted?
```

```
Scanning foobar.rb
An error occurred while Style/SafeNavigation cop was inspecting foobar.rb:11:54.
Expected a Parser::Source::Range, Comment or RuboCop::AST::Node, got NilClass
/Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/corrector.rb:91:in `to_range'
/Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/corrector.rb:100:in `check_range_validity'
/Users/fatkodima/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/parser-3.1.2.1/lib/parser/source/tree_rewriter.rb:398:in `combine'
/Users/fatkodima/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/parser-3.1.2.1/lib/parser/source/tree_rewriter.rb:207:in `wrap'
/Users/fatkodima/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/parser-3.1.2.1/lib/parser/source/tree_rewriter.rb:231:in `insert_before'
/Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/style/safe_navigation.rb:283:in `block in add_safe_nav_to_all_methods_in_chain'
/Users/fatkodima/Desktop/oss/rubocop-ast/lib/rubocop/ast/node.rb:588:in `visit_ancestors'
/Users/fatkodima/Desktop/oss/rubocop-ast/lib/rubocop/ast/node.rb:228:in `each_ancestor'
.....
```

It started to fail after https://github.com/rubocop/rubocop/pull/10929.