### PR TITLE
Fix `Style/IdenticalConditionalBranches` to ignore identical leading lines when branch has single child and is used in return context

### DIFF
--- a/changelog/fix_identical_conditional_branches_ignore_empty_left_branches.md
+++ b/changelog/fix_identical_conditional_branches_ignore_empty_left_branches.md
@@ -1,0 +1,1 @@
+* [#10858](https://github.com/rubocop/rubocop/issues/10858): Fix `Style/IdenticalConditionalBranches` to ignore identical leading lines when branch has single child and is used in return context. ([@fatkodima][])

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -72,6 +72,31 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
     end
   end
 
+  context 'on if..else with identical leading lines, single child branch and last node of the parent' do
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        def foo
+          if something
+            do_x
+          else
+            do_x
+            1 + 2 + 3
+          end
+        end
+
+        def bar
+          y = if something
+                do_x
+              else
+                do_x
+                1 + 2 + 3
+              end
+          do_something_else
+        end
+      RUBY
+    end
+  end
+
   context 'on if..elsif with no else' do
     it "doesn't register an offense" do
       expect_no_offenses(<<~RUBY)
@@ -214,6 +239,39 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
           x2
         else
           x3
+        end
+      RUBY
+    end
+  end
+
+  context 'on case with identical leading lines, single child branch and last node of the parent' do
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        def foo
+          case something
+          when :a
+            do_x
+          when :b
+            do_x
+            x2
+          else
+            do_x
+            x3
+          end
+        end
+
+        def bar
+          x = case something
+              when :a
+                do_x
+              when :b
+                do_x
+                x2
+              else
+                do_x
+                x3
+              end
+          do_something
         end
       RUBY
     end
@@ -383,6 +441,39 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
             x2
           else
             x3
+          end
+        RUBY
+      end
+    end
+
+    context 'on case-match with identical leading lines, single child branch and last node of the parent' do
+      it "doesn't register an offense" do
+        expect_no_offenses(<<~RUBY)
+          def foo
+            case something
+            in :a
+              do_x
+            in :b
+              do_x
+              x2
+            else
+              do_x
+              x3
+            end
+          end
+
+          def bar
+            y = case something
+                in :a
+                  do_x
+                in :b
+                  do_x
+                  x2
+                else
+                  do_x
+                  x3
+                end
+            do_something
           end
         RUBY
       end


### PR DESCRIPTION
Fixes #10858.

We should ignore branches with identical leading lines, if any of them has only one child and the whole `if`/`case`/etc is used in return contexts, like
```ruby
def method
  if something
    foo
  else
    foo
    bar
  end
end
```

because otherwise it will be changed to
```ruby
def method
  foo
  if something
  else
    bar
  end
end
```

and incorrectly return `nil` when `something` is truthy, instead of the value of `foo` (as before).