### PR TITLE
[Fix #11418] Fix a false positive for `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_method_call_with_args_parentheses.md
+++ b/changelog/fix_a_false_positive_for_style_method_call_with_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#11418](https://github.com/rubocop/rubocop/issues/11418): Fix a false positive for `Style/MethodCallWithArgsParentheses` when using anonymous rest arguments or anonymous keyword rest arguments. ([@koic][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -208,6 +208,8 @@ module RuboCop
         end
 
         def on_send(node)
+          return if requrie_argument_parentheses?(node)
+
           send(style, node) # call require_parentheses or omit_parentheses
         end
         alias on_csend on_send
@@ -234,6 +236,13 @@ module RuboCop
 
           first_node = node.arguments.first
           first_node.begin_type? && first_node.parenthesized_call?
+        end
+
+        def requrie_argument_parentheses?(node)
+          return false unless (last_arg = node.last_argument)
+          return true if last_arg.forwarded_restarg_type?
+
+          last_arg.hash_type? && last_arg.children.first.forwarded_kwrestarg_type?
         end
       end
     end

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -468,6 +468,27 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       end
     end
 
+    context 'anonymous rest arguments in 3.2', :ruby32 do
+      it 'does not regiester an offense when method calls to have parens' do
+        expect_no_offenses(<<~RUBY)
+          def foo(*)
+            foo(*)
+            do_something
+          end
+        RUBY
+      end
+    end
+
+    context 'anonymous keyword rest arguments in 3.2', :ruby32 do
+      it 'does not regiester an offense when method calls to have parens' do
+        expect_no_offenses(<<~RUBY)
+          def foo(**)
+            foo(**)
+          end
+        RUBY
+      end
+    end
+
     it 'register an offense for parens in method call without args' do
       trailing_whitespace = ' '
 


### PR DESCRIPTION
Fixes #11418.

This PR fixes a false positive for `Style/MethodCallWithArgsParentheses` when using anonymous rest arguments or anonymous keyword rest arguments.
These parentheses are always required because omitting them would result in either a semantic change or a syntax error.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
