### PR TITLE
[Fix #11104] Fix an error for `Style/CollectionCompact`

### DIFF
--- a/changelog/fix_an_error_for_style_collection_compact.md
+++ b/changelog/fix_an_error_for_style_collection_compact.md
@@ -1,0 +1,1 @@
+* [#11104](https://github.com/rubocop/rubocop/issues/11104): Fix an error for `Style/CollectionCompact` when using `reject` method and receiver is a variable. ([@koic][])

--- a/lib/rubocop/cop/style/collection_compact.rb
+++ b/lib/rubocop/cop/style/collection_compact.rb
@@ -96,7 +96,9 @@ module RuboCop
         end
 
         def to_enum_method?(node)
-          TO_ENUM_METHODS.include?(node.children.first.method_name)
+          return false unless node.receiver.send_type?
+
+          TO_ENUM_METHODS.include?(node.receiver.method_name)
         end
 
         def good_method_name(node)

--- a/spec/rubocop/cop/style/collection_compact_spec.rb
+++ b/spec/rubocop/cop/style/collection_compact_spec.rb
@@ -57,6 +57,21 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `reject` and receiver is a variable' do
+    expect_offense(<<~RUBY)
+      def foo(params)
+        params.reject { |_k, v| v.nil? }
+               ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `reject { |_k, v| v.nil? }`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo(params)
+        params.compact
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using `reject` to not to rejecting nils' do
     expect_no_offenses(<<~RUBY)
       array.reject { |e| e.odd? }


### PR DESCRIPTION
Fixes #11104.

This PR fixes an error for `Style/CollectionCompact` when using `reject` method and receiver is a variable.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
