### PR TITLE
Opt-in cop compatibility in redundant directives

### DIFF
--- a/changelog/new_optin_cop_compatibility_in_redundant.md
+++ b/changelog/new_optin_cop_compatibility_in_redundant.md
@@ -1,0 +1,1 @@
+* [#10987](https://github.com/rubocop/rubocop/pull/10987): Opt-in cop compatibility in redundant directives. ([@tdeo][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -730,6 +730,63 @@ Do not write anything other than cop name in the disabling comment. E.g.:
 # rubocop:disable Layout/LineLength --This is a bad comment that includes other than cop name.
 ----
 
+== Temporarily enabling cops in source code
+
+In a similar way to disabling cops within source code, you can also temporarily enable specific
+cops if you want to enforce specific rules for part of the totality of a file.
+
+Let's use the cop `Style/AsciiComments`, which is by default `Enabled: false`. If you want a
+specific file to have ASCII-only comments to be compatible with some specific post-processing.
+
+[source,ruby]
+----
+# rubocop:enable Style/AsciiComments
+# If applicable, leave a comment to others explaining the rationale:
+# We need the comments to remain ASCII only for compatibility with lib/post_processor.rb
+
+class Restaurant
+  # This comment has to be ASCII-only because of the rubocop:enable directive
+  def menu
+    return dishes.map(&:humanize)
+  end
+end
+----
+
+You can also enforce the same for part of a file by disabling the cop afterwards
+
+[source,ruby]
+----
+class Dish
+  def humanize
+    return [
+      "Delicious #{self.name}"
+      *ingredients
+    ].join("\n")
+  end
+end
+
+# rubocop:enable Style/AsciiComments
+# If applicable, leave a comment to others explaining the rationale:
+# We need the comments to remain ASCII only for compatibility with lib/post_processor.rb
+
+class Restaurant
+  # This comment has to be ASCII-only because of the rubocop:enable directive
+  def menu
+    return dishes.map(&:humanize)
+  end
+end
+
+# rubocop:disable Style/AsciiComments
+
+class Ingredient
+  # Notice how the comment below is non-ASCII
+  # Gets rid of odd characters like 😀, ͸
+  def sanitize
+    self.name.gsub(/[^a-z]/, '')
+  end
+end
+----
+
 == Setting the style guide URL
 
 You can specify the base URL of the style guide using `StyleGuideBaseURL`.

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -149,16 +149,22 @@ module RuboCop
         @registry.size
       end
 
-      def enabled(config, only = [], only_safe: false)
-        select { |cop| only.include?(cop.cop_name) || enabled?(cop, config, only_safe) }
+      def enabled(config)
+        select { |cop| enabled?(cop, config) }
       end
 
-      def enabled?(cop, config, only_safe)
+      def disabled(config)
+        reject { |cop| enabled?(cop, config) }
+      end
+
+      def enabled?(cop, config)
+        return true if options.fetch(:only, []).include?(cop.cop_name)
+
         cfg = config.for_cop(cop)
 
         cop_enabled = cfg.fetch('Enabled') == true || enabled_pending_cop?(cfg, config)
 
-        if only_safe
+        if options.fetch(:safe, false)
           cop_enabled && cfg.fetch('Safe', true)
         else
           cop_enabled

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -40,10 +40,9 @@ module RuboCop
 
       # @return [Array<Cop::Cop>]
       def self.mobilize_cops(cop_classes, config, options = {})
-        cop_classes = Registry.new(cop_classes.to_a) unless cop_classes.is_a?(Registry)
-        only = options.fetch(:only, [])
-        safe = options.fetch(:safe, false)
-        cop_classes.enabled(config, only, only_safe: safe).map do |cop_class|
+        cop_classes = Registry.new(cop_classes.to_a, options) unless cop_classes.is_a?(Registry)
+
+        cop_classes.enabled(config).map do |cop_class|
           cop_class.new(config, options)
         end
       end

--- a/lib/rubocop/ext/processed_source.rb
+++ b/lib/rubocop/ext/processed_source.rb
@@ -4,6 +4,8 @@ module RuboCop
   module Ext
     # Extensions to AST::ProcessedSource for our cached comment_config
     module ProcessedSource
+      attr_accessor :registry, :config
+
       def comment_config
         @comment_config ||= CommentConfig.new(self)
       end

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -423,17 +423,21 @@ module RuboCop
     end
 
     def get_processed_source(file)
-      ruby_version = @config_store.for_file(file).target_ruby_version
+      config = @config_store.for_file(file)
+      ruby_version = config.target_ruby_version
 
-      if @options[:stdin]
-        ProcessedSource.new(@options[:stdin], ruby_version, file)
-      else
-        begin
-          ProcessedSource.from_file(file, ruby_version)
-        rescue Errno::ENOENT
-          raise RuboCop::Error, "No such file or directory: #{file}"
-        end
-      end
+      processed_source = if @options[:stdin]
+                           ProcessedSource.new(@options[:stdin], ruby_version, file)
+                         else
+                           begin
+                             ProcessedSource.from_file(file, ruby_version)
+                           rescue Errno::ENOENT
+                             raise RuboCop::Error, "No such file or directory: #{file}"
+                           end
+                         end
+      processed_source.config = config
+      processed_source.registry = mobilized_cop_classes(config)
+      processed_source
     end
 
     # A Cop::Team instance is stateful and may change when inspecting.

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -278,6 +278,36 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     end
   end
 
+  describe 'for a disabled cop' do
+    it 'reports no offense when enabled on part of a file' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          SuggestExtensions: false
+        Lint/UselessAssignment:
+          Enabled: false
+      YAML
+
+      create_file('example.rb', <<~RUBY)
+        # frozen_string_literal: true
+
+        a = 1
+        # rubocop:enable Lint/UselessAssignment
+        b = a
+        b += 1
+        # rubocop:disable Lint/UselessAssignment
+        c = 2
+      RUBY
+
+      expect(cli.run(['--format', 'offenses', 'example.rb'])).to eq(0)
+      expect($stdout.string).to eq(<<~RESULT)
+
+        --
+        0  Total
+
+      RESULT
+    end
+  end
+
   describe 'rubocop:disable comment' do
     it 'can disable all cops in a code section' do
       src = ['# rubocop:disable all',

--- a/spec/rubocop/cop/layout/line_end_string_concatenation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/line_end_string_concatenation_indentation_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe RuboCop::Cop::Layout::LineEndStringConcatenationIndentation, :con
     merged = RuboCop::ConfigLoader
              .default_configuration['Layout/LineEndStringConcatenationIndentation']
              .merge(cop_config)
+             .merge('Enabled' => true)
              .merge('IndentationWidth' => cop_indent)
     RuboCop::Config
       .new('Layout/LineEndStringConcatenationIndentation' => merged,

--- a/spec/rubocop/cop/lint/missing_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/missing_cop_enable_directive_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe RuboCop::Cop::Lint::MissingCopEnableDirective, :config do
   context 'when the maximum range size is infinite' do
     let(:cop_config) { { 'MaximumRangeSize' => Float::INFINITY } }
+    let(:other_cops) { { 'Layout/SpaceAroundOperators' => { 'Enabled' => true } } }
 
     it 'registers an offense when a cop is disabled and never re-enabled' do
       expect_offense(<<~RUBY)
@@ -101,6 +102,17 @@ RSpec.describe RuboCop::Cop::Lint::MissingCopEnableDirective, :config do
         y = 1
         # rubocop:enable Layout
         # Some other code
+      RUBY
+    end
+  end
+
+  context 'when the cop is disabled in the config' do
+    let(:other_cops) { { 'Layout/LineLength' => { 'Enabled' => false } } }
+
+    it 'reports no offense when re-disabling it until EOF' do
+      expect_no_offenses(<<~RUBY)
+        # rubocop:enable Layout/LineLength
+        # rubocop:disable Layout/LineLength
       RUBY
     end
   end

--- a/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
@@ -1,6 +1,26 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::RedundantCopEnableDirective, :config do
+  describe 'when cop is disabled in the configuration' do
+    let(:other_cops) { { 'Layout/LineLength' => { 'Enabled' => false } } }
+
+    it 'registers no offense when enabling the cop' do
+      expect_no_offenses(<<~RUBY)
+        foo
+        # rubocop:enable Layout/LineLength
+      RUBY
+    end
+
+    it 'registers an offense if enabling it twice' do
+      expect_offense(<<~RUBY)
+        foo
+        # rubocop:enable Layout/LineLength
+        # rubocop:enable Layout/LineLength
+                         ^^^^^^^^^^^^^^^^^ Unnecessary enabling of Layout/LineLength.
+      RUBY
+    end
+  end
+
   it 'registers offense and corrects unnecessary enable' do
     expect_offense(<<~RUBY)
       foo

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -182,6 +182,8 @@ RSpec.describe RuboCop::Cop::Registry do
   end
 
   describe '#enabled' do
+    subject(:enabled_cops) { registry.enabled(config) }
+
     let(:config) do
       RuboCop::Config.new(
         'Test/FirstArrayElementIndentation' => { 'Enabled' => false },
@@ -190,16 +192,16 @@ RSpec.describe RuboCop::Cop::Registry do
     end
 
     it 'selects cops which are enabled in the config' do
-      expect(registry.enabled(config, [])).to eql(cops.first(5))
+      expect(registry.enabled(config)).to eql(cops.first(5))
     end
 
     it 'overrides config if :only includes the cop' do
-      result = registry.enabled(config, ['Test/FirstArrayElementIndentation'])
-      expect(result).to eql(cops)
+      options[:only] = ['Test/FirstArrayElementIndentation']
+      expect(enabled_cops).to eql(cops)
     end
 
     it 'selects only safe cops if :safe passed' do
-      enabled_cops = registry.enabled(config, [], only_safe: true)
+      options[:safe] = true
       expect(enabled_cops).not_to include(RuboCop::Cop::RSpec::Foo)
     end
 
@@ -207,21 +209,19 @@ RSpec.describe RuboCop::Cop::Registry do
       let(:config) { RuboCop::Config.new('Lint/BooleanSymbol' => { 'Enabled' => 'pending' }) }
 
       it 'does not include them' do
-        result = registry.enabled(config, [])
-        expect(result).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+        expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
       end
 
       it 'overrides config if :only includes the cop' do
-        result = registry.enabled(config, ['Lint/BooleanSymbol'])
-        expect(result).to eql(cops)
+        options[:only] = ['Lint/BooleanSymbol']
+        expect(enabled_cops).to eql(cops)
       end
 
       context 'when specifying `--disable-pending-cops` command-line option' do
         let(:options) { { disable_pending_cops: true } }
 
         it 'does not include them' do
-          result = registry.enabled(config, [])
-          expect(result).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+          expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
         end
 
         context 'when specifying `NewCops: enable` option in .rubocop.yml' do
@@ -234,8 +234,7 @@ RSpec.describe RuboCop::Cop::Registry do
 
           it 'does not include them because command-line option takes ' \
              'precedence over .rubocop.yml' do
-            result = registry.enabled(config, [])
-            expect(result).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+            expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
           end
         end
       end
@@ -244,8 +243,7 @@ RSpec.describe RuboCop::Cop::Registry do
         let(:options) { { enable_pending_cops: true } }
 
         it 'includes them' do
-          result = registry.enabled(config, [])
-          expect(result).to include(RuboCop::Cop::Lint::BooleanSymbol)
+          expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
         end
 
         context 'when specifying `NewCops: disable` option in .rubocop.yml' do
@@ -257,8 +255,7 @@ RSpec.describe RuboCop::Cop::Registry do
           end
 
           it 'includes them because command-line option takes precedence over .rubocop.yml' do
-            result = registry.enabled(config, [])
-            expect(result).to include(RuboCop::Cop::Lint::BooleanSymbol)
+            expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
           end
         end
       end
@@ -272,8 +269,7 @@ RSpec.describe RuboCop::Cop::Registry do
         end
 
         it 'does not include them' do
-          result = registry.enabled(config, [])
-          expect(result).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+          expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
         end
       end
 
@@ -286,8 +282,7 @@ RSpec.describe RuboCop::Cop::Registry do
         end
 
         it 'does not include them' do
-          result = registry.enabled(config, [])
-          expect(result).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+          expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
         end
       end
 
@@ -300,8 +295,7 @@ RSpec.describe RuboCop::Cop::Registry do
         end
 
         it 'includes them' do
-          result = registry.enabled(config, [])
-          expect(result).to include(RuboCop::Cop::Lint::BooleanSymbol)
+          expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
         end
       end
     end

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -663,7 +663,7 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
 
   describe 'using custom indentation width' do
     let(:config) do
-      RuboCop::Config.new('Performance/ParallelAssignment' => {
+      RuboCop::Config.new('Style/ParallelAssignment' => {
                             'Enabled' => true
                           },
                           'Layout/IndentationWidth' => {


### PR DESCRIPTION
Add compatibility in `Lint/RedundantCopDisableDirective`, `Lint/RedundantCopEnableDirective` and `Lint/MissingCopEnableDirective` for opt-in cops.

I mean by "opt-in" having a cop which is globally disabled in the configuration, but that we want to enable only on specific parts of a file.

My use-case specifically is the following: we sometimes have large-ish arrays maintaining list of allowed values for an attribute, let's imagine:
```ruby
allowed_prefixes = %w[
  ab_
  ad_
  bc_
  ...
  zz_
]
```
I wrote a custom cop that checks that this array remains alphabetically sorted for human readibility. Obviously, I don't want to enable it globally in the codebase as array ordering is important in many use-cases, but would like to enable it specifically on that part with:
```ruby
# rubocop:enable Pennylane/SortedArray
allowed_prefixes = %w[
  ...
]
# rubocop:disable Pennylane/SortedArray
```

But rubocop currently reports various offenses with this pattern:
```
sample.rb:3:18: W: [Correctable] Lint/RedundantCopEnableDirective: Unnecessary enabling of Pennylane/SortedArray.
# rubocop:enable Pennylane/SortedArray
                 ^^^^^^^^^^^^^^^^^^^^^
sample.rb:7:1: W: Lint/MissingCopEnableDirective: Re-enable Pennylane/SortedArray cop with # rubocop:enable after disabling it.
# rubocop:disable Pennylane/SortedArray
^
sample.rb:7:1: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of Pennylane/SortedArray.
# rubocop:disable Pennylane/SortedArray
```

To be able to implement that, I had to inject both `config` as well as the cop registry into `processed_source`, which turns out to be pretty isolated changes in `RuboCop::Runner` as well as in the `CopHelper` test module to mimic the behaviour.

I also made a small api change to `RuboCop::Registry#enabled` as 2 arguments were already available from instance variables, please let me know if that isn't an acceptable change.

I didn't squash commits yet to be able to discuss implementation strategy. I originally (until https://github.com/rubocop/rubocop/pull/10987/commits/bf4e4b7ca2bb18515f97323471c7884e09c3156a) tried to only inject `config` within `CommentConfig` instead of `ProcessedSource`, but things were getting a bit more out of hand.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
