### PR TITLE
Add autocorrect for `Lint/AssignmentInCondition`

### DIFF
--- a/changelog/new_add_autocorrect_for_lint_assignment_in_condition.md
+++ b/changelog/new_add_autocorrect_for_lint_assignment_in_condition.md
@@ -1,0 +1,1 @@
+* [#11211](https://github.com/rubocop/rubocop/pull/11211): Add autocorrect for `Lint/AssignmentInCondition`. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -378,8 +378,9 @@ Layout/AssignmentIndentation:
                 Checks the indentation of the first line of the
                 right-hand-side of a multi-line assignment.
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.49'
-  VersionChanged: '0.77'
+  VersionChanged: '<<next>>'
   # By default the indentation width from `Layout/IndentationWidth` is used,
   # but it can be overridden by setting this parameter.
   IndentationWidth: ~

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -11,6 +11,10 @@ module RuboCop
       # an assignment to indicate "I know I'm using an assignment
       # as a condition. It's not a mistake."
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because it assumes that
+      #   the author meant to use an assignment result as a condition.
+      #
       # @example
       #   # bad
       #   if some_var = true
@@ -35,6 +39,8 @@ module RuboCop
       #   end
       #
       class AssignmentInCondition < Base
+        extend AutoCorrector
+
         include SafeAssignment
 
         MSG_WITH_SAFE_ASSIGNMENT_ALLOWED =
@@ -53,7 +59,11 @@ module RuboCop
             next :skip_children if skip_children?(asgn_node)
             next if allowed_construct?(asgn_node)
 
-            add_offense(asgn_node.loc.operator)
+            add_offense(asgn_node.loc.operator) do |corrector|
+              next unless safe_assignment_allowed?
+
+              corrector.replace(asgn_node, "(#{asgn_node.source})")
+            end
           end
         end
         alias on_while on_if

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -62,7 +62,7 @@ module RuboCop
             add_offense(asgn_node.loc.operator) do |corrector|
               next unless safe_assignment_allowed?
 
-              corrector.replace(asgn_node, "(#{asgn_node.source})")
+              corrector.wrap(asgn_node, '(', ')')
             end
           end
         end

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -9,12 +9,22 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
               ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      if (test = 10)
+      end
+    RUBY
   end
 
   it 'registers an offense for lvar assignment in while condition' do
     expect_offense(<<~RUBY)
       while test = 10
                  ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      while (test = 10)
       end
     RUBY
   end
@@ -25,12 +35,22 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
                  ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      until (test = 10)
+      end
+    RUBY
   end
 
   it 'registers an offense for ivar assignment in condition' do
     expect_offense(<<~RUBY)
       if @test = 10
                ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if (@test = 10)
       end
     RUBY
   end
@@ -41,12 +61,22 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
                 ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      if (@@test = 10)
+      end
+    RUBY
   end
 
   it 'registers an offense for gvar assignment in condition' do
     expect_offense(<<~RUBY)
       if $test = 10
                ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if ($test = 10)
       end
     RUBY
   end
@@ -57,12 +87,22 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
               ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      if (TEST = 10)
+      end
+    RUBY
   end
 
   it 'registers an offense for collection element assignment in condition' do
     expect_offense(<<~RUBY)
       if a[3] = 10
               ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if (a[3] = 10)
       end
     RUBY
   end
@@ -78,6 +118,11 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     expect_offense(<<~RUBY)
       if test == 10 || foobar = 1
                               ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if test == 10 || (foobar = 1)
       end
     RUBY
   end
@@ -103,6 +148,10 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
       foo { x if y = z }
                    ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo { x if (y = z) }
+    RUBY
   end
 
   it 'accepts ||= in condition' do
@@ -114,12 +163,21 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
       raise StandardError unless (foo ||= bar) || a = b
                                                     ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
     RUBY
+
+    expect_correction(<<~RUBY)
+      raise StandardError unless (foo ||= bar) || (a = b)
+    RUBY
   end
 
   it 'registers an offense for assignment methods' do
     expect_offense(<<~RUBY)
       if test.method = 10
                      ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if (test.method = 10)
       end
     RUBY
   end
@@ -163,6 +221,8 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
                  ^ Use `==` if you meant to do a comparison or move the assignment up out of the condition.
         end
       RUBY
+
+      expect_no_corrections
     end
 
     it 'does not accept []= in condition surrounded with braces' do
@@ -171,6 +231,8 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
                     ^ Use `==` if you meant to do a comparison or move the assignment up out of the condition.
         end
       RUBY
+
+      expect_no_corrections
     end
   end
 end


### PR DESCRIPTION
I think adding support for unsafe autocorrection to `Lint/AssignmentInCondition` would be more useful in some cases. Now that `SafeAutoCorrect: false` allows us to indicate to users that it is unsafe, I don't think we will have much trouble because of this support.

I decided to replace the code as assignment by default in this autocorrection because it does not change the behavior of the current code. If there seem to be many use cases where the behavior of autocorrection needs to be changed, we can add such configuration in this Pull Request or the future change. (In fact, is there any Cop that allows the autocorrection behavior to be switched by configuration in that way?)

Depending on the policy, this type of autocorrection support may not be acceptable in RuboCop. In which case, please do not hesitate to close this Pull Request.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
