### PR TITLE
Suggest `each` when `map` or `collect` is used in void context

### DIFF
--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -46,19 +46,23 @@ module RuboCop
         LIT_MSG = 'Literal `%<lit>s` used in void context.'
         SELF_MSG = '`self` used in void context.'
         EXPRESSION_MSG = '`%<expression>s` used in void context.'
-        NONMUTATING_MSG = 'Method `#%<method>s` used in void context. Did you mean `#%<method>s!`?'
+        NONMUTATING_MSG = 'Method `#%<method>s` used in void context. Did you mean `#%<suggest>s`?'
 
         BINARY_OPERATORS = %i[* / % + - == === != < > <= >= <=>].freeze
         UNARY_OPERATORS = %i[+@ -@ ~ !].freeze
         OPERATORS = (BINARY_OPERATORS + UNARY_OPERATORS).freeze
         VOID_CONTEXT_TYPES = %i[def for block].freeze
-        NONMUTATING_METHODS = %i[capitalize chomp chop collect compact
-                                 delete_prefix delete_suffix downcase
-                                 encode flatten gsub lstrip map merge next
-                                 reject reverse rotate rstrip scrub select
-                                 shuffle slice sort sort_by squeeze strip sub
-                                 succ swapcase tr tr_s transform_values
-                                 unicode_normalize uniq upcase].freeze
+        NONMUTATING_METHODS_WITH_BANG_VERSION = %i[capitalize chomp chop compact
+                                                   delete_prefix delete_suffix downcase
+                                                   encode flatten gsub lstrip merge next
+                                                   reject reverse rotate rstrip scrub select
+                                                   shuffle slice sort sort_by squeeze strip sub
+                                                   succ swapcase tr tr_s transform_values
+                                                   unicode_normalize uniq upcase].freeze
+        METHODS_REPLACABLE_BY_EACH = %i[collect map].freeze
+
+        NONMUTATING_METHODS = (NONMUTATING_METHODS_WITH_BANG_VERSION +
+                               METHODS_REPLACABLE_BY_EACH).freeze
 
         def on_block(node)
           return unless node.body && !node.body.begin_type?
@@ -124,9 +128,12 @@ module RuboCop
         end
 
         def check_nonmutating(node)
-          return unless NONMUTATING_METHODS.include?(node.method_name)
+          method_name = node.method_name
+          return unless NONMUTATING_METHODS.include?(method_name)
 
-          add_offense(node, message: format(NONMUTATING_MSG, method: node.method_name))
+          suggestion = METHODS_REPLACABLE_BY_EACH.include?(method_name) ? 'each' : "#{method_name}!"
+          add_offense(node,
+                      message: format(NONMUTATING_MSG, method: method_name, suggest: suggestion))
         end
 
         def in_void_context?(node)

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -220,8 +220,8 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
 
     it 'registers offense for nonmutating method that takes a block' do
       expect_offense(<<~RUBY)
-        [1,2,3].map do |n|
-        ^^^^^^^^^^^^^^^^^^ Method `#map` used in void context. Did you mean `#map!`?
+        [1,2,3].collect do |n|
+        ^^^^^^^^^^^^^^^^^^^^^^ Method `#collect` used in void context. Did you mean `#each`?
           n.to_s
         end
         "done"
@@ -232,7 +232,7 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       it 'registers offense for nonmutating method that takes a numbered parameter block' do
         expect_offense(<<~RUBY)
           [1,2,3].map do
-          ^^^^^^^^^^^^^^ Method `#map` used in void context. Did you mean `#map!`?
+          ^^^^^^^^^^^^^^ Method `#map` used in void context. Did you mean `#each`?
             _1.to_s
           end
           "done"


### PR DESCRIPTION
Using `map` in a void context can either be replaced with `map!` if mutation of the underlying object is desired, or with `each` when it is only being invoked for the side effects produced by a block passed in.

This PR updates the cop to suggest `each` in instead of `map!`.

Fixes https://github.com/rubocop/rubocop/issues/8270
Fixes https://github.com/rubocop/rubocop/issues/4305
Fixes https://github.com/rubocop/rubocop/issues/1052

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
