### PR TITLE
Accept bracketed arrays within 2d arrays containing subarrays with complex content for `Style/WordArray` cop

### DIFF
--- a/changelog/fix_word_array_to_accept_2d_arrays.md
+++ b/changelog/fix_word_array_to_accept_2d_arrays.md
@@ -1,0 +1,1 @@
+* [#10194](https://github.com/rubocop/rubocop/issues/10194): Accept bracketed arrays within 2d arrays containing subarrays with complex content for `Style/WordArray` cop. ([@fatkodima][])

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -53,6 +53,7 @@ module RuboCop
         def on_array(node)
           if bracketed_array_of?(:str, node)
             return if complex_content?(node.values)
+            return if within_2d_array_of_complex_content?(node)
 
             check_bracketed_array(node, 'w')
           elsif node.percent_literal?(:string)
@@ -61,6 +62,12 @@ module RuboCop
         end
 
         private
+
+        def within_2d_array_of_complex_content?(node)
+          return false unless (parent = node.parent)
+
+          parent.array_type? && parent.values.any? { |subarray| complex_content?(subarray.values) }
+        end
 
         def complex_content?(strings, complex_regex: word_regex)
           strings.any? do |s|

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -347,6 +347,34 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
         A = %w(one two)
       RUBY
     end
+
+    it 'registers an offense and corrects for array within 2d array' do
+      expect_offense(<<~RUBY)
+        [
+          ['one', 'One'],
+          ^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+          ['two', 'Two']
+          ^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+        ]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [
+          %w(one One),
+          %w(two Two)
+        ]
+      RUBY
+    end
+
+    it 'does not register an offense for array within 2d array containing subarrays with complex content' do
+      expect_no_offenses(<<~RUBY)
+        [
+          ['one', 'One'],
+          ['two', 'Two'],
+          ['forty two', 'Forty Two']
+        ]
+      RUBY
+    end
   end
 
   context 'when EnforcedStyle is array' do


### PR DESCRIPTION
Fixes #10194.

Should we check for more than 2 dimensions?
