### PR TITLE
Make `rubocop` command aware of `--server` option from .rubocop and RUBOCOP_OPTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ vendor/
 /spec/examples.txt
 /.test_queue_stats
 
+# RuboCop
+.rubocop
+
 # jeweler generated
 pkg
 

--- a/changelog/new_make_rubocop_aware_of_server_option_from_file_and_env.md
+++ b/changelog/new_make_rubocop_aware_of_server_option_from_file_and_env.md
@@ -1,0 +1,1 @@
+* [#10997](https://github.com/rubocop/rubocop/pull/10997): Make `rubocop` command aware of `--server` option from .rubocop and RUBOCOP_OPTS. ([@koic][])

--- a/docs/modules/ROOT/pages/usage/server.adoc
+++ b/docs/modules/ROOT/pages/usage/server.adoc
@@ -96,6 +96,9 @@ These are the command-line options for server operations:
 
 TIP: You can specify the server host and port with the $RUBOCOP_SERVER_HOST and the $RUBOCOP_SERVER_PORT environment variables.
 
+If `RUBOCOP_OPTS` environment variable or `.rubocop` file contains `--server` option, `rubocop` command defaults to server mode.
+Other server options such as `stop-server`, `restart-server` specified on the command line will take precedence over them.
+
 == Environment Variables
 
 You can change the startup host and port of server process with

--- a/lib/rubocop/arguments_env.rb
+++ b/lib/rubocop/arguments_env.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # This is a class that reads optional command line arguments to rubocop from environment variable.
+  # @api private
+  class ArgumentsEnv
+    def self.read_as_arguments
+      if (arguments = ENV.fetch('RUBOCOP_OPTS', '')).empty?
+        []
+      else
+        require 'shellwords'
+
+        Shellwords.split(arguments)
+      end
+    end
+  end
+end

--- a/lib/rubocop/arguments_file.rb
+++ b/lib/rubocop/arguments_file.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # This is a class that reads optional command line arguments to rubocop from .rubocop file.
+  # @api private
+  class ArgumentsFile
+    def self.read_as_arguments
+      if File.exist?('.rubocop') && !File.directory?('.rubocop')
+        require 'shellwords'
+
+        File.read('.rubocop').shellsplit
+      else
+        []
+      end
+    end
+  end
+end

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require 'optparse'
-require 'shellwords'
+require_relative 'arguments_env'
+require_relative 'arguments_file'
 
 module RuboCop
   class IncorrectCopNameError < StandardError; end
@@ -24,7 +25,10 @@ module RuboCop
     end
 
     def parse(command_line_args)
+      args_from_file = ArgumentsFile.read_as_arguments
+      args_from_env = ArgumentsEnv.read_as_arguments
       args = args_from_file.concat(args_from_env).concat(command_line_args)
+
       define_options.parse!(args)
 
       @validator.validate_compatibility
@@ -44,18 +48,6 @@ module RuboCop
     end
 
     private
-
-    def args_from_file
-      if File.exist?('.rubocop') && !File.directory?('.rubocop')
-        File.read('.rubocop').shellsplit
-      else
-        []
-      end
-    end
-
-    def args_from_env
-      Shellwords.split(ENV.fetch('RUBOCOP_OPTS', ''))
-    end
 
     def define_options
       OptionParser.new do |opts|

--- a/lib/rubocop/server/cli.rb
+++ b/lib/rubocop/server/cli.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'rainbow'
+require_relative '../arguments_env'
+require_relative '../arguments_file'
 
 #
 # This code is based on https://github.com/fohte/rubocop-daemon.
@@ -29,7 +31,7 @@ module RuboCop
         @exit = false
       end
 
-      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
       def run(argv = ARGV)
         unless Server.support_server?
           return error('RuboCop server is not supported by this Ruby.') if use_server_option?(argv)
@@ -50,11 +52,16 @@ module RuboCop
           return error("#{server_command} cannot be combined with other options.")
         end
 
+        if server_command.nil?
+          server_command = ArgumentsEnv.read_as_arguments.delete('--server') ||
+                           ArgumentsFile.read_as_arguments.delete('--server')
+        end
+
         run_command(server_command)
 
         STATUS_SUCCESS
       end
-      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
 
       def exit?
         @exit

--- a/spec/rubocop/server/cli_spec.rb
+++ b/spec/rubocop/server/cli_spec.rb
@@ -95,6 +95,47 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
       end
     end
 
+    context 'when not using any server options and specifying `--server` in .rubocop file' do
+      before { create_file('.rubocop', '--server') }
+
+      it 'returns exit status 0 and display an information message' do
+        create_file('example.rb', <<~RUBY)
+          # frozen_string_literal: true
+
+          x = 0
+          puts x
+        RUBY
+        expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(0)
+        expect(cli.exit?).to be(false)
+        expect($stdout.string).to start_with 'RuboCop server starting on '
+        expect($stderr.string).to eq ''
+      end
+    end
+
+    context 'when not using any server options and specifying `--server` in `RUBOCOP_OPTS` environment variable' do
+      around do |example|
+        ENV['RUBOCOP_OPTS'] = '--server'
+        begin
+          example.run
+        ensure
+          ENV.delete('RUBOCOP_OPTS')
+        end
+      end
+
+      it 'returns exit status 0 and display an information message' do
+        create_file('example.rb', <<~RUBY)
+          # frozen_string_literal: true
+
+          x = 0
+          puts x
+        RUBY
+        expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(0)
+        expect(cli.exit?).to be(false)
+        expect($stdout.string).to start_with 'RuboCop server starting on '
+        expect($stderr.string).to eq ''
+      end
+    end
+
     context 'when using multiple server options' do
       it 'returns exit status 2 and display an error message' do
         create_file('example.rb', <<~RUBY)


### PR DESCRIPTION
## Summary

This PR makes `rubocop` command aware of `--server` option from .rubocop and RUBOCOP_OPTS.

If `RUBOCOP_OPTS` environment variable or `.rubocop` file contains `--server` option, `rubocop` command defaults to server mode. Other server options such as `stop-server`, `restart-server` specified on the command line will take precedence over them.

This feature rides on the existing following feature.

> Default command-line options are loaded from `.rubocop` and `RUBOCOP_OPTS` and
> are combined with command-line options that are explicitly passed to `rubocop`.
> Thus, the options have the following order of precedence (from highest to lowest):
>
> 1. Explicit command-line options
>
> 2. Options from RUBOCOP_OPTS environment variable
>
> 3. Options from .rubocop file.

https://docs.rubocop.org/rubocop/1.36/usage/basic_usage.html#command-line-flags

## Other Information

This PR adds .rubocop to .gitignore so that it used for RuboCop development is not mixed in git commit.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
