### PR TITLE
Fix an error for `Style/RedundantStringEscape` cop

### DIFF
--- a/changelog/fix_an_error_for_style_redundant_string_escape.md
+++ b/changelog/fix_an_error_for_style_redundant_string_escape.md
@@ -1,0 +1,1 @@
+* [#11095](https://github.com/rubocop/rubocop/pull/11095): Fix an error for `Style/RedundantStringEscape` cop when using `?\n` string character literal. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_string_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_string_escape_spec.rb
@@ -279,10 +279,16 @@ RSpec.describe RuboCop::Cop::Style::RedundantStringEscape, :config do
     end
   end
 
-  context 'when using character literals (e.g. `?a`)' do
-    it 'does not register an offense' do
+  context 'when using character literals' do
+    it 'does not register an offense for `?a`' do
       expect_no_offenses(<<~RUBY)
         ?a
+      RUBY
+    end
+
+    it 'does not register an offense for `?\n`' do
+      expect_no_offenses(<<~'RUBY')
+        ?\n
       RUBY
     end
   end


### PR DESCRIPTION
This PR fixes the following error for `Style/RedundantStringEscape` cop when using `?\n` string character literal.

```console
% cat example.rb
?\n

% bundle exec rubocop --only Style/RedundantStringEscape -d
(snip)

An error occurred while Style/RedundantStringEscape cop was inspecting /Users/koic/src/github.com/koic/rubocop-issues/11090/example.rb:1:0.
undefined method `source' for nil:NilClass

          delimiters = [node.loc.begin.source[-1], node.loc.end.source[0]]
                                                               ^^^^^^^
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/redundant_string_escape.rb:162:in `delimiter?'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/redundant_string_escape.rb:110:in `single_quoted?'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/redundant_string_escape.rb:103:in `interpolation_not_enabled?'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/redundant_string_escape.rb:85:in `allowed_escape?'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/redundant_string_escape.rb:51:in `block in on_str'
```

Similar case to #11089, but not resolved by #11090. It also removes a bit of unnecessary implementation logic I found.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
