### PR TITLE
Add new `InternalAffairs/LambdaOrProc` cop

### DIFF
--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -6,6 +6,7 @@ require_relative 'internal_affairs/empty_line_between_expect_offense_and_correct
 require_relative 'internal_affairs/example_description'
 require_relative 'internal_affairs/example_heredoc_delimiter'
 require_relative 'internal_affairs/inherit_deprecated_cop_class'
+require_relative 'internal_affairs/lambda_or_proc'
 require_relative 'internal_affairs/location_line_equality_comparison'
 require_relative 'internal_affairs/method_name_end_with'
 require_relative 'internal_affairs/method_name_equal'

--- a/lib/rubocop/cop/internal_affairs/lambda_or_proc.rb
+++ b/lib/rubocop/cop/internal_affairs/lambda_or_proc.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # Enforces the use of `node.lambda_or_proc?` instead of `node.lambda? || node.proc?`.
+      #
+      # @example
+      #   # bad
+      #   node.lambda? || node.proc?
+      #   node.proc? || node.lambda?
+      #
+      #   # good
+      #   node.lambda_or_proc?
+      #
+      class LambdaOrProc < Base
+        extend AutoCorrector
+
+        MSG = 'Use `%<prefer>s`.'
+
+        # @!method lambda_or_proc(node)
+        def_node_matcher :lambda_or_proc, <<~PATTERN
+          {
+            (or $(send _node :lambda?) $(send _node :proc?))
+            (or $(send _node :proc?) $(send _node :lambda?))
+            (or
+              (or _ $(send _node :lambda?)) $(send _node :proc?))
+            (or
+              (or _ $(send _node :proc?)) $(send _node :lambda?))
+          }
+        PATTERN
+
+        def on_or(node)
+          return unless (lhs, rhs = lambda_or_proc(node))
+
+          offense = lhs.receiver.source_range.join(rhs.source_range.end)
+          prefer = "#{lhs.receiver.source}.lambda_or_proc?"
+
+          add_offense(offense, message: format(MSG, prefer: prefer)) do |corrector|
+            corrector.replace(offense, prefer)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -63,7 +63,7 @@ module RuboCop
           return unless node.arguments?
 
           return unless ambiguous_block_association?(node)
-          return if node.parenthesized? || node.last_argument.lambda? || node.last_argument.proc? ||
+          return if node.parenthesized? || node.last_argument.lambda_or_proc? ||
                     allowed_method_pattern?(node)
 
           message = message(node)

--- a/lib/rubocop/cop/lint/empty_block.rb
+++ b/lib/rubocop/cop/lint/empty_block.rb
@@ -65,7 +65,7 @@ module RuboCop
 
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return if node.body
-          return if allow_empty_lambdas? && lambda_or_proc?(node)
+          return if allow_empty_lambdas? && node.lambda_or_proc?
           return if cop_config['AllowComments'] && allow_comment?(node)
 
           add_offense(node)
@@ -87,10 +87,6 @@ module RuboCop
         def comment_disables_cop?(comment)
           regexp_pattern = "# rubocop : (disable|todo) ([^,],)* (all|#{cop_name})"
           Regexp.new(regexp_pattern.gsub(' ', '\s*')).match?(comment)
-        end
-
-        def lambda_or_proc?(node)
-          node.lambda? || node.proc?
         end
       end
     end

--- a/lib/rubocop/cop/style/nil_lambda.rb
+++ b/lib/rubocop/cop/style/nil_lambda.rb
@@ -44,7 +44,7 @@ module RuboCop
         PATTERN
 
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
-          return unless node.lambda? || node.proc?
+          return unless node.lambda_or_proc?
           return unless nil_return?(node.body)
 
           message = format(MSG, type: node.lambda? ? 'lambda' : 'proc')

--- a/spec/rubocop/cop/internal_affairs/lambda_or_proc_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/lambda_or_proc_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::InternalAffairs::LambdaOrProc, :config do
+  it 'registers an offense when using `node.lambda? || node.proc?`' do
+    expect_offense(<<~RUBY)
+      node.lambda? || node.proc?
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.lambda_or_proc?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node.lambda_or_proc?
+    RUBY
+  end
+
+  it 'registers an offense when using `node.proc? || node.lambda?`' do
+    expect_offense(<<~RUBY)
+      node.proc? || node.lambda?
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.lambda_or_proc?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node.lambda_or_proc?
+    RUBY
+  end
+
+  it 'registers an offense when using `node.parenthesized? || node.lambda? || node.proc?`' do
+    expect_offense(<<~RUBY)
+      node.parenthesized? || node.lambda? || node.proc?
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.lambda_or_proc?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node.parenthesized? || node.lambda_or_proc?
+    RUBY
+  end
+
+  it 'registers an offense when using `node.parenthesized? || node.proc? || node.lambda?`' do
+    expect_offense(<<~RUBY)
+      node.parenthesized? || node.proc? || node.lambda?
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.lambda_or_proc?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node.parenthesized? || node.lambda_or_proc?
+    RUBY
+  end
+
+  it 'does not register an offense when using `node.lambda_or_proc?`' do
+    expect_no_offenses(<<~RUBY)
+      node.lambda_or_proc?
+    RUBY
+  end
+
+  it 'does not register an offense when LHS and RHS have different receivers' do
+    expect_no_offenses(<<~RUBY)
+      node1.lambda? || node2.proc?
+    RUBY
+  end
+end


### PR DESCRIPTION
Enforces the use of `node.lambda_or_proc?` instead of `node.lambda? || node.proc?`.

```ruby
# bad
node.lambda? || node.proc?
node.proc? || node.lambda?

# good
node.lambda_or_proc?
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
