### PR TITLE
[Fix #11164] Suppress a server mode message

### DIFF
--- a/changelog/fix_suppress_a_server_mode_message.md
+++ b/changelog/fix_suppress_a_server_mode_message.md
@@ -1,0 +1,1 @@
+* [#11164](https://github.com/rubocop/rubocop/issues/11164): Suppress "RuboCop server starting..." message with `--server --format json`. ([@koic][])

--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -67,6 +67,64 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
       end
     end
 
+    context 'when using `--server` and json is specified as the format' do
+      context 'when `--format=json`' do
+        it 'does not display the server start message' do
+          create_file('example.rb', <<~RUBY)
+            puts 0
+          RUBY
+
+          stdout, _stderr, _status = Open3.capture3(
+            'ruby', '-I', '.',
+            rubocop, '--server', '--format=json', '--stdin', 'example.rb', stdin_data: 'puts 0'
+          )
+          expect(stdout).not_to start_with 'RuboCop server starting on '
+        end
+      end
+
+      context 'when `--format=j`' do
+        it 'does not display the server start message' do
+          create_file('example.rb', <<~RUBY)
+            puts 0
+          RUBY
+
+          stdout, _stderr, _status = Open3.capture3(
+            'ruby', '-I', '.',
+            rubocop, '--server', '--format=j', '--stdin', 'example.rb', stdin_data: 'puts 0'
+          )
+          expect(stdout).not_to start_with 'RuboCop server starting on '
+        end
+      end
+
+      context 'when `--format json`' do
+        it 'does not display the server start message' do
+          create_file('example.rb', <<~RUBY)
+            puts 0
+          RUBY
+
+          stdout, _stderr, _status = Open3.capture3(
+            'ruby', '-I', '.',
+            rubocop, '--server', '--format', 'json', '--stdin', 'example.rb', stdin_data: 'puts 0'
+          )
+          expect(stdout).not_to start_with 'RuboCop server starting on '
+        end
+      end
+
+      context 'when `--format j`' do
+        it 'does not display the server start message' do
+          create_file('example.rb', <<~RUBY)
+            puts 0
+          RUBY
+
+          stdout, _stderr, _status = Open3.capture3(
+            'ruby', '-I', '.',
+            rubocop, '--server', '--format', 'j', '--stdin', 'example.rb', stdin_data: 'puts 0'
+          )
+          expect(stdout).not_to start_with 'RuboCop server starting on '
+        end
+      end
+    end
+
     context 'when using `--server` option after running server and updating configuration' do
       it 'applies .rubocop.yml configuration changes even during server startup' do
         create_file('example.rb', <<~RUBY)


### PR DESCRIPTION
Fixes #11164

This PR suppresses "RuboCop server starting..." message with `--server --format json` because JSON format does not expected output message when IDE integration with server mode.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
