### PR TITLE
Apply concurrency for GHA workflow `pull_requests` envents only

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,7 +5,7 @@ on:
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   yamllint:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -13,7 +13,7 @@ permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/spell_checking.yml
+++ b/.github/workflows/spell_checking.yml
@@ -6,7 +6,7 @@ permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
~~This reverts commit bf6ea9bd153d33d9e5e263c8c7f584b9314b646a.~~

~~This reverts the setting introduced in #11402.~~

When multiple commits continue, the workflow that wants to know the outcome is also canceled, like this: https://github.com/rubocop/rubocop/actions

<img width="1389" alt="github-actions-cuncurrency" src="https://user-images.githubusercontent.com/13203/211541772-8e9c3706-1e84-4d69-8589-073706f87b95.png">

~~That "GitHub Actions concurrency" way, if CI has a failing commit, we don't know where it failed on CI. I think this risk reduction should be taken over GitHub Actions concurrency in this repository. There may be repositories where this is useful, but at least not in this repository.~~

To reduce this risk, apply GitHub Actions concurrency only to `pull_requests` events:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
