### PR TITLE
Support inline visibility definition on checking visibility

### DIFF
--- a/changelog/change_support_visibility_definition.md
+++ b/changelog/change_support_visibility_definition.md
@@ -1,0 +1,1 @@
+* [#11171](https://github.com/rubocop/rubocop/pull/11171): Support inline visibility definition on checking visibility. ([@r7kamura][])

--- a/lib/rubocop/cop/mixin/visibility_help.rb
+++ b/lib/rubocop/cop/mixin/visibility_help.rb
@@ -1,18 +1,43 @@
 # frozen_string_literal: true
 
+require 'set'
+
 module RuboCop
   module Cop
     # Help methods for determining node visibility.
     module VisibilityHelp
       extend NodePattern::Macros
 
-      VISIBILITY_SCOPES = %i[private protected public].freeze
+      VISIBILITY_SCOPES = ::Set[:private, :protected, :public].freeze
 
       private
 
       def node_visibility(node)
-        scope = find_visibility_start(node)
-        scope&.method_name || :public
+        node_visibility_from_visibility_inline(node) ||
+          node_visibility_from_visibility_block(node) ||
+          :public
+      end
+
+      def node_visibility_from_visibility_inline(node)
+        return unless node.def_type?
+
+        node_visibility_from_visibility_inline_on_def(node) ||
+          node_visibility_from_visibility_inline_on_method_name(node)
+      end
+
+      def node_visibility_from_visibility_inline_on_def(node)
+        parent = node.parent
+        parent.method_name if visibility_inline_on_def?(parent)
+      end
+
+      def node_visibility_from_visibility_inline_on_method_name(node)
+        node.right_siblings.reverse.find do |sibling|
+          visibility_inline_on_method_name?(sibling, method_name: node.method_name)
+        end&.method_name
+      end
+
+      def node_visibility_from_visibility_block(node)
+        find_visibility_start(node)&.method_name
       end
 
       def find_visibility_start(node)
@@ -21,7 +46,7 @@ module RuboCop
 
       # Navigate to find the last protected method
       def find_visibility_end(node)
-        possible_visibilities = VISIBILITY_SCOPES - [node_visibility(node)]
+        possible_visibilities = VISIBILITY_SCOPES - ::Set[node_visibility(node)]
         right = node.right_siblings
         right.find do |child_node|
           possible_visibilities.include?(node_visibility(child_node))
@@ -30,7 +55,17 @@ module RuboCop
 
       # @!method visibility_block?(node)
       def_node_matcher :visibility_block?, <<~PATTERN
-        (send nil? { :private :protected :public })
+        (send nil? VISIBILITY_SCOPES)
+      PATTERN
+
+      # @!method visibility_inline_on_def?(node)
+      def_node_matcher :visibility_inline_on_def?, <<~PATTERN
+        (send nil? VISIBILITY_SCOPES def)
+      PATTERN
+
+      # @!method visibility_inline_on_method_name?(node, method_name:)
+      def_node_matcher :visibility_inline_on_method_name?, <<~PATTERN
+        (send nil? VISIBILITY_SCOPES (sym %method_name))
       PATTERN
     end
   end

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -186,10 +186,6 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
         def some_public_method
         end
 
-        def other_public_method
-        end
-
-        private :other_public_method
 
         def yet_other_public_method
         end
@@ -198,6 +194,11 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
 
         def some_protected_method
         end
+
+        def other_public_method
+        end
+
+        private :other_public_method
 
         private
 
@@ -381,6 +382,31 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
 
           private def foo
           end
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects public method after private method marked by its name' do
+      expect_offense(<<~RUBY)
+        class A
+          def foo
+          end
+          private :foo
+
+          def bar
+          ^^^^^^^ `public_methods` is supposed to appear before `private_methods`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class A
+          def bar
+          end
+
+          def foo
+          end
+          private :foo
         end
       RUBY
     end

--- a/spec/rubocop/cop/visibility_help_spec.rb
+++ b/spec/rubocop/cop/visibility_help_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::VisibilityHelp do
+  describe '#node_visibility' do
+    subject do
+      instance.__send__(:node_visibility, node)
+    end
+
+    let(:instance) do
+      klass.new
+    end
+
+    let(:klass) do
+      mod = described_class
+      Class.new do
+        include mod
+      end
+    end
+
+    let(:node) do
+      processed_source.ast.each_node(:def).first
+    end
+
+    let(:processed_source) do
+      parse_source(source)
+    end
+
+    let(:source) do
+      raise NotImplementedError
+    end
+
+    context 'without visibility block' do
+      let(:source) do
+        <<~RUBY
+          class A
+            def x; end
+          end
+        RUBY
+      end
+
+      it { is_expected.to eq(:public) }
+    end
+
+    context 'with visibility block public' do
+      let(:source) do
+        <<~RUBY
+          class A
+            public
+
+            def x; end
+          end
+        RUBY
+      end
+
+      it { is_expected.to eq(:public) }
+    end
+
+    context 'with visibility block private' do
+      let(:source) do
+        <<~RUBY
+          class A
+            private
+
+            def x; end
+          end
+        RUBY
+      end
+
+      it { is_expected.to eq(:private) }
+    end
+
+    context 'with visibility block private after public' do
+      let(:source) do
+        <<~RUBY
+          class A
+            public
+
+            private
+
+            def x; end
+          end
+        RUBY
+      end
+
+      it { is_expected.to eq(:private) }
+    end
+
+    context 'with inline public' do
+      let(:source) do
+        <<~RUBY
+          class A
+            public def x; end
+          end
+        RUBY
+      end
+
+      it { is_expected.to eq(:public) }
+    end
+
+    context 'with inline private' do
+      let(:source) do
+        <<~RUBY
+          class A
+            private def x; end
+          end
+        RUBY
+      end
+
+      it { is_expected.to eq(:private) }
+    end
+
+    context 'with inline private with symbol' do
+      let(:source) do
+        <<~RUBY
+          class A
+            def x; end
+            private :x
+          end
+        RUBY
+      end
+
+      it { is_expected.to eq(:private) }
+    end
+  end
+end


### PR DESCRIPTION
The following patterns have not been supported by `RuboCop::Cop::VisibilityHelp#node_visibility`:

```ruby
class A
  private def x
  end
end
```

```ruby
class A
  def x
  end
  private :x
end
```

```ruby
node_visibility(def_x_node) #=> :public
```

I think it would be good to support them as well.

The background leading me to this change is as follows:

I am trying to create a Cop that inspects unrecommended visibility of some method definitions. I tried to use the `#node_visibility` for this implementation, but realized that this would not work as intended in this case if inline style visibility was used. There seemed to be no obvious reason not to support it, so I decided to create this Pull Request.
(FYI: In fact, I'm trying to create a cop that detects some public methods in Rails controller that actually should be private.)

After making the changes, several tests began to fail, so I decided to improve those as well.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
