### PR TITLE
[Fix #11346] Fix a false positive for `Style/RedundantStringEscape`

### DIFF
--- a/changelog/fix_false_positive_style_redundant_string_escape.md
+++ b/changelog/fix_false_positive_style_redundant_string_escape.md
@@ -1,0 +1,1 @@
+* [#11346](https://github.com/rubocop/rubocop/issues/11346): Fix a false positive for `Style/RedundantStringEscape` when using escaped space in heredoc. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_string_escape.rb
+++ b/lib/rubocop/cop/style/redundant_string_escape.rb
@@ -76,6 +76,7 @@ module RuboCop
           node.loc.to_hash.key?(:begin) && !node.loc.begin.nil?
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def allowed_escape?(node, range)
           escaped = range.source[(1..-1)]
 
@@ -88,13 +89,14 @@ module RuboCop
           # with different versions of Ruby so that e.g. /\d/ != /d/
           return true if /[\n\\[[:alnum:]]]/.match?(escaped[0])
 
-          return true if escaped[0] == ' ' && percent_array_literal?(node)
+          return true if escaped[0] == ' ' && (percent_array_literal?(node) || node.heredoc?)
 
           return true if disabling_interpolation?(range)
           return true if delimiter?(node, escaped[0])
 
           false
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def interpolation_not_enabled?(node)
           single_quoted?(node) ||

--- a/spec/rubocop/cop/style/redundant_string_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_string_escape_spec.rb
@@ -417,6 +417,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantStringEscape, :config do
         MYHEREDOC
       RUBY
     end
+
+    it 'does register an offense an escaped space' do
+      expect_no_offenses(<<~'RUBY')
+        <<~MYHEREDOC
+          \ text
+        MYHEREDOC
+      RUBY
+    end
   end
 
   context 'with an interpolation-disabled HEREDOC' do


### PR DESCRIPTION
Fixes #11346.

This PR fixes a false positive for `Style/RedundantStringEscape` when using escaped space in heredoc.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
