### PR TITLE
More rubocop optimizations

### DIFF
--- a/lib/rubocop/cop/layout/indentation_style.rb
+++ b/lib/rubocop/cop/layout/indentation_style.rb
@@ -40,10 +40,13 @@ module RuboCop
         MSG = '%<type>s detected in indentation.'
 
         def on_new_investigation
-          str_ranges = string_literal_ranges(processed_source.ast)
+          str_ranges = nil
 
           processed_source.lines.each.with_index(1) do |line, lineno|
             next unless (range = find_offense(line, lineno))
+
+            # Perform costly calculation only when needed.
+            str_ranges ||= string_literal_ranges(processed_source.ast)
             next if in_string_literal?(str_ranges, range)
 
             add_offense(range) { |corrector| autocorrect(corrector, range) }

--- a/lib/rubocop/cop/layout/line_continuation_spacing.rb
+++ b/lib/rubocop/cop/layout/line_continuation_spacing.rb
@@ -31,14 +31,10 @@ module RuboCop
         include RangeHelp
         extend AutoCorrector
 
-        # rubocop:disable Metrics/AbcSize
         def on_new_investigation
           return unless processed_source.raw_source.include?('\\')
 
           last_line = last_line(processed_source)
-
-          @ignored_ranges = string_literal_ranges(processed_source.ast) +
-                            comment_ranges(processed_source.comments)
 
           processed_source.raw_source.lines.each_with_index do |line, index|
             break if index >= last_line
@@ -47,7 +43,6 @@ module RuboCop
             investigate(line, line_number)
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         private
 
@@ -120,7 +115,12 @@ module RuboCop
         end
 
         def ignore_range?(backtick_range)
-          @ignored_ranges.any? { |range| range.contains?(backtick_range) }
+          ignored_ranges.any? { |range| range.contains?(backtick_range) }
+        end
+
+        def ignored_ranges
+          @ignored_ranges ||= string_literal_ranges(processed_source.ast) +
+                              comment_ranges(processed_source.comments)
         end
 
         def no_space_style?

--- a/lib/rubocop/cop/layout/trailing_whitespace.rb
+++ b/lib/rubocop/cop/layout/trailing_whitespace.rb
@@ -47,7 +47,6 @@ module RuboCop
         MSG = 'Trailing whitespace detected.'
 
         def on_new_investigation
-          @heredocs = extract_heredocs(processed_source.ast)
           processed_source.lines.each_with_index do |line, index|
             next unless line.end_with?(' ', "\t")
 
@@ -102,8 +101,12 @@ module RuboCop
         end
 
         def find_heredoc(line_number)
-          @heredocs.each { |node, r| return node if r.include?(line_number) }
+          heredocs.each { |node, r| return node if r.include?(line_number) }
           nil
+        end
+
+        def heredocs
+          @heredocs ||= extract_heredocs(processed_source.ast)
         end
 
         def extract_heredocs(ast)

--- a/lib/rubocop/cop/style/signal_exception.rb
+++ b/lib/rubocop/cop/style/signal_exception.rb
@@ -119,11 +119,6 @@ module RuboCop
         # @!method custom_fail_methods(node)
         def_node_search :custom_fail_methods, '{(def :fail ...) (defs _ :fail ...)}'
 
-        def on_new_investigation
-          ast = processed_source.ast
-          @custom_fail_defined = ast && custom_fail_methods(ast).any?
-        end
-
         def on_rescue(node)
           return unless style == :semantic
 
@@ -141,7 +136,7 @@ module RuboCop
           when :semantic
             check_send(:raise, node) unless ignored_node?(node)
           when :only_raise
-            return if @custom_fail_defined
+            return if custom_fail_defined?
 
             check_send(:fail, node)
           when :only_fail
@@ -150,6 +145,13 @@ module RuboCop
         end
 
         private
+
+        def custom_fail_defined?
+          return @custom_fail_defined if defined?(@custom_fail_defined)
+
+          ast = processed_source.ast
+          @custom_fail_defined = ast && custom_fail_methods(ast).any?
+        end
 
         def message(method_name)
           case style


### PR DESCRIPTION
Tested on [`chef` project](https://github.com/chef/chef).

### Before
Time: `111.5s`
```
==================================
  Mode: wall(1000)
  Samples: 111354 (0.10% miss rate)
  GC: 4496 (4.04%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     19979  (17.9%)       14380  (12.9%)     RuboCop::AST::Descendence#visit_descendants  <========
     17151  (15.4%)        9584   (8.6%)     Parser::Lexer#advance
      5513   (5.0%)        5513   (5.0%)     Parser::Source::Buffer#slice
      4268   (3.8%)        3136   (2.8%)     AST::Node#initialize
      2840   (2.6%)        2840   (2.6%)     (sweeping)
     14789  (13.3%)        2621   (2.4%)     RuboCop::Cop::GemspecHelp#gem_specification  <========
      3714   (3.3%)        2460   (2.2%)     Parser::Source::Buffer#line_index_for_position
      2430   (2.2%)        2430   (2.2%)     RuboCop::AST::Node#node_parts  <========
      5352   (4.8%)        2350   (2.1%)     RuboCop::AST::Descendence#each_child_node
      2188   (2.0%)        2188   (2.0%)     Parser::Source::Range#initialize
      2003   (1.8%)        2003   (1.8%)     RuboCop::AST::Node#block_type?  <========
      1656   (1.5%)        1656   (1.5%)     RuboCop::AST::SendNode#first_argument_index
      1630   (1.5%)        1630   (1.5%)     (marking)
      1562   (1.4%)        1562   (1.4%)     Unicode::DisplayWidth.of
       976   (0.9%)         954   (0.9%)     RuboCop::Cop::Base#cop_name
       862   (0.8%)         862   (0.8%)     RuboCop::AST::Node#parent
       837   (0.8%)         837   (0.8%)     Parser::Source::Buffer#bsearch
     39677  (35.6%)         829   (0.7%)     RuboCop::Cop::Commissioner#trigger_responding_cops
       818   (0.7%)         818   (0.7%)     RuboCop::AST::SendNode#send_type?
       768   (0.7%)         768   (0.7%)     RuboCop::AST::Node#casgn_type?
       968   (0.9%)         751   (0.7%)     RuboCop::AST::ProcessedSource#sorted_tokens
       658   (0.6%)         658   (0.6%)     RuboCop::Cop::SurroundingSpace#empty_brackets?
       974   (0.9%)         655   (0.6%)     RuboCop::Cop::PrecedingFollowingAlignment#relevant_assignment_lines
       715   (0.6%)         647   (0.6%)     RuboCop::Cop::Base#cop_config
      1369   (1.2%)         630   (0.6%)     RuboCop::AST::Node#each_ancestor
       621   (0.6%)         621   (0.6%)     RuboCop::AST::Token#initialize
       587   (0.5%)         587   (0.5%)     Parser::Builders::Default#value
       570   (0.5%)         570   (0.5%)     Parser::Source::Map#initialize
       566   (0.5%)         566   (0.5%)     Parser::Source::Buffer#line_begins
       561   (0.5%)         557   (0.5%)     Set#include?
```

### After
Time: `90.7s` (19% speedup) 🔥 🔥
```
==================================
  Mode: wall(1000)
  Samples: 90623 (0.09% miss rate)
  GC: 4093 (4.52%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     16828  (18.6%)        9407  (10.4%)     Parser::Lexer#advance
      5469   (6.0%)        5469   (6.0%)     Parser::Source::Buffer#slice
      4368   (4.8%)        3214   (3.5%)     AST::Node#initialize
      2668   (2.9%)        2668   (2.9%)     (sweeping)
      3707   (4.1%)        2452   (2.7%)     Parser::Source::Buffer#line_index_for_position
      5256   (5.8%)        2339   (2.6%)     RuboCop::AST::Descendence#each_child_node
      2139   (2.4%)        2139   (2.4%)     Parser::Source::Range#initialize
      2003   (2.2%)        1639   (1.8%)     RuboCop::AST::Descendence#visit_descendants
      1581   (1.7%)        1581   (1.7%)     Unicode::DisplayWidth.of
      1554   (1.7%)        1554   (1.7%)     RuboCop::AST::SendNode#first_argument_index
      1402   (1.5%)        1402   (1.5%)     (marking)
      1219   (1.3%)        1219   (1.3%)     RuboCop::AST::MethodDispatchNode#receiver
       999   (1.1%)         981   (1.1%)     RuboCop::Cop::Base#cop_name
       844   (0.9%)         844   (0.9%)     RuboCop::AST::Node#parent
       816   (0.9%)         816   (0.9%)     RuboCop::AST::SendNode#send_type?
     38455  (42.4%)         801   (0.9%)     RuboCop::Cop::Commissioner#trigger_responding_cops
       794   (0.9%)         794   (0.9%)     Parser::Source::Buffer#bsearch
       918   (1.0%)         713   (0.8%)     RuboCop::AST::ProcessedSource#sorted_tokens
       688   (0.8%)         688   (0.8%)     RuboCop::AST::MethodDispatchNode#method_name
       655   (0.7%)         655   (0.7%)     RuboCop::AST::Node#casgn_type?
       968   (1.1%)         643   (0.7%)     RuboCop::Cop::PrecedingFollowingAlignment#relevant_assignment_lines
       705   (0.8%)         634   (0.7%)     RuboCop::Cop::Base#cop_config
       622   (0.7%)         622   (0.7%)     RuboCop::Cop::SurroundingSpace#empty_brackets?
       619   (0.7%)         619   (0.7%)     Parser::Source::Buffer#line_begins
      1319   (1.5%)         583   (0.6%)     RuboCop::AST::Node#each_ancestor
       568   (0.6%)         568   (0.6%)     RuboCop::AST::Token#initialize
       557   (0.6%)         551   (0.6%)     Set#include?
       547   (0.6%)         547   (0.6%)     Parser::Source::Map#initialize
       849   (0.9%)         523   (0.6%)     RuboCop::Cop::Lint::Debugger#debugger_method?
       499   (0.6%)         499   (0.6%)     Parser::Builders::Default#value
```

After working on a series of optimizations, I identified that different projects have different performance problems with rubocop. Wdyt about implementing something like `rubocop --profile` option (behaving similar to the currently existing`bin/rubocop-profile` script) for people to be able to easily profile rubocop within their projects (and possibly send PRs with improvements)?