### PR TITLE
Fix an error for `Lint/UselessRuby2Keywords`

### DIFF
--- a/changelog/fix_an_error_for_lint_useless_ruby2_keywords.md
+++ b/changelog/fix_an_error_for_lint_useless_ruby2_keywords.md
@@ -1,0 +1,1 @@
+* [#11369](https://github.com/rubocop/rubocop/pull/11369): Fix an error for `Lint/UselessRuby2Keywords` when using `Proc#ruby2_keywords`. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
+++ b/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
@@ -77,10 +77,12 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          if node.first_argument.def_type?
-            inspect_def(node, node.first_argument)
+          return unless (first_argument = node.first_argument)
+
+          if first_argument.def_type?
+            inspect_def(node, first_argument)
           elsif node.first_argument.sym_type?
-            inspect_sym(node, node.first_argument)
+            inspect_sym(node, first_argument)
           end
         end
 

--- a/spec/rubocop/cop/lint/useless_ruby2_keywords_spec.rb
+++ b/spec/rubocop/cop/lint/useless_ruby2_keywords_spec.rb
@@ -163,5 +163,12 @@ RSpec.describe RuboCop::Cop::Lint::UselessRuby2Keywords, :config do
         ^^^^^^^^^^^^^^^^^^^ `ruby2_keywords` is unnecessary for method `foo`.
       RUBY
     end
+
+    it 'does not register an offense for `Proc#ruby2_keywords`' do
+      expect_no_offenses(<<~RUBY)
+        block = proc { |_, *args| klass.new(*args) }
+        block.ruby2_keywords if block.respond_to?(:ruby2_keywords)
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the following error for `Lint/UselessRuby2Keywords` when using `Proc#ruby2_keywords`.

```ruby
block = proc { |_, *args| klass.new(*args) }
block.ruby2_keywords if block.respond_to?(:ruby2_keywords
```

```console
% bundle exec rubocop --only Lint/UselessRuby2Keywords -d
(snip)

An error occurred while Lint/UselessRuby2Keywords cop was inspecting /Users/koic/src/github.com/koic/rubocop-issues/ruby2_keywords/example.rb:2:0.
undefined method `def_type?' for nil:NilClass
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/lint/useless_ruby2_keywords.rb:80:in `on_send'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
