### PR TITLE
Fix a false positive for `Style/HashSyntax`

### DIFF
--- a/changelog/fix_a_false_positive_for_hash_syntax.md
+++ b/changelog/fix_a_false_positive_for_hash_syntax.md
@@ -1,0 +1,1 @@
+* [#11015](https://github.com/rubocop/rubocop/pull/11015): Fix a false positive for `Style/HashSyntax` when without parentheses call expr follows after nested method call. ([@koic][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -96,11 +96,14 @@ module RuboCop
       end
 
       def without_parentheses_call_expr_follows?(ancestor)
-        right_sibling = ancestor.right_sibling
-        right_sibling ||= ancestor.each_ancestor.find(&:assignment?)&.right_sibling
-        return false unless right_sibling
+        return false unless ancestor.respond_to?(:parenthesized?) && !ancestor.parenthesized?
 
-        ancestor.respond_to?(:parenthesized?) && !ancestor.parenthesized? && !!right_sibling
+        right_sibling = ancestor.right_sibling
+        right_sibling ||= ancestor.each_ancestor.find do |node|
+          node.assignment? || node.send_type?
+        end&.right_sibling
+
+        !!right_sibling
       end
 
       def breakdown_value_types_of_hash(hash_node)

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1066,6 +1066,14 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'does not register an offense when without parentheses call expr follows after nested method call' do
+        # Prevent syntax errors shown in the URL: https://bugs.ruby-lang.org/issues/18396
+        expect_no_offenses(<<~RUBY)
+          foo bar value: value
+          baz
+        RUBY
+      end
+
       it 'registers an offense when one line `if` condition follows (with parentheses)' do
         expect_offense(<<~RUBY)
           foo(value: value) if bar


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/issues/10545#issuecomment-1256631116.

This PR fixes a false positive for `Style/HashSyntax` when without parentheses call expr follows after nested method call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
