### PR TITLE
Improve generated changelog filenames

### DIFF
--- a/spec/tasks/changelog_spec.rb
+++ b/spec/tasks/changelog_spec.rb
@@ -128,6 +128,14 @@ RSpec.describe Changelog do
         it { is_expected.to eq('Fix something') }
       end
     end
+
+    describe '#path' do
+      it 'generates correct file name' do
+        body = 'Add new `Lint/UselessRescue` cop'
+        entry = described_class.new(type: :new, body: body, user: github_user)
+        expect(entry.path).to eq('changelog/new_add_new_lint_useless_rescue_cop.md')
+      end
+    end
   end
 
   it 'parses correctly' do

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -53,10 +53,9 @@ class Changelog
 
     def str_to_filename(str)
       str
-        .downcase
         .split
-        .each { |s| s.gsub!(/\W/, '') }
         .reject(&:empty?)
+        .map { |s| prettify(s) }
         .inject do |result, word|
           s = "#{result}_#{word}"
           return result if s.length > MAX_LENGTH
@@ -72,6 +71,21 @@ class Changelog
       end
 
       user
+    end
+
+    private
+
+    def prettify(str)
+      str.gsub!(/\W/, '_')
+
+      # Separate word boundaries by `_`.
+      str.gsub!(/([A-Z]+)(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) do
+        (Regexp.last_match(1) || Regexp.last_match(2)) << '_'
+      end
+
+      str.gsub!(/\A_+|_+\z/, '')
+      str.downcase!
+      str
     end
   end
 


### PR DESCRIPTION
Small convenience to avoid editing the generated file name.

Before:
```
▶ bundle exec rake changelog:new
Entry 'changelog/new_add_new_lintuselessrescue_cop.md' created and added to git index
```

After:
```
▶ bundle exec rake changelog:new
Entry 'changelog/new_add_new_lint_useless_rescue_cop.md' created and added to git index
```