### PR TITLE
[Fix #11139] Fix a false negative for `Style/HashEachMethods` when using each with a symbol proc argument

### DIFF
--- a/changelog/fix_fix_a_false_negative_for_style_hash_each_methods.md
+++ b/changelog/fix_fix_a_false_negative_for_style_hash_each_methods.md
@@ -1,0 +1,1 @@
+* [#11139](https://github.com/rubocop/rubocop/issues/11139): Fix a false negative for `Style/HashEachMethods` when using each with a symbol proc argument. ([@ydah][])

--- a/spec/rubocop/cop/style/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/style/hash_each_methods_spec.rb
@@ -25,6 +25,28 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         RUBY
       end
 
+      it 'registers offense, autocorrects foo#keys.each to foo#each_key with a symbol proc argument' do
+        expect_offense(<<~RUBY)
+          foo.keys.each(&:bar)
+              ^^^^^^^^^ Use `each_key` instead of `keys.each`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo.each_key(&:bar)
+        RUBY
+      end
+
+      it 'registers offense, autocorrects foo#values.each to foo#each_value with a symbol proc argument' do
+        expect_offense(<<~RUBY)
+          foo.values.each(&:bar)
+              ^^^^^^^^^^^ Use `each_value` instead of `values.each`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo.each_value(&:bar)
+        RUBY
+      end
+
       it 'does not register an offense for foo#each_key' do
         expect_no_offenses('foo.each_key { |k| p k }')
       end
@@ -70,6 +92,28 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         RUBY
       end
 
+      it 'registers offense, autocorrects {}#keys.each to {}#each_key with a symbol proc argument' do
+        expect_offense(<<~RUBY)
+          {}.keys.each(&:bar)
+             ^^^^^^^^^ Use `each_key` instead of `keys.each`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {}.each_key(&:bar)
+        RUBY
+      end
+
+      it 'registers offense, autocorrects {}#values.each to {}#each_value with a symbol proc argument' do
+        expect_offense(<<~RUBY)
+          {}.values.each(&:bar)
+             ^^^^^^^^^^^ Use `each_value` instead of `values.each`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {}.each_value(&:bar)
+        RUBY
+      end
+
       it 'does not register an offense for {}#each_key' do
         expect_no_offenses('{}.each_key { |k| p k }')
       end
@@ -89,6 +133,18 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
       it 'does not register an offense for `values.each`' do
         expect_no_offenses(<<~RUBY)
           values.each { |v| p v }
+        RUBY
+      end
+
+      it 'does not register an offense for `keys.each` with a symbol proc argument' do
+        expect_no_offenses(<<~RUBY)
+          keys.each(&:bar)
+        RUBY
+      end
+
+      it 'does not register an offense for `values.each` with a symbol proc argument' do
+        expect_no_offenses(<<~RUBY)
+          values.each(&:bar)
         RUBY
       end
 
@@ -114,6 +170,12 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         expect_no_offenses(<<~RUBY)
           execute = do_something(argument)
           execute.values.each { |v| p v }
+        RUBY
+      end
+
+      it 'does not register an offense when receiver is `execute` method with a symbol proc argument' do
+        expect_no_offenses(<<~RUBY)
+          execute(sql).values.each(&:bar)
         RUBY
       end
 


### PR DESCRIPTION
Fix: #11139

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
