### PR TITLE
[Fix #11409] Fix an incorrect autocorrect for `Style/HashSyntax`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_hash_syntax.md
+++ b/changelog/fix_a_false_positive_for_style_hash_syntax.md
@@ -1,0 +1,1 @@
+* [#11409](https://github.com/rubocop/rubocop/issues/11409): Fix an incorrect autocorrect for `Style/HashSyntax` when using hash value omission and `EnforcedStyle: no_mixed_keys`. ([@koic][])

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -254,6 +254,7 @@ module RuboCop
           op = pair_node.loc.operator
 
           key_with_hash_rocket = ":#{pair_node.key.source}#{pair_node.inverse_delimiter(true)}"
+          key_with_hash_rocket += pair_node.key.source if pair_node.value_omission?
           corrector.replace(pair_node.key, key_with_hash_rocket)
           corrector.remove(range_with_surrounding_space(op))
         end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -788,6 +788,19 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       expect_no_offenses('x = { :"t o" => 0, :b => 1 }')
     end
 
+    context 'Ruby >= 3.1', :ruby31 do
+      it 'registers hash rockets when keys have whitespaces in them and using hash value omission' do
+        expect_offense(<<~RUBY)
+          {:"t o" => 0, b:}
+                        ^^ Don't mix styles in the same hash.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {:"t o" => 0, :b => b}
+        RUBY
+      end
+    end
+
     it 'registers an offense when keys have whitespaces and mix styles' do
       expect_offense(<<~RUBY)
         x = { :"t o" => 0, b: 1 }


### PR DESCRIPTION
Fixes #11409.

This PR fixes an incorrect autocorrect for `Style/HashSyntax` when using hash value omission and `EnforcedStyle: no_mixed_keys`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
