### PR TITLE
Fix an error for `Style/AccessModifierDeclarations`

### DIFF
--- a/changelog/fix_an_error_for_style_access_modifier_declarations.md
+++ b/changelog/fix_an_error_for_style_access_modifier_declarations.md
@@ -1,0 +1,1 @@
+* [#11437](https://github.com/rubocop/rubocop/pull/11437): Fix an error for `Style/AccessModifierDeclarations` when access modifier is inlined with a method on the top level. ([@koic][])

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -62,6 +62,19 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         RUBY
       end
 
+      it "offends when #{access_modifier} is inlined with a method on the top level" do
+        expect_offense(<<~RUBY, access_modifier: access_modifier)
+          %{access_modifier} def foo; end
+          ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{access_modifier}
+
+          def foo; end
+        RUBY
+      end
+
       it "does not offend when #{access_modifier} is not inlined" do
         expect_no_offenses(<<~RUBY)
           class Test


### PR DESCRIPTION
This PR fixes an error for `Style/AccessModifierDeclarations` when access modifier is inlined with a method on the top level:

```ruby
private def foo
end
```

```console
% bundle exec rubocop --only Style/AccessModifierDeclarations -d
(snip)

An error occurred while Style/AccessModifierDeclarations cop was inspecting /Users/koic/src/github.com/koic/rubocop-issues/access_modifier/example.rb:1:0.
undefined method `each_child_node' for nil:NilClass
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/access_modifier_declarations.rb:176:in `find_argument_less_modifier_node'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/access_modifier_declarations.rb:189:in `insert_def'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
