### PR TITLE
Fix a false positive for `Style/OperatorMethodCall`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_operator_method_call.md
+++ b/changelog/fix_a_false_positive_for_style_operator_method_call.md
@@ -1,0 +1,1 @@
+* [#11386](https://github.com/rubocop/rubocop/pull/11386): Fix a false positive for `Style/OperatorMethodCall` when using anonymous forwarding. ([@koic][])


### PR DESCRIPTION
This PR fixes a false positive for `Style/OperatorMethodCall` when using anonymous forwarding.

A similar case to #11378. It adds tests for anonymous block forwarding, anonymous rest arguments forwarding, and anonymous keyword rest argument forwarding to pass.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
