### PR TITLE
Fix server cache pollution between tests 

### DIFF
--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -2,7 +2,13 @@
 
 require 'tmpdir'
 
-RSpec.shared_context 'isolated environment' do
+RSpec.shared_context 'isolated environment' do # rubocop:disable Metrics/BlockLength
+  before do
+    # Bust server cache to behave as an isolated environment
+    RuboCop::Server::Cache.cache_root_path = nil
+    RuboCop::Server::Cache.instance_variable_set(:@project_dir_cache_key, nil)
+  end
+
   around do |example|
     Dir.mktmpdir do |tmpdir|
       original_home = Dir.home
@@ -32,6 +38,8 @@ RSpec.shared_context 'isolated environment' do
         ENV['HOME'] = original_home
         ENV['XDG_CONFIG_HOME'] = original_xdg_config_home
 
+        RuboCop::Server::Cache.cache_root_path = nil
+        RuboCop::Server::Cache.instance_variable_set(:@project_dir_cache_key, nil)
         RuboCop::FileFinder.root_level = nil
       end
     end

--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -21,10 +21,6 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
       end
 
       it 'displays a restart information message' do
-        # FIXME: Avoid flaky test for RSpec 4. It may be related that test-queue is not available.
-        # https://github.com/rubocop/rubocop/pull/10806#discussion_r918415067
-        skip if ENV['GITHUB_JOB'] == 'rspec4'
-
         create_file('example.rb', <<~RUBY)
           # frozen_string_literal: true
 
@@ -40,10 +36,6 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
 
     context 'when using `--server` option after running server and updating configuration' do
       it 'applies .rubocop.yml configuration changes even during server startup' do
-        # FIXME: Avoid flaky test for RSpec 4. It may be related that test-queue is not available.
-        # https://github.com/rubocop/rubocop/pull/10806#discussion_r918415067
-        skip if ENV['GITHUB_JOB'] == 'rspec4'
-
         create_file('example.rb', <<~RUBY)
           x = 0
           puts x


### PR DESCRIPTION
While working on https://github.com/rubocop/rubocop/pull/10987, I sometimes had intermittent test failures in `/rubocop/server/rubocop_server_spec.rb`, one example can be seen [here](https://app.circleci.com/pipelines/github/rubocop/rubocop/7260/workflows/2ec04e3d-e56f-4704-b1c6-a9871c48daea/jobs/240271).

I managed to reproduce on the master branch with `bundle exec rspec ./spec/rubocop/server/cli_spec.rb[1:5:1] ./spec/rubocop/server/rubocop_server_spec.rb[1:1:1] --seed 61707 -fd`, and finally figured out the following: 
When doing `RuboCop::Server::Cache.write_version_file('0.99.9')`, `RuboCop::Server::Cache` was still using memoized data generated during the run of `spec/rubocop/server/cli_spec.rb`, which is the previous isolated environment, so the version cache file read during the run of `ruby -I. "#{rubocop}" --server` was not the one that had been updated to contain `0.99.9`

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] ~~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~~Added tests.~~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
