### PR TITLE
Fix an error for `Style/RequireOrder` when using `require` inside `rescue` body

### DIFF
--- a/changelog/fix_require_order_for_require_inside_rescue.md
+++ b/changelog/fix_require_order_for_require_inside_rescue.md
@@ -1,0 +1,1 @@
+* [#11330](https://github.com/rubocop/rubocop/pull/11330): Fix an error for `Style/RequireOrder` when using `require` inside `rescue` body. ([@fatkodima][])

--- a/lib/rubocop/cop/style/require_order.rb
+++ b/lib/rubocop/cop/style/require_order.rb
@@ -102,8 +102,10 @@ module RuboCop
           node.if_type? && !node.modifier_form?
         end
 
-        def find_previous_older_sibling(node) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity
+        def find_previous_older_sibling(node) # rubocop:disable Metrics
           search_node(node).left_siblings.reverse.find do |sibling|
+            next unless sibling.is_a?(AST::Node)
+
             sibling = sibling_node(sibling)
             break unless sibling&.send_type? && sibling&.method?(node.method_name)
             break unless sibling.arguments? && !sibling.receiver

--- a/spec/rubocop/cop/style/require_order_spec.rb
+++ b/spec/rubocop/cop/style/require_order_spec.rb
@@ -251,4 +251,37 @@ RSpec.describe RuboCop::Cop::Style::RequireOrder, :config do
       RUBY
     end
   end
+
+  context 'when rescue block' do
+    it 'registers offense for multiple unsorted `require`s' do
+      expect_offense(<<~RUBY)
+        begin
+          do_something
+        rescue
+          require 'b'
+          require 'a'
+          ^^^^^^^^^^^ Sort `require` in alphabetical order.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          do_something
+        rescue
+          require 'a'
+          require 'b'
+        end
+      RUBY
+    end
+
+    it 'registers no offense for single `require`' do
+      expect_no_offenses(<<~RUBY)
+        begin
+          do_something
+        rescue
+          require 'a'
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
For the following code
```ruby
begin
rescue
  require "foo"
end
```

I got
```
undefined method `if_type?' for nil:NilClass

          node.if_type? && !node.modifier_form?
              ^^^^^^^^^
rubocop/lib/rubocop/cop/style/require_order.rb:102:in `not_modifier_form?'
rubocop/lib/rubocop/cop/style/require_order.rb:121:in `sibling_node'
rubocop/lib/rubocop/cop/style/require_order.rb:107:in `block in find_previous_older_sibling'
rubocop/lib/rubocop/cop/style/require_order.rb:106:in `each'
rubocop/lib/rubocop/cop/style/require_order.rb:106:in `find'
rubocop/lib/rubocop/cop/style/require_order.rb:106:in `find_previous_older_sibling'
rubocop/lib/rubocop/cop/style/require_order.rb:87:in `on_send'
rubocop/lib/rubocop/cop/commissioner.rb:137:in `public_send'
```

`Node#left_siblings` returns all (sibling) children of the parent node (not only of `AST::Node` type), but we should work only with nodes.