### PR TITLE
[Fix rubocop#11180] Fix `Style/RedundantRegexpEscape` bug when regexp provided within `%r{...}` literal

### DIFF
--- a/changelog/fix_an_error_for_redundant_regexp_escape.md
+++ b/changelog/fix_an_error_for_redundant_regexp_escape.md
@@ -1,0 +1,1 @@
+* [#11180](https://github.com/rubocop/rubocop/issues/11180): Fix an error for `Style/RedundantRegexpEscape` when using `%r` to provide regexp expressions. ([@si-lens][])

--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -77,7 +77,8 @@ module RuboCop
           # but it's not necessry to escape hyphen if it's the first or last character
           # within the character class. This method checks if that's the case.
           # e.g. "[0-9\\-]" or "[\\-0-9]" would return true
-          node.source[index] == '[' || node.source[index + 3] == ']'
+          contents_range(node).source[index - 1] == '[' ||
+            contents_range(node).source[index + 2] == ']'
         end
 
         def delimiter?(node, char)

--- a/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
@@ -112,28 +112,65 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpEscape, :config do
     end
 
     context "with an escaped '-' character being the last character inside a character class" do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~'RUBY')
-          foo = /[0-9\-]/
-                     ^^ Redundant escape inside regexp literal
-        RUBY
+      context 'with a regexp %r{...} literal' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~'RUBY')
+            foo = %r{[0-9\-]}
+                         ^^ Redundant escape inside regexp literal
+          RUBY
 
-        expect_correction(<<~RUBY)
-          foo = /[0-9-]/
-        RUBY
+          expect_correction(<<~RUBY)
+            foo = %r{[0-9-]}
+          RUBY
+        end
+      end
+
+      context 'with a regexp /.../ literal' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~'RUBY')
+            foo = /[0-9\-]/
+                       ^^ Redundant escape inside regexp literal
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo = /[0-9-]/
+          RUBY
+        end
       end
     end
 
     context "with an escaped '-' character being the first character inside a character class" do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~'RUBY')
-          foo = /[\-0-9]/
-                  ^^ Redundant escape inside regexp literal
-        RUBY
+      context 'with a regexp %r{...} literal' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~'RUBY')
+            foo = %r{[\-0-9]}
+                      ^^ Redundant escape inside regexp literal
+          RUBY
 
-        expect_correction(<<~RUBY)
-          foo = /[-0-9]/
-        RUBY
+          expect_correction(<<~RUBY)
+            foo = %r{[-0-9]}
+          RUBY
+        end
+      end
+
+      context 'with a regexp /.../ literal' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~'RUBY')
+            foo = /[\-0-9]/
+                    ^^ Redundant escape inside regexp literal
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo = /[-0-9]/
+          RUBY
+        end
+      end
+    end
+
+    context "with an escaped '-' character being neither first nor last inside a character class" do
+      it 'does not register an offense' do
+        expect_no_offenses('foo = %r{[\w\-\#]}')
+        expect_no_offenses('foo = /[\w\-\#]/')
       end
     end
 


### PR DESCRIPTION
In https://github.com/rubocop/rubocop/pull/11152 i added catching of redundant hyphen escape within character class.
It [turned out](https://github.com/rubocop/rubocop/issues/11180) this can cause `SyntaxError` due to the corrected Regexp when it is provided using `%r{...}` literal.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
