### PR TITLE
[Fix #10924] `Style/NegatedIfElseCondition` looks inside parentheses (and begin-ends)

### DIFF
--- a/changelog/change_style_negated_if_else_condition_looks_inside_parentheses.md
+++ b/changelog/change_style_negated_if_else_condition_looks_inside_parentheses.md
@@ -1,0 +1,1 @@
+* [#10924](https://github.com/rubocop/rubocop/issues/10924): `Style/NegatedIfElseCondition` also checks negative conditions inside parentheses. ([@tsugimoto][])

--- a/lib/rubocop/cop/style/negated_if_else_condition.rb
+++ b/lib/rubocop/cop/style/negated_if_else_condition.rb
@@ -49,7 +49,8 @@ module RuboCop
         def on_if(node)
           return unless if_else?(node)
 
-          condition = node.condition
+          condition = unwrap_begin_nodes(node.condition)
+
           return if double_negation?(condition) || !negated_condition?(condition)
 
           type = node.ternary? ? 'ternary' : 'if-else'
@@ -69,6 +70,11 @@ module RuboCop
         def if_else?(node)
           else_branch = node.else_branch
           !node.elsif? && else_branch && (!else_branch.if_type? || !else_branch.elsif?)
+        end
+
+        def unwrap_begin_nodes(node)
+          node = node.children.first while node.begin_type? || node.kwbegin_type?
+          node
         end
 
         def negated_condition?(node)

--- a/spec/rubocop/cop/style/negated_if_else_condition_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_else_condition_spec.rb
@@ -95,6 +95,74 @@ RSpec.describe RuboCop::Cop::Style::NegatedIfElseCondition, :config do
         x #{inverted_method} y ? do_something_else : do_something
       RUBY
     end
+
+    it "registers an offense and corrects when negating condition with `#{method}` in parentheses for `if-else`" do
+      expect_offense(<<~RUBY, method: method)
+        if (x %{method} y)
+        ^^^^^^^{method}^^^ Invert the negated condition and swap the if-else branches.
+          do_something
+        else
+          do_something_else
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if (x #{inverted_method} y)
+          do_something_else
+        else
+          do_something
+        end
+      RUBY
+    end
+
+    it "registers an offense and corrects when negating condition with `#{method}` in parentheses for ternary" do
+      expect_offense(<<~RUBY, method: method)
+        (x %{method} y) ? do_something : do_something_else
+        ^^^^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invert the negated condition and swap the ternary branches.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (x #{inverted_method} y) ? do_something_else : do_something
+      RUBY
+    end
+
+    it "registers an offense and corrects when negating condition with `#{method}` in begin-end for `if-else`" do
+      expect_offense(<<~RUBY, method: method)
+        if begin
+        ^^^^^^^^ Invert the negated condition and swap the if-else branches.
+          x %{method} y
+        end
+          do_something
+        else
+          do_something_else
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if begin
+          x #{inverted_method} y
+        end
+          do_something_else
+        else
+          do_something
+        end
+      RUBY
+    end
+
+    it "registers an offense and corrects when negating condition with `#{method}` in begin-end for ternary" do
+      expect_offense(<<~RUBY, method: method)
+        begin
+        ^^^^^ Invert the negated condition and swap the ternary branches.
+          x %{method} y
+        end ? do_something : do_something_else
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          x #{inverted_method} y
+        end ? do_something_else : do_something
+      RUBY
+    end
   end
 
   it_behaves_like('negation method', '!=', '==')


### PR DESCRIPTION
Style/NegatedIfElseCondition looks inside parentheses for checking negated conditions.

```ruby
(x != y) ? do_something : do_something_else
```

would be marked offense and corrected into:

```ruby
(x == y) ? do_something_else : do_something
```

As a bonus, `begin-end`s used as conditions receive the same treatment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
