### PR TITLE
[Fix #11137] Fix a false positive for `Style/RedundantEach` when using `each` with a symbol proc argument

### DIFF
--- a/changelog/fix_fix_a_false_positive_for_style_redundant_each.md
+++ b/changelog/fix_fix_a_false_positive_for_style_redundant_each.md
@@ -1,0 +1,1 @@
+* [#11137](https://github.com/rubocop/rubocop/issues/11137): Fix a false positive for `Style/RedundantEach` when using a symbol proc argument. ([@ydah][])

--- a/lib/rubocop/cop/style/redundant_each.rb
+++ b/lib/rubocop/cop/style/redundant_each.rb
@@ -61,6 +61,8 @@ module RuboCop
 
         # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def redundant_each_method(node)
+          return if node.last_argument&.block_pass_type?
+
           if node.method?(:each) && !node.parent&.block_type?
             ancestor_node = node.each_ancestor(:send).detect do |ancestor|
               ancestor.receiver == node &&
@@ -69,7 +71,7 @@ module RuboCop
           end
 
           ancestor_node || node.each_descendant(:send).detect do |descendant|
-            next if descendant.parent.block_type?
+            next if descendant.parent.block_type? || descendant.last_argument&.block_pass_type?
 
             detected = descendant.method_name.to_s.start_with?('each_') unless node.method?(:each)
 

--- a/spec/rubocop/cop/style/redundant_each_spec.rb
+++ b/spec/rubocop/cop/style/redundant_each_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantEach, :config do
     RUBY
   end
 
+  it 'registers an offense when using `each.each(&:foo)`' do
+    expect_offense(<<~RUBY)
+      array.each.each(&:foo)
+           ^^^^^ Remove redundant `each`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array.each(&:foo)
+    RUBY
+  end
+
   it 'registers an offense when using `each.each_with_index`' do
     expect_offense(<<~RUBY)
       array.each.each_with_index { |v| do_something(v) }
@@ -191,6 +202,26 @@ RSpec.describe RuboCop::Cop::Style::RedundantEach, :config do
   it 'does not register an offense when not chaining `each_` calls' do
     expect_no_offenses(<<~RUBY)
       [foo.each].each
+    RUBY
+  end
+
+  it 'does not register an offense when using `each` with a symbol proc argument' do
+    expect_no_offenses(<<~RUBY)
+      array.each(&:foo).each do |i|
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `each` with a symbol proc for last argument' do
+    expect_no_offenses(<<~RUBY)
+      array.each(foo, &:bar).each do |i|
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `reverse_each(&:foo).each {...}`' do
+    expect_no_offenses(<<~RUBY)
+      array.reverse_each(&:foo).each { |i| bar(i) }
     RUBY
   end
 end


### PR DESCRIPTION
Fix: #11137

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
