### PR TITLE
Update severity of some `Bundler` and `RubyGems` cops to warning

### DIFF
--- a/changelog/change_update_raise_severity_of_some_cops_to_warning.md
+++ b/changelog/change_update_raise_severity_of_some_cops_to_warning.md
@@ -1,0 +1,1 @@
+* [#11218](https://github.com/rubocop/rubocop/pull/11218): Update severity of `Bundler/DuplicatedGem`, `Bundler/InsecureProtocolSource`, `Gemspec/DeprecatedAttributeAssignment`, `Gemspec/DuplicatedAssignment`, `Gemspec/RequireMFA`, `Gemspec/RequiredRubyVersion`, and `Gemspec/RubyVersionGlobalsUsage` cops to warning. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -161,7 +161,9 @@ AllCops:
 Bundler/DuplicatedGem:
   Description: 'Checks for duplicate gem entries in Gemfile.'
   Enabled: true
+  Severity: warning
   VersionAdded: '0.46'
+  VersionChanged: '<<next>>'
   Include:
     - '**/*.gemfile'
     - '**/Gemfile'
@@ -213,7 +215,9 @@ Bundler/InsecureProtocolSource:
                  because HTTP requests are insecure. Please change your source to
                  'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
   Enabled: true
+  Severity: warning
   VersionAdded: '0.50'
+  VersionChanged: '<<next>>'
   AllowHttpProtocol: true
   Include:
     - '**/*.gemfile'
@@ -252,14 +256,18 @@ Gemspec/DependencyVersion:
 Gemspec/DeprecatedAttributeAssignment:
   Description: Checks that deprecated attribute assignments are not set in a gemspec file.
   Enabled: pending
+  Severity: warning
   VersionAdded: '1.30'
+  VersionChanged: '<<next>>'
   Include:
     - '**/*.gemspec'
 
 Gemspec/DuplicatedAssignment:
   Description: 'An attribute assignment method calls should be listed only once in a gemspec.'
   Enabled: true
+  Severity: warning
   VersionAdded: '0.52'
+  VersionChanged: '<<next>>'
   Include:
     - '**/*.gemspec'
 
@@ -278,7 +286,9 @@ Gemspec/OrderedDependencies:
 Gemspec/RequireMFA:
   Description: 'Checks that the gemspec has metadata to require Multi-Factor Authentication from RubyGems.'
   Enabled: pending
+  Severity: warning
   VersionAdded: '1.23'
+  VersionChanged: '<<next>>'
   Reference:
     - https://guides.rubygems.org/mfa-requirement-opt-in/
   Include:
@@ -287,8 +297,9 @@ Gemspec/RequireMFA:
 Gemspec/RequiredRubyVersion:
   Description: 'Checks that `required_ruby_version` of gemspec is specified and equal to `TargetRubyVersion` of .rubocop.yml.'
   Enabled: true
+  Severity: warning
   VersionAdded: '0.52'
-  VersionChanged: '1.22'
+  VersionChanged: '<<next>>'
   Include:
     - '**/*.gemspec'
 
@@ -296,7 +307,9 @@ Gemspec/RubyVersionGlobalsUsage:
   Description: Checks usage of RUBY_VERSION in gemspec.
   StyleGuide: '#no-ruby-version-in-the-gemspec'
   Enabled: true
+  Severity: warning
   VersionAdded: '0.72'
+  VersionChanged: '<<next>>'
   Include:
     - '**/*.gemspec'
 


### PR DESCRIPTION
`Bundler` and `RubyGems` are special departments that depend on specific tools (not language) , and some cops belonging to them should be treated as de facto Lints.

So, the following cops below belong to linting, not style preference, make set the severity to warning.

1. The following emulates warnings for deprecated usage:

- `Bundler/InsecureProtocolSource` cop

2. The following suggests incorrect usage of Bundler and RubyGems APIs:

- `Bundler/DuplicatedGem` cop
- `Gemspec/DeprecatedAttributeAssignment` cop
- `Gemspec/DuplicatedAssignment` cop
- `Gemspec/RequiredRubyVersion` cop
- `Gemspec/RubyVersionGlobalsUsage` cop

3. RubyGems strongly recommends MFA, so I think the following cop is equivalent to linting:

- `Gemspec/RequireMFA` cop

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
