### PR TITLE
[Fix #11040] Fix a false positive for `Style/IfUnlessModifier`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_if_unless_modifier.md
+++ b/changelog/fix_a_false_positive_for_style_if_unless_modifier.md
@@ -1,0 +1,1 @@
+* [#11040](https://github.com/rubocop/rubocop/issues/11040): Fix a false positive for `Style/IfUnlessModifier` when `defined?`'s argument value is undefined. ([@koic][])

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -371,6 +371,81 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
     end
   end
 
+  context 'using `defined?` in the condtion' do
+    it 'registers for argument value is defined' do
+      expect_offense(<<~RUBY)
+        value = :custom
+
+        unless defined?(value)
+        ^^^^^^ Favor modifier `unless` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+          value = :default
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        value = :custom
+
+        value = :default unless defined?(value)
+      RUBY
+    end
+
+    it 'registers for argument value is `yield`' do
+      expect_offense(<<~RUBY)
+        unless defined?(yield)
+        ^^^^^^ Favor modifier `unless` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+          value = :default
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        value = :default unless defined?(yield)
+      RUBY
+    end
+
+    it 'registers for argument value is `super`' do
+      expect_offense(<<~RUBY)
+        unless defined?(super)
+        ^^^^^^ Favor modifier `unless` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+          value = :default
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        value = :default unless defined?(super)
+      RUBY
+    end
+
+    it 'accepts `defined?` when argument value is undefined' do
+      expect_no_offenses(<<~RUBY)
+        other_value = do_something
+
+        unless defined?(value)
+          value = :default
+        end
+      RUBY
+    end
+
+    it 'accepts `defined?` when argument value is undefined and the first condition' do
+      expect_no_offenses(<<~RUBY)
+        other_value = do_something
+
+        unless defined?(value) && condition
+          value = :default
+        end
+      RUBY
+    end
+
+    it 'accepts `defined?` when argument value is undefined and the last condition' do
+      expect_no_offenses(<<~RUBY)
+        other_value = do_something
+
+        unless condition && defined?(value)
+          value = :default
+        end
+      RUBY
+    end
+  end
+
   context 'with implicit match conditional' do
     let(:body) { 'b' * 36 }
 


### PR DESCRIPTION
Fixes #11040.

This PR fixes a false positive for `Style/IfUnlessModifier` when `defined?`'s argument value is undefined.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
