### PR TITLE
Update `rubocop-ast` to include performance improvements

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
   s.add_runtime_dependency('rexml', '>= 3.2.5', '< 4.0')
-  s.add_runtime_dependency('rubocop-ast', '>= 1.23.0', '< 2.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 1.24.1', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 3.0')
 


### PR DESCRIPTION
https://github.com/rubocop/rubocop-ast/pull/249 was released in `1.24.1`.