### PR TITLE
Remove `respond_to` from default value of `AllowedMethods` for `Style/SymbolProc`

### DIFF
--- a/changelog/change_remove_respond_to_from_allowed_methods_of_style_symbol_proc.md
+++ b/changelog/change_remove_respond_to_from_allowed_methods_of_style_symbol_proc.md
@@ -1,0 +1,1 @@
+* [#11236](https://github.com/rubocop/rubocop/pull/11236): Remove `respond_to` from default value of `AllowedMethods` for `Style/SymbolProc`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5150,12 +5150,11 @@ Style/SymbolProc:
   Enabled: true
   Safe: false
   VersionAdded: '0.26'
-  VersionChanged: '1.28'
+  VersionChanged: '<<next>>'
   AllowMethodsWithArguments: false
   # A list of method names to be always allowed by the check.
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
   AllowedMethods:
-    - respond_to
     - define_method
   AllowedPatterns: []
   IgnoredMethods: [] # deprecated

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -7,7 +7,7 @@ module RuboCop
       #
       # If you prefer a style that allows block for method with arguments,
       # please set `true` to `AllowMethodsWithArguments`.
-      # respond_to , and `define_method?` methods are allowed by default.
+      # `define_method?` methods are allowed by default.
       # These are customizable with `AllowedMethods` option.
       #
       # @safety
@@ -72,11 +72,9 @@ module RuboCop
       #     # some comment
       #   end
       #
-      # @example AllowedMethods: [respond_to, define_method] (default)
+      # @example AllowedMethods: [define_method] (default)
       #   # good
-      #   respond_to { |foo| foo.bar }
       #   define_method(:foo) { |foo| foo.bar }
-      #
       #
       # @example AllowedPatterns: [] (default)
       #   # bad


### PR DESCRIPTION
The commit below adds `respond_to` to the config, which looks like a Rails method:
https://github.com/rubocop/rubocop/commit/54ff86ec93c270a267eb65879f7f7ab73cc02fb9

Ruby has method called `respond_to?`, not `respond_to`. So `respond_to` is a Rails API and `respond_to?` doesn't take a block argument.

RuboCop core does not depend on Rails, so move the `respond_to` config from RuboCop core to RuboCop Rails.

I noticed this by https://github.com/rubocop/rubocop-rails/issues/779.

This removed setting was added in RuboCop Rails 2.17. Rails application developers can get this change in the upgrade.
https://github.com/rubocop/rubocop-rails/pull/806

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
