### PR TITLE
[Fix #11503] Fix a false positive for `Style/RedundantCondition`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_condition.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_condition.md
@@ -1,0 +1,1 @@
+* [#11503](https://github.com/rubocop/rubocop/issues/11503): Fix a false positive for `Style/RedundantCondition` when using method argument with operator. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -352,6 +352,84 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
+      it 'does not register an offense when the branches contains splat argument' do
+        expect_no_offenses(<<~RUBY)
+          if foo
+            bar(foo)
+          else
+            bar(*baz)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when the branches contains double splat argument' do
+        expect_no_offenses(<<~RUBY)
+          if foo
+            bar(foo)
+          else
+            bar(**baz)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when the branches contains block argument' do
+        expect_no_offenses(<<~RUBY)
+          if foo
+            bar(foo)
+          else
+            bar(&baz)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when the branches contains anonymous splat argument', :ruby32 do
+        expect_no_offenses(<<~RUBY)
+          def do_something(foo, *)
+            if foo
+              bar(foo)
+            else
+              bar(*)
+            end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when the branches contains anonymous double splat argument', :ruby32 do
+        expect_no_offenses(<<~RUBY)
+          def do_something(foo, **)
+            if foo
+              bar(foo)
+            else
+              bar(**)
+            end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when the branches contains anonymous block argument', :ruby31 do
+        expect_no_offenses(<<~RUBY)
+          def do_something(foo, &)
+            if foo
+              bar(foo)
+            else
+              bar(&)
+            end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when the branches contains arguments fowarding', :ruby27 do
+        expect_no_offenses(<<~RUBY)
+          def do_something(foo, ...)
+            if foo
+              bar(foo)
+            else
+              bar(...)
+            end
+          end
+        RUBY
+      end
+
       it 'does not register offenses when using `nil?` and the branches contains assignment' do
         expect_no_offenses(<<~RUBY)
           if foo.nil?


### PR DESCRIPTION
Fixes #11503.

This PR fixes a false positive for `Style/RedundantCondition` when using method argument with operator.
It fixes false positives that produce syntax errors in addition to the cases reported in #11503.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
