### PR TITLE
Increase generated changelog entry's length

### DIFF
--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -10,7 +10,7 @@ class Changelog
   HEADER = /### (.*)/.freeze
   PATH = 'CHANGELOG.md'
   REF_URL = 'https://github.com/rubocop/rubocop'
-  MAX_LENGTH = 40
+  MAX_LENGTH = 50
   CONTRIBUTOR = '[@%<user>s]: https://github.com/%<user>s'
   SIGNATURE = Regexp.new(format(Regexp.escape('[@%<user>s][]'), user: '([\w-]+)'))
   EOF = "\n"


### PR DESCRIPTION
Not a big deal, but a small convenience.
When generating a changelog entry for https://github.com/rubocop/rubocop/pull/11432, it was truncated to just `new_add_new.md`. 
Looking at the existing `changelog/` intries lengths, I think we can increase this limit.