### PR TITLE
Add `InternalAffairs/ExampleHeredocDelimiter` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -163,6 +163,10 @@ InternalAffairs/ExampleDescription:
   Include:
     - 'spec/rubocop/cop/**/*.rb'
 
+InternalAffairs/ExampleHeredocDelimiter:
+  Include:
+    - 'spec/rubocop/cop/**/*.rb'
+
 InternalAffairs/UndefinedConfig:
   Include:
     - 'lib/rubocop/cop/**/*.rb'

--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -3,6 +3,7 @@
 require_relative 'internal_affairs/cop_description'
 require_relative 'internal_affairs/empty_line_between_expect_offense_and_correction'
 require_relative 'internal_affairs/example_description'
+require_relative 'internal_affairs/example_heredoc_delimiter'
 require_relative 'internal_affairs/inherit_deprecated_cop_class'
 require_relative 'internal_affairs/location_line_equality_comparison'
 require_relative 'internal_affairs/method_name_end_with'

--- a/lib/rubocop/cop/internal_affairs/example_heredoc_delimiter.rb
+++ b/lib/rubocop/cop/internal_affairs/example_heredoc_delimiter.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # Use `RUBY` for heredoc delimiter of example Ruby code.
+      #
+      # Some editors may apply better syntax highlighting by using appropriate language names for
+      # the delimiter.
+      #
+      # @example
+      #  # bad
+      #  expect_offense(<<~CODE)
+      #    example_ruby_code
+      #  CODE
+      #
+      #  # good
+      #  expect_offense(<<~RUBY)
+      #    example_ruby_code
+      #  RUBY
+      class ExampleHeredocDelimiter < Base
+        extend AutoCorrector
+
+        EXPECTED_HEREDOC_DELIMITER = 'RUBY'
+
+        MSG = 'Use `RUBY` for heredoc delimiter of example Ruby code.'
+
+        RESTRICT_ON_SEND = %i[
+          expect_correction
+          expect_no_corrections
+          expect_no_offenses
+          expect_offense
+        ].freeze
+
+        # @param node [RuboCop::AST::SendNode]
+        # @return [void]
+        def on_send(node)
+          heredoc_node = heredoc_node_from(node)
+          return unless heredoc_node
+          return if expected_heredoc_delimiter?(heredoc_node)
+          return if expected_heredoc_delimiter_in_body?(heredoc_node)
+
+          add_offense(heredoc_node) do |corrector|
+            autocorrect(corrector, heredoc_node)
+          end
+        end
+
+        private
+
+        # @param corrector [RuboCop::Cop::Corrector]
+        # @param node [RuboCop::AST::StrNode]
+        # @return [void]
+        def autocorrect(corrector, node)
+          [
+            heredoc_openning_delimiter_range_from(node),
+            heredoc_closing_delimiter_range_from(node)
+          ].each do |range|
+            corrector.replace(range, EXPECTED_HEREDOC_DELIMITER)
+          end
+        end
+
+        # @param node [RuboCop::AST::StrNode]
+        # @return [Boolean]
+        def expected_heredoc_delimiter_in_body?(node)
+          node.location.heredoc_body.source.lines.any? do |line|
+            line.strip == EXPECTED_HEREDOC_DELIMITER
+          end
+        end
+
+        # @param node [RuboCop::AST::StrNode]
+        # @return [Boolean]
+        def expected_heredoc_delimiter?(node)
+          heredoc_delimiter_string_from(node) == EXPECTED_HEREDOC_DELIMITER
+        end
+
+        # @param node [RuboCop::AST::SendNode]
+        # @return [RuboCop::AST::StrNode, nil]
+        def heredoc_node_from(node)
+          return unless node.first_argument.respond_to?(:heredoc?)
+          return unless node.first_argument.heredoc?
+
+          node.first_argument
+        end
+
+        # @param node [RuboCop::AST::StrNode]
+        # @return [String]
+        def heredoc_delimiter_string_from(node)
+          node.source[Heredoc::OPENING_DELIMITER, 2]
+        end
+
+        # @param node [RuboCop::AST::StrNode]
+        # @return [Parser::Source::Range]
+        def heredoc_openning_delimiter_range_from(node)
+          match_data = node.source.match(Heredoc::OPENING_DELIMITER)
+          node.location.expression.begin.adjust(
+            begin_pos: match_data.begin(2),
+            end_pos: match_data.end(2)
+          )
+        end
+
+        # @param node [RuboCop::AST::StrNode]
+        # @return [Parser::Source::Range]
+        def heredoc_closing_delimiter_range_from(node)
+          node.location.heredoc_end.end.adjust(
+            begin_pos: -heredoc_delimiter_string_from(node).length
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
@@ -31,29 +31,29 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
 
     context 'and a gem is duplicated in default group' do
       it 'registers an offense' do
-        expect_offense(<<-GEM, 'Gemfile')
+        expect_offense(<<-RUBY, 'Gemfile')
           source 'https://rubygems.org'
           gem 'rubocop'
           gem 'rubocop'
           ^^^^^^^^^^^^^ Gem `rubocop` requirements already given on line 2 of the Gemfile.
-        GEM
+        RUBY
       end
     end
 
     context 'and a duplicated gem is in a git/path/group/platforms block' do
       it 'registers an offense' do
-        expect_offense(<<-GEM, 'Gemfile')
+        expect_offense(<<-RUBY, 'Gemfile')
           gem 'rubocop'
           group :development do
             gem 'rubocop', path: '/path/to/gem'
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Gem `rubocop` requirements already given on line 1 of the Gemfile.
           end
-        GEM
+        RUBY
       end
     end
 
     it 'registers an offense when gem from default group is conditionally duplicated' do
-      expect_offense(<<-GEM, 'Gemfile')
+      expect_offense(<<-RUBY, 'Gemfile')
         gem 'rubocop'
         if Dir.exist? local
           gem 'rubocop', path: local
@@ -62,22 +62,22 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
           gem 'rubocop', '~> 0.90.0'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Gem `rubocop` requirements already given on line 1 of the Gemfile.
         end
-      GEM
+      RUBY
     end
 
     it 'does not register an offense when gem is duplicated within `if-else` statement' do
-      expect_no_offenses(<<-GEM, 'Gemfile')
+      expect_no_offenses(<<-RUBY, 'Gemfile')
         if Dir.exist?(local)
           gem 'rubocop', path: local
           gem 'flog', path: local
         else
           gem 'rubocop', '~> 0.90.0'
         end
-      GEM
+      RUBY
     end
 
     it 'does not register an offense when gem is duplicated within `if-elsif` statement' do
-      expect_no_offenses(<<-GEM, 'Gemfile')
+      expect_no_offenses(<<-RUBY, 'Gemfile')
         if Dir.exist?(local)
           gem 'rubocop', path: local
         elsif ENV['RUBOCOP_VERSION'] == 'master'
@@ -87,11 +87,11 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
         else
           gem 'rubocop', '~> 0.90.0'
         end
-      GEM
+      RUBY
     end
 
     it 'does not register an offense when gem is duplicated within `case` statement' do
-      expect_no_offenses(<<-GEM, 'Gemfile')
+      expect_no_offenses(<<-RUBY, 'Gemfile')
         case
         when Dir.exist?(local)
           gem 'rubocop', path: local
@@ -100,7 +100,7 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
         else
           gem 'rubocop', '~> 0.90.0'
         end
-      GEM
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/bundler/gem_comment_spec.rb
+++ b/spec/rubocop/cop/bundler/gem_comment_spec.rb
@@ -64,10 +64,10 @@ RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
 
     context 'and a gem has no comment' do
       it 'registers an offense' do
-        expect_offense(<<-GEM, 'Gemfile')
+        expect_offense(<<-RUBY, 'Gemfile')
           gem 'rubocop'
           ^^^^^^^^^^^^^ Missing gem description comment.
-        GEM
+        RUBY
       end
     end
 
@@ -88,44 +88,44 @@ RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
 
         context 'when a gem is uncommented and has no version specified' do
           it 'does not register an offense' do
-            expect_no_offenses(<<-GEM, 'Gemfile')
+            expect_no_offenses(<<-RUBY, 'Gemfile')
             gem 'rubocop'
-            GEM
+            RUBY
           end
         end
 
         context 'when a gem is uncommented and has options but no version specifiers' do
           it 'does not register an offense' do
-            expect_no_offenses(<<-GEM, 'Gemfile')
+            expect_no_offenses(<<-RUBY, 'Gemfile')
               gem 'rubocop', group: development
-            GEM
+            RUBY
           end
         end
 
         context 'when a gem is uncommented and has a version specifier' do
           it 'registers an offense' do
-            expect_offense(<<-GEM, 'Gemfile')
+            expect_offense(<<-RUBY, 'Gemfile')
                 gem 'rubocop', '~> 12.0'
                 ^^^^^^^^^^^^^^^^^^^^^^^^ Missing gem description comment.
-            GEM
+            RUBY
           end
         end
 
         context 'when a gem is uncommented and has multiple version specifiers' do
           it 'registers an offense' do
-            expect_offense(<<-GEM, 'Gemfile')
+            expect_offense(<<-RUBY, 'Gemfile')
                 gem 'rubocop', '~> 12.0', '>= 11.0'
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing gem description comment.
-            GEM
+            RUBY
           end
         end
 
         context 'when a gem is uncommented and has a version specifier along with other options' do
           it 'registers an offense' do
-            expect_offense(<<-GEM, 'Gemfile')
+            expect_offense(<<-RUBY, 'Gemfile')
               gem 'rubocop', '~> 12.0', required: true
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing gem description comment.
-            GEM
+            RUBY
           end
         end
       end
@@ -144,79 +144,79 @@ RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
 
         context 'when a gem is uncommented and has no version specified' do
           it 'does not register an offense' do
-            expect_no_offenses(<<-GEM, 'Gemfile')
+            expect_no_offenses(<<-RUBY, 'Gemfile')
             gem 'rubocop'
-            GEM
+            RUBY
           end
         end
 
         context 'when a gem is uncommented and has options but no version specifiers' do
           it 'does not register an offense' do
-            expect_no_offenses(<<-GEM, 'Gemfile')
+            expect_no_offenses(<<-RUBY, 'Gemfile')
               gem 'rubocop', group: development
-            GEM
+            RUBY
           end
         end
 
         context 'when a gem is uncommented and has only a minimum version specifier' do
           it 'does not register an offense' do
-            expect_no_offenses(<<-GEM, 'Gemfile')
+            expect_no_offenses(<<-RUBY, 'Gemfile')
               gem 'rubocop', '>= 12.0'
-            GEM
+            RUBY
           end
         end
 
         context 'when a gem is uncommented and has a non-minimum version specifier with a leading space' do
           it 'registers an offense' do
-            expect_offense(<<-GEM, 'Gemfile')
+            expect_offense(<<-RUBY, 'Gemfile')
                 gem 'rubocop', ' ~> 12.0'
                 ^^^^^^^^^^^^^^^^^^^^^^^^^ Missing gem description comment.
-            GEM
+            RUBY
           end
         end
 
         context 'when a gem is uncommented and has a version specifier without operator' do
           it 'registers an offense' do
-            expect_offense(<<-GEM, 'Gemfile')
+            expect_offense(<<-RUBY, 'Gemfile')
                 gem 'rubocop', '12.0'
                 ^^^^^^^^^^^^^^^^^^^^^ Missing gem description comment.
-            GEM
+            RUBY
           end
         end
 
         context 'when a gem is uncommented and has a frozen version specifier' do
           it 'registers an offense' do
-            expect_offense(<<-GEM, 'Gemfile')
+            expect_offense(<<-RUBY, 'Gemfile')
                 gem 'rubocop', '= 12.0'
                 ^^^^^^^^^^^^^^^^^^^^^^^ Missing gem description comment.
-            GEM
+            RUBY
           end
         end
 
         context 'when a gem is uncommented and has a pessimistic version specifier' do
           it 'registers an offense' do
-            expect_offense(<<-GEM, 'Gemfile')
+            expect_offense(<<-RUBY, 'Gemfile')
                 gem 'rubocop', '~> 12.0'
                 ^^^^^^^^^^^^^^^^^^^^^^^^ Missing gem description comment.
-            GEM
+            RUBY
           end
         end
 
         context 'when a gem is uncommented and has both minimum and non-minimum version specifier' do
           it 'registers an offense' do
-            expect_offense(<<-GEM, 'Gemfile')
+            expect_offense(<<-RUBY, 'Gemfile')
                 gem 'rubocop', '~> 12.0', '>= 11.0'
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing gem description comment.
-            GEM
+            RUBY
           end
         end
 
         context 'when a gem is uncommented and has a version specifier along with other options' do
           it 'registers an offense' do
-            expect_offense(<<-GEM, 'Gemfile')
+            expect_offense(<<-RUBY, 'Gemfile')
               gem 'rubocop', '~> 12.0', required: true
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing gem description comment.
-            GEM
+            RUBY
           end
         end
       end
@@ -226,26 +226,26 @@ RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
 
         context 'when a gem is uncommented and has one of the specified options' do
           it 'registers an offense' do
-            expect_offense(<<-GEM, 'Gemfile')
+            expect_offense(<<-RUBY, 'Gemfile')
               gem 'rubocop', github: 'some_user/some_fork'
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing gem description comment.
-            GEM
+            RUBY
           end
         end
 
         context 'when a gem is uncommented and has a version specifier but none of the specified options' do
           it 'does not register an offense' do
-            expect_no_offenses(<<-GEM, 'Gemfile')
+            expect_no_offenses(<<-RUBY, 'Gemfile')
               gem 'rubocop', '~> 12.0'
-            GEM
+            RUBY
           end
         end
 
         context 'when a gem is uncommented and contains only options not specified' do
           it 'does not register an offense' do
-            expect_no_offenses(<<-GEM, 'Gemfile')
+            expect_no_offenses(<<-RUBY, 'Gemfile')
               gem 'rubocop', group: development
-            GEM
+            RUBY
           end
         end
       end

--- a/spec/rubocop/cop/internal_affairs/example_heredoc_delimiter_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/example_heredoc_delimiter_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::InternalAffairs::ExampleHeredocDelimiter, :config do
+  context 'when expected heredoc delimiter is used at RuboCop specific expectation' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY_)
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            example_ruby_code
+          RUBY
+        end
+      RUBY_
+    end
+  end
+
+  context 'when unexpected heredoc delimiter is used at non RuboCop specific expectation' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        expect_foo(<<~CODE)
+          example_text
+        CODE
+      RUBY
+    end
+  end
+
+  context 'when unexpected heredoc delimiter is used but heredoc body contains an expected delimiter line' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY_)
+        it 'does not register an offense' do
+          expect_no_offenses(<<~CODE)
+            RUBY
+          CODE
+        end
+      RUBY_
+    end
+  end
+
+  context 'when unexpected heredoc delimiter is used in single-line heredoc' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        it 'does not register an offense' do
+          expect_no_offenses(<<~CODE)
+                             ^^^^^^^ Use `RUBY` for heredoc delimiter of example Ruby code.
+            example_ruby_code
+          CODE
+        end
+      RUBY
+
+      expect_correction(<<~RUBY_)
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            example_ruby_code
+          RUBY
+        end
+      RUBY_
+    end
+  end
+
+  context 'when unexpected heredoc delimiter is used in multi-line heredoc' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        it 'does not register an offense' do
+          expect_no_offenses(<<~CODE)
+                             ^^^^^^^ Use `RUBY` for heredoc delimiter of example Ruby code.
+            example_ruby_code1
+            example_ruby_code2
+          CODE
+        end
+      RUBY
+
+      expect_correction(<<~RUBY_)
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            example_ruby_code1
+            example_ruby_code2
+          RUBY
+        end
+      RUBY_
+    end
+  end
+end

--- a/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
@@ -74,11 +74,11 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
           RUBY2
         RUBY
 
-        expect_correction(<<~CORRECTION)
+        expect_correction(<<~RUBY)
           <<~#{quote}RUBY2#{quote}
             something
           RUBY2
-        CORRECTION
+        RUBY
       end
 
       it 'registers an offense for minus level indented' do
@@ -91,13 +91,13 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
           end
         RUBY
 
-        expect_correction(<<~CORRECTION)
+        expect_correction(<<~RUBY)
           def foo
             <<~#{quote}RUBY2#{quote}
               something
             RUBY2
           end
-        CORRECTION
+        RUBY
       end
 
       it 'registers an offense for too deep indented' do
@@ -108,11 +108,11 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
           RUBY2
         RUBY
 
-        expect_correction(<<~CORRECTION)
+        expect_correction(<<~RUBY)
           <<~#{quote}RUBY2#{quote}
             something
           RUBY2
-        CORRECTION
+        RUBY
       end
 
       it 'registers an offense for not indented, without `~`' do
@@ -123,11 +123,11 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
           RUBY2
         RUBY
 
-        expect_correction(<<~CORRECTION)
+        expect_correction(<<~RUBY)
           <<~#{quote}RUBY2#{quote}
             foo
           RUBY2
-        CORRECTION
+        RUBY
       end
 
       it 'registers an offense for not indented, with `~`' do
@@ -138,11 +138,11 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
           RUBY2
         RUBY
 
-        expect_correction(<<~CORRECTION)
+        expect_correction(<<~RUBY)
           <<~#{quote}RUBY2#{quote}
             foo
           RUBY2
-        CORRECTION
+        RUBY
       end
 
       it 'registers an offense for first line minus-level indented, with `-`' do
@@ -155,13 +155,13 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
           RUBY2
         RUBY
 
-        expect_correction(<<-CORRECTION)
+        expect_correction(<<-RUBY)
         puts <<~#{quote}RUBY2#{quote}
           def foo
             bar
           end
         RUBY2
-        CORRECTION
+        RUBY
       end
 
       it 'accepts for indented, with `~`' do
@@ -199,7 +199,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
             end
           RUBY
 
-          expect_correction(<<-CORRECTION)
+          expect_correction(<<-RUBY)
             def baz
               <<~#{quote}MSG#{quote}
                 foo
@@ -207,7 +207,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
                   bar
               MSG
             end
-          CORRECTION
+          RUBY
         end
 
         it "registers an offense for too deep indented with #{description} line" do
@@ -220,13 +220,13 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
             RUBY2
           RUBY
 
-          expect_correction(<<-CORRECTION)
+          expect_correction(<<-RUBY)
             <<~#{quote}RUBY2#{quote}
                 foo
 #{line}
               bar
             RUBY2
-          CORRECTION
+          RUBY
         end
         # rubocop:enable Layout/HeredocIndentation
       end

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -18,23 +18,23 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
     context 'without documentation comment' do
       context 'when method is public' do
         it 'registers an offense' do
-          expect_offense(<<~CODE)
+          expect_offense(<<~RUBY)
             def foo
             ^^^^^^^ Missing method documentation comment.
               puts 'bar'
             end
-          CODE
+          RUBY
         end
 
         it 'registers an offense with `end` on the same line' do
-          expect_offense(<<~CODE)
+          expect_offense(<<~RUBY)
             def method; end
             ^^^^^^^^^^^^^^^ Missing method documentation comment.
-          CODE
+          RUBY
         end
 
         it 'registers an offense when method is public, but there were private methods before' do
-          expect_offense(<<~CODE)
+          expect_offense(<<~RUBY)
             class Foo
                 private
 
@@ -48,35 +48,35 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                   puts 'bar'
                 end
             end
-          CODE
+          RUBY
         end
       end
 
       context 'when method is private' do
         it 'does not register an offense' do
-          expect_no_offenses(<<~CODE)
+          expect_no_offenses(<<~RUBY)
             private
 
             def foo
               puts 'bar'
             end
-          CODE
+          RUBY
         end
 
         it 'does not register an offense with `end` on the same line' do
-          expect_no_offenses(<<~CODE)
+          expect_no_offenses(<<~RUBY)
             private
 
             def foo; end
-          CODE
+          RUBY
         end
 
         it 'does not register an offense with inline `private`' do
-          expect_no_offenses(<<~CODE)
+          expect_no_offenses(<<~RUBY)
             private def foo
               puts 'bar'
             end
-          CODE
+          RUBY
         end
 
         it 'does not register an offense with inline `private` and `end`' do
@@ -87,83 +87,83 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
           let(:require_for_non_public_methods) { true }
 
           it 'registers an offense' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               private
 
               def foo
               ^^^^^^^ Missing method documentation comment.
                 puts 'bar'
               end
-            CODE
+            RUBY
           end
 
           it 'registers an offense with `end` on the same line' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               private
 
               def foo; end
               ^^^^^^^^^^^^ Missing method documentation comment.
-            CODE
+            RUBY
           end
 
           it 'registers an offense with inline `private`' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               private def foo
                       ^^^^^^^ Missing method documentation comment.
                 puts 'bar'
               end
-            CODE
+            RUBY
           end
 
           it 'registers an offense with inline `private` and `end`' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               private def method; end
                       ^^^^^^^^^^^^^^^ Missing method documentation comment.
-            CODE
+            RUBY
           end
         end
       end
 
       context 'when method is protected' do
         it 'does not register an offense' do
-          expect_no_offenses(<<~CODE)
+          expect_no_offenses(<<~RUBY)
             protected
 
             def foo
               puts 'bar'
             end
-          CODE
+          RUBY
         end
 
         it 'does not register an offense with inline `protected`' do
-          expect_no_offenses(<<~CODE)
+          expect_no_offenses(<<~RUBY)
             protected def foo
               puts 'bar'
             end
-          CODE
+          RUBY
         end
 
         context 'when required for non-public methods' do
           let(:require_for_non_public_methods) { true }
 
           it 'registers an offense' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               protected
 
               def foo
               ^^^^^^^ Missing method documentation comment.
                 puts 'bar'
               end
-            CODE
+            RUBY
           end
 
           it 'registers an offense with inline `protected`' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               protected def foo
                         ^^^^^^^ Missing method documentation comment.
                 puts 'bar'
               end
-            CODE
+            RUBY
           end
         end
       end
@@ -171,26 +171,26 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
 
     context 'with documentation comment' do
       it 'does not register an offense' do
-        expect_no_offenses(<<~CODE)
+        expect_no_offenses(<<~RUBY)
           # Documentation
           def foo
             puts 'bar'
           end
-        CODE
+        RUBY
       end
 
       it 'does not register an offense with `end` on the same line' do
-        expect_no_offenses(<<~CODE)
+        expect_no_offenses(<<~RUBY)
           # Documentation
           def foo; end
-        CODE
+        RUBY
       end
     end
 
     context 'with both public and private methods' do
       context 'when the public method has no documentation' do
         it 'registers an offense' do
-          expect_offense(<<~CODE)
+          expect_offense(<<~RUBY)
             def foo
             ^^^^^^^ Missing method documentation comment.
               puts 'bar'
@@ -201,13 +201,13 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
             def baz
               puts 'bar'
             end
-          CODE
+          RUBY
         end
       end
 
       context 'when the public method has documentation' do
         it 'does not register an offense' do
-          expect_no_offenses(<<~CODE)
+          expect_no_offenses(<<~RUBY)
             # Documentation
             def foo
               puts 'bar'
@@ -218,7 +218,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
             def baz
               puts 'bar'
             end
-          CODE
+          RUBY
         end
       end
 
@@ -226,7 +226,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
         let(:require_for_non_public_methods) { true }
 
         it 'registers an offense' do
-          expect_offense(<<~CODE)
+          expect_offense(<<~RUBY)
             # Documentation
             def foo
               puts 'bar'
@@ -238,7 +238,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
             ^^^^^^^ Missing method documentation comment.
               puts 'bar'
             end
-          CODE
+          RUBY
         end
       end
     end
@@ -247,29 +247,29 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
       context 'without documentation comment' do
         context 'when method is public' do
           it 'registers an offense' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               class Foo
                 def bar
                 ^^^^^^^ Missing method documentation comment.
                   puts 'baz'
                 end
               end
-            CODE
+            RUBY
           end
 
           it 'registers an offense with `end` on the same line' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               class Foo
                 def method; end
                 ^^^^^^^^^^^^^^^ Missing method documentation comment.
               end
-            CODE
+            RUBY
           end
         end
 
         context 'when method is private' do
           it 'does not register an offense' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               class Foo
                 private
 
@@ -277,42 +277,42 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                   puts 'baz'
                 end
               end
-            CODE
+            RUBY
           end
 
           it 'does not register an offense with inline `private`' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               class Foo
                 private def bar
                   puts 'baz'
                 end
               end
-            CODE
+            RUBY
           end
 
           it 'does not register an offense with `end` on the same line' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               class Foo
                 private
 
                 def bar; end
               end
-            CODE
+            RUBY
           end
 
           it 'does not register an offense with inline `private` and `end`' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               class Foo
                 private def bar; end
               end
-            CODE
+            RUBY
           end
 
           context 'when required for non-public methods' do
             let(:require_for_non_public_methods) { true }
 
             it 'registers an offense' do
-              expect_offense(<<~CODE)
+              expect_offense(<<~RUBY)
                 class Foo
                   private
 
@@ -321,38 +321,38 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                     puts 'baz'
                   end
                 end
-              CODE
+              RUBY
             end
 
             it 'registers an offense with inline `private`' do
-              expect_offense(<<~CODE)
+              expect_offense(<<~RUBY)
                 class Foo
                   private def bar
                           ^^^^^^^ Missing method documentation comment.
                     puts 'baz'
                   end
                 end
-              CODE
+              RUBY
             end
 
             it 'registers an offense with `end` on the same line' do
-              expect_offense(<<~CODE)
+              expect_offense(<<~RUBY)
                 class Foo
                   private
 
                   def bar; end
                   ^^^^^^^^^^^^ Missing method documentation comment.
                 end
-              CODE
+              RUBY
             end
 
             it 'registers an offense with inline `private` and `end`' do
-              expect_offense(<<~CODE)
+              expect_offense(<<~RUBY)
                 class Foo
                   private def bar; end
                           ^^^^^^^^^^^^ Missing method documentation comment.
                 end
-              CODE
+              RUBY
             end
           end
         end
@@ -361,30 +361,30 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
       context 'with documentation comment' do
         context 'when method is public' do
           it 'does not register an offense' do
-            expect_no_offenses(<<-CODE)
+            expect_no_offenses(<<-RUBY)
               class Foo
                 # Documentation
                 def bar
                   puts 'baz'
                 end
               end
-            CODE
+            RUBY
           end
 
           it 'does not register an offense with `end` on the same line' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               class Foo
                 # Documentation
                 def bar; end
               end
-            CODE
+            RUBY
           end
         end
       end
 
       context 'with annotation comment' do
         it 'registers an offense' do
-          expect_offense(<<~CODE)
+          expect_offense(<<~RUBY)
             class Foo
               # FIXME: offense
               def bar
@@ -392,13 +392,13 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                 puts 'baz'
               end
             end
-          CODE
+          RUBY
         end
       end
 
       context 'with directive comment' do
         it 'registers an offense' do
-          expect_offense(<<~CODE)
+          expect_offense(<<~RUBY)
             class Foo
               # rubocop:disable Style/For
               def bar
@@ -406,14 +406,14 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                 puts 'baz'
               end
             end
-          CODE
+          RUBY
         end
       end
 
       context 'with both public and private methods' do
         context 'when the public method has no documentation' do
           it 'registers an offense' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               class Foo
                 def bar
                 ^^^^^^^ Missing method documentation comment.
@@ -426,13 +426,13 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                   puts 'baz'
                 end
               end
-            CODE
+            RUBY
           end
         end
 
         context 'when the public method has documentation' do
           it 'does not register an offense' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               class Foo
                 # Documentation
                 def bar
@@ -445,7 +445,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                   puts 'baz'
                 end
               end
-            CODE
+            RUBY
           end
         end
 
@@ -453,7 +453,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
           let(:require_for_non_public_methods) { true }
 
           it 'registers an offense' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               class Foo
                 # Documentation
                 def bar
@@ -467,7 +467,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                   puts 'baz'
                 end
               end
-            CODE
+            RUBY
           end
         end
       end
@@ -477,29 +477,29 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
       context 'without documentation comment' do
         context 'when method is public' do
           it 'registers an offense' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               module Foo
                 def bar
                 ^^^^^^^ Missing method documentation comment.
                   puts 'baz'
                 end
               end
-            CODE
+            RUBY
           end
 
           it 'registers an offense with `end` on the same line' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               module Foo
                 def method; end
                 ^^^^^^^^^^^^^^^ Missing method documentation comment.
               end
-            CODE
+            RUBY
           end
         end
 
         context 'when method is private' do
           it 'does not register an offense' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               module Foo
                 private
 
@@ -507,42 +507,42 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                   puts 'baz'
                 end
               end
-            CODE
+            RUBY
           end
 
           it 'does not register an offense with inline `private`' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               module Foo
                 private def bar
                   puts 'baz'
                 end
               end
-            CODE
+            RUBY
           end
 
           it 'does not register an offense with `end` on the same line' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               module Foo
                 private
 
                 def bar; end
               end
-            CODE
+            RUBY
           end
 
           it 'does not register an offense with inline `private` and `end`' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               module Foo
                 private def bar; end
               end
-            CODE
+            RUBY
           end
 
           context 'when required for non-public methods' do
             let(:require_for_non_public_methods) { true }
 
             it 'registers an offense' do
-              expect_offense(<<~CODE)
+              expect_offense(<<~RUBY)
                 module Foo
                   private
 
@@ -551,55 +551,55 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                     puts 'baz'
                   end
                 end
-              CODE
+              RUBY
             end
 
             it 'registers an offense with inline `private`' do
-              expect_offense(<<~CODE)
+              expect_offense(<<~RUBY)
                 module Foo
                   private def bar
                           ^^^^^^^ Missing method documentation comment.
                     puts 'baz'
                   end
                 end
-              CODE
+              RUBY
             end
 
             it 'registers an offense with `end` on the same line' do
-              expect_offense(<<~CODE)
+              expect_offense(<<~RUBY)
                 module Foo
                   private
 
                   def bar; end
                   ^^^^^^^^^^^^ Missing method documentation comment.
                 end
-              CODE
+              RUBY
             end
 
             it 'registers an offense with inline `private` and `end`' do
-              expect_offense(<<~CODE)
+              expect_offense(<<~RUBY)
                 module Foo
                   private def bar; end
                           ^^^^^^^^^^^^ Missing method documentation comment.
                 end
-              CODE
+              RUBY
             end
           end
         end
 
         context 'when method is module_function' do
           it 'registers an offense for inline def' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               module Foo
                 module_function def bar
                 ^^^^^^^^^^^^^^^^^^^^^^^ Missing method documentation comment.
                 end
               end
-            CODE
+            RUBY
           end
 
           it 'registers an offense for separate def' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               module Foo
                 def bar
                 ^^^^^^^ Missing method documentation comment.
@@ -607,7 +607,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
 
                 module_function :bar
               end
-            CODE
+            RUBY
           end
         end
       end
@@ -615,45 +615,45 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
       context 'with documentation comment' do
         context 'when method is public' do
           it 'does not register an offense' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               module Foo
                 # Documentation
                 def bar
                   puts 'baz'
                 end
               end
-            CODE
+            RUBY
           end
 
           it 'does not register an offense with `end` on the same line' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               module Foo
                 # Documentation
                 def bar; end
               end
-            CODE
+            RUBY
           end
         end
 
         context 'when method is module_function' do
           it 'does not register an offense for inline def' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               module Foo
                 # Documentation
                 module_function def bar; end
               end
-            CODE
+            RUBY
           end
 
           it 'does not register an offense for separate def' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               module Foo
                 # Documentation
                 def bar; end
 
                 module_function :bar
               end
-            CODE
+            RUBY
           end
         end
       end
@@ -661,7 +661,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
       context 'with both public and private methods' do
         context 'when the public method has no documentation' do
           it 'registers an offense' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               module Foo
                 def bar
                 ^^^^^^^ Missing method documentation comment.
@@ -674,13 +674,13 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                   puts 'baz'
                 end
               end
-            CODE
+            RUBY
           end
         end
 
         context 'when the public method has documentation' do
           it 'does not register an offense' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               module Foo
                 # Documentation
                 def bar
@@ -693,7 +693,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                   puts 'baz'
                 end
               end
-            CODE
+            RUBY
           end
         end
 
@@ -701,7 +701,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
           let(:require_for_non_public_methods) { true }
 
           it 'registers an offense' do
-            expect_offense(<<~CODE)
+            expect_offense(<<~RUBY)
               module Foo
                 # Documentation
                 def bar
@@ -715,7 +715,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                   puts 'baz'
                 end
               end
-            CODE
+            RUBY
           end
         end
       end
@@ -724,7 +724,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
     context 'when declaring methods for class instance' do
       context 'without documentation comment' do
         it 'registers an offense' do
-          expect_offense(<<~CODE)
+          expect_offense(<<~RUBY)
             class Foo; end
 
             foo = Foo.new
@@ -733,24 +733,24 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
             ^^^^^^^^^^^ Missing method documentation comment.
               puts 'baz'
             end
-          CODE
+          RUBY
         end
 
         it 'registers an offense with `end` on the same line' do
-          expect_offense(<<~CODE)
+          expect_offense(<<~RUBY)
             class Foo; end
 
             foo = Foo.new
 
             def foo.bar; end
             ^^^^^^^^^^^^^^^^ Missing method documentation comment.
-          CODE
+          RUBY
         end
       end
 
       context 'with documentation comment' do
         it 'does not register an offense' do
-          expect_no_offenses(<<~CODE)
+          expect_no_offenses(<<~RUBY)
             class Foo; end
 
             foo = Foo.new
@@ -759,23 +759,23 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
             def foo.bar
               puts 'baz'
             end
-          CODE
+          RUBY
         end
 
         it 'does not register an offense with `end` on the same line' do
-          expect_no_offenses(<<~CODE)
+          expect_no_offenses(<<~RUBY)
             class Foo; end
 
             foo = Foo.new
 
             # Documentation
             def foo.bar; end
-          CODE
+          RUBY
         end
 
         context 'when method is private' do
           it 'does not register an offense with `end` on the same line' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               class Foo; end
 
               foo = Foo.bar
@@ -783,11 +783,11 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
               private
 
               def foo.bar; end
-            CODE
+            RUBY
           end
 
           it 'does not register an offense' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               class Foo; end
 
               foo = Foo.new
@@ -797,21 +797,21 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
               def foo.bar
                 puts 'baz'
               end
-            CODE
+            RUBY
           end
 
           it 'does not register an offense with inline `private` and `end`' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               class Foo; end
 
               foo = Foo.new
 
               private def foo.bar; end
-            CODE
+            RUBY
           end
 
           it 'does not register an offense with inline `private`' do
-            expect_no_offenses(<<~CODE)
+            expect_no_offenses(<<~RUBY)
               class Foo; end
 
               foo = Foo.new
@@ -819,14 +819,14 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
               private def foo.bar
                 puts 'baz'
               end
-            CODE
+            RUBY
           end
 
           context 'when required for non-public methods' do
             let(:require_for_non_public_methods) { true }
 
             it 'registers an offense with `end` on the same line' do
-              expect_offense(<<~CODE)
+              expect_offense(<<~RUBY)
                 class Foo; end
 
                 foo = Foo.bar
@@ -835,11 +835,11 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
 
                 def foo.bar; end
                 ^^^^^^^^^^^^^^^^ Missing method documentation comment.
-              CODE
+              RUBY
             end
 
             it 'registers an offense' do
-              expect_offense(<<~CODE)
+              expect_offense(<<~RUBY)
                 class Foo; end
 
                 foo = Foo.new
@@ -850,22 +850,22 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                 ^^^^^^^^^^^ Missing method documentation comment.
                   puts 'baz'
                 end
-              CODE
+              RUBY
             end
 
             it 'registers an offense with inline `private` and `end`' do
-              expect_offense(<<~CODE)
+              expect_offense(<<~RUBY)
                 class Foo; end
 
                 foo = Foo.new
 
                 private def foo.bar; end
                         ^^^^^^^^^^^^^^^^ Missing method documentation comment.
-              CODE
+              RUBY
             end
 
             it 'registers an offense with inline `private`' do
-              expect_offense(<<~CODE)
+              expect_offense(<<~RUBY)
                 class Foo; end
 
                 foo = Foo.new
@@ -874,7 +874,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                         ^^^^^^^^^^^ Missing method documentation comment.
                   puts 'baz'
                 end
-              CODE
+              RUBY
             end
           end
         end
@@ -882,7 +882,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
         context 'with both public and private methods' do
           context 'when the public method has no documentation' do
             it 'registers an offense' do
-              expect_offense(<<~CODE)
+              expect_offense(<<~RUBY)
                 class Foo; end
 
                 foo = Foo.new
@@ -897,13 +897,13 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                 def foo.baz
                   puts 'baz'
                 end
-              CODE
+              RUBY
             end
           end
 
           context 'when the public method has documentation' do
             it 'does not register an offense' do
-              expect_no_offenses(<<~CODE)
+              expect_no_offenses(<<~RUBY)
                 class Foo; end
 
                 foo = Foo.new
@@ -918,7 +918,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                 def foo.baz
                   puts 'baz'
                 end
-              CODE
+              RUBY
             end
           end
 
@@ -926,7 +926,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
             let(:require_for_non_public_methods) { true }
 
             it 'registers an offense' do
-              expect_offense(<<~CODE)
+              expect_offense(<<~RUBY)
                 class Foo; end
 
                 foo = Foo.new
@@ -942,7 +942,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
                 ^^^^^^^^^^^ Missing method documentation comment.
                   puts 'baz'
                 end
-              CODE
+              RUBY
             end
           end
         end


### PR DESCRIPTION
In response to the following review comment, I have created a cop to consistently use `RUBY` delimiter for heredocs in cop tests.

- https://github.com/rubocop/rubocop-performance/pull/297#discussion_r930636473

cc: @koic 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
