### PR TITLE
Fix a crash in Style/HashSyntax

### DIFF
--- a/changelog/fix_a_crash_in_style_hash_syntax.md
+++ b/changelog/fix_a_crash_in_style_hash_syntax.md
@@ -1,0 +1,1 @@
+* [#11431](https://github.com/rubocop/rubocop/pull/11431): Fix a crash in Style/HashSyntax. ([@gsamokovarov][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -46,21 +46,22 @@ module RuboCop
 
       private
 
-      # rubocop:disable Metrics/AbcSize
-      def register_offense(node, message, replacement)
+      def register_offense(node, message, replacement) # rubocop:disable Metrics/AbcSize
         add_offense(node.value, message: message) do |corrector|
           if (def_node = def_node_that_require_parentheses(node))
+            last_argument = def_node.last_argument
+            if last_argument.nil? || !last_argument.hash_type?
+              next corrector.replace(node, replacement)
+            end
+
             white_spaces = range_between(def_node.loc.selector.end_pos,
                                          def_node.first_argument.source_range.begin_pos)
             corrector.replace(white_spaces, '(')
-
-            last_argument = def_node.arguments.last
             corrector.insert_after(last_argument, ')') if node == last_argument.pairs.last
           end
           corrector.replace(node, replacement)
         end
       end
-      # rubocop:enable Metrics/AbcSize
 
       def ignore_mixed_hash_shorthand_syntax?(hash_node)
         target_ruby_version <= 3.0 || enforced_shorthand_syntax != 'consistent' ||

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1281,6 +1281,18 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'registers an offense in method receiving hash literals' do
+        expect_offense(<<~RUBY)
+          foo = {bar: bar, baz: :baz, quux: quux}.merge foo
+                                            ^^^^ Omit the hash value.
+                      ^^^ Omit the hash value.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo = {bar:, baz: :baz, quux:}.merge foo
+        RUBY
+      end
+
       context 'when hash roket syntax' do
         let(:enforced_style) { 'hash_rockets' }
 


### PR DESCRIPTION
The crash used to happen when an offense is registered in method receiving hash literals. Here is real world example that results in a crash inside RuboCop:

```ruby
attributes = {account: account, integ_name: shop_name, primary_integ_id: primary_integ_id}.merge attributes
```

The crash was:

```
undefined method `pairs' for s(:lvar, :attributes):RuboCop::AST::Node

            corrector.insert_after(last_argument, ')') if node == last_argument.pairs.last
                                                                  ^^^^^^^^^^^^^
```