### PR TITLE
Accept simple freezed constants in `Layout/ClassStructure` and correctly handle class methods

### DIFF
--- a/changelog/fix_class_structure_freezed_consts_and_public_class_methods.md
+++ b/changelog/fix_class_structure_freezed_consts_and_public_class_methods.md
@@ -1,0 +1,1 @@
+* [#11329](https://github.com/rubocop/rubocop/pull/11329): Accept simple freezed constants in `Layout/ClassStructure` and correctly handle class methods. ([@fatkodima][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -21,6 +21,13 @@ module RuboCop
     DEFAULT_RAILS_VERSION = 5.0
     attr_reader :loaded_path
 
+    def self.create(hash, path, check: true)
+      config = new(hash, path)
+      config.check if check
+
+      config
+    end
+
     # rubocop:disable Metrics/AbcSize
     def initialize(hash = {}, loaded_path = nil)
       @loaded_path = loaded_path
@@ -38,13 +45,6 @@ module RuboCop
       @clusivity_config_exists_cache = {}
     end
     # rubocop:enable Metrics/AbcSize
-
-    def self.create(hash, path, check: true)
-      config = new(hash, path)
-      config.check if check
-
-      config
-    end
 
     def loaded_features
       @loaded_features ||= ConfigLoader.loaded_features

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -22,6 +22,34 @@ module RuboCop
         end
       end
 
+      def self.support_autocorrect?
+        method_defined?(:autocorrect)
+      end
+
+      def self.joining_forces
+        return unless method_defined?(:join_force?)
+
+        cop = new
+        Force.all.select { |force_class| cop.join_force?(force_class) }
+      end
+
+      ### Deprecated registry access
+
+      # @deprecated Use Registry.global
+      def self.registry
+        Registry.global
+      end
+
+      # @deprecated Use Registry.all
+      def self.all
+        Registry.all
+      end
+
+      # @deprecated Use Registry.qualified_cop_name
+      def self.qualified_cop_name(name, origin)
+        Registry.qualified_cop_name(name, origin)
+      end
+
       def add_offense(node_or_range, location: :expression, message: nil, severity: nil, &block)
         @v0_argument = node_or_range
         range = find_location(node_or_range, location)
@@ -45,17 +73,6 @@ module RuboCop
         self.class.support_autocorrect?
       end
 
-      def self.support_autocorrect?
-        method_defined?(:autocorrect)
-      end
-
-      def self.joining_forces
-        return unless method_defined?(:join_force?)
-
-        cop = new
-        Force.all.select { |force_class| cop.join_force?(force_class) }
-      end
-
       # @deprecated
       def corrections
         # warn 'Cop#corrections is deprecated' TODO
@@ -74,23 +91,6 @@ module RuboCop
       def on_investigation_end
         investigate_post_walk(processed_source) if respond_to?(:investigate_post_walk)
         super
-      end
-
-      ### Deprecated registry access
-
-      # @deprecated Use Registry.global
-      def self.registry
-        Registry.global
-      end
-
-      # @deprecated Use Registry.all
-      def self.all
-        Registry.all
-      end
-
-      # @deprecated Use Registry.qualified_cop_name
-      def self.qualified_cop_name(name, origin)
-        Registry.qualified_cop_name(name, origin)
       end
 
       private

--- a/lib/rubocop/cop/corrector.rb
+++ b/lib/rubocop/cop/corrector.rb
@@ -11,6 +11,20 @@ module RuboCop
     class Corrector < ::Parser::Source::TreeRewriter
       NOOP_CONSUMER = ->(diagnostic) {} # noop
 
+      # Duck typing for get to a ::Parser::Source::Buffer
+      def self.source_buffer(source)
+        source = source.processed_source if source.respond_to?(:processed_source)
+        source = source.buffer if source.respond_to?(:buffer)
+        source = source.source_buffer if source.respond_to?(:source_buffer)
+
+        unless source.is_a? ::Parser::Source::Buffer
+          raise TypeError, 'Expected argument to lead to a Parser::Source::Buffer ' \
+                           "but got #{source.inspect}"
+        end
+
+        source
+      end
+
       # @param source [Parser::Source::Buffer, or anything
       #                leading to one via `(processed_source.)buffer`]
       #
@@ -62,20 +76,6 @@ module RuboCop
         range = to_range(node_or_range)
         to_remove = range.with(begin_pos: range.end_pos - size)
         remove(to_remove)
-      end
-
-      # Duck typing for get to a ::Parser::Source::Buffer
-      def self.source_buffer(source)
-        source = source.processed_source if source.respond_to?(:processed_source)
-        source = source.buffer if source.respond_to?(:buffer)
-        source = source.source_buffer if source.respond_to?(:source_buffer)
-
-        unless source.is_a? ::Parser::Source::Buffer
-          raise TypeError, 'Expected argument to lead to a Parser::Source::Buffer ' \
-                           "but got #{source.inspect}"
-        end
-
-        source
       end
 
       private

--- a/lib/rubocop/cop/metrics/utils/abc_size_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/abc_size_calculator.rb
@@ -25,14 +25,14 @@ module RuboCop
           # > http://c2.com/cgi/wiki?AbcMetric
           CONDITION_NODES = CyclomaticComplexity::COUNTED_NODES.freeze
 
-          def self.calculate(node, discount_repeated_attributes: false)
-            new(node, discount_repeated_attributes: discount_repeated_attributes).calculate
-          end
-
           # TODO: move to rubocop-ast
           ARGUMENT_TYPES = %i[arg optarg restarg kwarg kwoptarg kwrestarg blockarg].freeze
 
           private_constant :BRANCH_NODES, :CONDITION_NODES, :ARGUMENT_TYPES
+
+          def self.calculate(node, discount_repeated_attributes: false)
+            new(node, discount_repeated_attributes: discount_repeated_attributes).calculate
+          end
 
           def initialize(node)
             @assignment = 0

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -19,6 +19,28 @@ module RuboCop
     class Registry
       include Enumerable
 
+      def self.all
+        global.without_department(:Test).cops
+      end
+
+      def self.qualified_cop_name(name, origin)
+        global.qualified_cop_name(name, origin)
+      end
+
+      # Changes momentarily the global registry
+      # Intended for testing purposes
+      def self.with_temporary_global(temp_global = global.dup)
+        previous = @global
+        @global = temp_global
+        yield
+      ensure
+        @global = previous
+      end
+
+      def self.reset!
+        @global = new
+      end
+
       attr_reader :options
 
       def initialize(cops = [], options = {})
@@ -236,28 +258,6 @@ module RuboCop
 
       class << self
         attr_reader :global
-      end
-
-      def self.all
-        global.without_department(:Test).cops
-      end
-
-      def self.qualified_cop_name(name, origin)
-        global.qualified_cop_name(name, origin)
-      end
-
-      # Changes momentarily the global registry
-      # Intended for testing purposes
-      def self.with_temporary_global(temp_global = global.dup)
-        previous = @global
-        @global = temp_global
-        yield
-      ensure
-        @global = previous
-      end
-
-      def self.reset!
-        @global = new
       end
 
       private

--- a/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
@@ -88,6 +88,10 @@ module RuboCop
         include TrailingComma
         extend AutoCorrector
 
+        def self.autocorrect_incompatible_with
+          [Layout::HeredocArgumentClosingParenthesis]
+        end
+
         def on_send(node)
           return unless node.arguments? && node.parenthesized?
 
@@ -96,10 +100,6 @@ module RuboCop
                 node.source_range.end_pos)
         end
         alias on_csend on_send
-
-        def self.autocorrect_incompatible_with
-          [Layout::HeredocArgumentClosingParenthesis]
-        end
       end
     end
   end

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -234,6 +234,7 @@ module RuboCop
       KNOWN_RUBIES
     end
 
+    # rubocop:disable Layout/ClassStructure
     SOURCES = [
       RuboCopConfig,
       RubyVersionFile,
@@ -244,6 +245,7 @@ module RuboCop
     ].freeze
 
     private_constant :SOURCES
+    # rubocop:enable Layout/ClassStructure
 
     def initialize(config)
       @config = config

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -136,6 +136,23 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
     end
   end
 
+  it 'registers an offense and corrects when public instance method is before class method' do
+    expect_offense(<<~RUBY)
+      class Foo
+        def instance_method; end
+        def self.class_method; end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ `public_class_methods` is supposed to appear before `public_methods`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo
+        def self.class_method; end
+        def instance_method; end
+      end
+    RUBY
+  end
+
   context 'with protected methods declared before private' do
     let(:code) { <<-RUBY }
       class MyClass
@@ -252,14 +269,20 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
 
         LIMIT = 10
         ^^^^^^^^^^ `constants` is supposed to appear before `public_methods`.
+        CONST = 'wrong place'.freeze
+        RECURSIVE_BASIC_LITERALS_CONST = [1, 2].freeze
+        DYNAMIC_CONST = foo.freeze
       end
     RUBY
 
     expect_correction(<<~RUBY)
       class Foo
         LIMIT = 10
+        CONST = 'wrong place'.freeze
+        RECURSIVE_BASIC_LITERALS_CONST = [1, 2].freeze
         def name; end
 
+        DYNAMIC_CONST = foo.freeze
       end
     RUBY
   end

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -74,6 +74,19 @@ class Changelog
       user
     end
   end
+
+  def self.pending?
+    entry_paths.any?
+  end
+
+  def self.entry_paths
+    Dir["#{ENTRIES_PATH}*"]
+  end
+
+  def self.read_entries
+    entry_paths.to_h { |path| [path, File.read(path)] }
+  end
+
   attr_reader :header, :rest
 
   def initialize(content: File.read(PATH), entries: Changelog.read_entries)
@@ -102,18 +115,6 @@ class Changelog
     merged_content = [@header, unreleased_content, @rest.chomp, *new_contributor_lines].join("\n")
 
     merged_content << EOF
-  end
-
-  def self.pending?
-    entry_paths.any?
-  end
-
-  def self.entry_paths
-    Dir["#{ENTRIES_PATH}*"]
-  end
-
-  def self.read_entries
-    entry_paths.to_h { |path| [path, File.read(path)] }
   end
 
   def new_contributor_lines


### PR DESCRIPTION
This PR fixes 2 problems:
1. Previously, rubocop hasn't correctly detected and autocorrected class methods (as you can see from the 2nd commit), because of the misspelling.
2. Simple `.freeze` constants are considered as "dynamic constants" and are ignored from the consideration. Changed that.

This PR also fixes #8034.

As a follow up to this, I will extend this cop to be able to detect private constants and class methods, to avoid having disables like https://github.com/rubocop/rubocop/blob/20b32e434160716d07182d512be6da3d8ba96d71/lib/rubocop/cop/base.rb#L330-L333 - that constant is used in the method that follows and makes sense to keep it near that method (not at the top as `Layout/ClassStructure` currently suggests, thats why `# rubocop:disable`).
