### PR TITLE
Check newline in empty reference bracket on `Layout/SpaceInsideReferenceBrackets`

### DIFF
--- a/changelog/change_check_newline_in_empty_reference_bracket.md
+++ b/changelog/change_check_newline_in_empty_reference_bracket.md
@@ -1,0 +1,1 @@
+* [#11131](https://github.com/rubocop/rubocop/pull/11131): Check newline in empty reference bracket on `Layout/SpaceInsideReferenceBrackets`. ([@r7kamura][])

--- a/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
@@ -38,6 +38,8 @@ module RuboCop
       #   # bad
       #   foo[ ]
       #   foo[     ]
+      #   foo[
+      #   ]
       #
       #   # good
       #   foo[]
@@ -49,6 +51,8 @@ module RuboCop
       #   # bad
       #   foo[]
       #   foo[    ]
+      #   foo[
+      #   ]
       #
       #   # good
       #   foo[ ]
@@ -64,8 +68,6 @@ module RuboCop
         RESTRICT_ON_SEND = %i[[] []=].freeze
 
         def on_send(node)
-          return if node.multiline?
-
           tokens = processed_source.tokens_within(node)
           left_token = left_ref_bracket(node, tokens)
           return unless left_token
@@ -75,6 +77,8 @@ module RuboCop
           if empty_brackets?(left_token, right_token)
             return empty_offenses(node, left_token, right_token, EMPTY_MSG)
           end
+
+          return if node.multiline?
 
           if style == :no_space
             no_space_offenses(node, left_token, right_token, MSG)

--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -118,14 +118,15 @@ module RuboCop
       end
 
       def offending_empty_no_space?(config, left_token, right_token)
-        config == 'no_space' && !no_space_between?(left_token, right_token)
+        config == 'no_space' && !no_character_between?(left_token, right_token)
       end
 
       def space_between?(left_bracket_token, right_bracket_token)
-        left_bracket_token.end_pos + 1 == right_bracket_token.begin_pos
+        left_bracket_token.end_pos + 1 == right_bracket_token.begin_pos &&
+          processed_source.buffer.source[left_bracket_token.end_pos] == ' '
       end
 
-      def no_space_between?(left_bracket_token, right_bracket_token)
+      def no_character_between?(left_bracket_token, right_bracket_token)
         left_bracket_token.end_pos == right_bracket_token.begin_pos
       end
     end

--- a/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
         a[]
       RUBY
     end
+
+    it 'registers an offense and corrects empty brackets with newline inside' do
+      expect_offense(<<~RUBY)
+        a[
+         ^ Do not use space inside empty reference brackets.
+        ]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a[]
+      RUBY
+    end
   end
 
   context 'with space inside empty braces allowed' do
@@ -53,6 +65,18 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
       expect_offense(<<~RUBY)
         a[      ]
          ^^^^^^^^ Use one space inside empty reference brackets.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a[ ]
+      RUBY
+    end
+
+    it 'registers offense and corrects empty brackets with newline inside' do
+      expect_offense(<<~RUBY)
+        a[
+         ^ Use one space inside empty reference brackets.
+        ]
       RUBY
 
       expect_correction(<<~RUBY)
@@ -90,6 +114,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
         c["foo"] = "qux"
         d[:bar] = var
         e[] = foo
+      RUBY
+    end
+
+    it 'does not register offense for non-empty brackets with newline inside' do
+      expect_no_offenses(<<-RUBY)
+        foo[
+          bar
+        ]
       RUBY
     end
 


### PR DESCRIPTION
This is the reference bracket version of the following Pull Request:

- https://github.com/rubocop/rubocop/pull/11032

which will add the following rule about newline in empty reference bracket:

```ruby
# bad
foo[
]

# good - EnforcedStyleForEmptyBrackets: no_space (default)
foo[]

# good - EnforcedStyleForEmptyBrackets: space
foo[ ]
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
