### PR TITLE
Fix a false positive for `Style/RedundantBegin`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_begin.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_begin.md
@@ -1,0 +1,1 @@
+* [#11078](https://github.com/rubocop/rubocop/pull/11078): Fix a false positive for `Style/RedundantBegin` when using endless method definition for `begin` with multiple statements. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -75,6 +75,7 @@ module RuboCop
 
         def on_def(node)
           return unless node.body&.kwbegin_type?
+          return if node.endless? && !node.body.children.one?
 
           register_offense(node.body)
         end

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -569,4 +569,33 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
       RUBY
     end
   end
+
+  context 'when using endless method definition', :ruby30 do
+    it 'registers when `begin` block has a single statement' do
+      expect_offense(<<~RUBY)
+        def foo = begin
+                  ^^^^^ Redundant `begin` block detected.
+          bar
+        end
+      RUBY
+
+      expect_correction("def foo = \n  bar\n\n")
+    end
+
+    it 'accepts when `begin` block has multiple statements' do
+      expect_no_offenses(<<~RUBY)
+        def foo = begin
+          bar
+          baz
+        end
+      RUBY
+    end
+
+    it 'accepts when `begin` block has no statements' do
+      expect_no_offenses(<<~RUBY)
+        def foo = begin
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes a false positive for `Style/RedundantBegin` when using endless method definition for `begin` with multiple statements.

For example, the following `begin` is not redundant.

```ruby
def foo = begin
  bar
  baz
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
