### PR TITLE
Make `Style/Semicolon` aware of redundant semicolon in block

### DIFF
--- a/changelog/change_make_style_semicolon_aware_of_semicolon_in_block.md
+++ b/changelog/change_make_style_semicolon_aware_of_semicolon_in_block.md
@@ -1,0 +1,1 @@
+* [#11465](https://github.com/rubocop/rubocop/pull/11465): Make `Style/Semicolon` aware of redundant semicolon in block. ([@koic][])

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1748,7 +1748,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
 
       {foo: bar,
        bar: baz,}
-      foo.each { bar; }
+      foo.each { bar }
     RUBY
   end
 

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -108,6 +108,40 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
     expect_correction(" puts 1\n")
   end
 
+  it 'registers an offense for a semicolon at the beginning of a block' do
+    expect_offense(<<~RUBY)
+      foo {; bar }
+           ^ Do not use semicolons to terminate expressions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo { bar }
+    RUBY
+  end
+
+  it 'registers an offense for a semicolon at the end of a block' do
+    expect_offense(<<~RUBY)
+      foo { bar; }
+               ^ Do not use semicolons to terminate expressions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo { bar }
+    RUBY
+  end
+
+  it 'registers an offense for a semicolon at the middle of a block' do
+    expect_offense(<<~RUBY)
+      foo { bar; baz }
+               ^ Do not use semicolons to terminate expressions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo { bar
+       baz }
+    RUBY
+  end
+
   it 'registers an offense for range (`1..42`) with semicolon' do
     expect_offense(<<~RUBY)
       1..42;


### PR DESCRIPTION
This PR makes `Style/Semicolon` aware of redundant semicolon in block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
