### PR TITLE
Permit "extends" directive to support adding to a parent .rubocop.yml without changing path relativity

### DIFF
--- a/changelog/new_permit_extends_directive_to_support.md
+++ b/changelog/new_permit_extends_directive_to_support.md
@@ -1,0 +1,1 @@
+* [#11260](https://github.com/rubocop/rubocop/pull/11260): Permit "extends" directive to support adding to a parent .rubocop.yml without changing path relativity. ([@alexevanczuk][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -275,6 +275,42 @@ Style/For:
 
 In this example the `Exclude` would only include `bar.rb`.
 
+=== Extending a parent .rubocop.yml using extends
+
+The optional directive `extends` allows a child `.rubocop.yml` to specify
+that it changes a parent `.rubocop.yml` without affecting path-relativity rules.
+
+Given the following configs:
+
+[source,yaml]
+----
+# .rubocop.yml
+AllCops:
+  Exclude:
+    - 'generated/**/*.rb'
+
+Layout/LineLength:
+  Enabled: true
+  Include:
+    - 'child_directory/**/*.rb'
+
+Rails/HasAndBelongsToMany:
+  Enabled: false
+----
+
+[source,yaml]
+----
+# child_directory/.rubocop.yml
+extends: '../../.rubocop.yml'
+
+Rails/HasAndBelongsToMany:
+  Enabled: true
+----
+
+Using `extends: '../../.rubocop.yml` within the child `.rubocop.yml` file allows the path relativity of the parent `.rubocop.yml` to remain the same. That is, the `Include` for `Layout/LineLength` is still relative to `.rubocop.yml` rather than relative to `child_directory/.rubocop.yml`.
+
+Contrast this with `inherit_from: '../../.rubocop.yml`, which would make the `Include` for `Layout/LineLength` be `child_directory/child_directory/**/*.rb`, since paths would be made relative to `child_directory/.rubocop.yml`.
+
 == Pre-processing
 
 Configuration files are pre-processed using the ERB templating mechanism. This

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -285,31 +285,21 @@ Given the following configs:
 [source,yaml]
 ----
 # .rubocop.yml
-AllCops:
-  Exclude:
-    - 'generated/**/*.rb'
-
 Layout/LineLength:
   Enabled: true
   Include:
     - 'child_directory/**/*.rb'
-
-Rails/HasAndBelongsToMany:
-  Enabled: false
 ----
 
 [source,yaml]
 ----
 # child_directory/.rubocop.yml
-extends: '../../.rubocop.yml'
-
-Rails/HasAndBelongsToMany:
-  Enabled: true
+extends: '../.rubocop.yml'
 ----
 
-Using `extends: '../../.rubocop.yml` within the child `.rubocop.yml` file allows the path relativity of the parent `.rubocop.yml` to remain the same. That is, the `Include` for `Layout/LineLength` is still relative to `.rubocop.yml` rather than relative to `child_directory/.rubocop.yml`.
+Using `extends: '../.rubocop.yml` within the child `.rubocop.yml` file allows the path relativity of the parent `.rubocop.yml` to remain the same. That is, the `Include` for `Layout/LineLength` is still relative to `.rubocop.yml` rather than relative to `child_directory/.rubocop.yml`.
 
-Contrast this with `inherit_from: '../../.rubocop.yml`, which would make the `Include` for `Layout/LineLength` be `child_directory/child_directory/**/*.rb`, since paths would be made relative to `child_directory/.rubocop.yml`.
+Contrast this with `inherit_from: '../.rubocop.yml`, which would make the `Include` for `Layout/LineLength` be `../**/*.rb`, since paths would be made relative to `child_directory/.rubocop.yml`.
 
 == Pre-processing
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -37,7 +37,7 @@ module RuboCop
         FileFinder.root_level = nil
       end
 
-      def load_file(file, check: true)
+      def load_file(file, check: true) # rubocop:disable Metrics/AbcSize
         path = file_path(file)
 
         hash = load_yaml_configuration(path)
@@ -47,8 +47,11 @@ module RuboCop
 
         resolver.override_department_setting_for_cops({}, hash)
         resolver.resolve_inheritance_from_gems(hash)
-        resolver.resolve_inheritance(path, hash, file, debug?)
+        resolver.resolve_inheritance_for_inherit_from(path, hash, file, debug?)
+        resolver.resolve_inheritance_for_extends(path, hash, file, debug?)
+
         hash.delete('inherit_from')
+        hash.delete('extends')
 
         # Adding missing namespaces only after resolving requires & inheritance,
         # since both can introduce new cops that need to be considered here.

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -6,7 +6,7 @@ require 'yaml'
 module RuboCop
   # A help class for ConfigLoader that handles configuration resolution.
   # @api private
-  class ConfigLoaderResolver
+  class ConfigLoaderResolver # rubocop:disable Metrics/ClassLength
     def resolve_requires(path, hash)
       config_dir = File.dirname(path)
       hash.delete('require').tap do |loaded_features|
@@ -16,8 +16,17 @@ module RuboCop
       end
     end
 
-    def resolve_inheritance(path, hash, file, debug) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    def resolve_inheritance_for_inherit_from(path, hash, file, debug)
       inherited_files = Array(hash['inherit_from'])
+      resolve_inheritance(inherited_files, path, hash, file, debug, mark_paths_relative: true)
+    end
+
+    def resolve_inheritance_for_extends(path, hash, file, debug)
+      extended_files = Array(hash['extends'])
+      resolve_inheritance(extended_files, path, hash, file, debug, mark_paths_relative: false)
+    end
+
+    def resolve_inheritance(inherited_files, path, hash, file, debug, mark_paths_relative: true) # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists, Metrics/AbcSize
       base_configs(path, inherited_files, file)
         .each_with_index.reverse_each do |base_config, index|
         override_department_setting_for_cops(base_config, hash)
@@ -33,7 +42,10 @@ module RuboCop
                       inherit_mode: determine_inherit_mode(hash, k))
           end
           hash[k] = v
-          fix_include_paths(base_config.loaded_path, hash, path, k, v) if v.key?('Include')
+
+          if mark_paths_relative && v.key?('Include')
+            mark_paths_relative_to_derived_configuration(base_config.loaded_path, hash, path, k, v)
+          end
         end
       end
     end
@@ -42,7 +54,7 @@ module RuboCop
     # base configuration are relative to the directory where the base configuration file is. For the
     # derived configuration, we need to make those paths relative to where the derived configuration
     # file is.
-    def fix_include_paths(base_config_path, hash, path, key, value)
+    def mark_paths_relative_to_derived_configuration(base_config_path, hash, path, key, value)
       return unless File.basename(base_config_path).start_with?('.rubocop')
 
       base_dir = File.dirname(base_config_path)

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe RuboCop::ConfigObsoletion do
 
         # Resolve `inherit_gem`
         resolver.resolve_inheritance_from_gems(hash)
-        resolver.resolve_inheritance(loaded_path, hash, loaded_path, false)
+        resolver.resolve_inheritance_for_inherit_from(loaded_path, hash, loaded_path, false)
 
         allow(configuration).to receive(:loaded_features).and_call_original
       end


### PR DESCRIPTION
This PR supports the idea of `extends`, which permits us to allow a child `.rubocop.yml` to make changes to a parent's configuration *without* affecting path relativity.

I chose this different directive since configuration inheritance changes are complex, so I wanted to be really clear that this is a new feature with different behavior and for different use cases to leave the existing feature unaffected.
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
