### PR TITLE
Mark autocorrection for Lint/UnusedMethodArgument as unsafe

### DIFF
--- a/changelog/fix_mark_autocorrection_for.md
+++ b/changelog/fix_mark_autocorrection_for.md
@@ -1,0 +1,1 @@
+* [#11020](https://github.com/rubocop/rubocop/pull/11020): Mark autocorrection for Lint/UnusedMethodArgument as unsafe. ([@dduugg][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2366,8 +2366,9 @@ Lint/UnusedMethodArgument:
   Description: 'Checks for unused method arguments.'
   StyleGuide: '#underscore-unused-vars'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.21'
-  VersionChanged: '0.81'
+  VersionChanged: '<<next>>'
   AllowUnusedKeywordArguments: false
   IgnoreEmptyMethods: true
   IgnoreNotImplementedMethods: true

--- a/lib/rubocop/cop/lint/unused_method_argument.rb
+++ b/lib/rubocop/cop/lint/unused_method_argument.rb
@@ -5,6 +5,11 @@ module RuboCop
     module Lint
       # Checks for unused method arguments.
       #
+      # @safety
+      #   Autocorrection for this cop is not safe. There may be metaprogramming attached to the
+      #   method (such as a Sorbet `sig`), YARD annoations, and type signtures in RBI or RBS files,
+      #   which will retain the previous argument names under autocorrection.
+      #
       # @example
       #   # bad
       #   def some_method(used, unused, _unused_but_allowed)


### PR DESCRIPTION
Renaming a method argument will break code with Sorbet type signatures, e.g.

```ruby
sig { params(x: Integer).void }
def foo(x); end
```
becomes
```ruby
sig { params(x: Integer).void }
def foo(_x); end
```
which will fail to typecheck, as well as resulting in a `RuntimeError` on method invocation.

(I used https://github.com/rubocop/rubocop/pull/10867 as a template for creating this PR)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
