### PR TITLE
[Fix #10963] Fix a false positive for `Layout/IndentationWidth`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_indentation_width.md
+++ b/changelog/fix_a_false_positive_for_layout_indentation_width.md
@@ -1,0 +1,1 @@
+* [#10963](https://github.com/rubocop/rubocop/issues/10963): Fix a false positive for `Layout/IndentationWidth` when using aligned empty `else` in pattern matching. ([@koic][])

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -148,7 +148,9 @@ module RuboCop
             check_indentation(in_pattern_node.loc.keyword, in_pattern_node.body)
           end
 
-          check_indentation(case_match.in_pattern_branches.last.loc.keyword, case_match.else_branch)
+          else_branch = case_match.else_branch&.empty_else_type? ? nil : case_match.else_branch
+
+          check_indentation(case_match.in_pattern_branches.last.loc.keyword, else_branch)
         end
 
         def on_if(node, base = node)

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -915,6 +915,16 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         RUBY
       end
 
+      it 'accepts aligned value in `in` clause and `else` is empty' do
+        expect_no_offenses(<<~'RUBY')
+          case x
+          in 42
+            foo
+          else
+          end
+        RUBY
+      end
+
       it 'accepts case/in/else laid out as a table' do
         expect_no_offenses(<<~RUBY)
           case sexp.loc.keyword.source


### PR DESCRIPTION
Fixes #10963.

This PR fixes a false positive for `Layout/IndentationWidth` when using aligned empty `else` in pattern matching.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
