### PR TITLE
Use broken vertical bar as adoc table separator

### DIFF
--- a/lib/rubocop/cops_documentation_generator.rb
+++ b/lib/rubocop/cops_documentation_generator.rb
@@ -183,9 +183,11 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
   # rubocop:enable Metrics/CyclomaticComplexity,Metrics/MethodLength
 
   def to_table(header, content)
-    table = ['|===', "| #{header.join(' | ')}\n\n"].join("\n")
+    # Specify `[separator=¦]` to prevent the regexp `|` is not used as a table separator.
+    # See: https://docs.asciidoctor.org/asciidoc/latest/tables/data-format/#escape-the-cell-separator
+    table = ['[separator=¦]', '|===', "| #{header.join(' | ')}\n\n"].join("\n")
     marked_contents = content.map do |plain_content|
-      plain_content.map { |c| "| #{c}" }.join("\n")
+      plain_content.map { |c| "¦ #{c}" }.join("\n")
     end
     table << marked_contents.join("\n\n")
     table << "\n|===\n"


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/11134#issuecomment-1296134804.

This PR uses broken vertical bar as adoc table separator. It specifies `[separator=¦]` for adoc table to prevent broken regexp format. https://docs.asciidoctor.org/asciidoc/latest/tables/data-format/#escape-the-cell-separator

adoc generation is updated as follows:

```diff
% bundle exec rake update_cops_documentation
(snip)

% git diff
(snip)

@@ -587,12 +603,13 @@ EOS

 === Configurable attributes

+[separator=¦]
 |===
 | Name | Default value | Configurable values

-| ForbiddenDelimiters
-| `(?-mix:(^|\s)(EO[A-Z]{1}|END)(\s|$))`
-| Array
+¦ ForbiddenDelimiters
+¦ `(?-mix:(^|\s)(EO[A-Z]{1}|END)(\s|$))`
+¦ Array
 |===

 === References
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
