### PR TITLE
Fix an error for `Style/RequireOrder`

### DIFF
--- a/changelog/fix_error_for_style_require_order.md
+++ b/changelog/fix_error_for_style_require_order.md
@@ -1,0 +1,1 @@
+* [#11335](https://github.com/rubocop/rubocop/pull/11335): Fix an error for `Style/RequireOrder` when only one `reuqire`. ([@koic][])

--- a/lib/rubocop/cop/style/require_order.rb
+++ b/lib/rubocop/cop/style/require_order.rb
@@ -81,7 +81,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return unless node.arguments?
+          return unless node.parent && node.arguments?
           return if not_modifier_form?(node.parent)
 
           previous_older_sibling = find_previous_older_sibling(node)

--- a/spec/rubocop/cop/style/require_order_spec.rb
+++ b/spec/rubocop/cop/style/require_order_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe RuboCop::Cop::Style::RequireOrder, :config do
     end
   end
 
+  context 'when only one `require`' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        require 'a'
+      RUBY
+    end
+  end
+
   context 'when `require` is not sorted in different sections' do
     it 'registers no offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR fixes the following error for `Style/RequireOrder` when only one `reuqire`.

```ruby
require 'a'
```

```console
% bundle exec rubocop example.rb --only Style/RequireOrder -d
(snip)

undefined method `if_type?' for nil:NilClass
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/require_order.rb:102:in `not_modifier_form?'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/require_order.rb:85:in `on_send'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
