### PR TITLE
Speed up `empty_brackets?`

### DIFF
--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -80,7 +80,7 @@ module RuboCop
 
           tokens, left, right = array_brackets(node)
 
-          if empty_brackets?(tokens, left, right)
+          if empty_brackets?(left, right, tokens: tokens)
             return empty_offenses(node, left, right, EMPTY_MSG)
           end
 
@@ -95,7 +95,7 @@ module RuboCop
         def autocorrect(corrector, node)
           tokens, left, right = array_brackets(node)
 
-          if empty_brackets?(tokens, left, right)
+          if empty_brackets?(left, right, tokens: tokens)
             SpaceCorrector.empty_corrections(processed_source, corrector, empty_config, left, right)
           elsif style == :no_space
             SpaceCorrector.remove_space(processed_source, corrector, left, right)

--- a/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
@@ -74,7 +74,7 @@ module RuboCop
 
           right_token = closing_bracket(tokens, left_token)
 
-          if empty_brackets?(left_token, right_token)
+          if empty_brackets?(tokens, left_token, right_token)
             return empty_offenses(node, left_token, right_token, EMPTY_MSG)
           end
 
@@ -90,9 +90,9 @@ module RuboCop
         private
 
         def autocorrect(corrector, node)
-          left, right = reference_brackets(node)
+          tokens, left, right = reference_brackets(node)
 
-          if empty_brackets?(left, right)
+          if empty_brackets?(tokens, left, right)
             SpaceCorrector.empty_corrections(processed_source, corrector, empty_config, left, right)
           elsif style == :no_space
             SpaceCorrector.remove_space(processed_source, corrector, left, right)
@@ -104,7 +104,7 @@ module RuboCop
         def reference_brackets(node)
           tokens = processed_source.tokens_within(node)
           left = left_ref_bracket(node, tokens)
-          [left, closing_bracket(tokens, left)]
+          [tokens, left, closing_bracket(tokens, left)]
         end
 
         def left_ref_bracket(node, tokens)

--- a/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
@@ -74,7 +74,7 @@ module RuboCop
 
           right_token = closing_bracket(tokens, left_token)
 
-          if empty_brackets?(tokens, left_token, right_token)
+          if empty_brackets?(left_token, right_token, tokens: tokens)
             return empty_offenses(node, left_token, right_token, EMPTY_MSG)
           end
 
@@ -92,7 +92,7 @@ module RuboCop
         def autocorrect(corrector, node)
           tokens, left, right = reference_brackets(node)
 
-          if empty_brackets?(tokens, left, right)
+          if empty_brackets?(left, right, tokens: tokens)
             SpaceCorrector.empty_corrections(processed_source, corrector, empty_config, left, right)
           elsif style == :no_space
             SpaceCorrector.remove_space(processed_source, corrector, left, right)

--- a/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
+++ b/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
@@ -31,13 +31,14 @@ module RuboCop
         def on_interpolation(begin_node)
           return if begin_node.multiline?
 
-          delims = delimiters(begin_node)
-          return if empty_brackets?(*delims)
+          tokens = processed_source.tokens_within(begin_node)
+          left, right = delimiters(begin_node)
+          return if empty_brackets?(tokens, left, right)
 
           if style == :no_space
-            no_space_offenses(begin_node, *delims, NO_SPACE_MSG)
+            no_space_offenses(begin_node, left, right, NO_SPACE_MSG)
           else
-            space_offenses(begin_node, *delims, SPACE_MSG)
+            space_offenses(begin_node, left, right, SPACE_MSG)
           end
         end
 

--- a/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
+++ b/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
@@ -33,7 +33,7 @@ module RuboCop
 
           tokens = processed_source.tokens_within(begin_node)
           left, right = delimiters(begin_node)
-          return if empty_brackets?(tokens, left, right)
+          return if empty_brackets?(left, right, tokens: tokens)
 
           if style == :no_space
             no_space_offenses(begin_node, left, right, NO_SPACE_MSG)

--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -107,7 +107,7 @@ module RuboCop
         end
       end
 
-      def empty_brackets?(tokens, left_bracket_token, right_bracket_token)
+      def empty_brackets?(left_bracket_token, right_bracket_token, tokens: processed_source.tokens)
         left_index = tokens.index(left_bracket_token)
         right_index = tokens.index(right_bracket_token)
         right_index && left_index == right_index - 1

--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -107,9 +107,9 @@ module RuboCop
         end
       end
 
-      def empty_brackets?(left_bracket_token, right_bracket_token)
-        left_index = processed_source.tokens.index(left_bracket_token)
-        right_index = processed_source.tokens.index(right_bracket_token)
+      def empty_brackets?(tokens, left_bracket_token, right_bracket_token)
+        left_index = tokens.index(left_bracket_token)
+        right_index = tokens.index(right_bracket_token)
         right_index && left_index == right_index - 1
       end
 


### PR DESCRIPTION
Pass pre-filtered tokens instead of looking up left and right tokens in all processed tokens. This avoids scanning the whole (and potential huge) `processed_source.tokens` list over and over again.

`empty_brackets?` popped up in stack profile when investigating performance of RuboCop at GitLab. See https://gitlab.com/gitlab-org/gitlab/-/issues/377469#note_1130358088.

This commit improves performance when inspecting files in rubocop repository. The runtime drops from 62s seconds to 59s when running `bundle exec bin/rubocop-profile`. The offended method `empty_brackets?` disappears in the stack profile from the top 100 (`stackprof --limit 100 tmp/stackprof.dump`).

## RuboCop

### Before

Runtime: 62.5s

```
==================================
  Mode: wall(1000)
  Samples: 62473 (0.01% miss rate)
  GC: 2846 (4.56%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      7938  (12.7%)        3502   (5.6%)     Parser::Lexer#advance
      3082   (4.9%)        3082   (4.9%)     Parser::Source::Buffer#slice
      4900   (7.8%)        2080   (3.3%)     RuboCop::AST::Descendence#each_child_node
      1861   (3.0%)        1861   (3.0%)     (sweeping)
      2426   (3.9%)        1849   (3.0%)     RuboCop::AST::Descendence#visit_descendants
      2036   (3.3%)        1495   (2.4%)     Parser::Source::Buffer#line_index_for_position
      1211   (1.9%)         998   (1.6%)     RuboCop::Cop::Base#initialize
       977   (1.6%)         977   (1.6%)     (marking)
      1346   (2.2%)         909   (1.5%)     AST::Node#initialize
       790   (1.3%)         790   (1.3%)     Parser::Source::Range#initialize
       761   (1.2%)         761   (1.2%)     RuboCop::AST::SendNode#first_argument_index
       745   (1.2%)         745   (1.2%)     RuboCop::AST::Node#parent
       778   (1.2%)         675   (1.1%)     RuboCop::Cop::Base#cop_config
     30278  (48.5%)         610   (1.0%)     RuboCop::Cop::Commissioner#trigger_responding_cops
      2296   (3.7%)         575   (0.9%)     RuboCop::Cop::Base#relevant_file?
       527   (0.8%)         527   (0.8%)     RuboCop::AST::SendNode#send_type?
       642   (1.0%)         485   (0.8%)     RuboCop::Cop::Base#complete_investigation
       617   (1.0%)         484   (0.8%)     RuboCop::PathUtil.match_path?
       472   (0.8%)         458   (0.7%)     RuboCop::Config#for_cop
       457   (0.7%)         457   (0.7%)     RuboCop::AST::Node#block_type?
       522   (0.8%)         454   (0.7%)     RuboCop::AST::ProcessedSource#sorted_tokens
      1143   (1.8%)         450   (0.7%)     RuboCop::AST::Node#each_ancestor
       426   (0.7%)         425   (0.7%)     RuboCop::Cop::Base.badge
       423   (0.7%)         423   (0.7%)     RuboCop::AST::StrNode#heredoc?
       413   (0.7%)         413   (0.7%)     Parser::Lexer::Literal#extend_string
       401   (0.6%)         401   (0.6%)     RuboCop::Cop::Base#on_investigation_end
       413   (0.7%)         395   (0.6%)     RuboCop::Cop::Team#validate_config
       388   (0.6%)         388   (0.6%)     RuboCop::AST::MethodDispatchNode#receiver
       383   (0.6%)         372   (0.6%)     RuboCop::Cop::Base#cop_name
       370   (0.6%)         370   (0.6%)     RuboCop::Cop::Base#reset_investigation
       363   (0.6%)         363   (0.6%)     RuboCop::AST::Node#source_range
       354   (0.6%)         354   (0.6%)     RuboCop::AST::MethodDispatchNode#method_name
       345   (0.6%)         345   (0.6%)     Set#include?
       317   (0.5%)         317   (0.5%)     Parser::Source::Buffer#line_begins
       318   (0.5%)         309   (0.5%)     RuboCop::RSpec::Language#rspec?
       493   (0.8%)         286   (0.5%)     RuboCop::Config#clusivity_config_for_badge?
       285   (0.5%)         285   (0.5%)     RuboCop::Cop::Base#begin_investigation
       281   (0.4%)         281   (0.4%)     RuboCop::AST::Node#casgn_type?
       290   (0.5%)         269   (0.4%)     RuboCop::Cop::Layout::TrailingEmptyLines#on_new_investigation
       267   (0.4%)         267   (0.4%)     Parser::Source::Map#to_hash
       589   (0.9%)         264   (0.4%)     RuboCop::Cop::Commissioner#build_callbacks
       264   (0.4%)         264   (0.4%)     Parser::Lexer::StackState#active?
       263   (0.4%)         263   (0.4%)     RuboCop::RSpec::Language::ExampleGroups.regular
       258   (0.4%)         258   (0.4%)     Parser::Source::Buffer#bsearch
       255   (0.4%)         255   (0.4%)     RuboCop::Cop::AutocorrectLogic#autocorrect_requested?
       249   (0.4%)         249   (0.4%)     RuboCop::Cop::Base#on_new_investigation
       237   (0.4%)         237   (0.4%)     RuboCop::AST::BlockNode#send_node
       668   (1.1%)         217   (0.3%)     Parser::Lexer#emit
       215   (0.3%)         215   (0.3%)     Parser::Lexer::Literal#coerce_encoding
       213   (0.3%)         213   (0.3%)     RuboCop::AST::Node#send_type?
       268   (0.4%)         207   (0.3%)     RuboCop::Cop::Team#support_target_ruby_version?
       225   (0.4%)         203   (0.3%)     RuboCop::Cop::AllowedPattern#matches_allowed_pattern?
       201   (0.3%)         201   (0.3%)     RuboCop::AST::Token#initialize
       200   (0.3%)         200   (0.3%)     Parser::Lexer#literal
       561   (0.9%)         199   (0.3%)     RuboCop::Cop::Util#begins_its_line?
       325   (0.5%)         195   (0.3%)     RuboCop::Cop::Base#callbacks_needed
       195   (0.3%)         195   (0.3%)     RuboCop::RSpec::Language::Examples.regular
       193   (0.3%)         193   (0.3%)     RuboCop::AST::IfNode#ternary?
       262   (0.4%)         191   (0.3%)     RuboCop::Cop::Commissioner#restricted_map
       190   (0.3%)         190   (0.3%)     Parser::Lexer::Dedenter#dedent
       189   (0.3%)         189   (0.3%)     Parser::Source::Map#initialize
       187   (0.3%)         187   (0.3%)     Parser::Builders::Default#value
       205   (0.3%)         183   (0.3%)     RuboCop::Cop::Naming::InclusiveLanguage#scan_for_words
       304   (0.5%)         180   (0.3%)     Parser::AST::Node#assign_properties
       238   (0.4%)         168   (0.3%)     RuboCop::AST::SendNode#attribute_accessor?
       166   (0.3%)         166   (0.3%)     RuboCop::Cop::Style::LineEndConcatenation#standard_string_literal?
       195   (0.3%)         162   (0.3%)     RuboCop::Cop::Naming::HeredocDelimiterNaming#meaningful_delimiters?
       156   (0.2%)         156   (0.2%)     RuboCop::Cop::Badge#to_s
       151   (0.2%)         151   (0.2%)     RuboCop::AST::Token#semicolon?
       151   (0.2%)         151   (0.2%)     Parser::Lexer::Literal#heredoc?
       270   (0.4%)         150   (0.2%)     RuboCop::Cop::Util#line
       149   (0.2%)         149   (0.2%)     RuboCop::Cop::Team#support_target_rails_version?
       680   (1.1%)         149   (0.2%)     RuboCop::AST::MethodDispatchNode#in_macro_scope?
       148   (0.2%)         148   (0.2%)     Set#include?
       147   (0.2%)         147   (0.2%)     RuboCop::TargetRuby#source
       209   (0.3%)         147   (0.2%)     Parser::Source::Buffer#source_line
       249   (0.4%)         145   (0.2%)     RuboCop::Cop::Team.forces_for
       304   (0.5%)         143   (0.2%)     RuboCop::Cop::Force#run_hook
       355   (0.6%)         142   (0.2%)     RuboCop::RSpec::Language#example_group?
       693   (1.1%)         140   (0.2%)     RuboCop::AST::Node#visit_ancestors
       138   (0.2%)         138   (0.2%)     RuboCop::AST::Token#comma?
       334   (0.5%)         137   (0.2%)     RuboCop::AST::ProcessedSource#lines
       135   (0.2%)         135   (0.2%)     RuboCop::Cop::SurroundingSpace#empty_brackets?
       134   (0.2%)         134   (0.2%)     RuboCop::Cop::RangeHelp#move_pos
       230   (0.4%)         133   (0.2%)     RuboCop::Cop::Lint::Debugger#debugger_method?
       133   (0.2%)         133   (0.2%)     RuboCop::Cop::IgnoredNode#ignored_nodes
       130   (0.2%)         130   (0.2%)     RuboCop::Cop::Base.callbacks_needed
       189   (0.3%)         128   (0.2%)     RuboCop::AST::MethodDispatchNode#dot?
       128   (0.2%)         128   (0.2%)     RuboCop::RSpec::Language::ExampleGroups.skipped
       126   (0.2%)         126   (0.2%)     Parser::Source::Buffer#source_lines
       125   (0.2%)         125   (0.2%)     Parser::Source::Range#<=>
       124   (0.2%)         124   (0.2%)     Parser::Builders::Default#loc
      1422   (2.3%)         124   (0.2%)     RuboCop::AST::Descendence#each_node
       122   (0.2%)         122   (0.2%)     RuboCop::RSpec::Language::ExampleGroups.focused
       116   (0.2%)         116   (0.2%)     RuboCop::Config#for_badge
       109   (0.2%)         109   (0.2%)     RuboCop::AST::Node#begin_type?
       585   (0.9%)         109   (0.2%)     RuboCop::Cop::Style::RedundantSelf#add_scope
       248   (0.4%)         109   (0.2%)     RuboCop::RSpec::Language#example_group_with_body?
       108   (0.2%)         108   (0.2%)     RuboCop::AST::Token#begin_pos
       130   (0.2%)         106   (0.2%)     RuboCop::Cop::PercentLiteral#begin_source
```

### After

Runtime: 58.9s

```
==================================
  Mode: wall(1000)
  Samples: 58934 (0.02% miss rate)
  GC: 2504 (4.25%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      7471  (12.7%)        3235   (5.5%)     Parser::Lexer#advance
      2973   (5.0%)        2973   (5.0%)     Parser::Source::Buffer#slice
      4579   (7.8%)        1900   (3.2%)     RuboCop::AST::Descendence#each_child_node
      2426   (4.1%)        1877   (3.2%)     RuboCop::AST::Descendence#visit_descendants
      1644   (2.8%)        1644   (2.8%)     (sweeping)
      1717   (2.9%)        1200   (2.0%)     Parser::Source::Buffer#line_index_for_position
      1164   (2.0%)         979   (1.7%)     RuboCop::Cop::Base#initialize
      1278   (2.2%)         893   (1.5%)     AST::Node#initialize
       854   (1.4%)         854   (1.4%)     (marking)
       742   (1.3%)         742   (1.3%)     Parser::Source::Range#initialize
       686   (1.2%)         686   (1.2%)     RuboCop::AST::Node#parent
       677   (1.1%)         677   (1.1%)     RuboCop::AST::SendNode#first_argument_index
       693   (1.2%)         609   (1.0%)     RuboCop::Cop::Base#cop_config
     28655  (48.6%)         591   (1.0%)     RuboCop::Cop::Commissioner#trigger_responding_cops
      2225   (3.8%)         511   (0.9%)     RuboCop::Cop::Base#relevant_file?
       597   (1.0%)         493   (0.8%)     RuboCop::PathUtil.match_path?
       485   (0.8%)         485   (0.8%)     RuboCop::AST::SendNode#send_type?
       633   (1.1%)         483   (0.8%)     RuboCop::Cop::Base#complete_investigation
      1074   (1.8%)         440   (0.7%)     RuboCop::AST::Node#each_ancestor
       429   (0.7%)         429   (0.7%)     Parser::Lexer::Literal#extend_string
       428   (0.7%)         428   (0.7%)     RuboCop::AST::StrNode#heredoc?
       480   (0.8%)         424   (0.7%)     RuboCop::AST::ProcessedSource#sorted_tokens
       416   (0.7%)         416   (0.7%)     RuboCop::AST::Node#block_type?
       405   (0.7%)         405   (0.7%)     RuboCop::Cop::Base#on_investigation_end
       408   (0.7%)         400   (0.7%)     RuboCop::Config#for_cop
       395   (0.7%)         395   (0.7%)     RuboCop::AST::MethodDispatchNode#receiver
       390   (0.7%)         390   (0.7%)     RuboCop::AST::MethodDispatchNode#method_name
       379   (0.6%)         378   (0.6%)     RuboCop::Cop::Base.badge
       384   (0.7%)         378   (0.6%)     RuboCop::Cop::Base#cop_name
       375   (0.6%)         354   (0.6%)     RuboCop::Cop::Team#validate_config
       361   (0.6%)         348   (0.6%)     RuboCop::RSpec::Language#rspec?
       335   (0.6%)         335   (0.6%)     RuboCop::Cop::Base#reset_investigation
       327   (0.6%)         326   (0.6%)     Set#include?
       323   (0.5%)         323   (0.5%)     RuboCop::AST::Node#source_range
       323   (0.5%)         323   (0.5%)     Parser::Source::Buffer#line_begins
       532   (0.9%)         304   (0.5%)     RuboCop::Config#clusivity_config_for_badge?
       296   (0.5%)         296   (0.5%)     RuboCop::Cop::Base#begin_investigation
       289   (0.5%)         289   (0.5%)     RuboCop::RSpec::Language::ExampleGroups.regular
       279   (0.5%)         279   (0.5%)     RuboCop::AST::Node#casgn_type?
       266   (0.5%)         266   (0.5%)     Parser::Lexer::StackState#active?
       284   (0.5%)         261   (0.4%)     RuboCop::Cop::Layout::TrailingEmptyLines#on_new_investigation
       245   (0.4%)         245   (0.4%)     RuboCop::Cop::AutocorrectLogic#autocorrect_requested?
       527   (0.9%)         245   (0.4%)     RuboCop::Cop::Commissioner#build_callbacks
       243   (0.4%)         243   (0.4%)     Parser::Source::Buffer#bsearch
       243   (0.4%)         243   (0.4%)     RuboCop::Cop::Base#on_new_investigation
       232   (0.4%)         232   (0.4%)     RuboCop::AST::BlockNode#send_node
       223   (0.4%)         223   (0.4%)     Parser::Source::Map#to_hash
       644   (1.1%)         214   (0.4%)     Parser::Lexer#emit
       240   (0.4%)         213   (0.4%)     RuboCop::Cop::AllowedPattern#matches_allowed_pattern?
       252   (0.4%)         211   (0.4%)     RuboCop::Cop::Team#support_target_ruby_version?
       204   (0.3%)         204   (0.3%)     RuboCop::RSpec::Language::Examples.regular
       199   (0.3%)         199   (0.3%)     Parser::Lexer::Literal#coerce_encoding
       198   (0.3%)         198   (0.3%)     RuboCop::AST::Token#initialize
       184   (0.3%)         184   (0.3%)     Parser::Lexer#literal
       183   (0.3%)         183   (0.3%)     RuboCop::AST::IfNode#ternary?
       245   (0.4%)         181   (0.3%)     RuboCop::Cop::Commissioner#restricted_map
       180   (0.3%)         180   (0.3%)     RuboCop::Cop::Badge#to_s
       180   (0.3%)         180   (0.3%)     Parser::Lexer::Dedenter#dedent
       176   (0.3%)         176   (0.3%)     RuboCop::AST::Node#send_type?
       498   (0.8%)         173   (0.3%)     RuboCop::Cop::Util#begins_its_line?
       232   (0.4%)         173   (0.3%)     RuboCop::AST::SendNode#attribute_accessor?
       201   (0.3%)         173   (0.3%)     RuboCop::Cop::Naming::InclusiveLanguage#scan_for_words
       311   (0.5%)         167   (0.3%)     RuboCop::Cop::Force#run_hook
       253   (0.4%)         166   (0.3%)     RuboCop::Cop::Team.forces_for
       193   (0.3%)         165   (0.3%)     RuboCop::Cop::Naming::HeredocDelimiterNaming#meaningful_delimiters?
       164   (0.3%)         164   (0.3%)     Parser::Source::Map#initialize
       282   (0.5%)         151   (0.3%)     RuboCop::Cop::Base#callbacks_needed
       253   (0.4%)         150   (0.3%)     Parser::AST::Node#assign_properties
       150   (0.3%)         150   (0.3%)     RuboCop::Cop::RangeHelp#move_pos
       342   (0.6%)         146   (0.2%)     RuboCop::RSpec::Language#example_group?
       141   (0.2%)         141   (0.2%)     RuboCop::Cop::Style::LineEndConcatenation#standard_string_literal?
       139   (0.2%)         139   (0.2%)     Parser::Builders::Default#value
       240   (0.4%)         138   (0.2%)     RuboCop::Cop::Lint::Debugger#debugger_method?
       137   (0.2%)         137   (0.2%)     RuboCop::TargetRuby#source
       135   (0.2%)         135   (0.2%)     RuboCop::Cop::Team#support_target_rails_version?
       131   (0.2%)         131   (0.2%)     RuboCop::Cop::Base.callbacks_needed
       128   (0.2%)         128   (0.2%)     RuboCop::AST::Token#comma?
      1388   (2.4%)         127   (0.2%)     RuboCop::AST::Descendence#each_node
       166   (0.3%)         125   (0.2%)     Parser::Source::Buffer#source_line
       124   (0.2%)         124   (0.2%)     RuboCop::Cop::IgnoredNode#ignored_nodes
       139   (0.2%)         124   (0.2%)     RuboCop::Cop::PercentLiteral#begin_source
       608   (1.0%)         122   (0.2%)     RuboCop::AST::MethodDispatchNode#in_macro_scope?
       635   (1.1%)         119   (0.2%)     RuboCop::AST::Node#visit_ancestors
       119   (0.2%)         119   (0.2%)     RuboCop::AST::Token#semicolon?
       116   (0.2%)         116   (0.2%)     Set#include?
       140   (0.2%)         116   (0.2%)     RuboCop::Cop::Metrics::BlockNesting#consider_node?
      6177  (10.5%)         115   (0.2%)     RuboCop::AST::Traversal#on_send
       113   (0.2%)         113   (0.2%)     RuboCop::RSpec::Language::ExampleGroups.focused
       112   (0.2%)         112   (0.2%)     RuboCop::RSpec::Language::ExampleGroups.skipped
       178   (0.3%)         110   (0.2%)     RuboCop::AST::MethodDispatchNode#dot?
       110   (0.2%)         110   (0.2%)     Parser::Lexer::Literal#heredoc?
       208   (0.4%)         109   (0.2%)     RuboCop::Cop::Util#line
       109   (0.2%)         109   (0.2%)     RuboCop::Config#for_badge
       109   (0.2%)         109   (0.2%)     RuboCop::Cop::Heredoc#indent_level
       601   (1.0%)         105   (0.2%)     RuboCop::Cop::Style::RedundantSelf#add_scope
       223   (0.4%)         104   (0.2%)     RuboCop::RSpec::Language#example?
       278   (0.5%)         104   (0.2%)     RuboCop::RSpec::Language#example_group_with_body?
       283   (0.5%)         103   (0.2%)     RuboCop::AST::ProcessedSource#lines
       192   (0.3%)         101   (0.2%)     RuboCop::Cop::Style::ConditionalAssignment#assignment_type?
       100   (0.2%)         100   (0.2%)     Parser::Builders::Default#loc
```

## GitLab

Refs https://gitlab.com/gitlab-org/gitlab/-/issues/377469#note_1130358088

Run: `bin/rubocop-profile {spec,app}/models/project*`

### Before

Runtime: 10s

```
==================================
  Mode: wall(1000)
  Samples: 9953 (0.16% miss rate)
  GC: 745 (7.49%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       372   (3.7%)         372   (3.7%)     (marking)
       370   (3.7%)         370   (3.7%)     (sweeping)
       418   (4.2%)         355   (3.6%)     RuboCop::AST::Descendence#visit_descendants
       550   (5.5%)         341   (3.4%)     Parser::Lexer#advance
       660   (6.6%)         278   (2.8%)     RuboCop::AST::Descendence#each_child_node
       191   (1.9%)         191   (1.9%)     Parser::Source::Buffer#slice
       247   (2.5%)         175   (1.8%)     Parser::Source::Buffer#line_index_for_position
       145   (1.5%)         145   (1.5%)     RuboCop::Cop::SurroundingSpace#empty_brackets?
       126   (1.3%)         126   (1.3%)     RuboCop::AST::SendNode#send_type?
       158   (1.6%)         123   (1.2%)     AST::Node#initialize
      5519  (55.5%)         117   (1.2%)     RuboCop::Cop::Commissioner#trigger_responding_cops
       107   (1.1%)         107   (1.1%)     RuboCop::AST::SendNode#first_argument_index
        90   (0.9%)          90   (0.9%)     Psych::TreeBuilder#event_location
        83   (0.8%)          83   (0.8%)     RuboCop::AST::Node#parent
        79   (0.8%)          79   (0.8%)     RuboCop::AST::Node#block_type?
        74   (0.7%)          74   (0.7%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
       361   (3.6%)          72   (0.7%)     <top (required)>
        72   (0.7%)          72   (0.7%)     RuboCop::Cop::SurroundingSpace#empty_brackets?
        71   (0.7%)          71   (0.7%)     Parser::Source::Range#initialize
        80   (0.8%)          70   (0.7%)     RuboCop::AST::ProcessedSource#sorted_tokens
        70   (0.7%)          70   (0.7%)     RuboCop::AST::MethodDispatchNode#receiver
        76   (0.8%)          68   (0.7%)     Gem::BasicSpecification#have_file?
        75   (0.8%)          65   (0.7%)     RuboCop::AST::NodePattern::MethodDefiner#def_helper
        69   (0.7%)          65   (0.7%)     RuboCop::Cop::Lint::LastKeywordArgument#known_match?
        64   (0.6%)          63   (0.6%)     RuboCop::Cop::Base.badge
       478   (4.8%)          61   (0.6%)     Kernel#require
        57   (0.6%)          57   (0.6%)     RuboCop::AST::MethodDispatchNode#method_name
        57   (0.6%)          57   (0.6%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
        55   (0.6%)          55   (0.6%)     Psych::Nodes::Scalar#initialize
        58   (0.6%)          53   (0.5%)     RuboCop::Cop::Base#initialize
```

### After

Rutime: 9.5s

`empty_brackets?` no more in the top 30.

```
==================================
  Mode: wall(1000)
  Samples: 9504 (0.16% miss rate)
  GC: 742 (7.81%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       379   (4.0%)         379   (4.0%)     (marking)
       359   (3.8%)         359   (3.8%)     (sweeping)
       410   (4.3%)         350   (3.7%)     RuboCop::AST::Descendence#visit_descendants
       519   (5.5%)         306   (3.2%)     Parser::Lexer#advance
       552   (5.8%)         253   (2.7%)     RuboCop::AST::Descendence#each_child_node
       188   (2.0%)         188   (2.0%)     Parser::Source::Buffer#slice
       259   (2.7%)         186   (2.0%)     Parser::Source::Buffer#line_index_for_position
       169   (1.8%)         143   (1.5%)     AST::Node#initialize
      5069  (53.3%)         111   (1.2%)     RuboCop::Cop::Commissioner#trigger_responding_cops
       101   (1.1%)         101   (1.1%)     Psych::TreeBuilder#event_location
       100   (1.1%)         100   (1.1%)     RuboCop::AST::SendNode#first_argument_index
        98   (1.0%)          98   (1.0%)     RuboCop::AST::SendNode#send_type?
        92   (1.0%)          91   (1.0%)     RuboCop::Cop::Lint::LastKeywordArgument#known_match?
        89   (0.9%)          89   (0.9%)     Parser::Source::Range#initialize
        88   (0.9%)          88   (0.9%)     RuboCop::AST::Node#parent
       379   (4.0%)          84   (0.9%)     <top (required)>
        82   (0.9%)          75   (0.8%)     Gem::BasicSpecification#have_file?
        75   (0.8%)          74   (0.8%)     RuboCop::Cop::Base.badge
        74   (0.8%)          74   (0.8%)     RuboCop::AST::MethodDispatchNode#receiver
        71   (0.7%)          71   (0.7%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
        83   (0.9%)          70   (0.7%)     RuboCop::AST::ProcessedSource#sorted_tokens
       461   (4.9%)          64   (0.7%)     Kernel#require
        64   (0.7%)          64   (0.7%)     RuboCop::AST::MethodDispatchNode#method_name
        66   (0.7%)          58   (0.6%)     RuboCop::AST::NodePattern::MethodDefiner#def_helper
        58   (0.6%)          58   (0.6%)     RuboCop::AST::Node#block_type?
        57   (0.6%)          57   (0.6%)     RuboCop::AST::Node#casgn_type?
        66   (0.7%)          54   (0.6%)     RuboCop::Cop::Base#initialize
        54   (0.6%)          54   (0.6%)     Gitlab::Styles::Rubocop::ModelHelpers#in_model?
       390   (4.1%)          51   (0.5%)     Kernel#require
        55   (0.6%)          51   (0.5%)     RuboCop::Cop::Base#cop_config
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
