### PR TITLE
Fix an error for `Style/IfWithSemicolon`

### DIFF
--- a/changelog/fix_an_error_for_style_if_with_semicolon.md
+++ b/changelog/fix_an_error_for_style_if_with_semicolon.md
@@ -1,0 +1,1 @@
+* [#11190](https://github.com/rubocop/rubocop/pull/11190): Fix an error for `Style/IfWithSemicolon` when one using line if/;/end without then boby. ([@koic][])

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -39,9 +39,10 @@ module RuboCop
         def autocorrect(node)
           return correct_elsif(node) if node.else_branch.if_type?
 
+          then_code = node.if_branch ? node.if_branch.source : 'nil'
           else_code = node.else_branch ? node.else_branch.source : 'nil'
 
-          "#{node.condition.source} ? #{node.if_branch.source} : #{else_code}"
+          "#{node.condition.source} ? #{then_code} : #{else_code}"
         end
 
         def correct_elsif(node)

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects for one line if/;/end without then body' do
+    expect_offense(<<~RUBY)
+      if cond; else dont end
+      ^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      cond ? nil : dont
+    RUBY
+  end
+
   it 'accepts without `else` branch' do
     # This case is corrected to a modifier form by `Style/IfUnlessModifier` cop.
     # Therefore, this cop does not handle it.


### PR DESCRIPTION
This PR fixes the following error for `Style/IfWithSemicolon` when one using line if/;/end without then boby.

```ruby
if cond; else dont end
```

```console
bundle exec rubocop --only Style/IfWithSemicolon
(snip)

undefined method `source' for nil:NilClass

          "#{node.condition.source} ? #{node.if_branch.source} : #{else_code}"
                                                      ^^^^^^^
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/if_with_semicolon.rb:44:in `autocorrect'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
