### PR TITLE
[Fix #11322] Fix message for Lint/UnusedMethodArgument

### DIFF
--- a/lib/rubocop/cop/lint/unused_method_argument.rb
+++ b/lib/rubocop/cop/lint/unused_method_argument.rb
@@ -100,7 +100,8 @@ module RuboCop
 
           unless variable.keyword_argument?
             message << " If it's necessary, use `_` or `_#{variable.name}` " \
-                       "as an argument name to indicate that it won't be used."
+                       "as an argument name to indicate that it won't be used. " \
+                       "If it's unnecessary, remove it."
           end
 
           scope = variable.scope

--- a/spec/rubocop/cli/disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/disable_uncorrectable_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
         expect($stdout.string).to eq(<<~OUTPUT)
           == example.rb ==
           C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
-          W:  1: 21: [Corrected] Lint/UnusedMethodArgument: Unused method argument - some_arg. If it's necessary, use _ or _some_arg as an argument name to indicate that it won't be used. You can also write as ordinary_method(*) if you want the method to accept any arguments but don't care about them.
+          W:  1: 21: [Corrected] Lint/UnusedMethodArgument: Unused method argument - some_arg. If it's necessary, use _ or _some_arg as an argument name to indicate that it won't be used. If it's unnecessary, remove it. You can also write as ordinary_method(*) if you want the method to accept any arguments but don't care about them.
           C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
           W:  5: 29: [Todo] Lint/UnusedMethodArgument: Unused method argument - some_keyword_arg. You can also write as method_with_keyword_arg(*) if you want the method to accept any arguments but don't care about them.
 

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
         it 'registers an offense and adds underscore-prefix' do
           message = 'Unused method argument - `foo`. ' \
                     "If it's necessary, use `_` or `_foo` " \
-                    "as an argument name to indicate that it won't be used."
+                    "as an argument name to indicate that it won't be used. " \
+                    "If it's unnecessary, remove it."
 
           expect_offense(<<~RUBY)
             def some_method(foo, bar)
@@ -35,7 +36,8 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
           it 'registers an offense and preserves whitespace' do
             message = 'Unused method argument - `bar`. ' \
                       "If it's necessary, use `_` or `_bar` " \
-                      "as an argument name to indicate that it won't be used."
+                      "as an argument name to indicate that it won't be used. " \
+                      "If it's unnecessary, remove it."
 
             expect_offense(<<~RUBY)
               def some_method(foo,
@@ -68,7 +70,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
           it 'registers an offense' do
             message = "Unused method argument - `a`. If it's necessary, use " \
                       '`_` or `_a` as an argument name to indicate that ' \
-                      "it won't be used."
+                      "it won't be used. If it's unnecessary, remove it."
 
             expect_offense(<<~RUBY)
               def foo(a, b)
@@ -93,6 +95,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
             "Unused method argument - `#{arg}`. " \
               "If it's necessary, use `_` or `_#{arg}` " \
               "as an argument name to indicate that it won't be used. " \
+              "If it's unnecessary, remove it. " \
               'You can also write as `some_method(*)` if you want the method ' \
               "to accept any arguments but don't care about them."
           end
@@ -116,7 +119,8 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       it 'registers an offense and preserves the splat' do
         message = 'Unused method argument - `bar`. ' \
                   "If it's necessary, use `_` or `_bar` " \
-                  "as an argument name to indicate that it won't be used."
+                  "as an argument name to indicate that it won't be used. " \
+                  "If it's unnecessary, remove it."
 
         expect_offense(<<~RUBY)
           def some_method(foo, *bar)
@@ -137,7 +141,8 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       it 'registers an offense and preserves the default value' do
         message = 'Unused method argument - `bar`. ' \
                   "If it's necessary, use `_` or `_bar` " \
-                  "as an argument name to indicate that it won't be used."
+                  "as an argument name to indicate that it won't be used. " \
+                  "If it's unnecessary, remove it."
 
         expect_offense(<<~RUBY)
           def some_method(foo, bar = 1)
@@ -198,7 +203,8 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       it 'registers an offense and removes the unused block arg' do
         message = 'Unused method argument - `block`. ' \
                   "If it's necessary, use `_` or `_block` " \
-                  "as an argument name to indicate that it won't be used."
+                  "as an argument name to indicate that it won't be used. " \
+                  "If it's unnecessary, remove it."
 
         expect_offense(<<~RUBY)
           def some_method(foo, bar, &block)
@@ -219,9 +225,9 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       it 'registers an offense' do
         message = "Unused method argument - `foo`. If it's necessary, use " \
                   '`_` or `_foo` as an argument name to indicate that it ' \
-                  "won't be used. You can also write as `some_method(*)` " \
-                  'if you want the method to accept any arguments but ' \
-                  "don't care about them."
+                  "won't be used. If it's unnecessary, remove it. " \
+                  'You can also write as `some_method(*)` if you want the ' \
+                  "method to accept any arguments but don't care about them."
 
         expect_offense(<<~RUBY)
           def self.some_method(foo)
@@ -300,9 +306,10 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
         it 'registers an offense' do
           message = "Unused method argument - `foo`. If it's necessary, use " \
                     '`_` or `_foo` as an argument name to indicate that ' \
-                    "it won't be used. You can also write as " \
-                    '`some_method(*)` if you want the method to accept any ' \
-                    "arguments but don't care about them."
+                    "it won't be used. If it's unnecessary, remove it. " \
+                    'You can also write as `some_method(*)` if you want ' \
+                    "the method to accept any arguments but don't care about " \
+                    'them.'
 
           expect_offense(<<~RUBY)
             def some_method(foo)
@@ -335,8 +342,9 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
         (foo_message, bar_message) = %w[foo bar].map do |arg|
           "Unused method argument - `#{arg}`. If it's necessary, use `_` or " \
             "`_#{arg}` as an argument name to indicate that it won't be " \
-            'used. You can also write as `some_method(*)` if you want the ' \
-            "method to accept any arguments but don't care about them."
+            "used. If it's unnecessary, remove it. You can also write as " \
+            '`some_method(*)` if you want the method to accept any arguments ' \
+            "but don't care about them."
         end
 
         it 'registers offenses' do
@@ -366,9 +374,9 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
         it 'registers an offense' do
           message = "Unused method argument - `foo`. If it's necessary, use " \
                     '`_` or `_foo` as an argument name to indicate that it ' \
-                    "won't be used. You can also write as `some_method(*)` " \
-                    'if you want the method to accept any arguments but ' \
-                    "don't care about them."
+                    "won't be used. If it's unnecessary, remove it. You can " \
+                    'also write as `some_method(*)` if you want the method ' \
+                    "to accept any arguments but don't care about them."
 
           expect_offense(<<~RUBY)
             def some_method(foo)
@@ -407,9 +415,9 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
     it 'registers an offense for a non-empty method with a single unused parameter' do
       message = "Unused method argument - `arg`. If it's necessary, use " \
                 '`_` or `_arg` as an argument name to indicate that it ' \
-                "won't be used. You can also write as `method(*)` if you " \
-                "want the method to accept any arguments but don't care " \
-                'about them.'
+                "won't be used. If it's unnecessary, remove it. You can also write " \
+                'as `method(*)` if you want the method to accept any arguments ' \
+                "but don't care about them."
 
       expect_offense(<<~RUBY)
         def method(arg)
@@ -436,6 +444,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       (a_message, b_message, others_message) = %w[a b others].map do |arg|
         "Unused method argument - `#{arg}`. If it's necessary, use `_` or " \
           "`_#{arg}` as an argument name to indicate that it won't be used. " \
+          "If it's unnecessary, remove it. " \
           'You can also write as `method(*)` if you want the method ' \
           "to accept any arguments but don't care about them."
       end
@@ -512,9 +521,9 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
     it 'registers an offense for a non-empty method with a single unused parameter' do
       message = "Unused method argument - `arg`. If it's necessary, use " \
                 '`_` or `_arg` as an argument name to indicate that it ' \
-                "won't be used. You can also write as `method(*)` if you " \
-                "want the method to accept any arguments but don't care " \
-                'about them.'
+                "won't be used. If it's unnecessary, remove it. You can also " \
+                'write as `method(*)` if you want the method to accept any ' \
+                "arguments but don't care about them."
 
       expect_offense(<<~RUBY)
         def method(arg)
@@ -542,6 +551,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       (a_message, b_message, others_message) = %w[a b others].map do |arg|
         "Unused method argument - `#{arg}`. If it's necessary, use `_` or " \
           "`_#{arg}` as an argument name to indicate that it won't be used. " \
+          "If it's unnecessary, remove it. " \
           'You can also write as `method(*)` if you want the method ' \
           "to accept any arguments but don't care about them."
       end


### PR DESCRIPTION
Closes https://github.com/rubocop/rubocop/issues/11322

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
