### PR TITLE
[Fix #10919] Fix a huge performance regression between 1.32.0 and 1.33.0

### DIFF
--- a/changelog/fix_fix_a_huge_performance_regression.md
+++ b/changelog/fix_fix_a_huge_performance_regression.md
@@ -1,0 +1,1 @@
+* [#10919](https://github.com/rubocop/rubocop/issues/10919): Fix a huge performance regression between 1.32.0 and 1.33.0. ([@ydah][])

--- a/lib/rubocop/cop/mixin/allowed_methods.rb
+++ b/lib/rubocop/cop/mixin/allowed_methods.rb
@@ -17,16 +17,21 @@ module RuboCop
 
       # @api public
       def allowed_methods
-        deprecated_values = cop_config_deprecated_values
-        if deprecated_values.any?(Regexp)
-          cop_config.fetch('AllowedMethods', [])
+        if cop_config_deprecated_values.any?(Regexp)
+          cop_config_allowed_methods
         else
-          Array(cop_config['AllowedMethods']).concat(deprecated_values)
+          cop_config_allowed_methods + cop_config_deprecated_values
         end
       end
 
+      def cop_config_allowed_methods
+        @cop_config_allowed_methods ||= Array(cop_config.fetch('AllowedMethods', []))
+      end
+
       def cop_config_deprecated_values
-        Array(cop_config['IgnoredMethods']).concat(Array(cop_config['ExcludedMethods']))
+        @cop_config_deprecated_values ||=
+          Array(cop_config.fetch('IgnoredMethods', [])) +
+          Array(cop_config.fetch('ExcludedMethods', []))
       end
     end
     # @deprecated IgnoredMethods class has been replaced with AllowedMethods.

--- a/lib/rubocop/cop/mixin/allowed_pattern.rb
+++ b/lib/rubocop/cop/mixin/allowed_pattern.rb
@@ -30,15 +30,23 @@ module RuboCop
       def allowed_patterns
         # Since there could be a pattern specified in the default config, merge the two
         # arrays together.
-        patterns = Array(cop_config['AllowedPatterns']).concat(Array(cop_config['IgnoredPatterns']))
-        deprecated_values = cop_config_deprecated_methods_values
-        return patterns unless deprecated_values.any?(Regexp)
+        if cop_config_deprecated_methods_values.any?(Regexp)
+          cop_config_patterns_values + cop_config_deprecated_methods_values
+        else
+          cop_config_patterns_values
+        end
+      end
 
-        Array(patterns.concat(deprecated_values))
+      def cop_config_patterns_values
+        @cop_config_patterns_values ||=
+          Array(cop_config.fetch('AllowedPatterns', [])) +
+          Array(cop_config.fetch('IgnoredPatterns', []))
       end
 
       def cop_config_deprecated_methods_values
-        Array(cop_config['IgnoredMethods']).concat(Array(cop_config['ExcludedMethods']))
+        @cop_config_deprecated_methods_values ||=
+          Array(cop_config.fetch('IgnoredMethods', [])) +
+          Array(cop_config.fetch('ExcludedMethods', []))
       end
     end
 


### PR DESCRIPTION
Fix: #10919

Before:
- 1.32.0 (using Parser 3.1.2.1, rubocop-ast 1.21.0, running on ruby 2.7.2 x86_64-darwin21)

`bundle exec rubocop --cache false --only   16.83s user 1.30s system 93% cpu 19.320 total`

- 1.35.0 (using Parser 3.1.2.1, rubocop-ast 1.21.0, running on ruby 2.7.2 x86_64-darwin21)

`bundle exec rubocop --cache false --only   1255.21s user 5.32s system 71% cpu 29:17.76 total`

After:

`bundle exec rubocop --cache false --only 16.64s user 1.25s system 94% cpu 19.002 total`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
