### PR TITLE
Windows specs - remove references to File objects before unlinking

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,7 @@
 name: Linting
 on:
   - pull_request
+  - workflow_dispatch
 jobs:
   yamllint:
     name: Yamllint

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
   main:

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ doc
 .bundle
 Gemfile.lock
 Gemfile.local
+vendor/
 
 # rbenv
 .ruby-version


### PR DESCRIPTION
Commits:

Three commits, first is a spec fix, next two make working in a fork easier.

1. 'formatter/formatter_set_spec.rb - remove references to file IO on Windows' - Windows will error if a file is deleted when references to its File object exist.  Removes the 'skip' code from PR #10955.

2. '.gitignore - add `vendor/` for local development' - if one prefers to `bundle install` within the repo, this is the standard folder.

3. `Actions - add workflow_dispatch for use in forks` - Currently, running `linting.yml` and `rubocop.yml` are difficult to run in a fork.  `workflow_dispatch` allows an owner/maintainer to force a workflow to run on any branch.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
