### PR TITLE
Mark `Style/HashExcept` as unsafe

### DIFF
--- a/changelog/change_mark_style_hash_except_as_unsafe.md
+++ b/changelog/change_mark_style_hash_except_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#11163](https://github.com/rubocop/rubocop/pull/11163): Mark `Style/HashExcept` as unsafe. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3820,8 +3820,9 @@ Style/HashExcept:
                  Checks for usages of `Hash#reject`, `Hash#select`, and `Hash#filter` methods
                  that can be replaced with `Hash#except` method.
   Enabled: pending
+  Safe: false
   VersionAdded: '1.7'
-  VersionChanged: '1.31'
+  VersionChanged: '<<next>>'
 
 Style/HashLikeCase:
   Description: >-

--- a/lib/rubocop/cop/style/hash_except.rb
+++ b/lib/rubocop/cop/style/hash_except.rb
@@ -13,6 +13,10 @@ module RuboCop
       # when used `==`.
       # And do not check `Hash#delete_if` and `Hash#keep_if` to change receiver object.
       #
+      # @safety
+      #   This cop is unsafe because it cannot be guaranteed that the receiver
+      #   is a `Hash` or responds to the replacement method.
+      #
       # @example
       #
       #   # bad


### PR DESCRIPTION
I think it would be better to assume that `Style/HashExcept` is unsafe because it detects and replaces even things that should not be replaced.

For example:

```ruby
invalid_values = [3, 5]

[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].each_slice(2).reject do |value1, _value2|
  invalid_values.include?(value1)
end
#=> [[1, 2], [7, 8], [9, 10]]
```

The above code is currently auto-corrected as follows:

```ruby
invalid_values = [3, 5]

[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].each_slice(2).except(*invalid_values)
#=> undefined method `except' for #<Enumerator: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]:each_slice(2)> (NoMethodError)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
