### PR TITLE
[Fix #11439] Fix an incorrect autocorrect for `Style/MinMaxComparison` when using `a < b a : b` with `elsif/else`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_min_max_comparison.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_min_max_comparison.md
@@ -1,0 +1,1 @@
+* [#11439](https://github.com/rubocop/rubocop/issues/11439): Fix an incorrect autocorrect for `Style/MinMaxComparison` when using `a < b a : b` with `elsif/else`. ([@ydah][])

--- a/spec/rubocop/cop/style/min_max_comparison_spec.rb
+++ b/spec/rubocop/cop/style/min_max_comparison_spec.rb
@@ -119,6 +119,25 @@ RSpec.describe RuboCop::Cop::Style::MinMaxComparison, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when using `a < b a : b` with `elsif/else`' do
+    expect_offense(<<~RUBY)
+      if x
+      elsif a < b
+      ^^^^^^^^^^^ Use `[a, b].min` instead.
+        a
+      else
+        b
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if x
+      else
+        [a, b].min
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using `a > b ? c : d`' do
     expect_no_offenses(<<~RUBY)
       a > b ? c : d


### PR DESCRIPTION
Fix: #11439

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
