### PR TITLE
Implement `Lint/DuplicateMethods` for object singleton class

### DIFF
--- a/changelog/new_implement_lintduplicatemethods_for.md
+++ b/changelog/new_implement_lintduplicatemethods_for.md
@@ -1,0 +1,1 @@
+* [#11055](https://github.com/rubocop/rubocop/pull/11055): Implement `Lint/DuplicateMethods` for object singleton class. ([@tdeo][])

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -133,7 +133,7 @@ module RuboCop
         end
 
         def found_instance_method(node, name)
-          return unless (scope = node.parent_module_name)
+          return found_sclass_method(node, name) unless (scope = node.parent_module_name)
 
           # Humanize the scope
           scope = scope.sub(
@@ -143,6 +143,16 @@ module RuboCop
           scope << '#' unless scope.end_with?('.')
 
           found_method(node, "#{scope}#{name}")
+        end
+
+        def found_sclass_method(node, name)
+          singleton_ancestor = node.each_ancestor.find(&:sclass_type?)
+          return unless singleton_ancestor
+
+          singleton_receiver_node = singleton_ancestor.children[0]
+          return unless singleton_receiver_node.send_type?
+
+          found_method(node, "#{singleton_receiver_node.method_name}.#{name}")
         end
 
         def found_method(node, method_name)

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -234,7 +234,6 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
     end
 
     it 'registers an offense when class << exp is used' do
-      pending
       expect_offense(<<~RUBY, 'test.rb')
         #{opening_line}
           class << blah
@@ -242,7 +241,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
               implement 1
             end
             def some_method
-            ^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both test.rb:3 and test.rb:6.
+            ^^^^^^^^^^^^^^^ Method `blah.some_method` is defined at both test.rb:3 and test.rb:6.
               implement 2
             end
           end


### PR DESCRIPTION
The cop implementation for an object singleton class when opening `class << foo` hadn't been done, this implements the expected behavior in the pending tests.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
