### PR TITLE
Add autocorrect for `Style/StaticClass`

### DIFF
--- a/changelog/new_add_autocorrect_for_style_static_class.md
+++ b/changelog/new_add_autocorrect_for_style_static_class.md
@@ -1,0 +1,1 @@
+* Add autocorrect for `Style/StaticClass`. ([@FnControlOption][])

--- a/spec/rubocop/cop/style/static_class_spec.rb
+++ b/spec/rubocop/cop/style/static_class_spec.rb
@@ -8,6 +8,14 @@ RSpec.describe RuboCop::Cop::Style::StaticClass, :config do
         def self.class_method; end
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      module C
+      module_function
+
+        def class_method; end
+      end
+    RUBY
   end
 
   it 'registers an offense when class has `class << self` with class methods' do
@@ -19,6 +27,18 @@ RSpec.describe RuboCop::Cop::Style::StaticClass, :config do
         class << self
           def other_class_method; end
         end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module C
+      module_function
+
+        def class_method; end
+
+       #{trailing_whitespace}
+          def other_class_method; end
+       #{trailing_whitespace}
       end
     RUBY
   end
@@ -42,6 +62,16 @@ RSpec.describe RuboCop::Cop::Style::StaticClass, :config do
         CONST = 1
 
         def self.class_method; end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module C
+      module_function
+
+        CONST = 1
+
+        def class_method; end
       end
     RUBY
   end
@@ -101,6 +131,15 @@ RSpec.describe RuboCop::Cop::Style::StaticClass, :config do
       ^^^^^^^ Prefer modules to classes with only class methods.
         extend M
         def self.class_method; end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module C
+      module_function
+
+        extend M
+        def class_method; end
       end
     RUBY
   end


### PR DESCRIPTION
Bad:

```rb
class SomeClass
  def self.some_method
    # body omitted
  end

  class << self
    def some_other_method
      # body omitted
    end
  end
end
```

Autocorrect:

1. Change `class` -> `module` and add `module_function`
3. Delete `self.` in method definitions
4. Unwrap `class << self`

```rb
module SomeModule
  module_function

  def some_method
    # body omitted
  end

  def some_other_method
    # body omitted
  end
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
