### PR TITLE
Fix an error for `Style/HashSyntax` when expression follows hash key assignment

### DIFF
--- a/changelog/fix_an_error_for_hash_syntax.md
+++ b/changelog/fix_an_error_for_hash_syntax.md
@@ -1,0 +1,1 @@
+* [#11407](https://github.com/rubocop/rubocop/pull/11407): Fix an error for `Style/HashSyntax` when expression follows hash key assignment. ([@fatkodima][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -3,6 +3,7 @@
 module RuboCop
   module Cop
     # This module checks for Ruby 3.1's hash value omission syntax.
+    # rubocop:disable Metrics/ModuleLength
     module HashShorthandSyntax
       OMIT_HASH_VALUE_MSG = 'Omit the hash value.'
       EXPLICIT_HASH_VALUE_MSG = 'Include the hash value.'
@@ -106,7 +107,11 @@ module RuboCop
       def find_ancestor_send_node(node)
         ancestor = node.parent.parent
 
-        ancestor if ancestor&.call_type? && !ancestor&.method?(:[])
+        ancestor if ancestor&.call_type? && !brackets?(ancestor)
+      end
+
+      def brackets?(send_node)
+        send_node.method?(:[]) || send_node.method?(:[]=)
       end
 
       def use_element_of_hash_literal_as_receiver?(ancestor, parent)
@@ -186,4 +191,5 @@ module RuboCop
       end
     end
   end
+  # rubocop:enable Metrics/ModuleLength
 end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1106,6 +1106,19 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'registers an offense when expression follows hash key assignment' do
+        expect_offense(<<~RUBY)
+          hash[:key] = { foo: foo }
+                              ^^^ Omit the hash value.
+          bar
+        RUBY
+
+        expect_correction(<<~RUBY)
+          hash[:key] = { foo: }
+          bar
+        RUBY
+      end
+
       it 'registers an offense when one line `if` condition follows (with parentheses)' do
         expect_offense(<<~RUBY)
           foo(value: value) if bar


### PR DESCRIPTION
For something like
```ruby
hash[cache_key] = { repository: repository }
cache_key
```

I got
```
Parser::Source::Range: end_pos must not be less than begin_pos
/Users/fatkodima/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/parser-3.2.0.0/lib/parser/source/range.rb:39:in `initialize'
rubocop/lib/rubocop/cop/mixin/range_help.rb:37:in `new'
rubocop/lib/rubocop/cop/mixin/range_help.rb:37:in `range_between'
rubocop/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb:52:in `block in register_offense'
rubocop/lib/rubocop/cop/base.rb:363:in `correct'
rubocop/lib/rubocop/cop/base.rb:181:in `add_offense'
rubocop/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb:50:in `register_offense'
rubocop/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb:43:in `on_pair'
```

The bug was introduced in https://github.com/rubocop/rubocop/pull/11185.