### PR TITLE
[fix #11143] Fix RedundantCopDisableDirective when used with departments

### DIFF
--- a/changelog/fix_redundant_cop_disable_with_departments.md
+++ b/changelog/fix_redundant_cop_disable_with_departments.md
@@ -1,0 +1,1 @@
+* [#11143](https://github.com/rubocop/rubocop/issues/11143): Fix RedundantCopDisableDirective errors when encountering several department comments. ([@isarcasm][])

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -131,18 +131,21 @@ module RuboCop
         def each_already_disabled(cop, line_ranges)
           line_ranges.each_cons(2) do |previous_range, range|
             next if ignore_offense?(range)
-            next unless followed_ranges?(previous_range, range)
-
             # If a cop is disabled in a range that begins on the same line as
             # the end of the previous range, it means that the cop was
             # already disabled by an earlier comment. So it's redundant
             # whether there are offenses or not.
-            comment = processed_source.comment_at_line(range.begin)
+            next unless followed_ranges?(previous_range, range)
 
+            comment = processed_source.comment_at_line(range.begin)
+            # Disabling department can not be redundant
+            next if department_disabled?(cop, comment)
             # Comments disabling all cops don't count since it's reasonable
             # to disable a few select cops first and then all cops further
             # down in the code.
-            yield comment, cop if comment && !all_disabled?(comment)
+            next if all_disabled?(comment)
+
+            yield comment, cop if comment
           end
         end
 

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -23,10 +23,17 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
           context 'a cop that is disabled in the config' do
             let(:other_cops) { { 'Metrics/MethodLength' => { 'Enabled' => false } } }
 
-            it 'returns an offense' do
+            it 'returns an offense when disabling same cop' do
               expect_offense(<<~RUBY)
                 # rubocop:disable Metrics/MethodLength
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/MethodLength`.
+              RUBY
+            end
+
+            it 'returns an offense when disabling parent department' do
+              expect_offense(<<~RUBY)
+                # rubocop:disable Metrics
+                ^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics` department.
               RUBY
             end
 


### PR DESCRIPTION
This is a fix for #11143 and #11160, and the issue was introduced in this Opt-In PR: #10987.

It seems like the current implementation of `RedundantCopDisableDirective` is designed to ignore department-disable comments (based on specs). 

The `RedundantCopDisableDirective` has 2 different reasons to mark a cop disable comment as redundant: it is already disabled, OR there is no reason to disable it since there are no offenses of this type
```
def each_redundant_disable(&block)
  cop_disabled_line_ranges.each do |cop, line_ranges|
    each_already_disabled(cop, line_ranges, &block)
    each_line_range(cop, line_ranges, &block)
  end
end
```

The error occurs due to unnecessary cops added in the `each_already_disabled` block. It only happens when we have 2 or more department-disable comments. If we have less than 2 comments, we never even enter the iteration here:
```
def each_already_disabled(cop, line_ranges)
  line_ranges.each_cons(2) do |previous_range, range|
    ...
  end
end
```

The reason people noticed it after #10987 is that this change injects an extra `line_range` when a cop is disabled via config, and we end up with `line_ranges` like `{ “Metrics/MethodLength"=>[-Infinity..1, 1..Infinity], ... }` where `-Infinity..1` comes from the config (see `CommentConfig#inject_disabled_cops_directives`), and `1..Infinity` comes from an actual `# rubocop:disable Metrics/MethodLength` comment therefore, we now enter the `each_already_disabled` loop.

The `each_already_disabled` is simply not designed to handle departments being disabled, and it does not matter if they come from config or comments. For example, the following example causes errors as well:
```
# rubocop:disable Metrics
# rubocop:disable Metrics
```

Ideally, we would want to flag the example above as redundant, but I decided to keep it focused on the current problem. Should I open a separate issue for the simple snippet above? 

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
