### PR TITLE
Make `Style/IfWithSemicolon` aware of one line without `else` body

### DIFF
--- a/changelog/change_make_style_if_with_semicolon_aware_of_oneline_without_else_body.md
+++ b/changelog/change_make_style_if_with_semicolon_aware_of_oneline_without_else_body.md
@@ -1,0 +1,1 @@
+* [#11306](https://github.com/rubocop/rubocop/pull/11306): Make `Style/IfWithSemicolon` aware of one line without `else` body. ([@koic][])

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -21,13 +21,12 @@ module RuboCop
         MSG_TERNARY = 'Do not use `if %<expr>s;` - use a ternary operator instead.'
 
         def on_normal_if_unless(node)
-          return unless node.else_branch
           return if node.parent&.if_type?
 
           beginning = node.loc.begin
           return unless beginning&.is?(';')
 
-          message = node.else_branch.if_type? ? MSG_IF_ELSE : MSG_TERNARY
+          message = node.else_branch&.if_type? ? MSG_IF_ELSE : MSG_TERNARY
 
           add_offense(node, message: format(message, expr: node.condition.source)) do |corrector|
             corrector.replace(node, autocorrect(node))
@@ -37,7 +36,7 @@ module RuboCop
         private
 
         def autocorrect(node)
-          return correct_elsif(node) if node.else_branch.if_type?
+          return correct_elsif(node) if node.else_branch&.if_type?
 
           then_code = node.if_branch ? node.if_branch.source : 'nil'
           else_code = node.else_branch ? node.else_branch.source : 'nil'

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -23,11 +23,25 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
     RUBY
   end
 
-  it 'accepts without `else` branch' do
-    # This case is corrected to a modifier form by `Style/IfUnlessModifier` cop.
-    # Therefore, this cop does not handle it.
-    expect_no_offenses(<<~RUBY)
+  it 'registers an offense and corrects for one line if/;/end without else body' do
+    expect_offense(<<~RUBY)
+      if cond; run else; end
+      ^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      cond ? run : nil
+    RUBY
+  end
+
+  it 'registers an offense when not using `else` branch' do
+    expect_offense(<<~RUBY)
       if cond; run end
+      ^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      cond ? run : nil
     RUBY
   end
 


### PR DESCRIPTION
This PR makes `Style/IfWithSemicolon` aware of one line without `else` body:

```ruby
if cond; run else; end
```

## Before

No offenses:

```console
% bundle exec rubocop --only Style/IfWithSemicolon -a
(snip)

1 file inspected, no offenses detected
```

## After

Registers an offense and corrects:

```console
% bundle exec rubocop --only Style/IfWithSemicolon -a
(snip)

Offenses:

example.rb:1:1: C: [Corrected] Style/IfWithSemicolon: Do not use if cond; - use a ternary operator instead.
if cond; run else; end
^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

Diff:

```diff
-if cond; run else; end
+cond ? run : nil
```

It can be addressed with a minor implementation update.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
