### PR TITLE
Allow specifying code ranges for autocorrect

### DIFF
--- a/changelog/new_check_range_when_provided.md
+++ b/changelog/new_check_range_when_provided.md
@@ -1,0 +1,1 @@
+* [#10930](https://github.com/rubocop/rubocop/issues/10930): Check range for autocorrections when providing new cli options. ([@HeroProtagonist][])

--- a/docs/modules/ROOT/pages/usage/autocorrect.adoc
+++ b/docs/modules/ROOT/pages/usage/autocorrect.adoc
@@ -115,3 +115,12 @@ $ rubocop --autocorrect-all --disable-uncorrectable
 You can add the flag `--disable-uncorrectable`, which will generate
 `# rubocop:todo` comments in the code to stop the reporting of offenses that
 could not be corrected automatically.
+
+== Specifying ranges
+
+You can add `--[start|end]-line` and/or `--[start|end]-column` with integers to limit the range where corrections will be applied. The ranges are inclusive.
+
+[source,sh]
+----
+$ rubocop --autocorrect --start-line 5 --end-line 7 --start-column 1 --end-column 5
+----

--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -180,6 +180,12 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | `--enable-pending-cops`
 | Run with pending cops.
 
+| `--end-column`
+| Used with --autocorrect to specify last column to apply corrections.
+
+| `--end-line`
+| Used with --autocorrect to specify last line to apply corrections.
+
 | `--except`
 | Run all cops enabled by configuration except the specified cop(s) and/or departments.
 
@@ -257,6 +263,12 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 
 | `--show-docs-url`
 | Shows urls for documentation pages of supplied cops.
+
+| `--start-column`
+| Used with --autocorrect to specify first column to apply corrections.
+
+| `--start-line`
+| Used with --autocorrect to specify first line to apply corrections.
 
 | `--stderr`
 | Write all output to stderr except for the autocorrected source. This is especially useful when combined with `--autocorrect` and `--stdin`.

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -4,8 +4,10 @@ module RuboCop
   module Cop
     # This module encapsulates the logic for autocorrect behavior for a cop.
     module AutocorrectLogic
-      def autocorrect?
-        autocorrect_requested? && correctable? && autocorrect_enabled?
+      # @param range [Parser::Source::Range] Used for bounding autocorrections
+      # @return [Boolean]
+      def autocorrect?(range = nil)
+        autocorrect_requested? && correctable? && autocorrect_enabled? && in_range?(range)
       end
 
       def autocorrect_with_disable_uncorrectable?
@@ -41,7 +43,36 @@ module RuboCop
         true
       end
 
+      def in_range?(range)
+        return true unless range
+
+        bounds = []
+
+        bounds << start_line_in_range?(range) if @options[:start_line]
+        bounds << start_column_in_range?(range) if @options[:start_column]
+        bounds << end_line_in_range?(range) if @options[:end_line]
+        bounds << end_column_in_range?(range) if @options[:end_column]
+
+        bounds.all?
+      end
+
       private
+
+      def start_line_in_range?(range)
+        range.line >= @options[:start_line]
+      end
+
+      def start_column_in_range?(range)
+        range.column >= @options[:start_column]
+      end
+
+      def end_line_in_range?(range)
+        range.last_line <= @options[:end_line]
+      end
+
+      def end_column_in_range?(range)
+        range.last_column <= @options[:end_column]
+      end
 
       def disable_offense(range)
         heredoc_range = surrounding_heredoc(range)

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -356,7 +356,7 @@ module RuboCop
 
       # @return [Symbol] offense status
       def use_corrector(range, corrector)
-        if autocorrect?
+        if autocorrect?(range)
           attempt_correction(range, corrector)
         elsif corrector && cop_config.fetch('AutoCorrect', true)
           :uncorrected

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -129,7 +129,7 @@ module RuboCop
     # -a, --auto-correct         -            true          true               -
     #     --safe-auto-correct    -            true          true               -
     # -A, --auto-correct-all     -            true          -                  true
-    def add_autocorrection_options(opts) # rubocop:disable Metrics/MethodLength
+    def add_autocorrection_options(opts) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       section(opts, 'Autocorrection') do
         option(opts, '-a', '--autocorrect') { @options[:safe_autocorrect] = true }
         option(opts, '--auto-correct') do
@@ -148,6 +148,10 @@ module RuboCop
         end
 
         option(opts, '--disable-uncorrectable')
+        option(opts, '--start-line LINE', Integer)
+        option(opts, '--end-line LINE', Integer)
+        option(opts, '--start-column COLUMN', Integer)
+        option(opts, '--end-column COLUMN', Integer)
       end
     end
     # rubocop:enable Naming/InclusiveLanguage
@@ -463,7 +467,7 @@ module RuboCop
 
   # This module contains help texts for command line options.
   # @api private
-  module OptionsHelp
+  module OptionsHelp # rubocop:disable Metrics/ModuleLength
     MAX_EXCL = RuboCop::Options::DEFAULT_MAXIMUM_EXCLUSION_ITEMS.to_s
     FORMATTER_OPTION_LIST = RuboCop::Formatter::FormatterSet::BUILTIN_FORMATTERS_FOR_KEYS.keys
 
@@ -496,6 +500,14 @@ module RuboCop
       disable_uncorrectable:            ['Used with --autocorrect to annotate any',
                                          'offenses that do not support autocorrect',
                                          'with `rubocop:todo` comments.'],
+      start_line:                       ['Used with --autocorrect to specify',
+                                         'first line to apply corrections.'],
+      end_line:                         ['Used with --autocorrect to specify',
+                                         'last line to apply corrections.'],
+      start_column:                     ['Used with --autocorrect to specify',
+                                         'first column to apply corrections.'],
+      end_column:                       ['Used with --autocorrect to specify',
+                                         'last column to apply corrections.'],
       no_exclude_limit:                 ['Do not set the limit for how many files to exclude.'],
       force_exclusion:                  ['Any files excluded by `Exclude` in configuration',
                                          'files will be excluded, even if given explicitly',

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2684,4 +2684,70 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       (foo) ? bar : baz
     RUBY
   end
+
+  context 'with ranges provided' do
+    it 'corrects within line boundaries' do
+      source_file = Pathname('example.rb')
+      create_file(source_file, <<~RUBY)
+        class A
+          def foo
+          end
+
+          def bar
+          end
+        end
+
+        def biz
+        end
+      RUBY
+
+      status = cli.run(%w[--autocorrect-all --start-line 5 --end-line 7 --only Style/EmptyMethod])
+
+      expect(status).to eq(1)
+      expect(source_file.read).to eq(<<~RUBY)
+        class A
+          def foo
+          end
+
+          def bar; end
+        end
+
+        def biz
+        end
+      RUBY
+    end
+
+    it 'corrects within column boundaries' do
+      source_file = Pathname('example.rb')
+      create_file(source_file, <<~RUBY)
+        class A
+          def foo
+          end
+
+          def bar
+          end
+        end
+
+        def biz
+        end
+      RUBY
+
+      status = cli.run(
+        %w[--autocorrect-all --start-column 0 --end-column 3 --only Style/EmptyMethod]
+      )
+
+      expect(status).to eq(1)
+      expect(source_file.read).to eq(<<~RUBY)
+        class A
+          def foo
+          end
+
+          def bar
+          end
+        end
+
+        def biz; end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -149,6 +149,14 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                   --disable-uncorrectable      Used with --autocorrect to annotate any
                                                offenses that do not support autocorrect
                                                with `rubocop:todo` comments.
+                  --start-line LINE            Used with --autocorrect to specify
+                                               first line to apply corrections.
+                  --end-line LINE              Used with --autocorrect to specify
+                                               last line to apply corrections.
+                  --start-column COLUMN        Used with --autocorrect to specify
+                                               first column to apply corrections.
+                  --end-column COLUMN          Used with --autocorrect to specify
+                                               last column to apply corrections.
 
           Config Generation:
                   --auto-gen-config            Generate a configuration file acting as a


### PR DESCRIPTION
Adds command line flags that when present will filter autocorrections performed

Fixes https://github.com/rubocop/rubocop/issues/10930

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
