### PR TITLE
Disable `Style/YodaExpression` by default

### DIFF
--- a/changelog/change_disable_style_yoda_expression_by_default.md
+++ b/changelog/change_disable_style_yoda_expression_by_default.md
@@ -1,0 +1,1 @@
+* [#11380](https://github.com/rubocop/rubocop/pull/11380): Disable `Style/YodaExpression` by default. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5440,9 +5440,10 @@ Style/YodaCondition:
 
 Style/YodaExpression:
   Description: 'Forbid the use of yoda expressions.'
-  Enabled: pending
+  Enabled: false
   Safe: false
   VersionAdded: '1.42'
+  VersionChanged: '<<next>>'
   SupportedOperators:
     - '*'
     - '+'

--- a/lib/rubocop/cop/style/yoda_expression.rb
+++ b/lib/rubocop/cop/style/yoda_expression.rb
@@ -7,6 +7,13 @@ module RuboCop
       # and `^` operators) where the order of expression is reversed, eg. `1 + x`.
       # This cop complements `Style/YodaCondition` cop, which has a similar purpose.
       #
+      # This cop is disabled by default to respect user intentions such as:
+      #
+      # [source,ruby]
+      # ----
+      # config.server_port = 9000 + ENV["TEST_ENV_NUMBER"].to_i
+      # ----
+      #
       # @safety
       #   This cop is unsafe because binary operators can be defined
       #   differently on different classes, and are not guaranteed to


### PR DESCRIPTION
Follow https://github.com/rubocop/rubocop/pull/11333#issuecomment-1369486444

This PR disables `Style/YodaExpression` by default to respect user intentions such as:

```ruby
config.server_port = 9000 + ENV["TEST_ENV_NUMBER"].to_i
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
