### PR TITLE
[Fix #11173] Fix an incorrect autocorrect for `Style/CollectionCompact`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_collection_compact.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_collection_compact.md
@@ -1,0 +1,1 @@
+* [#11173](https://github.com/rubocop/rubocop/issues/11173): Fix an incorrect autocorrect for `Style/CollectionCompact` when using `reject` with block pass arg and no parentheses. ([@koic][])

--- a/lib/rubocop/cop/style/collection_compact.rb
+++ b/lib/rubocop/cop/style/collection_compact.rb
@@ -112,7 +112,7 @@ module RuboCop
         end
 
         def range(begin_pos_node, end_pos_node)
-          range_between(begin_pos_node.loc.selector.begin_pos, end_pos_node.loc.end.end_pos)
+          range_between(begin_pos_node.loc.selector.begin_pos, end_pos_node.loc.expression.end_pos)
         end
       end
     end

--- a/spec/rubocop/cop/style/collection_compact_spec.rb
+++ b/spec/rubocop/cop/style/collection_compact_spec.rb
@@ -29,6 +29,17 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `reject` with block pass arg and no parentheses' do
+    expect_offense(<<~RUBY)
+      array.reject &:nil?
+            ^^^^^^^^^^^^^ Use `compact` instead of `reject &:nil?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array.compact
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `reject` on hash to reject nils' do
     expect_offense(<<~RUBY)
       hash.reject { |k, v| v.nil? }


### PR DESCRIPTION
Fixes #11173.

This PR fixes an incorrect autocorrect for `Style/CollectionCompact` when using `reject` with block pass arg and no parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
