### PR TITLE
[RuboCop] RBS Signature Files

### DIFF
--- a/sig/rubocop/target_ruby.rbs
+++ b/sig/rubocop/target_ruby.rbs
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RuboCop
+  class TargetRuby
+    DEFAULT_VERSION: Float
+    KNOWN_RUBIES: Array[Float]
+    OBSOLETE_RUBIES: Hash[Float, String]
+    SOURCES: Array[Class]
+
+    @source: TargetRuby::Source
+
+    def self.supported_versions: () -> Array[Float]
+
+    def initialize: (RuboCop::Config) -> void
+
+    def source: () -> TargetRuby::Source
+
+    def supported?: () -> bool
+
+    def rubocop_version_with_support: () -> String
+  end
+end

--- a/sig/rubocop/target_ruby/bundler_lock_file.rbs
+++ b/sig/rubocop/target_ruby/bundler_lock_file.rbs
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module RuboCop
+  class TargetRuby::BundlerLockFile < TargetRuby::Source
+  end
+end

--- a/sig/rubocop/target_ruby/default.rbs
+++ b/sig/rubocop/target_ruby/default.rbs
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module RuboCop
+  class TargetRuby::Default < TargetRuby::Source
+  end
+end

--- a/sig/rubocop/target_ruby/gemspec_file.rbs
+++ b/sig/rubocop/target_ruby/gemspec_file.rbs
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module RuboCop
+  class TargetRuby::GemspecFile < TargetRuby::Source
+    GEMSPEC_EXTENSION: String
+  end
+end

--- a/sig/rubocop/target_ruby/rubo_cop_config.rbs
+++ b/sig/rubocop/target_ruby/rubo_cop_config.rbs
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module RuboCop
+  class TargetRuby::RuboCopConfig < TargetRuby::Source
+  end
+end

--- a/sig/rubocop/target_ruby/ruby_version_file.rbs
+++ b/sig/rubocop/target_ruby/ruby_version_file.rbs
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module RuboCop
+  class TargetRuby::RubyVersionFile < TargetRuby::Source
+    RUBY_VERSION_FILENAME: String
+    RUBY_VERSION_PATTERN: String
+  end
+end

--- a/sig/rubocop/target_ruby/source.rbs
+++ b/sig/rubocop/target_ruby/source.rbs
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module RuboCop
+  class TargetRuby::Source
+    @config: Config
+    @name: String
+    @version: Float
+
+    def initialize: (Config) -> void
+
+    def name: () -> String
+    def to_s: () -> String
+    def version: () -> Float
+  end
+end

--- a/sig/rubocop/target_ruby/tool_versions_file.rbs
+++ b/sig/rubocop/target_ruby/tool_versions_file.rbs
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module RuboCop
+  class TargetRuby::ToolVersionsFile < TargetRuby::RubyVersionFile
+    TOOL_VERSIONS_FILENAME: String
+    TOOL_VERSIONS_PATTERN: Regexp
+  end
+end

--- a/sig/rubocop/util.rbs
+++ b/sig/rubocop/util.rbs
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Util
+    def self.silence_warnings: () -> void
+  end
+end

--- a/sig/rubocop/version.rbs
+++ b/sig/rubocop/version.rbs
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Version
+    STRING: String
+    MSG: String
+    CANONICAL_FEATURE_NAMES: Hash[String, String]
+    EXTENSION_PATH_NAMES: Hash[String, String]
+
+    def self.document_version: () -> String
+    def self.extension_versions: (RuboCop::CLI::Environment) -> Array[String]
+    def self.feature_version: (String) -> String | (String) -> nil
+    def self.server_mode: () -> String
+    def self.version: (?debug: bool, ?env: RuboCop::CLI::Environment) -> String
+  end
+end

--- a/sig/rubocop/warning.rbs
+++ b/sig/rubocop/warning.rbs
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module RuboCop
+  class Warning < StandardError
+
+  end
+end


### PR DESCRIPTION
This pull request introduces RBS Signature files to the core of RuboCop. This gives tools such as Steep to perform type-checking, and allows upstream consumes to use our typing to write compatible code. The idea is to introduce some type-checking and reduce the potential of bugs. Only works with the new Ruby 3.1
