### PR TITLE
Fix `Style/RedundantEach` for non-chained `each_` calls

### DIFF
--- a/changelog/fix_style_redundant_each_for_non_chaining.md
+++ b/changelog/fix_style_redundant_each_for_non_chaining.md
@@ -1,0 +1,1 @@
+* [#11142](https://github.com/rubocop/rubocop/pull/11142): Fix `Style/RedundantEach` for non-chained `each_` calls. ([@fatkodima][])

--- a/lib/rubocop/cop/style/redundant_each.rb
+++ b/lib/rubocop/cop/style/redundant_each.rb
@@ -61,9 +61,10 @@ module RuboCop
 
         # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def redundant_each_method(node)
-          if node.method?(:each) && !node.parent.block_type?
+          if node.method?(:each) && !node.parent&.block_type?
             ancestor_node = node.each_ancestor(:send).detect do |ancestor|
-              RESTRICT_ON_SEND.include?(ancestor.method_name) || ancestor.method?(:reverse_each)
+              ancestor.receiver == node &&
+                (RESTRICT_ON_SEND.include?(ancestor.method_name) || ancestor.method?(:reverse_each))
             end
           end
 

--- a/spec/rubocop/cop/style/redundant_each_spec.rb
+++ b/spec/rubocop/cop/style/redundant_each_spec.rb
@@ -114,6 +114,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantEach, :config do
     RUBY
   end
 
+  it 'does not register an offense when using `each` as enumerator' do
+    expect_no_offenses(<<~RUBY)
+      array.each
+    RUBY
+  end
+
   it 'does not register an offense when using `each.with_index`' do
     expect_no_offenses(<<~RUBY)
       array.each.with_index { |v, i| do_something(v, i) }
@@ -179,6 +185,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantEach, :config do
   it 'does not register an offense when using `each_foo {}.each_with_object([]) {}`' do
     expect_no_offenses(<<~RUBY)
       array.each_foo { |i| foo(i) }.each_with_object([]) { |i| bar(i) }
+    RUBY
+  end
+
+  it 'does not register an offense when not chaining `each_` calls' do
+    expect_no_offenses(<<~RUBY)
+      [foo.each].each
     RUBY
   end
 end


### PR DESCRIPTION
`Style/RedundantEach` fails for `[1, 2, 3].each` with no method `block_type?` for nil.

And incorrectly detects as offense the following:
```ruby
build_enumerator(outer: [[1, 2, 3].each]).each
```