### PR TITLE
Fix `OperatorMethodCall` when forwarding arguments

### DIFF
--- a/changelog/fix_fix_operatormethodcall_when_forwarding.md
+++ b/changelog/fix_fix_operatormethodcall_when_forwarding.md
@@ -1,0 +1,1 @@
+* [#11377](https://github.com/rubocop/rubocop/issues/11377): Fix `Style/OperatorMethodCall` when forwarding arguments. ([@sambostock][])

--- a/lib/rubocop/cop/style/operator_method_call.rb
+++ b/lib/rubocop/cop/style/operator_method_call.rb
@@ -28,7 +28,7 @@ module RuboCop
           return if node.receiver.const_type?
 
           _lhs, _op, rhs = *node
-          return if rhs.nil? || rhs.children.first
+          return if rhs.nil? || rhs.children.first || rhs.forwarded_args_type?
 
           add_offense(dot) do |corrector|
             wrap_in_parentheses_if_chained(corrector, node)

--- a/spec/rubocop/cop/style/operator_method_call_spec.rb
+++ b/spec/rubocop/cop/style/operator_method_call_spec.rb
@@ -90,4 +90,12 @@ RSpec.describe RuboCop::Cop::Style::OperatorMethodCall, :config do
       obj.!
     RUBY
   end
+
+  it 'does not register an offense when using argument is `...`', :ruby27 do
+    expect_no_offenses(<<~RUBY)
+      def m(...)
+        obj.==(...)
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
`...` cannot be used as an argument to an operator, so it should not be an offense. For example,

```ruby
def m(...) = obj.==(...)
```

would be autocorrected as

```ruby
def m(...) = obj ==(...)
```

which is a syntax error, as would be

```ruby
def m(...) = obj == (...)
```

and

```ruby
def m(...) = obj == ...
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/

---

Closes #11377
