### PR TITLE
Add `--[no-]auto-gen-enforced-style` CLI option

### DIFF
--- a/changelog/new_add_no_auto_gen_enforced_style_cli_option.md
+++ b/changelog/new_add_no_auto_gen_enforced_style_cli_option.md
@@ -1,0 +1,1 @@
+* [#11205](https://github.com/rubocop/rubocop/pull/11205): Add `--[no-]auto-gen-enforced-style` CLI option. ([@ydah][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -645,6 +645,12 @@ prefer to exclude files, like for other cops, add `--auto-gen-only-exclude`
 when running with `--auto-gen-config`. It will still change the maximum if the
 number of excluded files is higher than the exclude limit.
 
+Some cops have a configurable option named `EnforcedStyle`.
+By default, when generating the `.rubocop_todo.yml`, if one style is used
+for all files, these cops will add the settings for the style being used.
+If you want to excluded on a file-by-file basis,
+add the `--no-auto-gen-enforced-style` option along with `--auto-gen-config`.
+
 == Updating the configuration file
 
 When you update RuboCop version, sometimes you need to change `.rubocop.yml`.

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -167,6 +167,7 @@ module RuboCop
         option(opts, '--[no-]offense-counts')
         option(opts, '--[no-]auto-gen-only-exclude')
         option(opts, '--[no-]auto-gen-timestamp')
+        option(opts, '--[no-]auto-gen-enforced-style')
       end
     end
 
@@ -464,7 +465,7 @@ module RuboCop
 
   # This module contains help texts for command line options.
   # @api private
-  module OptionsHelp
+  module OptionsHelp # rubocop:disable Metrics/ModuleLength
     MAX_EXCL = RuboCop::Options::DEFAULT_MAXIMUM_EXCLUSION_ITEMS.to_s
     FORMATTER_OPTION_LIST = RuboCop::Formatter::FormatterSet::BUILTIN_FORMATTERS_FOR_KEYS.keys
 
@@ -486,6 +487,13 @@ module RuboCop
       auto_gen_timestamp:
                                         ['Include the date and time when the --auto-gen-config',
                                          'was run in the file it generates. Default is true.'],
+      auto_gen_enforced_style:
+                                        ['Add a setting to the TODO configuration file to enforce',
+                                         'the style used, rather than a per-file exclusion',
+                                         'if one style is used in all files for cop with',
+                                         'EnforcedStyle as a configurable option',
+                                         'when the --auto-gen-config was run',
+                                         'in the file it generates. Default is true.'],
       auto_gen_only_exclude:
                                         ['Generate only Exclude parameters and not Max',
                                          'when running --auto-gen-config, except if the',

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -1339,33 +1339,67 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
       end
     end
 
-    it 'generates EnforcedStyle parameter if it solves all offenses' do
-      create_file('example1.rb', ['# frozen_string_literal: true', '', 'h(:a => 1)'])
+    describe 'when `--auto-gen-enforced-style` is given' do
+      it 'generates EnforcedStyle parameter if it solves all offenses' do
+        create_file('example1.rb', ['# frozen_string_literal: true', '', 'h(:a => 1)'])
 
-      expect(cli.run(['--auto-gen-config'])).to eq(0)
-      expect(File.readlines('.rubocop_todo.yml')[10..].join)
-        .to eq(<<~YAML)
-          # Configuration parameters: EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
-          # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-          # SupportedShorthandSyntax: always, never, either, consistent
-          Style/HashSyntax:
-            EnforcedStyle: hash_rockets
-        YAML
+        expect(cli.run(['--auto-gen-config', '--auto-gen-enforced-style'])).to eq(0)
+        expect(File.readlines('.rubocop_todo.yml')[10..].join)
+          .to eq(<<~YAML)
+            # Configuration parameters: EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
+            # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
+            # SupportedShorthandSyntax: always, never, either, consistent
+            Style/HashSyntax:
+              EnforcedStyle: hash_rockets
+          YAML
+      end
+
+      it 'generates Exclude if no EnforcedStyle solves all offenses' do
+        create_file('example1.rb', ['# frozen_string_literal: true', '', 'h(:a => 1)', 'h(b: 2)'])
+
+        expect(cli.run(['--auto-gen-config', '--auto-gen-enforced-style'])).to eq(0)
+        expect(File.readlines('.rubocop_todo.yml')[10..].join)
+          .to eq(<<~YAML)
+            # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
+            # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
+            # SupportedShorthandSyntax: always, never, either, consistent
+            Style/HashSyntax:
+              Exclude:
+                - 'example1.rb'
+          YAML
+      end
     end
 
-    it 'generates Exclude if no EnforcedStyle solves all offenses' do
-      create_file('example1.rb', ['# frozen_string_literal: true', '', 'h(:a => 1)', 'h(b: 2)'])
+    describe 'when `--no-auto-gen-enforced-style` is given' do
+      it 'generates Exclude if it solves all offenses' do
+        create_file('example1.rb', ['# frozen_string_literal: true', '', 'h(:a => 1)'])
 
-      expect(cli.run(['--auto-gen-config'])).to eq(0)
-      expect(File.readlines('.rubocop_todo.yml')[10..].join)
-        .to eq(<<~YAML)
-          # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
-          # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-          # SupportedShorthandSyntax: always, never, either, consistent
-          Style/HashSyntax:
-            Exclude:
-              - 'example1.rb'
+        expect(cli.run(['--auto-gen-config', '--no-auto-gen-enforced-style'])).to eq(0)
+        expect(File.readlines('.rubocop_todo.yml')[10..].join)
+          .to eq(<<~YAML)
+            # Configuration parameters: EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
+            # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
+            # SupportedShorthandSyntax: always, never, either, consistent
+            Style/HashSyntax:
+              Exclude:
+                - 'example1.rb'
         YAML
+      end
+
+      it 'generates Exclude if no EnforcedStyle solves all offenses' do
+        create_file('example1.rb', ['# frozen_string_literal: true', '', 'h(:a => 1)', 'h(b: 2)'])
+
+        expect(cli.run(['--auto-gen-config', '--no-auto-gen-enforced-style'])).to eq(0)
+        expect(File.readlines('.rubocop_todo.yml')[10..].join)
+          .to eq(<<~YAML)
+            # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
+            # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
+            # SupportedShorthandSyntax: always, never, either, consistent
+            Style/HashSyntax:
+              Exclude:
+                - 'example1.rb'
+          YAML
+      end
     end
 
     context 'when hash value omission enabled', :ruby31 do

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -172,6 +172,13 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                exclude-limit. Default is false.
                   --[no-]auto-gen-timestamp    Include the date and time when the --auto-gen-config
                                                was run in the file it generates. Default is true.
+                  --[no-]auto-gen-enforced-style
+                                               Add a setting to the TODO configuration file to enforce
+                                               the style used, rather than a per-file exclusion
+                                               if one style is used in all files for cop with
+                                               EnforcedStyle as a configurable option
+                                               when the --auto-gen-config was run
+                                               in the file it generates. Default is true.
 
           Additional Modes:
               -L, --list-target-files          List all files RuboCop will inspect.


### PR DESCRIPTION
This PR is add `--[no-]auto-gen-enforced-style` CLI option.

As a motivation, for a cop that has EnforcedStyle and other options as configurable options, the offense may remain
even if `--auto-gen-cofig` is done.

Normally, this may not be a problem, but there are cases where you want to update RuboCop, and you want to make only updates.
For example, if we do not want to include the newly added cop violations up to the point of fixing them, we can run `rubocop --auto-gen-config` when updating and slowly resolve them later.

The following is a case where `rubocop --auto-gen-config` does not make all offense TODO:
```ruby
# test.rb

a = {

}
```

Run `bundle exec rubocop --auto-gen-config`.
The following TODO configuration file is then created.

```yaml
# .rubocop_todo.yml

# Offense count: 1
# This cop supports safe autocorrection (--autocorrect).
# Configuration parameters: EnforcedStyleForEmptyBraces.
# SupportedStyles: space, no_space, compact
# SupportedStylesForEmptyBraces: space, no_space
Layout/SpaceInsideHashLiteralBraces:
  EnforcedStyle: space
```

If I run `bundle exec rubocop` again in this state, the error still offense.

```
test.rb:1:6: C: [Correctable] Layout/SpaceInsideHashLiteralBraces: Space inside empty hash literal braces detected.
a = { ...
```

-----------------

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
