### PR TITLE
[Fix #11244] Fix a false negative for `Style/RedundantReturn` when dynamic define methods

### DIFF
--- a/changelog/fix_a_false_negative_for_style_redundant_return.md
+++ b/changelog/fix_a_false_negative_for_style_redundant_return.md
@@ -1,0 +1,1 @@
+* [#11244](https://github.com/rubocop/rubocop/pull/11244): Fix a false negative for `Style/RedundantReturn` when dynamic define methods. ([@ydah][])

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -53,6 +53,13 @@ module RuboCop
 
         MSG = 'Redundant `return` detected.'
         MULTI_RETURN_MSG = 'To return multiple values, use an array.'
+        RESTRICT_ON_SEND = %i[define_method define_singleton_method].freeze
+
+        def on_send(node)
+          return unless (parent = node.parent) && parent.block_type?
+
+          check_branch(parent.body)
+        end
 
         def on_def(node)
           check_branch(node.body)

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -54,6 +54,70 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
     RUBY
   end
 
+  it 'reports an offense for define_method with only a return' do
+    expect_offense(<<~RUBY)
+      define_method(:foo) do
+        return something
+        ^^^^^^ Redundant `return` detected.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      define_method(:foo) do
+        something
+      end
+    RUBY
+  end
+
+  it 'reports an offense for define_singleton_method with only a return' do
+    expect_offense(<<~RUBY)
+      define_singleton_method(:foo) do
+        return something
+        ^^^^^^ Redundant `return` detected.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      define_singleton_method(:foo) do
+        something
+      end
+    RUBY
+  end
+
+  it 'reports an offense for define_method ending with return' do
+    expect_offense(<<~RUBY)
+      define_method(:foo) do
+        some_preceding_statements
+        return something
+        ^^^^^^ Redundant `return` detected.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      define_method(:foo) do
+        some_preceding_statements
+        something
+      end
+    RUBY
+  end
+
+  it 'reports an offense for define_singleton_method ending with return' do
+    expect_offense(<<~RUBY)
+      define_singleton_method(:foo) do
+        some_preceding_statements
+        return something
+        ^^^^^^ Redundant `return` detected.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      define_singleton_method(:foo) do
+        some_preceding_statements
+        something
+      end
+    RUBY
+  end
+
   it 'reports an offense for def ending with return with splat argument' do
     expect_offense(<<~RUBY)
       def func


### PR DESCRIPTION
Fix: #11244

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
