### PR TITLE
Suggest to "Open the singleton class with `class << self`" when `Style/ModuleFunction` is set to `forbidden`

### DIFF
--- a/changelog/change_module_function-forbidden_msg.md
+++ b/changelog/change_module_function-forbidden_msg.md
@@ -1,1 +1,0 @@
-* [#11045](https://github.com/rubocop/rubocop/pull/11045): Change the message by adding "*Open the singleton class with `class << self` instead*" when `Style/ModuleFunction` is set to `forbidden`. ([@rdeckard][])

--- a/changelog/change_module_function-forbidden_msg.md
+++ b/changelog/change_module_function-forbidden_msg.md
@@ -1,0 +1,1 @@
+* [#11045](https://github.com/rubocop/rubocop/pull/11045): Change the message by adding "*Open the singleton class with `class << self` instead*" when `Style/ModuleFunction` is set to `forbidden`. ([@rdeckard][])

--- a/changelog/change_module_function-forbidden_msg.md
+++ b/changelog/change_module_function-forbidden_msg.md
@@ -1,0 +1,1 @@
+* [#11045](https://github.com/rubocop/rubocop/pull/11045): Update the `Style/ModuleFunction` documentation to suggest `class << self` as an alternative. ([@rdeckard][])

--- a/lib/rubocop/cop/style/module_function.rb
+++ b/lib/rubocop/cop/style/module_function.rb
@@ -3,13 +3,15 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for use of `extend self` or `module_function` in a
-      # module.
+      # Checks for use of `extend self` or `module_function` in a module.
       #
-      # Supported styles are: module_function, extend_self, forbidden. `forbidden`
-      # style prohibits the usage of both styles.
+      # Supported styles are: `module_function` (default), `extend_self` and `forbidden`.
       #
-      # NOTE: the cop won't be activated when the module contains any private methods.
+      # NOTES:
+      #
+      # - `forbidden` style prohibits the usage of both styles
+      # - in default mode (`module_function`), the cop won't be activated when the module
+      #   contains any private methods
       #
       # @safety
       #   Autocorrection is unsafe (and is disabled by default) because `extend self`
@@ -28,13 +30,19 @@ module RuboCop
       #     # ...
       #   end
       #
-      # @example EnforcedStyle: module_function (default)
       #   # good
       #   module Test
       #     extend self
       #     # ...
       #     private
       #     # ...
+      #   end
+      #
+      #   # good
+      #   module Test
+      #     class << self
+      #       # ...
+      #     end
       #   end
       #
       # @example EnforcedStyle: extend_self
@@ -48,6 +56,13 @@ module RuboCop
       #   module Test
       #     extend self
       #     # ...
+      #   end
+      #
+      #   # good
+      #   module Test
+      #     class << self
+      #       # ...
+      #     end
       #   end
       #
       # @example EnforcedStyle: forbidden
@@ -69,6 +84,13 @@ module RuboCop
       #     # ...
       #     private
       #     # ...
+      #   end
+      #
+      #   # good
+      #   module Test
+      #     class << self
+      #       # ...
+      #     end
       #   end
       class ModuleFunction < Base
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/style/module_function.rb
+++ b/lib/rubocop/cop/style/module_function.rb
@@ -76,7 +76,8 @@ module RuboCop
 
         MODULE_FUNCTION_MSG = 'Use `module_function` instead of `extend self`.'
         EXTEND_SELF_MSG = 'Use `extend self` instead of `module_function`.'
-        FORBIDDEN_MSG = 'Do not use `module_function` or `extend self`.'
+        FORBIDDEN_MSG = 'Do not use `module_function` or `extend self`. ' \
+                        'Open the singleton class with `class << self` instead.'
 
         # @!method module_function_node?(node)
         def_node_matcher :module_function_node?, '(send nil? :module_function)'

--- a/lib/rubocop/cop/style/module_function.rb
+++ b/lib/rubocop/cop/style/module_function.rb
@@ -76,8 +76,7 @@ module RuboCop
 
         MODULE_FUNCTION_MSG = 'Use `module_function` instead of `extend self`.'
         EXTEND_SELF_MSG = 'Use `extend self` instead of `module_function`.'
-        FORBIDDEN_MSG = 'Do not use `module_function` or `extend self`. ' \
-                        'Open the singleton class with `class << self` instead.'
+        FORBIDDEN_MSG = 'Do not use `module_function` or `extend self`.'
 
         # @!method module_function_node?(node)
         def_node_matcher :module_function_node?, '(send nil? :module_function)'

--- a/spec/rubocop/cop/style/module_function_spec.rb
+++ b/spec/rubocop/cop/style/module_function_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::Style::ModuleFunction, :config do
         expect_offense(<<~RUBY)
           module Test
             extend self
-            ^^^^^^^^^^^ Do not use `module_function` or `extend self`.
+            ^^^^^^^^^^^ Do not use `module_function` or `extend self`. Open the singleton class with `class << self` instead.
             def test; end
           end
         RUBY
@@ -101,7 +101,7 @@ RSpec.describe RuboCop::Cop::Style::ModuleFunction, :config do
         expect_offense(<<~RUBY)
           module Test
             extend self
-            ^^^^^^^^^^^ Do not use `module_function` or `extend self`.
+            ^^^^^^^^^^^ Do not use `module_function` or `extend self`. Open the singleton class with `class << self` instead.
             def test; end
             private
             def test_private;end
@@ -115,7 +115,7 @@ RSpec.describe RuboCop::Cop::Style::ModuleFunction, :config do
         expect_offense(<<~RUBY)
           module Test
             extend self
-            ^^^^^^^^^^^ Do not use `module_function` or `extend self`.
+            ^^^^^^^^^^^ Do not use `module_function` or `extend self`. Open the singleton class with `class << self` instead.
             def test; end
             private :test
           end
@@ -137,7 +137,7 @@ RSpec.describe RuboCop::Cop::Style::ModuleFunction, :config do
       expect_offense(<<~RUBY)
         module Test
           module_function
-          ^^^^^^^^^^^^^^^ Do not use `module_function` or `extend self`.
+          ^^^^^^^^^^^^^^^ Do not use `module_function` or `extend self`. Open the singleton class with `class << self` instead.
           def test; end
         end
       RUBY

--- a/spec/rubocop/cop/style/module_function_spec.rb
+++ b/spec/rubocop/cop/style/module_function_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::Style::ModuleFunction, :config do
         expect_offense(<<~RUBY)
           module Test
             extend self
-            ^^^^^^^^^^^ Do not use `module_function` or `extend self`. Open the singleton class with `class << self` instead.
+            ^^^^^^^^^^^ Do not use `module_function` or `extend self`.
             def test; end
           end
         RUBY
@@ -101,7 +101,7 @@ RSpec.describe RuboCop::Cop::Style::ModuleFunction, :config do
         expect_offense(<<~RUBY)
           module Test
             extend self
-            ^^^^^^^^^^^ Do not use `module_function` or `extend self`. Open the singleton class with `class << self` instead.
+            ^^^^^^^^^^^ Do not use `module_function` or `extend self`.
             def test; end
             private
             def test_private;end
@@ -115,7 +115,7 @@ RSpec.describe RuboCop::Cop::Style::ModuleFunction, :config do
         expect_offense(<<~RUBY)
           module Test
             extend self
-            ^^^^^^^^^^^ Do not use `module_function` or `extend self`. Open the singleton class with `class << self` instead.
+            ^^^^^^^^^^^ Do not use `module_function` or `extend self`.
             def test; end
             private :test
           end
@@ -137,7 +137,7 @@ RSpec.describe RuboCop::Cop::Style::ModuleFunction, :config do
       expect_offense(<<~RUBY)
         module Test
           module_function
-          ^^^^^^^^^^^^^^^ Do not use `module_function` or `extend self`. Open the singleton class with `class << self` instead.
+          ^^^^^^^^^^^^^^^ Do not use `module_function` or `extend self`.
           def test; end
         end
       RUBY


### PR DESCRIPTION
**Context:**
``` yml
Style/ModuleFunction:
  EnforcedStyle: forbidden
```

When `extend self` or `module_function` is used in this context ⬆️, the cop message might suggest to "_Open the singleton class with `class << self` instead._".
WDYT?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
