### PR TITLE
Change `Lint/InterpolationCheck` from `Safe: false` to `SafeAutoCorrect: false`

### DIFF
--- a/changelog/change_lint_interpolation_check.md
+++ b/changelog/change_lint_interpolation_check.md
@@ -1,0 +1,1 @@
+* [#11205](https://github.com/rubocop/rubocop/pull/11205): Change `Lint/InterpolationCheck` from `Safe: false` to `SafeAutoCorrect: false`. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1894,11 +1894,11 @@ Lint/InheritException:
     - runtime_error
 
 Lint/InterpolationCheck:
-  Description: 'Raise warning for interpolation in single q strs.'
+  Description: 'Checks for interpolation in a single quoted string.'
   Enabled: true
-  Safe: false
+  SafeAutoCorrect: false
   VersionAdded: '0.50'
-  VersionChanged: '0.87'
+  VersionChanged: '<<next>>'
 
 Lint/LambdaWithoutLiteralBlock:
   Description: 'Checks uses of lambda without a literal block.'

--- a/lib/rubocop/cop/lint/interpolation_check.rb
+++ b/lib/rubocop/cop/lint/interpolation_check.rb
@@ -6,9 +6,10 @@ module RuboCop
       # Checks for interpolation in a single quoted string.
       #
       # @safety
-      #   This cop is generally safe, but is marked as unsafe because
-      #   it is possible to actually intentionally have text inside
-      #   `#{...}` in a single quoted string.
+      #   This cop's autocorrection is unsafe because although it always replaces single quotes as
+      #   if it were miswritten double quotes, it is not always the case. For example,
+      #   `'#{foo} bar'` would be replaced by `"#{foo} bar"`, so the replaced code would evaluate
+      #   the expression `foo`.
       #
       # @example
       #


### PR DESCRIPTION
In this Cop, I think it would be easier to understand to have a simple policy that all `#{...}` in single-quotes are considered offenses, regardless of how they are intended to be written. Given this, it would be nice to set `SafeAutoCorrect: false`, since I don't think there are any false-positives cases under this policy.

What do you think?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
