### PR TITLE
[Fix #11066] -- Update Docs for `Style/CollectionCompact`

### DIFF
--- a/lib/rubocop/cop/style/collection_compact.rb
+++ b/lib/rubocop/cop/style/collection_compact.rb
@@ -8,7 +8,8 @@ module RuboCop
       #
       # @safety
       #   It is unsafe by default because false positives may occur in the
-      #   `nil` check of block arguments to the receiver object.
+      #   `nil` check of block arguments to the receiver object. Additionally,
+      #    .compact may not exist for the highlighted object.
       #
       #   For example, `[[1, 2], [3, nil]].reject { |first, second| second.nil? }`
       #   and `[[1, 2], [3, nil]].compact` are not compatible. This will work fine

--- a/lib/rubocop/cop/style/collection_compact.rb
+++ b/lib/rubocop/cop/style/collection_compact.rb
@@ -9,7 +9,8 @@ module RuboCop
       # @safety
       #   It is unsafe by default because false positives may occur in the
       #   `nil` check of block arguments to the receiver object. Additionally,
-      #    .compact may not exist for the highlighted object.
+      #    we can't know the type of the receiver object for sure, which may
+      #    result in false positives as well.
       #
       #   For example, `[[1, 2], [3, nil]].reject { |first, second| second.nil? }`
       #   and `[[1, 2], [3, nil]].compact` are not compatible. This will work fine


### PR DESCRIPTION
- This PR fixes #11066. 
- Essentially, there's a situation that can happen where Rubocop says that `params.reject { |n| ... }` should be replaced with `params.compact`. However, the params object doesn't have an implementation of `compact`. 
- Since `Style/CollectionCompact` is already marked unsafe, the solution here was to update the associated documentation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
    * Didn't actually add tests seeing as this is a documentation change, but if y'all have some way to run unit tests against docs lemme know and I'm happy to get that added 😁 
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
   * `"If the new code introduces user-observable changes"` -- I don't believe these changes are user-observable, but am more than happy to add this if it's necessary.

[1]: https://chris.beams.io/posts/git-commit/
