### PR TITLE
Fix loading of configuration in multi-file edge case

### DIFF
--- a/changelog/fix_multifile_require_config.md
+++ b/changelog/fix_multifile_require_config.md
@@ -1,0 +1,1 @@
+* [#5251](https://github.com/rubocop/rubocop/issues/5251): Fix loading of configuration in multi-file edge case. ([@NobodysNightmare][])

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -42,17 +42,17 @@ module RuboCop
 
         hash = load_yaml_configuration(path)
 
-        # Resolve requires first in case they define additional cops
         loaded_features = resolver.resolve_requires(path, hash)
         add_loaded_features(loaded_features)
-
-        add_missing_namespaces(path, hash)
 
         resolver.override_department_setting_for_cops({}, hash)
         resolver.resolve_inheritance_from_gems(hash)
         resolver.resolve_inheritance(path, hash, file, debug?)
-
         hash.delete('inherit_from')
+
+        # Adding missing namespaces only after resolving requires & inheritance,
+        # since both can introduce new cops that need to be considered here.
+        add_missing_namespaces(path, hash)
 
         Config.create(hash, path, check: check)
       end


### PR DESCRIPTION
This PR fixes loading of configuration files that inherit from other configuration files, which require a gem. This was first documented in https://github.com/rubocop/rubocop/issues/5251.

### Reproduction

Locally I used three files for reproduction.

#### .rubocop.yml

```yaml
inherit_from:
  - more-rubocop.yml

RSpec/VariableName:
  Enabled: false

AllCops:
  NewCops: enable
```

#### more-rubocop.yml

```yaml
require:
  - rubocop-rspec
```

#### my_spec.rb

```ruby
# frozen_string_literal: true

RSpec.describe 'Banana' do
  let(:Banana) { '🍌' }

  it 'is delicious' do
    expect(send(:Banana)).to eq '🍌'
  end
end
```

### Output without this PR

```
.rubocop.yml: RSpec/VariableName has the wrong namespace - should be Naming
Inspecting 1 file
C

Offenses:

my_spec.rb:4:7: C: RSpec/VariableName: Use snake_case for variable names.
  let(:Banana) { '🍌' }
      ^^^^^^^

1 file inspected, 1 offense detected
```
This is unexpected:
* the offending cop should have been disabled
* the warning about the wrong namespace should not appear

### Output with this PR

```
Inspecting 1 file
.

1 file inspected, no offenses detected
```

### Caveats

* I did not add any tests for the case fixed in this PR
    * reproduction steps are reasonably complex that I am unsure how to properly approach a spec for this
---

Before submitting the PR make sure the following are checked:

* [x] The PR relates to only one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
* [x] Commit message starts with [Fix #issue-number] (if the related issue exists).
* [x] Feature branch is up-to-date with master (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran bundle exec rake default. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named {change_type}_{change_description}.md if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

Closes https://github.com/rubocop/rubocop/issues/5251