### PR TITLE
Fix a false positive for `Lint/FormatParameterMismatch` when format string is only interpolated string

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_format_paramater_mismatch.md
+++ b/changelog/fix_a_false_positive_for_lint_format_paramater_mismatch.md
@@ -1,0 +1,1 @@
+* [#11487](https://github.com/rubocop/rubocop/pull/11487): Fix a false positive for `Lint/FormatParameterMismatch` when format string is only interpolated string. ([@ydah][])

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -80,6 +80,7 @@ module RuboCop
           num_of_format_args, num_of_expected_fields = count_matches(node)
 
           return false if num_of_format_args == :unknown
+          return false if num_of_expected_fields.zero? && node.child_nodes.first.dstr_type?
 
           matched_arguments_count?(num_of_expected_fields, num_of_format_args)
         end

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -51,6 +51,13 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch, :config do
     RUBY
   end
 
+  it 'registers an offense when there are no expected format string' do
+    expect_offense(<<~RUBY)
+      format("something", 1)
+      ^^^^^^ Number of arguments (1) to `format` doesn't match the number of fields (0).
+    RUBY
+  end
+
   it 'registers an offense when there are more arguments than expected' do
     expect_offense(<<~RUBY)
       format("%s %s", 1, 2, 3)
@@ -314,6 +321,10 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch, :config do
       expect_no_offenses('format("#{foo} %s", "bar")')
     end
 
+    it 'does not register an offense when only interpolated string' do
+      expect_no_offenses('format("#{foo}", "bar", "baz")')
+    end
+
     it 'registers an offense for String#% when the fields do not match' do
       expect_offense(<<~'RUBY')
         "%s %s" % ["#{foo}", 1, 2]
@@ -323,6 +334,10 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch, :config do
 
     it 'does not register an offense for String#% when the fields match' do
       expect_no_offenses('"%s %s" % ["#{foo}", 1]')
+    end
+
+    it 'does not register an offense for String#% when only interpolated string' do
+      expect_no_offenses('"#{foo}" % [1, 2]')
     end
   end
 


### PR DESCRIPTION
This PR is Follow up: https://github.com/rubocop/rubocop/pull/11464#issuecomment-1400880819

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
