### PR TITLE
[Fix #10962] Fix a false positive for `Lint/ShadowingOuterLocalVariable` when conditional with if/elsif/else branches

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_shadowing_outer_local_variable.md
+++ b/changelog/fix_a_false_positive_for_lint_shadowing_outer_local_variable.md
@@ -1,0 +1,1 @@
+* [#10962](https://github.com/rubocop/rubocop/pull/10962): Fix a false positive for `Lint/ShadowingOuterLocalVariable` when conditional with if/elsif/else branches. ([@ydah][])

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -64,14 +64,26 @@ module RuboCop
         end
 
         def same_conditions_node_different_branch?(variable, outer_local_variable)
-          variable_node = variable.scope.node.parent
+          variable_node = variable_node(variable)
           return false unless variable_node.conditional?
 
           outer_local_variable_node =
             find_conditional_node_from_ascendant(outer_local_variable.declaration_node)
           return true unless outer_local_variable_node
 
-          outer_local_variable_node.conditional? && variable_node == outer_local_variable_node
+          outer_local_variable_node.conditional? &&
+            (variable_node == outer_local_variable_node ||
+              variable_node == outer_local_variable_node.else_branch)
+        end
+
+        def variable_node(variable)
+          parent_node = variable.scope.node.parent
+
+          if parent_node.when_type?
+            parent_node.parent
+          else
+            parent_node
+          end
         end
 
         def find_conditional_node_from_ascendant(node)

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -111,6 +111,9 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
                            ^^^ Shadowing outer local variable - `foo`.
               end
             end
+          elsif other_condition?
+            bar.each do |foo|
+            end
           else
             bar.each do |foo|
             end
@@ -152,6 +155,9 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
             bar.each do |foo|
                          ^^^ Shadowing outer local variable - `foo`.
             end
+          when bar then
+            bar.each do |foo|
+            end
           else
             bar.each do |foo|
             end
@@ -168,6 +174,9 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
         def some_method
           if condition?
             foo = 1
+          elsif other_condition?
+            bar.each do |foo|
+            end
           else
             bar.each do |foo|
             end


### PR DESCRIPTION
Fix: #10962

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
