### PR TITLE
[Fix #11168] Fix an incorrect autocorrect for `Style/ClassEqualityComparison`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_class_equality_comparison.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_class_equality_comparison.md
@@ -1,0 +1,1 @@
+* [#11168](https://github.com/rubocop/rubocop/issues/11168): Fix an incorrect autocorrect for `Style/ClassEqualityComparison` when using instance variable comparison in module. ([@koic][])

--- a/lib/rubocop/cop/style/class_equality_comparison.rb
+++ b/lib/rubocop/cop/style/class_equality_comparison.rb
@@ -97,12 +97,14 @@ module RuboCop
           if node.children.first.method?(:name)
             return class_node.receiver.source if class_node.receiver
 
-            value = class_node.source.delete('"').delete("'")
-            value.prepend('::') if class_node.each_ancestor(:class, :module).any?
-            value
-          else
-            class_node.source
+            if class_node.str_type?
+              value = class_node.source.delete('"').delete("'")
+              value.prepend('::') if class_node.each_ancestor(:class, :module).any?
+              return value
+            end
           end
+
+          class_node.source
         end
 
         def offense_range(receiver_node, node)

--- a/spec/rubocop/cop/style/class_equality_comparison_spec.rb
+++ b/spec/rubocop/cop/style/class_equality_comparison_spec.rb
@@ -127,4 +127,25 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
       RUBY
     end
   end
+
+  context 'with instance variable comparison in module' do
+    it 'registers and corrects an offense' do
+      expect_offense(<<~RUBY)
+        module Foo
+          def bar?(value)
+            bar.class.name == @class_name
+                ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(@class_name)` instead of comparing classes.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Foo
+          def bar?(value)
+            bar.instance_of?(@class_name)
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #11168.

This PR fixes an incorrect autocorrect for `Style/ClassEqualityComparison` when using instance variable comparison in module.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
