### PR TITLE
Fix NoMethodError for Style/Documentation when a class nested under non-constant values

### DIFF
--- a/changelog/fix_nomethoderror_for_styledocumentation.md
+++ b/changelog/fix_nomethoderror_for_styledocumentation.md
@@ -1,0 +1,1 @@
+* [#11281](https://github.com/rubocop/rubocop/pull/11281): Fix `NoMethodError` for `Style/Documentation` when a class nested under non-constant values. ([@arika][])

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -176,7 +176,7 @@ module RuboCop
         end
 
         def qualify_const(node)
-          return if node.nil? || node.cbase_type?
+          return if node.nil? || node.cbase_type? || node.self_type? || node.send_type?
 
           [qualify_const(node.namespace), node.short_name].compact
         end

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -27,6 +27,26 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
     RUBY
   end
 
+  it 'registers an offense for non-empty class nested under self' do
+    expect_offense(<<~RUBY)
+      class self::MyClass
+      ^^^^^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class MyClass`.
+        def method
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for non-empty class nested under method call' do
+    expect_offense(<<~RUBY)
+      class my_method::MyClass
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class MyClass`.
+        def method
+        end
+      end
+    RUBY
+  end
+
   it 'does not consider comment followed by empty line to be class documentation' do
     expect_offense(<<~RUBY)
       # Copyright 2014


### PR DESCRIPTION
Style/Documentation raises NoMethodError for the following code:

```ruby
module self::Foo
end

module foo::Bar
end
```

output:

```console
$ rubocop --only Style/Documentation test.rb
Inspecting 1 file
An error occurred while Style/Documentation cop was inspecting /tmp/test.rb:1:0.
To see the complete backtrace run rubocop -d.
An error occurred while Style/Documentation cop was inspecting /tmp/test.rb:4:0.
To see the complete backtrace run rubocop -d.
.

1 file inspected, no offenses detected

2 errors occurred:
An error occurred while Style/Documentation cop was inspecting /tmp/test.rb:1:0.
An error occurred while Style/Documentation cop was inspecting /tmp/test.rb:4:0.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop/rubocop/issues

Mention the following information in the issue report:
1.40.0 (using Parser 3.1.3.0, rubocop-ast 1.24.0, running on ruby 2.7.6) [x86_64-darwin21]
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/