### PR TITLE
[Fix #11204] Fix a false negative for `Lint/RedundantCopDisableDirective`

### DIFF
--- a/changelog/fix_a_false_negative_for_lint_redundant_cop_disable_directive.md
+++ b/changelog/fix_a_false_negative_for_lint_redundant_cop_disable_directive.md
@@ -1,0 +1,1 @@
+* [#11204](https://github.com/rubocop/rubocop/issues/11204): Fix a false negative for `Lint/RedundantCopDisableDirective` when using `--except` command line option. ([@koic][])

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -27,6 +27,11 @@ module RuboCop
     # @api private
     MAX_ITERATIONS = 200
 
+    # @api private
+    REDUNDANT_COP_DISABLE_DIRECTIVE_RULES = %w[
+      Lint/RedundantCopDisableDirective RedundantCopDisableDirective Lint
+    ].freeze
+
     attr_reader :errors, :warnings
     attr_writer :aborting
 
@@ -194,7 +199,9 @@ module RuboCop
     end
 
     def check_for_redundant_disables?(source)
-      !source.disabled_line_ranges.empty? && !filtered_run?
+      return false if source.disabled_line_ranges.empty? || except_redundant_cop_disable_directive?
+
+      !@options[:only]
     end
 
     def redundant_cop_disable_directive(file)
@@ -205,8 +212,8 @@ module RuboCop
       yield cop if cop.relevant_file?(file)
     end
 
-    def filtered_run?
-      @options[:except] || @options[:only]
+    def except_redundant_cop_disable_directive?
+      @options[:except] && (@options[:except] & REDUNDANT_COP_DISABLE_DIRECTIVE_RULES).any?
     end
 
     def file_started(file)

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -916,15 +916,36 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       end
     end
 
-    context 'when one cop plus one namespace are given' do
+    context 'when two cop plus one namespace are given' do
       it 'runs all cops except the given' do
         # The disable comment should not be reported as unnecessary (even if
         # it is) since --except overrides configuration.
         create_file('example.rb', ['# rubocop:disable LineLength', 'if x== 0 ', "\ty = 3", 'end'])
         expect(cli.run(['--format', 'offenses',
-                        '--except', 'Style/IfUnlessModifier,Lint',
+                        '--except', 'Style/IfUnlessModifier,Lint/UselessAssignment,Layout',
                         'example.rb'])).to eq(1)
         # NOTE: No Lint/UselessAssignment offense.
+        expect($stdout.string)
+          .to eq(<<~RESULT)
+
+            1  Lint/MissingCopEnableDirective
+            1  Lint/RedundantCopDisableDirective
+            1  Migration/DepartmentName
+            1  Style/FrozenStringLiteralComment
+            1  Style/NumericPredicate
+            --
+            5  Total in 1 files
+
+          RESULT
+      end
+    end
+
+    context 'when one cop plus `Lint/RedundantCopDisableDirective` are given' do
+      it 'runs all cops except the given' do
+        create_file('example.rb', ['# rubocop:disable LineLength', 'if x== 0 ', "\ty = 3", 'end'])
+        expect(cli.run(['--format', 'offenses',
+                        '--except', 'Style/IfUnlessModifier,Lint/RedundantCopDisableDirective',
+                        'example.rb'])).to eq(1)
         expect($stdout.string)
           .to eq(<<~RESULT)
 
@@ -932,11 +953,13 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
             1  Layout/IndentationWidth
             1  Layout/SpaceAroundOperators
             1  Layout/TrailingWhitespace
+            1  Lint/MissingCopEnableDirective
+            1  Lint/UselessAssignment
             1  Migration/DepartmentName
             1  Style/FrozenStringLiteralComment
             1  Style/NumericPredicate
             --
-            7  Total in 1 files
+            9  Total in 1 files
 
           RESULT
       end


### PR DESCRIPTION
Fixes #11204.

This PR fixes a false negative for `Lint/RedundantCopDisableDirective` when using `--except` command line option.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
