### PR TITLE
[Fix #11219] Make `Style/SelectByRegexp` aware of `!~` method

### DIFF
--- a/changelog/new_make_style_select_by_regexp_aware_of_doesnt_match.md
+++ b/changelog/new_make_style_select_by_regexp_aware_of_doesnt_match.md
@@ -1,0 +1,1 @@
+* [#11219](https://github.com/rubocop/rubocop/issues/11219): Make `Style/SelectByRegexp` aware of `!~` method. ([@koic][])


### PR DESCRIPTION
Fixes #11219.

This PR makes `Style/SelectByRegexp` aware of `!~` method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
