### PR TITLE
Support multiple arguments on `Lint/SendWithMixinArgument`

### DIFF
--- a/changelog/change_support_multiple_arguments_on.md
+++ b/changelog/change_support_multiple_arguments_on.md
@@ -1,0 +1,1 @@
+* [#11203](https://github.com/rubocop/rubocop/pull/11203): Support multiple arguments on `Lint/SendWithMixinArgument`. ([@r7kamura][])

--- a/lib/rubocop/cop/lint/send_with_mixin_argument.rb
+++ b/lib/rubocop/cop/lint/send_with_mixin_argument.rb
@@ -48,16 +48,17 @@ module RuboCop
           (send
             (const _ _) {:#{SEND_METHODS.join(' :')}}
             ({sym str} $#mixin_method?)
-              $(const _ _))
+              $(const _ _)+)
         PATTERN
 
         def on_send(node)
-          send_with_mixin_argument?(node) do |method, module_name|
-            message = message(method, module_name.source, bad_location(node).source)
+          send_with_mixin_argument?(node) do |method, module_names|
+            module_names_source = module_names.map(&:source).join(', ')
+            message = message(method, module_names_source, bad_location(node).source)
 
             bad_location = bad_location(node)
             add_offense(bad_location, message: message) do |corrector|
-              corrector.replace(bad_location, "#{method} #{module_name.source}")
+              corrector.replace(bad_location, "#{method} #{module_names_source}")
             end
           end
         end

--- a/spec/rubocop/cop/lint/send_with_mixin_argument_spec.rb
+++ b/spec/rubocop/cop/lint/send_with_mixin_argument_spec.rb
@@ -127,4 +127,17 @@ RSpec.describe RuboCop::Cop::Lint::SendWithMixinArgument, :config do
       RUBY
     end
   end
+
+  context 'when multiple arguments are passed' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        Foo.send(:include, Bar, Baz)
+            ^^^^^^^^^^^^^^^^^^^^^^^^ Use `include Bar, Baz` instead of `send(:include, Bar, Baz)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Foo.include Bar, Baz
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
These mixin methods can take multiple arguments, so these patterns should also be supported in this cop.

- `Module#include`
- `Module#prepend`
- `Object#extend`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
