### PR TITLE
[Fix #11445] Fix an incorrect autocorrect for `Style/BlockDelimiters`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_block_delimiters.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_block_delimiters.md
@@ -1,0 +1,1 @@
+* [#11445](https://github.com/rubocop/rubocop/issues/11445): Fix an incorrect autocorrect for `Style/BlockDelimiters` when there is a comment after the closing brace and bracket. ([@koic][])

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -299,8 +299,8 @@ module RuboCop
 
         def move_comment_before_block(corrector, comment, block_node, closing_brace)
           range = block_node.chained? ? end_of_chain(block_node.parent).source_range : closing_brace
-          comment_range = range_between(range.end_pos, comment.loc.expression.end_pos)
-          corrector.remove(range_with_surrounding_space(comment_range, side: :right))
+          corrector.remove(range_with_surrounding_space(comment.loc.expression, side: :right))
+          remove_trailing_whitespace(corrector, range, comment)
           corrector.insert_after(range, "\n")
 
           corrector.insert_before(block_node, "#{comment.text}\n")
@@ -311,6 +311,12 @@ module RuboCop
           return node unless node.chained?
 
           end_of_chain(node.parent)
+        end
+
+        def remove_trailing_whitespace(corrector, range, comment)
+          range_of_trailing = range.end.join(comment.loc.expression.begin)
+
+          corrector.remove(range_of_trailing) if range_of_trailing.source.match?(/\A\s+\z/)
         end
 
         def with_block?(node)

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -448,6 +448,21 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
 
+      it 'registers an offense when there is a comment after the closing brace and bracket' do
+        expect_offense(<<~RUBY)
+          [foo {
+               ^ Avoid using `{...}` for multi-line blocks.
+          }] # comment
+        RUBY
+
+        expect_correction(<<~RUBY.chop)
+          [# comment
+          foo do
+          end
+          ]#{trailing_whitespace}
+        RUBY
+      end
+
       it 'registers an offense and keep chained block when there is a comment after the closing brace and block body is not empty' do
         expect_offense(<<~RUBY)
           baz.map { |x|


### PR DESCRIPTION
Fixes #11445.

This PR fixes an incorrect autocorrect for `Style/BlockDelimiters` when there is a comment after the closing brace and bracket.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
