### PR TITLE
Use `registers an offense` instead of `registers a offense`

### DIFF
--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
   context 'compact style' do
     let(:cop_config) { { 'EnforcedStyle' => 'compact' } }
 
-    it 'registers a offense for classes with nested children' do
+    it 'registers an offense for classes with nested children' do
       expect_offense(<<~RUBY)
         class FooClass
               ^^^^^^^^ Use compact module/class definition instead of nested style.
@@ -205,7 +205,7 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       RUBY
     end
 
-    it 'registers a offense for modules with nested children' do
+    it 'registers an offense for modules with nested children' do
       expect_offense(<<~RUBY)
         module FooModule
                ^^^^^^^^^ Use compact module/class definition instead of nested style.
@@ -367,7 +367,7 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       RUBY
     end
 
-    it 'registers a offense for classes with nested one-liner children' do
+    it 'registers an offense for classes with nested one-liner children' do
       expect_offense(<<~RUBY)
         class FooClass
               ^^^^^^^^ Use compact module/class definition instead of nested style.


### PR DESCRIPTION
This PR is use `registers an offense` instead of `registers a offense`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
