### PR TITLE
Fix `table missing leading separator; recovering automatically`

### DIFF
--- a/lib/rubocop/cops_documentation_generator.rb
+++ b/lib/rubocop/cops_documentation_generator.rb
@@ -183,11 +183,10 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
   # rubocop:enable Metrics/CyclomaticComplexity,Metrics/MethodLength
 
   def to_table(header, content)
-    # Specify `[separator=¦]` to prevent the regexp `|` is not used as a table separator.
-    # See: https://docs.asciidoctor.org/asciidoc/latest/tables/data-format/#escape-the-cell-separator
-    table = ['[separator=¦]', '|===', "| #{header.join(' | ')}\n\n"].join("\n")
+    table = ['|===', "| #{header.join(' | ')}\n\n"].join("\n")
     marked_contents = content.map do |plain_content|
-      plain_content.map { |c| "¦ #{c}" }.join("\n")
+      # Escape `|` with backslash to prevent the regexp `|` is not used as a table separator.
+      plain_content.map { |c| "| #{c.gsub(/\|/, '\|')}" }.join("\n")
     end
     table << marked_contents.join("\n\n")
     table << "\n|===\n"


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/11135#issuecomment-1298131681.

This PR fixes `table missing leading separator; recovering automatically` error when runnig `antora --fetch antora-playbook.yml` in the docs.rubocop.org repo.

I've tried some things, but unfortunately `[separator=¦]` doesn't behave as expected. So, this PR escapes `|` with backslash to prevent the regexp `|` is not used as a table separator.

https://github.com/rubocop/docs.rubocop.org

## Before (1.37 docs)

`Configurable attributes` table is broken.

<img width="1776" alt="1 37" src="https://user-images.githubusercontent.com/13203/199201407-5b35dd7a-ac1b-4d16-82ba-90e722230027.png">

## Current (1.38 docs)

All tables are broken...

<img width="1781" alt="1 38" src="https://user-images.githubusercontent.com/13203/199201440-1b1021e9-23f2-492f-85a7-5dbca2935150.png">

## After (This PR)

All tables (includes `Configurable attributes`) are recovered.

<img width="1790" alt="after" src="https://user-images.githubusercontent.com/13203/199201503-541ef249-96d0-4366-baf2-6a728d3beddf.png">

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
