### PR TITLE
Add `if` to allowed names list for MethodParameterName

### DIFF
--- a/changelog/change_add_if_to_allowed_names_list.md
+++ b/changelog/change_add_if_to_allowed_names_list.md
@@ -1,0 +1,1 @@
+* [#11158](https://github.com/rubocop/rubocop/pull/11158): Add `if` to allowed names list for MethodParameterName. ([@okuramasafumi][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2808,6 +2808,7 @@ Naming/MethodParameterName:
     - by
     - db
     - id
+    - if
     - in
     - io
     - ip


### PR DESCRIPTION
In library development, we sometimes use `if` as a keyword argument.
The meaning of `if` is clear enough so we can accept it as an allowed name.

I'm not sure if it deserves its own CHANGELOG entry, but please let me know if I should add it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
