### PR TITLE
Make `Lint/UselessRuby2Keywords` aware of conditions

### DIFF
--- a/changelog/fix_make_lint_useless_ruby2_keywords_aware_of.md
+++ b/changelog/fix_make_lint_useless_ruby2_keywords_aware_of.md
@@ -1,0 +1,1 @@
+* [#11459](https://github.com/rubocop/rubocop/pull/11459): Make `Lint/UselessRuby2Keywords` aware of conditions. ([@splattael][])

--- a/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
+++ b/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
@@ -98,12 +98,20 @@ module RuboCop
           return unless node.parent
 
           method_name = sym_node.value
-          definition = node.parent.each_child_node.detect { |n| method_definition(n, method_name) }
+          definition = find_method_definition(node, method_name)
 
           return unless definition
           return if allowed_arguments(definition.arguments)
 
           add_offense(node, message: format(MSG, method_name: method_name))
+        end
+
+        def find_method_definition(node, method_name)
+          node.each_ancestor.lazy.map do |ancestor|
+            ancestor.each_child_node(:def, :block, :numblock).find do |child|
+              method_definition(child, method_name)
+            end
+          end.find(&:itself)
         end
 
         # `ruby2_keywords` is only allowed if there's a `restarg` and no keyword arguments

--- a/spec/rubocop/cop/lint/useless_ruby2_keywords_spec.rb
+++ b/spec/rubocop/cop/lint/useless_ruby2_keywords_spec.rb
@@ -97,6 +97,15 @@ RSpec.describe RuboCop::Cop::Lint::UselessRuby2Keywords, :config do
       RUBY
     end
 
+    it 'registers an offense for an unnecessary `ruby2_keywords` in a condition' do
+      expect_offense(<<~RUBY)
+        def foo(**kwargs)
+        end
+        ruby2_keywords :foo if respond_to?(:ruby2_keywords, true)
+        ^^^^^^^^^^^^^^^^^^^ `ruby2_keywords` is unnecessary for method `foo`.
+      RUBY
+    end
+
     it 'does not register an offense for an allowed def' do
       expect_no_offenses(<<~RUBY)
         def foo(*args)


### PR DESCRIPTION
The following code is not flagged yet:

```ruby
  def foo(**args)
  end
  ruby2_keywords :foo if respond_to?(:ruby2_keywords, true)
```

This PR fixes this issue.

Real world example: https://gitlab.com/gitlab-org/gitlab/-/blob/4598296ccc6d31414dd22d288882603d23a12296/config/initializers/6_labkit_middleware.rb#L13. Discovered during enabling this rule in https://gitlab.com/gitlab-org/ruby/gems/gitlab-styles/-/merge_requests/160.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
