### PR TITLE
Fix `Style/WordArray` for subarrays

### DIFF
--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -98,7 +98,9 @@ module RuboCop
         def within_2d_array_of_complex_content?(node)
           return false unless (parent = node.parent)
 
-          parent.array_type? && parent.values.any? { |subarray| complex_content?(subarray.values) }
+          parent.array_type? &&
+            parent.values.all?(&:array_type?) &&
+            parent.values.any? { |subarray| complex_content?(subarray.values) }
         end
 
         def complex_content?(strings, complex_regex: word_regex)

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -375,6 +375,17 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
         ]
       RUBY
     end
+
+    it 'registers an offense and corrects for nested arrays' do
+      expect_offense(<<~RUBY)
+        [['one', 'One'], 2, 3]
+         ^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [%w(one One), 2, 3]
+      RUBY
+    end
   end
 
   context 'when EnforcedStyle is array' do


### PR DESCRIPTION
In https://github.com/rubocop/rubocop/pull/11334, I introduced a bug for nested arrays 😐

```ruby
[['one', 'One'], 2, 3]
```

```
     Failure/Error: parent.values.any? { |subarray| complex_content?(subarray.values) }

     NoMethodError:
       undefined method `values' for s(:int, 2):RuboCop::AST::IntNode
       Did you mean?  value
     # ./lib/rubocop/cop/style/word_array.rb:103:in `block in within_2d_array_of_complex_content?'
     # ./lib/rubocop/cop/style/word_array.rb:103:in `any?'
     # ./lib/rubocop/cop/style/word_array.rb:103:in `within_2d_array_of_complex_content?'
     # ./lib/rubocop/cop/style/word_array.rb:88:in `on_array'
     # ./lib/rubocop/cop/commissioner.rb:101:in `public_send'
     # ./lib/rubocop/cop/commissioner.rb:101:in `block (2 levels) in trigger_responding_cops'
     # ./lib/rubocop/cop/commissioner.rb:165:in `with_cop_error_handling'
     # ./lib/rubocop/cop/commissioner.rb:100:in `block in trigger_responding_cops'
     # ./lib/rubocop/cop/commissioner.rb:99:in `each'
     # ./lib/rubocop/cop/commissioner.rb:99:in `trigger_responding_cops'
     # ./lib/rubocop/cop/commissioner.rb:69:in `on_array'
```