### PR TITLE
Implement correct compact mode for `SpaceInsideArrayLiteralBrackets`

### DIFF
--- a/changelog/change_space_array_bracket_compact_mode.md
+++ b/changelog/change_space_array_bracket_compact_mode.md
@@ -1,0 +1,1 @@
+* [#11054](https://github.com/rubocop/rubocop/pull/11054): Implement correct behavior for compact mode for `Layout/SpaceInsideArrayLiteralBrackets`. ([@tdeo][])

--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -13,7 +13,7 @@ module RuboCop
 
       private
 
-      def side_space_range(range:, side:)
+      def side_space_range(range:, side:, include_newlines: false)
         buffer = processed_source.buffer
         src = buffer.source
 
@@ -21,11 +21,11 @@ module RuboCop
         end_pos = range.end_pos
         if side == :left
           end_pos = begin_pos
-          begin_pos = reposition(src, begin_pos, -1)
+          begin_pos = reposition(src, begin_pos, -1, include_newlines: include_newlines)
         end
         if side == :right
           begin_pos = end_pos
-          end_pos = reposition(src, end_pos, 1)
+          end_pos = reposition(src, end_pos, 1, include_newlines: include_newlines)
         end
         Parser::Source::Range.new(buffer, begin_pos, end_pos)
       end
@@ -75,9 +75,10 @@ module RuboCop
         end
       end
 
-      def reposition(src, pos, step)
+      def reposition(src, pos, step, include_newlines: false)
         offset = step == -1 ? -1 : 0
-        pos += step while SINGLE_SPACE_REGEXP.match?(src[pos + offset])
+        pos += step while SINGLE_SPACE_REGEXP.match?(src[pos + offset]) ||
+                          (include_newlines && src[pos + offset] == "\n")
         pos.negative? ? 0 : pos
       end
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
   s.add_runtime_dependency('rexml', '>= 3.2.5', '< 4.0')
-  s.add_runtime_dependency('rubocop-ast', '>= 1.20.1', '< 2.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 1.22.0', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 3.0')
 

--- a/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
@@ -513,27 +513,27 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
     end
 
     context 'multiline, 2-dimensional array with spaces' do
-      pending 'registers an offense and corrects at the beginning of array' do
+      it 'registers an offense and corrects at the beginning of array' do
         expect_offense(<<~RUBY)
           multiline = [ [ 1, 2, 3, 4 ],
                        ^ #{no_space_message}
             [ 3, 4, 5, 6 ]]
         RUBY
 
-        expect_correction(<<~RUBY, loop: false)
+        expect_correction(<<~RUBY)
           multiline = [[ 1, 2, 3, 4 ],
             [ 3, 4, 5, 6 ]]
         RUBY
       end
 
-      pending 'registers an offense and corrects at the end of array' do
+      it 'registers an offense and corrects at the end of array' do
         expect_offense(<<~RUBY)
           multiline = [[ 1, 2, 3, 4 ],
             [ 3, 4, 5, 6 ] ]
                           ^ #{no_space_message}
         RUBY
 
-        expect_correction(<<~RUBY, loop: false)
+        expect_correction(<<~RUBY)
           multiline = [[ 1, 2, 3, 4 ],
             [ 3, 4, 5, 6 ]]
         RUBY
@@ -541,7 +541,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
     end
 
     context 'multiline, 2-dimensional array with newlines' do
-      pending 'registers an offense and corrects at the beginning of array' do
+      it 'registers an offense and corrects at the beginning of array' do
         expect_offense(<<~RUBY)
           multiline = [
                        ^{} #{no_space_message}
@@ -549,21 +549,21 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
             [ 3, 4, 5, 6 ]]
         RUBY
 
-        expect_correction(<<~RUBY, loop: false)
+        expect_correction(<<~RUBY)
           multiline = [[ 1, 2, 3, 4 ],
             [ 3, 4, 5, 6 ]]
         RUBY
       end
 
-      pending 'registers an offense and corrects at the end of array' do
+      it 'registers an offense and corrects at the end of array' do
         expect_offense(<<~RUBY)
           multiline = [[ 1, 2, 3, 4 ],
             [ 3, 4, 5, 6 ]
-                          ^{} #{no_space_message}
           ]
+          ^{} #{no_space_message}
         RUBY
 
-        expect_correction(<<~RUBY, loop: false)
+        expect_correction(<<~RUBY)
           multiline = [[ 1, 2, 3, 4 ],
             [ 3, 4, 5, 6 ]]
         RUBY


### PR DESCRIPTION
The `compact` mode for `Layout/SpaceInsideArrayLiteralBrackets` wasn't implemented according to the expected behavior in the tests, this PRs makes the relevant fixes for the tests to pass.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] ~~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
