### PR TITLE
[Fix #11003] Fix EmptyConditionalBody clobbering

### DIFF
--- a/changelog/fix_clobbering_exception_for_empty_conditional_body_cop.md
+++ b/changelog/fix_clobbering_exception_for_empty_conditional_body_cop.md
@@ -1,0 +1,1 @@
+* [#11003](https://github.com/rubocop/rubocop/issues/11003): Fix clobbering exception in EmptyConditionalBody cop when if branch is empty but else is not. ([@srcoley][])

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -24,6 +24,26 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     expect_correction('')
   end
 
+  it 'registers an offense for missing `if` body with present `else` body' do
+    expect_offense(<<~RUBY)
+      class Foo
+        if condition
+        ^^^^^^^^^^^^ Avoid `if` branches without a body.
+        else
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo
+        unless condition
+          do_something
+        end
+      end
+    RUBY
+  end
+
   it 'does not register an offense for missing `if` body with a comment' do
     expect_no_offenses(<<~RUBY)
       if condition


### PR DESCRIPTION
This PR fixes an error that occurs in `Lint/EmptyConditionalBody` when an `if` branch is empty but the `else` branch is not.

When `rubocop` detects this situation, it will attempt to autocorrect by removing the `if` block, all the way up to the `else` keyword. It then attempts to invert the `else` into `unless` - but `else` is already missing.

Before autocorrection:
```ruby
class SomeClass
  if condition
  else
    do_something
  end
end
```

After autocorrection:
```ruby
class SomeClass
    do_something
  end
end
```

This will cause `parser` to raise a `Parser::Source::TreeRewriter detected clobbering` exception.

This change checks for an empty `if` body with a present `else` body, and ensures that only the `if` block is removed(not including the `else` keyword). Now `else` is still present and can be inverted into `unless`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
