### PR TITLE
Fix possible wrong autocorrection in namespace on `Style/PerlBackrefs`

### DIFF
--- a/changelog/fix_possible_wrong_autocorrection_in_namespace_on.md
+++ b/changelog/fix_possible_wrong_autocorrection_in_namespace_on.md
@@ -1,0 +1,1 @@
+* [#10975](https://github.com/rubocop/rubocop/pull/10975): Fix possible wrong autocorrection in namespace on `Style/PerlBackrefs`. ([@r7kamura][])

--- a/lib/rubocop/cop/style/perl_backrefs.rb
+++ b/lib/rubocop/cop/style/perl_backrefs.rb
@@ -85,8 +85,29 @@ module RuboCop
 
         # @private
         # @param [RuboCop::AST::Node] node
+        # @return [String, nil]
+        def preferred_expression_to_node_with_constant_prefix(node)
+          expression = preferred_expression_to(node)
+          return unless expression
+
+          "#{constant_prefix(node)}#{expression}"
+        end
+
+        # @private
+        # @param [RuboCop::AST::Node] node
+        # @return [String]
+        def constant_prefix(node)
+          if node.each_ancestor(:class, :module).any?
+            '::'
+          else
+            ''
+          end
+        end
+
+        # @private
+        # @param [RuboCop::AST::Node] node
         def on_back_ref_or_gvar_or_nth_ref(node)
-          preferred_expression = preferred_expression_to(node)
+          preferred_expression = preferred_expression_to_node_with_constant_prefix(node)
           return unless preferred_expression
 
           add_offense(

--- a/spec/rubocop/cop/style/perl_backrefs_spec.rb
+++ b/spec/rubocop/cop/style/perl_backrefs_spec.rb
@@ -143,4 +143,25 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
       /#{Regexp.last_match(1)}/
     RUBY
   end
+
+  it 'autocorrects $1 to ::Regexp.last_match(1) in namespace' do
+    expect_offense(<<~RUBY)
+      module Foo
+        class Regexp
+        end
+
+        puts $1
+             ^^ Prefer `::Regexp.last_match(1)` over `$1`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module Foo
+        class Regexp
+        end
+
+        puts ::Regexp.last_match(1)
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Inserting constants in the code without `::` prefix may cause problems in situations where `Module.nesting` is not empty, as the test case I added describes.

In order to eliminate the possibility of such unsafe autocorrection, it would be better to prepend `::`, even if it looks a bit verbose.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
