### PR TITLE
Make `Lint/Void` aware of used lambda and proc

### DIFF
--- a/changelog/change_make_lint_void_aware_of_lambda_and_proc.md
+++ b/changelog/change_make_lint_void_aware_of_lambda_and_proc.md
@@ -1,0 +1,1 @@
+* [#11226](https://github.com/rubocop/rubocop/pull/11226): Make `Lint/Void` aware of used lambda and proc in void context. ([@koic][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Checks for operators, variables, literals, and nonmutating
+      # Checks for operators, variables, literals, lambda, proc and nonmutating
       # methods used in void context.
       #
       # @example CheckForMethodsWithNoSideEffects: false (default)
@@ -45,7 +45,7 @@ module RuboCop
         VAR_MSG = 'Variable `%<var>s` used in void context.'
         LIT_MSG = 'Literal `%<lit>s` used in void context.'
         SELF_MSG = '`self` used in void context.'
-        DEFINED_MSG = '`%<defined>s` used in void context.'
+        EXPRESSION_MSG = '`%<expression>s` used in void context.'
         NONMUTATING_MSG = 'Method `#%<method>s` used in void context. Did you mean `#%<method>s!`?'
 
         BINARY_OPERATORS = %i[* / % + - == === != < > <= >= <=>].freeze
@@ -87,7 +87,7 @@ module RuboCop
           check_literal(expr)
           check_var(expr)
           check_self(expr)
-          check_defined(expr)
+          check_void_expression(expr)
           return unless cop_config['CheckForMethodsWithNoSideEffects']
 
           check_nonmutating(expr)
@@ -117,10 +117,10 @@ module RuboCop
           add_offense(node, message: SELF_MSG)
         end
 
-        def check_defined(node)
-          return unless node.defined_type?
+        def check_void_expression(node)
+          return unless node.defined_type? || node.lambda_or_proc?
 
-          add_offense(node, message: format(DEFINED_MSG, defined: node.source))
+          add_offense(node, message: format(EXPRESSION_MSG, expression: node.source))
         end
 
         def check_nonmutating(node)

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -101,6 +101,118 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     RUBY
   end
 
+  it 'registers an offense for void `-> { bar }` if not on last line' do
+    expect_offense(<<~RUBY)
+      def foo
+        -> { bar }
+        ^^^^^^^^^^ `-> { bar }` used in void context.
+        top
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for void `-> { bar }` if on last line' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        top
+        -> { bar }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for void `-> { bar }.call` if not on last line' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        -> { bar }.call
+        top
+      end
+    RUBY
+  end
+
+  it 'registers an offense for void `lambda { bar }` if not on last line' do
+    expect_offense(<<~RUBY)
+      def foo
+        lambda { bar }
+        ^^^^^^^^^^^^^^ `lambda { bar }` used in void context.
+        top
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for void `lambda { bar }` if on last line' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        top
+        lambda { bar }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for void `lambda { bar }.call` if not on last line' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        lambda { bar }.call
+        top
+      end
+    RUBY
+  end
+
+  it 'registers an offense for void `proc { bar }` if not on last line' do
+    expect_offense(<<~RUBY)
+      def foo
+        proc { bar }
+        ^^^^^^^^^^^^ `proc { bar }` used in void context.
+        top
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for void `proc { bar }` if on last line' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        top
+        proc { bar }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for void `proc { bar }.call` if not on last line' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        proc { bar }.call
+        top
+      end
+    RUBY
+  end
+
+  it 'registers an offense for void `Proc.new { bar }` if not on last line' do
+    expect_offense(<<~RUBY)
+      def foo
+        Proc.new { bar }
+        ^^^^^^^^^^^^^^^^ `Proc.new { bar }` used in void context.
+        top
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for void `Proc.new { bar }` if on last line' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        top
+        Proc.new { bar }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for void `Proc.new { bar }.call` if not on last line' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        Proc.new { bar }.call
+        top
+      end
+    RUBY
+  end
+
   context 'when checking for methods with no side effects' do
     let(:config) do
       RuboCop::Config.new('Lint/Void' => { 'CheckForMethodsWithNoSideEffects' => true })


### PR DESCRIPTION
This PR makes `Lint/Void` aware of used lambda and proc in void context. e.g.:

```ruby
def foo
  -> { bar }
  lambda { bar }
  proc { bar }
  Proc.new { bar }

  top
end
```

These blocks of lambdas and procs are never called.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
