### PR TITLE
[WIP] [Fix: #11462] Fix over-indentation in `Layout/FirstElementHashIndentation`

### DIFF
--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2763,4 +2763,50 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       end
     RUBY
   end
+
+  it 'indents hashes correctly when adding a line break' do
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~RUBY)
+      def example
+        { key1:
+          { key2:
+            { key3:
+              { key4:
+                { key5:
+                  :value
+                }
+              }
+            }
+          }
+        }
+      end
+    RUBY
+
+    status = cli.run(%W[--autocorrect-all --only #{%w[
+      Layout/FirstHashElementIndentation
+      Layout/FirstHashElementLineBreak
+      Layout/TrailingWhitespace
+    ].join(',')}])
+    expect(status).to eq(0)
+    expect(source_file.read).to eq(<<~RUBY)
+      def example
+        {
+          key1:
+          {
+            key2:
+            {
+              key3:
+              {
+                key4:
+                {
+                  key5:
+                  :value
+                }
+              }
+            }
+          }
+        }
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This investigates fixing #11462. So far, it adds an autocorrection test. I'm still figuring out the details of the autocorrector logic, which I am very much unfamiliar with (cc. @dvandersluis ).

Starting with the example:

```ruby
def example
  { key1:
    { key2:
      { key3:
	{ key4:
	  { key5:
	    :value
	  }
	}
      }
    }
  }
end
```

What seems to be happening is that a line break is inserted between `{` and `keyN:`. `Layout/TrailingWhitespace` handles getting rid of the space remaining after `{`, but everything goes wrong in `Layout/FirstHashElementIndentation`.

```ruby
def example
  {
key1:
    {
key2:
      {
key3:
	{
key4:
	  {
key5:
	    :value
	  }
	}
      }
    }
  }
end
```

It finds `key1:` in column 0, computes a column delta of 4, which it applies to the key and value lines, even though the value lines don't have the same indentation.

```ruby
def example
  {
    key1:
        {
    key2:
          {
    key3:
    	{
    key4:
    	  {
    key5:
    	    :value
    	  }
    	}
          }
        }
  }
end
```

This repeats for `key2:`, which is not indented as much as it should be relative to its opening `{`, so the entire thing is indented by the column delta.

```ruby
def example
  {
    key1:
        {
          key2:
                {
          key3:
          	{
          key4:
          	  {
          key5:
          	    :value
          	  }
          	}
                }
        }
  }
end
```

This continues to repeat for `key3:`, `key4:`, and `key5:`, respectively:

```ruby
def example
  {
    key1:
        {
          key2:
                {
                  key3:
                  	{
                  key4:
                  	  {
                  key5:
                  	    :value
                  	  }
                  	}
                }
        }
  }
end
```

```ruby
def example
  {
    key1:
        {
          key2:
                {
                  key3:
                  	{
                          key4:
                          	  {
                          key5:
                          	    :value
                          	  }
                  	}
                }
        }
  }
end
```

```ruby
def example
  {
    key1:
        {
          key2:
                {
                  key3:
                  	{
                          key4:
                          	  {
                                    key5:
                                    	    :value
                          	  }
                  	}
                }
        }
  }
end
```

Every level is incorrectly corrected once for each of it's parents, and finally for itself, compounding the error.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
