### PR TITLE
Add `Gemspec/DevelopmentDependencies` cop

### DIFF
--- a/changelog/new_add_gemspec_development_dependencies_cop.md
+++ b/changelog/new_add_gemspec_development_dependencies_cop.md
@@ -1,0 +1,1 @@
+* [#11469](https://github.com/rubocop/rubocop/pull/11469): Add `Gemspec/DevelopmentDependencies` cop. ([@sambostock][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -262,6 +262,22 @@ Gemspec/DeprecatedAttributeAssignment:
   Include:
     - '**/*.gemspec'
 
+Gemspec/DevelopmentDependencies:
+  Description: Checks that development dependencies are specified in Gemfile rather than gemspec.
+  Enabled: pending
+  VersionAdded: '<<next>>'
+  EnforcedStyle: Gemfile
+  SupportedStyles:
+    - Gemfile
+    - gems.rb
+    - gemspec
+  AllowedGems:
+    - bundler
+  Include:
+    - '**/*.gemspec'
+    - '**/Gemfile'
+    - '**/gems.rb'
+
 Gemspec/DuplicatedAssignment:
   Description: 'An attribute assignment method calls should be listed only once in a gemspec.'
   Enabled: true

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -166,6 +166,7 @@ require_relative 'rubocop/cop/bundler/ordered_gems'
 
 require_relative 'rubocop/cop/gemspec/dependency_version'
 require_relative 'rubocop/cop/gemspec/deprecated_attribute_assignment'
+require_relative 'rubocop/cop/gemspec/development_dependencies'
 require_relative 'rubocop/cop/gemspec/duplicated_assignment'
 require_relative 'rubocop/cop/gemspec/ordered_dependencies'
 require_relative 'rubocop/cop/gemspec/require_mfa'

--- a/lib/rubocop/cop/gemspec/development_dependencies.rb
+++ b/lib/rubocop/cop/gemspec/development_dependencies.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Gemspec
+      # Enforce that development dependencies for a gem are specified in
+      # `Gemfile`, rather than in the `gemspec` using
+      # `add_development_dependency`. Alternatively, using `EnforcedStyle:
+      # gemspec`, enforce that all dependencies are specified in `gemspec`,
+      # rather than in `Gemfile`.
+      #
+      # @example EnforcedStyle: Gemfile (default)
+      #   # Specify runtime dependencies in your gemspec,
+      #   # but all other dependencies in your Gemfile.
+      #
+      #   # bad
+      #   # example.gemspec
+      #   s.add_development_dependency "foo"
+      #
+      #   # good
+      #   # Gemfile
+      #   gem "foo"
+      #
+      #   # good
+      #   # gems.rb
+      #   gem "foo"
+      #
+      #   # good (with AllowedGems: ["bar"])
+      #   # example.gemspec
+      #   s.add_development_dependency "bar"
+      #
+      # @example EnforcedStyle: gems.rb
+      #   # Specify runtime dependencies in your gemspec,
+      #   # but all other dependencies in your Gemfile.
+      #   #
+      #   # Identical to `EnforcedStyle: Gemfile`, but with a different error message.
+      #   # Rely on Bundler/GemFilename to enforce the use of `Gemfile` vs `gems.rb`.
+      #
+      #   # bad
+      #   # example.gemspec
+      #   s.add_development_dependency "foo"
+      #
+      #   # good
+      #   # Gemfile
+      #   gem "foo"
+      #
+      #   # good
+      #   # gems.rb
+      #   gem "foo"
+      #
+      #   # good (with AllowedGems: ["bar"])
+      #   # example.gemspec
+      #   s.add_development_dependency "bar"
+      #
+      # @example EnforcedStyle: gemspec
+      #   # Specify all dependencies in your gemspec.
+      #
+      #   # bad
+      #   # Gemfile
+      #   gem "foo"
+      #
+      #   # good
+      #   # example.gemspec
+      #   s.add_development_dependency "foo"
+      #
+      #   # good (with AllowedGems: ["bar"])
+      #   # Gemfile
+      #   gem "bar"
+      #
+      class DevelopmentDependencies < Base
+        include ConfigurableEnforcedStyle
+
+        MSG = 'Specify development dependencies in %<preferred>s.'
+        RESTRICT_ON_SEND = %i[add_development_dependency gem].freeze
+
+        # @!method add_development_dependency?(node)
+        def_node_matcher :add_development_dependency?, <<~PATTERN
+          (send _ :add_development_dependency (str #forbidden_gem? ...))
+        PATTERN
+
+        # @!method gem?(node)
+        def_node_matcher :gem?, <<~PATTERN
+          (send _ :gem (str #forbidden_gem? ...))
+        PATTERN
+
+        def on_send(node)
+          case style
+          when :Gemfile, :'gems.rb'
+            add_offense(node) if add_development_dependency?(node)
+          when :gemspec
+            add_offense(node) if gem?(node)
+          end
+        end
+
+        private
+
+        def forbidden_gem?(gem_name)
+          !cop_config['AllowedGems'].include?(gem_name)
+        end
+
+        def message(_range)
+          format(MSG, preferred: style)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/gemspec/development_dependencies_spec.rb
+++ b/spec/rubocop/cop/gemspec/development_dependencies_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Gemspec::DevelopmentDependencies, :config do
+  let(:cop_config) do
+    {
+      'Enabled' => true,
+      'EnforcedStyle' => enforced_style,
+      'AllowedGems' => [
+        'allowed'
+      ]
+    }
+  end
+
+  shared_examples 'prefer gem file' do
+    it 'registers an offense when using `#add_development_dependency` in a gemspec' do
+      expect_offense(<<~RUBY, 'example.gemspec', preferred_file: enforced_style)
+        Gem::Specification.new do |spec|
+          spec.name = 'example'
+          spec.add_development_dependency 'foo'
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify development dependencies in %{preferred_file}.
+          spec.add_development_dependency 'allowed'
+        end
+      RUBY
+    end
+
+    it 'registers no offenses when specifying dependencies in Gemfile' do
+      expect_no_offenses(<<~RUBY, 'Gemfile')
+        gem 'example'
+      RUBY
+    end
+
+    it 'registers no offenses when specifying dependencies in gems.rb' do
+      expect_no_offenses(<<~RUBY, 'gems.rb')
+        gem 'example'
+      RUBY
+    end
+  end
+
+  context 'with `EnforcedStyle: Gemfile`' do
+    let(:enforced_style) { 'Gemfile' }
+
+    include_examples 'prefer gem file'
+  end
+
+  context 'with `EnforcedStyle: gems.rb`' do
+    let(:enforced_style) { 'gems.rb' }
+
+    include_examples 'prefer gem file'
+  end
+
+  context 'with `EnforcedStyle: gemspec`' do
+    let(:enforced_style) { 'gemspec' }
+
+    it 'registers no offenses when using `#add_development_dependency`' do
+      expect_no_offenses(<<~RUBY, 'example.gemspec')
+        Gem::Specification.new do |spec|
+          spec.name = 'example'
+          spec.add_development_dependency 'foo'
+        end
+      RUBY
+    end
+
+    it 'registers an offense when specifying dependencies in Gemfile' do
+      expect_offense(<<~RUBY, 'Gemfile')
+        gem 'example'
+        ^^^^^^^^^^^^^ Specify development dependencies in gemspec.
+        gem 'allowed'
+      RUBY
+    end
+
+    it 'registers an offense when specifying dependencies in gems.rb' do
+      expect_offense(<<~RUBY, 'gems.rb')
+        gem 'example'
+        ^^^^^^^^^^^^^ Specify development dependencies in gemspec.
+        gem 'allowed'
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
This cop checks that development dependencies are specified in `Gemfile` rather than `gemspec`. It also supports `EnforcedStyle: gems.rb`, which behaves the same way, but mentions `gems.rb` in the error message, or `EnforcedStyle: gemspec`, which inverts the check and enforces that all dependencies be specified in the gemspec file.

An `AllowedGems` config is also included, for projects that want to include some gems in their gemspec. For example, Rubocop itself specifies

```ruby
s.add_development_dependency 'bundler'
```

but specifies all other development dependencies in `Gemfile`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists)~.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
