### PR TITLE
[Fix #11267] Fix an error for Style/RequireOrder when modifier conditional is used between `require`

### DIFF
--- a/changelog/fix_fix_an_error_for_style_require_order_modifier_conditional.md
+++ b/changelog/fix_fix_an_error_for_style_require_order_modifier_conditional.md
@@ -1,0 +1,1 @@
+* [#11267](https://github.com/rubocop/rubocop/issues/11267): Fix an error for Style/RequireOrder when modifier conditional is used between `require`. ([@ydah][])

--- a/spec/rubocop/cop/style/require_order_spec.rb
+++ b/spec/rubocop/cop/style/require_order_spec.rb
@@ -141,4 +141,114 @@ RSpec.describe RuboCop::Cop::Style::RequireOrder, :config do
       RUBY
     end
   end
+
+  context 'when `if` is used between `require`' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        require 'c'
+        if foo
+          require 'a'
+        end
+        require 'b'
+      RUBY
+    end
+  end
+
+  context 'when `unless` is used between `require`' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        require 'c'
+        unless foo
+          require 'a'
+        end
+        require 'b'
+      RUBY
+    end
+  end
+
+  context 'when conditional with multiple `require` is used between `require`' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        require 'd'
+        if foo
+          require 'a'
+          require 'b'
+        end
+        require 'c'
+      RUBY
+    end
+  end
+
+  context 'when conditional with multiple unsorted `require` is used between `require`' do
+    it 'registers no offense' do
+      expect_offense(<<~RUBY)
+        require 'd'
+        if foo
+          require 'b'
+          require 'a'
+          ^^^^^^^^^^^ Sort `require` in alphabetical order.
+        end
+        require 'c'
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require 'd'
+        if foo
+          require 'a'
+          require 'b'
+        end
+        require 'c'
+      RUBY
+    end
+  end
+
+  context 'when nested conditionals is used between `require`' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        require 'c'
+        if foo
+          if bar
+            require 'a'
+          end
+        end
+        require 'b'
+      RUBY
+    end
+  end
+
+  context 'when modifier conditional `if` is used between `require`' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        require 'c'
+        require 'a' if foo
+        ^^^^^^^^^^^ Sort `require` in alphabetical order.
+        require 'b'
+        ^^^^^^^^^^^ Sort `require` in alphabetical order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require 'a' if foo
+        require 'b'
+        require 'c'
+      RUBY
+    end
+  end
+
+  context 'when modifier conditional `unless` is used between `require`' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        require 'c'
+        require 'a' unless foo
+        ^^^^^^^^^^^ Sort `require` in alphabetical order.
+        require 'b'
+        ^^^^^^^^^^^ Sort `require` in alphabetical order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require 'a' unless foo
+        require 'b'
+        require 'c'
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fix: #11267

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
