### PR TITLE
[Fix #11390] Fix an incorrect autocorrect for `Style/HashSyntax`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,7 +23,7 @@ Metrics/MethodLength:
 # Offense count: 8
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 136
+  Max: 138
 
 # Offense count: 9
 RSpec/AnyInstance:

--- a/changelog/fix_an_incorrect_autocorrect_for_style_hash_syntax.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_hash_syntax.md
@@ -1,0 +1,1 @@
+* [#11390](https://github.com/rubocop/rubocop/issues/11390): Fix an incorrect autocorrect for `Style/HashSyntax` when hash first argument key and hash value only are the same which has a method call on the next line. ([@koic][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -93,6 +93,8 @@ module RuboCop
       end
 
       def def_node_that_require_parentheses(node)
+        last_pair = node.parent.pairs.last
+        return unless last_pair.key.source == last_pair.value.source
         return unless (send_node = find_ancestor_send_node(node))
         return unless without_parentheses_call_expr_follows?(send_node)
 

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1240,6 +1240,21 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'registers an offense when hash first arg key and hash value only are the same which has a method call on the next line' do
+        expect_offense(<<~RUBY)
+          buz foo: foo, bar: 'bar'
+                   ^^^ Omit the hash value.
+
+          def buz(foo:, bar:); end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          buz foo:, bar: 'bar'
+
+          def buz(foo:, bar:); end
+        RUBY
+      end
+
       context 'when hash roket syntax' do
         let(:enforced_style) { 'hash_rockets' }
 


### PR DESCRIPTION
Fixes #11390.

This PR fixes an incorrect autocorrect for `Style/HashSyntax` when hash first argument key and hash value only are the same which has a method call on the next line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
