### PR TITLE
[Fix #11182] Fix an incorrect autocorrect for `Style/IfUnlessModifier` with `Style/HashSyntax`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,7 +23,7 @@ Metrics/MethodLength:
 # Offense count: 8
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 129
+  Max: 135
 
 # Offense count: 9
 RSpec/AnyInstance:

--- a/changelog/change_make_style_hash_syntax_aware_of_without_parentheses_call_expr_follows.md
+++ b/changelog/change_make_style_hash_syntax_aware_of_without_parentheses_call_expr_follows.md
@@ -1,0 +1,1 @@
+* [#11185](https://github.com/rubocop/rubocop/pull/11185): Make `Style/HashSyntax` aware of without parentheses call expr follows. ([@koic][])

--- a/changelog/fix_an_incorrect_autocorrect_for_style_if_unless_modifier.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_if_unless_modifier.md
@@ -1,0 +1,1 @@
+* [#11182](https://github.com/rubocop/rubocop/issues/11182): Fix an incorrect autocorrect for `EnforcedShorthandSyntax: always` of `Style/HashSyntax` with `Style/IfUnlessModifier` when using Ruby 3.1. ([@koic][])

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -196,6 +196,25 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `EnforcedShorthandSyntax: always` of `Style/HashSyntax` with `Style/IfUnlessModifier` when using Ruby 3.1' do
+    create_file('.rubocop.yml', <<~YAML)
+      AllCops:
+        TargetRubyVersion: 3.1
+      Style/HashSyntax:
+        EnforcedShorthandSyntax: always
+    YAML
+    source = <<~RUBY
+      if condition
+        do_something foo: foo
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run(['--autocorrect', '--only', 'Style/HashSyntax,Style/IfUnlessModifier'])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      do_something(foo:) if condition
+    RUBY
+  end
+
   it 'corrects `EnforcedStyle: line_count_based` of `Style/BlockDelimiters` with `Style/CommentedKeyword` and `Layout/BlockEndNewline`' do
     create_file('.rubocop.yml', <<~YAML)
       Style/BlockDelimiters:

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1054,22 +1054,39 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
-      it 'does not register an offense when without parentheses call expr follows' do
-        # Prevent syntax errors shown in the URL: https://bugs.ruby-lang.org/issues/18396
-        expect_no_offenses(<<~RUBY)
+      it 'registers an offense when without parentheses call expr follows' do
+        # Add parentheses to prevent syntax errors shown in the URL: https://bugs.ruby-lang.org/issues/18396
+        expect_offense(<<~RUBY)
           foo value: value
+                     ^^^^^ Omit the hash value.
           foo arg
 
           value = 'a'
           foo value: value
+                     ^^^^^ Omit the hash value.
+          foo arg
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo(value:)
+          foo arg
+
+          value = 'a'
+          foo(value:)
           foo arg
         RUBY
       end
 
-      it 'does not register an offense when without parentheses call expr follows after nested method call' do
-        # Prevent syntax errors shown in the URL: https://bugs.ruby-lang.org/issues/18396
-        expect_no_offenses(<<~RUBY)
+      it 'registers an offense when without parentheses call expr follows after nested method call' do
+        # Add parentheses to prevent syntax errors shown in the URL: https://bugs.ruby-lang.org/issues/18396
+        expect_offense(<<~RUBY)
           foo bar value: value
+                         ^^^^^ Omit the hash value.
+          baz
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo bar(value:)
           baz
         RUBY
       end
@@ -1085,9 +1102,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
-      it 'does not register an offense when one line `if` condition follows (without parentheses)' do
+      it 'does not registers an offense when one line `if` condition follows (without parentheses)' do
         expect_no_offenses(<<~RUBY)
-          foo value: value if bar
+          foo x, value: value if bar
         RUBY
       end
 
@@ -1114,45 +1131,95 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
-      it 'does not register an offense when call expr with argument and a block follows' do
-        expect_no_offenses(<<~RUBY)
+      it 'registers an offense when call expr with argument and a block follows' do
+        expect_offense(<<~RUBY)
           foo value: value
+                     ^^^^^ Omit the hash value.
+          foo arg do
+            value
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo(value:)
           foo arg do
             value
           end
         RUBY
       end
 
-      it 'does not register an offense when call expr without arguments and with a block follows' do
-        # Prevent syntax semantic changes shown in the URL: https://bugs.ruby-lang.org/issues/18396
-        expect_no_offenses(<<~RUBY)
+      it 'registers an offense when call expr without arguments and with a block follows' do
+        # Add parentheses to prevent syntax semantic changes shown in the URL: https://bugs.ruby-lang.org/issues/18396
+        expect_offense(<<~RUBY)
           foo value: value
+                     ^^^^^ Omit the hash value.
+          bar do
+            value
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo(value:)
           bar do
             value
           end
         RUBY
       end
 
-      it 'does not register an offense when with parentheses call expr follows' do
-        # Prevent syntax semantic changes shown in the URL: https://bugs.ruby-lang.org/issues/18396
-        expect_no_offenses(<<~RUBY)
+      it 'registers an offense when with parentheses call expr follows' do
+        # Add parentheses to prevent syntax semantic changes shown in the URL: https://bugs.ruby-lang.org/issues/18396
+        expect_offense(<<~RUBY)
           foo value: value
+                     ^^^^^ Omit the hash value.
+          foo(arg)
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo(value:)
           foo(arg)
         RUBY
       end
 
-      it 'does not register an offense when with parentheses call expr follows assignment expr' do
-        # Prevent syntax semantic changes shown in the URL: https://bugs.ruby-lang.org/issues/18396
-        expect_no_offenses(<<~RUBY)
+      it 'registers an offense when with parentheses safe navigation call expr follows' do
+        # Add parentheses to prevent syntax semantic changes shown in the URL: https://bugs.ruby-lang.org/issues/18396
+        expect_offense(<<~RUBY)
+          x&.foo value: value
+                        ^^^^^ Omit the hash value.
+          foo(arg)
+        RUBY
+
+        expect_correction(<<~RUBY)
+          x&.foo(value:)
+          foo(arg)
+        RUBY
+      end
+
+      it 'registers an offense when with parentheses call expr follows assignment expr' do
+        # Add parentheses to prevent syntax semantic changes shown in the URL: https://bugs.ruby-lang.org/issues/18396
+        expect_offense(<<~RUBY)
           var = foo value: value
+                           ^^^^^ Omit the hash value.
+          foo(arg)
+        RUBY
+
+        expect_correction(<<~RUBY)
+          var = foo(value:)
           foo(arg)
         RUBY
       end
 
-      it 'does not register an offense when hash key and hash value are partially the same' do
-        expect_no_offenses(<<~RUBY)
+      it 'registers an offense when hash key and hash value are partially the same' do
+        expect_offense(<<~RUBY)
           def do_something
             do_something foo: foo
+                              ^^^ Omit the hash value.
+            do_something(arg)
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def do_something
+            do_something(foo:)
             do_something(arg)
           end
         RUBY

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -334,6 +334,28 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
     RUBY
   end
 
+  context 'multiline `if` that fits on one line and using hash value omission syntax', :ruby31 do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        if condition
+        ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+          obj.do_something foo:
+        end
+
+        if condition
+        ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+          obj&.do_something foo:
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        obj.do_something(foo:) if condition
+
+        obj&.do_something(foo:) if condition
+      RUBY
+    end
+  end
+
   context 'with implicit match conditional' do
     let(:body) { 'b' * 36 }
 


### PR DESCRIPTION
This PR intentionally separates two commits to resolve #11182.

First, this resolution of #11182 requires a change of `Style/HashSyntax` behavior.

The first change makes `Style/HashSyntax` aware of without parentheses call expr follows. It prepares to prevent `Style/HashSyntax` with `Style/IfUnlessModifier` autocorrection conflicts that resolve #11182.

## Before

Previously `Style/HashSyntax` accepted the following syntax to prevent syntax errors:

```ruby
foo bar value: value
baz
```

This avoids the following incompatible syntax:

```ruby
foo bar value:
baz
```

## After

`Style/HashSyntax` registers an offense for:

```ruby
foo bar value: value
baz
```

And the autocorrection adds parentheses to prevent syntax errors shown in the URL:
https://bugs.ruby-lang.org/issues/18396

```ruby
foo bar(value:)
baz
```

By assuming the above first change of `Style/HashSyntax`, the next commit fixes an incorrect autocorrect for `EnforcedShorthandSyntax: always` of `Style/HashSyntax` with `Style/IfUnlessModifier` when using Ruby 3.1.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
