### PR TITLE
[Fix #11182] Fix an incorrect autocorrect for `Style/IfUnlessModifer` when the last argument of the method is a 3.1 syntax hash

### DIFF
--- a/changelog/fix_fix_an_incorrect_autocorrect_for_style_if_unless_modifer.md
+++ b/changelog/fix_fix_an_incorrect_autocorrect_for_style_if_unless_modifer.md
@@ -1,0 +1,1 @@
+* [#11182](https://github.com/rubocop/rubocop/pull/11182): Fix an incorrect autocorrect for `Style/IfUnlessModifer` when the last argument of the method is a 3.1 syntax hash with no parentheses. ([@ydah][])

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -107,6 +107,34 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         end
       end
 
+      context 'Ruby >= 3.1', :ruby31 do
+        it 'registers an offense when the last argument of the method is a 3.1 syntax hash with no parentheses' do
+          expect_offense(<<~RUBY)
+            if condition
+            ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+              do_something 'foo', bar:
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            do_something('foo', bar:) if condition
+          RUBY
+        end
+
+        it 'registers an offense when the last argument of the method is a 3.1 syntax hash with parentheses' do
+          expect_offense(<<~RUBY)
+            if condition
+            ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+              do_something('foo', bar:)
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            do_something('foo', bar:) if condition
+          RUBY
+        end
+      end
+
       describe 'IgnoreCopDirectives' do
         let(:spaces) { ' ' * 57 }
         let(:comment) { '# rubocop:disable Style/For' }


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop/issues/11182

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
