### PR TITLE
Make `Style/RedundantArgument` aware of `Array#sum`

### DIFF
--- a/changelog/change_make_style_redundant_argument_aware_of_array_sum.md
+++ b/changelog/change_make_style_redundant_argument_aware_of_array_sum.md
@@ -1,0 +1,1 @@
+* [#11222](https://github.com/rubocop/rubocop/pull/11222): Make `Style/RedundantArgument` aware of `Array#sum`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4667,10 +4667,12 @@ Style/RedundantArgument:
   Enabled: pending
   Safe: false
   VersionAdded: '1.4'
-  VersionChanged: '1.7'
+  VersionChanged: '<<next>>'
   Methods:
     # Array#join
     join: ''
+    # Array#sum
+    sum: 0
     # String#split
     split: ' '
     # String#chomp

--- a/lib/rubocop/cop/style/redundant_argument.rb
+++ b/lib/rubocop/cop/style/redundant_argument.rb
@@ -13,6 +13,7 @@ module RuboCop
       # ----
       # Methods:
       #   join: ''
+      #   sum: 0
       #   split: ' '
       #   chomp: "\n"
       #   chomp!: "\n"
@@ -33,6 +34,7 @@ module RuboCop
       #   # bad
       #   array.join('')
       #   [1, 2, 3].join("")
+      #   array.sum(0)
       #   string.split(" ")
       #   "first\nsecond".split(" ")
       #   string.chomp("\n")
@@ -42,6 +44,7 @@ module RuboCop
       #   # good
       #   array.join
       #   [1, 2, 3].join
+      #   array.sum
       #   string.split
       #   "first second".split
       #   string.chomp

--- a/spec/rubocop/cop/style/redundant_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_argument_spec.rb
@@ -2,13 +2,15 @@
 
 RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
   let(:cop_config) do
-    { 'Methods' => { 'join' => '', 'split' => ' ', 'chomp' => "\n", 'chomp!' => "\n" } }
+    { 'Methods' => { 'join' => '', 'sum' => 0, 'split' => ' ', 'chomp' => "\n", 'chomp!' => "\n" } }
   end
 
   it 'registers an offense and corrects when method called on variable' do
     expect_offense(<<~'RUBY')
       foo.join('')
               ^^^^ Argument '' is redundant because it is implied by default.
+      foo.sum(0)
+             ^^^ Argument 0 is redundant because it is implied by default.
       foo.split(' ')
                ^^^^^ Argument ' ' is redundant because it is implied by default.
       foo.chomp("\n")
@@ -19,6 +21,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
 
     expect_correction(<<~RUBY)
       foo.join
+      foo.sum
       foo.split
       foo.chomp
       foo.chomp!
@@ -95,6 +98,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
   it 'does not register an offense when method called with different argument' do
     expect_no_offenses(<<~RUBY)
       foo.join(',')
+      foo.sum(42)
       foo.split(',')
     RUBY
   end


### PR DESCRIPTION
This PR makes `Style/RedundantArgument` aware of `Array#sum`.

For example, by omitting the initial value argument of `sum` it could be simply updated by `Style/SymbolProc`.

```ruby
# Before
items.sum(0) { |item| item.price }

# After
items.sum(&:price)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
