### PR TITLE
Fix a false positive for `Lint/SuppressedException`

### DIFF
--- a/changelog/fix_fix_a_false_positive_for.md
+++ b/changelog/fix_fix_a_false_positive_for.md
@@ -1,0 +1,1 @@
+* [#11151](https://github.com/rubocop/rubocop/pull/11151): Fix a false positive for `Lint/SuppressedException`. ([@akihikodaki][])

--- a/lib/rubocop/cop/lint/suppressed_exception.rb
+++ b/lib/rubocop/cop/lint/suppressed_exception.rb
@@ -116,7 +116,7 @@ module RuboCop
         private
 
         def comment_between_rescue_and_end?(node)
-          ancestor = node.each_ancestor(:kwbegin, :def, :defs, :block).first
+          ancestor = node.each_ancestor(:kwbegin, :def, :defs, :block, :numblock).first
           return unless ancestor
 
           end_line = ancestor.loc.end.line

--- a/spec/rubocop/cop/lint/suppressed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/suppressed_exception_spec.rb
@@ -220,6 +220,30 @@ RSpec.describe RuboCop::Cop::Lint::SuppressedException, :config do
       end
     end
 
+    context 'Ruby 2.7 or higher', :ruby27 do
+      context 'when empty rescue for `do` block with a numbered parameter' do
+        it 'registers an offense for empty rescue without comment' do
+          expect_offense(<<~RUBY)
+            foo do
+              _1
+            rescue
+            ^^^^^^ Do not suppress exceptions.
+            end
+          RUBY
+        end
+
+        it 'does not register an offense for empty rescue with comment' do
+          expect_no_offenses(<<~RUBY)
+            foo do
+              _1
+            rescue
+              # do nothing
+            end
+          RUBY
+        end
+      end
+    end
+
     it 'registers an offense for empty rescue on single line with a comment after it' do
       expect_offense(<<~RUBY)
         RSpec.describe Dummy do


### PR DESCRIPTION
When there is a rescue with no statement but a comment in a `do` block with a numbered parameter, it incorrectly registered an offense even if AllowComments is set true.

Cover the case of `do` block with a numbered parameter to fix the issue.

-----------------

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists). No related issue found.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

Well, running `bundle exec rake changelog:fix` will give a template containing `[#x](https://github.com/rubocop/rubocop/pull/x)` but I don't think that's what you want...

[1]: https://chris.beams.io/posts/git-commit/
