### PR TITLE
Fix a false negative on `Lint/Void`

### DIFF
--- a/changelog/fix_a_false_negative_for_methods_that_take_a_block_in_void_context.md
+++ b/changelog/fix_a_false_negative_for_methods_that_take_a_block_in_void_context.md
@@ -1,0 +1,1 @@
+* [#11425](https://github.com/rubocop/rubocop/pull/11425): Fix a false negative for `Lint/Void` when using methods that takes blocks. ([@krishanbhasin-shopify][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -124,7 +124,7 @@ module RuboCop
         end
 
         def check_nonmutating(node)
-          return unless node.send_type? && NONMUTATING_METHODS.include?(node.method_name)
+          return unless NONMUTATING_METHODS.include?(node.method_name)
 
           add_offense(node, message: format(NONMUTATING_MSG, method: node.method_name))
         end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -218,6 +218,28 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       RuboCop::Config.new('Lint/Void' => { 'CheckForMethodsWithNoSideEffects' => true })
     end
 
+    it 'registers offense for nonmutating method that takes a block' do
+      expect_offense(<<~RUBY)
+        [1,2,3].map do |n|
+        ^^^^^^^^^^^^^^^^^^ Method `#map` used in void context. Did you mean `#map!`?
+          n.to_s
+        end
+        "done"
+      RUBY
+    end
+
+    context 'Ruby 2.7', :ruby27 do
+      it 'registers offense for nonmutating method that takes a numbered parameter block' do
+        expect_offense(<<~RUBY)
+          [1,2,3].map do
+          ^^^^^^^^^^^^^^ Method `#map` used in void context. Did you mean `#map!`?
+            _1.to_s
+          end
+          "done"
+        RUBY
+      end
+    end
+
     it 'registers an offense if not on last line' do
       expect_offense(<<~RUBY)
         x.sort


### PR DESCRIPTION
Co-authored-by: Ryan Quanz <ryan.quanz@shopify.com>
Co-authored-by: Anderson Sequera <anderson.sequera@shopify.com>

`Lint/Void` cop detects nonmutating methods that act in a void context and marks them as an offence. Prior to this PR, if those methods took a block the cop would fail to detect the offence; this PR fixes those false negatives.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
