### PR TITLE
[Fix #11184] Fix an error for `Lint/ShadowingOuterLocalVariable`

### DIFF
--- a/changelog/fix_error_for_lint_shadowing_outer_local_variable.md
+++ b/changelog/fix_error_for_lint_shadowing_outer_local_variable.md
@@ -1,0 +1,1 @@
+* [#11184](https://github.com/rubocop/rubocop/issues/11184): Fix an error for `Lint/ShadowingOuterLocalVariable` when a block local variable has same name as an outer `until` scope variable. ([@koic][])

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -73,10 +73,11 @@ module RuboCop
           outer_local_variable_node =
             find_conditional_node_from_ascendant(outer_local_variable.declaration_node)
           return true unless outer_local_variable_node
+          return false unless outer_local_variable_node.conditional?
+          return true if variable_node == outer_local_variable_node
 
-          outer_local_variable_node.conditional? &&
-            (variable_node == outer_local_variable_node ||
-              variable_node == outer_local_variable_node.else_branch)
+          outer_local_variable_node.if_type? &&
+            variable_node == outer_local_variable_node.else_branch
         end
 
         def variable_node(variable)

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -60,6 +60,38 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
     end
   end
 
+  context 'when a block local variable has same name as an outer `until` scope variable' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        until foo
+          var = do_something
+        end
+
+        if bar
+          array.each do |var|
+                         ^^^ Shadowing outer local variable - `var`.
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a block local variable has same name as an outer `while` scope variable' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        while foo
+          var = do_something
+        end
+
+        if bar
+          array.each do |var|
+                         ^^^ Shadowing outer local variable - `var`.
+          end
+        end
+      RUBY
+    end
+  end
+
   context 'when a block local variable has same name as an outer scope variable' \
           'with same branches of same `if` condition node not in the method definition' do
     it 'registers an offense' do


### PR DESCRIPTION
Fixes #11184.

This PR fixes an error for `Lint/ShadowingOuterLocalVariable` when a block local variable has same name as an outer `until` scope variable.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
