### PR TITLE
More rubocop optimizations

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -124,7 +124,7 @@ module RuboCop
     # Note: the 'Enabled' attribute is same as that returned by `for_cop`
     def for_badge(badge)
       cop_config = for_cop(badge.to_s)
-      fetch(badge.department.to_s) { return cop_config }.merge(cop_config)
+      fetch(badge.department) { return cop_config }.merge(cop_config)
     end
 
     # @return [Config] for the given department name.

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -179,7 +179,7 @@ module RuboCop
       end
 
       def self.lint?
-        department == :Lint
+        department == 'Lint'
       end
 
       # Returns true if the cop name or the cop namespace matches any of the
@@ -187,7 +187,7 @@ module RuboCop
       def self.match?(given_names)
         return false unless given_names
 
-        given_names.include?(cop_name) || given_names.include?(department.to_s)
+        given_names.include?(cop_name) || given_names.include?(department)
       end
 
       def cop_name
@@ -292,7 +292,7 @@ module RuboCop
       end
 
       def apply_correction(corrector)
-        @current_corrector&.merge!(corrector) if corrector
+        current_corrector&.merge!(corrector) if corrector
       end
 
       ### Reserved for Commissioner:
@@ -305,6 +305,10 @@ module RuboCop
         @currently_disabled_lines ||= Set.new
       end
 
+      def current_corrector
+        @current_corrector ||= Corrector.new(@processed_source) if @processed_source.valid_syntax?
+      end
+
       private_class_method def self.restrict_on_send
         @restrict_on_send ||= self::RESTRICT_ON_SEND.to_a.freeze
       end
@@ -315,7 +319,7 @@ module RuboCop
         @current_offense_locations = nil
         @currently_disabled_lines = nil
         @processed_source = processed_source
-        @current_corrector = Corrector.new(@processed_source) if @processed_source.valid_syntax?
+        @current_corrector = nil
       end
 
       # Called to complete an investigation

--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -42,7 +42,7 @@ module RuboCop
         MSG = 'Unnecessary enabling of %<cop>s.'
 
         def on_new_investigation
-          return if processed_source.blank?
+          return if processed_source.blank? || !processed_source.raw_source.include?('enable')
 
           offenses = processed_source.comment_config.extra_enabled_comments
           offenses.each { |comment, cop_names| register_offense(comment, cop_names) }

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -35,7 +35,7 @@ module RuboCop
 
     # Checks if this directive relates to single line
     def single_line?
-      !self.class.before_comment(comment.text).empty?
+      !comment.text.start_with?(DIRECTIVE_COMMENT_REGEXP)
     end
 
     # Checks if this directive contains all the given cop names

--- a/spec/rubocop/cop/badge_spec.rb
+++ b/spec/rubocop/cop/badge_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::Badge do
   subject(:badge) { described_class.new(%w[Test ModuleMustBeAClassCop]) }
 
   it 'exposes department name' do
-    expect(badge.department).to be(:Test)
+    expect(badge.department).to eq('Test')
   end
 
   it 'exposes cop name' do
@@ -23,9 +23,9 @@ RSpec.describe RuboCop::Cop::Badge do
     end
 
     include_examples 'assignment of department and name', %w[Foo], nil, 'Foo'
-    include_examples 'assignment of department and name', %w[Foo Bar], :Foo, 'Bar'
-    include_examples 'assignment of department and name', %w[Foo Bar Baz], :'Foo/Bar', 'Baz'
-    include_examples 'assignment of department and name', %w[Foo Bar Baz Qux], :'Foo/Bar/Baz', 'Qux'
+    include_examples 'assignment of department and name', %w[Foo Bar], 'Foo', 'Bar'
+    include_examples 'assignment of department and name', %w[Foo Bar Baz], 'Foo/Bar', 'Baz'
+    include_examples 'assignment of department and name', %w[Foo Bar Baz Qux], 'Foo/Bar/Baz', 'Qux'
   end
 
   describe '.parse' do

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -213,21 +213,21 @@ RSpec.describe RuboCop::Cop::Cop, :config do
 
   context 'with no submodule' do
     it('has right name') { expect(cop_class.cop_name).to eq('Cop/Cop') }
-    it('has right department') { expect(cop_class.department).to eq(:Cop) }
+    it('has right department') { expect(cop_class.department).to eq('Cop') }
   end
 
   context 'with style cops' do
     let(:cop_class) { RuboCop::Cop::Style::For }
 
     it('has right name') { expect(cop_class.cop_name).to eq('Style/For') }
-    it('has right department') { expect(cop_class.department).to eq(:Style) }
+    it('has right department') { expect(cop_class.department).to eq('Style') }
   end
 
   context 'with lint cops' do
     let(:cop_class) { RuboCop::Cop::Lint::Loop }
 
     it('has right name') { expect(cop_class.cop_name).to eq('Lint/Loop') }
-    it('has right department') { expect(cop_class.department).to eq(:Lint) }
+    it('has right department') { expect(cop_class.department).to eq('Lint') }
   end
 
   describe 'Registry' do
@@ -235,8 +235,8 @@ RSpec.describe RuboCop::Cop::Cop, :config do
       subject(:departments) { described_class.registry.departments }
 
       it('has departments') { expect(departments.length).not_to eq(0) }
-      it { is_expected.to include(:Lint) }
-      it { is_expected.to include(:Style) }
+      it { is_expected.to include('Lint') }
+      it { is_expected.to include('Style') }
 
       it 'contains every value only once' do
         expect(departments.length).to eq(departments.uniq.length)

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::Registry do
   end
 
   it 'exposes cop departments' do
-    expect(registry.departments).to eql(%i[Lint Layout Metrics RSpec Test])
+    expect(registry.departments).to eql(%w[Lint Layout Metrics RSpec Test])
   end
 
   it 'can filter down to one type' do


### PR DESCRIPTION
Tested on Gitlab's `lib/` directory.

## Before
Time: `223.3s`
Memory: `1.17 GB (16961837 objects)`

```
==================================
  Mode: wall(1000)
  Samples: 222211 (0.05% miss rate)
  GC: 11808 (5.31%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      9497   (4.3%)        9497   (4.3%)     (sweeping)   <========
      8099   (3.6%)        8065   (3.6%)     RuboCop::Config#for_cop  <========
     13641   (6.1%)        7715   (3.5%)     RuboCop::AST::Descendence#each_child_node
      7630   (3.4%)        7630   (3.4%)     block (2 levels) in <class:Node>
     11282   (5.1%)        7269   (3.3%)     Parser::Lexer#advance
      5510   (2.5%)        5510   (2.5%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
      9903   (4.5%)        5357   (2.4%)     RuboCop::Cop::Base#cop_config
      6016   (2.7%)        5037   (2.3%)     RuboCop::PathUtil.match_path?
      3942   (1.8%)        3942   (1.8%)     Parser::Source::Buffer#slice
     11335   (5.1%)        3927   (1.8%)     RuboCop::Cop::Registry#enabled?  <========
      3504   (1.6%)        3504   (1.6%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
      3430   (1.5%)        3430   (1.5%)     RuboCop::QAHelpers#in_qa_file?
      3330   (1.5%)        3330   (1.5%)     RuboCop::AST::Node#node_parts
      3288   (1.5%)        3288   (1.5%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
      4039   (1.8%)        3051   (1.4%)     AST::Node#initialize
      4024   (1.8%)        3039   (1.4%)     Parser::Source::Buffer#line_index_for_position
      2806   (1.3%)        2806   (1.3%)     RuboCop::AST::ProcessedSource#valid_syntax?
      3752   (1.7%)        2756   (1.2%)     RuboCop::Cop::Base#initialize
      2731   (1.2%)        2731   (1.2%)     Parser::Source::Range#initialize
      2463   (1.1%)        2461   (1.1%)     RuboCop::Cop::Base.badge
      2250   (1.0%)        2250   (1.0%)     (marking)
      6226   (2.8%)        2241   (1.0%)     Parser::Source::TreeRewriter#initialize  <========
      2642   (1.2%)        2121   (1.0%)     RuboCop::Cop::Base#complete_investigation
      1849   (0.8%)        1849   (0.8%)     RuboCop::Cop::AutocorrectLogic#autocorrect_requested?
      3329   (1.5%)        1760   (0.8%)     RuboCop::Config#for_badge
      1743   (0.8%)        1743   (0.8%)     RuboCop::Cop::Base#on_new_investigation
      1720   (0.8%)        1608   (0.7%)     RuboCop::Cop::Team#validate_config
      1539   (0.7%)        1534   (0.7%)     Set#include?
      1517   (0.7%)        1517   (0.7%)     RuboCop::Cop::Base#reset_investigation
      1492   (0.7%)        1492   (0.7%)     RuboCop::Cop::Base#on_investigation_end
```

## After
Time: `201.2s` (`10%` speedup) 🔥
Memory: `928.20 MB (13420048 objects)` (`22.5%` improvement) 🔥 

```
==================================
  Mode: wall(1000)
  Samples: 201151 (0.05% miss rate)
  GC: 9392 (4.67%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      7757   (3.9%)        7757   (3.9%)     block (2 levels) in <class:Node>
     13608   (6.8%)        7663   (3.8%)     RuboCop::AST::Descendence#each_child_node
     11885   (5.9%)        7599   (3.8%)     Parser::Lexer#advance
      7388   (3.7%)        7388   (3.7%)     (sweeping)
      5750   (2.9%)        5750   (2.9%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
      9970   (5.0%)        5573   (2.8%)     RuboCop::Cop::Base#cop_config
      6593   (3.3%)        5475   (2.7%)     RuboCop::PathUtil.match_path?
      4028   (2.0%)        4028   (2.0%)     Parser::Source::Buffer#slice
      3644   (1.8%)        3644   (1.8%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
      3510   (1.7%)        3510   (1.7%)     RuboCop::QAHelpers#in_qa_file?
      3399   (1.7%)        3399   (1.7%)     RuboCop::AST::Node#node_parts
      3319   (1.7%)        3319   (1.7%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
      4103   (2.0%)        3120   (1.6%)     AST::Node#initialize
      3949   (2.0%)        2995   (1.5%)     RuboCop::Cop::Base#initialize
      3937   (2.0%)        2904   (1.4%)     Parser::Source::Buffer#line_index_for_position
      1963   (1.0%)        1963   (1.0%)     RuboCop::Cop::Base#begin_investigation
      1962   (1.0%)        1962   (1.0%)     (marking)
      1869   (0.9%)        1869   (0.9%)     Parser::Source::Range#initialize
      1842   (0.9%)        1842   (0.9%)     RuboCop::Cop::AutocorrectLogic#autocorrect_requested?
      1841   (0.9%)        1838   (0.9%)     RuboCop::Cop::Base.badge
      2370   (1.2%)        1822   (0.9%)     RuboCop::Cop::Base#complete_investigation
      1902   (0.9%)        1808   (0.9%)     RuboCop::Cop::Team#validate_config
      1643   (0.8%)        1643   (0.8%)     RuboCop::AST::Node#parent
      1562   (0.8%)        1557   (0.8%)     Set#include?
      1519   (0.8%)        1519   (0.8%)     RuboCop::AST::SendNode#first_argument_index
      1512   (0.8%)        1512   (0.8%)     RuboCop::Cop::Base#on_new_investigation
      1502   (0.7%)        1502   (0.7%)     RuboCop::Cop::Base#reset_investigation
      3141   (1.6%)        1502   (0.7%)     RuboCop::Config#for_badge
      1501   (0.7%)        1501   (0.7%)     RuboCop::Cop::Base#on_investigation_end
      1495   (0.7%)        1481   (0.7%)     RuboCop::Config#for_cop
```

Note: I changed `Cop#department` to return strings instead of symbols. Is this a problem?