### PR TITLE
Fix a false positive for `Lint/DuplicateMethods`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_duplicate_methods.md
+++ b/changelog/fix_a_false_positive_for_lint_duplicate_methods.md
@@ -1,0 +1,1 @@
+* [#11176](https://github.com/rubocop/rubocop/pull/11176): Fix a false positive cases for `Lint/DuplicateMethods` when using duplicate nested method. ([@koic][])

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -385,6 +385,82 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
         end
       RUBY
     end
+
+    it "registers an offense for duplicate nested method in #{type}" do
+      expect_offense(<<-RUBY, 'example.rb')
+        #{opening_line}
+          def foo
+            def some_method
+              implement 1
+            end
+          end
+
+          def foo
+          ^^^^^^^ Method `A#foo` is defined at both example.rb:2 and example.rb:8.
+            def some_method
+            ^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both example.rb:3 and example.rb:9.
+              implement 2
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "registers an offense for duplicate nested method in self method of #{type}" do
+      expect_offense(<<-RUBY, 'example.rb')
+        #{opening_line}
+          def self.foo
+            def some_method
+              implement 1
+            end
+          end
+
+          def self.foo
+          ^^^^^^^^^^^^ Method `A.foo` is defined at both example.rb:2 and example.rb:8.
+            def some_method
+            ^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both example.rb:3 and example.rb:9.
+              implement 2
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for same method name defined in different methods' do
+      expect_no_offenses(<<~RUBY)
+        #{opening_line}
+          def foo
+            def some_method
+              implement 1
+            end
+          end
+
+          def bar
+            def some_method
+              implement 2
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for same method name defined in different self methods' do
+      expect_no_offenses(<<~RUBY)
+        #{opening_line}
+          def self.foo
+            def some_method
+              implement 1
+            end
+          end
+
+          def self.bar
+            def some_method
+              implement 2
+            end
+          end
+        end
+      RUBY
+    end
   end
 
   include_examples('in scope', 'class', 'class A')


### PR DESCRIPTION
This PR fixes the following false positive cases for `Lint/DuplicateMethods` when using duplicate nested method.

It prevents false positives in test cases such as:

```ruby
def test_foo
  class A
    def x
      prepare_for_foo
    end
  end

  assert...
end

def test_bar
  class A
    def x
      prepare_for_bar
    end
  end

  assert...
end
```

The above is a false positive found in the rails/rails repository.

Also as an edge case, nested methods may have been intended.

```ruby
def foo
  def x
    puts 'foo'
  end
end

def bar
  def x
    puts 'bar'
  end
end

foo
x #=> foo

bar
x #=> bar

foo
x #=> foo
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
