### PR TITLE
[Fix #11361] Make `Style/MethodDefParentheses` aware of anonymous rest and keyword rest args

### DIFF
--- a/changelog/fix_false_positive_for_style_method_def_parentheses.md
+++ b/changelog/fix_false_positive_for_style_method_def_parentheses.md
@@ -1,0 +1,1 @@
+* [#11361](https://github.com/rubocop/rubocop/issues/11361): Make `Style/MethodDefParentheses` aware of Ruby 3.2's anonymous rest and keyword rest arguments. ([@koic][])

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -10,7 +10,9 @@ module RuboCop
       #
       # 1. Endless methods
       # 2. Argument lists containing a `forward-arg` (`...`)
-      # 3. Argument lists containing an anonymous block forwarding (`&`)
+      # 3. Argument lists containing an anonymous rest arguments forwarding (`*`)
+      # 4. Argument lists containing an anonymous keyword rest arguments forwarding (`**`)
+      # 5. Argument lists containing an anonymous block forwarding (`&`)
       #
       # Removing the parens would be a syntax error here.
       #
@@ -130,9 +132,11 @@ module RuboCop
           # Regardless of style, parentheses are necessary for:
           # 1. Endless methods
           # 2. Argument lists containing a `forward-arg` (`...`)
-          # 3. Argument lists containing an anonymous block forwarding (`&`)
+          # 3. Argument lists containing an anonymous rest arguments forwarding (`*`)
+          # 4. Argument lists containing an anonymous keyword rest arguments forwarding (`**`)
+          # 5. Argument lists containing an anonymous block forwarding (`&`)
           # Removing the parens would be a syntax error here.
-          node.endless? || node.arguments.any?(&:forward_arg_type?) || anonymous_block_arg?(node)
+          node.endless? || anonymous_arguments?(node)
         end
 
         def require_parentheses?(args)
@@ -162,7 +166,10 @@ module RuboCop
           end
         end
 
-        def anonymous_block_arg?(node)
+        def anonymous_arguments?(node)
+          return true if node.arguments.any? do |arg|
+            arg.forward_arg_type? || arg.restarg_type? || arg.kwrestarg_type?
+          end
           return false unless (last_argument = node.arguments.last)
 
           last_argument.blockarg_type? && last_argument.name.nil?

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -107,6 +107,22 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         end
       RUBY
     end
+
+    it 'requires parens for anonymous rest arguments forwarding', :ruby32 do
+      expect_no_offenses(<<~RUBY)
+        def foo(*)
+          bar(*)
+        end
+      RUBY
+    end
+
+    it 'requires parens for anonymous keyword rest arguments forwarding', :ruby32 do
+      expect_no_offenses(<<~RUBY)
+        def foo(**)
+          bar(**)
+        end
+      RUBY
+    end
   end
 
   shared_examples 'endless methods' do


### PR DESCRIPTION
Fixes #11361

This PR fixes a false positive for `Style/MethodDefParentheses` when using `EnforcedStyle: require_no_parentheses` and Ruby 3.2's anonymous rest and keyword rest arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
