### PR TITLE
Fix random test failures for server reload behavior

### DIFF
--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -3,14 +3,6 @@
 require 'tmpdir'
 
 RSpec.shared_context 'isolated environment' do # rubocop:disable Metrics/BlockLength
-  before do
-    if RuboCop.const_defined?(:Server)
-      # Bust server cache to behave as an isolated environment
-      RuboCop::Server::Cache.cache_root_path = nil
-      RuboCop::Server::Cache.instance_variable_set(:@project_dir_cache_key, nil)
-    end
-  end
-
   around do |example|
     Dir.mktmpdir do |tmpdir|
       original_home = Dir.home
@@ -40,11 +32,20 @@ RSpec.shared_context 'isolated environment' do # rubocop:disable Metrics/BlockLe
         ENV['HOME'] = original_home
         ENV['XDG_CONFIG_HOME'] = original_xdg_config_home
 
-        if RuboCop.const_defined?(:Server)
-          RuboCop::Server::Cache.cache_root_path = nil
-          RuboCop::Server::Cache.instance_variable_set(:@project_dir_cache_key, nil)
-        end
         RuboCop::FileFinder.root_level = nil
+      end
+    end
+  end
+
+  if RuboCop.const_defined?(:Server)
+    around do |example|
+      RuboCop::Server::Cache.cache_root_path = nil
+      RuboCop::Server::Cache.instance_variable_set(:@project_dir_cache_key, nil)
+      begin
+        example.run
+      ensure
+        RuboCop::Server::Cache.cache_root_path = nil
+        RuboCop::Server::Cache.instance_variable_set(:@project_dir_cache_key, nil)
       end
     end
   end

--- a/lib/rubocop/server/core.rb
+++ b/lib/rubocop/server/core.rb
@@ -41,6 +41,7 @@ module RuboCop
 
         pid = fork do
           Process.daemon(true)
+          $stderr.reopen(Cache.stderr_path, 'w')
           Cache.write_pid_file do
             read_socket(@server.accept) until @server.closed?
           end


### PR DESCRIPTION
There seems to be a pretty random test failure on the test 
```
rubocop --server when using `--server` option after updating RuboCop displays a restart information message
```

For instance:
- https://github.com/rubocop/rubocop-ast/actions/runs/3210248983/jobs/5247557361
- https://app.circleci.com/pipelines/github/rubocop/rubocop/7366/workflows/aec22370-2fcf-4b4e-bd91-71c89ef3d638/jobs/242160

I'm unfortunately unable to reproduce locally, so trying to understand a bit more about it

Please let me know if using a PR for that purpose isn't appropriate and if you have alternative suggestions

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
