### PR TITLE
[Fix #11051] Preserve comments on `Style/AccessModifierDeclarations` autocorrection

### DIFF
--- a/changelog/fix_preserve_comments_on.md
+++ b/changelog/fix_preserve_comments_on.md
@@ -1,0 +1,1 @@
+* [#11051](https://github.com/rubocop/rubocop/issues/11051): Preserve comments on `Style/AccessModifierDeclarations` autocorrection. ([@r7kamura][])

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -202,6 +202,31 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         end
       end
 
+      context 'when method has comments' do
+        it 'registers and autocorrects an offense' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            class Test
+              # comment
+              #{access_modifier} def foo
+              ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+                # comment
+              end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class Test
+            #{access_modifier}
+
+            # comment
+            def foo
+                # comment
+              end
+            end
+          RUBY
+        end
+      end
+
       include_examples 'always accepted', access_modifier
     end
   end


### PR DESCRIPTION
Prepared to fix #11051.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
