### PR TITLE
[Fix #11430] Fix an infinite loop error for `Layout/BlockEndNewline`

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_layout_block_end_newline.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_block_end_newline.md
@@ -1,0 +1,1 @@
+* [#11430](https://github.com/rubocop/rubocop/issues/11430): Fix an infinite loop error for `Layout/BlockEndNewline` when multiline blocks with newlines before the `; end`. ([@koic][])

--- a/lib/rubocop/cop/layout/block_end_newline.rb
+++ b/lib/rubocop/cop/layout/block_end_newline.rb
@@ -46,7 +46,7 @@ module RuboCop
         def register_offense(node)
           add_offense(node.loc.end, message: message(node)) do |corrector|
             offense_range = offense_range(node)
-            replacement = "\n#{offense_range.source.strip}"
+            replacement = replacement(node)
 
             if (heredoc = last_heredoc_argument(node.body))
               corrector.remove(offense_range)
@@ -77,6 +77,12 @@ module RuboCop
             node.children.compact.last.loc.expression.end_pos,
             end_of_method_chain(node).loc.expression.end_pos
           )
+        end
+
+        def replacement(node)
+          end_with_method_chain = node.loc.end.join(end_of_method_chain(node).loc.expression.end)
+
+          "\n#{end_with_method_chain.source.strip}"
         end
 
         def end_of_method_chain(node)

--- a/spec/rubocop/cop/layout/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/layout/block_end_newline_spec.rb
@@ -13,6 +13,21 @@ RSpec.describe RuboCop::Cop::Layout::BlockEndNewline, :config do
     RUBY
   end
 
+  it 'registers an offense when multiline blocks with newlines before the `; end`' do
+    expect_offense(<<~RUBY)
+      test do
+        foo
+      ; end
+        ^^^ Expression at 3, 3 should be on its own line.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      test do
+        foo
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects when multiline block end is not on its own line' do
     expect_offense(<<~RUBY)
       test do


### PR DESCRIPTION
Fixes #11430.

This PR fixes an infinite loop error for `Layout/BlockEndNewline`. when multiline blocks with newlines before the `; end`. Below is a minimal reproduction:

```ruby
test do
  foo
; end
```

```ruby
% bundle exec rubocop -a --only Layout/BlockEndNewline
(snip)

Offenses:

example.rb:3:3: C: [Corrected] Layout/BlockEndNewline: Expression at 3, 3 should be on its own line.
; end
  ^^^

0 files inspected, 1 offense detected, 1 offense corrected
Infinite loop detected in /Users/koic/src/github.com/koic/rubocop-issues/11430/example.rb and caused by Layout/BlockEndNewline
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/runner.rb:311:in `check_for_infinite_loop'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/runner.rb:294:in `block in iterate_until_no_changes'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
