### PR TITLE
[Fix #11098] Fix false positive for Style/RedundantStringEscape

### DIFF
--- a/changelog/fix_fix_false_positive_for.md
+++ b/changelog/fix_fix_false_positive_for.md
@@ -1,0 +1,1 @@
+* [#11098](https://github.com/rubocop/rubocop/issues/11098): Fix false positive for Style/RedundantStringEscape. ([@tdeo][])

--- a/lib/rubocop/cop/style/redundant_string_escape.rb
+++ b/lib/rubocop/cop/style/redundant_string_escape.rb
@@ -90,9 +90,7 @@ module RuboCop
 
           return true if escaped[0] == ' ' && percent_array_literal?(node)
 
-          # Allow #{foo}, #$foo, #@foo, and #@@foo for escaping local, global, instance and class
-          # variable interpolations inside
-          return true if /\A#[{$@]/.match?(escaped)
+          return true if disabling_interpolation?(range)
           return true if delimiter?(node, escaped[0])
 
           false
@@ -165,6 +163,17 @@ module RuboCop
 
         def literal_in_interpolated_or_multiline_string?(node)
           node.str_type? && !begin_loc_present?(node) && node.parent&.dstr_type?
+        end
+
+        def disabling_interpolation?(range)
+          # Allow \#{foo}, \#$foo, \#@foo, and \#@@foo
+          # for escaping local, global, instance and class variable interpolations
+          return true if range.source.match?(/\A\\#[{$@]/)
+
+          # Also allow #\{foo}, #\$foo, #\@foo and #\@@foo
+          return true if range.adjust(begin_pos: -2).source.match?(/\A[^\\]#\\[{$@]/)
+
+          false
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_string_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_string_escape_spec.rb
@@ -21,20 +21,40 @@ RSpec.describe RuboCop::Cop::Style::RedundantStringEscape, :config do
       expect_no_offenses(wrap('\#$foo'))
     end
 
+    it 'does not register an offense for a $-escaped gvar interpolation' do
+      expect_no_offenses(wrap('#\$foo'))
+    end
+
     it 'does not register an offense for an escaped ivar interpolation' do
       expect_no_offenses(wrap('\#@foo'))
+    end
+
+    it 'does not register an offense for a @-escaped ivar interpolation' do
+      expect_no_offenses(wrap('#\@foo'))
     end
 
     it 'does not register an offense for an escaped cvar interpolation' do
       expect_no_offenses(wrap('\#@@foo'))
     end
 
+    it 'does not register an offense for a @-escaped cvar interpolation' do
+      expect_no_offenses(wrap('#\@@foo'))
+    end
+
     it 'does not register an offense for an escaped interpolation' do
       expect_no_offenses(wrap('\#{my_var}'))
     end
 
-    it 'does not register an offense for an escaped # an following {' do
+    it 'does not register an offense for a bracket-escaped interpolation' do
+      expect_no_offenses(wrap('#\{my_var}'))
+    end
+
+    it 'does not register an offense for an escaped # followed {' do
       expect_no_offenses(wrap('\#{my_lvar}'))
+    end
+
+    it 'does not register a bracket-escaped lvar interpolation' do
+      expect_no_offenses(wrap('#\{my_lvar}'))
     end
 
     it 'does not register an offense for an escaped newline' do
@@ -114,6 +134,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantStringEscape, :config do
 
       expect_correction(<<~RUBY)
         #{l}#whatever#{r}
+      RUBY
+    end
+
+    it 'registers an offense and corrects an escaped } when escaping both brackets to avoid interpolation' do
+      expect_offense(<<~'RUBY', l: l, r: r)
+        %{l}#\{whatever\}%{r}
+        _{l}           ^^ Redundant escape of } inside string literal.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #{l}#\\{whatever}#{r}
       RUBY
     end
 


### PR DESCRIPTION
Fix incorrect false-positives for escaped interpolation when escaping the character following the `#` instead of the `#` itself.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
