### PR TITLE
Improve singleton method example on `Lint/UselessAccessModifier` cop

### DIFF
--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -31,8 +31,8 @@ module RuboCop
       #   # bad
       #   class Foo
       #     # The following is redundant (methods defined on the class'
-      #     # singleton class are not affected by the public modifier)
-      #     public
+      #     # singleton class are not affected by the private modifier)
+      #     private
       #
       #     def self.method3
       #     end


### PR DESCRIPTION
It is not appropriate to use `public` in this example.

```ruby
# bad
class Foo
  public

  def self.method3
  end
end
```

As explained in the previous example, the access is `public` by default, which makes no sense regardless of whether it is a singleton method or not.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
