### PR TITLE
Fix a false negative for `Lint/FormatParameterMismatch` when include interpolated string

### DIFF
--- a/changelog/fix_a_false_negative_for_lint_format_parameter_mismatch.md
+++ b/changelog/fix_a_false_negative_for_lint_format_parameter_mismatch.md
@@ -1,0 +1,1 @@
+* [#11464](https://github.com/rubocop/rubocop/pull/11464): Fix a false negative for `Lint/FormatParameterMismatch` when include interpolated string. ([@ydah][])

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -301,4 +301,52 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch, :config do
       expect_no_offenses('format("%*.*f %*.*f", 10, 2, 20.19, 5, 1, 11.22)')
     end
   end
+
+  context 'with interpolated string in format string' do
+    it 'registers an offense when the fields do not match' do
+      expect_offense(<<~'RUBY')
+        format("#{foo} %s %s", "bar")
+        ^^^^^^ Number of arguments (1) to `format` doesn't match the number of fields (2).
+      RUBY
+    end
+
+    it 'does not register an offense when the fields match' do
+      expect_no_offenses('format("#{foo} %s", "bar")')
+    end
+
+    it 'registers an offense for String#% when the fields do not match' do
+      expect_offense(<<~'RUBY')
+        "%s %s" % ["#{foo}", 1, 2]
+                ^ Number of arguments (3) to `String#%` doesn't match the number of fields (2).
+      RUBY
+    end
+
+    it 'does not register an offense for String#% when the fields match' do
+      expect_no_offenses('"%s %s" % ["#{foo}", 1]')
+    end
+  end
+
+  context 'with interpolated string in argument' do
+    it 'registers an offense when the fields do not match' do
+      expect_offense(<<~'RUBY')
+        format("%s %s", "#{foo}")
+        ^^^^^^ Number of arguments (1) to `format` doesn't match the number of fields (2).
+      RUBY
+    end
+
+    it 'does not register an offense when the fields match' do
+      expect_no_offenses('format("%s", "#{foo}")')
+    end
+
+    it 'registers an offense for String#% when the fields do not match' do
+      expect_offense(<<~'RUBY')
+        "#{foo} %s %s" % [1, 2, 3]
+                       ^ Number of arguments (3) to `String#%` doesn't match the number of fields (2).
+      RUBY
+    end
+
+    it 'does not register an offense for String#% when the fields match' do
+      expect_no_offenses('"#{foo} %s %s" % [1, 2]')
+    end
+  end
 end


### PR DESCRIPTION
This PR is fix a false negative for `Lint/FormatParameterMismatch` when include interpolated string.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
