### PR TITLE
Add autocorrect for `Style/MissingElse`

### DIFF
--- a/changelog/new_add_autocorrect_for_style_missing_else.md
+++ b/changelog/new_add_autocorrect_for_style_missing_else.md
@@ -1,0 +1,1 @@
+* [#11389](https://github.com/rubocop/rubocop/pull/11389): Add autocorrect for `Style/MissingElse`. ([@FnControlOption][])

--- a/lib/rubocop/cop/style/missing_else.rb
+++ b/lib/rubocop/cop/style/missing_else.rb
@@ -99,6 +99,7 @@ module RuboCop
       class MissingElse < Base
         include OnNormalIfUnless
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         MSG = '`%<type>s` condition requires an `else`-clause.'
         MSG_NIL = '`%<type>s` condition requires an `else`-clause with `nil` in it.'
@@ -126,7 +127,9 @@ module RuboCop
         def check(node)
           return if node.else?
 
-          add_offense(node, message: format(message_template, type: node.type))
+          add_offense(node, message: format(message_template, type: node.type)) do |corrector|
+            autocorrect(corrector, node)
+          end
         end
 
         def message_template
@@ -137,6 +140,15 @@ module RuboCop
             MSG_EMPTY
           else
             MSG
+          end
+        end
+
+        def autocorrect(corrector, node)
+          case empty_else_style
+          when :empty
+            corrector.insert_before(node.loc.end, 'else; nil; ')
+          when :nil
+            corrector.insert_before(node.loc.end, 'else; ')
           end
         end
 

--- a/spec/rubocop/cop/style/missing_else_spec.rb
+++ b/spec/rubocop/cop/style/missing_else_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
             if cond; foo end
             ^^^^^^^^^^^^^^^^ `if` condition requires an `else`-clause.
           RUBY
+
+          expect_no_corrections
         end
       end
     end
@@ -101,6 +103,8 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
             case v; when a; foo; when b; bar; end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `case` condition requires an `else`-clause.
           RUBY
+
+          expect_no_corrections
         end
       end
     end
@@ -143,6 +147,8 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
             if cond; foo end
             ^^^^^^^^^^^^^^^^ `if` condition requires an `else`-clause.
           RUBY
+
+          expect_no_corrections
         end
       end
     end
@@ -172,6 +178,8 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
             unless cond; foo end
             ^^^^^^^^^^^^^^^^^^^^ `if` condition requires an `else`-clause.
           RUBY
+
+          expect_no_corrections
         end
       end
     end
@@ -201,6 +209,8 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
             case v; when a; foo; when b; bar; end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `case` condition requires an `else`-clause.
           RUBY
+
+          expect_no_corrections
         end
       end
     end
@@ -249,6 +259,10 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
             if cond; foo end
             ^^^^^^^^^^^^^^^^ `if` condition requires an `else`-clause with `nil` in it.
           RUBY
+
+          expect_correction(<<~RUBY)
+            if cond; foo else; nil; end
+          RUBY
         end
       end
     end
@@ -278,6 +292,10 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
             unless cond; foo end
             ^^^^^^^^^^^^^^^^^^^^ `if` condition requires an `else`-clause with `nil` in it.
           RUBY
+
+          expect_correction(<<~RUBY)
+            unless cond; foo else; nil; end
+          RUBY
         end
       end
     end
@@ -306,6 +324,10 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
           expect_offense(<<~RUBY)
             case v; when a; foo; when b; bar; end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `case` condition requires an `else`-clause with `nil` in it.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            case v; when a; foo; when b; bar; else; nil; end
           RUBY
         end
       end
@@ -355,6 +377,10 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
             if cond; foo end
             ^^^^^^^^^^^^^^^^ `if` condition requires an empty `else`-clause.
           RUBY
+
+          expect_correction(<<~RUBY)
+            if cond; foo else; end
+          RUBY
         end
       end
     end
@@ -384,6 +410,10 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
             unless cond; foo end
             ^^^^^^^^^^^^^^^^^^^^ `if` condition requires an empty `else`-clause.
           RUBY
+
+          expect_correction(<<~RUBY)
+            unless cond; foo else; end
+          RUBY
         end
       end
     end
@@ -412,6 +442,10 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
           expect_offense(<<~RUBY)
             case v; when a; foo; when b; bar; end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `case` condition requires an empty `else`-clause.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            case v; when a; foo; when b; bar; else; end
           RUBY
         end
       end
@@ -461,6 +495,10 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
             if cond; foo end
             ^^^^^^^^^^^^^^^^ `if` condition requires an empty `else`-clause.
           RUBY
+
+          expect_correction(<<~RUBY)
+            if cond; foo else; end
+          RUBY
         end
       end
     end
@@ -489,6 +527,10 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
           expect_offense(<<~RUBY)
             unless cond; foo end
             ^^^^^^^^^^^^^^^^^^^^ `if` condition requires an empty `else`-clause.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            unless cond; foo else; end
           RUBY
         end
       end
@@ -615,6 +657,10 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
           expect_offense(<<~RUBY)
             case v; when a; foo; when b; bar; end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `case` condition requires an empty `else`-clause.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            case v; when a; foo; when b; bar; else; end
           RUBY
         end
       end


### PR DESCRIPTION
If the enforced style for [`EmptyElse`](https://docs.rubocop.org/rubocop/cops_style.html#styleemptyelse) is `empty`, `MissingElse` is autocorrected like so:

```rb
if cond; foo end
# becomes
if cond; foo else; nil; end
```

If the enforced style is `nil`:

```rb
if cond; foo end
# becomes
if cond; foo else; end
```

No corrections are made if the enforced style is `both`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
