### PR TITLE
Support redundant department disable in scope of `RedundantCopDisable`

### DIFF
--- a/changelog/fix_redundant_department_disable.md
+++ b/changelog/fix_redundant_department_disable.md
@@ -1,0 +1,1 @@
+* [#11213](https://github.com/rubocop/rubocop/pull/11213): Support redundant department disable in scope of `Lint/RedundantCopDisableDirective` cop. ([@isarcasm][])

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -138,14 +138,21 @@ module RuboCop
             next unless followed_ranges?(previous_range, range)
 
             comment = processed_source.comment_at_line(range.begin)
-            # Disabling department can not be redundant
-            next if department_disabled?(cop, comment)
+
+            next unless comment
             # Comments disabling all cops don't count since it's reasonable
             # to disable a few select cops first and then all cops further
             # down in the code.
             next if all_disabled?(comment)
 
-            yield comment, cop if comment
+            redundant =
+              if department_disabled?(cop, comment)
+                find_redundant_department(cop, range)
+              else
+                cop
+              end
+
+            yield comment, redundant
           end
         end
 

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -182,8 +182,12 @@ module RuboCop
         cops.map(&:cop_name)
       end
 
+      def cops_for_department(department)
+        cops.select { |cop| cop.department == department.to_sym }
+      end
+
       def names_for_department(department)
-        cops.select { |cop| cop.department == department.to_sym }.map(&:cop_name)
+        cops_for_department(department).map(&:cop_name)
       end
 
       def ==(other)
@@ -209,6 +213,14 @@ module RuboCop
       # @return [Class, nil]
       def find_by_cop_name(cop_name)
         to_h[cop_name].first
+      end
+
+      # When a cop name is given returns a single-element array with the cop class.
+      # When a department name is given returns an array with all the cop classes
+      # for that department.
+      def find_cops_by_directive(directive)
+        cop = find_by_cop_name(directive)
+        cop ? [cop] : cops_for_department(directive)
       end
 
       def freeze

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -44,7 +44,10 @@ module CopHelper
 
   def registry
     @registry ||= begin
-      cops = configuration.keys.map { |cop| RuboCop::Cop::Registry.global.find_by_cop_name(cop) }
+      keys = configuration.keys
+      cops =
+        keys.map { |directive| RuboCop::Cop::Registry.global.find_cops_by_directive(directive) }
+            .flatten
       cops << cop_class if defined?(cop_class) && !cops.include?(cop_class)
       cops.compact!
       RuboCop::Cop::Registry.new(cops)


### PR DESCRIPTION
Fixes #11213 

The `Registry#disabled?` was not including cops disabled via department config like `Metrics => {'Enabled' => false}` this is why I added a new `Registry#find_cops_by_directive` which also finds cops for given department config (`#find_by_cop_name` ignores it since a department is not a cop).


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
