### PR TITLE
Accept `super` within ranges for `Layout/SpaceAroundKeyword` cop

### DIFF
--- a/changelog/fix_space_around_keyword_accept_super_within_ranges.md
+++ b/changelog/fix_space_around_keyword_accept_super_within_ranges.md
@@ -1,0 +1,1 @@
+* [#8751](https://github.com/rubocop/rubocop/issues/8751): Accept `super` within ranges for `Layout/SpaceAroundKeyword` cop. ([@fatkodima][])

--- a/lib/rubocop/cop/layout/space_around_keyword.rb
+++ b/lib/rubocop/cop/layout/space_around_keyword.rb
@@ -256,7 +256,7 @@ module RuboCop
           # regular dotted method calls bind more tightly than operators
           # so we need to climb up the AST past them
           node.each_ancestor do |ancestor|
-            return true if ancestor.and_type? || ancestor.or_type?
+            return true if ancestor.and_type? || ancestor.or_type? || ancestor.range_type?
             return false unless ancestor.send_type?
             return true if ancestor.operator_method?
           end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -653,6 +653,20 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     expect(File.read('example.rb')).to eq(corrected)
   end
 
+  it 'corrects `Layout/SpaceAroundKeyword` with `Layout/SpaceInsideRangeLiteral`' do
+    source = <<~RUBY
+      def method
+        1..super
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(
+      cli.run(['-a', '--only', 'Layout/SpaceAroundKeyword,Layout/SpaceInsideRangeLiteral'])
+    ).to eq(0)
+    expect($stdout.string).to include('no offenses detected')
+    expect(File.read('example.rb')).to eq(source)
+  end
+
   it 'corrects LineEndConcatenation offenses leaving the ' \
      'RedundantInterpolation offense unchanged' do
     # If we change string concatenation from plus to backslash, the string

--- a/spec/rubocop/cop/layout/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_keyword_spec.rb
@@ -172,6 +172,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   # Layout/SpaceAroundBlockParameters
   it_behaves_like 'accept before', '|', 'loop { |x|break }'
 
+  # Layout/SpaceInsideRangeLiteral
+  it_behaves_like 'accept before', '..', '1..super.size'
+  it_behaves_like 'accept before', '...', '1...super.size'
+
   # Layout/SpaceAroundOperators
   it_behaves_like 'accept before', '=', 'a=begin end'
   it_behaves_like 'accept before', '==', 'a==begin end'


### PR DESCRIPTION
Fixes #8751.

For the following
```ruby
1..super
```

An infinite loop is detected:
```
Infinite loop detected in snippet.rb and caused by Layout/SpaceAroundKeyword -> Layout/SpaceInsideRangeLiteral
rubocop/lib/rubocop/runner.rb:311:in `check_for_infinite_loop'
rubocop/lib/rubocop/runner.rb:294:in `block in iterate_until_no_changes'
rubocop/lib/rubocop/runner.rb:293:in `loop'
rubocop/lib/rubocop/runner.rb:293:in `iterate_until_no_changes'
```