### PR TITLE
Add new MatchCaseSensitive config in FileName cop

### DIFF
--- a/changelog/new_add_new_match_case_sensitive_config.md
+++ b/changelog/new_add_new_match_case_sensitive_config.md
@@ -1,0 +1,1 @@
+* [#11097](https://github.com/rubocop/rubocop/pull/11097): Adds a new config called `MatchCaseSensitive` in the `FileName` cop, allowing to have non-sensitive file name matching. ([@marctorrelles][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2663,6 +2663,9 @@ Naming/FileName:
     - spec
     - test
     - src
+  # This allows to compare class names and module names insensitively. Many eager
+  # loading methods are able to match names with different case patterns.
+  MatchCaseSensitive: true
   # If non-`nil`, expect all source file names to match the following regex.
   # Only the file name itself is matched, not the entire file path.
   # Use anchors as necessary if you want to match the entire name rather than

--- a/lib/rubocop/cop/naming/file_name.rb
+++ b/lib/rubocop/cop/naming/file_name.rb
@@ -127,6 +127,10 @@ module RuboCop
           cop_config['CheckDefinitionPathHierarchyRoots'] || []
         end
 
+        def match_case_sensitive?
+          cop_config['MatchCaseSensitive']
+        end
+
         def regex
           cop_config['Regex']
         end
@@ -153,13 +157,19 @@ module RuboCop
             next unless (const = find_definition(child))
 
             const_namespace, const_name = *const
-            next if name != const_name && !match_acronym?(name, const_name)
+            next if match_name?(name, const_name) && !match_acronym?(name, const_name)
             next unless namespace.empty? || match_namespace(child, const_namespace, namespace)
 
             return node
           end
 
           nil
+        end
+
+        def match_name?(name, const_name)
+          return !name.casecmp(const_name).zero? unless match_case_sensitive?
+
+          name != const_name
         end
 
         def find_definition(node)

--- a/spec/rubocop/cop/naming/file_name_spec.rb
+++ b/spec/rubocop/cop/naming/file_name_spec.rb
@@ -474,4 +474,21 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
       RUBY
     end
   end
+
+  context 'when MatchCaseSensitive is false' do
+    let(:cop_config) do
+      super().merge('MatchCaseSensitive' => false)
+    end
+
+    context 'on a file with a matching class' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY, '/lib/us_collection.rb')
+          begin
+            class USCollection
+            end
+          end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds a new config called `MatchCaseSensitive` in the `FileName` cop. It allows to have matching names without taking into account the sensitivity of the class name, as many eager loading methods allow it.

With `MatchCaseSensitive: true`, this is not allowed:
- filename: `us_collection.rb`
- classname: `USCollection`

With `MatchCaseSensitive: false`, this is allowed:
- filename: `us_collection.rb`
- classname: `USCollection`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
