### PR TITLE
[Fix #11284] Fix an incorrect autocorrect for `Style/WordArray`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_word_array.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_word_array.md
@@ -1,0 +1,1 @@
+* [#11284](https://github.com/rubocop/rubocop/issues/11284): Fix an incorrect autocorrect for `Style/WordArray` when assigning `%w()` array. ([@koic][])

--- a/lib/rubocop/cop/mixin/percent_array.rb
+++ b/lib/rubocop/cop/mixin/percent_array.rb
@@ -97,9 +97,7 @@ module RuboCop
       # @return [String]
       def whitespace_between(node)
         if node.children.length >= 2
-          node.source[
-            node.children[0].loc.expression.end_pos...node.children[1].loc.expression.begin_pos
-          ]
+          node.children[0].source_range.end.join(node.children[1].source_range.begin).source
         else
           ' '
         end
@@ -111,7 +109,7 @@ module RuboCop
       # @param [RuboCop::AST::ArrayNode] node
       # @return [String]
       def whitespace_leading(node)
-        node.source[node.loc.begin.end_pos...node.children[0].loc.expression.begin_pos]
+        node.loc.begin.end.join(node.children[0].source_range.begin).source
       end
 
       # Provides trailing whitespace for building a bracketed array.
@@ -120,7 +118,7 @@ module RuboCop
       # @param [RuboCop::AST::ArrayNode] node
       # @return [String]
       def whitespace_trailing(node)
-        node.source[node.children[-1].loc.expression.end_pos...node.loc.end.begin_pos]
+        node.children[-1].source_range.end.join(node.loc.end.begin).source
       end
     end
   end

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -383,6 +383,34 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       RUBY
     end
 
+    it 'registers an offense when assigning `%w()` array' do
+      expect_offense(<<~RUBY)
+        FOO = %w(one@example.com two@example.com)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `['one@example.com', 'two@example.com']` for an array of words.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        FOO = ['one@example.com', 'two@example.com']
+      RUBY
+    end
+
+    it 'registers an offense when assigning multiline `%w()` array' do
+      expect_offense(<<~RUBY)
+        FOO = %w(
+              ^^^ Use an array literal `[...]` for an array of words.
+          one@example.com
+          two@example.com
+        )
+      RUBY
+
+      expect_correction(<<~RUBY)
+        FOO = [
+          'one@example.com',
+          'two@example.com'
+        ]
+      RUBY
+    end
+
     it 'registers an offense for an empty %w() array' do
       expect_offense(<<~RUBY)
         %w()


### PR DESCRIPTION
Fixes #11284.

This PR fixes an incorrect autocorrect for `Style/WordArray` when assigning `%w()` array.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
