### PR TITLE
Remove obsolete code for Psych

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -241,18 +241,10 @@ module RuboCop
         raise
       end
 
-      if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0')
-        def yaml_safe_load!(yaml_code, filename)
-          YAML.safe_load(yaml_code,
-                         permitted_classes: [Regexp, Symbol],
-                         permitted_symbols: [],
-                         aliases: true,
-                         filename: filename)
-        end
-      else # Ruby < 2.6
-        def yaml_safe_load!(yaml_code, filename)
-          YAML.safe_load(yaml_code, [Regexp, Symbol], [], true, filename)
-        end
+      def yaml_safe_load!(yaml_code, filename)
+        YAML.safe_load(
+          yaml_code, permitted_classes: [Regexp, Symbol], aliases: true, filename: filename
+        )
       end
     end
 


### PR DESCRIPTION
This PR removes old Pysch code because Ruby 2.5 runtime support already dropped.

```console
% ruby -ryaml -ve 'p Psych::VERSION'
ruby 2.5.9p229 (2021-04-05 revision 67939) [x86_64-darwin19]
"3.0.2"
% ruby -ryaml -ve 'p Psych::VERSION'
ruby 2.6.10p210 (2022-04-12 revision 67958) [x86_64-darwin19]
"3.1.0"
% ruby -ryaml -ve 'p Psych::VERSION'
jruby 9.3.9.0 (2.6.8) 2022-10-24 537cd1f8bc Java HotSpot(TM) 64-Bit Server VM 25.271-b09 on 1.8.0_271-b09 +jit [x86_64-darwin]
"3.3.4
```

And it removes redundant `permitted_symbols` keyword parameter (`[]` by default) from `YAML.safe_load`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
