### PR TITLE
Fix an incorrect autocorrect for `Lint/RegexpAsCondition`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_regexp_as_condition.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_regexp_as_condition.md
@@ -1,0 +1,1 @@
+* [#11351](https://github.com/rubocop/rubocop/pull/11351): Fix an incorrect autocorrect for `Lint/RegexpAsCondition` when using regexp literal with bang. ([@koic][])

--- a/lib/rubocop/cop/lint/regexp_as_condition.rb
+++ b/lib/rubocop/cop/lint/regexp_as_condition.rb
@@ -17,13 +17,19 @@ module RuboCop
       #     do_something
       #   end
       class RegexpAsCondition < Base
+        include IgnoredNode
         extend AutoCorrector
 
         MSG = 'Do not use regexp literal as a condition. ' \
               'The regexp literal matches `$_` implicitly.'
 
         def on_match_current_line(node)
+          return if node.ancestors.none?(&:conditional?)
+          return if part_of_ignored_node?(node)
+
           add_offense(node) { |corrector| corrector.replace(node, "#{node.source} =~ $_") }
+
+          ignore_node(node)
         end
       end
     end

--- a/spec/rubocop/cop/lint/regexp_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/regexp_as_condition_spec.rb
@@ -14,9 +14,28 @@ RSpec.describe RuboCop::Cop::Lint::RegexpAsCondition, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects for a regexp literal with bang in `if` condition' do
+    expect_offense(<<~RUBY)
+      if !/foo/
+          ^^^^^ Do not use regexp literal as a condition. The regexp literal matches `$_` implicitly.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if !/foo/ =~ $_
+      end
+    RUBY
+  end
+
   it 'does not register an offense for a regexp literal outside conditions' do
     expect_no_offenses(<<~RUBY)
       /foo/
+    RUBY
+  end
+
+  it 'does not register an offense for a regexp literal with bang outside conditions' do
+    expect_no_offenses(<<~RUBY)
+      !/foo/
     RUBY
   end
 


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for `Lint/RegexpAsCondition` when using regexp literal with bang:

```ruby
if !/foo/ =~ $_ =~ $_
end
```

```console
% be rubocop --only Lint/RegexpAsCondition -a
(snip)

Offenses:

example.rb:1:5: W: [Corrected] Lint/RegexpAsCondition: Do not use regexp literal as a condition. The regexp literal matches $_ implicitly.
if !/foo/
    ^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

```diff
% git diff .
diff --git a/regexp_as_condition/example.rb b/regexp_as_condition/example.rb
index 3cb37b3..6f925a3 100644
--- a/regexp_as_condition/example.rb
+++ b/regexp_as_condition/example.rb
@@ -1,2 +1,2 @@
-if !/foo/
+if !/foo/ =~ $_ =~ $_
 end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
