### PR TITLE
[Fix #11120] Fix an incorrect autocorrect for `Lint/RedundantRequireStatement`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_redundant_require_statement.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_redundant_require_statement.md
@@ -1,0 +1,1 @@
+* [#11120](https://github.com/rubocop/rubocop/issues/11120): Fix an incorrect autocorrect for `Lint/RedundantRequireStatement` when using redundant `require` with modifier form. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_require_statement.rb
+++ b/lib/rubocop/cop/lint/redundant_require_statement.rb
@@ -49,7 +49,13 @@ module RuboCop
           return unless redundant_require_statement?(node)
 
           add_offense(node) do |corrector|
-            range = range_with_surrounding_space(node.loc.expression, side: :right)
+            if node.parent.respond_to?(:modifier_form?) && node.parent.modifier_form?
+              corrector.insert_after(node.parent, "\nend")
+
+              range = range_with_surrounding_space(node.loc.expression, side: :right)
+            else
+              range = range_by_whole_lines(node.source_range, include_final_newline: true)
+            end
 
             corrector.remove(range)
           end

--- a/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
@@ -13,6 +13,36 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
     RUBY
   end
 
+  it 'registers an offense when using requiring `enumerator` with modifier form' do
+    expect_offense(<<~RUBY)
+      require 'enumerator' if condition
+      ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+      require 'uri'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if condition
+      end
+      require 'uri'
+    RUBY
+  end
+
+  it 'registers an offense when using requiring `enumerator` in condition' do
+    expect_offense(<<~RUBY)
+      if condition
+        require 'enumerator'
+        ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+      end
+      require 'uri'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if condition
+      end
+      require 'uri'
+    RUBY
+  end
+
   context 'target ruby version <= 2.0', :ruby20 do
     it 'does not register an offense when using requiring `thread`' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #11120.

This PR fixes an incorrect autocorrect for `Lint/RedundantRequireStatement` when using redundant `require` with modifier form.

For example, in essential it is unknown how many times `do_something` will be executed when `require 'enumerator' while do_something`. So it does not autocorrects when modifier form is used to avoid side effects.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
