### PR TITLE
[Fix #11089] Fix an error for `Style/RedundantStringEscape` when using character literals (e.g. `?a`)

### DIFF
--- a/changelog/fix_fix_an_error_for_redundant_string_escape.md
+++ b/changelog/fix_fix_an_error_for_redundant_string_escape.md
@@ -1,0 +1,1 @@
+* [#11089](https://github.com/rubocop/rubocop/issues/11089): Fix an error for `Style/RedundantStringEscape` when using character literals (e.g. `?a`). ([@ydah][])

--- a/lib/rubocop/cop/style/redundant_string_escape.rb
+++ b/lib/rubocop/cop/style/redundant_string_escape.rb
@@ -65,7 +65,7 @@ module RuboCop
         def str_contents_range(node)
           if heredoc?(node)
             node.loc.heredoc_body
-          elsif begin_loc_present?(node)
+          elsif begin_loc_present?(node) && node.loc.end
             contents_range(node)
           else
             node.loc.expression

--- a/spec/rubocop/cop/style/redundant_string_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_string_escape_spec.rb
@@ -279,6 +279,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantStringEscape, :config do
     end
   end
 
+  context 'when using character literals (e.g. `?a`)' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        ?a
+      RUBY
+    end
+  end
+
   context 'with an interpolation-enabled HEREDOC' do
     include_examples 'common no offenses', "<<~MYHEREDOC\n", "\nMYHEREDOC"
 


### PR DESCRIPTION
Fix: #11089

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
