### PR TITLE
[Fix #11026] Fix an error occurred for `Style/SymbolArray` and `Style/WordArray` when empty percent array

### DIFF
--- a/changelog/fix_an_error_occurred_for_style_symbol_array_and_style_word_array.md
+++ b/changelog/fix_an_error_occurred_for_style_symbol_array_and_style_word_array.md
@@ -1,0 +1,1 @@
+* [#11026](https://github.com/rubocop/rubocop/issues/11026): Fix an error occurred for `Style/SymbolArray` and `Style/WordArray` when empty percent array. ([@ydah][])

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -65,6 +65,8 @@ module RuboCop
         end
 
         def build_bracketed_array(node)
+          return '[]' if node.children.empty?
+
           syms = node.children.map do |c|
             if c.dsym_type?
               string_literal = to_string_literal(c.source)

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -83,6 +83,8 @@ module RuboCop
         end
 
         def build_bracketed_array(node)
+          return '[]' if node.children.empty?
+
           words = node.children.map do |word|
             if word.dstr_type?
               string_literal = to_string_literal(word.source)

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -209,6 +209,17 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
       RUBY
     end
 
+    it 'registers an offense for empty array starting with %i' do
+      expect_offense(<<~RUBY)
+        %i()
+        ^^^^ Use `[]` for an array of symbols.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        []
+      RUBY
+    end
+
     it 'autocorrects an array starting with %i' do
       expect_offense(<<~RUBY)
         %i(one @two $three four-five)

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -383,6 +383,17 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       RUBY
     end
 
+    it 'registers an offense for an empty %w() array' do
+      expect_offense(<<~RUBY)
+        %w()
+        ^^^^ Use `[]` for an array of words.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        []
+      RUBY
+    end
+
     it 'autocorrects a %w() array which uses single quotes' do
       expect_offense(<<~RUBY)
         %w(one's two's three's)


### PR DESCRIPTION
Fixes #11026.

This PR fixed an error with an empty percent array.

The original issue #11026 was reported for `Style/SymbolArray`, but it was also occurring for `Style/WordArray`,
so it has been corrected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
