### PR TITLE
[Fix #11165] Fix a false positive for `Style/RedundantEach`

### DIFF
--- a/changelog/fix_false_positive_for_style_redundant_each.md
+++ b/changelog/fix_false_positive_for_style_redundant_each.md
@@ -1,0 +1,1 @@
+* [#11165](https://github.com/rubocop/rubocop/issues/11165): Fix a false positive for `Style/RedundantEach` when any method is used between methods containing `each` in the method name. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_each.rb
+++ b/lib/rubocop/cop/style/redundant_each.rb
@@ -68,15 +68,17 @@ module RuboCop
               ancestor.receiver == node &&
                 (RESTRICT_ON_SEND.include?(ancestor.method_name) || ancestor.method?(:reverse_each))
             end
+
+            return ancestor_node if ancestor_node
           end
 
-          ancestor_node || node.each_descendant(:send).detect do |descendant|
-            next if descendant.parent.block_type? || descendant.last_argument&.block_pass_type?
+          return unless (prev_method = node.children.first)
+          return if !prev_method.send_type? ||
+                    prev_method.parent.block_type? || prev_method.last_argument&.block_pass_type?
 
-            detected = descendant.method_name.to_s.start_with?('each_') unless node.method?(:each)
+          detected = prev_method.method_name.to_s.start_with?('each_') unless node.method?(:each)
 
-            detected || descendant.method?(:reverse_each)
-          end
+          prev_method if detected || prev_method.method?(:reverse_each)
         end
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 

--- a/spec/rubocop/cop/style/redundant_each_spec.rb
+++ b/spec/rubocop/cop/style/redundant_each_spec.rb
@@ -143,6 +143,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantEach, :config do
     RUBY
   end
 
+  it 'does not register an offense when any method is used between methods with `each` in the method name' do
+    expect_no_offenses(<<~RUBY)
+      string.each_char.map(&:to_i).reverse.each_with_index.map { |v, i| do_something(v, i) }
+    RUBY
+  end
+
   it 'does not register an offense when using `each.with_object`' do
     expect_no_offenses(<<~RUBY)
       array.each.with_object { |v, o| do_something(v, o) }


### PR DESCRIPTION
Follow up https://github.com/faker-ruby/faker/pull/2613#issuecomment-1304316381.
Fixes #11165.

This PR fixes a false positive for `Style/RedundantEach` when any method is used between methods containing `each` in the method name.

That method in between may convert from `Enumerator` to `Array`. e.g. `map(&:do_something)`

```ruby
'string'.each_char.class             # => Enumerator
'string'.each_char.map(&:to_i).class # => Array
```

`each_with_index` is a method of `Array`, not of `Enumerator`.

```ruby
'string'.each_char.map(&:to_i).respond_to?(:each_with_index) # => true
'string'.each_char.map(&:to_i).respond_to?(:with_index)      # => false
```

Therefore, it allows any method to be used between methods containing `each` to prevent `NoMethodError`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
