### PR TITLE
Add description of linting YAML files to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,15 @@ We also run [codespell](https://github.com/codespell-project/codespell) with Git
 $ codespell --ignore-words=codespell.txt
 ```
 
+### Linting YAML files
+
+We are running [yamllint](https://github.com/adrienverge/yamllint) for linting YAML files. This is also run by [GitHub Actions](https://github.com/rubocop/rubocop/blob/master/.github/workflows/linting.yml).
+`yamllint` is written in [Python](https://www.python.org/) and you can run it with:
+
+```console
+$ yamllint .
+```
+
 ### Creating changelog entries
 
 Changelog entries are just files under the `changelog/` folder that will be merged


### PR DESCRIPTION
This PR is add description of linting YAML files to CONTRIBUTING.md

Ref: https://github.com/rubocop/rubocop/pull/10392

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
