### PR TITLE
Add `cc` to `AllowedNames` of `MethodParameterName` cop

### DIFF
--- a/changelog/change_add_cc_to_allowednames_of_methodparametername.md
+++ b/changelog/change_add_cc_to_allowednames_of_methodparametername.md
@@ -1,0 +1,1 @@
+* [#11229](https://github.com/rubocop/rubocop/pull/11229): Add `cc` to `AllowedNames` of `MethodParameterName` cop. ([@tjschuck][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2826,6 +2826,7 @@ Naming/MethodParameterName:
     - as
     - at
     - by
+    - cc
     - db
     - id
     - if

--- a/docs/modules/ROOT/pages/cops_naming.adoc
+++ b/docs/modules/ROOT/pages/cops_naming.adoc
@@ -1055,7 +1055,7 @@ end
 | Boolean
 
 | AllowedNames
-| `as`, `at`, `by`, `db`, `id`, `if`, `in`, `io`, `ip`, `of`, `on`, `os`, `pp`, `to`
+| `as`, `at`, `by`, `cc`, `db`, `id`, `if`, `in`, `io`, `ip`, `of`, `on`, `os`, `pp`, `to`
 | Array
 
 | ForbiddenNames


### PR DESCRIPTION
`cc` is a common method parameter for email-related methods, e.g.:

```ruby
def invitation_email(to:, cc:, subject:)
  # ...
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
