### PR TITLE
Fix disabling departments via comment

### DIFF
--- a/changelog/fix_disabling_departments_via_comment.md
+++ b/changelog/fix_disabling_departments_via_comment.md
@@ -1,0 +1,1 @@
+* [#11308](https://github.com/rubocop/rubocop/issues/11308): Fix disabling departments via comment. ([@fatkodima][])

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -128,6 +128,7 @@ module RuboCop
           end
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def each_already_disabled(cop, line_ranges)
           line_ranges.each_cons(2) do |previous_range, range|
             next if ignore_offense?(range)
@@ -152,9 +153,10 @@ module RuboCop
                 cop
               end
 
-            yield comment, redundant
+            yield comment, redundant if redundant
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def find_redundant_cop(cop, range)
           cop_offenses = offenses_to_check.select { |offense| offense.cop_name == cop }


### PR DESCRIPTION
Fixes #11308.
This is a solution as in a similar from this cop - https://github.com/rubocop/rubocop/blob/8bb0c47e7a654a72dcfb7024083cbb4898cae03d/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb#L127

I was not able to reproduce it on an existing app, only on a sample new app (as mentioned in the issue description).
Was not able to create a failing test script for this too.