### PR TITLE
[Fix #10979] Fix a false positive for `Style/Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_parentheses.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#10979](https://github.com/rubocop/rubocop/issues/10979): Fix a false positive for `Style/Style/RedundantParentheses` when using parentheses in method call with pin operator. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -58,7 +58,8 @@ module RuboCop
           allowed_ancestor?(node) ||
             allowed_method_call?(node) ||
             allowed_multiple_expression?(node) ||
-            allowed_ternary?(node)
+            allowed_ternary?(node) ||
+            allowed_pin_operator?(node)
         end
 
         def allowed_ancestor?(node)
@@ -84,6 +85,10 @@ module RuboCop
           return unless node&.parent&.if_type?
 
           node.parent.ternary? && ternary_parentheses_required?
+        end
+
+        def allowed_pin_operator?(node)
+          node&.parent&.pin_type? && node.children.first.call_type?
         end
 
         def ternary_parentheses_required?

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -626,4 +626,33 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
       ]
     RUBY
   end
+
+  context 'pin operator', :ruby31 do
+    it 'does not register an offense when using parentheses in method call with pin operator' do
+      expect_no_offenses(<<~RUBY)
+        foo in { bar: ^(baz.to_i) }
+      RUBY
+    end
+
+    it 'does not register an offense when using parentheses in safe navigation method call with pin operator' do
+      expect_no_offenses(<<~RUBY)
+        foo in { bar: ^(baz&.to_i) }
+      RUBY
+    end
+
+    it 'registers an offense when using parentheses in lvar with pin operator' do
+      expect_offense(<<~RUBY)
+        baz = 42
+
+        foo in { bar: ^(baz) }
+                       ^^^^^ Don't use parentheses around a variable.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        baz = 42
+
+        foo in { bar: ^baz }
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #10979.

This PR fixes a false positive for `Style/Style/RedundantParentheses` when using parentheses in method call with pin operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
