### PR TITLE
Improve doc of EnforcedShorthandSyntax: consistent

### DIFF
--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -28,7 +28,7 @@ module RuboCop
       # * always - forces use of the 3.1 syntax (e.g. {foo:})
       # * never - forces use of explicit hash literal value
       # * either - accepts both shorthand and explicit use of hash literal value
-      # * consistent - like "either", but will avoid mixing styles in a single hash
+      # * consistent - forces use of the 3.1 syntax only if all values can be omitted in the hash
       #
       # @example EnforcedStyle: ruby19 (default)
       #   # bad
@@ -92,17 +92,20 @@ module RuboCop
       #
       # @example EnforcedShorthandSyntax: consistent
       #
-      #   # bad
-      #   {foo: , bar: bar}
-      #
       #   # good
       #   {foo:, bar:}
       #
-      #   # bad
-      #   {foo: , bar: baz}
+      #   # good - can't omit `qux`
+      #   {foo: foo, bar: qux}
       #
-      #   # good
-      #   {foo: foo, bar: baz}
+      #   # bad - `foo' and `bar` can be omitted
+      #   {foo: foo, bar: bar}
+      #
+      #   # bad - `bar` can be omitted
+      #   {foo:, bar: bar}
+      #
+      #   # bad - mixed syntaxes
+      #   {foo:, bar: qux}
       #
       class HashSyntax < Base
         include ConfigurableEnforcedStyle


### PR DESCRIPTION
This PR improves the documentation of `Style/HashSyntax`'s `EnforcedShorthandSyntax` for the `consistent` style.

The documentation (https://docs.rubocop.org/rubocop/1.40/cops_style.html#stylehashsyntax) says

> always - forces use of the 3.1 syntax (e.g. {foo:})
> never - forces use of explicit hash literal value
> either - accepts both shorthand and explicit use of hash literal value
> consistent - like "either", but will avoid mixing styles in a single hash

There is a recent change (https://github.com/rubocop/rubocop/pull/11049, the documentation was `like "always", but will avoid mixing styles in a single hash` before) about this, but it's still unclear IMHO (see also https://github.com/rubocop/rubocop/issues/10933).

This PR change the documentation to :

> consistent - forces use of the 3.1 syntax only if all values can be omitted in the hash

and updates the examples to be more explicit about why they are good or bad.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
➡️ No code change
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
➡️ ❓ Is it required for a documentation change ?

[1]: https://chris.beams.io/posts/git-commit/
