### PR TITLE
Re-enable xitted tests

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'RuboCop Project', type: :feature do
     RuboCop::Cop::Cop
       .registry
       .without_department(:Test)
+      .without_department(:Test2)
       .without_department(:InternalAffairs)
       .cops
       .map(&:cop_name)

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -9,7 +9,12 @@ RSpec.describe RuboCop::ConfigObsoletion do
   let(:loaded_path) { 'example/.rubocop.yml' }
   let(:requires) { [] }
 
-  before { allow(configuration).to receive(:loaded_features).and_return(requires) }
+  before do
+    allow(configuration).to receive(:loaded_features).and_return(requires)
+    described_class.files = [described_class::DEFAULT_RULES_FILE]
+  end
+
+  after { described_class.files = [described_class::DEFAULT_RULES_FILE] }
 
   describe '#validate', :isolated_environment do
     context 'when the configuration includes any obsolete cop name' do
@@ -212,7 +217,7 @@ RSpec.describe RuboCop::ConfigObsoletion do
         config_obsoletion.reject_obsolete!
         raise 'Expected a RuboCop::ValidationError'
       rescue RuboCop::ValidationError => e
-        expect(expected_message).to eq(e.message)
+        expect(e.message).to eq(expected_message)
       end
     end
 
@@ -248,7 +253,7 @@ RSpec.describe RuboCop::ConfigObsoletion do
           config_obsoletion.reject_obsolete!
           raise 'Expected a RuboCop::ValidationError'
         rescue RuboCop::ValidationError => e
-          expect(expected_message).to eq(e.message)
+          expect(e.message).to eq(expected_message)
         end
       end
 
@@ -262,13 +267,11 @@ RSpec.describe RuboCop::ConfigObsoletion do
           OUTPUT
         end
 
-        # FIXME: Workaround for the following random failure test.
-        # https://app.circleci.com/pipelines/github/rubocop/rubocop/5075/workflows/758481f3-39fa-4a89-9fb2-c6e78d3b4ff8/jobs/194419
-        xit 'prints a warning message' do
+        it 'prints a warning message' do
           config_obsoletion.reject_obsolete!
           raise 'Expected a RuboCop::ValidationError'
         rescue RuboCop::ValidationError => e
-          expect(expected_message).to eq(e.message)
+          expect(e.message).to eq(expected_message)
         end
       end
     end
@@ -392,7 +395,7 @@ RSpec.describe RuboCop::ConfigObsoletion do
         config_obsoletion.reject_obsolete!
         raise 'Expected a RuboCop::ValidationError'
       rescue RuboCop::ValidationError => e
-        expect(expected_message).to eq(e.message)
+        expect(e.message).to eq(expected_message)
       end
     end
 
@@ -492,8 +495,6 @@ RSpec.describe RuboCop::ConfigObsoletion do
     end
 
     context 'when additional obsoletions are defined externally' do
-      after { described_class.files = [described_class::DEFAULT_RULES_FILE] }
-
       let(:hash) do
         {
           'Foo/Bar' => { Enabled: true },
@@ -550,14 +551,12 @@ RSpec.describe RuboCop::ConfigObsoletion do
           config_obsoletion.reject_obsolete!
           raise 'Expected a RuboCop::ValidationError'
         rescue RuboCop::ValidationError => e
-          expect(expected_message).to eq(e.message)
+          expect(e.message).to eq(expected_message)
         end
       end
     end
 
     context 'when extractions are disabled by an external library' do
-      after { described_class.files = [described_class::DEFAULT_RULES_FILE] }
-
       let(:hash) { { 'Performance/CollectionLiteralInLoop' => { Enabled: true } } }
 
       let(:external_obsoletions) do
@@ -575,8 +574,6 @@ RSpec.describe RuboCop::ConfigObsoletion do
     end
 
     context 'when using `changed_parameters` by an external library' do
-      after { described_class.files = [described_class::DEFAULT_RULES_FILE] }
-
       let(:hash) { {} }
       let(:external_obsoletions) do
         create_file('external/obsoletions.yml', <<~YAML)

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe RuboCop::Cop::Cop, :config do
 
     # `Rails/SafeNavigation` was extracted to rubocop-rails gem,
     # there were no cop whose names overlapped.
-    xit 'raises an error if the cop name is in more than one namespace' do
-      expect { described_class.qualified_cop_name('SafeNavigation', '--only') }
+    it 'raises an error if the cop name is in more than one namespace' do
+      expect { described_class.qualified_cop_name('SameNameInMultipleNamespace', '--only') }
         .to raise_error(RuboCop::Cop::AmbiguousCopName)
     end
 

--- a/spec/support/cops/same_name_in_multiple_namespace.rb
+++ b/spec/support/cops/same_name_in_multiple_namespace.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Test
+      class SameNameInMultipleNamespace < RuboCop::Cop::Base; end
+    end
+
+    module Test2
+      class SameNameInMultipleNamespace < RuboCop::Cop::Base; end
+    end
+  end
+end


### PR DESCRIPTION
There are 2 tests currently xitted in the codebase:
1. Behavior of `qualified_cop_name` when 2 cops have the same name in different namespaces

Re-enabling this one by adding test cops matching this condition

2. One about `ConfigObsoletion` behavior for extracted cops which had been disabled because of random failures.

I was able to reproduce by running `rspec ./spec/rubocop/config_obsoletion_spec.rb[1:1:2:3:1,1:1:3:1] --seed 47550 -fd` and tracked it down to pollution of the `RuboCop::ConfigObsoletion.files` class variables, fixed by setting a cleanup `after` block for all tests in that file.
I also re-ordered values of some `expect` to have the expected order `expect(value).to eq expected_value` for the failure messages to be accurate.



-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] ~~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~~

[1]: https://chris.beams.io/posts/git-commit/
