### PR TITLE
Fix a false positive for `Style/RedundantRegexpCharacterClass`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_regexp_character_class.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_regexp_character_class.md
@@ -1,0 +1,1 @@
+* [#11068](https://github.com/rubocop/rubocop/pull/11068): Fix a false positive for `Style/RedundantRegexpCharacterClass` when using starting with "\0" number. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_regexp_character_class.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_character_class.rb
@@ -74,7 +74,7 @@ module RuboCop
 
           non_redundant =
             whitespace_in_free_space_mode?(node, class_elem) ||
-            backslash_b?(class_elem) ||
+            backslash_b?(class_elem) || backslash_zero?(class_elem) ||
             requires_escape_outside_char_class?(class_elem)
 
           !non_redundant
@@ -102,6 +102,13 @@ module RuboCop
           # \b's behavior is different inside and outside of a character class, matching word
           # boundaries outside but backspace (0x08) when inside.
           elem == '\b'
+        end
+
+        def backslash_zero?(elem)
+          # See https://github.com/rubocop/rubocop/issues/11067 for details - in short "\0" != "0" -
+          # the former means an Unicode code point `"\u0000"`, the latter a number character `"0"`.
+          # Similarly "\032" means "\u001A". Other numbers starting with "\0" can also be mentioned.
+          elem == '\0'
         end
 
         def requires_escape_outside_char_class?(elem)

--- a/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
@@ -307,6 +307,15 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpCharacterClass, :config do
     end
   end
 
+  context 'with a character class containing an escaped-0' do
+    # See https://github.com/rubocop/rubocop/issues/11067 for details - in short "\0" != "0" - the
+    # former means an Unicode code point `"\u0000"`, the latter a number character `"0"`.
+    # Similarly "\032" means "\u001A". Other numbers starting with "\0" can also be mentioned.
+    it 'does not register an offense' do
+      expect_no_offenses('foo = /[\032]/')
+    end
+  end
+
   context 'with a character class containing a character requiring escape outside' do
     # Not implemented for now, since we would have to escape on autocorrect, and the cop message
     # would need to be dynamic to not be misleading.


### PR DESCRIPTION
This is a similar issue to https://github.com/rubocop/rubocop/issues/11067.

This PR fixes a false positive for `Style/RedundantRegexpCharacterClass` when using starting with "\0" number.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
