### PR TITLE
Do not omit parentheses for calls in assignments in conditional branches

### DIFF
--- a/changelog/fix_parens_in_assignments_in_condition.md
+++ b/changelog/fix_parens_in_assignments_in_condition.md
@@ -1,0 +1,1 @@
+* [#10982](https://github.com/rubocop/rubocop/pull/10982): Do not autocorrect parentheses for calls in assignments in conditional branches for `Style/MethodCallWithArgsParentheses` with `omit_parentheses`. ([@gsamokovarov][])

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -829,6 +829,19 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    it 'accepts parens in assignment in conditions' do
+      expect_no_offenses(<<-RUBY)
+        case response = get("server/list")
+        when server = response.take(1)
+          if @size ||= server.take(:size)
+            pass
+          elsif @@image &&= server.take(:image)
+            pass
+          end
+        end
+      RUBY
+    end
+
     it 'autocorrects single-line calls' do
       expect_offense(<<~RUBY)
         top.test(1, 2, foo: bar(3))


### PR DESCRIPTION
Parentheses are required in assignments that call methods in conditional branches. Removing them is a syntax error and the `Style/MethodCallWithArgsParentheses` cop with the style of `omit_parentheses` has been doing just that during autocorrection.

Here is an example that needs the parentheses but is improperly autocorrected:

```ruby
if success = destroy_remote(server)
  delete server
end
```

Removing them, as the autocorrection does, is a syntax error:

```ruby
if success = destroy_remote server # 💣
  delete server
end
```

Such is the case for any assignment or shorthand assignment in any Ruby conditional.