### PR TITLE
Fix an incorrect autocorrect for `Style/RedundantDoubleSplatHashBraces`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_redundant_double_splat_hash_braces.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_redundant_double_splat_hash_braces.md
@@ -1,0 +1,1 @@
+* [#11447](https://github.com/rubocop/rubocop/pull/11447): Fix an incorrect autocorrect for `Style/RedundantDoubleSplatHashBraces` when using nested double splat hash braces. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
     RUBY
   end
 
+  it 'registers an offense when using nested double splat hash braces' do
+    expect_offense(<<~RUBY)
+      do_something(**{foo: bar, **{baz: qux}})
+                                ^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something(foo: bar, baz: qux)
+    RUBY
+  end
+
   it 'registers an offense when using double splat in double splat hash braces' do
     expect_offense(<<~RUBY)
       do_something(**{foo: bar, **options})
@@ -32,6 +44,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
   it 'does not register an offense when using empty double splat hash braces arguments' do
     expect_no_offenses(<<~RUBY)
       do_something(**{})
+    RUBY
+  end
+
+  it 'does not register an offense when using empty hash braces arguments' do
+    expect_no_offenses(<<~RUBY)
+      do_something({})
     RUBY
   end
 


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for `Style/RedundantDoubleSplatHashBraces` when using nested double splat hash braces:

```ruby
do_something(**{foo: bar, **{baz: qux}})
```

```console
% rubocop --only Style/RedundantDoubleSplatHashBraces -a
(snip)

example.rb:1:14: C: [Corrected] Style/RedundantDoubleSplatHashBraces:
Remove the redundant double splat and braces, use keyword arguments directly.
do_something(**{foo: bar, **{baz: qux}})
             ^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

Before:

```diff
-do_something(**{foo: bar, **{baz: qux}})
+do_something(foo: bar)
```

After:

```diff
-do_something(**{foo: bar, **{baz: qux}})
+do_something(foo: bar, baz: qux)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
