### PR TITLE
Fix an error for `Layout/SpaceInsideHashLiteralBraces`

### DIFF
--- a/changelog/fix_an_error_for_layout_space_inside_hash_literal.md
+++ b/changelog/fix_an_error_for_layout_space_inside_hash_literal.md
@@ -1,0 +1,1 @@
+* [#11125](https://github.com/rubocop/rubocop/pull/11125): Fix an error for `Layout/SpaceInsideHashLiteralBraces` when using method argument that both key and value are hash literals. ([@koic][])

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -194,6 +194,8 @@ module RuboCop
         end
 
         def range_inside_hash(node)
+          return node.source_range if node.location.begin.nil?
+
           range_between(node.location.begin.end_pos, node.location.end.begin_pos)
         end
 

--- a/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
@@ -55,6 +55,22 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
         h = { }
       RUBY
     end
+
+    context 'when using method argument that both key and value are hash literals' do
+      it 'registers hashes with no spaces' do
+        expect_offense(<<~RUBY)
+          foo({key: value} => {key: value})
+                                         ^ Space inside } missing.
+                              ^ Space inside { missing.
+                         ^ Space inside } missing.
+              ^ Space inside { missing.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo({ key: value } => { key: value })
+        RUBY
+      end
+    end
   end
 
   it 'registers an offense for hashes with no spaces if so configured' do
@@ -133,6 +149,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
               b: 2,
         }
       RUBY
+    end
+
+    context 'when using method argument that both key and value are hash literals' do
+      it 'accepts hashes with no spaces' do
+        expect_no_offenses(<<~RUBY)
+          foo({key: value} => {key: value})
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/11032#issuecomment-1292304322.

This PR fixes an error for `Layout/SpaceInsideHashLiteralBraces` when using method argument that both key and value are hash literals.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
