### PR TITLE
[Fix #11123 ] Fix auto correction bug for Style/StringLiterals

### DIFF
--- a/changelog/fix_auto_correction_bug_for_string_literals.md
+++ b/changelog/fix_auto_correction_bug_for_string_literals.md
@@ -1,0 +1,1 @@
+* [#11123](https://github.com/rubocop/rubocop/issues/11123): Fix autocorrection bug for `Style/StringLiterals` when using multiple escape characters. ([@si-lens][])

--- a/lib/rubocop/cop/style/quoted_symbols.rb
+++ b/lib/rubocop/cop/style/quoted_symbols.rb
@@ -93,7 +93,7 @@ module RuboCop
                        end
 
           # The conversion process doubles escaped slashes, so they have to be reverted
-          correction.gsub('\\\\', '\\')
+          correction.gsub('\\\\', '\\').gsub('\"', '"')
         end
 
         def style

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -122,7 +122,7 @@ module RuboCop
           string.inspect
         else
           # In a single-quoted strings, double quotes don't need to be escaped
-          "'#{string.gsub('\"', '"').gsub('\\') { '\\\\' }}'"
+          "'#{string.gsub('\\') { '\\\\' }.gsub('\"', '"')}'"
         end
       end
 

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
            ^^^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
         z = "a\\"
             ^^^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
+        t = "{\"[\\\"*\\\"]\""
+            ^^^^^^^^^^^^^^^^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
       RUBY
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'double_quotes')
 
@@ -22,6 +24,7 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
         x = 'a\\b'
         y ='\\b'
         z = 'a\\'
+        t = '{"[\"*\"]"'
       RUBY
     end
 


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop/issues/11123

Before:
```
a = {
  b: "{\"[\\\"*\\\"]\""
}
```
was corrected to:
```
a = {
  b: '{"["*"]"'
}
```
These two strings are not the same.
After my changes it should result in correct string:
```
a = {
  b: '{"[\"*\"]"'
}
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
