### PR TITLE
Preserve comments on `Style/AccessorGrouping` autocorrection

### DIFF
--- a/changelog/fix_preserve_comments_on_style_accessor_grouping.md
+++ b/changelog/fix_preserve_comments_on_style_accessor_grouping.md
@@ -1,0 +1,1 @@
+* [#11063](https://github.com/rubocop/rubocop/pull/11063): Preserve comments on `Style/AccessorGrouping` autocorrection. ([@r7kamura][])

--- a/lib/rubocop/cop/style/accessor_grouping.rb
+++ b/lib/rubocop/cop/style/accessor_grouping.rb
@@ -135,12 +135,16 @@ module RuboCop
         end
 
         def separate_accessors(node)
-          node.arguments.map do |arg|
-            if arg == node.arguments.first
+          node.arguments.flat_map do |arg|
+            lines = [
+              *processed_source.ast_with_comments[arg].map(&:text),
               "#{node.method_name} #{arg.source}"
+            ]
+            if arg == node.arguments.first
+              lines
             else
               indent = ' ' * node.loc.column
-              "#{indent}#{node.method_name} #{arg.source}"
+              lines.map { |line| "#{indent}#{line}" }
             end
           end.join("\n")
         end

--- a/spec/rubocop/cop/style/accessor_grouping_spec.rb
+++ b/spec/rubocop/cop/style/accessor_grouping_spec.rb
@@ -326,5 +326,34 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
         end
       RUBY
     end
+
+    context 'when there are comments for attributes' do
+      it 'registers and corrects an offense' do
+        expect_offense(<<~RUBY)
+          class Foo
+            attr_reader(
+            ^^^^^^^^^^^^ Use one attribute per `attr_reader`.
+              # comment one
+              :one,
+              # comment two A
+              :two, # comment two B
+              :three # comment three
+            )
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Foo
+            # comment one
+          attr_reader :one
+            # comment two A
+            # comment two B
+            attr_reader :two
+            # comment three
+            attr_reader :three
+          end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
When using `Style/AccessorGrouping` with `EnforcedStyle: separated`, I encountered a problem with comments being eraced by autocorrection.

```diff
 class A
-  attr_reader :foo,
-    :bar, # FIXME: remove this
-    :baz
+  attr_reader :foo
+  attr_reader :bar
+  attr_reader :baz
 end
```

I created this Pull Request to fix this problem. This change will result in the following autocorrection:

```diff
 class A
-  attr_reader :foo,
-    :bar, # FIXME: remove this
-    :baz
+  attr_reader :foo
+  # FIXME: remove this
+  attr_reader :bar
+  attr_reader :baz
 end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
