### PR TITLE
[Fix #11477] Fix an error when using YAML alias with server mode

### DIFF
--- a/changelog/fix_an_error_when_using_yaml_alias_with_server_mode.md
+++ b/changelog/fix_an_error_when_using_yaml_alias_with_server_mode.md
@@ -1,0 +1,1 @@
+* [#11477](https://github.com/rubocop/rubocop/issues/11477): Fix an error when using YAML alias with server mode. ([@koic][])

--- a/lib/rubocop/server/cache.rb
+++ b/lib/rubocop/server/cache.rb
@@ -68,7 +68,9 @@ module RuboCop
             file_contents = File.read(config_path)
             yaml_code = ERB.new(file_contents).result
 
-            config_yaml = YAML.safe_load(yaml_code, permitted_classes: [Regexp, Symbol])
+            config_yaml = YAML.safe_load(
+              yaml_code, permitted_classes: [Regexp, Symbol], aliases: true
+            )
 
             # For compatibility with Ruby 3.0 or lower.
             if Gem::Version.new(Psych::VERSION) < Gem::Version.new('4.0.0')

--- a/spec/rubocop/server/cache_spec.rb
+++ b/spec/rubocop/server/cache_spec.rb
@@ -240,6 +240,20 @@ RSpec.describe RuboCop::Server::Cache do
         end
       end
     end
+
+    context 'when using YAML alias in .rubocop.yml', :isolated_environment do
+      it 'does not raise an error' do
+        create_file('.rubocop.yml', <<~YAML)
+          AllCops:
+            Style/StringLiterals: &config
+              Enable: true
+            Style/HashSyntax:
+              <<: *config
+        YAML
+
+        expect { cache_class.cache_path }.not_to raise_error
+      end
+    end
   end
 
   unless RuboCop::Platform.windows?


### PR DESCRIPTION
Fixes #11477.

This PR fixes an error when using YAML alias with server mode. YAML alias should be allowed as well as non server mode.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
