### PR TITLE
Detect empty Hash literal braces containing only newlines and spaces on `Layout/SpaceInsideHashLiteralBraces`

### DIFF
--- a/changelog/change_detect_empty_hash_literal_braces.md
+++ b/changelog/change_detect_empty_hash_literal_braces.md
@@ -1,0 +1,1 @@
+* [#11032](https://github.com/rubocop/rubocop/pull/11032): Detect empty Hash literal braces containing only newlines and spaces on `Layout/SpaceInsideHashLiteralBraces`. ([@r7kamura][])

--- a/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
@@ -22,6 +22,22 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     end
   end
 
+  context 'with newline inside empty braces not allowed' do
+    let(:cop_config) { { 'EnforcedStyleForEmptyBraces' => 'no_space' } }
+
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        h = {
+             ^{} Space inside empty hash literal braces detected.
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        h = {}
+      RUBY
+    end
+  end
+
   context 'with space inside empty braces allowed' do
     let(:cop_config) { { 'EnforcedStyleForEmptyBraces' => 'space' } }
 


### PR DESCRIPTION
I changed `Layout/SpaceInsideHashLiteralBraces` so that it can detect the following pattern as empty Hash literal braces:

```ruby
# bad
foo = {
}

# good
foo = {}
```

One reason I think this should be is that `Layout/SpaceInsideArrayLiteralBrackets` already bahaves like this.

```ruby
# bad
foo = [
]

# good
foo = []
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
