### PR TITLE
[Fix #11492] Fix an error for `Lint/Void`

### DIFF
--- a/changelog/fix_an_error_for_lint_void.md
+++ b/changelog/fix_an_error_for_lint_void.md
@@ -1,0 +1,1 @@
+* [#11492](https://github.com/rubocop/rubocop/issues/11492): Fix an error for `Lint/Void` when configuring `CheckForMethodsWithNoSideEffects: true`. ([@koic][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -128,6 +128,8 @@ module RuboCop
         end
 
         def check_nonmutating(node)
+          return unless node.respond_to?(:method_name)
+
           method_name = node.method_name
           return unless NONMUTATING_METHODS.include?(method_name)
 

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -255,6 +255,13 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         top(x)
       RUBY
     end
+
+    it 'does not register an offense assigning variable' do
+      expect_no_offenses(<<~RUBY)
+        foo = bar
+        baz
+      RUBY
+    end
   end
 
   context 'when not checking for methods with no side effects' do


### PR DESCRIPTION
Fixes #11492.

This PR fixes an error for `Lint/Void` when configuring `CheckForMethodsWithNoSideEffects: true`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
