### PR TITLE
Fix a crash on Lint/UselessAssignment

### DIFF
--- a/changelog/fix_a_crash_on_lint_useless_assignment.md
+++ b/changelog/fix_a_crash_on_lint_useless_assignment.md
@@ -1,0 +1,1 @@
+* [#11491](https://github.com/rubocop/rubocop/pull/11491): Fix a crash on Lint/UselessAssignment. ([@gsamokovarov][])

--- a/lib/rubocop/cop/variable_force/scope.rb
+++ b/lib/rubocop/cop/variable_force/scope.rb
@@ -45,9 +45,9 @@ module RuboCop
             node
           else
             child_index = case node.type
-                          when :module, :sclass     then 1
-                          when :def, :class, :block then 2
-                          when :defs                then 3
+                          when :module, :sclass then 1
+                          when :def, :class, :block, :numblock then 2
+                          when :defs then 3
                           end
 
             node.children[child_index]

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -266,6 +266,13 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         end
       RUBY
     end
+
+    it 'registers offenses for self assignment in numblock', :ruby27 do
+      expect_offense(<<~RUBY)
+        do_something { foo += _1 }
+                       ^^^ Useless assignment to variable - `foo`. Use `+` instead of `+=`.
+      RUBY
+    end
   end
 
   context 'when a variable is assigned in loop body and unreferenced' do


### PR DESCRIPTION
The crash is:

```
TypeError:
  no implicit conversion from nil to integer
# ./lib/rubocop/cop/variable_force/scope.rb:53:in `body_node'
```

it happened for nodes like:

```
s(:numblock,
  s(:send,
    s(:begin,
      s(:irange,
        s(:int, 0),
        s(:int, 10))), :each), 1,
  s(:op_asgn,
    s(:lvasgn, :checksum_total), :+,
    s(:send,
      s(:send,
        s(:lvar, :checksum_multiplier_by_position), :[],
        s(:lvar, :_1)), :*,
      s(:send,
        s(:send,
          s(:lvar, :contact_tax_number), :[],
          s(:lvar, :_1)), :to_i))))
```