### PR TITLE
Fix an error for `Style/StringHashKeys`

### DIFF
--- a/changelog/fix_an_error_for_style_string_hash_keys.md
+++ b/changelog/fix_an_error_for_style_string_hash_keys.md
@@ -1,0 +1,1 @@
+* [#11374](https://github.com/rubocop/rubocop/pull/11374): Fix an error for `Style/StringHashKeys` when using invalid symbol in encoding UTF-8 as keys. ([@koic][])

--- a/lib/rubocop/cop/style/string_hash_keys.rb
+++ b/lib/rubocop/cop/style/string_hash_keys.rb
@@ -41,10 +41,13 @@ module RuboCop
 
         def on_pair(node)
           return unless string_hash_key?(node)
+
+          key_content = node.key.str_content
+          return unless key_content.valid_encoding?
           return if receive_environments_method?(node)
 
           add_offense(node.key) do |corrector|
-            symbol_content = node.key.str_content.to_sym.inspect
+            symbol_content = key_content.to_sym.inspect
 
             corrector.replace(node.key, symbol_content)
           end

--- a/spec/rubocop/cop/style/string_hash_keys_spec.rb
+++ b/spec/rubocop/cop/style/string_hash_keys_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe RuboCop::Cop::Style::StringHashKeys, :config do
     RUBY
   end
 
+  it 'does not register an offense when using invalid symbol in encoding UTF-8 as keys' do
+    expect_no_offenses(<<~RUBY)
+      { "Test with malformed utf8 \\251" => 'test-with-malformed-utf8' }
+    RUBY
+  end
+
   it 'does not register an offense when string key is used in IO.popen' do
     expect_no_offenses(<<~RUBY)
       IO.popen({"RUBYOPT" => '-w'}, 'ruby', 'foo.rb')


### PR DESCRIPTION
This PR fixes the following error for `Style/StringHashKeys` when using invalid symbol in encoding UTF-8 as keys.

```ruby
{ "Test with malformed utf8 \251" => 'test-with-malformed-utf8' }
```

```console
% bundle exec rubocop --only Style/StringHashKeys -d
(snip)

An error occurred while Style/StringHashKeys cop was inspecting /Users/koic/src/github.com/koic/rubocop-issues/style_string_hash_keys/example.rb:1:2.
invalid symbol in encoding UTF-8 :"Test with malformed utf8 \xA9"
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/string_hash_keys.rb:47:in `to_sym'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/string_hash_keys.rb:47:in `block in on_pair'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
