### PR TITLE
Fix `base_dir` in `TargetFinder#find_files()`

### DIFF
--- a/changelog/fix_fix_base_dir_in_target_finder_find_files.md
+++ b/changelog/fix_fix_base_dir_in_target_finder_find_files.md
@@ -1,0 +1,1 @@
+* [#11299](https://github.com/rubocop/rubocop/pull/11299): Fix `base_dir` in `TargetFinder#find_files()`. ([@dukaev][])

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -88,7 +88,7 @@ module RuboCop
       patterns.map! { |dir| File.join(dir, '*') }
       # We need this special case to avoid creating the pattern
       # /**/* which searches the entire file system.
-      patterns = [File.join(dir, '**/*')] if patterns.empty?
+      patterns = [File.join(base_dir, '**/*')] if patterns.empty?
 
       Dir.glob(patterns, flags).select { |path| FileTest.file?(path) }
     end

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -433,6 +433,21 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       expect(found_basenames).to include('ruby4.rb')
     end
 
+    it 'works if patterns are empty' do
+      allow(Dir).to receive(:glob).and_call_original
+      allow_any_instance_of(described_class).to receive(:wanted_dir_patterns).and_return([])
+
+      expect(Dir).to receive(:glob).with([File.join(base_dir, '**/*')], flags)
+      expect(found_basenames).to include(
+        'executable',
+        'file.txt',
+        'file',
+        'ruby1.rb',
+        'ruby2.rb',
+        'ruby3.rb'
+      )
+    end
+
     # Cannot create a directory with containing `*` character on Windows.
     # https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
     unless RuboCop::Platform.windows?


### PR DESCRIPTION
`dir` variable in `TargetFinder#find_files()` doesn't exist:
```
undefined local variable or method `dir' for 
```
I think it was just a misprint.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
