### PR TITLE
Allow extensions inject their defaults

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -137,6 +137,7 @@ module RuboCop
         end
       end
 
+      # @api private
       def inject_defaults!(project_root)
         path = File.join(project_root, 'config', 'default.yml')
         config = load_file(path)

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -137,6 +137,14 @@ module RuboCop
         end
       end
 
+      def inject_defaults!(project_root)
+        path = File.join(project_root, 'config', 'default.yml')
+        config = load_file(path)
+        new_config = ConfigLoader.merge_with_default(config, path)
+        puts "configuration from #{path}" if debug?
+        @default_configuration = new_config
+      end
+
       # Returns the path RuboCop inferred as the root of the project. No file
       # searches will go past this directory.
       # @deprecated Use `RuboCop::ConfigFinder.project_root` instead.


### PR DESCRIPTION
Presently, extensions (e.g. [rubocop-rspec](https://github.com/rubocop/rubocop-rspec/blob/63908ab48fad95e08c4e0dc21073a716cb91d06c/lib/rubocop/rspec/inject.rb#L8), [rubocop-rails](https://github.com/rubocop/rubocop-rails/blob/f94b23596821f80c861e6632807a959dbc306aab/lib/rubocop/rails/inject.rb#L8)) all include a similar piece of code, that is [called from their entry point](https://github.com/rubocop/rubocop-rspec/blob/63908ab48fad95e08c4e0dc21073a716cb91d06c/lib/rubocop-rspec.rb#L43).

This change would allow getting rid of this common code and streamline `config/default.yml` injection:
```ruby
# e.g. lib/rubocop-capybara.rb
require_relative 'rubocop/cop/capybara_cops'

project_root = File.join(__dir__, '..')
RuboCop::ConfigLoader.inject_defaults!(project_root)
```

:warning: no docs, no tests, no changelog entry - I consider this an experimental feature.
I'm all for this hack to be replaced with a better approach in RuboCop 2.0.

### Some food for the thought

```ruby
# e.g. lib/rubocop-capybara.rb
require_relative 'rubocop/cop/capybara_cops'

project_root = File.join(__dir__, '..')
obsoletion = File.join(project_root, 'config', 'obsoletion.yml')
RuboCop::ConfigObsoletion.files << obsoletion if File.exist?(obsoletion)
```

Looking at the above code for obsoletion config injection, it feels like adding something like
```ruby
# e.g. lib/rubocop-capybara.rb
require_relative 'rubocop/cop/capybara_cops'

project_root = File.join(__dir__, '..')
extension_config_defaults = File.join(project_root, 'config', 'defaults.yml')
RuboCop::ConfigLoader.defaults_files << extension_config_defaults
```
would be more natural. But I'm slightly concerned that `DEFAULT_FILE` is used in several places, and also the load order (extensions first, or default configs first?) and didn't dare to make such a change without knowing all potential consequences.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/