### PR TITLE
More rubocop optimizations

### DIFF
--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -224,6 +224,8 @@ module RuboCop
       end
 
       def relevant_file?(file)
+        return true unless @config.clusivity_config_for_badge?(self.class.badge)
+
         file == RuboCop::AST::ProcessedSource::STRING_SOURCE_NAME ||
           (file_name_matches_any?(file, 'Include', true) &&
             !file_name_matches_any?(file, 'Exclude', false))

--- a/lib/rubocop/cop/internal_affairs/cop_description.rb
+++ b/lib/rubocop/cop/internal_affairs/cop_description.rb
@@ -28,8 +28,9 @@ module RuboCop
           /^\s+# This cop (?<special>#{SPECIAL_WORDS.join('|')})?\s*(?<word>.+?) .*/.freeze
         REPLACEMENT_REGEX = /^\s+# This cop (#{SPECIAL_WORDS.join('|')})?\s*(.+?) /.freeze
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def on_class(node)
-          return unless (module_node = node.parent)
+          return unless (module_node = node.parent) && node.parent_class
 
           description_beginning = first_comment_line(module_node)
           return unless description_beginning
@@ -48,6 +49,7 @@ module RuboCop
             end
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         private
 

--- a/lib/rubocop/cop/layout/empty_lines.rb
+++ b/lib/rubocop/cop/layout/empty_lines.rb
@@ -27,6 +27,8 @@ module RuboCop
 
         def on_new_investigation
           return if processed_source.tokens.empty?
+          # Quick check if we possibly have consecutive blank lines.
+          return unless processed_source.raw_source.include?("\n\n\n")
 
           lines = Set.new
           processed_source.each_token { |token| lines << token.line }

--- a/lib/rubocop/cop/layout/extra_spacing.rb
+++ b/lib/rubocop/cop/layout/extra_spacing.rb
@@ -119,12 +119,16 @@ module RuboCop
         def ignored_ranges(ast)
           return [] unless ast
 
-          @ignored_ranges ||= on_node(:pair, ast).map do |pair|
-            next if pair.parent.single_line?
+          @ignored_ranges ||= begin
+            ranges = []
+            on_node(:pair, ast) do |pair|
+              next if pair.parent.single_line?
 
-            key, value = *pair
-            key.source_range.end_pos...value.source_range.begin_pos
-          end.compact
+              key, value = *pair
+              ranges << (key.source_range.end_pos...value.source_range.begin_pos)
+            end
+            ranges
+          end
         end
 
         def force_equal_sign_alignment?

--- a/lib/rubocop/cop/layout/indentation_style.rb
+++ b/lib/rubocop/cop/layout/indentation_style.rb
@@ -90,7 +90,8 @@ module RuboCop
           # which lines start inside a string literal?
           return [] if ast.nil?
 
-          ast.each_node(:str, :dstr).with_object(Set.new) do |str, ranges|
+          ranges = Set.new
+          ast.each_node(:str, :dstr) do |str|
             loc = str.location
 
             if str.heredoc?
@@ -99,6 +100,7 @@ module RuboCop
               ranges << loc.expression
             end
           end
+          ranges
         end
 
         def message(_node)

--- a/lib/rubocop/cop/layout/line_continuation_leading_space.rb
+++ b/lib/rubocop/cop/layout/line_continuation_leading_space.rb
@@ -51,7 +51,11 @@ module RuboCop
         private_constant :LINE_1_ENDING, :LINE_2_BEGINNING,
                          :LEADING_STYLE_OFFENSE, :TRAILING_STYLE_OFFENSE
 
+        # rubocop:disable Metrics/AbcSize
         def on_dstr(node)
+          # Quick check if we possibly have line continuations.
+          return unless node.source.include?('\\')
+
           end_of_first_line = node.loc.expression.begin_pos - node.loc.expression.column
 
           raw_lines(node).each_cons(2) do |raw_line_one, raw_line_two|
@@ -66,6 +70,7 @@ module RuboCop
             end
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/lib/rubocop/cop/layout/line_continuation_spacing.rb
+++ b/lib/rubocop/cop/layout/line_continuation_spacing.rb
@@ -96,7 +96,8 @@ module RuboCop
           # which lines start inside a string literal?
           return [] if ast.nil?
 
-          ast.each_node(:str, :dstr).with_object(Set.new) do |str, ranges|
+          ranges = Set.new
+          ast.each_node(:str, :dstr) do |str|
             loc = str.location
 
             if str.heredoc?
@@ -105,6 +106,7 @@ module RuboCop
               ranges << loc.expression
             end
           end
+          ranges
         end
 
         def comment_ranges(comments)

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -86,6 +86,8 @@ module RuboCop
         alias on_def on_potential_breakable_node
 
         def on_new_investigation
+          return unless processed_source.raw_source.include?(';')
+
           check_for_breakable_semicolons(processed_source)
         end
 

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -84,11 +84,11 @@ module RuboCop
           return true if other_cop_takes_precedence?(node)
 
           !cop_config['InspectBlocks'] && (node.block_type? ||
-                                           node.each_descendant(:block).any?(&:multiline?))
+                                           any_descendant?(node, :block, &:multiline?))
         end
 
         def other_cop_takes_precedence?(node)
-          single_line_block_chain_enabled? && node.each_descendant(:block).any? do |block_node|
+          single_line_block_chain_enabled? && any_descendant?(node, :block) do |block_node|
             block_node.parent.send_type? && block_node.parent.loc.dot && !block_node.multiline?
           end
         end

--- a/lib/rubocop/cop/layout/trailing_empty_lines.rb
+++ b/lib/rubocop/cop/layout/trailing_empty_lines.rb
@@ -79,7 +79,7 @@ module RuboCop
         def ends_in_end?(processed_source)
           buffer = processed_source.buffer
 
-          return true if buffer.source.strip.start_with?('__END__')
+          return true if buffer.source.match?(/\s*__END__/)
           return false if processed_source.tokens.empty?
 
           extra = buffer.source[processed_source.tokens.last.end_pos..]

--- a/lib/rubocop/cop/layout/trailing_whitespace.rb
+++ b/lib/rubocop/cop/layout/trailing_whitespace.rb
@@ -109,10 +109,14 @@ module RuboCop
         def extract_heredocs(ast)
           return [] unless ast
 
-          ast.each_node(:str, :dstr, :xstr).select(&:heredoc?).map do |node|
+          heredocs = []
+          ast.each_node(:str, :dstr, :xstr) do |node|
+            next unless node.heredoc?
+
             body = node.location.heredoc_body
-            [node, body.first_line...body.last_line]
+            heredocs << [node, body.first_line...body.last_line]
           end
+          heredocs
         end
 
         def offense_range(lineno, line)

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -63,14 +63,14 @@ module RuboCop
         def on_def(node)
           # if a method definition is inside an if, it is very likely
           # that a different definition is used depending on platform, etc.
-          return if node.ancestors.any?(&:if_type?)
+          return if node.each_ancestor.any?(&:if_type?)
           return if possible_dsl?(node)
 
           found_instance_method(node, node.method_name)
         end
 
         def on_defs(node)
-          return if node.ancestors.any?(&:if_type?)
+          return if node.each_ancestor.any?(&:if_type?)
           return if possible_dsl?(node)
 
           if node.receiver.const_type?

--- a/lib/rubocop/cop/mixin/allowed_identifiers.rb
+++ b/lib/rubocop/cop/mixin/allowed_identifiers.rb
@@ -11,7 +11,7 @@ module RuboCop
       end
 
       def allowed_identifiers
-        cop_config.fetch('AllowedIdentifiers', [])
+        cop_config.fetch('AllowedIdentifiers') { [] }
       end
     end
   end

--- a/lib/rubocop/cop/mixin/annotation_comment.rb
+++ b/lib/rubocop/cop/mixin/annotation_comment.rb
@@ -41,16 +41,23 @@ module RuboCop
       def split_comment(comment)
         # Sort keywords by reverse length so that if a keyword is in a phrase
         # but also on its own, both will match properly.
-        keywords_regex = Regexp.new(
-          Regexp.union(keywords.sort_by { |w| -w.length }).source,
-          Regexp::IGNORECASE
-        )
-        regex = /^(# ?)(\b#{keywords_regex}\b)(\s*:)?(\s+)?(\S+)?/i
-
         match = comment.text.match(regex)
         return false unless match
 
         match.captures
+      end
+
+      KEYWORDS_REGEX_CACHE = {} # rubocop:disable Layout/ClassStructure, Style/MutableConstant
+      private_constant :KEYWORDS_REGEX_CACHE
+
+      def regex
+        KEYWORDS_REGEX_CACHE[keywords] ||= begin
+          keywords_regex = Regexp.new(
+            Regexp.union(keywords.sort_by { |w| -w.length }).source,
+            Regexp::IGNORECASE
+          )
+          /^(# ?)(\b#{keywords_regex}\b)(\s*:)?(\s+)?(\S+)?/i
+        end
       end
 
       def keyword_appearance?

--- a/lib/rubocop/cop/mixin/line_length_help.rb
+++ b/lib/rubocop/cop/mixin/line_length_help.rb
@@ -58,7 +58,7 @@ module RuboCop
         return 0 unless tab_indentation_width
 
         index =
-          if line.start_with?(/[^\t]/)
+          if line.match?(/^[^\t]/)
             0
           else
             line.index(/[^\t]/) || 0

--- a/lib/rubocop/cop/mixin/method_complexity.rb
+++ b/lib/rubocop/cop/mixin/method_complexity.rb
@@ -59,13 +59,15 @@ module RuboCop
       end
 
       def complexity(body)
-        body.each_node(:lvasgn, *self.class::COUNTED_NODES).reduce(1) do |score, node|
+        score = 1
+        body.each_node(:lvasgn, *self.class::COUNTED_NODES) do |node|
           if node.lvasgn_type?
             reset_on_lvasgn(node)
-            next score
+          else
+            score += complexity_score_for(node)
           end
-          score + complexity_score_for(node)
         end
+        score
       end
     end
   end

--- a/lib/rubocop/cop/naming/class_and_module_camel_case.rb
+++ b/lib/rubocop/cop/naming/class_and_module_camel_case.rb
@@ -30,6 +30,8 @@ module RuboCop
         MSG = 'Use CamelCase for classes and modules.'
 
         def on_class(node)
+          return unless node.loc.name.source.include?('_')
+
           allowed = /#{cop_config['AllowedNames'].join('|')}/
           name = node.loc.name.source.gsub(allowed, '')
           return unless /_/.match?(name)

--- a/lib/rubocop/cop/naming/inclusive_language.rb
+++ b/lib/rubocop/cop/naming/inclusive_language.rb
@@ -208,7 +208,7 @@ module RuboCop
 
         def scan_for_words(input)
           masked_input = mask_input(input)
-          return [] unless masked_input.match?(@flagged_terms_regex)
+          return EMPTY_ARRAY unless masked_input.match?(@flagged_terms_regex)
 
           masked_input.enum_for(:scan, @flagged_terms_regex).map do
             match = Regexp.last_match

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -51,6 +51,8 @@ module RuboCop
         NEGATED_EQUALITY_METHODS = %i[!= !~].freeze
         CAMEL_CASE = /[A-Z]+[a-z]+/.freeze
 
+        RESTRICT_ON_SEND = [:!].freeze
+
         def self.autocorrect_incompatible_with
           [Style::Not, Style::SymbolProc]
         end

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -37,13 +37,14 @@ module RuboCop
         end
 
         def on_new_investigation
-          return if processed_source.blank?
+          return if processed_source.blank? || !processed_source.raw_source.include?(';')
 
           check_for_line_terminator_or_opener
         end
 
         def on_begin(node)
           return if cop_config['AllowAsExpressionSeparator']
+          return unless node.source.include?(';')
 
           exprs = node.children
 


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/pull/11279.

After adding some more changes into https://github.com/rubocop/rubocop-ast/pull/249 and https://github.com/whitequark/parser/pull/896, I got the following results:

### Before
Time: `107.5s`
Memory: `Total allocated: 1.03 GB (15500315 objects)`

```
==================================
  Mode: wall(1000)
  Samples: 107266 (0.14% miss rate)
  GC: 6540 (6.10%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      6394   (6.0%)        6394   (6.0%)     Parser::Source::Buffer#slice
     12609  (11.8%)        5326   (5.0%)     Parser::Lexer#advance
      4791   (4.5%)        4791   (4.5%)     (sweeping)
      5115   (4.8%)        3879   (3.6%)     RuboCop::AST::Descendence#visit_descendants
      7196   (6.7%)        3028   (2.8%)     RuboCop::AST::Descendence#each_child_node
      3031   (2.8%)        2218   (2.1%)     Parser::Source::Buffer#line_index_for_position
      3370   (3.1%)        2040   (1.9%)     RuboCop::Cop::Base#cop_config
      2025   (1.9%)        2025   (1.9%)     RuboCop::AST::Node#node_parts
      2320   (2.2%)        1741   (1.6%)     AST::Node#initialize
      1738   (1.6%)        1738   (1.6%)     (marking)
      1363   (1.3%)        1324   (1.2%)     RuboCop::Cop::Layout::LineContinuationLeadingSpace#raw_lines
      1324   (1.2%)        1324   (1.2%)     Parser::Source::Range#initialize
      1290   (1.2%)        1290   (1.2%)     RuboCop::AST::SendNode#first_argument_index
      1071   (1.0%)        1071   (1.0%)     Unicode::DisplayWidth.of
      1298   (1.2%)         981   (0.9%)     RuboCop::Cop::Base#initialize
      1068   (1.0%)         924   (0.9%)     RuboCop::PathUtil.match_path?
       920   (0.9%)         907   (0.8%)     RuboCop::Config#for_cop
       902   (0.8%)         902   (0.8%)     RuboCop::AST::Node#parent
     52071  (48.5%)         802   (0.7%)     RuboCop::Cop::Commissioner#trigger_responding_cops
       791   (0.7%)         791   (0.7%)     RuboCop::AST::SendNode#send_type?
       784   (0.7%)         784   (0.7%)     RuboCop::AST::StrNode#heredoc?
      1825   (1.7%)         737   (0.7%)     RuboCop::AST::Node#each_ancestor
       695   (0.6%)         695   (0.6%)     RuboCop::AST::Node#block_type?
       867   (0.8%)         659   (0.6%)     RuboCop::Cop::Base#complete_investigation
       735   (0.7%)         634   (0.6%)     RuboCop::AST::ProcessedSource#sorted_tokens
       630   (0.6%)         614   (0.6%)     RuboCop::Cop::Base#cop_name
       600   (0.6%)         565   (0.5%)     RuboCop::Cop::Team#validate_config
       552   (0.5%)         552   (0.5%)     RuboCop::Cop::Base#begin_investigation
       573   (0.5%)         550   (0.5%)     RuboCop::Cop::Layout::TrailingEmptyLines#on_new_investigation
       525   (0.5%)         525   (0.5%)     RuboCop::Cop::Base#reset_investigation
```

### After
Time: `99.0s` (7% speedup) 🔥 
Memory: `Total allocated: 816.27 MB (12538140 objects)` (23% less GB and 20% less allocated objects) 🔥 

```
==================================
  Mode: wall(1000)
  Samples: 98952 (0.05% miss rate)
  GC: 4346 (4.39%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     11544  (11.7%)        5236   (5.3%)     Parser::Lexer#advance
      5117   (5.2%)        5117   (5.2%)     Parser::Source::Buffer#slice
      4975   (5.0%)        3857   (3.9%)     RuboCop::AST::Descendence#visit_descendants
      3208   (3.2%)        3208   (3.2%)     (sweeping)
      6976   (7.0%)        2893   (2.9%)     RuboCop::AST::Descendence#each_child_node
      2133   (2.2%)        2133   (2.2%)     RuboCop::AST::Node#node_parts
      2717   (2.7%)        1975   (2.0%)     Parser::Source::Buffer#line_index_for_position
      2260   (2.3%)        1661   (1.7%)     AST::Node#initialize
      1255   (1.3%)        1255   (1.3%)     Parser::Source::Range#initialize
      1197   (1.2%)        1197   (1.2%)     RuboCop::AST::SendNode#first_argument_index
      1116   (1.1%)        1116   (1.1%)     (marking)
      1414   (1.4%)        1097   (1.1%)     RuboCop::Cop::Base#initialize
      1217   (1.2%)        1089   (1.1%)     RuboCop::Cop::Base#cop_config
      1013   (1.0%)        1013   (1.0%)     Unicode::DisplayWidth.of
       997   (1.0%)         997   (1.0%)     RuboCop::AST::Node#parent
      1074   (1.1%)         907   (0.9%)     RuboCop::PathUtil.match_path?
     49009  (49.5%)         817   (0.8%)     RuboCop::Cop::Commissioner#trigger_responding_cops
      1923   (1.9%)         813   (0.8%)     RuboCop::AST::Node#each_ancestor
       784   (0.8%)         784   (0.8%)     RuboCop::AST::SendNode#send_type?
      3258   (3.3%)         758   (0.8%)     RuboCop::Cop::Base#relevant_file?
       747   (0.8%)         747   (0.8%)     RuboCop::AST::Node#block_type?
       742   (0.7%)         742   (0.7%)     RuboCop::AST::StrNode#heredoc?
       943   (1.0%)         729   (0.7%)     RuboCop::Cop::Base#complete_investigation
       705   (0.7%)         684   (0.7%)     RuboCop::Config#for_cop
       766   (0.8%)         670   (0.7%)     RuboCop::AST::ProcessedSource#sorted_tokens
       622   (0.6%)         609   (0.6%)     RuboCop::Cop::Base#cop_name
       585   (0.6%)         585   (0.6%)     RuboCop::Cop::Base#begin_investigation
       552   (0.6%)         552   (0.6%)     RuboCop::AST::Node#source_range
       563   (0.6%)         541   (0.5%)     RuboCop::Cop::Team#validate_config
       534   (0.5%)         534   (0.5%)     RuboCop::Cop::AutocorrectLogic#autocorrect_requested?
```

While working on these optimizations, I got more cases to implement into `rubocop-performance`. Will implement them (or create issues) later.

So the next step in making rubocop faster is to rewrite everything in C 😄 