### PR TITLE
Fix an incorrect autocorrect for `Naming/BlockForwarding`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_block_forwarding.md
+++ b/changelog/fix_incorrect_autocorrect_for_block_forwarding.md
@@ -1,0 +1,1 @@
+* [#11400](https://github.com/rubocop/rubocop/issues/11400): Fix an incorrect autocorrect for `Naming/BlockForwarding` and `Lint/AmbiguousOperator` when autocorrection conflicts for ambiguous splat argument. ([@fatkodima][])

--- a/lib/rubocop/cop/lint/ambiguous_operator.rb
+++ b/lib/rubocop/cop/lint/ambiguous_operator.rb
@@ -38,6 +38,10 @@ module RuboCop
                      'a whitespace to the right of the `%<operator>s` if it ' \
                      'should be %<possible>s.'
 
+        def self.autocorrect_incompatible_with
+          [Naming::BlockForwarding]
+        end
+
         def on_new_investigation
           processed_source.diagnostics.each do |diagnostic|
             next unless diagnostic.reason == :ambiguous_prefix

--- a/lib/rubocop/cop/naming/block_forwarding.rb
+++ b/lib/rubocop/cop/naming/block_forwarding.rb
@@ -47,6 +47,10 @@ module RuboCop
 
         MSG = 'Use %<style>s block forwarding.'
 
+        def self.autocorrect_incompatible_with
+          [Lint::AmbiguousOperator]
+        end
+
         def on_def(node)
           return if node.arguments.empty?
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -405,6 +405,28 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Naming/BlockForwarding` with `Lint/AmbiguousOperator`' do
+    create_file('.rubocop.yml', <<~YAML)
+      AllCops:
+        TargetRubyVersion: 3.1
+    YAML
+    source = <<~RUBY
+      def foo(options, &block)
+        bar **options, &block
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--autocorrect',
+                     '--only', 'Naming/BlockForwarding,Lint/AmbiguousOperator'
+                   ])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      def foo(options, &)
+        bar(**options, &)
+      end
+    RUBY
+  end
+
   describe 'trailing comma cops' do
     let(:source) do
       <<~RUBY


### PR DESCRIPTION
Fixes #11400.