### PR TITLE
[Fix #11420] Fix a false positive for `Lint/UselessRescue`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_useless_rescue.md
+++ b/changelog/fix_a_false_positive_for_lint_useless_rescue.md
@@ -1,0 +1,1 @@
+* [#11420](https://github.com/rubocop/rubocop/issues/11420): Fix a false positive for `Lint/UselessRescue`  when using exception variable in `ensure` clause. ([@koic][])

--- a/spec/rubocop/cop/lint/useless_rescue_spec.rb
+++ b/spec/rubocop/cop/lint/useless_rescue_spec.rb
@@ -62,6 +62,18 @@ RSpec.describe RuboCop::Cop::Lint::UselessRescue, :config do
     RUBY
   end
 
+  it 'does not register an offense when using exception variable in `ensure` clause' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        do_something
+      rescue => e
+        raise
+      ensure
+        do_something(e)
+      end
+    RUBY
+  end
+
   it 'registers an offense when multiple `rescue`s and last is only reraises' do
     expect_offense(<<~RUBY)
       def foo


### PR DESCRIPTION
Fixes #11420.

This PR fixes a false positive for `Lint/UselessRescue` when using exception variable in `ensure` clause.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
