### PR TITLE
Actions - use --no-color so 'web ui' shows logs for RSpec steps

### DIFF
--- a/tasks/spec_runner.rake
+++ b/tasks/spec_runner.rake
@@ -23,7 +23,7 @@ module RuboCop
 
     def initialize(rspec_args = %w[spec --force-color], parallel: true,
                    external_encoding: 'UTF-8', internal_encoding: nil)
-      @rspec_args = rspec_args
+      @rspec_args = ENV['GITHUB_ACTIONS'] == 'true' ? %w[spec --no-color] : rspec_args
       @previous_external_encoding = Encoding.default_external
       @previous_internal_encoding = Encoding.default_internal
 


### PR DESCRIPTION
Currently, the `spec` & `ascii_spec` steps in GitHub Actions are rendered in color by RSpec.   That adds a lot of characters to the 'dot' output, and for whatever reason, GitHub Actions doesn't display the logs of those steps in the web ui.

Actions defines an ENV variable `GITHUB_ACTIONS`.  Use it to switch RSpec output to `--no-color`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
