### PR TITLE
Fix a false positive for `Naming/BlockForwarding` when the block argument is reassigned

### DIFF
--- a/changelog/fix_block_forwarding_reassignments.md
+++ b/changelog/fix_block_forwarding_reassignments.md
@@ -1,0 +1,1 @@
+* [#11313](https://github.com/rubocop/rubocop/issues/11313): Fix a false positive for `Naming/BlockForwarding` when the block argument is reassigned. ([@fatkodima][])

--- a/lib/rubocop/cop/naming/block_forwarding.rb
+++ b/lib/rubocop/cop/naming/block_forwarding.rb
@@ -108,7 +108,7 @@ module RuboCop
           return if node.body.nil?
 
           node.body.each_descendant(:lvar, :lvasgn).any? do |lvar|
-            !lvar.parent.block_pass_type? && lvar.source == last_argument
+            !lvar.parent.block_pass_type? && lvar.node_parts[0].to_s == last_argument
           end
         end
 

--- a/spec/rubocop/cop/naming/block_forwarding_spec.rb
+++ b/spec/rubocop/cop/naming/block_forwarding_spec.rb
@@ -196,6 +196,11 @@ RSpec.describe RuboCop::Cop::Naming::BlockForwarding, :config do
             block ||= -> { :foo }
             bar(&block)
           end
+
+          def example(&block)
+            block = proc {} unless block_given?
+            bar(&block)
+          end
         RUBY
       end
     end


### PR DESCRIPTION
Fixes #11313.

`node_parts[0]` is a name of a local variable.