### PR TITLE
[Fix #11018] Add `AllowedMethods` and `AllowedPatterns` for `Lint/NestedMethodDefinition`

### DIFF
--- a/changelog/new_add_allowed_methods_and_patterns_to_lint_nested_method_definition.md
+++ b/changelog/new_add_allowed_methods_and_patterns_to_lint_nested_method_definition.md
@@ -1,0 +1,1 @@
+* [#11018](https://github.com/rubocop/rubocop/issues/11018): Add `AllowedMethods` and `AllowedPatterns` for `Lint/NestedMethodDefinition`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1957,6 +1957,8 @@ Lint/NestedMethodDefinition:
   Description: 'Do not use nested method definitions.'
   StyleGuide: '#no-nested-methods'
   Enabled: true
+  AllowedMethods: []
+  AllowedPatterns: []
   VersionAdded: '0.32'
 
 Lint/NestedPercentLiteral:

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -266,4 +266,62 @@ RSpec.describe RuboCop::Cop::Lint::NestedMethodDefinition, :config do
       end
     RUBY
   end
+
+  context 'when `AllowedMethods: [has_many]`' do
+    let(:cop_config) do
+      { 'AllowedMethods' => ['has_many'] }
+    end
+
+    it 'does not register offense for nested definition inside `has_many`' do
+      expect_no_offenses(<<~RUBY)
+        def do_something
+          has_many :articles do
+            def find_or_create_by_name(name)
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'registers offense for nested definition inside `denied_method`' do
+      expect_offense(<<~RUBY)
+        def do_something
+          denied_method :articles do
+            def find_or_create_by_name(name)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method definitions must not be nested. Use `lambda` instead.
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when `AllowedPatterns: [baz]`' do
+    let(:cop_config) do
+      { 'AllowedPatterns' => ['baz'] }
+    end
+
+    it 'does not register offense for nested definition inside `do_baz`' do
+      expect_no_offenses(<<~RUBY)
+        def foo(obj)
+          obj.do_baz do
+            def bar
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'registers offense for nested definition inside `do_qux`' do
+      expect_offense(<<~RUBY)
+        def foo(obj)
+          obj.do_qux do
+            def bar
+            ^^^^^^^ Method definitions must not be nested. Use `lambda` instead.
+            end
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #11018 and #8860.

This PR adds `AllowedMethods` and `AllowedPatterns` for `Lint/NestedMethodDefinition`. For example, `has_many`, `extending`, and other Rails APIs can be specified in RuboCop Rails config.

`class_eval`, `instance_eval`, `module_eval`, `class_exec`, `instance_exec`, and `module_exec` leave hard-coded for core methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
