### PR TITLE
Fix an error for `Style/SelectByRegexp`

### DIFF
--- a/changelog/fix_error_for_style_select_by_regexp.md
+++ b/changelog/fix_error_for_style_select_by_regexp.md
@@ -1,0 +1,1 @@
+* [#11348](https://github.com/rubocop/rubocop/pull/11348): Fix an error for `Style/SelectByRegexp` when block body is empty. ([@koic][])

--- a/lib/rubocop/cop/style/select_by_regexp.rb
+++ b/lib/rubocop/cop/style/select_by_regexp.rb
@@ -86,12 +86,12 @@ module RuboCop
 
         def on_send(node)
           return unless (block_node = node.block_node)
-          return if block_node.body.begin_type?
+          return if block_node.body&.begin_type?
           return if receiver_allowed?(block_node.receiver)
           return unless (regexp_method_send_node = extract_send_node(block_node))
           return if match_predicate_without_receiver?(regexp_method_send_node)
 
-          opposite = regexp_method_send_node.send_type? && regexp_method_send_node.method?(:!~)
+          opposite = opposite?(regexp_method_send_node)
           regexp = find_regexp(regexp_method_send_node, block_node)
 
           register_offense(node, block_node, regexp, opposite)
@@ -126,6 +126,10 @@ module RuboCop
           return unless calls_lvar?(regexp_method_send_node, block_arg_name)
 
           regexp_method_send_node
+        end
+
+        def opposite?(regexp_method_send_node)
+          regexp_method_send_node.send_type? && regexp_method_send_node.method?(:!~)
         end
 
         def find_regexp(node, block)

--- a/spec/rubocop/cop/style/select_by_regexp_spec.rb
+++ b/spec/rubocop/cop/style/select_by_regexp_spec.rb
@@ -150,6 +150,12 @@ RSpec.describe RuboCop::Cop::Style::SelectByRegexp, :config do
         RUBY
       end
 
+      it 'does not register an offense when the block body is empty' do
+        expect_no_offenses(<<~RUBY)
+          array.#{method} { }
+        RUBY
+      end
+
       it 'registers an offense and corrects without a receiver' do
         expect_offense(<<~RUBY, method: method)
           #{method} { |x| x.match?(/regexp/) }


### PR DESCRIPTION
This PR fixes the following error for `Style/SelectByRegexp` when block body is empty:

```ruby
array.select { }
```

```console
% bundle exec rubocop --only Style/SelectByRegexp -d
(snip)

An error occurred while Style/SelectByRegexp cop was inspecting /Users/koic/src/github.com/koic/rubocop-issues/empty_body/example.rb:1:0.
undefined method `begin_type?' for nil:NilClass
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/select_by_regexp.rb:89:in `on_send'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
