### PR TITLE
Fix an error for `Lint/EmptyConditionalBody`

### DIFF
--- a/changelog/fix_error_for_lint_empty_conditional_body.md
+++ b/changelog/fix_error_for_lint_empty_conditional_body.md
@@ -1,0 +1,1 @@
+* [#11198](https://github.com/rubocop/rubocop/pull/11198): Fix an error for `Lint/EmptyConditionalBody` when one using line if/;/end without then boby. ([@koic][])

--- a/lib/rubocop/cop/lint/empty_conditional_body.rb
+++ b/lib/rubocop/cop/lint/empty_conditional_body.rb
@@ -68,7 +68,7 @@ module RuboCop
         MSG = 'Avoid `%<keyword>s` branches without a body.'
 
         def on_if(node)
-          return if node.body
+          return if node.body || same_line?(node.loc.begin, node.loc.end)
           return if cop_config['AllowComments'] && contains_comments?(node)
 
           add_offense(node, message: format(MSG, keyword: node.keyword)) do |corrector|

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     RUBY
   end
 
+  # This case is registered by `Style/IfWithSemicolon` cop. Therefore, this cop does not handle it.
+  it 'does not register an offense for missing `if` body with present `else` body on single line' do
+    expect_no_offenses(<<~RUBY)
+      if condition; else do_something end
+    RUBY
+  end
+
   it 'does not register an offense for missing `if` body with a comment' do
     expect_no_offenses(<<~RUBY)
       if condition


### PR DESCRIPTION
This PR fixes the following error for `Lint/EmptyConditionalBody` when one using line if/;/end without then boby.

```ruby
if cond; else dont end
```

```console
bundle exec rubocop --stdin example.rb --only Lint/EmptyConditionalBody -d
(snip)

Parser::Source::TreeRewriter detected clobbering
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
