### PR TITLE
Expect warnings for `EnforceSuperclass` during tests

### DIFF
--- a/spec/rubocop/cop/mixin/enforce_superclass_spec.rb
+++ b/spec/rubocop/cop/mixin/enforce_superclass_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe RuboCop::Cop::EnforceSuperclass, :restore_registry do
     stub_const("#{cop_class}::MSG", 'Models should subclass `ApplicationRecord`')
     stub_const("#{cop_class}::SUPERCLASS", 'ApplicationRecord')
     stub_const("#{cop_class}::BASE_PATTERN", '(const (const {nil? cbase} :ActiveRecord) :Base)')
+    allow(described_class).to receive(:warn).with(
+      /`RuboCop::Cop::EnforceSuperclass` is deprecated and will be removed/
+    )
     RuboCop::Cop::RSpec::ApplicationRecord.include(described_class)
   end
 


### PR DESCRIPTION
Right now when running `bundle exec rspec` to run the test suite, the following warning pops several times:
```
`RuboCop::Cop::EnforceSuperclass` is deprecated and will be removed in RuboCop 2.0. Please upgrade to RuboCop Rails 2.9 or newer to continue.
```

As I believe it's expected behavior, I'm suggesting to silence them during the test suite

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] ~~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] ~~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~~

[1]: https://chris.beams.io/posts/git-commit/
