### PR TITLE
Fix a false positive for `Style/ObjectThen` cop with TargetRubyVersion < 2.6

### DIFF
--- a/changelog/fix_a_false_positive_for_style_object_then.md
+++ b/changelog/fix_a_false_positive_for_style_object_then.md
@@ -1,0 +1,1 @@
+* [#11177](https://github.com/rubocop/rubocop/pull/11177): Fix a false positive for `Style/ObjectThen` cop with TargetRubyVersion < 2.6. ([@epaew][])

--- a/lib/rubocop/cop/style/object_then.rb
+++ b/lib/rubocop/cop/style/object_then.rb
@@ -25,6 +25,9 @@ module RuboCop
       class ObjectThen < Base
         include ConfigurableEnforcedStyle
         extend AutoCorrector
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.6
 
         MSG = 'Prefer `%<prefer>s` over `%<current>s`.'
 

--- a/spec/rubocop/cop/style/object_then_spec.rb
+++ b/spec/rubocop/cop/style/object_then_spec.rb
@@ -4,15 +4,25 @@ RSpec.describe RuboCop::Cop::Style::ObjectThen, :config do
   context 'EnforcedStyle: then' do
     let(:cop_config) { { 'EnforcedStyle' => 'then' } }
 
-    it 'registers an offense for yield_self with block' do
-      expect_offense(<<~RUBY)
-        obj.yield_self { |e| e.test }
-            ^^^^^^^^^^ Prefer `then` over `yield_self`.
-      RUBY
+    context 'Ruby 2.5', :ruby25 do
+      it 'accepts yield_self with block' do
+        expect_no_offenses(<<~RUBY)
+          obj.yield_self { |e| e.test }
+        RUBY
+      end
+    end
 
-      expect_correction(<<~RUBY)
-        obj.then { |e| e.test }
-      RUBY
+    context 'Ruby 2.6', :ruby26 do
+      it 'registers an offense for yield_self with block' do
+        expect_offense(<<~RUBY)
+          obj.yield_self { |e| e.test }
+              ^^^^^^^^^^ Prefer `then` over `yield_self`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          obj.then { |e| e.test }
+        RUBY
+      end
     end
 
     context 'Ruby 2.7', :ruby27 do


### PR DESCRIPTION
`Object#then` was introduced in Ruby 2.6.0, so this cop should target Ruby version 2.6 or later.
- https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
    * no related issue exists. 
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
