### PR TITLE
Make Lint/RedundantRequireStatement mark set as a redundant require in Ruby 3.2+

### DIFF
--- a/changelog/new_add_set_to_redundant_require_statement.md
+++ b/changelog/new_add_set_to_redundant_require_statement.md
@@ -1,0 +1,1 @@
+* [#11126](https://github.com/rubocop/rubocop/pull/11126): Have `Lint/RedundantRequireStatement` mark `set` as a redundant require in Ruby 3.2+. ([@drenmi][])

--- a/lib/rubocop/cop/lint/redundant_require_statement.rb
+++ b/lib/rubocop/cop/lint/redundant_require_statement.rb
@@ -20,6 +20,7 @@ module RuboCop
       #   * 2.5+ ... Add `pp` above
       #   * 2.7+ ... Add `ruby2_keywords` above
       #   * 3.1+ ... Add `fiber` above
+      #   * 3.2+ ... `set`
       #
       # This cop target those features.
       #
@@ -63,7 +64,8 @@ module RuboCop
             (target_ruby_version >= 2.2 && RUBY_22_LOADED_FEATURES.include?(feature_name)) ||
             (target_ruby_version >= 2.5 && feature_name == 'pp') ||
             (target_ruby_version >= 2.7 && feature_name == 'ruby2_keywords') ||
-            (target_ruby_version >= 3.1 && feature_name == 'fiber')
+            (target_ruby_version >= 3.1 && feature_name == 'fiber') ||
+            (target_ruby_version >= 3.2 && feature_name == 'set')
         end
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       end

--- a/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
@@ -160,5 +160,19 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
         require 'uri'
       RUBY
     end
+
+    context 'target ruby version >= 3.2', :ruby32 do
+      it 'registers an offense and corrects when using requiring `set`' do
+        expect_offense(<<~RUBY)
+          require 'set'
+          ^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+          require 'uri'
+        RUBY
+
+        expect_correction(<<~RUBY)
+          require 'uri'
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
In Ruby 3.2, `set` will be included by default.

From the Ruby [announcement](https://www.ruby-lang.org/en/news/2022/09/09/ruby-3-2-0-preview2-released/):

> Set is now available as a builtin class without the need for `require "set"`. [[Feature #16989](https://bugs.ruby-lang.org/issues/16989)] It is currently autoloaded via the `Set` constant or a call to `Enumerable#to_set`.

This PR updates `Lint/RedundantRequireStatement` to flag `require "set"` when configured to inspect Ruby 3.2 or higher.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
