### PR TITLE
Support autocorrection for percent literals in `Style/ConcatArrayLiterals`

### DIFF
--- a/changelog/change_concat_array_literals_support_autocorrection_for_percent_literals.md
+++ b/changelog/change_concat_array_literals_support_autocorrection_for_percent_literals.md
@@ -1,0 +1,1 @@
+* [#11325](https://github.com/rubocop/rubocop/issues/11325): Support autocorrection for percent literals in `Style/ConcatArrayLiterals`. ([@fatkodima][])

--- a/spec/rubocop/cop/style/concat_array_literals_spec.rb
+++ b/spec/rubocop/cop/style/concat_array_literals_spec.rb
@@ -3,41 +3,61 @@
 RSpec.describe RuboCop::Cop::Style::ConcatArrayLiterals, :config do
   it 'registers an offense when using `concat` with single element array literal argument' do
     expect_offense(<<~RUBY)
-      item.concat([item])
-           ^^^^^^^^^^^^^^ Use `push(item)` instead of `concat([item])`.
+      arr.concat([item])
+          ^^^^^^^^^^^^^^ Use `push(item)` instead of `concat([item])`.
     RUBY
 
     expect_correction(<<~RUBY)
-      item.push(item)
+      arr.push(item)
     RUBY
   end
 
   it 'registers an offense when using `concat` with multiple elements array literal argument' do
     expect_offense(<<~RUBY)
-      item.concat([foo, bar])
-           ^^^^^^^^^^^^^^^^^^ Use `push(foo, bar)` instead of `concat([foo, bar])`.
+      arr.concat([foo, bar])
+          ^^^^^^^^^^^^^^^^^^ Use `push(foo, bar)` instead of `concat([foo, bar])`.
     RUBY
 
     expect_correction(<<~RUBY)
-      item.push(foo, bar)
+      arr.push(foo, bar)
     RUBY
   end
 
   it 'registers an offense when using `concat` with multiple array literal arguments' do
     expect_offense(<<~RUBY)
-      item.concat([foo, bar], [baz])
-           ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `push(foo, bar, baz)` instead of `concat([foo, bar], [baz])`.
+      arr.concat([foo, bar], [baz])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `push(foo, bar, baz)` instead of `concat([foo, bar], [baz])`.
     RUBY
 
     expect_correction(<<~RUBY)
-      item.push(foo, bar, baz)
+      arr.push(foo, bar, baz)
     RUBY
   end
 
   it 'registers an offense when using `concat` with single element `%i` array literal argument' do
     expect_offense(<<~RUBY)
-      item.concat(%i[item])
-           ^^^^^^^^^^^^^^^^ Use `push` with elements as arguments without array brackets instead of `concat(%i[item])`.
+      arr.concat(%i[item])
+          ^^^^^^^^^^^^^^^^ Use `push(:item)` instead of `concat(%i[item])`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      arr.push(:item)
+    RUBY
+  end
+
+  it 'registers an offense when using `concat` with `%I` array literal argument consisting of non basic literals' do
+    expect_offense(<<~RUBY)
+      arr.concat(%I[item \#{foo}])
+          ^^^^^^^^^^^^^^^^^^^^^^^ Use `push` with elements as arguments without array brackets instead of `concat(%I[item \#{foo}])`.
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers an offense when using `concat` with `%W` array literal argument consisting of non basic literals' do
+    expect_offense(<<~RUBY)
+      arr.concat(%W[item \#{foo}])
+          ^^^^^^^^^^^^^^^^^^^^^^^ Use `push` with elements as arguments without array brackets instead of `concat(%W[item \#{foo}])`.
     RUBY
 
     expect_no_corrections
@@ -45,40 +65,42 @@ RSpec.describe RuboCop::Cop::Style::ConcatArrayLiterals, :config do
 
   it 'registers an offense when using `concat` with single element `%w` array literal argument' do
     expect_offense(<<~RUBY)
-      item.concat(%w[item])
-           ^^^^^^^^^^^^^^^^ Use `push` with elements as arguments without array brackets instead of `concat(%w[item])`.
+      arr.concat(%w[item])
+          ^^^^^^^^^^^^^^^^ Use `push("item")` instead of `concat(%w[item])`.
     RUBY
 
-    expect_no_corrections
+    expect_correction(<<~RUBY)
+      arr.push("item")
+    RUBY
   end
 
   it 'does not register an offense when using `concat` with variable argument' do
     expect_no_offenses(<<~RUBY)
-      item.concat(items)
+      arr.concat(items)
     RUBY
   end
 
   it 'does not register an offense when using `concat` with array literal and variable arguments' do
     expect_no_offenses(<<~RUBY)
-      item.concat([foo, bar], baz)
+      arr.concat([foo, bar], baz)
     RUBY
   end
 
   it 'does not register an offense when using `concat` with no arguments' do
     expect_no_offenses(<<~RUBY)
-      item.concat
+      arr.concat
     RUBY
   end
 
   it 'does not register an offense when using `push`' do
     expect_no_offenses(<<~RUBY)
-      item.push(item)
+      arr.push(item)
     RUBY
   end
 
   it 'does not register an offense when using `<<`' do
     expect_no_offenses(<<~RUBY)
-      item << item
+      arr << item
     RUBY
   end
 end


### PR DESCRIPTION
Fixes #11325.

`%W`/`%I` literals with interpolations inside are skipped for autocorrection, because they are rare and could further complicate this cop's logic. Other cases are pretty common.