### PR TITLE
Report the count of files in the Worst and Offense Count formatters

### DIFF
--- a/changelog/change_report_the_count_of_files_in_the_worst.md
+++ b/changelog/change_report_the_count_of_files_in_the_worst.md
@@ -1,1 +1,0 @@
-* [#11113](https://github.com/rubocop/rubocop/pull/11113): Report the count of files in the Worst formatter. ([@hosamaly][])

--- a/changelog/change_report_the_count_of_files_in_the_worst.md
+++ b/changelog/change_report_the_count_of_files_in_the_worst.md
@@ -1,0 +1,1 @@
+* [#11113](https://github.com/rubocop/rubocop/pull/11113): Report the count of files in the Worst formatter. ([@hosamaly][])

--- a/changelog/change_report_the_count_of_files_in_worst_and_offenses.md
+++ b/changelog/change_report_the_count_of_files_in_worst_and_offenses.md
@@ -1,0 +1,1 @@
+* [#11113](https://github.com/rubocop/rubocop/pull/11113): Report the count of files in the Worst and the Offense Count formatters. ([@hosamaly][])

--- a/lib/rubocop/formatter/worst_offenders_formatter.rb
+++ b/lib/rubocop/formatter/worst_offenders_formatter.rb
@@ -12,7 +12,7 @@ module RuboCop
     # 26  this/file/is/really/bad.rb
     # 3   just/ok.rb
     # --
-    # 29  Total
+    # 29  Total in 2 files
     class WorstOffendersFormatter < BaseFormatter
       attr_reader :offense_counts
 
@@ -36,14 +36,17 @@ module RuboCop
       def report_summary(offense_counts)
         per_file_counts = ordered_offense_counts(offense_counts)
         total_count = total_offense_count(offense_counts)
+        file_count = per_file_counts.size
 
         output.puts
 
+        column_width = total_count.to_s.length + 2
         per_file_counts.each do |file_name, count|
-          output.puts "#{count.to_s.ljust(total_count.to_s.length + 2)}#{file_name}\n"
+          output.puts "#{count.to_s.ljust(column_width)}#{file_name}\n"
         end
+
         output.puts '--'
-        output.puts "#{total_count}  Total"
+        output.puts "#{total_count}  Total in #{file_count} files"
 
         output.puts
       end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1383,7 +1383,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       1   Style/DefWithParentheses
       1   Style/TrailingBodyOnMethodDefinition
       --
-      15  Total
+      15  Total in 1 files
 
     RESULT
   end
@@ -1491,7 +1491,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
         4  Layout/SpaceAfterComma
         2  Style/WordArray
         --
-        6  Total
+        6  Total in 1 files
 
       RESULT
     expect(File.read('example.rb'))

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -774,7 +774,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
           1  Layout/SpaceAroundOperators
           1  Layout/TrailingWhitespace
           --
-          6  Total
+          6  Total in 1 files
 
         RESULT
       end
@@ -799,7 +799,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
             1  Style/FrozenStringLiteralComment
             1  Style/NumericLiterals
             --
-            7  Total
+            7  Total in 1 files
 
           RESULT
       end
@@ -936,7 +936,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
             1  Style/FrozenStringLiteralComment
             1  Style/NumericPredicate
             --
-            7  Total
+            7  Total in 1 files
 
           RESULT
       end
@@ -954,7 +954,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
         expect($stderr.string).to eq('')
         expect(without_option.split($RS) - with_option.split($RS))
-          .to eq(['1  Style/IfUnlessModifier', '7  Total'])
+          .to eq(['1  Style/IfUnlessModifier', '7  Total in 1 files'])
       end
     end
 
@@ -981,7 +981,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
               1  Style/FrozenStringLiteralComment
               1  Style/NumericLiterals
               --
-              4  Total
+              4  Total in 1 files
 
             RESULT
         end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
           1  Style/FrozenStringLiteralComment
           --
-          1  Total
+          1  Total in 1 files
 
         RESULT
         expect(File.read('example.rb'))
@@ -640,7 +640,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
               1  Style/AndOr
               --
-              1  Total
+              1  Total in 1 files
 
             RESULT
           end
@@ -657,7 +657,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               3  Layout/LineLength
               1  Style/AndOr
               --
-              4  Total
+              4  Total in 1 files
 
             RESULT
           end
@@ -677,7 +677,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
               3  Layout/LineLength
               --
-              3  Total
+              3  Total in 1 files
 
             RESULT
           end
@@ -694,7 +694,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               3  Layout/LineLength
               1  Style/AndOr
               --
-              4  Total
+              4  Total in 1 files
 
             RESULT
           end
@@ -988,7 +988,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
           1  Layout/TrailingWhitespace
           --
-          1  Total
+          1  Total in 1 files
 
         RESULT
     end

--- a/spec/rubocop/formatter/offense_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/offense_count_formatter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
     end
   end
 
-  let(:finish) { formatter.file_finished(files.first, offenses) }
+  let(:finish) { files.each { |file| formatter.file_finished(file, offenses) } }
 
   describe '#file_finished' do
     before { formatter.started(files) }
@@ -51,6 +51,8 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
 
   describe '#finished' do
     context 'when there are many offenses' do
+      let(:files) { super().take(1) }
+
       let(:offenses) do
         %w[CopB CopA CopC CopC].map do |cop|
           instance_double(RuboCop::Cop::Offense, cop_name: cop)
@@ -114,9 +116,9 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
         finish
       end
 
-      it 'has a progresbar' do
+      it 'has a progress bar' do
         formatter.finished(files)
-        expect(formatter.instance_variable_get(:@progressbar).progress).to eq 1
+        expect(formatter.instance_variable_get(:@progressbar).progress).to eq 3
       end
     end
   end

--- a/spec/rubocop/formatter/offense_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/offense_count_formatter_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
 
   let(:output) { StringIO.new }
   let(:options) { { display_style_guide: false } }
+  let(:file_count) { files.size }
 
   let(:files) do
     %w[lib/rubocop.rb spec/spec_helper.rb exe/rubocop].map do |path|
@@ -38,13 +39,17 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
 
   describe '#report_summary' do
     context 'when an offense is detected' do
-      let(:cop_counts) { { 'OffendedCop' => 1 } }
+      let(:cop_counts) { { 'OffendedCop' => 3 } }
 
       before { formatter.started(files) }
 
       it 'shows the cop and the offense count' do
-        formatter.report_summary(cop_counts)
-        expect(output.string).to include("\n1  OffendedCop\n--\n1  Total")
+        formatter.report_summary(cop_counts, 2)
+        expect(output.string).to include(<<~OUTPUT)
+          3  OffendedCop
+          --
+          3  Total in 2 files
+        OUTPUT
       end
     end
   end
@@ -78,7 +83,7 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
             1  CopA
             1  CopB
             --
-            4  Total
+            4  Total in 1 files
 
           OUTPUT
         end
@@ -95,7 +100,7 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
             1  CopA (https://rubystyle.guide#no-good-CopA)
             1  CopB (https://rubystyle.guide#no-good-CopB)
             --
-            4  Total
+            4  Total in 1 files
 
           OUTPUT
         end

--- a/spec/rubocop/formatter/worst_offenders_formatter_spec.rb
+++ b/spec/rubocop/formatter/worst_offenders_formatter_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Formatter::WorstOffendersFormatter do
           3  spec/spec_helper.rb
           2  lib/rubocop.rb
           --
-          9  Total
+          9  Total in 3 files
 
         OUTPUT
       end

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe RuboCop::RakeTask do
         1  Style/FrozenStringLiteralComment
         1  Style/SpecialGlobalVars
         --
-        2  Total
+        2  Total in 1 files
 
       RESULT
       expect($stderr.string.strip).to eq 'RuboCop failed!'


### PR DESCRIPTION
Report the count of files in the Worst and the Offence Counts formatters. Their output now looks like this:

```
# Worst:
4  exe/rubocop
3  spec/spec_helper.rb
2  lib/rubocop.rb
--
9  Total in 3 files

# Offenses:
2  CopC
1  CopA
1  CopB
--
4  Total in 1 files
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
