### PR TITLE
Mark `Lint/OrderedMagicComments` as unsafe autocorrection

### DIFF
--- a/changelog/change_mark_lint_ordered_magic_comments_as_unsafe_autocorrection.md
+++ b/changelog/change_mark_lint_ordered_magic_comments_as_unsafe_autocorrection.md
@@ -1,0 +1,1 @@
+* [#11042](https://github.com/rubocop/rubocop/pull/11042): Mark `Lint/OrderedMagicComments` as unsafe autocorrection. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2023,7 +2023,9 @@ Lint/OrAssignmentToConstant:
 Lint/OrderedMagicComments:
   Description: 'Checks the proper ordering of magic comments and whether a magic comment is not placed before a shebang.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.53'
+  VersionChanged: '<<next>>'
 
 Lint/OutOfRangeRegexpRef:
   Description: 'Checks for out of range reference for Regexp because it always returns nil.'

--- a/lib/rubocop/cop/lint/ordered_magic_comments.rb
+++ b/lib/rubocop/cop/lint/ordered_magic_comments.rb
@@ -7,6 +7,9 @@ module RuboCop
       # Checks the proper ordering of magic comments and whether
       # a magic comment is not placed before a shebang.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because file encoding may change.
+      #
       # @example
       #   # bad
       #


### PR DESCRIPTION
This cop's autocorrection is unsafe because file encoding may change.

```console
# bad

# frozen_string_literal: true
# encoding: ascii
p [''.frozen?, ''.encoding] #=> [true, #<Encoding:UTF-8>]

# good

# encoding: ascii
# frozen_string_literal: true
p [''.frozen?, ''.encoding] #=> [true, #<Encoding:US-ASCII>]
```

It may be the intended file encoding, but the behavior is changed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
