### PR TITLE
Add a project spec for future changelog entry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,6 @@ Here are a few examples:
 
 ```markdown
 * [#716](https://github.com/rubocop/rubocop/issues/716): Fixed a regression in the autocorrection logic of `MethodDefParentheses`. ([@bbatsov][])
-* New cop `ElseLayout` checks for odd arrangement of code in the `else` branch of a conditional expression. ([@bbatsov][])
 * [#7542](https://github.com/rubocop/rubocop/pull/7542): **(Breaking)** Move `LineLength` cop from `Metrics` department to `Layout` department. ([@koic][])
 ```
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -242,6 +242,13 @@ RSpec.describe 'RuboCop Project', type: :feature do
 
           include_examples 'has Changelog format'
 
+          it 'has a link to the issue or pull request address at the beginning' do
+            repo = 'rubocop/rubocop'
+            address_pattern = %r{\A\* \[#\d+\]\(https://github\.com/#{repo}/(issues|pull)/\d+\):}
+
+            expect(entries).to all(match(address_pattern))
+          end
+
           it 'has a link to the contributors at the end' do
             expect(entries).to all(match(/\(\[@\S+\]\[\](?:, \[@\S+\]\[\])*\)$/))
           end


### PR DESCRIPTION
CHANGELOG.md is already mixed with and without URLs, so direct editing of CHANGELOG.md was hard to prevent formatting without URL, but the new form of adding future changelog entry to the changelog directory can force URL.

Instead of reviewer pointing out, the automated test failure can inform that to reviewee.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
