### PR TITLE
Add a spec for server mode

### DIFF
--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
 
   include_context 'cli spec behavior'
 
+  after do
+    `ruby -I . "#{rubocop}" --stop-server`
+  end
+
   if RuboCop::Server.support_server?
     context 'when using `--server` option after updating RuboCop' do
       before do
@@ -14,10 +18,6 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
         # Emulating RuboCop updates. `0.99.9` is a version value for testing that
         # will never be used in the real world RuboCop version.
         RuboCop::Server::Cache.write_version_file('0.99.9')
-      end
-
-      after do
-        `ruby -I . "#{rubocop}" --stop-server`
       end
 
       it 'displays a restart information message' do
@@ -35,6 +35,47 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
         expect(`ruby -I . "#{rubocop}" #{options}`).to start_with(
           'RuboCop version incompatibility found, RuboCop server restarting...'
         )
+      end
+    end
+
+    context 'when using `--server` option after running server and updating configuration' do
+      it 'applies .rubocop.yml configuration changes even during server startup' do
+        # FIXME: Avoid flaky test for RSpec 4. It may be related that test-queue is not available.
+        # https://github.com/rubocop/rubocop/pull/10806#discussion_r918415067
+        skip if ENV['GITHUB_JOB'] == 'rspec4'
+
+        create_file('example.rb', <<~RUBY)
+          x = 0
+          puts x
+        RUBY
+
+        # Disable `Style/FrozenStringLiteralComment` cop.
+        create_file('.rubocop.yml', <<~RUBY)
+          AllCops:
+            NewCops: enable
+            SuggestExtensions: false
+          Style/FrozenStringLiteralComment:
+            Enabled: false
+        RUBY
+
+        message = expect(`ruby -I . "#{rubocop}" --server`)
+        message.to start_with('RuboCop server starting on ')
+        message.to include('no offenses')
+
+        # Enable `Style/FrozenStringLiteralComment` cop.
+        create_file('.rubocop.yml', <<~RUBY)
+          AllCops:
+            NewCops: enable
+            SuggestExtensions: false
+          Style/FrozenStringLiteralComment:
+            Enabled: true
+        RUBY
+
+        message = expect(`ruby -I . "#{rubocop}" --server`)
+        message.not_to start_with('RuboCop server starting on ')
+        message.to include(<<~OFFENSE_DETECTED)
+          Style/FrozenStringLiteralComment: Missing frozen string literal comment.
+        OFFENSE_DETECTED
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR adds a spec for server mode that applies .rubocop.yml configuration changes even during server startup.

This is already achieved because the server loads .rubocop.yml configuration for each analysis request from the client.

## Other Information

The feature mentioned in the following article has been implemented for configuration change of .rubocop.yml.

> You should keep in mind that you'll need to restart the server manually
> if you change RuboCop's configuration.

https://metaredux.com/posts/2022/07/26/rubocop-serves-much-faster.html

The test this PR adds ensure that behavior.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
