### PR TITLE
Improve `Style/NestedTernaryOperator` autocorrect for chained ternaries

### DIFF
--- a/changelog/change_improve_style_nested_ternary_operator_autocorrect_for_chained_ternaries.md
+++ b/changelog/change_improve_style_nested_ternary_operator_autocorrect_for_chained_ternaries.md
@@ -1,0 +1,1 @@
+* [#11451](https://github.com/rubocop/rubocop/pull/11451): Improve `Style/NestedTernaryOperator` autocorrect for chained ternaries. ([@FnControlOption][])

--- a/lib/rubocop/cop/style/nested_ternary_operator.rb
+++ b/lib/rubocop/cop/style/nested_ternary_operator.rb
@@ -24,14 +24,19 @@ module RuboCop
 
         def on_if(node)
           return unless node.ternary?
+          return if part_of_ignored_node?(node)
+
+          if (ternaries = chained_ternaries(node))
+            add_offense(node) do |corrector|
+              autocorrect_chained(corrector, node, ternaries)
+            end
+            ignore_node(node)
+            return
+          end
 
           node.each_descendant(:if).select(&:ternary?).each do |nested_ternary|
             add_offense(nested_ternary) do |corrector|
-              if_node = if_node(nested_ternary)
-              next if part_of_ignored_node?(if_node)
-
-              autocorrect(corrector, if_node)
-              ignore_node(if_node)
+              autocorrect_nested(corrector, nested_ternary)
             end
           end
         end
@@ -45,10 +50,13 @@ module RuboCop
           if_node(node)
         end
 
-        def autocorrect(corrector, if_node)
+        def autocorrect_else(corrector, if_node, colon_replacement)
           replace_loc_and_whitespace(corrector, if_node.loc.question, "\n")
-          replace_loc_and_whitespace(corrector, if_node.loc.colon, "\nelse\n")
+          replace_loc_and_whitespace(corrector, if_node.loc.colon, colon_replacement)
           corrector.replace(if_node.if_branch, remove_parentheses(if_node.if_branch.source))
+        end
+
+        def autocorrect_if(corrector, if_node)
           corrector.wrap(if_node, 'if ', "\nend")
         end
 
@@ -63,6 +71,37 @@ module RuboCop
             range_with_surrounding_space(range: range, whitespace: true),
             replacement
           )
+        end
+
+        def autocorrect_nested(corrector, nested_ternary)
+          if_node = if_node(nested_ternary)
+          return if part_of_ignored_node?(if_node)
+
+          autocorrect_else(corrector, if_node, "\nelse\n")
+          autocorrect_if(corrector, if_node)
+          ignore_node(if_node)
+        end
+
+        def autocorrect_chained(corrector, node, ternaries)
+          ternaries.each do |if_node|
+            if if_node == ternaries.last
+              autocorrect_else(corrector, if_node, "\nelse\n")
+            else
+              autocorrect_else(corrector, if_node, "\nelsif ")
+            end
+          end
+          autocorrect_if(corrector, node)
+        end
+
+        def chained_ternaries(node)
+          ternaries = []
+          while node.if_type? && node.ternary?
+            ternaries << node
+            node = node.else_branch
+          end
+          return if ternaries.count <= 1
+
+          ternaries
         end
       end
     end

--- a/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
@@ -60,19 +60,18 @@ RSpec.describe RuboCop::Cop::Style::NestedTernaryOperator, :config do
   it 'can handle multiple nested ternaries' do
     expect_offense(<<~RUBY)
       a ? b : c ? d : e ? f : g
-                      ^^^^^^^^^ Ternary operators must not be nested. Prefer `if` or `else` constructs instead.
-              ^^^^^^^^^^^^^^^^^ Ternary operators must not be nested. Prefer `if` or `else` constructs instead.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Ternary operators must not be nested. Prefer `if` or `else` constructs instead.
     RUBY
 
     expect_correction(<<~RUBY)
       if a
       b
-      else
-      if c
+      elsif c
       d
+      elsif e
+      f
       else
-      e ? f : g
-      end
+      g
       end
     RUBY
   end


### PR DESCRIPTION
`a ? b : c ? d : e` should be autocorrected to:

```
if a
  b
elsif c
  d
else
  e
end
```

instead of:

```
if a
  b
else
  c ? d : e
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
