### PR TITLE
[Fix rubocop#10969] Allow `Lint/AmbiguousBlockAssociation` `AllowedPa…

### DIFF
--- a/changelog/fix_allow_ambigious_block_association_to_match_source.md
+++ b/changelog/fix_allow_ambigious_block_association_to_match_source.md
@@ -1,0 +1,1 @@
+* [#10969](https://github.com/rubocop/rubocop/issues/10969): Fix a false negative for `AllowedPatterns` of `Lint/AmbiguousBlockAssociation` when using a method chain. ([@jcalvert][])

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -81,7 +81,7 @@ module RuboCop
         def allowed_method_pattern?(node)
           node.assignment? || node.operator_method? || node.method?(:[]) ||
             allowed_method?(node.last_argument.method_name) ||
-            matches_allowed_pattern?(node.last_argument.method_name)
+            matches_allowed_pattern?(node.last_argument.send_node.source)
         end
 
         def message(send_node)

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -104,12 +104,15 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
   end
 
   context 'when AllowedPatterns is enabled' do
-    let(:cop_config) { { 'AllowedPatterns' => [/change/] } }
+    let(:cop_config) { { 'AllowedPatterns' => [/change/, /receive\(.*?\)\.twice/] } }
 
     it 'does not register an offense for an allowed method' do
       expect_no_offenses(<<~RUBY)
-        expect { order.expire }.to change { order.events }
         expect { order.expire }.to not_change { order.events }
+      RUBY
+
+      expect_no_offenses(<<~RUBY)
+        expect(order).to receive(:complete).twice { OrderCount.update! }
       RUBY
     end
 


### PR DESCRIPTION
[Fix rubocop#10969] Allow `Lint/AmbiguousBlockAssociation` `AllowedPattern` to match on

`send_node.source` instead of `method_name`


-----------------


* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
