### PR TITLE
Fix `Layout/ClosingParenthesisIndentation` for keyword splat arguments

### DIFF
--- a/changelog/fix_closing_parenthesis_indentation_for_keyword_splat.md
+++ b/changelog/fix_closing_parenthesis_indentation_for_keyword_splat.md
@@ -1,0 +1,1 @@
+* [#11483](https://github.com/rubocop/rubocop/issues/11483): Fix `Layout/ClosingParenthesisIndentation` for keyword splat arguments. ([@fatkodima][])

--- a/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
+++ b/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
@@ -157,7 +157,7 @@ module RuboCop
         def all_elements_aligned?(elements)
           elements.flat_map do |e|
             if e.hash_type?
-              e.each_pair.map { |pair| pair.loc.column }
+              e.each_child_node.map { |child| child.loc.column }
             else
               e.loc.column
             end

--- a/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation, :config do
         RUBY
       end
 
+      it 'does not register an offense when using keyword splat arguments' do
+        expect_no_offenses(<<~RUBY)
+          some_method(x,
+            **options
+          )
+        RUBY
+      end
+
       it 'accepts a correctly indented )' do
         expect_no_offenses(<<~RUBY)
           some_method(a,


### PR DESCRIPTION
Fixes #11483.

We need to check all the hash children nodes (not only `pair`s).

```
$ ruby-parse -e 'foo(x: 1, **options, y: 2)'
```
```
(send nil :foo
  (kwargs
    (pair
      (sym :x)
      (int 1))
    (kwsplat
      (send nil :options))
    (pair
      (sym :y)
      (int 2))))
```