### PR TITLE
[Fix #11074] Fix a false positive for `Lint/RedundantDirGlobSort`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_redundant_cop_disable_directive.md
+++ b/changelog/fix_a_false_positive_for_lint_redundant_cop_disable_directive.md
@@ -1,0 +1,1 @@
+* [#11074](https://github.com/rubocop/rubocop/issues/11074): Fix a false positive for `Lint/RedundantDirGlobSort` when using `Dir.glob` with multiple arguments. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_dir_glob_sort.rb
+++ b/lib/rubocop/cop/lint/redundant_dir_glob_sort.rb
@@ -41,6 +41,7 @@ module RuboCop
           return unless (receiver = node.receiver)
           return unless receiver.receiver&.const_type? && receiver.receiver.short_name == :Dir
           return unless GLOB_METHODS.include?(receiver.method_name)
+          return if multiple_argument?(receiver)
 
           selector = node.loc.selector
 
@@ -48,6 +49,12 @@ module RuboCop
             corrector.remove(selector)
             corrector.remove(node.loc.dot)
           end
+        end
+
+        private
+
+        def multiple_argument?(glob_method)
+          glob_method.arguments.count >= 2 || glob_method.first_argument&.splat_type?
         end
       end
     end

--- a/spec/rubocop/cop/lint/redundant_dir_glob_sort_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_dir_glob_sort_spec.rb
@@ -55,6 +55,30 @@ RSpec.describe RuboCop::Cop::Lint::RedundantDirGlobSort, :config do
       RUBY
     end
 
+    it "does not register an offense when using `Dir.glob('./b/*.txt', './a/*.txt').sort`" do
+      expect_no_offenses(<<~RUBY)
+        Dir.glob('./b/*.txt', './a/*.txt').sort.each(&method(:require))
+      RUBY
+    end
+
+    it 'does not register an offense when using `Dir.glob(*path).sort`' do
+      expect_no_offenses(<<~RUBY)
+        Dir.glob(*path).sort.each(&method(:require))
+      RUBY
+    end
+
+    it "does not register an offense when using `Dir['./b/*.txt', './a/*.txt'].sort`" do
+      expect_no_offenses(<<~RUBY)
+        Dir['./b/*.txt', './a/*.txt'].sort.each(&method(:require))
+      RUBY
+    end
+
+    it 'does not register an offense when using `Dir[*path].sort`' do
+      expect_no_offenses(<<~RUBY)
+        Dir[*path].sort.each(&method(:require))
+      RUBY
+    end
+
     it 'does not register an offense when using `collection.sort`' do
       expect_no_offenses(<<~RUBY)
         collection.sort


### PR DESCRIPTION
Fixes #11074.

This PR fixes a false positive for `Lint/RedundantDirGlobSort` when using `Dir.glob` with multiple arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
