### PR TITLE
Change to not output not configured warning when renamed and pending cop

### DIFF
--- a/changelog/change_change_to_not_output_not_configured_warning.md
+++ b/changelog/change_change_to_not_output_not_configured_warning.md
@@ -1,0 +1,1 @@
+* [#11471](https://github.com/rubocop/rubocop/pull/11471): Change to not output not configured warning when renamed and pending cop. ([@ydah][])

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -111,8 +111,15 @@ module RuboCop
         end
 
         merge_with_default(config, config_file).tap do |merged_config|
-          warn_on_pending_cops(merged_config.pending_cops) unless possible_new_cops?(merged_config)
+          unless possible_new_cops?(merged_config)
+            pending_cops = pending_cops_only_qualified(merged_config.pending_cops)
+            warn_on_pending_cops(pending_cops) unless pending_cops.empty?
+          end
         end
+      end
+
+      def pending_cops_only_qualified(pending_cops)
+        pending_cops.select { |cop| Cop::Registry.qualified_cop?(cop.name) }
       end
 
       def possible_new_cops?(config)
@@ -167,8 +174,6 @@ module RuboCop
       BANNER
 
       def warn_on_pending_cops(pending_cops)
-        return if pending_cops.empty?
-
         warn Rainbow(PENDING_BANNER).yellow
 
         pending_cops.each { |cop| warn_pending_cop cop }

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -41,6 +41,11 @@ module RuboCop
         @global = new
       end
 
+      def self.qualified_cop?(name)
+        badge = Badge.parse(name)
+        global.qualify_badge(badge).first == badge
+      end
+
       attr_reader :options
 
       def initialize(cops = [], options = {})
@@ -156,6 +161,13 @@ module RuboCop
         @unqualified_cop_names ||=
           Set.new(@cops_by_cop_name.keys.map { |qn| File.basename(qn) }) <<
           'RedundantCopDisableDirective'
+      end
+
+      def qualify_badge(badge)
+        clear_enrollment_queue
+        @departments
+          .map { |department, _| badge.with_department(department) }
+          .select { |potential_badge| registered?(potential_badge) }
       end
 
       # @return [Hash{String => Array<Class>}]
@@ -280,13 +292,6 @@ module RuboCop
 
       def with(cops)
         self.class.new(cops)
-      end
-
-      def qualify_badge(badge)
-        clear_enrollment_queue
-        @departments
-          .map { |department, _| badge.with_department(department) }
-          .select { |potential_badge| registered?(potential_badge) }
       end
 
       def resolve_badge(given_badge, real_badge, source_path)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1852,9 +1852,26 @@ RSpec.describe RuboCop::ConfigLoader do
     context 'when NewCops is not configured in a required file' do
       let(:parent_config) { { 'AllCops' => { 'Exclude:' => ['coverage/**/*'] } } }
 
-      it 'prints a warning' do
-        expect(described_class).to receive(:warn_on_pending_cops)
-        from_file
+      context 'when `pending_cops_only_qualified` returns empty array' do
+        before do
+          allow(described_class).to receive(:pending_cops_only_qualified).and_return([])
+        end
+
+        it 'does not print a warning' do
+          expect(described_class).not_to receive(:warn_on_pending_cops)
+          from_file
+        end
+      end
+
+      context 'when `pending_cops_only_qualified` returns not empty array' do
+        before do
+          allow(described_class).to receive(:pending_cops_only_qualified).and_return(['Foo/Bar'])
+        end
+
+        it 'prints a warning' do
+          expect(described_class).to receive(:warn_on_pending_cops)
+          from_file
+        end
       end
     end
   end


### PR DESCRIPTION
This PR is change to not output not configured warning when renamed and pending cop.

Resolve: https://github.com/rubocop/rubocop-rspec/issues/1561

## Motivation
This will help eliminate some of the confusion that occurred when we extracted from the Capybara section of RuboCop RSpec to RuboCop Capybara.

RuboCop RSpec 2.18.0 renamed and extracted cop still pending in RuboCop Capybara section.
`RSpec/Capybara/FooCop` -> `Capybara/FooCop`.

If we have the following .rubocop.yml.
```yaml
require:
  - rubocop-capybara
  - rubocop-rspec

Capybara/MatchStyle:
  Enabled: true
Capybara/NegationMatcher:
  Enabled: true
Capybara/SpecificActions:
  Enabled: true
Capybara/SpecificFinders:
  Enabled: true
Capybara/SpecificMatcher:
  Enabled: true
```

If we run RuboCop in this state, we will get the following warning:
```
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.

Please also note that you can opt-in to new cops by default by adding this to your config:
  AllCops:
    NewCops: enable

Gemspec/DeprecatedAttributeAssignment: # new in 1.30
  Enabled: true
(snip)
RSpec/Capybara/MatchStyle: # new in 2.17
  Enabled: true
RSpec/Capybara/NegationMatcher: # new in 2.14
  Enabled: true
RSpec/Capybara/SpecificActions: # new in 2.14
  Enabled: true
RSpec/Capybara/SpecificFinders: # new in 2.13
  Enabled: true
RSpec/Capybara/SpecificMatcher: # new in 2.12
  Enabled: true
:
For more information: https://docs.rubocop.org/rubocop/versioning.html
```

However, I think it is confusing to see this in the output, since the `RSpec/Capybara` department cop, such as `RSpec/Capybara/MatchStyle`, is actually renamed.

To resolve this, it needs to be added to .rubocop.yml, but it feels a bit strange to explicitly disable the renamed cop.

```yaml
require:
  - rubocop-capybara
  - rubocop-rspec

Capybara/MatchStyle:
  Enabled: true
Capybara/NegationMatcher:
  Enabled: true
Capybara/SpecificActions:
  Enabled: true
Capybara/SpecificFinders:
  Enabled: true
Capybara/SpecificMatcher:
  Enabled: true
RSpec/Capybara:
  Enabled: false
RSpec/Capybara/FeatureMethods: # Moreover, this is not extracted into RuboCop Capybara and must be enabled.
  Enabled: true
```


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
