### PR TITLE
[Fix #11102] Fix an error for `Style/AccessModifierDeclarations`

### DIFF
--- a/changelog/fix_an_error_for_style_access_modifier_declaration.md
+++ b/changelog/fix_an_error_for_style_access_modifier_declaration.md
@@ -1,0 +1,1 @@
+* [#11102](https://github.com/rubocop/rubocop/issues/11102): Fix an error for `Style/AccessModifierDeclarations` when using access modifier in a block. ([@koic][])

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -85,6 +85,8 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[private protected public module_function].freeze
 
+        ALLOWED_NODE_TYPES = %i[pair block].freeze
+
         # @!method access_modifier_with_symbol?(node)
         def_node_matcher :access_modifier_with_symbol?, <<~PATTERN
           (send nil? {:private :protected :public :module_function} (sym _))
@@ -92,7 +94,7 @@ module RuboCop
 
         def on_send(node)
           return unless node.access_modifier?
-          return if node.parent&.pair_type?
+          return if ALLOWED_NODE_TYPES.include?(node.parent&.type)
           return if allow_modifiers_on_symbols?(node)
 
           if offense?(node)

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -139,6 +139,14 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         end
       end
 
+      it 'does not registers an offense when using #{access_modifier} in a block' do
+        expect_no_offenses(<<~RUBY, access_modifier: access_modifier)
+          module MyModule
+            singleton_methods.each { |method| #{access_modifier}(method) }
+          end
+        RUBY
+      end
+
       context 'when method is modified by inline modifier with disallowed symbol' do
         let(:cop_config) do
           { 'AllowModifiersOnSymbols' => false }


### PR DESCRIPTION
Fixes #11102.

This PR fixes an error for `Style/AccessModifierDeclarations` when using access modifier in a block.

It wouldn't be expected to enforce a style on how it's used as a method call within a block like this:

```ruby
module MyModule
  singleton_methods.each { |method| module_function(method) }
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
