### PR TITLE
Add autocorrect for `Layout/LineContinuationLeadingSpace`

### DIFF
--- a/changelog/new_add_autocorrect_for_layout_line_continuation_leading_space.md
+++ b/changelog/new_add_autocorrect_for_layout_line_continuation_leading_space.md
@@ -1,0 +1,1 @@
+* [#11091](https://github.com/rubocop/rubocop/pull/11091): Add autocorrect for `Layout/LineContinuationLeadingSpace`. ([@FnControlOption][])

--- a/spec/rubocop/cop/layout/line_continuation_leading_space_spec.rb
+++ b/spec/rubocop/cop/layout/line_continuation_leading_space_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
         ' long'
          ^ Move leading spaces to the end of previous line.
       RUBY
+
+      expect_correction(<<~'RUBY')
+        'this text is too ' \
+        'long'
+      RUBY
     end
 
     it 'puts the offense message in correct position also on indented line' do
@@ -18,6 +23,11 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
           ' long'
            ^ Move leading spaces to the end of previous line.
       RUBY
+
+      expect_correction(<<~'RUBY')
+        'this text is too ' \
+          'long'
+      RUBY
     end
 
     it 'registers an offense when 2nd line has multiple leading spaces' do
@@ -25,6 +35,11 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
         'this text contains a lot of' \
         '               spaces'
          ^^^^^^^^^^^^^^^ Move leading spaces to the end of previous line.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        'this text contains a lot of               ' \
+        'spaces'
       RUBY
     end
 
@@ -36,6 +51,12 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
         '  long long'
          ^^ Move leading spaces to the end of previous line.
       RUBY
+
+      expect_correction(<<~'RUBY')
+        'this text is too ' \
+        'long  ' \
+        'long long'
+      RUBY
     end
 
     it 'registers offense in the right location when 1st line is not the string' do
@@ -44,6 +65,12 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
         'this text is too' \
         ' long'
          ^ Move leading spaces to the end of previous line.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        something_unrelated_to_the_line_continuation_below
+        'this text is too ' \
+        'long'
       RUBY
     end
 
@@ -54,6 +81,12 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
            ^ Move leading spaces to the end of previous line.
         end
       RUBY
+
+      expect_correction(<<~'RUBY')
+        long_method_name 'this text is too ' \
+          'long' do
+        end
+      RUBY
     end
 
     it 'marks the correct range when string is a positional method argument' do
@@ -62,6 +95,13 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
           'this text is too' \
           ' long'
            ^ Move leading spaces to the end of previous line.
+        )
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        long_method_name(
+          'this text is too ' \
+          'long'
         )
       RUBY
     end
@@ -85,6 +125,11 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
           ' long'
            ^ Move leading spaces to the end of previous line.
         RUBY
+
+        expect_correction(<<~'RUBY')
+          "foo #{bar} " \
+          'long'
+        RUBY
       end
 
       it 'registers offenses when 2nd line has leading spaces and 2nd line is interpolated' do
@@ -92,6 +137,11 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
           'this line is' \
           " #{foo}"
            ^ Move leading spaces to the end of previous line.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          'this line is ' \
+          "#{foo}"
         RUBY
       end
 
@@ -115,6 +165,11 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
             ' baz'}"
              ^ Move leading spaces to the end of previous line.
         RUBY
+
+        expect_correction(<<~'RUBY')
+          "foo #{'bar ' \
+            'baz'}"
+        RUBY
       end
     end
   end
@@ -128,6 +183,11 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
                          ^ Move trailing spaces to the start of next line.
         'long'
       RUBY
+
+      expect_correction(<<~'RUBY')
+        'this text is too' \
+        ' long'
+      RUBY
     end
 
     it 'puts the offense message in correct position also on indented line' do
@@ -137,6 +197,12 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
                 ^ Move trailing spaces to the start of next line.
           'long'
       RUBY
+
+      expect_correction(<<~'RUBY')
+        'this text is too' \
+          ' very' \
+          ' long'
+      RUBY
     end
 
     it 'registers an offense when 1st line has multiple trailing spaces' do
@@ -144,6 +210,11 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
         'this text contains a lot of               ' \
                                     ^^^^^^^^^^^^^^^ Move trailing spaces to the start of next line.
         'spaces'
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        'this text contains a lot of' \
+        '               spaces'
       RUBY
     end
 
@@ -155,6 +226,12 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
              ^^ Move trailing spaces to the start of next line.
         'long long'
       RUBY
+
+      expect_correction(<<~'RUBY')
+        'this text is too' \
+        ' long' \
+        '  long long'
+      RUBY
     end
 
     it 'registers offense in the right location when 1st line is not the string' do
@@ -163,6 +240,12 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
         'this text is too ' \
                          ^ Move trailing spaces to the start of next line.
         'long'
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        something_unrelated_to_the_line_continuation_below
+        'this text is too' \
+        ' long'
       RUBY
     end
 
@@ -174,6 +257,13 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
           'long' do
         end
       RUBY
+
+      expect_correction(<<~'RUBY')
+        long_method_name 'this text is too' \
+          ' very' \
+          ' long' do
+        end
+      RUBY
     end
 
     it 'marks the correct range when string is a positional method argument' do
@@ -182,6 +272,13 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
           'this text is too ' \
                            ^ Move trailing spaces to the start of next line.
           'long'
+        )
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        long_method_name(
+          'this text is too' \
+          ' long'
         )
       RUBY
     end
@@ -205,6 +302,11 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
               ^ Move trailing spaces to the start of next line.
           "#{bar} long"
         RUBY
+
+        expect_correction(<<~'RUBY')
+          'foo' \
+          " #{bar} long"
+        RUBY
       end
 
       it 'registers offenses when 1st line has leading spaces and 1st line is interpolated' do
@@ -212,6 +314,11 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
           "this #{foo} is " \
                          ^ Move trailing spaces to the start of next line.
           'long'
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          "this #{foo} is" \
+          ' long'
         RUBY
       end
 
@@ -234,6 +341,11 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
           "foo #{'bar ' \
                      ^ Move trailing spaces to the start of next line.
             'baz'}"
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          "foo #{'bar' \
+            ' baz'}"
         RUBY
       end
     end


### PR DESCRIPTION
Autocorrects

```rb
'this text contains a lot of' \
'               spaces'
```

to

```rb
'this text contains a lot of               ' \
'spaces'
```

[Layout/LineContinuationLeadingSpace](https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinecontinuationleadingspace)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
