### PR TITLE
Add new `InternalAffairs/CreateEmptyFile` cop

### DIFF
--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'internal_affairs/cop_description'
+require_relative 'internal_affairs/create_empty_file'
 require_relative 'internal_affairs/empty_line_between_expect_offense_and_correction'
 require_relative 'internal_affairs/example_description'
 require_relative 'internal_affairs/example_heredoc_delimiter'

--- a/lib/rubocop/cop/internal_affairs/create_empty_file.rb
+++ b/lib/rubocop/cop/internal_affairs/create_empty_file.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # Checks for uses of `create_file` with empty string second argument.
+      #
+      # @example
+      #
+      #   # bad
+      #   create_file(path, '')
+      #
+      #   # good
+      #   create_empty_file(path)
+      #
+      class CreateEmptyFile < Base
+        extend AutoCorrector
+
+        MSG = 'Use `%<replacement>s`.'
+        RESTRICT_ON_SEND = %i[create_file].freeze
+
+        def on_send(node)
+          return if node.receiver
+          return unless (argument = node.arguments[1])
+          return unless argument.str_type? && argument.value.empty?
+
+          replacement = "create_empty_file(#{node.first_argument.source})"
+          message = format(MSG, replacement: replacement)
+
+          add_offense(node, message: message) do |corrector|
+            corrector.replace(node, replacement)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1042,7 +1042,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
   end
 
   describe '--display-time' do
-    before { create_file('example1.rb', '') }
+    before { create_empty_file('example1.rb') }
 
     regex = /Finished in [0-9]*\.[0-9]* seconds/
 

--- a/spec/rubocop/cop/internal_affairs/create_empty_file_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/create_empty_file_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::InternalAffairs::CreateEmptyFile, :config do
+  it "registers an offense when using `create_file(path, '')" do
+    expect_offense(<<~RUBY)
+      create_file(path, '')
+      ^^^^^^^^^^^^^^^^^^^^^ Use `create_empty_file(path)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      create_empty_file(path)
+    RUBY
+  end
+
+  it 'registers an offense when using `create_file(path, "")' do
+    expect_offense(<<~RUBY)
+      create_file(path, "")
+      ^^^^^^^^^^^^^^^^^^^^^ Use `create_empty_file(path)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      create_empty_file(path)
+    RUBY
+  end
+
+  it "does not register an offense when using `create_file(path, 'hello')`" do
+    expect_no_offenses(<<~RUBY)
+      create_file(path, 'hello')
+    RUBY
+  end
+
+  it "does not register an offense when using `create_file(path, ['foo', 'bar'])`" do
+    expect_no_offenses(<<~RUBY)
+      create_file(path, ['foo', 'bar'])
+    RUBY
+  end
+
+  it 'does not register an offense when using `create_file(path)`' do
+    expect_no_offenses(<<~RUBY)
+      create_file(path)
+    RUBY
+  end
+
+  it "does not register an offense when using `receiver.create_file(path, '')`" do
+    expect_no_offenses(<<~RUBY)
+      receiver.create_file(path, '')
+    RUBY
+  end
+end

--- a/spec/rubocop/server/cache_spec.rb
+++ b/spec/rubocop/server/cache_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe RuboCop::Server::Cache do
         end
 
         it 'does not raise an error' do
-          create_file('.rubocop.yml', '')
+          create_empty_file('.rubocop.yml')
 
           expect { cache_class.cache_path }.not_to raise_error
         end

--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
 
   before do
     # Makes sure the project dir of rubocop server is the isolated_environment
-    create_file('Gemfile', '')
+    create_empty_file('Gemfile')
   end
 
   after do

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -21,9 +21,11 @@ module FileHelper
     file_path
   end
 
+  # rubocop:disable InternalAffairs/CreateEmptyFile
   def create_empty_file(file_path)
     create_file(file_path, '')
   end
+  # rubocop:enable InternalAffairs/CreateEmptyFile
 
   def create_link(link_path, target_path)
     link_path = File.expand_path(link_path)


### PR DESCRIPTION
This PR adds new `InternalAffairs/CreateEmptyFile` cop. It checks for uses of `create_file` with empty string second argument.

```ruby
# bad
create_file(path, '')

# good
create_empty_file(path)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
