### PR TITLE
Fix cop generator for nested department start with `RSpec`

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -206,9 +206,8 @@ module RuboCop
       end
 
       def snake_case(camel_case_string)
-        return 'rspec' if camel_case_string == 'RSpec'
-
         camel_case_string
+          .gsub('RSpec', 'Rspec')
           .gsub(%r{([^A-Z/])([A-Z]+)}, '\1_\2')
           .gsub(%r{([A-Z])([A-Z][^A-Z\d/]+)}, '\1_\2')
           .downcase

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -322,6 +322,14 @@ RSpec.describe RuboCop::Cop::Generator do
     it 'converts "RSpec" to snake_case' do
       expect(generator.__send__(:snake_case, 'RSpec')).to eq('rspec')
     end
+
+    it 'converts "RSpec/Foo" to snake_case' do
+      expect(generator.__send__(:snake_case, 'RSpec/Foo')).to eq('rspec/foo')
+    end
+
+    it 'converts "RSpecFoo/Bar" to snake_case' do
+      expect(generator.__send__(:snake_case, 'RSpecFoo/Bar')).to eq('rspec_foo/bar')
+    end
   end
 
   context 'nested departments' do


### PR DESCRIPTION
This PR fix cop generator for nested department start with `RSpec`. For example, the following execute new_cop:
```
bundle exec rake 'new_cop[RSpec/Foo/Bar]'
```

Then expect the following file to be created:
```
lib/rubocop/cop/rspec/foo/bar.rb
spec/rubocop/cop/rspec/foo/bar_spec.rb
```

In actual, however, the following file is generated:
```
lib/rubocop/cop/r_spec/foo/bar.rb
spec/rubocop/cop/r_spec/foo/bar_spec.rb
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
