### PR TITLE
[Fix #11230] Fix an incorrect autocorrect for `Lint/SafeNavigationChain`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_safe_navigation_chain.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_safe_navigation_chain.md
@@ -1,0 +1,1 @@
+* [#11230](https://github.com/rubocop/rubocop/issues/11230): Fix an incorrect autocorrect for `Lint/SafeNavigationChain` when using safe navigation with `[]` operator followed by method chain. ([@koic][])

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -178,6 +178,17 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
       RUBY
     end
 
+    it 'registers an offense for safe navigation with [] operator followed by method chain' do
+      expect_offense(<<~RUBY)
+        x&.foo[bar].to_s
+              ^^^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.foo&.[](bar).to_s
+      RUBY
+    end
+
     it 'registers an offense for safe navigation with []= operator' do
       expect_offense(<<~RUBY)
         x&.foo[bar] = baz


### PR DESCRIPTION
Fixes #11230.

This PR fixes an incorrect autocorrect for `Lint/SafeNavigationChain` when using safe navigation with `[]` operator followed method chain.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
