### PR TITLE
Make `Lint/RedundantRequireStatement` aware of `pp`, `ruby2_keywords`, and `fiber`

### DIFF
--- a/changelog/change_make_lint_redundant_require_statement_aware_of_pp_ruby2_keywords_and_fiber.md
+++ b/changelog/change_make_lint_redundant_require_statement_aware_of_pp_ruby2_keywords_and_fiber.md
@@ -1,0 +1,1 @@
+* [#11057](https://github.com/rubocop/rubocop/pull/11057): Make `Lint/RedundantRequireStatement` aware of `pp`, `ruby2_keywords`, and `fiber`. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_require_statement.rb
+++ b/lib/rubocop/cop/lint/redundant_require_statement.rb
@@ -6,13 +6,22 @@ module RuboCop
       # Checks for unnecessary `require` statement.
       #
       # The following features are unnecessary `require` statement because
-      # they are already loaded.
+      # they are already loaded. e.g. Ruby 2.2:
       #
       #   ruby -ve 'p $LOADED_FEATURES.reject { |feature| %r|/| =~ feature }'
       #   ruby 2.2.8p477 (2017-09-14 revision 59906) [x86_64-darwin13]
       #   ["enumerator.so", "rational.so", "complex.so", "thread.rb"]
       #
-      # This cop targets Ruby 2.2 or higher containing these 4 features.
+      # Below are the features that each `TargetRubyVersion` targets.
+      #
+      #   * 2.0+ ... `enumerator`
+      #   * 2.1+ ... `thread`
+      #   * 2.2+ ... Add `rational` and `complex` above
+      #   * 2.5+ ... Add `pp` above
+      #   * 2.7+ ... Add `ruby2_keywords` above
+      #   * 3.1+ ... Add `fiber` above
+      #
+      # This cop target those features.
       #
       # @example
       #   # bad
@@ -24,21 +33,19 @@ module RuboCop
       class RedundantRequireStatement < Base
         include RangeHelp
         extend AutoCorrector
-        extend TargetRubyVersion
-
-        minimum_target_ruby_version 2.2
 
         MSG = 'Remove unnecessary `require` statement.'
         RESTRICT_ON_SEND = %i[require].freeze
+        RUBY_22_LOADED_FEATURES = %w[rational complex].freeze
 
-        # @!method unnecessary_require_statement?(node)
-        def_node_matcher :unnecessary_require_statement?, <<~PATTERN
+        # @!method redundant_require_statement?(node)
+        def_node_matcher :redundant_require_statement?, <<~PATTERN
           (send nil? :require
-            (str {"enumerator" "rational" "complex" "thread"}))
+            (str #redundant_feature?))
         PATTERN
 
         def on_send(node)
-          return unless unnecessary_require_statement?(node)
+          return unless redundant_require_statement?(node)
 
           add_offense(node) do |corrector|
             range = range_with_surrounding_space(node.loc.expression, side: :right)
@@ -46,6 +53,19 @@ module RuboCop
             corrector.remove(range)
           end
         end
+
+        private
+
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        def redundant_feature?(feature_name)
+          feature_name == 'enumerator' ||
+            (target_ruby_version >= 2.1 && feature_name == 'thread') ||
+            (target_ruby_version >= 2.2 && RUBY_22_LOADED_FEATURES.include?(feature_name)) ||
+            (target_ruby_version >= 2.5 && feature_name == 'pp') ||
+            (target_ruby_version >= 2.7 && feature_name == 'ruby2_keywords') ||
+            (target_ruby_version >= 3.1 && feature_name == 'fiber')
+        end
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       end
     end
   end

--- a/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
@@ -1,19 +1,158 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
-  context 'target ruby version < 2.2', :ruby21 do
-    it "does not register an offense when using `require 'enumerator'`" do
+  it 'registers an offense when using requiring `enumerator`' do
+    expect_offense(<<~RUBY)
+      require 'enumerator'
+      ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+      require 'uri'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      require 'uri'
+    RUBY
+  end
+
+  context 'target ruby version <= 2.0', :ruby20 do
+    it 'does not register an offense when using requiring `thread`' do
       expect_no_offenses(<<~RUBY)
+        require 'thread'
+      RUBY
+    end
+  end
+
+  context 'target ruby version >= 2.1', :ruby21 do
+    it 'register an offense and corrects when using requiring `thread` or already redundant features' do
+      expect_offense(<<~RUBY)
         require 'enumerator'
+        ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'thread'
+        ^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'uri'
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require 'uri'
+      RUBY
+    end
+  end
+
+  context 'target ruby version <= 2.1', :ruby21 do
+    it 'does not register an offense when using requiring `rational`, `complex`' do
+      expect_no_offenses(<<~RUBY)
+        require 'rational'
+        require 'complex'
       RUBY
     end
   end
 
   context 'target ruby version >= 2.2', :ruby22 do
-    it "registers an offense and corrects when using `require 'enumerator'`" do
+    it 'registers an offense when using requiring `rational`, `complex`' do
       expect_offense(<<~RUBY)
         require 'enumerator'
         ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'rational'
+        ^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'complex'
+        ^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'thread'
+        ^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'uri'
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require 'uri'
+      RUBY
+    end
+  end
+
+  context 'target ruby version <= 2.4', :ruby24 do
+    it 'does not register an offense when using requiring `pp`' do
+      expect_no_offenses(<<~RUBY)
+        require 'pp'
+      RUBY
+    end
+  end
+
+  context 'target ruby version >= 2.5', :ruby25 do
+    it 'register an offense and corrects when using requiring `pp` or already redundant features' do
+      expect_offense(<<~RUBY)
+        require 'enumerator'
+        ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'rational'
+        ^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'complex'
+        ^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'thread'
+        ^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'pp'
+        ^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'uri'
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require 'uri'
+      RUBY
+    end
+  end
+
+  context 'target ruby version <= 2.6', :ruby26 do
+    it 'does not register an offense when using requiring `ruby2_keywords`' do
+      expect_no_offenses(<<~RUBY)
+        require 'ruby2_keywords'
+      RUBY
+    end
+  end
+
+  context 'target ruby version >= 2.7', :ruby27 do
+    it 'registers an offense when using requiring `ruby2_keywords` or already redundant features' do
+      expect_offense(<<~RUBY)
+        require 'enumerator'
+        ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'rational'
+        ^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'complex'
+        ^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'thread'
+        ^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'pp'
+        ^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'ruby2_keywords'
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'uri'
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require 'uri'
+      RUBY
+    end
+  end
+
+  context 'target ruby version < 3.1', :ruby30 do
+    it 'does not register an offense and corrects when using requiring `fiber`' do
+      expect_no_offenses(<<~RUBY)
+        require 'fiber'
+      RUBY
+    end
+  end
+
+  context 'target ruby version >= 3.1', :ruby31 do
+    it 'registers an offense and corrects when using requiring `fiber` or already redundant features' do
+      expect_offense(<<~RUBY)
+        require 'enumerator'
+        ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'rational'
+        ^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'complex'
+        ^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'thread'
+        ^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'pp'
+        ^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'ruby2_keywords'
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+        require 'fiber'
+        ^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
         require 'uri'
       RUBY
 


### PR DESCRIPTION
This PR makes `Lint/RedundantRequireStatement` aware of `pp`, `ruby2_keywords`, and `fiber`. Also, RuboCop's `TargetRubyVersion` has been recovered up to 2.0, so it will be corrected as follows.

## Before

- 2.2+: `enumerator`, `thread`, `rational`, and `complex`

## After

- 2.0+: `enumerator`
- 2.1+: `thread`
- 2.2+: `rational` and `complex`
- 2.5+: `pp`
- 2.7+: `ruby2_keywords`
- 3.1+: `fiber`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
