### PR TITLE
[Fix #11200] Fix an incorrect autocorrect for `Layout/MultilineMethodCallBraceLayout`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_layout_multiline_method_call_brace_layout.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_layout_multiline_method_call_brace_layout.md
@@ -1,0 +1,1 @@
+* [#11200](https://github.com/rubocop/rubocop/issues/11200): Fix an incorrect autocorrect for `Layout/MultilineMethodCallBraceLayout` when using method chain for heredoc argument in multiline literal brace layout. ([@koic][])

--- a/spec/rubocop/cop/layout/multiline_method_call_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_brace_layout_spec.rb
@@ -29,6 +29,38 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallBraceLayout, :config do
     RUBY
   end
 
+  it 'registers an offense when using method chain for heredoc argument in multiline literal brace layout' do
+    expect_offense(<<~RUBY)
+      foo(<<~EOS, arg
+        text
+      EOS
+      ).do_something
+      ^ Closing method call brace must be on the same line as the last argument when opening brace is on the same line as the first argument.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo(<<~EOS, arg).do_something
+        text
+      EOS
+    RUBY
+  end
+
+  it 'registers an offense when using safe navigation method chain for heredoc argument in multiline literal brace layout' do
+    expect_offense(<<~RUBY)
+      foo(<<~EOS, arg
+        text
+      EOS
+      )&.do_something
+      ^ Closing method call brace must be on the same line as the last argument when opening brace is on the same line as the first argument.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo(<<~EOS, arg)&.do_something
+        text
+      EOS
+    RUBY
+  end
+
   it_behaves_like 'multiline literal brace layout' do
     let(:open) { 'foo(' }
     let(:close) { ')' }


### PR DESCRIPTION
Fixes #11200.

This PR fixes an incorrect autocorrect for `Layout/MultilineMethodCallBraceLayout` when using method chain for heredoc argument in multiline literal brace layout.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
