### PR TITLE
Display warning message when both safe and unsafe autocorrect options are specified

### DIFF
--- a/changelog/change_warn_for_both_safe_and_unsafe_autocorrect_options_are_specified.md
+++ b/changelog/change_warn_for_both_safe_and_unsafe_autocorrect_options_are_specified.md
@@ -1,0 +1,1 @@
+* [#10988](https://github.com/rubocop/rubocop/pull/10988): Raise error when both safe and unsafe autocorrect options are specified. ([@koic][])

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -400,6 +400,12 @@ module RuboCop
     end
 
     def validate_autocorrect
+      if @options.key?(:safe_autocorrect) && @options.key?(:autocorrect_all)
+        message = Rainbow(<<~MESSAGE).red
+          Error: Both safe and unsafe autocorrect options are specified, use only one.
+        MESSAGE
+        raise OptionArgumentError, message
+      end
       return if @options.key?(:autocorrect)
       return unless @options.key?(:disable_uncorrectable)
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -423,8 +423,14 @@ RSpec.describe RuboCop::Options, :isolated_environment do
     end
 
     describe '--disable-uncorrectable' do
-      it 'accepts together with an autocorrect argument' do
-        %w[--fix-layout -x --autocorrect -a --autocorrect-all -A].each do |o|
+      it 'accepts together with a safe autocorrect argument' do
+        %w[--fix-layout -x --autocorrect -a].each do |o|
+          expect { options.parse ['--disable-uncorrectable', o] }.not_to raise_error
+        end
+      end
+
+      it 'accepts together with an unsafe autocorrect argument' do
+        %w[--fix-layout -x --autocorrect-all -A].each do |o|
           expect { options.parse ['--disable-uncorrectable', o] }.not_to raise_error
         end
       end
@@ -456,9 +462,20 @@ RSpec.describe RuboCop::Options, :isolated_environment do
     end
 
     describe '--autocorrect' do
-      it 'sets some autocorrect options' do
-        options.parse %w[--autocorrect]
-        expect_autocorrect_options_for_autocorrect
+      context 'Specify only --autocorrect' do
+        it 'sets some autocorrect options' do
+          options.parse %w[--autocorrect]
+          expect_autocorrect_options_for_autocorrect
+        end
+      end
+
+      context 'Specify --autocorrect and --autocorrect-all' do
+        it 'emits a warning and sets some autocorrect options' do
+          expect { options.parse options.parse %w[--autocorrect --autocorrect-all] }.to raise_error(
+            RuboCop::OptionArgumentError,
+            /Error: Both safe and unsafe autocorrect options are specified, use only one./
+          )
+        end
       end
     end
 


### PR DESCRIPTION
If both `-a` option and `-A` option are specified then `-a` is applied. This is obviously misused and will raise an error.

```console
% echo 'puts "Hi"' | bundle exec rubocop --stdin example.rb -A -a
Error: Both safe and unsafe autocorrect options are specified, use only one.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
