### PR TITLE
[Fix #11485] Fix a false positive for `Lint/UselessAssignment`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_useless_assignment.md
+++ b/changelog/fix_a_false_positive_for_lint_useless_assignment.md
@@ -1,0 +1,1 @@
+* [#11485](https://github.com/rubocop/rubocop/issues/11485): Fix a false positive for `Lint/UselessAssignment` when using numbered block parameter. ([@koic][])

--- a/lib/rubocop/cop/variable_force/variable_table.rb
+++ b/lib/rubocop/cop/variable_force/variable_table.rb
@@ -97,8 +97,10 @@ module RuboCop
           scope_stack.reverse_each do |scope|
             variable = scope.variables[name]
             return variable if variable
+
             # Only block scope allows referencing outer scope variables.
-            return nil unless scope.node.block_type?
+            node = scope.node
+            return nil unless node.block_type? || node.numblock_type?
           end
 
           nil

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1318,6 +1318,16 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'using numbered block parameter', :ruby27 do
+    it 'does not register an offense when the variable is used' do
+      expect_no_offenses(<<~RUBY)
+        var = 42
+
+        do_something { _1 == var }
+      RUBY
+    end
+  end
+
   # regression test, from problem in Locatable
   context 'when a variable is assigned in 2 identical if branches' do
     it "doesn't think 1 of the 2 assignments is useless" do


### PR DESCRIPTION
Fixes #11485.

This PR fixes a false positive for `Lint/UselessAssignment` when using numbered block parameter.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
