### PR TITLE
Add new `Style/YodaExpression` cop

### DIFF
--- a/changelog/new_add_new_style_yoda_expression_cop.md
+++ b/changelog/new_add_new_style_yoda_expression_cop.md
@@ -1,0 +1,1 @@
+* [#9222](https://github.com/rubocop/rubocop/issues/9222): Add new `Style/YodaExpression` cop. ([@fatkodima][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5432,6 +5432,18 @@ Style/YodaCondition:
   VersionAdded: '0.49'
   VersionChanged: '0.75'
 
+Style/YodaExpression:
+  Description: 'Forbid the use of yoda expressions.'
+  Enabled: pending
+  Safe: false
+  VersionAdded: '<<next>>'
+  SupportedOperators:
+    - '*'
+    - '+'
+    - '&'
+    - '|'
+    - '^'
+
 Style/ZeroLengthPredicate:
   Description: 'Use #empty? when testing for objects of length 0.'
   Enabled: true

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -676,6 +676,7 @@ require_relative 'rubocop/cop/style/while_until_do'
 require_relative 'rubocop/cop/style/while_until_modifier'
 require_relative 'rubocop/cop/style/word_array'
 require_relative 'rubocop/cop/style/yoda_condition'
+require_relative 'rubocop/cop/style/yoda_expression'
 require_relative 'rubocop/cop/style/zero_length_predicate'
 
 require_relative 'rubocop/cop/security/compound_hash'

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -7,7 +7,7 @@ module RuboCop
     STATUS_SUCCESS     = 0
     STATUS_OFFENSES    = 1
     STATUS_ERROR       = 2
-    STATUS_INTERRUPTED = 128 + Signal.list['INT']
+    STATUS_INTERRUPTED = Signal.list['INT'] + 128
     DEFAULT_PARALLEL_OPTIONS = %i[
       color debug display_style_guide display_time display_only_fail_level_offenses
       display_only_failed except extra_details fail_level fix_layout format

--- a/lib/rubocop/cop/corrector.rb
+++ b/lib/rubocop/cop/corrector.rb
@@ -78,6 +78,18 @@ module RuboCop
         remove(to_remove)
       end
 
+      # Swaps sources at the given ranges.
+      #
+      # @param [Parser::Source::Range, RuboCop::AST::Node] node_or_range1
+      # @param [Parser::Source::Range, RuboCop::AST::Node] node_or_range2
+      def swap(node_or_range1, node_or_range2)
+        range1 = to_range(node_or_range1)
+        range2 = to_range(node_or_range2)
+
+        replace(range1, range2.source)
+        replace(range2, range1.source)
+      end
+
       private
 
       # :nodoc:

--- a/lib/rubocop/cop/layout/multiline_block_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_block_layout.rb
@@ -91,7 +91,7 @@ module RuboCop
           if node.source.lines.first.end_with?("|\n")
             PIPE_SIZE
           else
-            1 + (PIPE_SIZE * 2)
+            (PIPE_SIZE * 2) + 1
           end
         end
 

--- a/lib/rubocop/cop/metrics/perceived_complexity.rb
+++ b/lib/rubocop/cop/metrics/perceived_complexity.rb
@@ -45,7 +45,7 @@ module RuboCop
             else
               # Otherwise, the case node gets 0.8 complexity points and each
               # when gets 0.2.
-              (0.8 + (0.2 * nb_branches)).round
+              ((nb_branches * 0.2) + 0.8).round
             end
           when :if
             node.else? && !node.elsif? ? 2 : 1

--- a/lib/rubocop/cop/style/yoda_expression.rb
+++ b/lib/rubocop/cop/style/yoda_expression.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Style
+      # Forbids Yoda expressions, i.e. binary operations (using `*`, `+`, `&`, `|`,
+      # and `^` operators) where the order of expression is reversed, eg. `1 + x`.
+      # This cop complements `Style/YodaCondition` cop, which has a similar purpose.
+      #
+      # @safety
+      #   This cop is unsafe because binary operators can be defined
+      #   differently on different classes, and are not guaranteed to
+      #   have the same result if reversed.
+      #
+      # @example SupportedOperators: ['*', '+', '&'']
+      #   # bad
+      #   1 + x
+      #   10 * y
+      #   1 & z
+      #
+      #   # good
+      #   60 * 24
+      #   x + 1
+      #   y * 10
+      #   z & 1
+      #
+      #   # good
+      #   1 | x
+      #
+      class YodaExpression < Base
+        extend AutoCorrector
+
+        MSG = 'Non literal operand should be first.'
+
+        RESTRICT_ON_SEND = %i[* + & | ^].freeze
+
+        def on_new_investigation
+          @offended_nodes = nil
+        end
+
+        def on_send(node)
+          return unless supported_operators.include?(node.method_name.to_s)
+
+          lhs = node.receiver
+          rhs = node.first_argument
+          return if !lhs.numeric_type? || rhs.numeric_type?
+
+          return if offended_ancestor?(node)
+
+          add_offense(node) do |corrector|
+            corrector.swap(lhs, rhs)
+          end
+
+          @offended_nodes ||= Set.new.compare_by_identity
+          @offended_nodes.add(node)
+        end
+
+        private
+
+        def supported_operators
+          Array(cop_config['SupportedOperators'])
+        end
+
+        def offended_ancestor?(node)
+          node.each_ancestor(:send).any? { |ancestor| @offended_nodes&.include?(ancestor) }
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -53,7 +53,7 @@ module RuboCop
       def remove_oldest_files(files, dirs, cache_root, verbose)
         # Add 1 to half the number of files, so that we remove the file if
         # there's only 1 left.
-        remove_count = 1 + (files.length / 2)
+        remove_count = (files.length / 2) + 1
         puts "Removing the #{remove_count} oldest files from #{cache_root}" if verbose
         sorted = files.sort_by { |path| File.mtime(path) }
         remove_files(sorted, dirs, remove_count)

--- a/spec/rubocop/cop/corrector_spec.rb
+++ b/spec/rubocop/cop/corrector_spec.rb
@@ -65,6 +65,10 @@ RSpec.describe RuboCop::Cop::Corrector do
       expect { |corrector| corrector.remove_trailing(operator, 2) }.to rewrite_to 'true a false'
     end
 
+    it 'allows swapping sources of two nodes' do
+      expect { |corrector| corrector.swap(node.lhs, node.rhs) }.to rewrite_to 'false and true'
+    end
+
     it 'accepts a node instead of a range' do
       expect { |corrector| corrector.replace(node.rhs, 'maybe') }.to rewrite_to 'true and maybe'
     end

--- a/spec/rubocop/cop/style/yoda_expression_spec.rb
+++ b/spec/rubocop/cop/style/yoda_expression_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Style::YodaExpression, :config do
+  let(:cop_config) { { 'SupportedOperators' => ['*', '+'] } }
+
+  it 'registers an offense when using simple offended example' do
+    expect_offense(<<~RUBY)
+      1 + x
+      ^^^^^ Non literal operand should be first.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x + 1
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using complex offended example' do
+    expect_offense(<<~RUBY)
+      2 + (1 + x)
+      ^^^^^^^^^^^ Non literal operand should be first.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (x + 1) + 2
+    RUBY
+  end
+
+  it 'accepts numeric on the right' do
+    expect_no_offenses(<<~RUBY)
+      1 + 2
+      1 + 2.2
+    RUBY
+  end
+
+  it 'accepts non integer' do
+    expect_no_offenses(<<~RUBY)
+      x + 1
+    RUBY
+  end
+
+  it 'accepts `|`' do
+    expect_no_offenses(<<~RUBY)
+      1 | x
+    RUBY
+  end
+end

--- a/spec/rubocop/formatter/progress_formatter_spec.rb
+++ b/spec/rubocop/formatter/progress_formatter_spec.rb
@@ -118,16 +118,16 @@ RSpec.describe RuboCop::Formatter::ProgressFormatter do
             RuboCop::Cop::Offense.new(
               :error,
               Parser::Source::Range.new(source_buffer,
-                                        (4 * line_length) + 1,
-                                        (4 * line_length) + 2),
+                                        (line_length * 4) + 1,
+                                        (line_length * 4) + 2),
               'bar',
               'Cop'
             ),
             RuboCop::Cop::Offense.new(
               :convention,
               Parser::Source::Range.new(source_buffer,
-                                        5 * line_length,
-                                        (5 * line_length) + 1),
+                                        line_length * 5,
+                                        (line_length * 5) + 1),
               'foo',
               'Cop'
             )

--- a/spec/rubocop/formatter/tap_formatter_spec.rb
+++ b/spec/rubocop/formatter/tap_formatter_spec.rb
@@ -86,16 +86,16 @@ RSpec.describe RuboCop::Formatter::TapFormatter do
             RuboCop::Cop::Offense.new(
               :error,
               Parser::Source::Range.new(source_buffer,
-                                        (4 * line_length) + 1,
-                                        (4 * line_length) + 2),
+                                        (line_length * 4) + 1,
+                                        (line_length * 4) + 2),
               'bar',
               'Cop'
             ),
             RuboCop::Cop::Offense.new(
               :convention,
               Parser::Source::Range.new(source_buffer,
-                                        5 * line_length,
-                                        (5 * line_length) + 1),
+                                        line_length * 5,
+                                        (line_length * 5) + 1),
               'foo',
               'Cop'
             )


### PR DESCRIPTION
Closes #9222.

Considerations:
1. I excluded `*` from the checked binary operators, as it looks fine for me both ways: `1000 * milliseconds` vs `milliseconds * 1000`.
2. I check only for integer values, because of the same reason as above: `0.8 + 0.2 * count` vs `0.2 * count + 0.8`.
3. This cop only forbids yoda expressions. Should it be able to enforce it?
4. When forbiding, which edge cases we should ignore? 
5. Etc.