### PR TITLE
Fix `Style/OperatorMethodCall` autocorrection when operators are chained

### DIFF
--- a/changelog/fix_styleoperatormethodcall.md
+++ b/changelog/fix_styleoperatormethodcall.md
@@ -1,0 +1,1 @@
+* [#11156](https://github.com/rubocop/rubocop/pull/11156): Fix `Style/OperatorMethodCall` autocorrection when operators are chained. ([@gsamokovarov][])

--- a/lib/rubocop/cop/style/operator_method_call.rb
+++ b/lib/rubocop/cop/style/operator_method_call.rb
@@ -31,8 +31,21 @@ module RuboCop
           return if rhs.nil? || rhs.children.first
 
           add_offense(dot) do |corrector|
+            wrap_in_parentheses_if_chained(corrector, node)
             corrector.replace(dot, ' ')
           end
+        end
+
+        private
+
+        def wrap_in_parentheses_if_chained(corrector, node)
+          return unless node.parent&.call_type?
+
+          operator = node.loc.selector
+
+          ParenthesesCorrector.correct(corrector, node)
+          corrector.insert_after(operator, ' ')
+          corrector.wrap(node, '(', ')')
         end
       end
     end

--- a/spec/rubocop/cop/style/operator_method_call_spec.rb
+++ b/spec/rubocop/cop/style/operator_method_call_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe RuboCop::Cop::Style::OperatorMethodCall, :config do
         foo #{operator_method}(bar)
       RUBY
     end
+
+    it "registers an offense when chaining `foo.bar.#{operator_method}(baz).round(2)`" do
+      expect_offense(<<~RUBY, operator_method: operator_method)
+        foo.bar.#{operator_method}(baz).quux(2)
+               ^ Redundant dot detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (foo.bar #{operator_method} baz).quux(2)
+      RUBY
+    end
   end
 
   it 'does not register an offense when using `foo.+@bar.to_s`' do


### PR DESCRIPTION
Ran it in Dext and this little gem of a code...

```ruby
receipt_total = receipt.total_amount.*(convert_rate).round(2)
receipt_vat = receipt.tax_amount.*(convert_rate).round(2)
```

got autocorrected to:

```ruby
receipt_total = receipt.total_amount(*convert_rate.round(2))
receipt_vat = receipt.tax_amount(*convert_rate.round(2))
```

I expected:

```ruby
receipt_total = (receipt.total_amount * convert_rate).round(2)
receipt_vat = (receipt.tax_amount * convert_rate).round(2)
```

The `Style/OperatorMethodCall` didn't autocorrect operator method calls in chaining properly so I made it so.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
