### PR TITLE
[fix rubocop#11157] -- Update Registry Docs

### DIFF
--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -72,27 +72,27 @@ module RuboCop
       #
       # @example gives back a correctly qualified cop name
       #
-      #   cops = RuboCop::Cop::Cop.all
-      #   cops.
-      #     qualified_cop_name('Layout/EndOfLine') # => 'Layout/EndOfLine'
+      #   registry = RuboCop::Cop::Registry
+      #   registry.qualified_cop_name('Layout/EndOfLine', '') # => 'Layout/EndOfLine'
       #
       # @example fixes incorrect namespaces
       #
-      #   cops = RuboCop::Cop::Cop.all
-      #   cops.qualified_cop_name('Lint/EndOfLine') # => 'Layout/EndOfLine'
+      #   registry = RuboCop::Cop::Registry
+      #   registry.qualified_cop_name('Lint/EndOfLine', '') # => 'Layout/EndOfLine'
       #
       # @example namespaces bare cop identifiers
       #
-      #   cops = RuboCop::Cop::Cop.all
-      #   cops.qualified_cop_name('EndOfLine') # => 'Layout/EndOfLine'
+      #   registry = RuboCop::Cop::Registry
+      #   registry.qualified_cop_name('EndOfLine', '') # => 'Layout/EndOfLine'
       #
       # @example passes back unrecognized cop names
       #
-      #   cops = RuboCop::Cop::Cop.all
-      #   cops.qualified_cop_name('NotACop') # => 'NotACop'
+      #   registry = RuboCop::Cop::Registry
+      #   registry.qualified_cop_name('NotACop', '') # => 'NotACop'
       #
       # @param name [String] Cop name extracted from config
       # @param path [String, nil] Path of file that `name` was extracted from
+      # @param warn [Boolean] Print a warning if no department given for `name`
       #
       # @raise [AmbiguousCopName]
       #   if a bare identifier with two possible namespaces is provided


### PR DESCRIPTION
- This PR fixes https://github.com/rubocop/rubocop/issues/11157.
- `RuboCop::Cop::Cop` is deprecated, so updated to `RuboCop::Cop::Registry`
- Updated to run `qualified_cop_name` on the `registry` as opposed to the array of cops (`RuboCop::Cop::Cop.all`)
- Added `warn` yard documentation 

<img width="532" alt="image" src="https://user-images.githubusercontent.com/7718178/204176345-e2e3273d-e3be-45fc-899d-fa70c9e6c77c.png">

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
  * Didn't add tests as this is a documentation change
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
  * did not add one - I checked other documentation only PR's and appears it is required for `user-observable changes` 

[1]: https://chris.beams.io/posts/git-commit/
