### PR TITLE
[Fix #11037] Fix a false positive for `Style/CollectionCompact`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_collection_compact.md
+++ b/changelog/fix_a_false_positive_for_style_collection_compact.md
@@ -1,0 +1,1 @@
+* [#11037](https://github.com/rubocop/rubocop/issues/11037): Fix a false positive for `Style/CollectionCompact` when using `to_enum.reject` or `lazy.reject` methods with Ruby 3.0 or lower. ([@koic][])

--- a/spec/rubocop/cop/style/collection_compact_spec.rb
+++ b/spec/rubocop/cop/style/collection_compact_spec.rb
@@ -85,4 +85,50 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config do
       RUBY
     end
   end
+
+  context 'Ruby >= 3.1', :ruby31 do
+    it 'registers an offense and corrects when using `to_enum.reject` on array to reject nils' do
+      expect_offense(<<~RUBY)
+        array.to_enum.reject { |e| e.nil? }
+                      ^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `reject { |e| e.nil? }`.
+        array.to_enum.reject! { |e| e.nil? }
+                      ^^^^^^^^^^^^^^^^^^^^^^ Use `compact!` instead of `reject! { |e| e.nil? }`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.to_enum.compact
+        array.to_enum.compact!
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using `lazy.reject` on array to reject nils' do
+      expect_offense(<<~RUBY)
+        array.lazy.reject { |e| e.nil? }
+                   ^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `reject { |e| e.nil? }`.
+        array.lazy.reject! { |e| e.nil? }
+                   ^^^^^^^^^^^^^^^^^^^^^^ Use `compact!` instead of `reject! { |e| e.nil? }`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.lazy.compact
+        array.lazy.compact!
+      RUBY
+    end
+  end
+
+  context 'Ruby <= 3.0', :ruby30 do
+    it 'does not register an offense and corrects when using `to_enum.reject` on array to reject nils' do
+      expect_no_offenses(<<~RUBY)
+        array.to_enum.reject { |e| e.nil? }
+        array.to_enum.reject! { |e| e.nil? }
+      RUBY
+    end
+
+    it 'does not register an offense and corrects when using `lazy.reject` on array to reject nils' do
+      expect_no_offenses(<<~RUBY)
+        array.lazy.reject { |e| e.nil? }
+        array.lazy.reject! { |e| e.nil? }
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #11037.

This PR fixes a false positive for `Style/CollectionCompact` when using `to_enum.reject` or `lazy.reject` methods with Ruby 3.0 or lower.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
