### PR TITLE
Fix crash with `super value_omission:` followed by a method call

### DIFF
--- a/changelog/fix_crash_with_super_value_omission_followed_by_a.md
+++ b/changelog/fix_crash_with_super_value_omission_followed_by_a.md
@@ -1,0 +1,1 @@
+* [#11455](https://github.com/rubocop/rubocop/pull/11455): Fix crash with `super value_omission:` followed by a method call. ([@gsamokovarov][])

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1154,6 +1154,34 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'registers an offense in super followed by ivar assignment (without parentheses)' do
+        expect_offense(<<~RUBY)
+          super value: value, other: other
+                                     ^^^^^ Omit the hash value.
+                       ^^^^^ Omit the hash value.
+          @ivar = ivar
+        RUBY
+
+        expect_correction(<<~RUBY)
+          super(value:, other:)
+          @ivar = ivar
+        RUBY
+      end
+
+      it 'registers an offense in super followed by expr without parentheses' do
+        expect_offense(<<~RUBY)
+          super value: value, other: other
+                                     ^^^^^ Omit the hash value.
+                       ^^^^^ Omit the hash value.
+          foo baz
+        RUBY
+
+        expect_correction(<<~RUBY)
+          super(value:, other:)
+          foo baz
+        RUBY
+      end
+
       it 'registers an offense when one line `if` condition follows yield (with parentheses)' do
         expect_offense(<<~RUBY)
           yield(value: value) unless foo


### PR DESCRIPTION
I #11428, I have tried to fix the value omission syntax in `super` calls. Ironically, I have also introduced a crash for code like the following:

```ruby
super value: value
foo z
```

This case requires parentheses, because it's invalid with value omission but without parentheses. It should be autocorrected to:

```ruby
super(value:)
foo z
```

However, the code that handles value omissions followed by code afterwards making it require parentheses didn't expect to get location produced by keyword nodes.

In #11428, I have changed the `def_node_that_require_parentheses` method to return `super` nodes, along the other method dispatch nodes with types of `send` and `csend`. This created an issue, because `super` returns a `Parser::Source::Map::Keyword` instance for its `#location`.

`Parser::Source::Map::Keyword` does not respond to the `selector` method which we use to get the location of the opening paren. We can get a similar code range for `super` with the `#keyword` method, which this map type do respond to.

I have abstracted this knowledge with a custom `DefNode` result type, however the problem is deeper than this and will require an `rubocop-ast` fix.

[`super`][super] nodes are [`MethodDispatchNode`][MethodDispatchNode] nodes and we freely call `loc.selector` on them. This can lead to crashes. I can fix this independently in `rubocop-ast` by introducing `MethodDispatch#selector` that knows how to guess the selector for `super` calls.

This can be a problem for value omissions in `yield` nodes too, which we don't handle at the moment. I'll fix them in another change.

[super]: https://github.com/rubocop/rubocop-ast/blob/33a74df26e15f9e5ae9f0ec1a86949779ec239ec/lib/rubocop/ast/node/super_node.rb#L10
[MethodDispatchNode]: https://github.com/rubocop/rubocop-ast/blob/33a74df26e15f9e5ae9f0ec1a86949779ec239ec/lib/rubocop/ast/node/mixin/method_dispatch_node.rb#L8
