### PR TITLE
Fix an autocorrect for `Lint/EmptyConditionalBody` that causes a SyntaxError when missing `if` and `else` body

### DIFF
--- a/changelog/fix_fix_an_autocorrect_for_lint_empty_conditional_body.md
+++ b/changelog/fix_fix_an_autocorrect_for_lint_empty_conditional_body.md
@@ -1,0 +1,1 @@
+* [#11017](https://github.com/rubocop/rubocop/pull/11017): Fix an autocorrect for `Lint/EmptyConditionalBody` that causes a SyntaxError when missing `if` and `else` body. ([@ydah][])

--- a/lib/rubocop/cop/lint/empty_conditional_body.rb
+++ b/lib/rubocop/cop/lint/empty_conditional_body.rb
@@ -98,7 +98,7 @@ module RuboCop
         def correct_other_branches(corrector, node)
           return unless require_other_branches_correction?(node)
 
-          if node.else_branch.if_type?
+          if node.else_branch&.if_type?
             # Replace an orphaned `elsif` with `if`
             corrector.replace(node.else_branch.loc.keyword, 'if')
           else
@@ -108,7 +108,7 @@ module RuboCop
         end
 
         def require_other_branches_correction?(node)
-          return false unless node.if_type? && node.else_branch
+          return false unless node.if_type? && node.else?
           return false if !empty_if_branch?(node) && node.elsif?
 
           !empty_else_branch?(node)
@@ -123,7 +123,9 @@ module RuboCop
         end
 
         def empty_else_branch?(node)
-          node.else_branch.if_type? && !node.else_branch.body
+          return false unless (else_branch = node.else_branch)
+
+          else_branch.if_type? && !else_branch.body
         end
 
         # rubocop:disable Metrics/AbcSize

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     expect_correction('')
   end
 
+  it 'registers an offense for missing `if` and `else` body' do
+    expect_offense(<<~RUBY)
+      if condition
+      ^^^^^^^^^^^^ Avoid `if` branches without a body.
+      else
+      end
+    RUBY
+
+    expect_correction('')
+  end
+
   it 'does not register an offense for missing `if` body with a comment' do
     expect_no_offenses(<<~RUBY)
       if condition
@@ -115,6 +126,17 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
         do_something
       end
     RUBY
+  end
+
+  it 'registers an offense for missing `unless` and `else` body' do
+    expect_offense(<<~RUBY)
+      unless condition
+      ^^^^^^^^^^^^^^^^ Avoid `unless` branches without a body.
+      else
+      end
+    RUBY
+
+    expect_correction('')
   end
 
   it 'registers an offense for missing `if` body with `elsif`' do


### PR DESCRIPTION
Syntax Error was generated when the following code was autocorrect.

### before
```ruby
# before
 if condition
 else
 end
```

### after
```ruby
 end
```

### log
```
Inspecting 1 file
E

Offenses:

test.rb:1:1: W: [Corrected] Lint/EmptyConditionalBody: Avoid if branches without a body.
if condition ...
^^^^^^^^^^^^
test.rb:1:1: C: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
if condition
^
test.rb:2:1: E: Lint/Syntax: unexpected token kEND
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
end
^^^
test.rb:2:1: C: [Corrected] Style/EmptyElse: Redundant else-clause.
else
^^^^

1 file inspected, 4 offenses detected, 3 offenses corrected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
