### PR TITLE
Fix an error for `Style/IfUnlessModifier` when the body is a method call with hash splat

### DIFF
--- a/changelog/fix_an_error_for_if_unless_modifier_and_splat.md
+++ b/changelog/fix_an_error_for_if_unless_modifier_and_splat.md
@@ -1,0 +1,1 @@
+* [#11262](https://github.com/rubocop/rubocop/pull/11262): Fix an error for `Style/IfUnlessModifier` when the body is a method call with hash splat. ([@fatkodima][])

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -56,7 +56,7 @@ module RuboCop
 
       def if_body_source(if_body)
         if if_body.call_type? &&
-           if_body.last_argument&.hash_type? && if_body.last_argument.pairs.last.value_omission?
+           if_body.last_argument&.hash_type? && if_body.last_argument.pairs.last&.value_omission?
           "#{method_source(if_body)}(#{if_body.arguments.map(&:source).join(', ')})"
         else
           if_body.source

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -213,6 +213,21 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         RUBY
       end
     end
+
+    context 'and has a method call with kwargs splat' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          if condition
+          ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+            do_this(**options)
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          do_this(**options) if condition
+        RUBY
+      end
+    end
   end
 
   context 'modifier if that does not fit on one line, but is not the only statement on the line' do


### PR DESCRIPTION
For a code like
```ruby
if condition
  do_this(**options)
end
```

I got
```
     Failure/Error:
       if if_body.call_type? &&
          if_body.last_argument&.hash_type? && if_body.last_argument.pairs.last.value_omission?

     NoMethodError:
       undefined method `value_omission?' for nil:NilClass
     # ./lib/rubocop/cop/mixin/statement_modifier.rb:59:in `if_body_source'
     # ./lib/rubocop/cop/mixin/statement_modifier.rb:51:in `to_modifier_form'
     # ./lib/rubocop/cop/mixin/statement_modifier.rb:46:in `length_in_modifier_form'
     # ./lib/rubocop/cop/mixin/statement_modifier.rb:40:in `modifier_fits_on_single_line?'
     # ./lib/rubocop/cop/mixin/statement_modifier.rb:16:in `single_line_as_modifier?'
```