### PR TITLE
Add `RuboCop::Cop::RangeHelp#range_with_comments_and_lines`

### DIFF
--- a/lib/rubocop/cop/mixin/range_help.rb
+++ b/lib/rubocop/cop/mixin/range_help.rb
@@ -126,6 +126,29 @@ module RuboCop
         pos += size * step while condition && src[pos + offset, size] == needle
         pos.negative? ? 0 : pos
       end
+
+      def range_with_comments_and_lines(node)
+        range_by_whole_lines(range_with_comments(node), include_final_newline: true)
+      end
+
+      def range_with_comments(node)
+        ranges = [
+          node,
+          *@processed_source.ast_with_comments[node]
+        ].map do |element|
+          element.location.expression
+        end
+        ranges.reduce do |result, range|
+          add_range(result, range)
+        end
+      end
+
+      def add_range(range1, range2)
+        range1.with(
+          begin_pos: [range1.begin_pos, range2.begin_pos].min,
+          end_pos: [range1.end_pos, range2.end_pos].max
+        )
+      end
     end
   end
 end

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -202,31 +202,7 @@ module RuboCop
         end
 
         def remove_node(corrector, node)
-          corrector.remove(
-            range_by_whole_lines(
-              range_with_comments(node),
-              include_final_newline: true
-            )
-          )
-        end
-
-        def range_with_comments(node)
-          ranges = [
-            node,
-            *processed_source.ast_with_comments[node]
-          ].map do |element|
-            element.location.expression
-          end
-          ranges.reduce do |result, range|
-            add_range(result, range)
-          end
-        end
-
-        def add_range(range1, range2)
-          range1.with(
-            begin_pos: [range1.begin_pos, range2.begin_pos].min,
-            end_pos: [range1.end_pos, range2.end_pos].max
-          )
+          corrector.remove(range_with_comments_and_lines(node))
         end
       end
     end


### PR DESCRIPTION
Add a convenience method in response to the following comment:

- https://github.com/rubocop/rubocop-rails/pull/857#issuecomment-1304315239

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
