### PR TITLE
[Fix #11028] Fix a false positive for `Lint/RequireParentheses`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_require_parentheses.md
+++ b/changelog/fix_a_false_positive_for_lint_require_parentheses.md
@@ -1,0 +1,1 @@
+* [#11028](https://github.com/rubocop/rubocop/issues/11028): Fix a false positive for `Lint/RequireParentheses` when using ternary operator in square bracksts. ([@koic][])

--- a/lib/rubocop/cop/lint/require_parentheses.rb
+++ b/lib/rubocop/cop/lint/require_parentheses.rb
@@ -46,7 +46,7 @@ module RuboCop
         private
 
         def check_ternary(ternary, node)
-          return unless ternary.condition.operator_keyword?
+          return if node.method?(:[]) || !ternary.condition.operator_keyword?
 
           range = range_between(node.source_range.begin_pos, ternary.condition.source_range.end_pos)
 

--- a/spec/rubocop/cop/lint/require_parentheses_spec.rb
+++ b/spec/rubocop/cop/lint/require_parentheses_spec.rb
@@ -80,6 +80,14 @@ RSpec.describe RuboCop::Cop::Lint::RequireParentheses, :config do
     expect_no_offenses("weekdays.foo 'tuesday' && true == true")
   end
 
+  it 'accepts missing parentheses when using ternary operator' do
+    expect_no_offenses('foo && bar ? baz : qux')
+  end
+
+  it 'accepts missing parentheses when using ternary operator in square bracksts' do
+    expect_no_offenses('do_something[foo && bar ? baz : qux]')
+  end
+
   it 'accepts calls to methods that are setters' do
     expect_no_offenses('s.version = @version || ">= 1.8.5"')
   end


### PR DESCRIPTION
Fixes #11028

This PR fixes a false positive for `Lint/RequireParentheses` when using ternary operator in square bracksts.

This case should be allowed because it's the same as the already accepted ternary operator (`foo && bar ? baz : qux`) and the precedence is clear.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
