### PR TITLE
Fix some wrong backtick use in Asciidoc documents

### DIFF
--- a/lib/rubocop/cop/lint/duplicate_require.rb
+++ b/lib/rubocop/cop/lint/duplicate_require.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Checks for duplicate `require`s and `require_relative`s.
+      # Checks for duplicate ``require``s and ``require_relative``s.
       #
       # @safety
       #   This cop's autocorrection is unsafe because it may break the dependency order

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -12,7 +12,7 @@ module RuboCop
       # same `rescue` statement. In both cases, the more specific rescue is
       # unnecessary because it is covered by rescuing the less specific
       # exception. (ie. `rescue Exception, StandardError` has the same behavior
-      # whether `StandardError` is included or not, because all `StandardError`s
+      # whether `StandardError` is included or not, because all ``StandardError``s
       # are rescued by `rescue Exception`).
       #
       # @example

--- a/lib/rubocop/cop/lint/unreachable_loop.rb
+++ b/lib/rubocop/cop/lint/unreachable_loop.rb
@@ -9,7 +9,7 @@ module RuboCop
       # In rare cases where only one iteration (or at most one iteration) is intended behavior,
       # the code should be refactored to use `if` conditionals.
       #
-      # NOTE: Block methods that are used with `Enumerable`s are considered to be loops.
+      # NOTE: Block methods that are used with ``Enumerable``s are considered to be loops.
       #
       # `AllowedPatterns` can be used to match against the block receiver in order to allow
       # code that would otherwise be registered as an offense (eg. `times` used not in an

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -11,7 +11,7 @@ module RuboCop
       # These are customizable with `AllowedMethods` option.
       #
       # @safety
-      #   This cop is unsafe because `proc`s and blocks work differently
+      #   This cop is unsafe because ``proc``s and blocks work differently
       #   when additional arguments are passed in. A block will silently
       #   allow additional arguments, but a `proc` will raise
       #   an `ArgumentError`.


### PR DESCRIPTION
I found some documentation pages are wrongly rendered.

This is due to incorrect use of backtick in Asciidoc. If you want to insert character immediately after the code element without any spaces, you need to write a double backtick like this.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/