### PR TITLE
Check blank percent literal by `Layout/SpaceInsidePercentLiteralDelimiters`

### DIFF
--- a/changelog/change_check_blank_percent_literal.md
+++ b/changelog/change_check_blank_percent_literal.md
@@ -1,0 +1,1 @@
+* [#11130](https://github.com/rubocop/rubocop/pull/11130): Check blank percent literal by `Layout/SpaceInsidePercentLiteralDelimiters`. ([@r7kamura][])

--- a/lib/rubocop/cop/layout/space_inside_array_percent_literal.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_percent_literal.rb
@@ -6,6 +6,9 @@ module RuboCop
       # Checks for unnecessary additional spaces inside array percent literals
       # (i.e. %i/%w).
       #
+      # Note that blank percent literals (e.g. `%i( )`) are checked by
+      # `Layout/SpaceInsidePercentLiteralDelimiters`.
+      #
       # @example
       #
       #   # bad

--- a/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
@@ -86,6 +86,36 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsidePercentLiteralDelimiters, :confi
         it 'accepts spaces between entries' do
           expect_no_offenses(code_example('a  b  c'))
         end
+
+        context 'with space in blank percent literals' do
+          it 'registers and corrects an offense' do
+            expect_offense(<<~RUBY)
+              #{code_example(' ')}
+                 ^ #{message}
+            RUBY
+
+            expect_correction("#{code_example('')}\n")
+          end
+        end
+
+        context 'with spaces in blank percent literals' do
+          it 'registers and corrects an offense' do
+            expect_offense(<<~RUBY)
+              #{code_example('  ')}
+                 ^^ #{message}
+            RUBY
+
+            expect_correction("#{code_example('')}\n")
+          end
+        end
+
+        context 'with newline in blank percent literals' do
+          it 'registers and corrects an offense' do
+            expect_offense(code_example("\n").lines.insert(1, "   ^{} #{message}\n").join)
+
+            expect_correction(code_example('').to_s)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Previously, no particular investigation was made for whitespace in blank percent array literals on `Layout/SpaceInsideArrayPercentLiteral`.

I will change it in this Pull Request so that they are inspected as well.

```ruby
# bad
%w[ ]
%w[    ]
%w[
]

# good
%w[]
```

This is a similar change to:

- https://github.com/rubocop/rubocop/pull/11032

---

edit: At first I tried to change `Layout/SpaceInsideArrayPercentLiteral` Cop, but after discussion, it was decided to use `Layout/SpaceInsidePercentLiteralDelimiters` Cop instead.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
