### PR TITLE
Fix an error for `Style/GuardClause` when a method call whose last argument is not a string is in the condition body

### DIFF
--- a/changelog/fix_fix_an_error_for_guard_clause.md
+++ b/changelog/fix_fix_an_error_for_guard_clause.md
@@ -1,0 +1,1 @@
+* [#11250](https://github.com/rubocop/rubocop/pull/11250): Fix an error for `Style/GuardClause` when a method call whose last argument is not a string is in the condition body. ([@ydah][])

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -187,7 +187,7 @@ module RuboCop
           if_branch = node.if_branch
           else_branch = node.else_branch
 
-          if if_branch&.send_type? && if_branch.last_argument&.heredoc?
+          if if_branch&.send_type? && heredoc?(if_branch.last_argument)
             autocorrect_heredoc_argument(corrector, node, if_branch, else_branch, guard)
           elsif else_branch&.send_type? && else_branch.last_argument&.heredoc?
             autocorrect_heredoc_argument(corrector, node, else_branch, if_branch, guard)
@@ -200,6 +200,12 @@ module RuboCop
           end
         end
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+        def heredoc?(argument)
+          return false if argument.nil?
+
+          argument.respond_to?(:heredoc?) && argument.heredoc?
+        end
 
         def autocorrect_heredoc_argument(corrector, node, heredoc_branch, leave_branch, guard)
           remove_whole_lines(corrector, leave_branch.source_range)


### PR DESCRIPTION
This PR is fix an error for `Style/GuardClause` when a method call whose last argument is not a string is in the condition body

Prepare the following files
```ruby
# frozen_string_literal: true

def foo
  if foo?
    foo(bar)
  end
end
```

Get the following error when running RuboCop
```
bundle exec rubocop test.rb -d
For /ydah/test: configuration from /ydah/test/.rubocop.yml
configuration from /ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-performance-1.15.1/config/default.yml
configuration from /ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-performance-1.15.1/config/default.yml
Default configuration from /ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/config/default.yml
configuration from /ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-rake-0.6.0/config/default.yml
configuration from /ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-rake-0.6.0/config/default.yml
configuration from /ydah/test/config/default.yml
configuration from /ydah/test/config/default.yml
Inheriting configuration from /ydah/test/.rubocop_todo.yml
Use parallel by default.
Skipping parallel inspection: only a single file needs inspection
Inspecting 1 file
Scanning /ydah/test/test.rb
An error occurred while Style/GuardClause cop was inspecting /ydah/test/test.rb:3:0.
undefined method `heredoc?' for s(:send, nil, :bar):RuboCop::AST::SendNode

          if if_branch&.send_type? && if_branch.last_argument&.heredoc?
                                                             ^^^^^^^^^^
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/style/guard_clause.rb:190:in `autocorrect'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/style/guard_clause.rb:179:in `block in register_offense'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/base.rb:346:in `correct'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/base.rb:127:in `add_offense'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/style/guard_clause.rb:176:in `register_offense'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/style/guard_clause.rb:149:in `check_ending_if'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/style/guard_clause.rb:137:in `check_ending_body'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/style/guard_clause.rb:109:in `on_def'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/commissioner.rb:100:in `public_send'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/commissioner.rb:100:in `block (2 levels) in trigger_responding_cops'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/commissioner.rb:160:in `with_cop_error_handling'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/commissioner.rb:99:in `block in trigger_responding_cops'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/commissioner.rb:98:in `each'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/commissioner.rb:98:in `trigger_responding_cops'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/commissioner.rb:69:in `on_def'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.24.0/lib/rubocop/ast/traversal.rb:20:in `walk'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/commissioner.rb:86:in `investigate'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/team.rb:154:in `investigate_partial'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/team.rb:82:in `investigate'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:315:in `inspect_file'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:259:in `block in do_inspection_loop'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:293:in `block in iterate_until_no_changes'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:286:in `loop'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:286:in `iterate_until_no_changes'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:255:in `do_inspection_loop'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:138:in `block in file_offenses'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:163:in `file_offense_cache'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:137:in `file_offenses'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:128:in `process_file'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:109:in `block in each_inspected_file'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:108:in `each'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:108:in `reduce'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:108:in `each_inspected_file'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:94:in `inspect_files'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/runner.rb:47:in `run'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cli/command/execute_runner.rb:26:in `block in execute_runner'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cli/command/execute_runner.rb:52:in `with_redirect'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cli/command/execute_runner.rb:25:in `execute_runner'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cli/command/execute_runner.rb:17:in `run'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cli/command.rb:11:in `run'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cli/environment.rb:18:in `run'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cli.rb:72:in `run_command'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cli.rb:79:in `execute_runners'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cli.rb:48:in `run'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/exe/rubocop:19:in `block in <top (required)>'
/ydah/.rbenv/versions/3.1.2/lib/ruby/3.1.0/benchmark.rb:311:in `realtime'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/exe/rubocop:19:in `<top (required)>'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bin/rubocop:25:in `load'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bin/rubocop:25:in `<top (required)>'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.13/lib/bundler/cli/exec.rb:58:in `load'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.13/lib/bundler/cli/exec.rb:58:in `kernel_load'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.13/lib/bundler/cli/exec.rb:23:in `run'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.13/lib/bundler/cli.rb:483:in `exec'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.13/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.13/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.13/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.13/lib/bundler/cli.rb:31:in `dispatch'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.13/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.13/lib/bundler/cli.rb:25:in `start'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.13/exe/bundle:48:in `block in <top (required)>'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.13/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
/ydah/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.13/exe/bundle:36:in `<top (required)>'
/ydah/.rbenv/versions/3.1.2/bin/bundle:25:in `load'
/ydah/.rbenv/versions/3.1.2/bin/bundle:25:in `<main>'
C

Offenses:

test.rb:4:3: C: [Correctable] Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
  if foo?
  ^^

1 file inspected, 1 offense detected, 1 offense autocorrectable

1 error occurred:
An error occurred while Style/GuardClause cop was inspecting /ydah/test/test.rb:3:0.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop/rubocop/issues

Mention the following information in the issue report:
1.40.0 (using Parser 3.1.3.0, rubocop-ast 1.24.0, running on ruby 3.1.2) [x86_64-darwin21]
Finished in 0.6836519999997108 seconds
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
