### PR TITLE
Add intentionally empty file to implicitly test cops on it

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,6 +80,11 @@ Lint/UselessAccessModifier:
     - 'def_matcher'
     - 'def_node_matcher'
 
+Lint/EmptyFile:
+  Exclude:
+    # This file is intentionally empty to catch rubocop cops failing on empty files.
+    - spec/rubocop/intentionally_empty_file.rb
+
 Metrics/BlockLength:
   Exclude:
     - 'Rakefile'


### PR DESCRIPTION
Here and there are error reports that some cop fails on an empty file. The latest of them - https://github.com/rubocop/rubocop-minitest/issues/225. Some of the cops already have test cases for empty files, but it is tedious to write them and very often just forgotten.

So I added an empty file into the project so that cops (at least which are not disabled) are always tested (implicitly) on an empty file.
I think, we should add a similar file to the `test/` directory of the `rubocop-minitest` gem and somewhere to the `rubocop-rails` too.