### PR TITLE
[Fix #11239] Fix an incorrect autocorrect for `Style/GuardClause`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_guard_clause.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_guard_clause.md
@@ -1,0 +1,1 @@
+* [#11239](https://github.com/rubocop/rubocop/issues/11239): Fix an incorrect autocorrect for `Style/GuardClause` when using heredoc as an argument of raise in branch body. ([@koic][])

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -244,6 +244,58 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
     RUBY
   end
 
+  it 'registers an offense when using heredoc as an argument of raise in `then` branch' do
+    expect_offense(<<~RUBY)
+      def func
+        if condition
+        ^^ Use a guard clause (`raise <<~MESSAGE unless condition`) instead of wrapping the code inside a conditional expression.
+          foo
+        else
+          raise <<~MESSAGE
+            oops
+          MESSAGE
+        end
+      end
+    RUBY
+
+    # NOTE: Let `Layout/HeredocIndentation`, `Layout/ClosingHeredocIndentation`, and
+    #       `Layout/IndentationConsistency` cops autocorrect inconsistent indentations.
+    expect_correction(<<~RUBY)
+      def func
+        raise <<~MESSAGE unless condition
+            oops
+          MESSAGE
+      foo
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using heredoc as an argument of raise in `else` branch' do
+    expect_offense(<<~RUBY)
+      def func
+        unless condition
+        ^^^^^^ Use a guard clause (`raise <<~MESSAGE unless condition`) instead of wrapping the code inside a conditional expression.
+          raise <<~MESSAGE
+            oops
+          MESSAGE
+        else
+          foo
+        end
+      end
+    RUBY
+
+    # NOTE: Let `Layout/HeredocIndentation`, `Layout/ClosingHeredocIndentation`, and
+    #       `Layout/IndentationConsistency` cops autocorrect inconsistent indentations.
+    expect_correction(<<~RUBY)
+      def func
+        raise <<~MESSAGE unless condition
+            oops
+          MESSAGE
+      foo
+      end
+    RUBY
+  end
+
   context 'MinBodyLength: 1' do
     let(:cop_config) { { 'MinBodyLength' => 1 } }
 


### PR DESCRIPTION
## Summary

Fixes #11239.

This PR fixes an incorrect autocorrect for `Style/GuardClause` when using heredoc as an argument of raise in branch body.

## Other Information

Let `Layout/HeredocIndentation`, `Layout/ClosingHeredocIndentation`, and `Layout/IndentationConsistency` cops autocorrect inconsistent indentations.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
