### PR TITLE
Docs: Make example code for ERB parsing function as expected

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -287,7 +287,7 @@ ignored by Git.
 AllCops:
   Exclude:
   <% `git status --ignored --porcelain`.lines.grep(/^!! /).each do |path| %>
-    - <%= path.sub(/^!! /, '') %>
+    - <%= path.sub(/^!! /, '').sub(/\/$/, '/**/*') %>
   <% end %>
 ----
 


### PR DESCRIPTION
In the existing example, the `.gitignore` lines would not be properly translated to something rubocop understands:

given the following setup in gitignore:
```
node_modules/**/*
```
The `git` command outputs `!! node_modules/`
result:
```
Exclude:
  - node_modules/
```
However rubocop needs `- node_modules/**/*` to actually ignore, this change makes the documentation more immediately useful. I have crossed out the below tasks I thought weren't needed in a documentation change of this type.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* ~[ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* ~[ ] Squashed related commits together.~
* ~[ ] Added tests.~
* ~[ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.~
* ~[ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
