### PR TITLE
[Fix #9116] Fix indentation of `super` method arguments

### DIFF
--- a/changelog/fix_fix_indentation_of_super_method.md
+++ b/changelog/fix_fix_indentation_of_super_method.md
@@ -1,0 +1,1 @@
+* [#9116](https://github.com/rubocop/rubocop/issues/9116): Support `super` method in `Layout/FirstArgumentIndentation`. ([@tdeo][])

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -162,6 +162,7 @@ module RuboCop
           check_alignment([node.first_argument], indent)
         end
         alias on_csend on_send
+        alias on_super on_send
 
         private
 

--- a/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
@@ -26,6 +26,23 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects an over-indented first argument of `super`' do
+        expect_offense(<<~RUBY)
+          super(
+              :foo,
+              ^^^^ Indent the first argument one step more than the start of the previous line.
+              bar: 3
+          )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          super(
+            :foo,
+              bar: 3
+          )
+        RUBY
+      end
+
       it 'registers an offense and corrects an over-indented first argument on an alphanumeric method name' do
         expect_offense(<<~RUBY)
           self.run(


### PR DESCRIPTION
Fixes the indentation of the first argument of `super` method. This is reported in https://github.com/rubocop/rubocop/issues/9116 and https://github.com/rubocop/rubocop/issues/11062 as bugs for the `Layout/FirstMethodArgumentLineBreak` cop but is actually the responsability of `Layout/FirstArgumentIndentation` for common methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
