### PR TITLE
[Fix #11460] Fix an error for `Style/OperatorMethodCall`

### DIFF
--- a/changelog/fix_an_error_for_style_operator_method_call.md
+++ b/changelog/fix_an_error_for_style_operator_method_call.md
@@ -1,0 +1,1 @@
+* [#11460](https://github.com/rubocop/rubocop/issues/11460): Fix an error for `Style/OperatorMethodCall` when using `foo.> 42`. ([@koic][])

--- a/lib/rubocop/cop/style/operator_method_call.rb
+++ b/lib/rubocop/cop/style/operator_method_call.rb
@@ -47,7 +47,7 @@ module RuboCop
 
         def anonymous_forwarding?(argument)
           return true if argument.forwarded_args_type? || argument.forwarded_restarg_type?
-          return true if argument.children.first&.forwarded_kwrestarg_type?
+          return true if argument.hash_type? && argument.children.first&.forwarded_kwrestarg_type?
 
           argument.block_pass_type? && argument.source == '&'
         end

--- a/spec/rubocop/cop/style/operator_method_call_spec.rb
+++ b/spec/rubocop/cop/style/operator_method_call_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe RuboCop::Cop::Style::OperatorMethodCall, :config do
       RUBY
     end
 
+    it "registers an offense when using `foo.#{operator_method} 42`" do
+      expect_offense(<<~RUBY)
+        foo.#{operator_method} 42
+           ^ Redundant dot detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo #{operator_method} 42
+      RUBY
+    end
+
     it "registers an offense when using `foo.#{operator_method}(bar)`" do
       expect_offense(<<~RUBY, operator_method: operator_method)
         foo.#{operator_method}(bar)


### PR DESCRIPTION
Fixes #11460.

This PR fixes an error for `Style/OperatorMethodCall` when using `foo.> 42`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
