### PR TITLE
Fixes documentation message for EnforcedShorthandSyntax: consistent

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3857,7 +3857,7 @@ Style/HashSyntax:
     - never
     # accepts both shorthand and explicit use of hash literal value.
     - either
-    # like "always", but will avoid mixing styles in a single hash
+    # like "either", but will avoid mixing styles in a single hash
     - consistent
   # Force hashes that have a symbol value to use hash rockets
   UseHashRocketsWithSymbolValues: false

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -5214,7 +5214,7 @@ The supported styles are:
 * always - forces use of the 3.1 syntax (e.g. {foo:})
 * never - forces use of explicit hash literal value
 * either - accepts both shorthand and explicit use of hash literal value
-* consistent - like "always", but will avoid mixing styles in a single hash
+* consistent - like "either", but will avoid mixing styles in a single hash
 
 === Examples
 

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -28,7 +28,7 @@ module RuboCop
       # * always - forces use of the 3.1 syntax (e.g. {foo:})
       # * never - forces use of explicit hash literal value
       # * either - accepts both shorthand and explicit use of hash literal value
-      # * consistent - like "always", but will avoid mixing styles in a single hash
+      # * consistent - like "either", but will avoid mixing styles in a single hash
       #
       # @example EnforcedStyle: ruby19 (default)
       #   # bad


### PR DESCRIPTION
`EnforcedShorthandSyntax: consistent` behave more like `either` than `always`

Why is it not like `always`:

- `consistent` allows regular and shorthand hash syntax, but not mixed
- `always`     allows only the shorthand syntax

=> `consistent` does not behave like `always

Why is like `either`:
- `consistent` allows regular and shorthand hash syntax, but not mixed
- `either`     allows regular and shorthand hash syntax.

=> `consistent` is similar to `either` but does not allow mixing syntax.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
