### PR TITLE
Allow inherit_from to accept a glob

### DIFF
--- a/changelog/new_allow_inherit_from_to_accept_a_glob.md
+++ b/changelog/new_allow_inherit_from_to_accept_a_glob.md
@@ -1,0 +1,1 @@
+* [#11261](https://github.com/rubocop/rubocop/pull/11261): Allow inherit_from to accept a glob. ([@alexevanczuk][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -115,11 +115,14 @@ inherit_from:
 ----
 
 `inherit_from` also accepts a glob, for example:
+
 [source,yaml]
 ----
 inherit_from:
   - packages/*/.rubocop_todo.yml
 ----
+
+The example above is one potential use-case: allowing components within your repo to organize their own `.rubocop_todo.yml` files.
 
 == Inheriting configuration from a remote URL
 

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -114,6 +114,13 @@ inherit_from:
   - ../conf/.rubocop.yml
 ----
 
+`inherit_from` also accepts a glob, for example:
+[source,yaml]
+----
+inherit_from:
+  - packages/*/.rubocop_todo.yml
+----
+
 == Inheriting configuration from a remote URL
 
 The optional `inherit_from` directive can contain a full url to a remote

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -207,7 +207,7 @@ module RuboCop
 
     def base_configs(path, inherit_from, file)
       inherit_froms = Array(inherit_from).compact.flat_map do |f|
-        PathUtils.glob?(f) ? Dir.glob(f) : f
+        PathUtil.glob?(f) ? Dir.glob(f) : f
       end
 
       configs = inherit_froms.map do |f|

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -206,7 +206,15 @@ module RuboCop
     end
 
     def base_configs(path, inherit_from, file)
-      configs = Array(inherit_from).compact.map do |f|
+      inherit_froms = Array(inherit_from).compact.flat_map do |f|
+        if f.match?(/[*{\[?]/)
+          Dir.glob(f)
+        else
+          f
+        end
+      end
+
+      configs = inherit_froms.map do |f|
         ConfigLoader.load_file(inherited_file(path, f, file))
       end
 

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -206,7 +206,9 @@ module RuboCop
     end
 
     def base_configs(path, inherit_from, file)
-      inherit_froms = Dir.glob(Array(inherit_from).compact)
+      inherit_froms = Array(inherit_from).compact.flat_map do |f|
+        PathUtils.glob?(f) ? Dir.glob(f) : f
+      end
 
       configs = inherit_froms.map do |f|
         ConfigLoader.load_file(inherited_file(path, f, file))

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -206,13 +206,7 @@ module RuboCop
     end
 
     def base_configs(path, inherit_from, file)
-      inherit_froms = Array(inherit_from).compact.flat_map do |f|
-        if f.match?(/[*{\[?]/)
-          Dir.glob(f)
-        else
-          f
-        end
-      end
+      inherit_froms = Dir.glob(Array(inherit_from).compact)
 
       configs = inherit_froms.map do |f|
         ConfigLoader.load_file(inherited_file(path, f, file))

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -40,7 +40,7 @@ module RuboCop
         matches =
           if pattern == path
             true
-          elsif pattern.match?(/[*{\[?]/)
+          elsif glob?(pattern)
             File.fnmatch?(pattern, path, File::FNM_PATHNAME | File::FNM_EXTGLOB)
           end
 
@@ -60,6 +60,11 @@ module RuboCop
     # Returns true for an absolute Unix or Windows path.
     def absolute?(path)
       %r{\A([A-Z]:)?/}i.match?(path)
+    end
+
+    # Returns true for a glob
+    def glob?(path)
+      path.match?(/[*{\[?]/)
     end
 
     def hidden_file_in_not_hidden_dir?(pattern, path)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -413,7 +413,6 @@ RSpec.describe RuboCop::ConfigLoader do
               - 'spec/models/expense_spec.rb'
         YAML
 
-
         create_file('packages/package_three/.rubocop_todo.yml', <<~YAML)
           Style/For:
             Exclude:
@@ -423,11 +422,11 @@ RSpec.describe RuboCop::ConfigLoader do
 
       it 'gets the Exclude merging the inherited one' do
         expect(configuration_from_file['Style/For']['Exclude']).to match_array([
-          File.expand_path('packages/package_two/spec/models/expense_spec.rb'),
-          File.expand_path('packages/package_one/spec/models/group_spec.rb'),
-          File.expand_path('packages/package_three/spec/models/order_spec.rb'),
-          File.expand_path('spec/requests/group_invite_spec.rb'),
-        ])
+                                                                                 File.expand_path('packages/package_two/spec/models/expense_spec.rb'),
+                                                                                 File.expand_path('packages/package_one/spec/models/group_spec.rb'),
+                                                                                 File.expand_path('packages/package_three/spec/models/order_spec.rb'),
+                                                                                 File.expand_path('spec/requests/group_invite_spec.rb')
+                                                                               ])
       end
     end
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -421,12 +421,13 @@ RSpec.describe RuboCop::ConfigLoader do
       end
 
       it 'gets the Exclude merging the inherited one' do
-        expect(configuration_from_file['Style/For']['Exclude']).to match_array([
-                                                                                 File.expand_path('packages/package_two/spec/models/expense_spec.rb'),
-                                                                                 File.expand_path('packages/package_one/spec/models/group_spec.rb'),
-                                                                                 File.expand_path('packages/package_three/spec/models/order_spec.rb'),
-                                                                                 File.expand_path('spec/requests/group_invite_spec.rb')
-                                                                               ])
+        expected = [
+          File.expand_path('packages/package_two/spec/models/expense_spec.rb'),
+          File.expand_path('packages/package_one/spec/models/group_spec.rb'),
+          File.expand_path('packages/package_three/spec/models/order_spec.rb'),
+          File.expand_path('spec/requests/group_invite_spec.rb')
+        ]
+        expect(configuration_from_file['Style/For']['Exclude']).to match_array(expected)
       end
     end
 


### PR DESCRIPTION
This PR allows `inherit_from` to accept a glob.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/

# Benchmarking
I ran benchmarks on `rails` to determine if this change causes a performance regression.

## 10x `bundle exec rubocop --show-cop=Style/EmptyMethod`
This reflects the basic startup time of Rubocop to process configurations and resolve inheritance.

### Before
```
real    0m1.325s
real    0m1.260s
real    0m1.255s
real    0m1.293s
real    0m1.241s
real    0m1.240s
real    0m1.220s
real    0m1.147s
real    0m1.168s
real    0m1.211s
```

### After
```
real    0m1.164s
real    0m1.213s
real    0m1.203s
real    0m1.200s
real    0m1.126s
real    0m1.198s
real    0m1.194s
real    0m1.191s
real    0m1.199s
real    0m1.200s
```

### Conclusion
No change.

## 10x `bundle exec rubocop`
This reflects overall rubocop execution time.

### Before
```
real    0m3.245s
real    0m3.169s
real    0m2.994s
real    0m2.898s
real    0m2.820s
real    0m2.848s
real    0m2.926s
real    0m3.006s
real    0m3.215s
real    0m3.227s
```

### After
```
real    0m3.258s
real    0m2.964s
real    0m2.986s
real    0m2.966s
real    0m2.835s
real    0m2.957s
real    0m3.163s
real    0m2.839s
real    0m2.970s
real    0m2.911s
```

### Conclusion
No change.