### PR TITLE
[Fix #10994] Fix an error when running 3rd party gem that does not require server

### DIFF
--- a/changelog/fix_an_error_when_running_3rd_party_gem_that_does_not_require_server.md
+++ b/changelog/fix_an_error_when_running_3rd_party_gem_that_does_not_require_server.md
@@ -1,0 +1,1 @@
+* [#10994](https://github.com/rubocop/rubocop/issues/10994): Fix an error when running 3rd party gem that does not require server. ([@koic][])

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -7,7 +7,7 @@ module RuboCop
 
     MSG = '%<version>s (using Parser %<parser_version>s, ' \
           'rubocop-ast %<rubocop_ast_version>s, ' \
-          'running on %<ruby_engine>s %<ruby_version>s)%<server>s [%<ruby_platform>s]'
+          'running on %<ruby_engine>s %<ruby_version>s)%<server_mode>s [%<ruby_platform>s]'
 
     CANONICAL_FEATURE_NAMES = { 'Rspec' => 'RSpec', 'Graphql' => 'GraphQL', 'Md' => 'Markdown',
                                 'Thread_safety' => 'ThreadSafety' }.freeze
@@ -19,7 +19,7 @@ module RuboCop
         verbose_version = format(MSG, version: STRING, parser_version: Parser::VERSION,
                                       rubocop_ast_version: RuboCop::AST::Version::STRING,
                                       ruby_engine: RUBY_ENGINE, ruby_version: RUBY_VERSION,
-                                      server: Server.running? ? ' +server' : '',
+                                      server_mode: server_mode,
                                       ruby_platform: RUBY_PLATFORM)
         return verbose_version unless env
 
@@ -88,6 +88,11 @@ module RuboCop
     # @api private
     def self.document_version
       STRING.match('\d+\.\d+').to_s
+    end
+
+    # @api private
+    def self.server_mode
+      RuboCop.const_defined?(:Server) && Server.running? ? ' +server' : ''
     end
   end
 end

--- a/spec/rubocop/version_spec.rb
+++ b/spec/rubocop/version_spec.rb
@@ -3,6 +3,23 @@
 RSpec.describe RuboCop::Version do
   include FileHelper
 
+  describe '.version' do
+    subject { described_class.version(debug: debug) }
+
+    context 'debug is false (default)' do
+      let(:debug) { false }
+
+      it { is_expected.to match(/\d+\.\d+\.\d+/) }
+      it { is_expected.not_to match(/\d+\.\d+\.\d+ \(using Parser/) }
+    end
+
+    context 'debug is true' do
+      let(:debug) { true }
+
+      it { is_expected.to match(/\d+\.\d+\.\d+ \(using Parser/) }
+    end
+  end
+
   describe '.extension_versions', :isolated_environment, :restore_registry do
     subject(:extension_versions) { described_class.extension_versions(env) }
 


### PR DESCRIPTION
Fixes #10994.

This PR fixes an error when running 3rd party gem that does not require server.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
