### PR TITLE
Experiment with extends directive and allow inherit_from to be a glob

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -47,8 +47,11 @@ module RuboCop
 
         resolver.override_department_setting_for_cops({}, hash)
         resolver.resolve_inheritance_from_gems(hash)
-        resolver.resolve_inheritance(path, hash, file, debug?)
+        resolver.resolve_inheritance_for_inherit_from(path, hash, file, debug?)
+        resolver.resolve_inheritance_for_extends(path, hash, file, debug?)
+
         hash.delete('inherit_from')
+        hash.delete('extends')
 
         # Adding missing namespaces only after resolving requires & inheritance,
         # since both can introduce new cops that need to be considered here.

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -16,8 +16,17 @@ module RuboCop
       end
     end
 
-    def resolve_inheritance(path, hash, file, debug) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    def resolve_inheritance_for_inherit_from(path, hash, file, debug) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       inherited_files = Array(hash['inherit_from'])
+      resolve_inheritance(inherited_files, path, hash, file, debug, should_mark_paths_relative_to_derived_configuration: true)
+    end
+
+    def resolve_inheritance_for_extends(path, hash, file, debug) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      extended_files = Array(hash['extends'])
+      resolve_inheritance(extended_files, path, hash, file, debug, should_mark_paths_relative_to_derived_configuration: false)
+    end
+
+    def resolve_inheritance(inherited_files, path, hash, file, debug, should_mark_paths_relative_to_derived_configuration: true) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       base_configs(path, inherited_files, file)
         .each_with_index.reverse_each do |base_config, index|
         override_department_setting_for_cops(base_config, hash)
@@ -33,7 +42,10 @@ module RuboCop
                       inherit_mode: determine_inherit_mode(hash, k))
           end
           hash[k] = v
-          fix_include_paths(base_config.loaded_path, hash, path, k, v) if v.key?('Include')
+
+          if should_mark_paths_relative_to_derived_configuration && v.key?('Include')
+            mark_paths_relative_to_derived_configuration(base_config.loaded_path, hash, path, k, v)
+          end
         end
       end
     end
@@ -42,7 +54,7 @@ module RuboCop
     # base configuration are relative to the directory where the base configuration file is. For the
     # derived configuration, we need to make those paths relative to where the derived configuration
     # file is.
-    def fix_include_paths(base_config_path, hash, path, key, value)
+    def mark_paths_relative_to_derived_configuration(base_config_path, hash, path, key, value)
       return unless File.basename(base_config_path).start_with?('.rubocop')
 
       base_dir = File.dirname(base_config_path)
@@ -206,7 +218,15 @@ module RuboCop
     end
 
     def base_configs(path, inherit_from, file)
-      configs = Array(inherit_from).compact.map do |f|
+      inherit_froms = Array(inherit_from).compact.flat_map do |f|
+        if f.match?(/[*{\[?]/)
+          Dir.glob(f)
+        else
+          f
+        end
+      end
+
+      configs = inherit_froms.map do |f|
         ConfigLoader.load_file(inherited_file(path, f, file))
       end
 

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe RuboCop::ConfigObsoletion do
 
         # Resolve `inherit_gem`
         resolver.resolve_inheritance_from_gems(hash)
-        resolver.resolve_inheritance(loaded_path, hash, loaded_path, false)
+        resolver.resolve_inheritance_for_inherit_from(loaded_path, hash, loaded_path, false)
 
         allow(configuration).to receive(:loaded_features).and_call_original
       end


### PR DESCRIPTION
This is a work in progress PR intended to spike on a couple of ideas:
1. An `extends` directive that is similar to `inherit_from`, but all paths for the derived configuration are relative to the configuration being extended. This is used to allow subdirectories to change a parent config without affecting path relativity.
  - I'd prefer to have `extended_by` on the top-level `.rubocop.yml` so that it only needs to be listed once, rather than for every child `.rubocop.yml`. However, at the moment I'm not sure with the current architecture how we would do that.
2. Allowing `inherit_from` to accept a glob.

I'd want to break (1) and (2) into separate PRs – this is mostly just for demonstration purposes at the moment. I have also not yet added tests!

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
