### PR TITLE
[Fix #8990] Make `Style/HashEachMethods` aware of `Thread.current`

### DIFF
--- a/changelog/fix_make_style_hash_each_methods_aware_of_thread_current.md
+++ b/changelog/fix_make_style_hash_each_methods_aware_of_thread_current.md
@@ -1,0 +1,1 @@
+* [#8990](https://github.com/rubocop/rubocop/issues/8990): Make `Style/HashEachMethods` aware of built-in `Thread.current`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3858,7 +3858,8 @@ Style/HashEachMethods:
   Safe: false
   VersionAdded: '0.80'
   VersionChanged: '1.16'
-  AllowedReceivers: []
+  AllowedReceivers:
+    - Thread.current
 
 Style/HashExcept:
   Description: >-

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -118,9 +118,21 @@ module RuboCop
         end
 
         def allowed_receiver?(receiver)
-          receiver_name = receiver.send_type? ? receiver.method_name.to_s : receiver.source
+          receiver_name = receiver_name(receiver)
 
           allowed_receivers.include?(receiver_name)
+        end
+
+        def receiver_name(receiver)
+          if receiver.send_type?
+            if receiver.receiver
+              "#{receiver_name(receiver.receiver)}.#{receiver.method_name}"
+            else
+              receiver.method_name.to_s
+            end
+          else
+            receiver.source
+          end
         end
 
         def allowed_receivers

--- a/spec/rubocop/cop/style/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/style/hash_each_methods_spec.rb
@@ -186,5 +186,15 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         RUBY
       end
     end
+
+    context "when `AllowedReceivers: ['Thread.current']`" do
+      let(:cop_config) { { 'AllowedReceivers' => ['Thread.current'] } }
+
+      it 'does not register an offense when receiver is `Thread.current` method' do
+        expect_no_offenses(<<~RUBY)
+          Thread.current.keys.each { |k| p k }
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #8990.

This PR makes `Style/HashEachMethods` aware of built-in `Thread.current`. And `Thread.current` is set to `AllowedReceivers` by default that can be specified for method calls.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
