### PR TITLE
[Fix #11161] Fix a false positive for `Style/HashAsLastArrayItem`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_hash_as_last_array_item.md
+++ b/changelog/fix_a_false_positive_for_style_hash_as_last_array_item.md
@@ -1,0 +1,1 @@
+* [#11161](https://github.com/rubocop/rubocop/issues/11161): Fix a false positive for `Style/HashAsLastArrayItem` when using double splat operator. ([@koic][])

--- a/lib/rubocop/cop/style/hash_as_last_array_item.rb
+++ b/lib/rubocop/cop/style/hash_as_last_array_item.rb
@@ -34,6 +34,7 @@ module RuboCop
         extend AutoCorrector
 
         def on_hash(node)
+          return if node.children.first&.kwsplat_type?
           return unless (array = containing_array(node))
           return unless last_array_item?(array, node) && explicit_array?(array)
 

--- a/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
+++ b/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe RuboCop::Cop::Style::HashAsLastArrayItem, :config do
         [1, {}]
       RUBY
     end
+
+    it 'does not register an offense when using double splat operator' do
+      expect_no_offenses(<<~RUBY)
+        [1, **options]
+      RUBY
+    end
   end
 
   context 'when EnforcedStyle is no_braces' do


### PR DESCRIPTION
Fixes #11161.

This PR fixes a false positive for `Style/HashAsLastArrayItem` when using double splat operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
