### PR TITLE
Fix a false positive for `Style/Alias`cop when alias in a method def

### DIFF
--- a/changelog/fix_fix_a_false_positive_for_style_alias.md
+++ b/changelog/fix_fix_a_false_positive_for_style_alias.md
@@ -1,0 +1,1 @@
+* [#11014](https://github.com/rubocop/rubocop/pull/11014): Fix a false positive for `Style/Alias`cop when alias in a method def. ([@ydah][])

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -106,18 +106,48 @@ RSpec.describe RuboCop::Cop::Style::Alias, :config do
       RUBY
     end
 
-    it 'does not register an offense for alias_method with explicit receiver' do
+    it 'does not register registers an offense for alias in a def' do
       expect_no_offenses(<<~RUBY)
-        class C
-          receiver.alias_method :ala, :bala
+        def foo
+          alias :ala :bala
         end
       RUBY
     end
 
-    it 'does not register an offense for alias_method in a method def' do
-      expect_no_offenses(<<~RUBY)
-        def method
+    it 'registers an offense for alias in a defs' do
+      expect_offense(<<~RUBY)
+        def some_obj.foo
+          alias :ala :bala
+          ^^^^^ Use `alias_method` instead of `alias`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_obj.foo
           alias_method :ala, :bala
+        end
+      RUBY
+    end
+
+    it 'registers an offense for alias in a block' do
+      expect_offense(<<~RUBY)
+        included do
+          alias :ala :bala
+          ^^^^^ Use `alias_method` instead of `alias`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        included do
+          alias_method :ala, :bala
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for alias_method with explicit receiver' do
+      expect_no_offenses(<<~RUBY)
+        class C
+          receiver.alias_method :ala, :bala
         end
       RUBY
     end


### PR DESCRIPTION
The following cases will result in a NoMethodError if replaced with alias_method.
Therefore, it is correct to regard it as a violation and not to replace it.

```ruby
def foo
  alias :ala :bala
end
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
