### PR TITLE
Make `Metrics/BlockNesting` aware of pattern matching

### DIFF
--- a/changelog/new_make_metrics_block_nesting_aware_of_pattern_matching.md
+++ b/changelog/new_make_metrics_block_nesting_aware_of_pattern_matching.md
@@ -1,0 +1,1 @@
+* [#11457](https://github.com/rubocop/rubocop/pull/11457): Make `Metrics/BlockNesting` aware of pattern matching. ([@koic][])

--- a/lib/rubocop/cop/metrics/block_nesting.rb
+++ b/lib/rubocop/cop/metrics/block_nesting.rb
@@ -12,7 +12,7 @@ module RuboCop
       #
       # The maximum level of nesting allowed is configurable.
       class BlockNesting < Base
-        NESTING_BLOCKS = %i[case if while while_post until until_post for resbody].freeze
+        NESTING_BLOCKS = %i[case case_match if while while_post until until_post for resbody].freeze
 
         exclude_limit 'Max'
 

--- a/spec/rubocop/cop/metrics/block_nesting_spec.rb
+++ b/spec/rubocop/cop/metrics/block_nesting_spec.rb
@@ -85,6 +85,22 @@ RSpec.describe RuboCop::Cop::Metrics::BlockNesting, :config do
     end
   end
 
+  context 'nested `case` as a pattern matching', :ruby27 do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        if a
+          if b
+            case c
+            ^^^^^^ Avoid more than 2 levels of block nesting.
+              in C
+                puts C
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
   context 'nested `while`' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR makes `Metrics/BlockNesting` aware of pattern matching.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
