### PR TITLE
Correctly detect Rails version when using only parts of the framework

### DIFF
--- a/changelog/fix_correctly_detect_rails_version.md
+++ b/changelog/fix_correctly_detect_rails_version.md
@@ -1,0 +1,1 @@
+* [#11289](https://github.com/rubocop/rubocop/pull/11289): Correctly detect Rails version when using only parts of the framework, instead of the "rails" gem. ([@bdewater][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -273,9 +273,10 @@ module RuboCop
       return nil unless lock_file_path
 
       File.foreach(lock_file_path) do |line|
-        # If rails is in Gemfile.lock or gems.lock, there should be a line like:
-        #         rails (X.X.X)
-        result = line.match(/^\s+rails\s+\((\d+\.\d+)/)
+        # If Rails (or one of its frameworks) is in Gemfile.lock or gems.lock, there should be
+        # a line like:
+        #         railties (X.X.X)
+        result = line.match(/^\s+railties\s+\((\d+\.\d+)/)
         return result.captures.first.to_f if result
       end
     end

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -160,6 +160,8 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
                   rails (4.1.0)
                     actionmailer (= 4.1.0)
                     actionpack (= 4.1.0)
+                    railties (= 4.1.0)
+                  railties (4.1.0)
 
                 PLATFORMS
                   ruby
@@ -188,6 +190,8 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
                   rails (4.1.0)
                     actionmailer (= 4.1.0)
                     actionpack (= 4.1.0)
+                    railties (= 4.1.0)
+                  railties (4.1.0)
 
                 PLATFORMS
                   ruby
@@ -458,6 +462,8 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
                   rails (4.1.0)
                     actionmailer (= 4.1.0)
                     actionpack (= 4.1.0)
+                    railties (= 4.1.0)
+                  railties (4.1.0)
 
                 PLATFORMS
                   ruby


### PR DESCRIPTION
The rails gem is a metapackage that [only contains the readme, license file](https://github.com/rails/rails/blob/main/rails.gemspec#L21) and a list of dependencies (including railties). The [railties gem](https://rubygems.org/gems/railties/) exists since Rails 3.0 and [contains the code](https://github.com/rails/rails/blob/main/railties/railties.gemspec#L20) that actually ties Rails together.

Apps requiring a subset of Rails in their Gemfile (eg skipping Action Cable/Text/Mailbox but keeping the rest) will have railties in their Gemfile.lock but not rails. The setup looks a bit like this:
```ruby
# Gemfile - replace `gem "rails"` with:
rails_version = ["~> 7.0.3", ">= 7.0.3.1"]
gem "activesupport", rails_version
gem "actionpack", rails_version
gem "actionview", rails_version
gem "activemodel", rails_version
gem "activerecord", rails_version
gem "actionmailer", rails_version
gem "activejob", rails_version
gem "activestorage", rails_version
gem "railties", rails_version

# config/application.rb - replace `require "rails/all"` with:
[
  "active_record/railtie",
  "active_storage/engine",
  "action_controller/railtie",
  "action_view/railtie",
  "action_mailer/railtie",
  "active_job/railtie",
  "rails/test_unit/railtie",
].each do |railtie|
  require railtie
end
```

This leads Rubocop to incorrectly assume that DEFAULT_RAILS_VERSION (5.0) is used, this pull request fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
