### PR TITLE
Fix wrong asterisk use in `Lint/UselessRuby2Keywords` document

### DIFF
--- a/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
+++ b/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Looks for `ruby2_keywords` calls for methods that do not need it.
       #
       # `ruby2_keywords` should only be called on methods that accept an argument splat
-      # (`*args`) but do not explicit keyword arguments (`k:` or `k: true`) or
+      # (`\*args`) but do not explicit keyword arguments (`k:` or `k: true`) or
       # a keyword splat (`**kwargs`).
       #
       # @example


### PR DESCRIPTION
I found a problem with the `UselessRuby2Keywords` cop documentation page not rendered well.

- https://docs.rubocop.org/rubocop/1.34/cops_lint.html#lintuselessruby2keywords

### Before

Look around the `<strong>` element.

```html
<p><code>ruby2_keywords</code> should only be called on methods that accept an argument splat
(<code><strong>args</code>) but do not explicit keyword arguments (<code>k:</code> or <code>k: true</code>) or
a keyword splat (<code></strong>*kwargs</code>).</p>
```

### After

```html
<p><code>ruby2_keywords</code> should only be called on methods that accept an argument splat
(<code>*args</code>) but do not explicit keyword arguments (<code>k:</code> or <code>k: true</code>) or
a keyword splat (<code>**kwargs</code>).</p>
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
