### PR TITLE
Use `Corrector#swap` where possible

### DIFF
--- a/lib/rubocop/cop/corrector.rb
+++ b/lib/rubocop/cop/corrector.rb
@@ -86,8 +86,16 @@ module RuboCop
         range1 = to_range(node_or_range1)
         range2 = to_range(node_or_range2)
 
-        replace(range1, range2.source)
-        replace(range2, range1.source)
+        if range1.end_pos == range2.begin_pos
+          insert_before(range1, range2.source)
+          remove(range2)
+        elsif range2.end_pos == range1.begin_pos
+          insert_before(range2, range1.source)
+          remove(range1)
+        else
+          replace(range1, range2.source)
+          replace(range2, range1.source)
+        end
       end
 
       private

--- a/lib/rubocop/cop/correctors/ordered_gem_corrector.rb
+++ b/lib/rubocop/cop/correctors/ordered_gem_corrector.rb
@@ -18,7 +18,7 @@ module RuboCop
           current_range = declaration_with_comment(node)
           previous_range = declaration_with_comment(previous_declaration)
 
-          ->(corrector) { swap_range(corrector, current_range, previous_range) }
+          ->(corrector) { corrector.swap(current_range, previous_range) }
         end
 
         private
@@ -31,11 +31,6 @@ module RuboCop
                                          include_final_newline: true).end_pos
 
           range_between(begin_pos, end_pos)
-        end
-
-        def swap_range(corrector, range1, range2)
-          corrector.insert_before(range2, range1.source)
-          corrector.remove(range1)
         end
       end
     end

--- a/lib/rubocop/cop/style/negated_if_else_condition.rb
+++ b/lib/rubocop/cop/style/negated_if_else_condition.rb
@@ -103,11 +103,7 @@ module RuboCop
           if node.if_branch.nil?
             corrector.remove(range_by_whole_lines(node.loc.else, include_final_newline: true))
           else
-            if_range = if_range(node)
-            else_range = else_range(node)
-
-            corrector.replace(if_range, else_range.source)
-            corrector.replace(else_range, if_range.source)
+            corrector.swap(if_range(node), else_range(node))
           end
         end
 

--- a/lib/rubocop/cop/style/require_order.rb
+++ b/lib/rubocop/cop/style/require_order.rb
@@ -88,10 +88,9 @@ module RuboCop
           return unless previous_older_sibling
 
           add_offense(node, message: format(MSG, name: node.method_name)) do |corrector|
-            swap(
+            corrector.swap(
               range_with_comments_and_lines(previous_older_sibling),
-              range_with_comments_and_lines(node.parent.if_type? ? node.parent : node),
-              corrector: corrector
+              range_with_comments_and_lines(node.parent.if_type? ? node.parent : node)
             )
           end
         end
@@ -129,12 +128,6 @@ module RuboCop
           !node1.location.expression.with(
             end_pos: node2.location.expression.end_pos
           ).source.include?("\n\n")
-        end
-
-        def swap(range1, range2, corrector:)
-          inserted = range2.source
-          corrector.insert_before(range1, inserted)
-          corrector.remove(range2)
         end
       end
     end


### PR DESCRIPTION
`Corrector#swap` was introduced in the PR for `YodaExpression` cop - https://github.com/rubocop/rubocop/pull/11333/files#diff-1341c76fbde042e0ad98b3df91749671b56de56e87ff63496b5c422db1d9e2b9R81-R91.

I tweak it to not raise clobbering error for two adjacent ranges and make it use where possible in the codebase.