### PR TITLE
[Fix #11303] Make `Metrics/ParameterLists` aware of `Struct.new` and `Data.define` blocks

### DIFF
--- a/changelog/change_make_metrics_parameter_lists_aware_of_struct_new_and_data_define.md
+++ b/changelog/change_make_metrics_parameter_lists_aware_of_struct_new_and_data_define.md
@@ -1,0 +1,1 @@
+* [#11303](https://github.com/rubocop/rubocop/issues/11303): Make `Metrics/ParameterLists` aware of `Struct.new` and `Data.define` blocks. ([@koic][])

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -96,4 +96,50 @@ RSpec.describe RuboCop::Cop::Metrics::ParameterLists, :config do
       end
     RUBY
   end
+
+  it 'registers an offense when defining `initialize` in the `class` definition' do
+    expect_offense(<<~RUBY)
+      class Foo
+        def initialize(one:, two:, three:, four:, five:)
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid parameter lists longer than 4 parameters. [5/4]
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when defining `initialize` in the block of `Struct.new`' do
+    expect_no_offenses(<<~RUBY)
+      Struct.new(:one, :two, :three, :four, :five) do
+        def initialize(one:, two:, three:, four:, five:)
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when defining `initialize` in the block of `::Struct.new`' do
+    expect_no_offenses(<<~RUBY)
+      ::Struct.new(:one, :two, :three, :four, :five) do
+        def initialize(one:, two:, three:, four:, five:)
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when defining `initialize` in the block of `Data.define`' do
+    expect_no_offenses(<<~RUBY)
+      Data.define(:one, :two, :three, :four, :five) do
+        def initialize(one:, two:, three:, four:, five:)
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when defining `initialize` in the block of `::Data.define`' do
+    expect_no_offenses(<<~RUBY)
+      ::Data.define(:one, :two, :three, :four, :five) do
+        def initialize(one:, two:, three:, four:, five:)
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #11303.

This PR makes `Metrics/ParameterLists` aware of `Struct.new` and `Data.define` blocks.

The number of these `initialize` arguments depends on the number of arguments of `Struct.new` and `Data.define`, so it wouldn't make sense as a metrics.

One abandoned design, the number of `initialize` argument will check no more than the number of `Struct.new` and `Data.define` arguments. However, considering a special case that the `keyword_init` parameter can be included in the number, I think there is no much benefit for the complexity of the design.

So this PR chooses an approach that doesn't always check for the number of `initialize` arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
