### PR TITLE
Optimize rubocop

### DIFF
--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -31,6 +31,7 @@ module RuboCop
 
     def initialize(processed_source)
       @processed_source = processed_source
+      @no_directives = !processed_source.raw_source.include?('rubocop')
     end
 
     def cop_enabled_at_line?(cop, line_number)
@@ -74,6 +75,8 @@ module RuboCop
     end
 
     def analyze # rubocop:todo Metrics/AbcSize
+      return {} if @no_directives
+
       analyses = Hash.new { |hash, key| hash[key] = CopAnalysis.new([], nil) }
       inject_disabled_cops_directives(analyses)
 
@@ -146,6 +149,8 @@ module RuboCop
     end
 
     def each_directive
+      return if @no_directives
+
       processed_source.comments.each do |comment|
         directive = DirectiveComment.new(comment)
         yield directive if directive.cop_names

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -24,10 +24,11 @@ module RuboCop
     def initialize(hash = {}, loaded_path = nil)
       @loaded_path = loaded_path
       @for_cop = Hash.new do |h, cop|
-        qualified_cop_name = Cop::Registry.qualified_cop_name(cop, loaded_path)
+        cop_name = cop.respond_to?(:cop_name) ? cop.cop_name : cop
+        qualified_cop_name = Cop::Registry.qualified_cop_name(cop_name, loaded_path)
         cop_options = self[qualified_cop_name].dup || {}
         cop_options['Enabled'] = enable_cop?(qualified_cop_name, cop_options)
-        h[cop] = cop_options
+        h[cop] = h[cop_name] = cop_options
       end
       @hash = hash
       @validator = ConfigValidator.new(self)
@@ -116,7 +117,7 @@ module RuboCop
     # Note: the 'Enabled' attribute is calculated according to the department's
     # and 'AllCops' configuration; other attributes are not inherited.
     def for_cop(cop)
-      @for_cop[cop.respond_to?(:cop_name) ? cop.cop_name : cop]
+      @for_cop[cop]
     end
 
     # @return [Config] for the given cop merged with that of its department (if any)

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -158,7 +158,7 @@ module RuboCop
       end
 
       def enabled?(cop, config)
-        return true if options.fetch(:only, []).include?(cop.cop_name)
+        return true if options[:only]&.include?(cop.cop_name)
 
         cfg = config.for_cop(cop)
 

--- a/lib/rubocop/cop/style/string_literals.rb
+++ b/lib/rubocop/cop/style/string_literals.rb
@@ -95,11 +95,7 @@ module RuboCop
         end
 
         def offense?(node)
-          # If it's a string within an interpolation, then it's not an offense
-          # for this cop.
-          return false if inside_interpolation?(node)
-
-          wrong_quotes?(node)
+          wrong_quotes?(node) && !inside_interpolation?(node)
         end
 
         def consistent_multiline?

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -108,34 +108,26 @@ module RuboCop
         :skip_children
       end
 
-      # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+      # rubocop:disable Layout/ClassStructure
+      NODE_HANDLER_METHOD_NAMES = [
+        [VARIABLE_ASSIGNMENT_TYPE, :process_variable_assignment],
+        [REGEXP_NAMED_CAPTURE_TYPE, :process_regexp_named_captures],
+        [MULTIPLE_ASSIGNMENT_TYPE, :process_variable_multiple_assignment],
+        [VARIABLE_REFERENCE_TYPE, :process_variable_referencing],
+        [RESCUE_TYPE, :process_rescue],
+        [ZERO_ARITY_SUPER_TYPE, :process_zero_arity_super],
+        [SEND_TYPE, :process_send],
+        *ARGUMENT_DECLARATION_TYPES.product([:process_variable_declaration]),
+        *OPERATOR_ASSIGNMENT_TYPES.product([:process_variable_operator_assignment]),
+        *LOOP_TYPES.product([:process_loop]),
+        *SCOPE_TYPES.product([:process_scope])
+      ].to_h.freeze
+      private_constant :NODE_HANDLER_METHOD_NAMES
+      # rubocop:enable Layout/ClassStructure
+
       def node_handler_method_name(node)
-        case node.type
-        when VARIABLE_ASSIGNMENT_TYPE
-          :process_variable_assignment
-        when REGEXP_NAMED_CAPTURE_TYPE
-          :process_regexp_named_captures
-        when MULTIPLE_ASSIGNMENT_TYPE
-          :process_variable_multiple_assignment
-        when VARIABLE_REFERENCE_TYPE
-          :process_variable_referencing
-        when RESCUE_TYPE
-          :process_rescue
-        when ZERO_ARITY_SUPER_TYPE
-          :process_zero_arity_super
-        when SEND_TYPE
-          :process_send
-        when *ARGUMENT_DECLARATION_TYPES
-          :process_variable_declaration
-        when *OPERATOR_ASSIGNMENT_TYPES
-          :process_variable_operator_assignment
-        when *LOOP_TYPES
-          :process_loop
-        when *SCOPE_TYPES
-          :process_scope
-        end
+        NODE_HANDLER_METHOD_NAMES[node.type]
       end
-      # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
 
       def process_variable_declaration(node)
         variable_name = node.children.first
@@ -358,13 +350,12 @@ module RuboCop
         end
       end
 
-      # Use Node#equal? for accurate check.
       def scanned_node?(node)
-        scanned_nodes.any? { |scanned_node| scanned_node.equal?(node) }
+        scanned_nodes.include?(node)
       end
 
       def scanned_nodes
-        @scanned_nodes ||= []
+        @scanned_nodes ||= Set.new.compare_by_identity
       end
 
       # Hooks invoked by VariableTable.


### PR DESCRIPTION
Tested on 3 projects.

## mastodon

### Before
Time: `50.0s`

```
==================================
  Mode: wall(1000)
  Samples: 48594 (1.61% miss rate)
  GC: 3154 (6.49%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      2114   (4.4%)        2112   (4.3%)     RuboCop::Cop::Base.badge
      2103   (4.3%)        2103   (4.3%)     (sweeping)
      3063   (6.3%)        1902   (3.9%)     Parser::Lexer#advance
      3156   (6.5%)        1585   (3.3%)     RuboCop::AST::Descendence#each_child_node
      1420   (2.9%)        1420   (2.9%)     block (2 levels) in <class:Node>
      1252   (2.6%)        1252   (2.6%)     Parser::Source::Buffer#slice
      4233   (8.7%)        1246   (2.6%)     RuboCop::Cop::Registry#enabled?
      1495   (3.1%)        1169   (2.4%)     RuboCop::Config#for_cop
      1045   (2.2%)        1045   (2.2%)     (marking)
      1677   (3.5%)         937   (1.9%)     RuboCop::Cop::Base#cop_config
       902   (1.9%)         902   (1.9%)     RuboCop::AST::Node#node_parts
      1085   (2.2%)         818   (1.7%)     RuboCop::PathUtil#match_path?
       818   (1.7%)         818   (1.7%)     RuboCop::DirectiveComment#match_captures
       984   (2.0%)         762   (1.6%)     AST::Node#initialize
       998   (2.1%)         731   (1.5%)     Parser::Source::Buffer#line_index_for_position
       719   (1.5%)         719   (1.5%)     RuboCop::DirectiveComment.before_comment
       632   (1.3%)         632   (1.3%)     Parser::Source::Range#initialize
      6779  (14.0%)         609   (1.3%)     RuboCop::AST::ProcessedSource.from_file
       527   (1.1%)         527   (1.1%)     RuboCop::Cop::Badge#to_s
```

### After
Time: `41.6s` (17% speedup) 🔥 

```
==================================
  Mode: wall(1000)
  Samples: 40957 (1.45% miss rate)
  GC: 2502 (6.11%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      3016   (7.4%)        1828   (4.5%)     Parser::Lexer#advance
      1629   (4.0%)        1629   (4.0%)     (sweeping)
      2987   (7.3%)        1599   (3.9%)     RuboCop::AST::Descendence#each_child_node
      1405   (3.4%)        1405   (3.4%)     block (2 levels) in <class:Node>
      1407   (3.4%)        1398   (3.4%)     RuboCop::Config#for_cop
      1161   (2.8%)        1161   (2.8%)     Parser::Source::Buffer#slice
      1638   (4.0%)         926   (2.3%)     RuboCop::Cop::Base#cop_config
      1063   (2.6%)         884   (2.2%)     RuboCop::PathUtil#match_path?
       868   (2.1%)         868   (2.1%)     (marking)
       849   (2.1%)         849   (2.1%)     RuboCop::AST::Node#node_parts
       987   (2.4%)         775   (1.9%)     AST::Node#initialize
       712   (1.7%)         712   (1.7%)     Parser::Source::Range#initialize
      2033   (5.0%)         694   (1.7%)     RuboCop::Cop::Registry#enabled?
       916   (2.2%)         686   (1.7%)     Parser::Source::Buffer#line_index_for_position
      6774  (16.5%)         558   (1.4%)     RuboCop::AST::ProcessedSource.from_file
       503   (1.2%)         503   (1.2%)     RuboCop::AST::ProcessedSource#valid_syntax?
       485   (1.2%)         485   (1.2%)     RuboCop::AST::SendNode#first_argument_index
       634   (1.5%)         480   (1.2%)     RuboCop::Cop::Base#initialize
      1248   (3.0%)         451   (1.1%)     Parser::Source::TreeRewriter#initialize
       387   (0.9%)         387   (0.9%)     Unicode::DisplayWidth.of
```

## rails

### Before
Time: `186.1s`

```
==================================
  Mode: wall(1000)
  Samples: 180627 (0.33% miss rate)
  GC: 11047 (6.12%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     30358  (16.8%)       16719   (9.3%)     Parser::Lexer#advance
      9117   (5.0%)        9117   (5.0%)     Parser::Source::Buffer#slice
      8911   (4.9%)        8911   (4.9%)     (sweeping)
      7598   (4.2%)        7598   (4.2%)     RuboCop::DirectiveComment#match_captures
      6555   (3.6%)        6555   (3.6%)     RuboCop::DirectiveComment.before_comment
      6450   (3.6%)        6449   (3.6%)     RuboCop::Cop::Base.badge
     16026   (8.9%)        6320   (3.5%)     RuboCop::AST::Descendence#each_child_node
      8485   (4.7%)        5867   (3.2%)     AST::Node#initialize
      7462   (4.1%)        5693   (3.2%)     RuboCop::CommentConfig#comment_only_line?
      3906   (2.2%)        3710   (2.1%)     RuboCop::Cop::VariableForce#scanned_node?
      3603   (2.0%)        3603   (2.0%)     block (2 levels) in <class:Node>
      3428   (1.9%)        3428   (1.9%)     Parser::Source::Range#initialize
      5918   (3.3%)        2951   (1.6%)     Parser::Source::Buffer#line_index_for_position
      3412   (1.9%)        2600   (1.4%)     RuboCop::Config#for_cop
      2455   (1.4%)        2455   (1.4%)     RuboCop::CommentConfig::ConfigDisabledCopDirectiveComment#initialize
     10280   (5.7%)        2441   (1.4%)     RuboCop::Cop::Registry#enabled?
     38768  (21.5%)        2094   (1.2%)     RuboCop::CommentConfig#analyze
      2080   (1.2%)        2080   (1.2%)     (marking)
     58653  (32.5%)        1917   (1.1%)     RuboCop::AST::ProcessedSource.from_file
      1848   (1.0%)        1848   (1.0%)     Unicode::DisplayWidth.of
      1728   (1.0%)        1728   (1.0%)     Parser::Source::Buffer#line_begins
```

### After
Time: `123.6s` (33% speedup) 🔥 

```
==================================
  Mode: wall(1000)
  Samples: 122269 (0.46% miss rate)
  GC: 7160 (5.86%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     28618  (23.4%)       15737  (12.9%)     Parser::Lexer#advance
      8584   (7.0%)        8584   (7.0%)     Parser::Source::Buffer#slice
     10566   (8.6%)        5919   (4.8%)     RuboCop::AST::Descendence#each_child_node
      8272   (6.8%)        5729   (4.7%)     AST::Node#initialize
      4821   (3.9%)        4821   (3.9%)     (sweeping)
      3149   (2.6%)        3149   (2.6%)     block (2 levels) in <class:Node>
      3140   (2.6%)        3140   (2.6%)     Parser::Source::Range#initialize
      2292   (1.9%)        2292   (1.9%)     (marking)
      4695   (3.8%)        2263   (1.9%)     Parser::Source::Buffer#line_index_for_position
      2210   (1.8%)        2194   (1.8%)     RuboCop::Config#for_cop
      1823   (1.5%)        1823   (1.5%)     Unicode::DisplayWidth.of
      1511   (1.2%)        1511   (1.2%)     Parser::Source::Buffer#line_begins
      1408   (1.2%)        1408   (1.2%)     RuboCop::AST::Node#node_parts
     54711  (44.7%)        1166   (1.0%)     RuboCop::AST::ProcessedSource.from_file
      1520   (1.2%)        1137   (0.9%)     RuboCop::AST::ProcessedSource#sorted_tokens
      1089   (0.9%)        1089   (0.9%)     RuboCop::AST::SendNode#first_argument_index
      1053   (0.9%)        1053   (0.9%)     Parser::Source::Buffer#bsearch
       985   (0.8%)         985   (0.8%)     Parser::Builders::Default#value
      3280   (2.7%)         982   (0.8%)     RuboCop::Cop::Registry#enabled?
       964   (0.8%)         964   (0.8%)     RuboCop::AST::Token#initialize
```

## gitlab

Ran only on `app/models`, because the project is too large.

### Before
Time: `130.4s`

```
==================================
  Mode: wall(1000)
  Samples: 129908 (0.12% miss rate)
  GC: 4940 (3.80%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     50100  (38.6%)       36482  (28.1%)     RuboCop::PathUtil#match_path?
     13200  (10.2%)       13200  (10.2%)     RuboCop::PathUtil#maybe_hidden_file?
      3583   (2.8%)        3583   (2.8%)     (sweeping)
      5596   (4.3%)        3136   (2.4%)     RuboCop::AST::Descendence#each_child_node
      3119   (2.4%)        3117   (2.4%)     RuboCop::Cop::Base.badge
      2619   (2.0%)        2619   (2.0%)     block (2 levels) in <class:Node>
      3660   (2.8%)        2465   (1.9%)     Parser::Lexer#advance
      2047   (1.6%)        2047   (1.6%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
      2231   (1.7%)        1747   (1.3%)     RuboCop::Config#for_cop
      2872   (2.2%)        1555   (1.2%)     RuboCop::Cop::Base#cop_config
      5820   (4.5%)        1531   (1.2%)     RuboCop::Cop::Registry#enabled?
      1382   (1.1%)        1382   (1.1%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
      1369   (1.1%)        1369   (1.1%)     RuboCop::QAHelpers#in_qa_file?
      1345   (1.0%)        1345   (1.0%)     (marking)
      1262   (1.0%)        1262   (1.0%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
      1244   (1.0%)        1244   (1.0%)     RuboCop::AST::Node#node_parts
      1221   (0.9%)        1221   (0.9%)     Parser::Source::Buffer#slice
      8491   (6.5%)        1024   (0.8%)     RuboCop::AST::ProcessedSource.from_file
```

### After
Time: `86.4s` (34% speedup) 🔥 

```
==================================
  Mode: wall(1000)
  Samples: 86352 (0.09% miss rate)
  GC: 3948 (4.57%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     18789  (21.8%)       11671  (13.5%)     RuboCop::PathUtil#match_path?
      6742   (7.8%)        6742   (7.8%)     RuboCop::PathUtil#maybe_hidden_file?
      4925   (5.7%)        3005   (3.5%)     RuboCop::AST::Descendence#each_child_node
      2814   (3.3%)        2814   (3.3%)     (sweeping)
      2475   (2.9%)        2475   (2.9%)     block (2 levels) in <class:Node>
      3383   (3.9%)        2304   (2.7%)     Parser::Lexer#advance
      2089   (2.4%)        2076   (2.4%)     RuboCop::Config#for_cop
      1935   (2.2%)        1935   (2.2%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
      2920   (3.4%)        1639   (1.9%)     RuboCop::Cop::Base#cop_config
      1388   (1.6%)        1388   (1.6%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
      1210   (1.4%)        1210   (1.4%)     RuboCop::QAHelpers#in_qa_file?
      1203   (1.4%)        1203   (1.4%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
      1128   (1.3%)        1128   (1.3%)     (marking)
      1081   (1.3%)        1081   (1.3%)     RuboCop::AST::Node#node_parts
      1067   (1.2%)        1067   (1.2%)     Parser::Source::Buffer#slice
      2802   (3.2%)         994   (1.2%)     RuboCop::Cop::Registry#enabled?
      1293   (1.5%)         964   (1.1%)     Parser::Source::Buffer#line_index_for_position
      1179   (1.4%)         899   (1.0%)     AST::Node#initialize
       757   (0.9%)         757   (0.9%)     Parser::Source::Range#initialize
```

Note: In the `Gitlab`s benchmark there is a possibility to optimize another 20%, but I would probably try that separately.