### PR TITLE
[Fix #10977] Add option to raise cop errors, `--raise-cop-error`

### DIFF
--- a/changelog/new_add_option_to_raise_cop_errors.md
+++ b/changelog/new_add_option_to_raise_cop_errors.md
@@ -1,0 +1,1 @@
+* [#11001](https://github.com/rubocop/rubocop/pull/11001): Add option to raise cop errors `--raise-cop-error`. ([@wildmaples][])

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -10,6 +10,9 @@ enforce different coding conventions.
 
 You can also load xref:extensions.adoc#custom-cops[custom cops].
 
+Cop-related failures are silenced by default but can be turned on using the
+`--raise-cop-errors` option.
+
 == Style
 
 Style cops check for stylistic consistency of your code. Many of the them are

--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -240,6 +240,9 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | `--[no-]parallel`
 | Use available CPUs to execute inspection in parallel. Default is parallel.
 
+| `--raise-cop-error`
+| Raise cop-related errors with cause and location. This is used to prevent cops from failing silently. Default is false.
+
 | `-r/--require`
 | Require Ruby file (see xref:extensions.adoc#loading-extensions[Loading Extensions]).
 

--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -159,9 +159,11 @@ module RuboCop
       def with_cop_error_handling(cop, node = nil)
         yield
       rescue StandardError => e
-        raise e if @options[:raise_error]
+        raise e if @options[:raise_error] # For internal testing
 
         err = ErrorWithAnalyzedFileLocation.new(cause: e, node: node, cop: cop)
+        raise err if @options[:raise_cop_error] # From user-input option
+
         @errors << err
       end
     end

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -592,6 +592,7 @@ module RuboCop
       stop_server:                      'Stop server process.',
       server_status:                    'Show server status.',
       raise_cop_error:                  ['Raise cop-related errors with cause and location.',
+                                         'This is used to prevent cops from failing silently.',
                                          'Default is false.']
     }.freeze
   end

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -65,7 +65,7 @@ module RuboCop
     end
 
     def add_check_options(opts) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      section(opts, 'Basic Options') do
+      section(opts, 'Basic Options') do # rubocop:disable Metrics/BlockLength
         option(opts, '-l', '--lint') do
           @options[:only] ||= []
           @options[:only] << 'Lint'
@@ -90,6 +90,7 @@ module RuboCop
         option(opts, '--force-default-config')
         option(opts, '-s', '--stdin FILE')
         option(opts, '-P', '--[no-]parallel')
+        option(opts, '--raise-cop-error')
         add_severity_option(opts)
       end
     end
@@ -589,7 +590,9 @@ module RuboCop
       restart_server:                   'Restart server process.',
       start_server:                     'Start server process.',
       stop_server:                      'Stop server process.',
-      server_status:                    'Show server status.'
+      server_status:                    'Show server status.',
+      raise_cop_error:                  ['Raise cop-related errors with cause and location.',
+                                         'Default is false.']
     }.freeze
   end
 end

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -114,6 +114,16 @@ RSpec.describe RuboCop::Cop::Commissioner do
       end
     end
 
+    context 'when passed :raise_cop_error option' do
+      let(:options) { { raise_cop_error: true } }
+
+      it 're-raises the exception received while processing' do
+        allow(cop).to receive(:on_int) { raise RuboCop::ErrorWithAnalyzedFileLocation }
+
+        expect { offenses }.to raise_error(RuboCop::ErrorWithAnalyzedFileLocation)
+      end
+    end
+
     context 'when given a force' do
       let(:force) { instance_double(RuboCop::Cop::Force).as_null_object }
       let(:forces) { [force] }

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -66,6 +66,8 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                reports. This is useful for editor integration.
               -P, --[no-]parallel              Use available CPUs to execute inspection in
                                                parallel. Default is true.
+                  --raise-cop-error            Raise cop-related errors with cause and location.
+                                               Default is false.
                   --fail-level SEVERITY        Minimum severity for exit with error code.
                                                  [A] autocorrect
                                                  [I] info
@@ -372,6 +374,13 @@ RSpec.describe RuboCop::Options, :isolated_environment do
         %w[autocorrect A].each do |severity|
           expect { options.parse(['--fail-level', severity]) }.not_to raise_error
         end
+      end
+    end
+
+    describe '--raise-cop-error' do
+      it 'raises cop errors' do
+        results = options.parse %w[--raise-cop-error]
+        expect(results).to eq([{ raise_cop_error: true }, []])
       end
     end
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
               -P, --[no-]parallel              Use available CPUs to execute inspection in
                                                parallel. Default is true.
                   --raise-cop-error            Raise cop-related errors with cause and location.
+                                               This is used to prevent cops from failing silently.
                                                Default is false.
                   --fail-level SEVERITY        Minimum severity for exit with error code.
                                                  [A] autocorrect


### PR DESCRIPTION
Fix https://github.com/rubocop/rubocop/issues/10977

We want to be able to rescue cop-related errors. 

There exists `:raise_error`, but it's used for internal tests such as through [cop helper](https://github.com/rubocop/rubocop/blob/master/lib/rubocop/rspec/cop_helper.rb#L49). 

I added a new option that raises with `RuboCop::ErrorWithAnalyzedFileLocation`, which surfaces more information. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
