### PR TITLE
Update docs page about `--no-exclude-limit` option

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -618,6 +618,9 @@ reached.
 By adding the option `--exclude-limit COUNT`, e.g., `rubocop
 --auto-gen-config --exclude-limit 5`, you can change how many files are
 excluded before the cop is entirely disabled. The default COUNT is 15.
+If you don't want the cop to be entirely disabled regardless of the
+number of files, use the `--no-exclude-limit` option, e.g.,
+`rubocop --auto-gen-config --no-exclude-limit`.
 
 The next step is to cut and paste configuration from `.rubocop_todo.yml`
 into `.rubocop.yml` for everything that you think is in line with your


### PR DESCRIPTION
I will add some more description to the documentation about `--no-exclude-limit` option.

- https://github.com/rubocop/rubocop/pull/11036
- https://docs.rubocop.org/rubocop/configuration.html#automatically-generated-configuration

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
