### PR TITLE
Fix an error for `Style/RequireOrder`

### DIFF
--- a/changelog/fix_an_error_for_style_require_order.md
+++ b/changelog/fix_an_error_for_style_require_order.md
@@ -1,0 +1,1 @@
+* [#11254](https://github.com/rubocop/rubocop/pull/11254): Fix an error for `Style/RequireOrder` when `require` is a method argument. ([@koic][])

--- a/lib/rubocop/cop/style/require_order.rb
+++ b/lib/rubocop/cop/style/require_order.rb
@@ -63,7 +63,7 @@ module RuboCop
 
         def find_previous_older_sibling(node)
           node.left_siblings.reverse.find do |sibling|
-            break unless sibling.send_type?
+            break unless sibling.respond_to?(:send_type?) && sibling.send_type?
             break unless sibling.method?(node.method_name)
             break unless in_same_section?(sibling, node)
 

--- a/spec/rubocop/cop/style/require_order_spec.rb
+++ b/spec/rubocop/cop/style/require_order_spec.rb
@@ -102,4 +102,12 @@ RSpec.describe RuboCop::Cop::Style::RequireOrder, :config do
       RUBY
     end
   end
+
+  context 'when `require` is a method argument' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        do_something(require)
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/11235#issuecomment-1342934983.

This PR fixes an error for `Style/RequireOrder` when `require` is a method argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
