### PR TITLE
[Fix #11006] Allow multiple `elsif` for `Style/IfWithBooleanLiteralBranches`

### DIFF
--- a/changelog/change_allow_multiple_elsif_for_style_if_with_boolean_literal_branches.md
+++ b/changelog/change_allow_multiple_elsif_for_style_if_with_boolean_literal_branches.md
@@ -1,0 +1,1 @@
+* [#11006](https://github.com/rubocop/rubocop/issues/11006): Allow multiple `elsif` for `Style/IfWithBooleanLiteralBranches`. ([@koic][])

--- a/spec/rubocop/cop/style/if_with_boolean_literal_branches_spec.rb
+++ b/spec/rubocop/cop/style/if_with_boolean_literal_branches_spec.rb
@@ -85,6 +85,25 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
         RUBY
       end
 
+      it 'registers and corrects an offense when using `if` with boolean literal branches directly under `def`' do
+        expect_offense(<<~RUBY, comparison_operator: comparison_operator)
+          def foo
+            if bar > baz
+            ^^ Remove redundant `if` with boolean literal branches.
+              true
+            else
+              false
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo
+            bar > baz
+          end
+        RUBY
+      end
+
       it 'does not register an offense when using a branch that is not boolean literal' do
         expect_no_offenses(<<~RUBY)
           if foo #{comparison_operator} bar
@@ -551,6 +570,43 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
 
       expect_correction(<<~RUBY)
         foo? && bar? || baz?
+      RUBY
+    end
+  end
+
+  context 'when using `elsif` with boolean literal branches' do
+    it 'registers and corrects an offense when using single `elsif` with boolean literal branches' do
+      expect_offense(<<~RUBY)
+        if foo
+          true
+        elsif bar > baz
+        ^^^^^ Use `else` instead of redundant `elsif` with boolean literal branches.
+          true
+        else
+          false
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if foo
+          true
+        else
+          bar > baz
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using multiple `elsif` with boolean literal branches' do
+      expect_no_offenses(<<~RUBY)
+        if foo
+          true
+        elsif bar > baz
+          true
+        elsif qux > quux
+          true
+        else
+          false
+        end
       RUBY
     end
   end


### PR DESCRIPTION
Fixes #11006.

This PR allows multiple `elsif` for `Style/IfWithBooleanLiteralBranches`.

I think it's good to allow when multiple `elsif`s are used instead of a new config option. OTOH, if there is only single `elsif`, `elsif` will not exist due to autocorrection. So I think the current behavior can be kept.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
