### PR TITLE
Handle ternaries in `Style/SafeNavigation`

### DIFF
--- a/changelog/change_safe_navigation_to_handle_ternaries.md
+++ b/changelog/change_safe_navigation_to_handle_ternaries.md
@@ -1,0 +1,1 @@
+* [#11116](https://github.com/rubocop/rubocop/issues/11116): Handle ternaries in `Style/SafeNavigation`. ([@fatkodima][])

--- a/lib/rubocop/cop/style/redundant_sort.rb
+++ b/lib/rubocop/cop/style/redundant_sort.rb
@@ -184,7 +184,7 @@ module RuboCop
         end
 
         def arg_value(node)
-          arg_node(node).nil? ? nil : arg_node(node).node_parts.first
+          arg_node(node)&.node_parts&.first
         end
 
         # This gets the start of the accessor whether it has a dot

--- a/lib/rubocop/cop/variable_force/assignment.rb
+++ b/lib/rubocop/cop/variable_force/assignment.rb
@@ -83,7 +83,7 @@ module RuboCop
         end
 
         def multiple_assignment_node
-          grandparent_node = node.parent ? node.parent.parent : nil
+          grandparent_node = node.parent&.parent
           return nil unless grandparent_node
           return nil unless grandparent_node.type == MULTIPLE_ASSIGNMENT_TYPE
           return nil unless node.parent.type == MULTIPLE_LEFT_HAND_SIDE_TYPE

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -743,9 +743,35 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
       end
 
       context 'ternary expression' do
-        it 'allows ternary expression' do
+        it 'allows non-convertible ternary expression' do
           expect_no_offenses(<<~RUBY)
             !#{variable}.nil? ? #{variable}.bar : something
+          RUBY
+        end
+
+        it 'registers an offense for convertible ternary expressions' do
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} ? %{variable}.bar : nil
+            ^{variable}^^^^{variable}^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+
+            %{variable}.nil? ? nil : %{variable}.bar
+            ^{variable}^^^^^^^^^^^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+
+            !%{variable}.nil? ? %{variable}.bar : nil
+            ^^{variable}^^^^^^^^^^{variable}^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+
+            !%{variable} ? nil : %{variable}.bar
+            ^^{variable}^^^^^^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{variable}&.bar
+
+            #{variable}&.bar
+
+            #{variable}&.bar
+
+            #{variable}&.bar
           RUBY
         end
       end


### PR DESCRIPTION
Closes #11116.

It handles new ternary cases like:
```ruby
x ? x.foo : nil

x.nil? ? nil : x.foo

!x.nil? ? x.foo : nil

!x ? nil : x.foo
```