### PR TITLE
Fix links on rubocop.org to reference new GitHub org name

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,10 +16,10 @@
   <body class="animated fadeIn">
     <div class="container-narrow">
       <div class="jumbotron">
-        <img src="https://raw.github.com/rubocop-hq/rubocop/master/logo/rubo-logo-horizontal.png" alt="RuboCop" />
+        <img src="https://raw.github.com/rubocop/rubocop/master/logo/rubo-logo-horizontal.png" alt="RuboCop" />
         <p class="lead">The Ruby Linter/Formatter that Serves and Protects</p>
 
-        <a class="btn btn-large btn-danger" href="https://github.com/rubocop-hq/rubocop"><i class="icon-github"></i> View on GitHub</a>
+        <a class="btn btn-large btn-danger" href="https://github.com/rubocop/rubocop"><i class="icon-github"></i> View on GitHub</a>
         <a class="btn btn-large btn-danger" href="https://docs.rubocop.org"><i class="icon-book"></i> Read Docs</a>
         <a class="btn btn-large btn-danger" href="https://rubystyle.guide"><i class="icon-book"></i> Style Guide</a>
       </div>


### PR DESCRIPTION
Save a redirect!