### PR TITLE
[Doc] Update the doc for `Style/MinMaxComparison`

### DIFF
--- a/lib/rubocop/cop/style/min_max_comparison.rb
+++ b/lib/rubocop/cop/style/min_max_comparison.rb
@@ -5,6 +5,15 @@ module RuboCop
     module Style
       # Enforces the use of `max` or `min` instead of comparison for greater or less.
       #
+      # NOTE: It can be used if you want to present limit or threshold in Ruby 2.7+.
+      # That it is slow though. So autocorrection will apply generic `max` or `min`:
+      #
+      # [source,ruby]
+      # ----
+      # a.clamp(b..) # Same as `[a, b].max`
+      # a.clamp(..b) # Same as `[a, b].min`
+      # ----
+      #
       # @safety
       #   This cop is unsafe because even if a value has `<` or `>` method,
       #   it is not necessarily `Comparable`.


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/issues/11338#issuecomment-1366406576.

This PR adds mention of the following to the doc of `Style/MinMaxComparison` based on the above discussion:

> NOTE: It can be used if you want to present limit or threshold in Ruby 2.7+.
> That it is slow though. So autocorrection will apply generic `max` or `min`:
>
> ```ruby
> a.clamp(b..) # Same as `[a, b].max`
> a.clamp(..b) # Same as `[a, b].min`
> ```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
