### PR TITLE
[Fix #11293] Fix a false negative for `Style/Documentation`

### DIFF
--- a/changelog/fix_false_negative_for_style_documentation.md
+++ b/changelog/fix_false_negative_for_style_documentation.md
@@ -1,0 +1,1 @@
+* [#11293](https://github.com/rubocop/rubocop/issues/11293): Fix a false negative for `Style/Documentation` when using macro. ([@koic][])

--- a/lib/rubocop/formatter.rb
+++ b/lib/rubocop/formatter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module RuboCop
+  # The bootstrap module for formatter.
+  # @api private
   module Formatter
     require_relative 'formatter/text_util'
 

--- a/spec/fixtures/html_formatter/expected.html
+++ b/spec/fixtures/html_formatter/expected.html
@@ -367,14 +367,14 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
       <div class="infobox">
         <div class="total">
           3 files inspected,
-          22 offenses detected:
+          23 offenses detected:
         </div>
         <ul class="offenses-list">
           
             
             <li>
               <a href="#offense_app/controllers/application_controller.rb">
-                app/controllers/application_controller.rb - 1 offense
+                app/controllers/application_controller.rb - 2 offenses
               </a>
             </li>
           
@@ -400,8 +400,19 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
       
       <div class="offense-box" id="offense_app/controllers/application_controller.rb">
         <div class="box-title-placeholder"><h3>&nbsp;</h3></div>
-        <div class="box-title"><h3>app/controllers/application_controller.rb - 1 offense</h3></div>
+        <div class="box-title"><h3>app/controllers/application_controller.rb - 2 offenses</h3></div>
         <div class="offense-reports">
+          
+          <div class="report">
+            <div class="meta">
+              <span class="location">Line #1</span> –
+              <span class="severity convention">convention:</span>
+              <span class="message">Style/Documentation: Missing top-level documentation comment for <code>class ApplicationController</code>.</span>
+            </div>
+            
+            <pre><code><span class="highlight convention">class ApplicationController</span> &lt; ActionController::Base</code></pre>
+            
+          </div>
           
           <div class="report">
             <div class="meta">

--- a/spec/fixtures/markdown_formatter/expected.md
+++ b/spec/fixtures/markdown_formatter/expected.md
@@ -1,8 +1,14 @@
 # RuboCop Inspection Report
 
-4 files inspected, 22 offenses detected:
+4 files inspected, 23 offenses detected:
 
-### app/controllers/application_controller.rb - (1 offense)
+### app/controllers/application_controller.rb - (2 offenses)
+  * **Line # 1 - convention:** Style/Documentation: Missing top-level documentation comment for `class ApplicationController`.
+
+    ```rb
+    class ApplicationController < ActionController::Base
+    ```
+
   * **Line # 1 - convention:** Style/FrozenStringLiteralComment: Missing frozen string literal comment.
 
     ```rb

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -244,8 +244,25 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
       end
     end
 
-    context 'macro-only class' do
-      it 'does not register offense with single macro' do
+    it 'registers offense with custom macro' do
+      expect_offense(<<~RUBY)
+        class Foo < ApplicationRecord
+        ^^^^^^^^^ Missing top-level documentation comment for `class Foo`.
+          belongs_to :bar
+        end
+      RUBY
+    end
+
+    context 'include statement-only class' do
+      it 'does not register offense with single `include` statements' do
+        expect_no_offenses(<<~RUBY)
+          module Foo
+            include Bar
+          end
+        RUBY
+      end
+
+      it 'does not register offense with single `extend` statements' do
         expect_no_offenses(<<~RUBY)
           module Foo
             extend Bar
@@ -253,17 +270,26 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
         RUBY
       end
 
-      it 'does not register offense with multiple macros' do
+      it 'does not register offense with single `prepend` statements' do
         expect_no_offenses(<<~RUBY)
           module Foo
-            extend A
-            extend B
-            include C
+            prepend Bar
           end
         RUBY
       end
 
-      it 'registers offense for macro with other methods' do
+      it 'does not register offense with multiple include macros' do
+        expect_no_offenses(<<~RUBY)
+          module Foo
+            include A
+            include B
+            extend C
+            prepend D
+          end
+        RUBY
+      end
+
+      it 'registers offense for include statement with other methods' do
         expect_offense(<<~RUBY)
           module Foo
           ^^^^^^^^^^ Missing top-level documentation comment for `module Foo`.

--- a/tasks/spec_runner.rake
+++ b/tasks/spec_runner.rake
@@ -4,9 +4,9 @@ require 'rspec/core'
 require 'test_queue'
 require 'test_queue/runner/rspec'
 
-# Add `failed_examples` into `TestQueue::Worker` so we can keep
-# track of the output for re-running failed examples from RSpec.
 module TestQueue
+  # Add `failed_examples` into `TestQueue::Worker` so we can keep
+  # track of the output for re-running failed examples from RSpec.
   class Worker
     attr_accessor :failed_examples
   end


### PR DESCRIPTION
Fixes #11293.

This PR fixes a false negative for `Style/Documentation` when using custom macro.

The built-in macros (e.g. `include`, `extend`, `prepend`) and DSL like `belongs_to` should be treated differently. Only `include`, `extend`, and `prepend` will be needed to resolve #8788.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
