### PR TITLE
[Fix #11067] Fix a false positive for `Lint/DuplicateRegexpCharacterClassElement`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_duplicate_regexp_character_class_element.md
+++ b/changelog/fix_a_false_positive_for_lint_duplicate_regexp_character_class_element.md
@@ -1,0 +1,1 @@
+* [#11067](https://github.com/rubocop/rubocop/issues/11067): Fix a false positive for `Lint/DuplicateRegexpCharacterClassElement` when using regexp character starts with escaped zero number. ([@koic][])

--- a/spec/rubocop/cop/lint/duplicate_regexp_character_class_element_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_regexp_character_class_element_spec.rb
@@ -43,6 +43,27 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateRegexpCharacterClassElement, :config
     end
   end
 
+  context 'with no repeated character class elements when `"\0\07"` (means `"\u0000\a"`)' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~'RUBY')
+        /[\0\07]/
+      RUBY
+    end
+  end
+
+  context 'with repeated character class elements when `"\0\08"` (means `"\u0000\u00008"`)' do
+    it 'registers an offense' do
+      expect_offense(<<~'RUBY')
+        /[\0\08]/
+            ^^ Duplicate element inside regexp character class
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        /[\08]/
+      RUBY
+    end
+  end
+
   context 'with a repeated character class element and %r{} literal' do
     it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #11067.

This PR fixes a false positive for `Lint/DuplicateRegexpCharacterClassElement` when using regexp character starts with escaped zero number.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
