### PR TITLE
[Fix #11022] Fix an incorrect autocorrect for `Style/RedundantCondition`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_condition.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_condition.md
@@ -1,0 +1,1 @@
+* [#11022](https://github.com/rubocop/rubocop/issues/11022): Fix an incorrect autocorrect for `Style/RedundantCondition`  when using redundant brackets access condition. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -145,9 +145,12 @@ module RuboCop
 
           return false unless if_branch && else_branch
 
-          if_branch.send_type? && if_branch.arguments.count == 1 &&
-            else_branch.send_type? && else_branch.arguments.count == 1 &&
+          single_argument_method?(if_branch) && single_argument_method?(else_branch) &&
             same_method?(if_branch, else_branch)
+        end
+
+        def single_argument_method?(node)
+          node.send_type? && !node.method?(:[]) && node.arguments.one?
         end
 
         def same_method?(if_branch, else_branch)

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -469,6 +469,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects brackets accesses' do
+        expect_offense(<<~RUBY)
+          a = b[:x] ? b[:x] : b[:y]
+                    ^^^^^^^^^ Use double pipes `||` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a = b[:x] || b[:y]
+        RUBY
+      end
+
       it 'registers an offense and corrects when the else branch contains an irange' do
         expect_offense(<<~RUBY)
           time_period = updated_during ? updated_during : 2.days.ago..Time.now


### PR DESCRIPTION
Fixes #11022.

This PR fixes an incorrect autocorrect for `Style/RedundantCondition` when using redundant brackets access condition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
