### PR TITLE
Fix an indentation for `Lint/HeredocMethodCallPosition` cop's documentation

### DIFF
--- a/lib/rubocop/cop/lint/heredoc_method_call_position.rb
+++ b/lib/rubocop/cop/lint/heredoc_method_call_position.rb
@@ -8,27 +8,25 @@ module RuboCop
       #
       # @example
       #   # bad
+      #   <<-SQL
+      #     bar
+      #   SQL
+      #   .strip_indent
       #
-      #      <<-SQL
-      #        bar
-      #      SQL
-      #      .strip_indent
-      #
-      #      <<-SQL
-      #        bar
-      #      SQL
-      #      .strip_indent
-      #      .trim
+      #   <<-SQL
+      #     bar
+      #   SQL
+      #   .strip_indent
+      #   .trim
       #
       #   # good
+      #   <<~SQL
+      #     bar
+      #   SQL
       #
-      #      <<~SQL
-      #        bar
-      #      SQL
-      #
-      #      <<~SQL.trim
-      #        bar
-      #      SQL
+      #   <<~SQL.trim
+      #     bar
+      #   SQL
       #
       class HeredocMethodCallPosition < Base
         include RangeHelp


### PR DESCRIPTION
This PR is fix an indentation for `Lint/HeredocMethodCallPosition` cop's documentation.

<img width="600px" src="https://user-images.githubusercontent.com/13041216/214262572-e0609b3a-3dae-49a3-8b95-8a4c5cff02f4.png"/>


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
