### PR TITLE
Fix an incorrect autocorrect for `Style/RedundantDoubleSplatHashBraces`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_double_splat_hash_braces.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_double_splat_hash_braces.md
@@ -1,0 +1,1 @@
+* [#11392](https://github.com/rubocop/rubocop/pull/11392): Fix an incorrect autocorrect for `Style/RedundantDoubleSplatHashBraces` using double splat in double splat hash braces. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -30,7 +30,7 @@ module RuboCop
           return unless double_splat_hash_braces?(grandparent)
 
           add_offense(grandparent) do |corrector|
-            corrector.replace(grandparent, node.pairs.map(&:source).join(', '))
+            corrector.replace(grandparent, node.children.map(&:source).join(', '))
           end
         end
       end

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
     RUBY
   end
 
+  it 'registers an offense when using double splat in double splat hash braces' do
+    expect_offense(<<~RUBY)
+      do_something(**{foo: bar, **options})
+                   ^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something(foo: bar, **options)
+    RUBY
+  end
+
   it 'does not register an offense when using keyword arguments' do
     expect_no_offenses(<<~RUBY)
       do_something(foo: bar, baz: qux)


### PR DESCRIPTION
Fixes https://github.com/testdouble/standard/issues/505.

This PR fixes an incorrect autocorrect for `Style/RedundantDoubleSplatHashBraces` using double splat in double splat hash braces.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
