### PR TITLE
Improve safety section on `Style/SymbolProc`

### DIFF
--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -11,10 +11,11 @@ module RuboCop
       # These are customizable with `AllowedMethods` option.
       #
       # @safety
-      #   This cop is unsafe because ``proc``s and blocks work differently
-      #   when additional arguments are passed in. A block will silently
-      #   allow additional arguments, but a `proc` will raise
-      #   an `ArgumentError`.
+      #   This cop is unsafe because there is a difference that a `Proc`
+      #   generated from `Symbol#to_proc` behaves as a lambda, while
+      #   a `Proc` generated from a block does not.
+      #   For example, a lambda will raise an `ArgumentError` if the
+      #   number of arguments is wrong, but a non-lambda `Proc` will not.
       #
       #   For example:
       #


### PR DESCRIPTION
Since `Symbol#to_proc` is a bit difficult concept to understand in Ruby and is often tripped up by beginners, I thought it would be better to document it more precisely.

The original text explains it as follows:

> ``proc``s and blocks work differently

but this is not a very appropriate explanation I think, since both equally create an instance of the `Proc` class, so it is not reasonable to explain them as opposites. And worse, Ruby also has a keyword `proc`, so it is better to avoid using this word in a way that could be misinterpreted as a keyword as much as possible.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
