### PR TITLE
Fix value omissions in `yield` invocations

### DIFF
--- a/changelog/fix_value_omissions_in_yield_invocations.md
+++ b/changelog/fix_value_omissions_in_yield_invocations.md
@@ -1,0 +1,1 @@
+* [#11456](https://github.com/rubocop/rubocop/pull/11456): Fix value omissions in `yield` invocations. ([@gsamokovarov][])

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1154,6 +1154,45 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'registers an offense when one line `if` condition follows yield (with parentheses)' do
+        expect_offense(<<~RUBY)
+          yield(value: value) unless foo
+                       ^^^^^ Omit the hash value.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          yield(value:) unless foo
+        RUBY
+      end
+
+      it 'registers an offense in yield followed by ivar assignment (without parentheses)' do
+        expect_offense(<<~RUBY)
+          yield value: value, other: other
+                                     ^^^^^ Omit the hash value.
+                       ^^^^^ Omit the hash value.
+          @ivar = ivar
+        RUBY
+
+        expect_correction(<<~RUBY)
+          yield(value:, other:)
+          @ivar = ivar
+        RUBY
+      end
+
+      it 'registers an offense in yield followed by expr without parentheses' do
+        expect_offense(<<~RUBY)
+          yield value: value, other: other
+                                     ^^^^^ Omit the hash value.
+                       ^^^^^ Omit the hash value.
+          foo baz
+        RUBY
+
+        expect_correction(<<~RUBY)
+          yield(value:, other:)
+          foo baz
+        RUBY
+      end
+
       it 'does not register an offense when one line `if` condition follows (without parentheses)' do
         expect_no_offenses(<<~RUBY)
           foo x, value: value if bar


### PR DESCRIPTION
I #11428, I have tried to fix the value omission syntax in `super` invocations. I have missed `yield` invocations too. They can have value omissions too.