### PR TITLE
[docs] Update sample output for offenses and worst formatters

### DIFF
--- a/docs/modules/ROOT/pages/formatters.adoc
+++ b/docs/modules/ROOT/pages/formatters.adoc
@@ -317,7 +317,7 @@ $ rubocop --format offenses
 1    Layout/AccessModifierIndentation
 1    Style/ClassAndModuleChildren
 --
-102  Total
+102  Total in 31 files
 ----
 
 == Worst Offenders Formatter
@@ -331,7 +331,7 @@ $ rubocop --format worst
 89  this/file/is/really/bad.rb
 2   much/better.rb
 --
-91  Total
+91  Total in 2 files
 ----
 
 == HTML Formatter


### PR DESCRIPTION
Update the sample output for the Offense Count and the Worst Offenders formatters to match the changes in #11113.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
