### PR TITLE
Fix a wrong AllowedPatterns example

### DIFF
--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -45,7 +45,7 @@ module RuboCop
       #   # bad
       #   expect { do_something }.to change { object.attribute }
       #
-      # @example AllowedPatterns: [/change/]
+      # @example AllowedPatterns: ['change']
       #
       #   # good
       #   expect { do_something }.to change { object.attribute }

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -61,7 +61,7 @@ module RuboCop
       #   # bad
       #   10.minutes.to_i
       #
-      # @example AllowedPatterns: [/min*/]
+      # @example AllowedPatterns: ['min*']
       #
       #   # good
       #   10.minutes.to_i

--- a/lib/rubocop/cop/lint/unreachable_loop.rb
+++ b/lib/rubocop/cop/lint/unreachable_loop.rb
@@ -79,7 +79,7 @@ module RuboCop
       #   # bad
       #   2.times { raise ArgumentError }
       #
-      # @example AllowedPatterns: [/(exactly|at_least|at_most)\(\d+\)\.times/] (default)
+      # @example AllowedPatterns: ['(exactly|at_least|at_most)\(\d+\)\.times'] (default)
       #
       #   # good
       #   exactly(2).times { raise StandardError }

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -157,7 +157,7 @@ module RuboCop
       #     process(something)
       #   }
       #
-      # @example AllowedPatterns: [/map/]
+      # @example AllowedPatterns: ['map']
       #
       #   # good
       #   things.map { |thing|

--- a/lib/rubocop/cop/style/class_equality_comparison.rb
+++ b/lib/rubocop/cop/style/class_equality_comparison.rb
@@ -48,7 +48,7 @@ module RuboCop
       #   var.class.eql?(Date)
       #   var.class.name == 'Date'
       #
-      # @example AllowedPatterns: [`/eq/`]
+      # @example AllowedPatterns: ['eq']
       #   # good
       #   var.instance_of?(Date)
       #   var.class.equal?(Date)

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -77,7 +77,7 @@ module RuboCop
       #   # bad
       #   redirect('foo/%{bar_id}')
       #
-      # @example AllowedPatterns: [/redirect/]
+      # @example AllowedPatterns: ['redirect']
       #
       #   # good
       #   redirect('foo/%{bar_id}')

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -66,7 +66,7 @@ module RuboCop
       #   foo.negative?
       #   bar.baz.positive?
       #
-      # @example AllowedPatterns: [/zero/] with EnforcedStyle: predicate
+      # @example AllowedPatterns: ['zero'] with EnforcedStyle: predicate
       #   # good
       #   # bad
       #   foo.zero?

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -82,7 +82,7 @@ module RuboCop
       #   # bad
       #   something.map { |s| s.upcase }
       #
-      # @example AllowedPatterns: [/map/] (default)
+      # @example AllowedPatterns: ['map'] (default)
       #   # good
       #   something.map { |s| s.upcase }
       #

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       'ProceduralMethods' => %w[tap],
       'FunctionalMethods' => %w[let],
       'AllowedMethods' => ['lambda'],
-      'AllowedPatterns' => [/test/]
+      'AllowedPatterns' => ['test']
     }
 
     let(:cop_config) { cop_config }
@@ -378,7 +378,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
     cop_config = {
       'EnforcedStyle' => 'line_count_based',
       'AllowedMethods' => ['proc'],
-      'AllowedPatterns' => [/test/]
+      'AllowedPatterns' => ['test']
     }
 
     let(:cop_config) { cop_config }
@@ -611,7 +611,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
     cop_config = {
       'EnforcedStyle' => 'braces_for_chaining',
       'AllowedMethods' => ['proc'],
-      'AllowedPatterns' => [/test/]
+      'AllowedPatterns' => ['test']
     }
 
     let(:cop_config) { cop_config }
@@ -780,7 +780,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
     cop_config = {
       'EnforcedStyle' => 'always_braces',
       'AllowedMethods' => ['proc'],
-      'AllowedPatterns' => [/test/]
+      'AllowedPatterns' => ['test']
     }
 
     let(:cop_config) { cop_config }

--- a/spec/rubocop/cop/style/class_equality_comparison_spec.rb
+++ b/spec/rubocop/cop/style/class_equality_comparison_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
   end
 
   context 'when AllowedPatterns is enabled' do
-    let(:cop_config) { { 'AllowedPatterns' => [/equal/] } }
+    let(:cop_config) { { 'AllowedPatterns' => ['equal'] } }
 
     it 'does not register an offense when comparing class for equality' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
   end
 
   context 'when AllowedPatterns is enabled' do
-    let(:cop_config) { { 'AllowedPatterns' => [/test/] } }
+    let(:cop_config) { { 'AllowedPatterns' => ['test'] } }
 
     it 'ignores method listed in AllowedMethods' do
       expect_no_offenses('my_test()')

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
   end
 
   context 'AllowedPatterns' do
-    let(:cop_config) { { 'AllowedPatterns' => [/\d{2}_\d{2}_\d{4}/] } }
+    let(:cop_config) { { 'AllowedPatterns' => ['\d{2}_\d{2}_\d{4}'] } }
 
     it 'does not register an offense for numbers that exactly match the pattern' do
       expect_no_offenses(<<~RUBY)
@@ -282,7 +282,7 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
     end
 
     context 'AllowedPatterns with repetition' do
-      let(:cop_config) { { 'AllowedPatterns' => [/\d{4}(_\d{4})+/] } }
+      let(:cop_config) { { 'AllowedPatterns' => ['\d{4}(_\d{4})+'] } }
 
       it 'does not register an offense for numbers that match the pattern' do
         expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
         'EnforcedStyle' => 'predicate',
         'AutoCorrect' => true,
         'AllowedMethods' => ['where'],
-        'AllowedPatterns' => [/order/]
+        'AllowedPatterns' => ['order']
       }
     end
 
@@ -276,7 +276,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
           {
             'EnforcedStyle' => 'comparison',
             'AllowedMethods' => [],
-            'AllowedPatterns' => [/zero/]
+            'AllowedPatterns' => ['zero']
           }
         end
 

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
   end
 
   context 'when AllowedPatterns is enabled' do
-    let(:cop_config) { { 'AllowedPatterns' => [/respond_/] } }
+    let(:cop_config) { { 'AllowedPatterns' => ['respond_'] } }
 
     it 'accepts ignored method' do
       expect_no_offenses('respond_to { |format| format.xml }')


### PR DESCRIPTION
This PR is fix a wrong AllowedPatterns example
When specifying in the .rubocop.yml file, it is necessary
to specify `AllowedPatterns: ['foo']` instead of `AllowedPatterns: [/foo/]`.

Follow up: https://github.com/rubocop/rubocop-rspec/issues/1395

The test code was also modified to match the actual behavior as mentioned in https://github.com/rubocop/rubocop-rspec/pull/1396#issuecomment-1257026847 .

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
