### PR TITLE
Escape cell delimiters in regexp on cops naming page

### DIFF
--- a/docs/modules/ROOT/pages/cops_naming.adoc
+++ b/docs/modules/ROOT/pages/cops_naming.adoc
@@ -591,7 +591,7 @@ EOS
 | Name | Default value | Configurable values
 
 | ForbiddenDelimiters
-| `(?-mix:(^|\s)(EO[A-Z]{1}|END)(\s|$))`
+| `(?-mix:(^\|\s)(EO[A-Z]{1}\|END)(\s\|$))`
 | Array
 |===
 


### PR DESCRIPTION
To use a cell delimiter in a table cell as a literal character, it must always be escaped.