### PR TITLE
Support pattern matching for `Lint/OutOfRangeRegexpRef` cop

### DIFF
--- a/changelog/change_out_of_range_regexp_ref_pattern_matching.md
+++ b/changelog/change_out_of_range_regexp_ref_pattern_matching.md
@@ -1,0 +1,1 @@
+* [#10976](https://github.com/rubocop/rubocop/issues/10976): Support pattern matching for `Lint/OutOfRangeRegexpRef` cop. ([@fatkodima][])


### PR DESCRIPTION
Closes #10976.

Note: This is the first time I familiarized myself with the pattern matching in ruby, so be a little more careful when reviewing this PR.