### PR TITLE
[Fix #11030] Fix an incorrect autocorrect for `Lint/UnusedMethodArgument`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_unused_method_argument.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_unused_method_argument.md
@@ -1,0 +1,1 @@
+* [#11030](https://github.com/rubocop/rubocop/issues/11030): Fix an incorrect autocorrect for `Lint/UnusedMethodArgument` and `Style::ExplicitBlockArgument` when autocorrection conflicts for `&block` argument. ([@koic][])

--- a/lib/rubocop/cop/lint/unused_method_argument.rb
+++ b/lib/rubocop/cop/lint/unused_method_argument.rb
@@ -68,6 +68,10 @@ module RuboCop
            (send nil? :fail ...)}
         PATTERN
 
+        def self.autocorrect_incompatible_with
+          [Style::ExplicitBlockArgument]
+        end
+
         def self.joining_forces
           VariableForce
         end

--- a/lib/rubocop/cop/style/explicit_block_argument.rb
+++ b/lib/rubocop/cop/style/explicit_block_argument.rb
@@ -50,6 +50,10 @@ module RuboCop
           (block $_ (args $...) (yield $...))
         PATTERN
 
+        def self.autocorrect_incompatible_with
+          [Lint::UnusedMethodArgument]
+        end
+
         def initialize(config = nil, options = nil)
           super
           @def_nodes = Set.new

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -368,6 +368,24 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Lint/UnusedMethodArgument` with `Style/ExplicitBlockArgument`' do
+    source = <<~RUBY
+      def foo(&block)
+        bar { yield }
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--autocorrect',
+                     '--only', 'Lint/UnusedMethodArgument,Style/ExplicitBlockArgument'
+                   ])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      def foo(&block)
+        bar(&block)
+      end
+    RUBY
+  end
+
   describe 'trailing comma cops' do
     let(:source) do
       <<~RUBY


### PR DESCRIPTION
Fixes #11030.

This PR fixes an incorrect autocorrect for `Lint/UnusedMethodArgument` and `Style::ExplicitBlockArgument` when autocorrection conflicts for `&block` argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
