### PR TITLE
[Fix #11309] Fix a false positive for `Style/RedundantStringEscape`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_string_escape.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_string_escape.md
@@ -1,0 +1,1 @@
+* [#11309](https://github.com/rubocop/rubocop/issues/11309): Fix a false positive for `Style/RedundantStringEscape` when using a redundant escaped string interpolation `\#\{foo}`. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_string_escape.rb
+++ b/lib/rubocop/cop/style/redundant_string_escape.rb
@@ -169,9 +169,10 @@ module RuboCop
           # Allow \#{foo}, \#$foo, \#@foo, and \#@@foo
           # for escaping local, global, instance and class variable interpolations
           return true if range.source.match?(/\A\\#[{$@]/)
-
           # Also allow #\{foo}, #\$foo, #\@foo and #\@@foo
           return true if range.adjust(begin_pos: -2).source.match?(/\A[^\\]#\\[{$@]/)
+          # For `\#\{foo} allow `\#` and warn `\{`
+          return true if range.adjust(end_pos: 1).source == '\\#\\{'
 
           false
         end

--- a/spec/rubocop/cop/style/redundant_string_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_string_escape_spec.rb
@@ -148,6 +148,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantStringEscape, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects an escaped `\{` when escaping `\#\{` to avoid interpolation' do
+      expect_offense(<<~'RUBY', l: l, r: r)
+        %{l}\#\{whatever}%{r}
+        _{l}  ^^ Redundant escape of { inside string literal.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #{l}\\\#{whatever}#{r}
+      RUBY
+    end
+
     it 'registers an offense and corrects an escaped # at end-of-string' do
       expect_offense(<<~'RUBY', l: l, r: r)
         %{l}\#%{r}


### PR DESCRIPTION
Fixes #11309.

This PR fixes a false positive for `Style/RedundantStringEscape` when using a redundant escaped string interpolation `\#\{foo}`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
