### PR TITLE
[Fix #11117] Fix a false positive for `Style/BlockDelimiters`

### DIFF
--- a/changelog/fix_a_false_positive_for_block_delimiters.md
+++ b/changelog/fix_a_false_positive_for_block_delimiters.md
@@ -1,0 +1,1 @@
+* [#11117](https://github.com/rubocop/rubocop/issues/11117): Fix a false positive for `Style/BlockDelimiters` when specifying `EnforcedStyle: semantic` and using a single line block with {} followed by a safe navigation method call. ([@koic][])

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -425,7 +425,7 @@ module RuboCop
           if node.parent.begin_type?
             return_value_used?(node.parent)
           else
-            node.parent.assignment? || node.parent.send_type?
+            node.parent.assignment? || node.parent.call_type?
           end
         end
 

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -183,6 +183,10 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       expect_no_offenses('detect { true }...other')
     end
 
+    it 'accepts a single line block with {} followed by a safe navigation method call' do
+      expect_no_offenses('ary.map { |e| foo(e) }&.bar')
+    end
+
     it 'accepts a multi-line functional block with do-end if it is a known procedural method' do
       expect_no_offenses(<<~RUBY)
         foo = bar.tap do |x|


### PR DESCRIPTION
Fixes #11117.

This PR fixes a false positive for `Style/BlockDelimiters` when specifying `EnforcedStyle: semantic` and using a single line block with {} followed by a safe navigation method call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
