### PR TITLE
Fix an error for `Lint/NonAtomicFileOperation`

### DIFF
--- a/changelog/fix_an_error_for_non_atomic_file_operation.md
+++ b/changelog/fix_an_error_for_non_atomic_file_operation.md
@@ -1,0 +1,1 @@
+* [#11296](https://github.com/rubocop/rubocop/pull/11296): Fix an error for `Lint/NonAtomicFileOperation` when use file existence checks line break `unless` by postfix before creating file. ([@koic][])

--- a/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
+++ b/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
@@ -185,6 +185,32 @@ RSpec.describe RuboCop::Cop::Lint::NonAtomicFileOperation, :config do
     RUBY
   end
 
+  it 'registers an offense when use file existence checks line break `unless` by postfix before creating file' do
+    expect_offense(<<~RUBY)
+      FileUtils.mkdir(path) unless
+                            ^^^^^^ Remove unnecessary existence check `FileTest.exist?`.
+      ^^^^^^^^^^^^^^^^^^^^^ Use atomic file operation method `FileUtils.mkdir_p`.
+                            FileTest.exist?(path)
+    RUBY
+
+    expect_correction(<<~RUBY)
+      FileUtils.mkdir_p(path)
+    RUBY
+  end
+
+  it 'registers an offense when use file existence checks line break `unless` (wrapped the in parentheses) by postfix before creating file' do
+    expect_offense(<<~RUBY)
+      FileUtils.mkdir(path) unless (
+                            ^^^^^^^^ Remove unnecessary existence check `FileTest.exist?`.
+      ^^^^^^^^^^^^^^^^^^^^^ Use atomic file operation method `FileUtils.mkdir_p`.
+                            FileTest.exist?(path))
+    RUBY
+
+    expect_correction(<<~RUBY)
+      FileUtils.mkdir_p(path)
+    RUBY
+  end
+
   it 'does not register an offense when not checking for the existence' do
     expect_no_offenses(<<~RUBY)
       FileUtils.mkdir_p(path)


### PR DESCRIPTION
This PR fixes the following error for `Lint/NonAtomicFileOperation` when use file existence checks line break `unless` by postfix before creating file.

```ruby
FileUtils.mkdir(path) unless
  FileTest.exist?(path)
```

```console
% bundle exec rubocop example.rb --only Lint/NonAtomicFileOperation -d
(snip)

Expected a Parser::Source::Range, Comment or RuboCop::AST::Node, got NilClass
/Users/koic/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/corrector.rb:91:in `to_range'
/Users/koic/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rubocop-1.40.0/lib/rubocop/cop/corrector.rb:100:in `check_range_validity'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
