### PR TITLE
Fix an error for `Style/GuardClause` when using lvar as an argument of raise in `else` branch

### DIFF
--- a/changelog/fix_fix_an_error_for_style_guard_clause.md
+++ b/changelog/fix_fix_an_error_for_style_guard_clause.md
@@ -1,0 +1,1 @@
+* [#11307](https://github.com/rubocop/rubocop/pull/11307): Fix an error for `Style/GuardClause` when using lvar as an argument of raise in `else` branch. ([@ydah][])

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -189,7 +189,7 @@ module RuboCop
 
           if if_branch&.send_type? && heredoc?(if_branch.last_argument)
             autocorrect_heredoc_argument(corrector, node, if_branch, else_branch, guard)
-          elsif else_branch&.send_type? && else_branch.last_argument&.heredoc?
+          elsif else_branch&.send_type? && heredoc?(else_branch.last_argument)
             autocorrect_heredoc_argument(corrector, node, else_branch, if_branch, guard)
           else
             corrector.remove(node.loc.end)

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -323,6 +323,28 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
     RUBY
   end
 
+  it 'registers an offense when using lvar as an argument of raise in `else` branch' do
+    expect_offense(<<~RUBY)
+      if condition
+      ^^ Use a guard clause (`raise e unless condition`) instead of wrapping the code inside a conditional expression.
+        do_something
+      else
+        raise e
+      end
+    RUBY
+
+    # NOTE: Let `Layout/TrailingWhitespace`, `Layout/EmptyLine`, and
+    #       `Layout/EmptyLinesAroundMethodBody` cops autocorrect inconsistent indentations
+    #       and blank lines.
+    expect_correction(<<~RUBY)
+      raise e unless condition
+        do_something
+
+       #{trailing_whitespace}
+
+    RUBY
+  end
+
   context 'MinBodyLength: 1' do
     let(:cop_config) { { 'MinBodyLength' => 1 } }
 


### PR DESCRIPTION
Follow up: https://github.com/rubocop/rubocop/pull/11250#issuecomment-1359051959

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
