### PR TITLE
[Fix #11114] Fix an error for `Style/OperatorMethodCall`

### DIFF
--- a/changelog/fix_an_error_for_style_operator_method_call.md
+++ b/changelog/fix_an_error_for_style_operator_method_call.md
@@ -1,0 +1,1 @@
+* [#11114](https://github.com/rubocop/rubocop/issues/11114): Fix an error for `Style/OperatorMethodCall` when using `obj.!`. ([@koic][])

--- a/lib/rubocop/cop/style/operator_method_call.rb
+++ b/lib/rubocop/cop/style/operator_method_call.rb
@@ -28,7 +28,7 @@ module RuboCop
           return if node.receiver.const_type?
 
           _lhs, _op, rhs = *node
-          return if rhs.children.first
+          return if rhs.nil? || rhs.children.first
 
           add_offense(dot) do |corrector|
             corrector.replace(dot, ' ')

--- a/spec/rubocop/cop/style/operator_method_call_spec.rb
+++ b/spec/rubocop/cop/style/operator_method_call_spec.rb
@@ -73,4 +73,10 @@ RSpec.describe RuboCop::Cop::Style::OperatorMethodCall, :config do
       Foo.+(bar)
     RUBY
   end
+
+  it 'does not register an offense when using `obj.!`' do
+    expect_no_offenses(<<~RUBY)
+      obj.!
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #11114

This PR fixes an error for `Style/OperatorMethodCall` when using `obj.!`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
