### PR TITLE
[Fix #11069] Fix an incorrect autocorrect for `Lint/RedundantCopDisableDirective`

### DIFF
--- a/changelog/fix_an_error_for_lint_redundant_cop_disable_directive.md
+++ b/changelog/fix_an_error_for_lint_redundant_cop_disable_directive.md
@@ -1,0 +1,1 @@
+* [#11069](https://github.com/rubocop/rubocop/issues/11069): Fix an incorrect autocorrect for `Lint/RedundantCopDisableDirective` when disable directive contains free comment. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -209,7 +209,12 @@ module RuboCop
 
           add_offense(location, message: message(cop_names)) do |corrector|
             range = comment_range_with_surrounding_space(location, comment.loc.expression)
-            corrector.remove(range)
+
+            if leave_free_comment?(comment, range)
+              corrector.replace(range, ' # ')
+            else
+              corrector.remove(range)
+            end
           end
         end
 
@@ -225,6 +230,12 @@ module RuboCop
               corrector.remove(range)
             end
           end
+        end
+
+        def leave_free_comment?(comment, range)
+          free_comment = comment.text.gsub(range.source.strip, '')
+
+          !free_comment.empty? && !free_comment.start_with?('#')
         end
 
         def cop_range(comment, cop)

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -581,6 +581,23 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
         RUBY
       end
 
+      it 'removes cop duplicated by department and leaves free text as a comment' do
+        expect_offense(<<~RUBY)
+          # rubocop:disable Metrics
+          def bar
+            do_something # rubocop:disable Metrics/ClassLength - note
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/ClassLength`.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # rubocop:disable Metrics
+          def bar
+            do_something # - note
+          end
+        RUBY
+      end
+
       it 'does not remove correct department' do
         expect_no_offenses(<<~RUBY)
           # rubocop:disable Metrics


### PR DESCRIPTION
Fix #11069.

This PR fixes an incorrect autocorrect for `Lint/RedundantCopDisableDirective` when disable directive contains free comment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
