### PR TITLE
[Fix #11320] Fix a false positive for `Lint/RequireParentheses`

### DIFF
--- a/changelog/fix_false_positive_for_lint_require_parentheses.md
+++ b/changelog/fix_false_positive_for_lint_require_parentheses.md
@@ -1,0 +1,1 @@
+* [#11320](https://github.com/rubocop/rubocop/issues/11320): Fix a false positive for `Lint/RequireParentheses` when assigning ternary operator. ([@koic][])

--- a/lib/rubocop/cop/lint/require_parentheses.rb
+++ b/lib/rubocop/cop/lint/require_parentheses.rb
@@ -46,7 +46,9 @@ module RuboCop
         private
 
         def check_ternary(ternary, node)
-          return if node.method?(:[]) || !ternary.condition.operator_keyword?
+          if node.method?(:[]) || node.assignment_method? || !ternary.condition.operator_keyword?
+            return
+          end
 
           range = range_between(node.source_range.begin_pos, ternary.condition.source_range.end_pos)
 

--- a/spec/rubocop/cop/lint/require_parentheses_spec.rb
+++ b/spec/rubocop/cop/lint/require_parentheses_spec.rb
@@ -88,6 +88,10 @@ RSpec.describe RuboCop::Cop::Lint::RequireParentheses, :config do
     expect_no_offenses('do_something[foo && bar ? baz : qux]')
   end
 
+  it 'accepts missing parentheses when assigning ternary operator' do
+    expect_no_offenses('self.foo = bar && baz ? qux : quux')
+  end
+
   it 'accepts calls to methods that are setters' do
     expect_no_offenses('s.version = @version || ">= 1.8.5"')
   end


### PR DESCRIPTION
Fixes #11320.

This PR fixes a false positive for `Lint/RequireParentheses` when assigning ternary operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
