### PR TITLE
[Fix #11256] Fix an incorrect autocorrect for `Style/HashSyntax`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,7 +23,7 @@ Metrics/MethodLength:
 # Offense count: 8
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 135
+  Max: 136
 
 # Offense count: 9
 RSpec/AnyInstance:

--- a/changelog/fix_an_incorrect_autocorrect_for_style_hash_syntax.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_hash_syntax.md
@@ -1,0 +1,1 @@
+* [#11256](https://github.com/rubocop/rubocop/issues/11256): Fix an incorrect autocorrect for `Style/HashSyntax` when without parentheses call expr follows after multiple keyword arguments method call. ([@koic][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -45,17 +45,21 @@ module RuboCop
 
       private
 
+      # rubocop:disable Metrics/AbcSize
       def register_offense(node, message, replacement)
         add_offense(node.value, message: message) do |corrector|
           if (def_node = def_node_that_require_parentheses(node))
             white_spaces = range_between(def_node.loc.selector.end_pos,
                                          def_node.first_argument.source_range.begin_pos)
             corrector.replace(white_spaces, '(')
-            corrector.insert_after(def_node.arguments.last, ')')
+
+            last_argument = def_node.arguments.last
+            corrector.insert_after(last_argument, ')') if node == last_argument.pairs.last
           end
           corrector.replace(node, replacement)
         end
       end
+      # rubocop:enable Metrics/AbcSize
 
       def ignore_mixed_hash_shorthand_syntax?(hash_node)
         target_ruby_version <= 3.0 || enforced_shorthand_syntax != 'consistent' ||

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -465,7 +465,7 @@ module RuboCop
 
   # This module contains help texts for command line options.
   # @api private
-  module OptionsHelp # rubocop:disable Metrics/ModuleLength
+  module OptionsHelp
     MAX_EXCL = RuboCop::Options::DEFAULT_MAXIMUM_EXCLUSION_ITEMS.to_s
     FORMATTER_OPTION_LIST = RuboCop::Formatter::FormatterSet::BUILTIN_FORMATTERS_FOR_KEYS.keys
 

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1091,6 +1091,21 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'registers an offense when without parentheses call expr follows after multiple keyword arguments method call' do
+        # Add parentheses to prevent syntax errors shown in the URL: https://bugs.ruby-lang.org/issues/18396
+        expect_offense(<<~RUBY)
+          foo baz: baz, qux: qux
+                             ^^^ Omit the hash value.
+                   ^^^ Omit the hash value.
+          baz
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo(baz:, qux:)
+          baz
+        RUBY
+      end
+
       it 'registers an offense when one line `if` condition follows (with parentheses)' do
         expect_offense(<<~RUBY)
           foo(value: value) if bar


### PR DESCRIPTION
Fixes #11256.

This PR fixes an incorrect autocorrect for `Style/HashSyntax` when without parentheses call expr follows after multiple keyword arguments method call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
