### PR TITLE
Fix exception in `Server::Cache#pid_running?`

### DIFF
--- a/lib/rubocop/server.rb
+++ b/lib/rubocop/server.rb
@@ -33,7 +33,7 @@ module RuboCop
       def running?
         return false unless support_server? # Never running.
 
-        Cache.dir.exist? && Cache.pid_path.file? && Cache.pid_running?
+        Cache.pid_running?
       end
 
       def wait_for_running_status!(expected)

--- a/lib/rubocop/server/cache.rb
+++ b/lib/rubocop/server/cache.rb
@@ -105,7 +105,7 @@ module RuboCop
 
         def pid_running?
           Process.kill(0, pid_path.read.to_i) == 1
-        rescue Errno::ESRCH
+        rescue Errno::ESRCH, Errno::ENOENT
           false
         end
 

--- a/spec/rubocop/server/cache_spec.rb
+++ b/spec/rubocop/server/cache_spec.rb
@@ -241,4 +241,17 @@ RSpec.describe RuboCop::Server::Cache do
       end
     end
   end
+
+  unless RuboCop::Platform.windows?
+    describe '.pid_running?', :isolated_environment do
+      it 'works properly when concurrency with server stopping and cleaning cache dir' do
+        expect(described_class).to receive(:pid_path).and_wrap_original do |method|
+          result = method.call
+          described_class.dir.rmtree # server stopping behavior
+          result
+        end
+        expect(described_class.pid_running?).to be(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
I regularly see the following error message while running the test suite:
```
$ bundle exec rspec spec/rubocop/cli/options_spec.rb:98
Run options: include {:locations=>{"./spec/rubocop/cli/options_spec.rb"=>[98]}}

Randomized with seed 64160
/Users/thierry/workspace_personal/rubocop/lib/rubocop/server/cache.rb:107:in `read': No such file or directory @ rb_sysopen - /private/var/folders/r6/h3876w6964lg75khh9435lx00000gn/T/d20221009-54597-an33p1/home/.cache/rubocop_cache/server/private+var+folders+r6+h3876w6964lg75khh9435lx00000gn+T+d20221009-54597-an33p1+work/pid (Errno::ENOENT)
	from /Users/thierry/workspace_personal/rubocop/lib/rubocop/server/cache.rb:107:in `read'
	from /Users/thierry/workspace_personal/rubocop/lib/rubocop/server/cache.rb:107:in `pid_running?'
	from /Users/thierry/workspace_personal/rubocop/lib/rubocop/server.rb:36:in `running?'
	from /Users/thierry/workspace_personal/rubocop/lib/rubocop/server.rb:41:in `wait_for_running_status!'
	from /Users/thierry/workspace_personal/rubocop/lib/rubocop/server/client_command/stop.rb:23:in `block in run'
	from /Users/thierry/workspace_personal/rubocop/lib/rubocop/server/client_command/stop.rb:21:in `fork'
	from /Users/thierry/workspace_personal/rubocop/lib/rubocop/server/client_command/stop.rb:21:in `run'
	from /Users/thierry/workspace_personal/rubocop/lib/rubocop/server/cli.rb:87:in `run_command'
	from /Users/thierry/workspace_personal/rubocop/lib/rubocop/server/cli.rb:60:in `run'
	from /Users/thierry/workspace_personal/rubocop/exe/rubocop:8:in `<main>'
.

Finished in 0.79382 seconds (files took 0.58821 seconds to load)
1 example, 0 failures

Randomized with seed 64160
```

My understanding of this is a concurrency issue between the client process doing `Cache.dir.exist? && Cache.pid_path.file? && Cache.pid_running?` and the server stopping.

Even though `Cache.pid_path.file?` should ensure pid file existence for `Cache.pid_running?`, the server may stop in between and have deleted the pid file, triggering the `Errno::ENOENT`. 

I'm suggesting instead to remove this condition `Cache.pid_path.file?` and rescue `ENOENT` in `pid_running?`, in which case to return false.

I'm also removing the `Cache.dir.exist?` condition because it's redundant by nature because of [the `Cache.dir` implementation](https://github.com/rubocop/rubocop/blob/ad4a8caf673a4de1eb02e82c0463bb3da834704f/lib/rubocop/server/cache.rb#L44-L48)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] ~~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~~

[1]: https://chris.beams.io/posts/git-commit/
