### PR TITLE
Make `Style/ZeroLengthPredicate` aware of `array.length.zero?`

### DIFF
--- a/changelog/change_make_style_zero_length_predicate_aware_of_zero.md
+++ b/changelog/change_make_style_zero_length_predicate_aware_of_zero.md
@@ -1,0 +1,1 @@
+* [#11327](https://github.com/rubocop/rubocop/pull/11327): Make `Style/ZeroLengthPredicate` aware of `array.length.zero?`. ([@koic][])

--- a/lib/rubocop/cop/style/block_comments.rb
+++ b/lib/rubocop/cop/style/block_comments.rb
@@ -32,7 +32,7 @@ module RuboCop
               eq_begin, eq_end, contents = parts(comment)
 
               corrector.remove(eq_begin)
-              unless contents.length.zero?
+              unless contents.empty?
                 corrector.replace(
                   contents,
                   contents.source.gsub(/\A/, '# ').gsub(/\n\n/, "\n#\n").gsub(/\n(?=[^#])/, "\n# ")

--- a/spec/rubocop/cop/style/zero_length_predicate_spec.rb
+++ b/spec/rubocop/cop/style/zero_length_predicate_spec.rb
@@ -24,6 +24,28 @@ RSpec.describe RuboCop::Cop::Style::ZeroLengthPredicate, :config do
       RUBY
     end
 
+    it 'registers an offense for `array.length.zero?`' do
+      expect_offense(<<~RUBY)
+        [1, 2, 3].length.zero?
+                  ^^^^^^^^^^^^ Use `empty?` instead of `length.zero?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `array.size.zero?`' do
+      expect_offense(<<~'RUBY')
+        [1, 2, 3].size.zero?
+                  ^^^^^^^^^^ Use `empty?` instead of `size.zero?`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        [1, 2, 3].empty?
+      RUBY
+    end
+
     it 'registers an offense for `0 == array.length`' do
       expect_offense(<<~'RUBY')
         0 == [1, 2, 3].length
@@ -127,6 +149,28 @@ RSpec.describe RuboCop::Cop::Style::ZeroLengthPredicate, :config do
       expect_offense(<<~'RUBY')
         [1, 2, 3].size != 0
         ^^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `size != 0`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        ![1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `!array.length.zero?`' do
+      expect_offense(<<~RUBY)
+        ![1, 2, 3].length.zero?
+                   ^^^^^^^^^^^^ Use `empty?` instead of `length.zero?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ![1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `!array.size.zero?`' do
+      expect_offense(<<~'RUBY')
+        ![1, 2, 3].size.zero?
+                   ^^^^^^^^^^ Use `empty?` instead of `size.zero?`.
       RUBY
 
       expect_correction(<<~'RUBY')


### PR DESCRIPTION
Closes #11314.

Follow https://github.com/rubocop/rubocop/issues/11314#issuecomment-1362982236.

This PR makes `Style/ZeroLengthPredicate` aware of `array.length.zero?`.

I'm not sure if `array.any?` is better than `array.length.positive` as answered in #11314.
But `array.length == 0` and `array.length.zero?` are equivalent, it should be possible to convert to `array.emtpy?` in the same way.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
