### PR TITLE
[Fix #11132] Fix clobbering error on `Lint/EmptyConditionalBody`

### DIFF
--- a/changelog/fix_clobbering_error_on_lint_empty_conditional_body.md
+++ b/changelog/fix_clobbering_error_on_lint_empty_conditional_body.md
@@ -1,0 +1,1 @@
+* [#11132](https://github.com/rubocop/rubocop/issues/11132): Fix clobbering error on `Lint/EmptyConditionalBody`. ([@r7kamura][])

--- a/lib/rubocop/cop/lint/empty_conditional_body.rb
+++ b/lib/rubocop/cop/lint/empty_conditional_body.rb
@@ -141,7 +141,7 @@ module RuboCop
           if empty_if_branch?(node) && else_branch?(node)
             node.source_range.with(end_pos: node.loc.else.begin_pos)
           elsif node.loc.else
-            node.source_range.with(end_pos: node.loc.else.begin_pos - 1)
+            node.source_range.with(end_pos: node.condition.loc.expression.end_pos)
           elsif all_branches_body_missing?(node)
             if_node = node.ancestors.detect(&:if?)
             node.source_range.with(end_pos: if_node.loc.end.end_pos)

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -24,6 +24,22 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     expect_correction('')
   end
 
+  it 'registers an offense for missing `if` and `else` body with some indentation' do
+    expect_offense(<<~RUBY)
+      def foo
+        if condition
+        ^^^^^^^^^^^^ Avoid `if` branches without a body.
+        else
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+          end
+    RUBY
+  end
+
   it 'registers an offense for missing `if` body with present `else` body' do
     expect_offense(<<~RUBY)
       class Foo


### PR DESCRIPTION
Fix https://github.com/rubocop/rubocop/issues/11132.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
