### PR TITLE
[Fix #10979] Fix a false positive for `Style/Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_parentheses.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#10979](https://github.com/rubocop/rubocop/issues/10979): Fix a false positive for `Style/RedundantParentheses` when using parentheses with pin operator except for variables. ([@Tietew][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -29,6 +29,9 @@ module RuboCop
         # @!method rescue?(node)
         def_node_matcher :rescue?, '{^resbody ^^resbody}'
 
+        # @!method allowed_pin_operator?(node)
+        def_node_matcher :allowed_pin_operator?, '^(pin (begin !{lvar ivar cvar gvar}))'
+
         # @!method arg_in_call_with_block?(node)
         def_node_matcher :arg_in_call_with_block?, '^^(block (send _ _ equal?(%0) ...) ...)'
 
@@ -44,6 +47,7 @@ module RuboCop
           empty_parentheses?(node) ||
             first_arg_begins_with_hash_literal?(node) ||
             rescue?(node) ||
+            allowed_pin_operator?(node) ||
             allowed_expression?(node)
         end
 


### PR DESCRIPTION
Fixes #10979.

This PR fixes a false positive for `Style/RedundantParentheses` when using parentheses with pin operator except for variables.

This PR also allows literals because:
`foo in { bar: ^(1) }` should be corrected to `foo in { bar: 1 }`.
`foo in { bar: ^([1]) }` should be corrected to `foo in { bar: [1] }`.
`foo in { bar: ^([var]) }` should be allowed because `foo in { bar: [var] }` performs capture.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
