### PR TITLE
[Fix #11024] Add `require_always` option to `Style/EndlessMethod`

### DIFF
--- a/changelog/new_add_require_endless_method_option_to_style_endless_method.md
+++ b/changelog/new_add_require_endless_method_option_to_style_endless_method.md
@@ -1,0 +1,1 @@
+* [#11024](https://github.com/rubocop/rubocop/issues/11024): Add `require_always` option to `Style/EndlessMethod`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3608,6 +3608,7 @@ Style/EndlessMethod:
     - allow_single_line
     - allow_always
     - disallow
+    - require_always
 
 Style/EnvHome:
   Description: "Checks for consistent usage of `ENV['HOME']`."

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -5,8 +5,10 @@ module RuboCop
     module Style
       # Checks for endless methods.
       #
-      # It can enforce either the use of endless methods definitions
-      # for single-lined method bodies, or disallow endless methods.
+      # It can enforce endless method definitions whenever possible. It can also disallow multiline
+      # endless method definitions or all endless definitions.
+      #
+      # `require_always` style enforces endless method definitions for single statement methods.
       #
       # Other method definition types are not considered by this cop.
       #
@@ -15,36 +17,94 @@ module RuboCop
       # * allow_single_line (default) - only single line endless method definitions are allowed.
       # * allow_always - all endless method definitions are allowed.
       # * disallow - all endless method definitions are disallowed.
+      # * require_always - all endless method definitions are required.
       #
       # NOTE: Incorrect endless method definitions will always be
       # corrected to a multi-line definition.
       #
       # @example EnforcedStyle: allow_single_line (default)
-      #   # good
-      #   def my_method() = x
-      #
       #   # bad, multi-line endless method
-      #   def my_method() = x.foo
-      #                      .bar
-      #                      .baz
+      #   def my_method = x.foo
+      #                    .bar
+      #                    .baz
+      #
+      #   # good
+      #   def my_method
+      #     x
+      #   end
+      #
+      #   # good
+      #   def my_method = x
+      #
+      #   # good
+      #   def my_method
+      #     x.foo
+      #      .bar
+      #      .baz
+      #   end
       #
       # @example EnforcedStyle: allow_always
       #   # good
-      #   def my_method() = x
+      #   def my_method
+      #     x
+      #   end
       #
       #   # good
-      #   def my_method() = x.foo
-      #                      .bar
-      #                      .baz
+      #   def my_method = x
+      #
+      #   # good
+      #   def my_method = x.foo
+      #                    .bar
+      #                    .baz
+      #
+      #   # good
+      #   def my_method
+      #     x.foo
+      #      .bar
+      #      .baz
+      #   end
       #
       # @example EnforcedStyle: disallow
       #   # bad
-      #   def my_method() = x
+      #   def my_method = x
       #
       #   # bad
-      #   def my_method() = x.foo
-      #                      .bar
-      #                      .baz
+      #   def my_method = x.foo
+      #                    .bar
+      #                    .baz
+      #
+      #   # good
+      #   def my_method
+      #     x
+      #   end
+      #
+      #   # good
+      #   def my_method
+      #     x.foo
+      #      .bar
+      #      .baz
+      #   end
+      #
+      # @example EnforcedStyle: require_always
+      #   # bad
+      #   def my_method
+      #     x
+      #   end
+      #
+      #   # bad
+      #   def my_method
+      #     x.foo
+      #      .bar
+      #      .baz
+      #   end
+      #
+      #   # good
+      #   def my_method = x
+      #
+      #   # good
+      #   def my_method = x.foo
+      #                    .bar
+      #                    .baz
       #
       class EndlessMethod < Base
         include ConfigurableEnforcedStyle
@@ -56,12 +116,16 @@ module RuboCop
         CORRECTION_STYLES = %w[multiline single_line].freeze
         MSG = 'Avoid endless method definitions.'
         MSG_MULTI_LINE = 'Avoid endless method definitions with multiple lines.'
+        MSG_REQUIRE_ALWAYS = 'Use endless method definitions.'
 
         def on_def(node)
-          if style == :disallow
-            handle_disallow_style(node)
-          else
+          case style
+          when :allow_single_line, :allow_always
             handle_allow_style(node)
+          when :disallow
+            handle_disallow_style(node)
+          when :require_always
+            handle_require_always_style(node)
           end
         end
 
@@ -76,6 +140,14 @@ module RuboCop
           end
         end
 
+        def handle_require_always_style(node)
+          return if node.endless? || !node.body || node.body.begin_type? || node.body.kwbegin_type?
+
+          add_offense(node, message: MSG_REQUIRE_ALWAYS) do |corrector|
+            correct_to_endless_method(corrector, node)
+          end
+        end
+
         def handle_disallow_style(node)
           return unless node.endless?
 
@@ -87,6 +159,14 @@ module RuboCop
             def #{node.method_name}#{arguments(node)}
               #{node.body.source}
             end
+          RUBY
+
+          corrector.replace(node, replacement)
+        end
+
+        def correct_to_endless_method(corrector, node)
+          replacement = <<~RUBY.strip
+            def #{node.method_name}#{arguments(node)} = #{node.body.source}
           RUBY
 
           corrector.replace(node, replacement)

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -8,8 +8,8 @@ module RuboCop
       #
       # Endless methods added in Ruby 3.0 are also accepted by this cop.
       #
-      # If `Style/EndlessMethod` is enabled with `EnforcedStyle: allow_single_line` or
-      # `allow_always`, single-line methods will be autocorrected to endless
+      # If `Style/EndlessMethod` is enabled with `EnforcedStyle: allow_single_line`, `allow_always`,
+      # or `require_always`, single-line methods will be autocorrected to endless
       # methods if there is only one statement in the body.
       #
       # @example

--- a/spec/rubocop/cop/style/endless_method_spec.rb
+++ b/spec/rubocop/cop/style/endless_method_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
           end
         RUBY
       end
+
+      it 'does not register an offense for a single line method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x
+          end
+        RUBY
+      end
     end
 
     context 'EnforcedStyle: allow_single_line' do
@@ -44,6 +52,14 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
       it 'does not register an offense for an endless method with arguments' do
         expect_no_offenses(<<~RUBY)
           def my_method(a, b) = x
+        RUBY
+      end
+
+      it 'does not register an offense for a single line method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x
+          end
         RUBY
       end
 
@@ -114,6 +130,14 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         RUBY
       end
 
+      it 'does not register an offense for a single line method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x
+          end
+        RUBY
+      end
+
       it 'does not register an offense for a multiline endless method' do
         expect_no_offenses(<<~RUBY)
           def my_method() = x.foo
@@ -135,6 +159,116 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
           def my_method(a, b) = x.foo
                                  .bar
                                  .baz
+        RUBY
+      end
+    end
+
+    context 'EnforcedStyle: require_always' do
+      let(:cop_config) { { 'EnforcedStyle' => 'require_always' } }
+
+      it 'does not register an offense for an endless method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method() = x
+        RUBY
+      end
+
+      it 'does not register an offense for an endless method with arguments' do
+        expect_no_offenses(<<~RUBY)
+          def my_method(a, b) = x
+        RUBY
+      end
+
+      it 'does not register an offense for an multiline endless method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method = x.foo
+                           .bar
+                           .baz
+        RUBY
+      end
+
+      it 'does not register an offense for no statements method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for multiple statements method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x.foo
+            x.bar
+          end
+        RUBY
+      end
+
+      it 'does not register an offenses for multiple statements method with `begin`' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            begin
+              foo && bar
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a single line method' do
+        expect_offense(<<~RUBY)
+          def my_method
+          ^^^^^^^^^^^^^ Use endless method definitions.
+            x
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_method = x
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a single line method with arguments' do
+        expect_offense(<<~RUBY)
+          def my_method(a, b)
+          ^^^^^^^^^^^^^^^^^^^ Use endless method definitions.
+            x
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_method(a, b) = x
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a multiline method' do
+        expect_offense(<<~RUBY)
+          def my_method
+          ^^^^^^^^^^^^^ Use endless method definitions.
+            x.foo
+             .bar
+             .baz
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_method = x.foo
+             .bar
+             .baz
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a multiline method with arguments' do
+        expect_offense(<<~RUBY)
+          def my_method(a, b)
+          ^^^^^^^^^^^^^^^^^^^ Use endless method definitions.
+            x.foo
+             .bar
+             .baz
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_method(a, b) = x.foo
+             .bar
+             .baz
         RUBY
       end
     end

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -318,6 +318,12 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
       it_behaves_like 'convert to endless method'
     end
 
+    context 'with `require_always` style' do
+      let(:endless_method_config) { { 'EnforcedStyle' => 'require_always' } }
+
+      it_behaves_like 'convert to endless method'
+    end
+
     context 'prior to ruby 3.0', :ruby27 do
       let(:endless_method_config) { { 'EnforcedStyle' => 'allow_always' } }
 


### PR DESCRIPTION
Fixes #11024.

This PR adds `require_always` option to `Style/EndlessMethod` that all endless method definitions are required.

```ruby
# EnforcedStyle: require_always

# bad
def my_method
  x
end

# bad
def my_method
  x.foo
   .bar
   .baz
end

# good
def my_method = x

# good
def my_method = x.foo
                 .bar
                 .baz
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
