### PR TITLE
[Fix #10927] Fix a false positive for `Style/HashTransformKeys` and `Style/HashTransformValues`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_hash_transform_values.md
+++ b/changelog/fix_a_false_positive_for_style_hash_transform_values.md
@@ -1,0 +1,1 @@
+* [#10927](https://github.com/rubocop/rubocop/issues/10927): Fix a false positive for `Style/HashTransformKeys` and `Style/HashTransformValues` when not using transformed block argument. ([@koic][])

--- a/spec/rubocop/cop/style/hash_transform_keys_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_keys_spec.rb
@@ -156,6 +156,12 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
       expect_no_offenses('Hash[x.map {|k, v| [k.to_sym, foo(v)]}]')
     end
 
+    it 'does not flag _.map {...}.to_h when key block argument is unused' do
+      expect_no_offenses(<<~RUBY)
+        x.map {|_k, v| [v, v]}.to_h
+      RUBY
+    end
+
     it 'does not flag key transformation in the absence of to_h' do
       expect_no_offenses('x.map {|k, v| [k.to_sym, v]}')
     end
@@ -271,6 +277,12 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
     it 'does not flag `_.to_h{...}` when both key & value are transformed' do
       expect_no_offenses(<<~RUBY)
         x.to_h { |k, v| [k.to_sym, foo(v)] }
+      RUBY
+    end
+
+    it 'does not flag _.to_h {...} when key block argument is unused' do
+      expect_no_offenses(<<~RUBY)
+        x.to_h {|_k, v| [v, v]}
       RUBY
     end
 

--- a/spec/rubocop/cop/style/hash_transform_values_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_values_spec.rb
@@ -156,6 +156,12 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
       expect_no_offenses('Hash[x.map {|k, v| [k.to_sym, foo(v)]}]')
     end
 
+    it 'does not flag _.map {...}.to_h when value block argument is unused' do
+      expect_no_offenses(<<~RUBY)
+        x.map {|k, _v| [k, k]}.to_h
+      RUBY
+    end
+
     it 'does not flag value transformation in the absence of to_h' do
       expect_no_offenses('x.map {|k, v| [k, foo(v)]}')
     end
@@ -257,6 +263,12 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
     it 'does not flag `_.to_h{...}` when both key & value are transformed' do
       expect_no_offenses(<<~RUBY)
         x.to_h { |k, v| [k.to_sym, foo(v)] }
+      RUBY
+    end
+
+    it 'does not flag _.to_h {...} when value block argument is unused' do
+      expect_no_offenses(<<~RUBY)
+        x.to_h {|k, _v| [k, k]}
       RUBY
     end
 


### PR DESCRIPTION
Fixes #10927.

This PR fixes a false positive for `Style/HashTransformKeys` and `Style/HashTransformValues` when not using transformed block argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
