### PR TITLE
Add ability to count method arguments as one line to code length related `Metric` cops

### DIFF
--- a/changelog/change_count_as_one_accepts_arguments.md
+++ b/changelog/change_count_as_one_accepts_arguments.md
@@ -1,0 +1,1 @@
+* [#11070](https://github.com/rubocop/rubocop/issues/11070): Add ability to count method calls as one line to code length related `Metric` cops. ([@fatkodima][])

--- a/lib/rubocop/cop/metrics/block_length.rb
+++ b/lib/rubocop/cop/metrics/block_length.rb
@@ -8,8 +8,8 @@ module RuboCop
       # The maximum allowed length is configurable.
       # The cop can be configured to ignore blocks passed to certain methods.
       #
-      # You can set literals you want to fold with `CountAsOne`.
-      # Available are: 'array', 'hash', and 'heredoc'. Each literal
+      # You can set constructs you want to fold with `CountAsOne`.
+      # Available are: 'array', 'hash', 'heredoc', and 'method_call'. Each construct
       # will be counted as one line regardless of its actual size.
       #
       #
@@ -17,7 +17,7 @@ module RuboCop
       # for backwards compatibility. Please use `AllowedMethods` and `AllowedPatterns`
       # instead. By default, there are no methods to allowed.
       #
-      # @example CountAsOne: ['array', 'heredoc']
+      # @example CountAsOne: ['array', 'heredoc', 'method_call']
       #
       #   something do
       #     array = [         # +1
@@ -33,7 +33,12 @@ module RuboCop
       #       Heredoc
       #       content.
       #     HEREDOC
-      #   end                 # 5 points
+      #
+      #     foo(              # +1
+      #       1,
+      #       2
+      #     )
+      #   end                 # 6 points
       #
       # NOTE: This cop does not apply for `Struct` definitions.
       class BlockLength < Base

--- a/lib/rubocop/cop/metrics/class_length.rb
+++ b/lib/rubocop/cop/metrics/class_length.rb
@@ -7,11 +7,11 @@ module RuboCop
       # Comment lines can optionally be ignored.
       # The maximum allowed length is configurable.
       #
-      # You can set literals you want to fold with `CountAsOne`.
-      # Available are: 'array', 'hash', and 'heredoc'. Each literal
+      # You can set constructs you want to fold with `CountAsOne`.
+      # Available are: 'array', 'hash', 'heredoc', and 'method_call'. Each construct
       # will be counted as one line regardless of its actual size.
       #
-      # @example CountAsOne: ['array', 'heredoc']
+      # @example CountAsOne: ['array', 'heredoc', 'method_call']
       #
       #   class Foo
       #     ARRAY = [         # +1
@@ -27,7 +27,12 @@ module RuboCop
       #       Heredoc
       #       content.
       #     HEREDOC
-      #   end                 # 5 points
+      #
+      #     foo(              # +1
+      #       1,
+      #       2
+      #     )
+      #   end                 # 6 points
       #
       #
       # NOTE: This cop also applies for `Struct` definitions.

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -7,8 +7,8 @@ module RuboCop
       # Comment lines can optionally be allowed.
       # The maximum allowed length is configurable.
       #
-      # You can set literals you want to fold with `CountAsOne`.
-      # Available are: 'array', 'hash', and 'heredoc'. Each literal
+      # You can set constructs you want to fold with `CountAsOne`.
+      # Available are: 'array', 'hash', 'heredoc', and 'method_call'. Each construct
       # will be counted as one line regardless of its actual size.
       #
       # NOTE: The `ExcludedMethods` and `IgnoredMethods` configuration is
@@ -16,7 +16,7 @@ module RuboCop
       # Please use `AllowedMethods` and `AllowedPatterns` instead.
       # By default, there are no methods to allowed.
       #
-      # @example CountAsOne: ['array', 'heredoc']
+      # @example CountAsOne: ['array', 'heredoc', 'method_call']
       #
       #   def m
       #     array = [       # +1
@@ -32,7 +32,12 @@ module RuboCop
       #       Heredoc
       #       content.
       #     HEREDOC
-      #   end               # 5 points
+      #
+      #     foo(            # +1
+      #       1,
+      #       2
+      #     )
+      #   end               # 6 points
       #
       class MethodLength < Base
         include CodeLength

--- a/lib/rubocop/cop/metrics/module_length.rb
+++ b/lib/rubocop/cop/metrics/module_length.rb
@@ -7,11 +7,11 @@ module RuboCop
       # Comment lines can optionally be ignored.
       # The maximum allowed length is configurable.
       #
-      # You can set literals you want to fold with `CountAsOne`.
-      # Available are: 'array', 'hash', and 'heredoc'. Each literal
+      # You can set constructs you want to fold with `CountAsOne`.
+      # Available are: 'array', 'hash', 'heredoc', and 'method_call'. Each construct
       # will be counted as one line regardless of its actual size.
       #
-      # @example CountAsOne: ['array', 'heredoc']
+      # @example CountAsOne: ['array', 'heredoc', 'method_call']
       #
       #   module M
       #     ARRAY = [         # +1
@@ -27,7 +27,12 @@ module RuboCop
       #       Heredoc
       #       content.
       #     HEREDOC
-      #   end                 # 5 points
+      #
+      #     foo(              # +1
+      #       1,
+      #       2
+      #     )
+      #   end                 # 6 points
       #
       class ModuleLength < Base
         include CodeLength

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -9,7 +9,7 @@ module RuboCop
           extend NodePattern::Macros
           include Util
 
-          FOLDABLE_TYPES = %i[array hash heredoc].freeze
+          FOLDABLE_TYPES = %i[array hash heredoc send csend].freeze
           CLASSLIKE_TYPES = %i[class module].freeze
           private_constant :FOLDABLE_TYPES, :CLASSLIKE_TYPES
 
@@ -39,7 +39,7 @@ module RuboCop
 
           private
 
-          def build_foldable_checks(types)
+          def build_foldable_checks(types) # rubocop:disable Metrics/MethodLength
             types.map do |type|
               case type
               when :array
@@ -48,6 +48,8 @@ module RuboCop
                 ->(node) { node.hash_type? }
               when :heredoc
                 ->(node) { heredoc_node?(node) }
+              when :method_call
+                ->(node) { node.call_type? }
               else
                 raise ArgumentError, "Unknown foldable type: #{type.inspect}. " \
                                      "Valid foldable types are: #{FOLDABLE_TYPES.join(', ')}."
@@ -57,6 +59,7 @@ module RuboCop
 
           def normalize_foldable_types(types)
             types.concat(%i[str dstr]) if types.delete(:heredoc)
+            types.concat(%i[send csend]) if types.delete(:method_call)
             types
           end
 

--- a/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
@@ -269,6 +269,27 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::CodeLengthCalculator do
         length = described_class.new(source.ast, source, foldable_types: %i[heredoc]).calculate
         expect(length).to eq(3)
       end
+
+      it 'folds method calls if asked' do
+        source = parse_source(<<~RUBY)
+          def test
+            a = 1
+            foo(
+              1,
+              2,
+              3
+            )
+            obj&.foo(
+              1,
+              2
+            )
+            foo(1)
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, foldable_types: %i[method_call]).calculate
+        expect(length).to eq(4)
+      end
     end
 
     context 'when class' do


### PR DESCRIPTION
Closes #11070.

With the
```yaml
# .rubocop.yml
Metric/MethodLength:
  CountAsOne: ['arguments']
```

the following will be counted as 1 line:
```ruby
foo(
  1,
  2
)
```