### PR TITLE
[Fix #11196] Fix a false positive for `Style/GuardClause`

### DIFF
--- a/changelog/fix_a_false_positive_for_guard_clause.md
+++ b/changelog/fix_a_false_positive_for_guard_clause.md
@@ -1,0 +1,1 @@
+* [#11196](https://github.com/rubocop/rubocop/issues/11196): Fix a false positive for `Style/GuardClause` when using `raise` in `then` body of `if..elsif..end` form. ([@koic][])

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -222,7 +222,7 @@ module RuboCop
         end
 
         def accepted_if?(node, ending)
-          return true if node.modifier_form? || node.ternary?
+          return true if node.modifier_form? || node.ternary? || node.elsif_conditional?
 
           if ending
             node.else?

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -438,6 +438,16 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
       RUBY
     end
 
+    it "does not report an offense if #{kw} is inside then body of if..elsif..end" do
+      expect_no_offenses(<<~RUBY)
+        if something
+          #{kw}
+        elsif something_else
+          a
+        end
+      RUBY
+    end
+
     it "does not report an offense if #{kw} is inside if..elsif..else..end" do
       expect_no_offenses(<<~RUBY)
         if something


### PR DESCRIPTION
Fixes #11196.

This PR fix a false positive for `Style/GuardClause` when using `raise` in `then` body of `if..elsif..end` form.
It would be unexpected to replace complex conditional forms using `elsif` with modifier form.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
