### PR TITLE
[Fix #11419] Fix a false positive for `Style/RedundantRequireStatement`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_require_statemen.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_require_statemen.md
@@ -1,0 +1,1 @@
+* [#11419](https://github.com/rubocop/rubocop/issues/11419): Fix a false positive for `Style/RedundantRequireStatement` when using `pretty_inspect`. ([@koic][])

--- a/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
@@ -100,6 +100,8 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
     it 'does not register an offense when using requiring `pp`' do
       expect_no_offenses(<<~RUBY)
         require 'pp'
+
+        pp foo
       RUBY
     end
   end
@@ -123,6 +125,48 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
       expect_correction(<<~RUBY)
         require 'uri'
       RUBY
+    end
+
+    context 'when requiring `pp`' do
+      it 'does not register an offense and corrects when using `pretty_inspect`' do
+        expect_no_offenses(<<~RUBY)
+          require 'pp'
+
+          foo.pretty_inspect
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `pretty_print`' do
+        expect_no_offenses(<<~RUBY)
+          require 'pp'
+
+          foo.pretty_print(pp_instance)
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `pretty_print_cycle`' do
+        expect_no_offenses(<<~RUBY)
+          require 'pp'
+
+          foo.pretty_print_cycle(pp_instance)
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `pretty_print_inspect`' do
+        expect_no_offenses(<<~RUBY)
+          require 'pp'
+
+          foo.pretty_print_inspect
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `pretty_print_instance_variables`' do
+        expect_no_offenses(<<~RUBY)
+          require 'pp'
+
+          foo.pretty_print_instance_variables
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #11419.

This PR fixes a false positive for `Style/RedundantRequireStatement` when using `pretty_inspect`.
It also fixes false positives for similar method usage.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
