### PR TITLE
[Fix #11467] Fix a false negative for `Style/MethodCallWithoutArgsParentheses`

### DIFF
--- a/changelog/fix_a_false_negative_for_style_method_call_without_args_parentheses.md
+++ b/changelog/fix_a_false_negative_for_style_method_call_without_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#11467](https://github.com/rubocop/rubocop/issues/11467): Fix a false negative for `Style/MethodCallWithoutArgsParentheses` when calling method on a receiver and assigning to a variable with the same name. ([@koic][])

--- a/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
@@ -62,6 +62,8 @@ module RuboCop
         end
 
         def same_name_assignment?(node)
+          return false if node.receiver
+
           any_assignment?(node) do |asgn_node|
             next variable_in_mass_assignment?(node.method_name, asgn_node) if asgn_node.masgn_type?
 

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -50,6 +50,17 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
       expect_no_offenses('test = test()')
     end
 
+    it 'registers an offense when calling method on a receiver' do
+      expect_offense(<<~RUBY)
+        test = x.test()
+                     ^^ Do not use parentheses for method calls with no arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        test = x.test
+      RUBY
+    end
+
     it 'accepts parens in default argument assignment' do
       expect_no_offenses(<<~RUBY)
         def foo(test = test())


### PR DESCRIPTION
Fixes #11467.

This PR fixes a false negative for `Style/MethodCallWithoutArgsParentheses` when calling method on a receiver and assigning to a variable with the same name.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
