### PR TITLE
More rubocop optimizations

### DIFF
--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -82,7 +82,8 @@ module RuboCop
         @cops.each { |cop| cop.send :begin_investigation, processed_source }
         if processed_source.valid_syntax?
           invoke(:on_new_investigation, @cops)
-          invoke(:investigate, @forces, processed_source)
+          invoke_with_argument(:investigate, @forces, processed_source)
+
           walk(processed_source.ast) unless @cops.empty?
           invoke(:on_investigation_end, @cops)
         else
@@ -149,8 +150,12 @@ module RuboCop
         map
       end
 
-      def invoke(callback, cops, *args)
-        cops.each { |cop| with_cop_error_handling(cop) { cop.send(callback, *args) } }
+      def invoke(callback, cops)
+        cops.each { |cop| with_cop_error_handling(cop) { cop.send(callback) } }
+      end
+
+      def invoke_with_argument(callback, cops, arg)
+        cops.each { |cop| with_cop_error_handling(cop) { cop.send(callback, arg) } }
       end
 
       # Allow blind rescues here, since we're absorbing and packaging or

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -97,7 +97,7 @@ module RuboCop
 
       def begin_investigation(processed_source)
         super
-        @offenses = @current_offenses
+        @offenses = current_offenses
         @last_corrector = @current_corrector
       end
 

--- a/lib/rubocop/cop/layout/line_continuation_spacing.rb
+++ b/lib/rubocop/cop/layout/line_continuation_spacing.rb
@@ -31,7 +31,10 @@ module RuboCop
         include RangeHelp
         extend AutoCorrector
 
+        # rubocop:disable Metrics/AbcSize
         def on_new_investigation
+          return unless processed_source.raw_source.include?('\\')
+
           last_line = last_line(processed_source)
 
           @ignored_ranges = string_literal_ranges(processed_source.ast) +
@@ -44,6 +47,7 @@ module RuboCop
             investigate(line, line_number)
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -96,8 +96,10 @@ module RuboCop
         end
 
         def debugger_method?(send_node)
+          method_name = send_node.method_name
+
           debugger_methods.any? do |method|
-            next unless method[:method_name] == send_node.method_name
+            next unless method[:method_name] == method_name
 
             if method[:receiver].nil?
               send_node.receiver.nil?

--- a/lib/rubocop/cop/lint/duplicate_branch.rb
+++ b/lib/rubocop/cop/lint/duplicate_branch.rb
@@ -84,8 +84,6 @@ module RuboCop
       #   end
       #
       class DuplicateBranch < Base
-        include RescueNode
-
         MSG = 'Duplicate branch body detected.'
 
         def on_branching_statement(node)

--- a/lib/rubocop/cop/mixin/alignment.rb
+++ b/lib/rubocop/cop/mixin/alignment.rb
@@ -28,7 +28,7 @@ module RuboCop
 
         each_bad_alignment(items, base_column) do |current|
           expr = current.source_range
-          if @current_offenses.any? { |o| within?(expr, o.location) }
+          if @current_offenses&.any? { |o| within?(expr, o.location) }
             # If this offense is within a line range that is already being
             # realigned by autocorrect, we report the offense without
             # autocorrecting it. Two rewrites in the same area by the same

--- a/lib/rubocop/cop/mixin/allowed_identifiers.rb
+++ b/lib/rubocop/cop/mixin/allowed_identifiers.rb
@@ -7,7 +7,7 @@ module RuboCop
       SIGILS = '@$' # if a variable starts with a sigil it will be removed
 
       def allowed_identifier?(name)
-        allowed_identifiers.include?(name.to_s.delete(SIGILS))
+        !allowed_identifiers.empty? && allowed_identifiers.include?(name.to_s.delete(SIGILS))
       end
 
       def allowed_identifiers

--- a/lib/rubocop/cop/mixin/line_length_help.rb
+++ b/lib/rubocop/cop/mixin/line_length_help.rb
@@ -57,7 +57,14 @@ module RuboCop
       def indentation_difference(line)
         return 0 unless tab_indentation_width
 
-        (line.index(/[^\t]/) || 0) * (tab_indentation_width - 1)
+        index =
+          if line.start_with?(/[^\t]/)
+            0
+          else
+            line.index(/[^\t]/) || 0
+          end
+
+        index * (tab_indentation_width - 1)
       end
 
       def extend_uri_end_position(line, end_position)

--- a/lib/rubocop/cop/mixin/require_library.rb
+++ b/lib/rubocop/cop/mixin/require_library.rb
@@ -7,6 +7,8 @@ module RuboCop
     module RequireLibrary
       extend NodePattern::Macros
 
+      RESTRICT_ON_SEND = [:require].freeze
+
       def ensure_required(corrector, node, library_name)
         node = node.parent while node.parent&.parent?
 

--- a/lib/rubocop/cop/mixin/rescue_node.rb
+++ b/lib/rubocop/cop/mixin/rescue_node.rb
@@ -4,8 +4,8 @@ module RuboCop
   module Cop
     # Common functionality for checking `rescue` nodes.
     module RescueNode
-      def on_new_investigation
-        @modifier_locations = processed_source.tokens.select(&:rescue_modifier?).map(&:pos)
+      def modifier_locations
+        @modifier_locations ||= processed_source.tokens.select(&:rescue_modifier?).map!(&:pos)
       end
 
       private
@@ -13,7 +13,7 @@ module RuboCop
       def rescue_modifier?(node)
         return false unless node.respond_to?(:resbody_type?)
 
-        node.resbody_type? && @modifier_locations.include?(node.loc.keyword)
+        node.resbody_type? && modifier_locations.include?(node.loc.keyword)
       end
 
       # @deprecated Use ResbodyNode#exceptions instead

--- a/lib/rubocop/cop/naming/inclusive_language.rb
+++ b/lib/rubocop/cop/naming/inclusive_language.rb
@@ -207,7 +207,10 @@ module RuboCop
         end
 
         def scan_for_words(input)
-          mask_input(input).enum_for(:scan, @flagged_terms_regex).map do
+          masked_input = mask_input(input)
+          return [] unless masked_input.match?(@flagged_terms_regex)
+
+          masked_input.enum_for(:scan, @flagged_terms_regex).map do
             match = Regexp.last_match
             WordLocation.new(match.to_s, match.offset(0).first)
           end

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -55,7 +55,10 @@ module RuboCop
         private
 
         def check_token_set(index)
-          predecessor, operator, successor = processed_source.tokens[index, 3]
+          tokens = processed_source.tokens
+          predecessor = tokens[index]
+          operator = tokens[index + 1]
+          successor = tokens[index + 2]
 
           return unless eligible_token_set?(predecessor, operator, successor)
 

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -152,8 +152,11 @@ module RuboCop
         ' ' * (node.loc.column + offset)
       end
 
+      @to_supported_styles_cache = {}
+
       def to_supported_styles(enforced_style)
-        enforced_style.sub(/^Enforced/, 'Supported').sub('Style', 'Styles')
+        @to_supported_styles_cache[enforced_style] ||=
+          enforced_style.sub(/^Enforced/, 'Supported').sub('Style', 'Styles')
       end
 
       private


### PR DESCRIPTION
Tested on rubocop itself.

Another part of the changes: https://github.com/rubocop/rubocop-ast/pull/249.

### Before
Time: `120.6s`
Memory: `Total allocated: 1.18 GB (18733428 objects)`

```
==================================
  Mode: wall(1000)
  Samples: 120365 (0.11% miss rate)
  GC: 7299 (6.06%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     14727  (12.2%)        7815   (6.5%)     RuboCop::AST::Descendence#each_child_node
      6497   (5.4%)        6497   (5.4%)     Parser::Source::Buffer#slice
      6168   (5.1%)        6168   (5.1%)     block (2 levels) in <class:Node>
     13309  (11.1%)        5612   (4.7%)     Parser::Lexer#advance
      5283   (4.4%)        5283   (4.4%)     (sweeping)
      2586   (2.1%)        2586   (2.1%)     RuboCop::AST::Node#node_parts
      3363   (2.8%)        2541   (2.1%)     Parser::Source::Buffer#line_index_for_position
      3760   (3.1%)        2350   (2.0%)     RuboCop::Cop::Base#cop_config
      2001   (1.7%)        2001   (1.7%)     (marking)
      2451   (2.0%)        1802   (1.5%)     AST::Node#initialize
      1411   (1.2%)        1411   (1.2%)     RuboCop::AST::SendNode#first_argument_index
      1436   (1.2%)        1395   (1.2%)     RuboCop::Cop::Layout::LineContinuationLeadingSpace#raw_lines
      1346   (1.1%)        1346   (1.1%)     Parser::Source::Range#initialize
      1334   (1.1%)        1334   (1.1%)     RuboCop::AST::Node#parent
      1083   (0.9%)        1083   (0.9%)     Unicode::DisplayWidth.of
      1084   (0.9%)        1068   (0.9%)     RuboCop::Config#for_cop
      1399   (1.2%)        1040   (0.9%)     RuboCop::Cop::Base#initialize
      1112   (0.9%)         956   (0.8%)     RuboCop::PathUtil.match_path?
     59477  (49.4%)         860   (0.7%)     RuboCop::Cop::Commissioner#trigger_responding_cops
      1050   (0.9%)         834   (0.7%)     RuboCop::Cop::Base#complete_investigation
       830   (0.7%)         830   (0.7%)     RuboCop::AST::StrNode#heredoc?
      2027   (1.7%)         809   (0.7%)     RuboCop::AST::Node#each_ancestor
      7011   (5.8%)         785   (0.7%)     RuboCop::AST::Descendence#visit_descendants
       692   (0.6%)         692   (0.6%)     RuboCop::Cop::Base#begin_investigation
       710   (0.6%)         645   (0.5%)     RuboCop::Cop::Team#validate_config
       744   (0.6%)         639   (0.5%)     RuboCop::AST::ProcessedSource#sorted_tokens
       606   (0.5%)         605   (0.5%)     Set#include?
       633   (0.5%)         591   (0.5%)     RuboCop::Cop::Naming::InclusiveLanguage#scan_for_words
       584   (0.5%)         584   (0.5%)     RuboCop::AST::Token#rescue_modifier?
       583   (0.5%)         583   (0.5%)     RuboCop::AST::Node#source_range
```

### After
Time: `107.5s` (11% speedup) 🔥
Memory: `Total allocated: 1.03 GB (15500315 objects)` (13% less GB and 17% less allocated objects) 🔥

```
==================================
  Mode: wall(1000)
  Samples: 107266 (0.14% miss rate)
  GC: 6540 (6.10%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      6394   (6.0%)        6394   (6.0%)     Parser::Source::Buffer#slice
     12609  (11.8%)        5326   (5.0%)     Parser::Lexer#advance
      4791   (4.5%)        4791   (4.5%)     (sweeping)
      5115   (4.8%)        3879   (3.6%)     RuboCop::AST::Descendence#visit_descendants
      7196   (6.7%)        3028   (2.8%)     RuboCop::AST::Descendence#each_child_node
      3031   (2.8%)        2218   (2.1%)     Parser::Source::Buffer#line_index_for_position
      3370   (3.1%)        2040   (1.9%)     RuboCop::Cop::Base#cop_config
      2025   (1.9%)        2025   (1.9%)     RuboCop::AST::Node#node_parts
      2320   (2.2%)        1741   (1.6%)     AST::Node#initialize
      1738   (1.6%)        1738   (1.6%)     (marking)
      1363   (1.3%)        1324   (1.2%)     RuboCop::Cop::Layout::LineContinuationLeadingSpace#raw_lines
      1324   (1.2%)        1324   (1.2%)     Parser::Source::Range#initialize
      1290   (1.2%)        1290   (1.2%)     RuboCop::AST::SendNode#first_argument_index
      1071   (1.0%)        1071   (1.0%)     Unicode::DisplayWidth.of
      1298   (1.2%)         981   (0.9%)     RuboCop::Cop::Base#initialize
      1068   (1.0%)         924   (0.9%)     RuboCop::PathUtil.match_path?
       920   (0.9%)         907   (0.8%)     RuboCop::Config#for_cop
       902   (0.8%)         902   (0.8%)     RuboCop::AST::Node#parent
     52071  (48.5%)         802   (0.7%)     RuboCop::Cop::Commissioner#trigger_responding_cops
       791   (0.7%)         791   (0.7%)     RuboCop::AST::SendNode#send_type?
       784   (0.7%)         784   (0.7%)     RuboCop::AST::StrNode#heredoc?
      1825   (1.7%)         737   (0.7%)     RuboCop::AST::Node#each_ancestor
       695   (0.6%)         695   (0.6%)     RuboCop::AST::Node#block_type?
       867   (0.8%)         659   (0.6%)     RuboCop::Cop::Base#complete_investigation
       735   (0.7%)         634   (0.6%)     RuboCop::AST::ProcessedSource#sorted_tokens
       630   (0.6%)         614   (0.6%)     RuboCop::Cop::Base#cop_name
       600   (0.6%)         565   (0.5%)     RuboCop::Cop::Team#validate_config
       552   (0.5%)         552   (0.5%)     RuboCop::Cop::Base#begin_investigation
       573   (0.5%)         550   (0.5%)     RuboCop::Cop::Layout::TrailingEmptyLines#on_new_investigation
       525   (0.5%)         525   (0.5%)     RuboCop::Cop::Base#reset_investigation
```