### PR TITLE
Add `Style/RequireOrder` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -187,3 +187,6 @@ InternalAffairs/NumblockHandler:
 
 Gemspec/DependencyVersion:
   Enabled: true
+
+Style/RequireOrder:
+  Enabled: true

--- a/changelog/new_add_stylerequireorder_cop.md
+++ b/changelog/new_add_stylerequireorder_cop.md
@@ -1,0 +1,1 @@
+* [#11224](https://github.com/rubocop/rubocop/pull/11224): Add `Style/RequireOrder` cop. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4861,6 +4861,12 @@ Style/RegexpLiteral:
   # are found in the regexp string.
   AllowInnerSlashes: false
 
+Style/RequireOrder:
+  Description: Sort `require` and `require_relative` in alphabetical order.
+  Enabled: false
+  SafeAutoCorrect: false
+  VersionAdded: '<<next>>'
+
 Style/RescueModifier:
   Description: 'Avoid using rescue in its modifier form.'
   StyleGuide: '#no-rescue-modifiers'

--- a/exe/rubocop
+++ b/exe/rubocop
@@ -11,8 +11,8 @@ exit exit_status if server_cli.exit?
 if RuboCop::Server.running?
   exit_status = RuboCop::Server::ClientCommand::Exec.new.run
 else
-  require 'rubocop'
   require 'benchmark'
+  require 'rubocop'
 
   cli = RuboCop::CLI.new
 

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -4,9 +4,9 @@ require 'English'
 before_us = $LOADED_FEATURES.dup
 require 'rainbow'
 
-require 'set'
 require 'forwardable'
 require 'regexp_parser'
+require 'set'
 require 'unicode/display_width'
 
 # we have to require RuboCop's version, before rubocop-ast's
@@ -14,21 +14,23 @@ require_relative 'rubocop/version'
 require 'rubocop-ast'
 
 require_relative 'rubocop/ast_aliases'
+require_relative 'rubocop/ext/range'
 require_relative 'rubocop/ext/regexp_node'
 require_relative 'rubocop/ext/regexp_parser'
-require_relative 'rubocop/ext/range'
 
 require_relative 'rubocop/core_ext/string'
 require_relative 'rubocop/ext/processed_source'
 
-require_relative 'rubocop/path_util'
-require_relative 'rubocop/file_finder'
-require_relative 'rubocop/platform'
-require_relative 'rubocop/name_similarity'
-require_relative 'rubocop/string_interpreter'
 require_relative 'rubocop/error'
-require_relative 'rubocop/warning'
+require_relative 'rubocop/file_finder'
+require_relative 'rubocop/name_similarity'
+require_relative 'rubocop/path_util'
+require_relative 'rubocop/platform'
+require_relative 'rubocop/string_interpreter'
 require_relative 'rubocop/util'
+require_relative 'rubocop/warning'
+
+# rubocop:disable Style/RequireOrder
 
 require_relative 'rubocop/cop/util'
 require_relative 'rubocop/cop/offense'
@@ -546,6 +548,7 @@ require_relative 'rubocop/cop/style/redundant_file_extension_in_require'
 require_relative 'rubocop/cop/style/redundant_initialize'
 require_relative 'rubocop/cop/style/redundant_self_assignment'
 require_relative 'rubocop/cop/style/redundant_self_assignment_branch'
+require_relative 'rubocop/cop/style/require_order'
 require_relative 'rubocop/cop/style/sole_nested_conditional'
 require_relative 'rubocop/cop/style/static_class'
 require_relative 'rubocop/cop/style/map_compact_with_conditional_block'
@@ -719,6 +722,8 @@ require_relative 'rubocop/options'
 require_relative 'rubocop/remote_config'
 require_relative 'rubocop/target_ruby'
 require_relative 'rubocop/yaml_duplication_checker'
+
+# rubocop:enable Style/RequireOrder
 
 unless File.exist?("#{__dir__}/../rubocop.gemspec") # Check if we are a gem
   RuboCop::ResultCache.rubocop_required_features = $LOADED_FEATURES - before_us

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require 'erb'
-require 'yaml'
 require 'pathname'
+require 'yaml'
 require_relative 'config_finder'
 
 module RuboCop

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'yaml'
 require 'pathname'
+require 'yaml'
 
 module RuboCop
   # A help class for ConfigLoader that handles configuration resolution.

--- a/lib/rubocop/cop/style/require_order.rb
+++ b/lib/rubocop/cop/style/require_order.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Style
+      # Sort `require` and `require_relative` in alphabetical order.
+      #
+      # @safety
+      #   This cop's autocorrection is unsafe because it will obviously change the execution order.
+      #
+      # @example
+      #   # bad
+      #   require 'b'
+      #   require 'a'
+      #
+      #   # good
+      #   require 'a'
+      #   require 'b'
+      #
+      #   # bad
+      #   require_relative 'b'
+      #   require_relative 'a'
+      #
+      #   # good
+      #   require_relative 'a'
+      #   require_relative 'b'
+      #
+      #   # good (sorted within each section separated by a blank line)
+      #   require 'a'
+      #   require 'd'
+      #
+      #   require 'b'
+      #   require 'c'
+      #
+      #   # good
+      #   require 'b'
+      #   require_relative 'c'
+      #   require 'a'
+      class RequireOrder < Base
+        extend AutoCorrector
+
+        include RangeHelp
+
+        RESTRICT_ON_SEND = %i[require require_relative].freeze
+
+        def on_send(node)
+          previous_older_sibling = find_previous_older_sibling(node)
+          return unless previous_older_sibling
+
+          add_offense(
+            node,
+            message: "Sort `#{node.method_name}` in alphabetical order."
+          ) do |corrector|
+            swap(
+              range_with_comments_and_lines(previous_older_sibling),
+              range_with_comments_and_lines(node),
+              corrector: corrector
+            )
+          end
+        end
+
+        private
+
+        def find_previous_older_sibling(node)
+          node.left_siblings.reverse.find do |sibling|
+            break unless sibling.send_type?
+            break unless sibling.method?(node.method_name)
+            break unless in_same_section?(sibling, node)
+
+            node.first_argument.source < sibling.first_argument.source
+          end
+        end
+
+        def in_same_section?(node1, node2)
+          !node1.location.expression.with(
+            end_pos: node2.location.expression.end_pos
+          ).source.include?("\n\n")
+        end
+
+        def swap(range1, range2, corrector:)
+          inserted = range2.source
+          corrector.insert_before(range1, inserted)
+          corrector.remove(range2)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/formatter.rb
+++ b/lib/rubocop/formatter.rb
@@ -6,6 +6,7 @@ module RuboCop
 
     require_relative 'formatter/base_formatter'
     require_relative 'formatter/simple_text_formatter'
+
     # relies on simple text
     require_relative 'formatter/clang_style_formatter'
     require_relative 'formatter/disabled_config_formatter'
@@ -18,11 +19,12 @@ module RuboCop
     require_relative 'formatter/junit_formatter'
     require_relative 'formatter/markdown_formatter'
     require_relative 'formatter/offense_count_formatter'
+    require_relative 'formatter/pacman_formatter'
     require_relative 'formatter/progress_formatter'
     require_relative 'formatter/quiet_formatter'
     require_relative 'formatter/tap_formatter'
     require_relative 'formatter/worst_offenders_formatter'
-    require_relative 'formatter/pacman_formatter'
+
     # relies on progress formatter
     require_relative 'formatter/auto_gen_config_formatter'
 

--- a/lib/rubocop/formatter/html_formatter.rb
+++ b/lib/rubocop/formatter/html_formatter.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
+require 'base64'
 require 'cgi'
 require 'erb'
 require 'ostruct'
-require 'base64'
 
 module RuboCop
   module Formatter

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require 'digest/sha1'
-require 'find'
 require 'etc'
+require 'find'
 require 'zlib'
 require_relative 'cache_config'
 

--- a/lib/rubocop/rspec/support.rb
+++ b/lib/rubocop/rspec/support.rb
@@ -3,10 +3,10 @@
 # Require this file to load code that supports testing using RSpec.
 
 require_relative 'cop_helper'
-require_relative 'host_environment_simulation_helper'
-require_relative 'shared_contexts'
 require_relative 'expect_offense'
+require_relative 'host_environment_simulation_helper'
 require_relative 'parallel_formatter'
+require_relative 'shared_contexts'
 
 RSpec.configure do |config|
   config.include CopHelper

--- a/lib/rubocop/server/core.rb
+++ b/lib/rubocop/server/core.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'socket'
 require 'securerandom'
+require 'socket'
 
 #
 # This code is based on https://github.com/fohte/rubocop-daemon.

--- a/spec/rubocop/cop/style/require_order_spec.rb
+++ b/spec/rubocop/cop/style/require_order_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Style::RequireOrder, :config do
+  context 'when `require` is sorted' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        require 'a'
+        require 'b'
+      RUBY
+    end
+  end
+
+  context 'when `require` is not sorted in different sections' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        require 'b'
+        require 'd'
+
+        require 'a'
+        require 'c'
+      RUBY
+    end
+  end
+
+  context 'when `require` is not sorted' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        require 'b'
+        require 'a'
+        ^^^^^^^^^^^ Sort `require` in alphabetical order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require 'a'
+        require 'b'
+      RUBY
+    end
+  end
+
+  context 'when unsorted `require` has some inline comments' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        require 'b' # comment
+        require 'a'
+        ^^^^^^^^^^^ Sort `require` in alphabetical order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require 'a'
+        require 'b' # comment
+      RUBY
+    end
+  end
+
+  context 'when unsorted `require` has some full-line comments' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        require 'b'
+        # comment
+        require 'a'
+        ^^^^^^^^^^^ Sort `require` in alphabetical order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # comment
+        require 'a'
+        require 'b'
+      RUBY
+    end
+  end
+
+  context 'when `require_relative` is not sorted' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        require_relative 'b'
+        require_relative 'a'
+        ^^^^^^^^^^^^^^^^^^^^ Sort `require_relative` in alphabetical order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require_relative 'a'
+        require_relative 'b'
+      RUBY
+    end
+  end
+
+  context 'when both `require` and `require_relative` are in same section' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        require 'b'
+        require_relative 'a'
+      RUBY
+    end
+  end
+
+  context 'when `require_relative` is put between unsorted `require`' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        require 'c'
+        require_relative 'b'
+        require 'a'
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'support/file_helper'
 require 'rubocop/rake_task'
+require 'support/file_helper'
 
 RSpec.describe RuboCop::RakeTask do
   include FileHelper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,8 @@ require 'rainbow'
 Rainbow.enabled = false
 
 require 'rubocop'
-require 'rubocop/server'
 require 'rubocop/cop/internal_affairs'
+require 'rubocop/server'
 
 require 'webmock/rspec'
 

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'yard'
 require 'rubocop'
 require 'rubocop/cops_documentation_generator'
+require 'yard'
 
 YARD::Rake::YardocTask.new(:yard_for_generate_documentation) do |task|
   task.files = ['lib/rubocop/cop/*/*.rb']


### PR DESCRIPTION
Many projects have `require` and `require_relative` in alphabetical order by convention, the rubocop gem itself being one example. I thought it would be good to have a cop to provide such consistency.

As a good example, rubocop-rspec inspects this with tests. Such checks are replaced by this cop.

- https://github.com/rubocop/rubocop-rspec/blob/v2.15.0/spec/project/project_requires_spec.rb

Like `Bundler/OrderedGems`, code separated by a blank line is considered a different group, so if there are obvious dependencies but you really don't want to write `require_relative` in each file, it is better to separate the groups. lib/rubocop/formatter.rb is a good example of that.

- https://github.com/rubocop/rubocop/blob/v1.39.0/lib/rubocop/formatter.rb#L9-L27

Unfortunately, the dependencies written in lib/rubocop.rb are too complex, so I gave up on organizing this at the time of introducing this cop and decided to ignore it from this cop. Personally, if one file A depends on another file B, I prefer to indicate that fact by writing `require_relative` in file A, but I don't think that is the practice in the rubocop gem, so I don't want to go into this issue here.

Since this cop enforces the rule "always sort them in alphabetical order within a group", I don't think false-positive will occur, but applying autocorrection obviously changes the behavior from the original code, so I have set `SafeAutoCorrect: false`.

Ideally, I believe it is a good manner that the code to always be written in such a way that it does not depend on the order of `require`, but I set `Enabled: false` because this cop has a large impact and may or may not be acceptable depending on the preference of the project. I think this cop is rather opinionated, so I would be glad to get your opinion on the policy.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
