### PR TITLE
[Fix #11405] Fix Style/WhileUntilModifier with ruby 3.1

### DIFF
--- a/changelog/fix_undefined_method_range_between.md
+++ b/changelog/fix_undefined_method_range_between.md
@@ -1,0 +1,1 @@
+* [#11405](https://github.com/rubocop/rubocop/issues/11405): Fix undefined method `range_between' for Style/WhileUntilModifier. ([@such][])

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -5,6 +5,7 @@ module RuboCop
     # Common functionality for modifier cops.
     module StatementModifier
       include LineLengthHelp
+      include RangeHelp
 
       private
 

--- a/spec/support/condition_modifier_cop.rb
+++ b/spec/support/condition_modifier_cop.rb
@@ -17,6 +17,19 @@ RSpec.shared_examples 'condition modifier cop' do |keyword, extra_message = nil|
       RUBY
     end
 
+    it 'accepts it if single line would not fit on one line and body last argument is a hash type with value omission', :ruby31 do
+      # This statement is one character too long to fit.
+      condition = 'a' * (40 - keyword.length)
+      body = "#{'b' * 35}(a:)"
+      expect("#{body} #{keyword} #{condition}".length).to eq(81)
+
+      expect_no_offenses(<<~RUBY)
+        #{keyword} #{condition}
+          #{body}
+        end
+      RUBY
+    end
+
     context 'when Layout/LineLength is disabled' do
       let(:other_cops) { { 'Layout/LineLength' => { 'Enabled' => false } } }
 


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/11405

-----------------

Before submitting the PR make sure the following are checked:

* [x ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
