### PR TITLE
Ignore private constants in `Layout/ClassStructure` cop

### DIFF
--- a/changelog/change_class_structure_to_ignore_private_constants.md
+++ b/changelog/change_class_structure_to_ignore_private_constants.md
@@ -1,0 +1,1 @@
+* [#8366](https://github.com/rubocop/rubocop/issues/8366): Ignore private constants in `Layout/ClassStructure` cop. ([@fatkodima][])

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -329,11 +329,8 @@ module RuboCop
         @current_corrector = nil
       end
 
-      # rubocop:disable Layout/ClassStructure
       EMPTY_OFFENSES = [].freeze
       private_constant :EMPTY_OFFENSES
-      # rubocop:enable Layout/ClassStructure
-
       # Called to complete an investigation
       def complete_investigation
         InvestigationReport.new(

--- a/lib/rubocop/cop/mixin/annotation_comment.rb
+++ b/lib/rubocop/cop/mixin/annotation_comment.rb
@@ -47,7 +47,7 @@ module RuboCop
         match.captures
       end
 
-      KEYWORDS_REGEX_CACHE = {} # rubocop:disable Layout/ClassStructure, Style/MutableConstant
+      KEYWORDS_REGEX_CACHE = {} # rubocop:disable Style/MutableConstant
       private_constant :KEYWORDS_REGEX_CACHE
 
       def regex

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -108,7 +108,6 @@ module RuboCop
         :skip_children
       end
 
-      # rubocop:disable Layout/ClassStructure
       NODE_HANDLER_METHOD_NAMES = [
         [VARIABLE_ASSIGNMENT_TYPE, :process_variable_assignment],
         [REGEXP_NAMED_CAPTURE_TYPE, :process_regexp_named_captures],
@@ -123,8 +122,6 @@ module RuboCop
         *SCOPE_TYPES.product([:process_scope])
       ].to_h.freeze
       private_constant :NODE_HANDLER_METHOD_NAMES
-      # rubocop:enable Layout/ClassStructure
-
       def node_handler_method_name(node)
         NODE_HANDLER_METHOD_NAMES[node.type]
       end

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -234,7 +234,6 @@ module RuboCop
       KNOWN_RUBIES
     end
 
-    # rubocop:disable Layout/ClassStructure
     SOURCES = [
       RuboCopConfig,
       RubyVersionFile,
@@ -245,8 +244,6 @@ module RuboCop
     ].freeze
 
     private_constant :SOURCES
-    # rubocop:enable Layout/ClassStructure
-
     def initialize(config)
       @config = config
     end

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -287,6 +287,31 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
     RUBY
   end
 
+  it 'ignores misplaced private constants' do
+    expect_offense(<<~RUBY)
+      class Foo
+        def name; end
+
+        PRIVATE_CONST1 = 1
+        PRIVATE_CONST2 = 2
+        private_constant :PRIVATE_CONST1, :PRIVATE_CONST2
+        PUBLIC_CONST = 'public'
+        ^^^^^^^^^^^^^^^^^^^^^^^ `constants` is supposed to appear before `public_methods`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo
+        PUBLIC_CONST = 'public'
+        def name; end
+
+        PRIVATE_CONST1 = 1
+        PRIVATE_CONST2 = 2
+        private_constant :PRIVATE_CONST1, :PRIVATE_CONST2
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects when str heredoc constant is defined after public method' do
     expect_offense(<<~RUBY)
       class Foo


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/pull/11329.
Closes https://github.com/rubocop/rubocop/issues/8366.

Example: often times we need to have a constant to act like a cache (see autocorrected changes in this PR) and it makes sense to make it private and keep it near the method that uses it. Rubocop suggests to move it to the top, which is not much useful. 

The same probably needs to be done for private class methods, as they are currently incorrectly considered as "public class methods". But we need to decide where to place them in the class hierarchy (after the public class methods, or before private instance methods, or ...)?