### PR TITLE
Fix bad offense for parenthesised calls in literals

### DIFF
--- a/changelog/fix_bad_offense_for_parenthesised_calls.md
+++ b/changelog/fix_bad_offense_for_parenthesised_calls.md
@@ -1,0 +1,1 @@
+* [#11403](https://github.com/rubocop/rubocop/pull/11403): Fix bad offense for parenthesised calls in literals for `omit_parentheses` style in `Style/MethodCallWithArgsParentheses`. ([@gsamokovarov][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -102,20 +102,23 @@ module RuboCop
           end
 
           def call_in_literals?(node)
-            node.parent &&
-              (node.parent.pair_type? ||
-              node.parent.array_type? ||
-              node.parent.range_type? ||
-              splat?(node.parent) ||
-              ternary_if?(node.parent))
+            parent = node.parent&.block_type? ? node.parent.parent : node.parent
+            return unless parent
+
+            parent.pair_type? ||
+              parent.array_type? ||
+              parent.range_type? ||
+              splat?(parent) ||
+              ternary_if?(parent)
           end
 
           def call_in_logical_operators?(node)
             parent = node.parent&.block_type? ? node.parent.parent : node.parent
-            parent &&
-              (logical_operator?(parent) ||
+            return unless parent
+
+            logical_operator?(parent) ||
               (parent.send_type? &&
-              parent.arguments.any? { |argument| logical_operator?(argument) }))
+              parent.arguments.any? { |argument| logical_operator?(argument) })
           end
 
           def call_in_optional_arguments?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -733,6 +733,16 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('foo(1) { 2 }')
     end
 
+    it 'accepts parens in array literal calls' do
+      expect_no_offenses(<<~RUBY)
+        [
+          foo.bar.quux(:args) do
+            pass
+          end,
+        ]
+      RUBY
+    end
+
     it 'accepts parens in calls with logical operators' do
       expect_no_offenses('foo(a) && bar(b)')
       expect_no_offenses('foo(a) || bar(b)')


### PR DESCRIPTION
In `omit_parentheses` style of `Style/MethodCallWithArgsParentheses` we issued an offense for code like this:

```ruby
[
  Stat.new("Users Today") do
          ^^^^^^^^^^^^^^^ Omit parentheses for method calls with arguments.
    User.today.count
  end,
  Stat.new("Servers Today") do
          ^^^^^^^^^^^^^^^^^ Omit parentheses for method calls with arguments.
    Server.today.count
  end
]
```
The problem here is that removing the parentheses leads invalid Ruby, and we should allow them:

```ruby
[
  Stat.new "Users Today" do
    User.today.count
  end,
  Stat.new "Servers Today" do
    Server.today.count
  end
]

# => test.rb:2: syntax error, unexpected string literal, expecting ']'
#     Stat.new "Users Today" do
#    test.rb:2: syntax error, unexpected `do', expecting end-of-input
#     Stat.new "Users Today" do
```

We have a check that allows parentheses in calls in literals but we missed the case for the calls with attached blocks.