### PR TITLE
[Fix #11415] Fix a false positive for `Lint/UselessMethodDefinition`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_useless_method_definition.md
+++ b/changelog/fix_a_false_positive_for_lint_useless_method_definition.md
@@ -1,0 +1,1 @@
+* [#11415](https://github.com/rubocop/rubocop/issues/11415): Fix a false positive for `Lint/UselessMethodDefinition` when method definition contains rest arguments. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_method_definition.rb
+++ b/lib/rubocop/cop/lint/useless_method_definition.rb
@@ -41,7 +41,7 @@ module RuboCop
         MSG = 'Useless method definition detected.'
 
         def on_def(node)
-          return if optional_args?(node)
+          return if use_rest_or_optional_args?(node)
           return unless delegating?(node.body, node)
 
           add_offense(node) { |corrector| corrector.remove(node) }
@@ -50,8 +50,8 @@ module RuboCop
 
         private
 
-        def optional_args?(node)
-          node.arguments.any? { |arg| arg.optarg_type? || arg.kwoptarg_type? }
+        def use_rest_or_optional_args?(node)
+          node.arguments.any? { |arg| arg.restarg_type? || arg.optarg_type? || arg.kwoptarg_type? }
         end
 
         def delegating?(node, def_node)

--- a/spec/rubocop/cop/lint/useless_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/useless_method_definition_spec.rb
@@ -146,6 +146,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessMethodDefinition, :config do
     RUBY
   end
 
+  it 'does not register an offense when method definition contains rest arguments' do
+    expect_no_offenses(<<~RUBY)
+      def method(*args)
+        super
+      end
+    RUBY
+  end
+
   it 'does not register an offense when method definition contains optional argument' do
     expect_no_offenses(<<~RUBY)
       def method(x = 1)


### PR DESCRIPTION
Fixes #11415.

This PR fixes a false positive for `Lint/UselessMethodDefinition` when method definition contains rest arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
