### PR TITLE
[Fix #10951] Fix an autocorrection error for `Lint/EmptyConditionalBody` when some conditional branch is empty

### DIFF
--- a/changelog/fix_fix_an_autocorrection_error_for_lint_empty_conditional_body.md
+++ b/changelog/fix_fix_an_autocorrection_error_for_lint_empty_conditional_body.md
@@ -1,0 +1,1 @@
+* [#10951](https://github.com/rubocop/rubocop/issues/10951): Fix an autocorrection error for `Lint/EmptyConditionalBody` when some conditional branch is empty. ([@ydah][])

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -24,17 +24,65 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
   it 'registers an offense for missing `elsif` body' do
     expect_offense(<<~RUBY)
       if condition
-        do_something
-      elsif other_condition
-      ^^^^^^^^^^^^^^^^^^^^^ Avoid `elsif` branches without a body.
+        do_something1
+      elsif other_condition1
+      ^^^^^^^^^^^^^^^^^^^^^^ Avoid `elsif` branches without a body.
+      elsif other_condition2
+        do_something2
       end
     RUBY
 
     expect_correction(<<~RUBY)
       if condition
+        do_something1
+      elsif other_condition2
+        do_something2
+      end
+    RUBY
+  end
+
+  it 'registers an offense for missing `if` and `elsif` body' do
+    expect_offense(<<~RUBY)
+      if condition
+      ^^^^^^^^^^^^ Avoid `if` branches without a body.
+      elsif other_condition1
+      ^^^^^^^^^^^^^^^^^^^^^^ Avoid `elsif` branches without a body.
+      elsif other_condition2
         do_something
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      if other_condition2
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense for missing all branches of `if` and `elsif` body' do
+    expect_offense(<<~RUBY)
+      if condition
+      ^^^^^^^^^^^^ Avoid `if` branches without a body.
+      elsif other_condition
+      ^^^^^^^^^^^^^^^^^^^^^ Avoid `elsif` branches without a body.
+      end
+    RUBY
+
+    expect_correction('')
+  end
+
+  it 'registers an offense for missing all branches of `if` and multiple `elsif` body' do
+    expect_offense(<<~RUBY)
+      if condition
+      ^^^^^^^^^^^^ Avoid `if` branches without a body.
+      elsif other_condition1
+      ^^^^^^^^^^^^^^^^^^^^^^ Avoid `elsif` branches without a body.
+      elsif other_condition2
+      ^^^^^^^^^^^^^^^^^^^^^^ Avoid `elsif` branches without a body.
+      end
+    RUBY
+
+    expect_correction('')
   end
 
   it 'registers an offense for missing `if` body with `else`' do


### PR DESCRIPTION
Fix: #10951

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
