### PR TITLE
Add autocorrect support to `Style/AccessModifierDeclarations`

### DIFF
--- a/changelog/change_add_autocorrect_support_to.md
+++ b/changelog/change_add_autocorrect_support_to.md
@@ -1,0 +1,1 @@
+* [#10966](https://github.com/rubocop/rubocop/pull/10966): Add autocorrect support to `Style/AccessModifierDeclarations`. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2949,6 +2949,7 @@ Style/AccessModifierDeclarations:
     - inline
     - group
   AllowModifiersOnSymbols: true
+  SafeAutoCorrect: false
 
 Style/AccessorGrouping:
   Description: 'Checks for grouping of accessors in `class` and `module` bodies.'


### PR DESCRIPTION
I would like to change `Style/AccessModifierDeclarations` to be able to autocorrect.

I made a little effort about indentation and empty lines with `RuboCop::Cop::RangeHelp#range_by_whole_lines` and some other treatments, but it does not handle them perfectly. They should be autocorrected by other Layout cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
