### PR TITLE
[Fix #11047] Fix an incorrect autocorrect for `Style/SafeNavigationChain`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_safe_navigation_chain.md
+++ b/changelog/fix_a_false_positive_for_lint_safe_navigation_chain.md
@@ -1,0 +1,1 @@
+* [#11047](https://github.com/rubocop/rubocop/issues/11047): Fix an incorrect autocorrect for `Style/SafeNavigationChain` when using `+@` and `-@` methods. ([@koic][])

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -31,6 +31,7 @@ module RuboCop
         minimum_target_ruby_version 2.3
 
         MSG = 'Do not chain ordinary method call after safe navigation operator.'
+        PLUS_MINUS_METHODS = %i[+@ -@].freeze
 
         # @!method bad_method?(node)
         def_node_matcher :bad_method?, <<~PATTERN
@@ -42,7 +43,7 @@ module RuboCop
 
         def on_send(node)
           bad_method?(node) do |safe_nav, method|
-            return if nil_methods.include?(method)
+            return if nil_methods.include?(method) || PLUS_MINUS_METHODS.include?(node.method_name)
 
             method_chain = method_chain(node)
             location =

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
       ['safe navigation with assignment method', 'x&.foo = bar'],
       ['safe navigation with self assignment method', 'x&.foo += bar'],
       ['safe navigation with `to_d` method', 'x&.foo.to_d'],
-      ['safe navigation with `in?` method', 'x&.foo.in?([:baz, :qux])']
+      ['safe navigation with `in?` method', 'x&.foo.in?([:baz, :qux])'],
+      ['safe navigation with `+@` method', '+str&.to_i'],
+      ['safe navigation with `-@` method', '-str&.to_i']
     ].each do |name, code|
       include_examples 'accepts', name, code
     end


### PR DESCRIPTION
Fixes #11047.

This PR fixes an incorrect autocorrect for `Style/SafeNavigationChain` when using `+@` and `-@` methods.
These methods are not intended for use with safe navigation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
