### PR TITLE
Optimize `ClangStyleFormatter`

### DIFF
--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -28,14 +28,19 @@ module RuboCop
         end
     end
 
-    def smart_path(path)
-      # Ideally, we calculate this relative to the project root.
-      base_dir = Dir.pwd
+    SMART_PATH_CACHE = {} # rubocop:disable Style/MutableConstant
+    private_constant :SMART_PATH_CACHE
 
-      if path.start_with? base_dir
-        relative_path(path, base_dir)
-      else
-        path
+    def smart_path(path)
+      SMART_PATH_CACHE[path] ||= begin
+        # Ideally, we calculate this relative to the project root.
+        base_dir = Dir.pwd
+
+        if path.start_with? base_dir
+          relative_path(path, base_dir)
+        else
+          path
+        end
       end
     end
 


### PR DESCRIPTION
Optimized for a case when the project has many offenses (for example, when the rubocop was run for the first time).

### Before
Time: `278.3s`

```
==================================
  Mode: wall(1000)
  Samples: 277552 (0.26% miss rate)
  GC: 20278 (7.31%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     28670  (10.3%)       15972   (5.8%)     Parser::Lexer#advance
     12764   (4.6%)       12764   (4.6%)     Parser::Source::Buffer#slice
     11578   (4.2%)       11578   (4.2%)     Unicode::DisplayWidth.of  <========
     10336   (3.7%)       10336   (3.7%)     (sweeping)
      9762   (3.5%)        9762   (3.5%)     (marking)
     11572   (4.2%)        8778   (3.2%)     Parser::Source::Buffer#line_index_for_position
     16685   (6.0%)        6799   (2.4%)     RuboCop::AST::Descendence#each_child_node
      7817   (2.8%)        5441   (2.0%)     AST::Node#initialize
      6217   (2.2%)        5396   (1.9%)     RuboCop::AST::Descendence#visit_descendants
      4129   (1.5%)        4006   (1.4%)     RuboCop::PathUtil#smart_path  <========
     29497  (10.6%)        3996   (1.4%)     RuboCop::Formatter::ClangStyleFormatter#report_offense  <========
      3994   (1.4%)        3994   (1.4%)     Parser::Source::Range#initialize
      3428   (1.2%)        3428   (1.2%)     RuboCop::AST::SendNode#first_argument_index
      3250   (1.2%)        3250   (1.2%)     Rainbow::StringUtils.wrap_with_sgr
      3467   (1.2%)        3243   (1.2%)     RuboCop::Cop::Base#cop_config
      5211   (1.9%)        2351   (0.8%)     RuboCop::AST::Node#each_ancestor
      2042   (0.7%)        2042   (0.7%)     RuboCop::AST::MethodDispatchNode#receiver
      2510   (0.9%)        1969   (0.7%)     RuboCop::PathUtil#match_path?
      1901   (0.7%)        1901   (0.7%)     RuboCop::AST::Node#parent
      1869   (0.7%)        1869   (0.7%)     RuboCop::AST::Node#source_range
      1862   (0.7%)        1860   (0.7%)     RuboCop::Config#for_cop
    121374  (43.7%)        1859   (0.7%)     RuboCop::Cop::Commissioner#trigger_responding_cops
      1770   (0.6%)        1770   (0.6%)     RuboCop::Cop::SurroundingSpace#empty_brackets?
      1759   (0.6%)        1759   (0.6%)     Parser::Source::Buffer#line_begins
      2257   (0.8%)        1751   (0.6%)     Set#include?
      1634   (0.6%)        1634   (0.6%)     RuboCop::AST::MethodDispatchNode#method_name
      8723   (3.1%)        1568   (0.6%)     RuboCop::Formatter::ClangStyleFormatter#report_highlighted_area
      2052   (0.7%)        1540   (0.6%)     RuboCop::Cop::Base#initialize
      1559   (0.6%)        1501   (0.5%)     RuboCop::Cop::Base#cop_name
      1490   (0.5%)        1490   (0.5%)     RuboCop::AST::SendNode#send_type?
```

### After
Time: `250.2s` (10% speedup) 🔥 
```
==================================
  Mode: wall(1000)
  Samples: 249412 (0.30% miss rate)
  GC: 18170 (7.29%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     28452  (11.4%)       15791   (6.3%)     Parser::Lexer#advance
     12558   (5.0%)       12558   (5.0%)     Parser::Source::Buffer#slice
      9231   (3.7%)        9231   (3.7%)     (marking)
      8789   (3.5%)        8789   (3.5%)     (sweeping)
     10876   (4.4%)        8071   (3.2%)     Parser::Source::Buffer#line_index_for_position
     16335   (6.5%)        6620   (2.7%)     RuboCop::AST::Descendence#each_child_node
      7701   (3.1%)        5271   (2.1%)     AST::Node#initialize
      6139   (2.5%)        5243   (2.1%)     RuboCop::AST::Descendence#visit_descendants
      4018   (1.6%)        4018   (1.6%)     Parser::Source::Range#initialize
      3568   (1.4%)        3568   (1.4%)     RuboCop::AST::SendNode#first_argument_index
      3251   (1.3%)        3049   (1.2%)     RuboCop::Cop::Base#cop_config
      2509   (1.0%)        2509   (1.0%)     Rainbow::StringUtils.wrap_with_sgr
      4934   (2.0%)        2146   (0.9%)     RuboCop::AST::Node#each_ancestor
      2036   (0.8%)        2036   (0.8%)     RuboCop::AST::MethodDispatchNode#receiver
      2533   (1.0%)        1979   (0.8%)     RuboCop::PathUtil#match_path?
      1940   (0.8%)        1940   (0.8%)     RuboCop::AST::Node#parent
      1875   (0.8%)        1875   (0.8%)     RuboCop::AST::Node#source_range
      1799   (0.7%)        1798   (0.7%)     RuboCop::Config#for_cop
    114600  (45.9%)        1788   (0.7%)     RuboCop::Cop::Commissioner#trigger_responding_cops
     12512   (5.0%)        1771   (0.7%)     RuboCop::Formatter::ClangStyleFormatter#report_offense
      1713   (0.7%)        1713   (0.7%)     RuboCop::Cop::SurroundingSpace#empty_brackets?
      1666   (0.7%)        1666   (0.7%)     Parser::Source::Buffer#line_begins
      2095   (0.8%)        1656   (0.7%)     Set#include?
      1556   (0.6%)        1556   (0.6%)     RuboCop::AST::MethodDispatchNode#method_name
      2043   (0.8%)        1530   (0.6%)     RuboCop::Cop::Base#initialize
      1519   (0.6%)        1519   (0.6%)     Parser::Source::Buffer#bsearch
      1560   (0.6%)        1509   (0.6%)     RuboCop::Cop::Base#cop_name
      1459   (0.6%)        1459   (0.6%)     RuboCop::AST::SendNode#send_type?
      1457   (0.6%)        1457   (0.6%)     RuboCop::Cop::SurroundingSpace#empty_brackets?
      1440   (0.6%)        1440   (0.6%)     RuboCop::AST::Node#casgn_type?
```