### PR TITLE
Require `unicode-display_width` 2.4.0 or higher

### DIFF
--- a/changelog/change_require_unicode_display_width_2_4_0.md
+++ b/changelog/change_require_unicode_display_width_2_4_0.md
@@ -1,0 +1,1 @@
+* [#11382](https://github.com/rubocop/rubocop/pull/11382): Require `unicode-display_width` 2.4.0 or higher. ([@fatkodima][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rexml', '>= 3.2.5', '< 4.0')
   s.add_runtime_dependency('rubocop-ast', '>= 1.24.1', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
-  s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 3.0')
+  s.add_runtime_dependency('unicode-display_width', '>= 2.4.0', '< 3.0')
 
   s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
 end


### PR DESCRIPTION
Context - https://github.com/rubocop/rubocop/pull/11373#discussion_r1059767728.

The new version of `unicode-display_width` gem was just released.