### PR TITLE
[Fix #11088] Fix an error when specifying `SuggestExtensions: true`

### DIFF
--- a/changelog/fix_an_error_when_specifing_suggest_extensions_is_true.md
+++ b/changelog/fix_an_error_when_specifing_suggest_extensions_is_true.md
@@ -1,0 +1,1 @@
+* [#11088](https://github.com/rubocop/rubocop/issues/11088): Fix an error when specifying `SuggestExtensions: true`. ([@koic][])

--- a/docs/modules/ROOT/pages/extensions.adoc
+++ b/docs/modules/ROOT/pages/extensions.adoc
@@ -38,6 +38,8 @@ AllCops:
   SuggestExtensions: false
 ----
 
+Suggest default extensions if `SuggestExtensions: true`.
+
 You can also opt-out of suggestions for a particular extension library as so (unspecified
 extensions will continue to be notified, as appropriate):
 

--- a/lib/rubocop/cli/command/suggest_extensions.rb
+++ b/lib/rubocop/cli/command/suggest_extensions.rb
@@ -73,7 +73,14 @@ module RuboCop
         def all_extensions
           return [] unless lockfile.dependencies.any?
 
-          extensions = @config_store.for_pwd.for_all_cops['SuggestExtensions'] || {}
+          extensions = @config_store.for_pwd.for_all_cops['SuggestExtensions']
+          case extensions
+          when true
+            extensions = ConfigLoader.default_configuration.for_all_cops['SuggestExtensions']
+          when false, nil
+            extensions = {}
+          end
+
           extensions.select { |_, v| (Array(v) & dependent_gems).any? }.keys
         end
 

--- a/spec/rubocop/cli/suggest_extensions_spec.rb
+++ b/spec/rubocop/cli/suggest_extensions_spec.rb
@@ -328,6 +328,35 @@ RSpec.describe 'RuboCop::CLI SuggestExtensions', :isolated_environment do # rubo
       end
     end
 
+    context 'with AllCops/SuggestExtensions: true' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          AllCops:
+            SuggestExtensions: true
+        YAML
+      end
+
+      let(:lockfile) do
+        create_file('Gemfile.lock', <<~LOCKFILE)
+          GEM
+            specs:
+              rspec (3.9.0)
+              rspec-rails (4.0.1)
+
+          PLATFORMS
+            ruby
+
+          DEPENDENCIES
+            rspec (~> 3.9)
+            rspec-rails (~> 4.0)
+        LOCKFILE
+      end
+
+      it 'shows the suggestion' do
+        expect { cli.run(['example.rb']) }.to suggest_extensions.to_install('rubocop-rspec')
+      end
+    end
+
     context 'when an extension is disabled in AllCops/SuggestExtensions' do
       before do
         create_file('.rubocop.yml', <<~YAML)


### PR DESCRIPTION
Fixes #11088.

This PR fixes an error when specifying `SuggestExtensions: true`.

It's no wonder users think they can set `SuggestExtensions: true` when they can specify `SuggestExtensions: false`.
So, suggest default extensions if `SuggestExtensions: true`. Anyway, it shouldn't be an error.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
