### PR TITLE
Request remote configs with RuboCop User-Agent

### DIFF
--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -54,6 +54,7 @@ module RuboCop
       request = Net::HTTP::Get.new(uri.request_uri)
 
       request.basic_auth(uri.user, uri.password) if uri.user
+      request['User-Agent'] = 'RuboCop'
       request['If-Modified-Since'] = File.stat(cache_path).mtime.rfc2822 if cache_path_exists?
 
       yield request

--- a/spec/rubocop/remote_config_spec.rb
+++ b/spec/rubocop/remote_config_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::RemoteConfig do
 
       before do
         stub_request(:get, stripped_remote_config_url)
-          .with(basic_auth: [token])
+          .with(basic_auth: [token], headers: { 'User-Agent' => 'RuboCop' })
           .to_return(status: 200, body: "Style/Encoding:\n    Enabled: true")
       end
 


### PR DESCRIPTION
Set the User-Agent to RuboCop when requesting a remote config, in order to allow the receiver to detect a RuboCop request. This will allow people to configure RuboCop to inherit from `https://goodcop.style`, for example, which will return a RuboCop configuration file when requested with a RuboCop User-Agent.

I’m not sure if this needs a CHANGELOG entry, but let me know if you'd like me to write one.

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
