### PR TITLE
[Fix #10958] Fix an infinite loop for `Layout/SpaceInsideBlockBraces` when multiline block

### DIFF
--- a/changelog/fix_fix_an_infinite_loop_for_layout_space_inside_block_braces.md
+++ b/changelog/fix_fix_an_infinite_loop_for_layout_space_inside_block_braces.md
@@ -1,0 +1,1 @@
+* [#10958](https://github.com/rubocop/rubocop/issues/10958): Fix an infinite loop for `Layout/SpaceInsideBlockBraces` when `EnforcedStyle` is `no_space` and using multiline block. ([@ydah][])

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -387,8 +387,37 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
           expect_offense(<<~RUBY)
             items.map {|item|
               item.do_something
-                               ^{} Space inside } detected.
               }
+            ^^ Space inside } detected.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            items.map {|item|
+              item.do_something
+            }
+          RUBY
+        end
+
+        it 'accepts when braces are aligned in multiline block with bracket' do
+          expect_no_offenses(<<~RUBY)
+            foo {[
+              bar
+            ]}
+          RUBY
+        end
+
+        it 'registers an offense when braces are not aligned in multiline block with bracket' do
+          expect_offense(<<~RUBY)
+            foo {[
+              bar
+              ]}
+            ^^ Space inside } detected.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo {[
+              bar
+            ]}
           RUBY
         end
       end


### PR DESCRIPTION
Fix: #10958

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
