### PR TITLE
Apply value omission exceptions in super invocations

### DIFF
--- a/changelog/fix_value_omissions_in_super.md
+++ b/changelog/fix_value_omissions_in_super.md
@@ -1,0 +1,1 @@
+* [#11428](https://github.com/rubocop/rubocop/pull/11428): Apply value omission exceptions in super invocations. ([@gsamokovarov][])

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1143,9 +1143,34 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'registers an offense when one line `if` condition follows super (with parentheses)' do
+        expect_offense(<<~RUBY)
+          super(value: value) unless foo
+                       ^^^^^ Omit the hash value.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          super(value:) unless foo
+        RUBY
+      end
+
       it 'does not register an offense when one line `if` condition follows (without parentheses)' do
         expect_no_offenses(<<~RUBY)
           foo x, value: value if bar
+        RUBY
+      end
+
+      it 'does not register an offense when one line `if` condition follows super (without parentheses)' do
+        expect_no_offenses(<<~RUBY)
+          super x, value: value unless foo
+        RUBY
+      end
+
+      it 'does not register an offense when one line `if` condition follows (without parentheses) in methods' do
+        expect_no_offenses(<<~RUBY)
+          def method
+            foo x, other:, value: value if bar
+          end
         RUBY
       end
 


### PR DESCRIPTION
Invocation to `super` were not covered by the special cases of value omissions that method calls have.

We ended up with a bad autocorrection in a super invocation. We got:

```ruby
return super current_user, primary: primary unless condition
```

autocorrected to:

```ruby
return super current_user, primary: unless condition
```

The code above is invalid Ruby. If we apply them method call edge cases to super invocations we end up with valid Ruby.