### PR TITLE
[Fix #11255] Fix an error for `Style/RequireOrder` when `require` with no arguments is put between `require`

### DIFF
--- a/changelog/fix_fix_an_error_for_style_require_order_no_args.md
+++ b/changelog/fix_fix_an_error_for_style_require_order_no_args.md
@@ -1,0 +1,1 @@
+* [#11255](https://github.com/rubocop/rubocop/pull/11255): Fix an error for `Style/RequireOrder` when `require` with no arguments is put between `require`. ([@ydah][])

--- a/lib/rubocop/cop/style/require_order.rb
+++ b/lib/rubocop/cop/style/require_order.rb
@@ -44,6 +44,8 @@ module RuboCop
         RESTRICT_ON_SEND = %i[require require_relative].freeze
 
         def on_send(node)
+          return unless node.arguments?
+
           previous_older_sibling = find_previous_older_sibling(node)
           return unless previous_older_sibling
 
@@ -63,8 +65,8 @@ module RuboCop
 
         def find_previous_older_sibling(node)
           node.left_siblings.reverse.find do |sibling|
-            break unless sibling.respond_to?(:send_type?) && sibling.send_type?
-            break unless sibling.method?(node.method_name)
+            break unless sibling.send_type? && sibling.method?(node.method_name)
+            break unless sibling.arguments? && !sibling.receiver
             break unless in_same_section?(sibling, node)
 
             node.first_argument.source < sibling.first_argument.source

--- a/spec/rubocop/cop/style/require_order_spec.rb
+++ b/spec/rubocop/cop/style/require_order_spec.rb
@@ -110,4 +110,35 @@ RSpec.describe RuboCop::Cop::Style::RequireOrder, :config do
       RUBY
     end
   end
+
+  context 'when `Bundler.require` is put between unsorted `require`' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        require 'e'
+        Bundler.require(:default)
+        require 'c'
+      RUBY
+    end
+  end
+
+  context 'when `Bundler.require` with no arguments is put between `require`' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        require 'c'
+        Bundler.require
+        require 'a'
+      RUBY
+    end
+  end
+
+  context 'when something other than a method call is used between `require`' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        require 'a'
+        begin
+        end
+        require 'b'
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fix: #11255

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
