### PR TITLE
[Fix #11444] Fix a false positive for `Lint/ShadowingOuterLocalVariable`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_shadowing_outer_local_variable.md
+++ b/changelog/fix_a_false_positive_for_lint_shadowing_outer_local_variable.md
@@ -1,0 +1,1 @@
+* [#11444](https://github.com/rubocop/rubocop/issues/11444): Fix a false positive for `Lint/ShadowingOuterLocalVariable` when using numbered block parameter. ([@koic][])

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -50,7 +50,7 @@ module RuboCop
 
       ZERO_ARITY_SUPER_TYPE = :zsuper
 
-      TWISTED_SCOPE_TYPES = %i[block class sclass defs module].freeze
+      TWISTED_SCOPE_TYPES = %i[block numblock class sclass defs module].freeze
       SCOPE_TYPES = (TWISTED_SCOPE_TYPES + [:def]).freeze
 
       SEND_TYPE = :send

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -365,6 +365,34 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
     end
   end
 
+  context 'when a block parameter has same name as a prior block body variable' do
+    context 'when assigning a block parameter' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def x(array)
+            array.each { |foo|
+              bar = foo
+            }.each { |bar|
+            }
+          end
+        RUBY
+      end
+    end
+
+    context 'when assigning a numbered block parameter', :ruby27 do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def x(array)
+            array.each {
+              bar = _1
+            }.each { |bar|
+            }
+          end
+        RUBY
+      end
+    end
+  end
+
   context 'with Ractor.new' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #11444.

This PR fixes a false positive for `Lint/ShadowingOuterLocalVariable` when using numbered block parameter.
It also fixes the following error as a side effect:

```ruby
array.each {
  bar = _1
}.each { |bar|
}
```

```console
% bundle exec rubocop example.rb --only Lint/ShadowingOuterLocalVariable -d
(snip)

Scanning /Users/koic/src/github.com/koic/rubocop-issues/11448/example.rb
An error occurred while VariableForce cop was inspecting /Users/koic/src/github.com/koic/rubocop-issues/11448/example.rb.
undefined method `when_type?' for nil:NilClass
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb:86:in `variable_node'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
