### PR TITLE
Workaround for a build error of formatter_set_spec.rb  in the windows mingw CI matrix

### DIFF
--- a/spec/rubocop/formatter/formatter_set_spec.rb
+++ b/spec/rubocop/formatter/formatter_set_spec.rb
@@ -60,6 +60,9 @@ RSpec.describe RuboCop::Formatter::FormatterSet do
         after { FileUtils.rm_rf(tmpdir) }
 
         it 'creates them' do
+          # FIXME: Skips this spec to prevent `Errno::EACCES` error in mingw CI matrix.
+          skip if ENV['GITHUB_JOB'] == 'main' && ENV['MSYSTEM'] == 'MINGW64'
+
           output_path = File.join(tmpdir, 'path/does/not/exist')
           formatter_set.add_formatter('simple', output_path)
           expect(formatter_set.first.output.class).to eq(File)


### PR DESCRIPTION
This PR skips the following build error of formatter_set_spec.rb in the windows mingw CI matrix.

```console
Failures:

  1) RuboCop::Formatter::FormatterSet add_formatter when output path is specified when parent directories don't exist creates them
     Failure/Error: after { FileUtils.rm_rf(tmpdir) }

     Errno::EACCES:
       Permission denied @ apply2files - D:/a/_temp/d20220824-1696-gdx8qj/path/does/not/exist
     # ./spec/rubocop/formatter/formatter_set_spec.rb:60:in `block (5 levels) in <top (required)>'
     # tasks/spec_runner.rake:40:in `block in run_specs'
     # tasks/spec_runner.rake:52:in `with_encoding'
     # tasks/spec_runner.rake:36:in `run_specs'
     # tasks/spec_runner.rake:165:in `block in <top (required)>'

Finished in 2 minutes 34.9 seconds (files took 3.68 seconds to load)
18699 examples, 1 failure, 15 pending
```

https://github.com/rubocop/rubocop/runs/7986996059

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
