### PR TITLE
[Fix #11504] Allow `initialize` method in `Style/DocumentationMethod`

### DIFF
--- a/changelog/change_allow_initialize_method_in_sytle_documentation_method.md
+++ b/changelog/change_allow_initialize_method_in_sytle_documentation_method.md
@@ -1,0 +1,1 @@
+* [#11504](https://github.com/rubocop/rubocop/issues/11504): Allow `initialize` method in `Style/DocumentationMethod`. ([@koic][])

--- a/lib/rubocop/cop/style/documentation_method.rb
+++ b/lib/rubocop/cop/style/documentation_method.rb
@@ -7,6 +7,10 @@ module RuboCop
       # It can optionally be configured to also require documentation for
       # non-public methods.
       #
+      # NOTE: This cop allows `initialize` method because `initialize` is
+      # a special method called from `new`. In some programming languages
+      # they are called constructor to distinguish it from method.
+      #
       # @example
       #
       #   # bad
@@ -103,6 +107,8 @@ module RuboCop
         PATTERN
 
         def on_def(node)
+          return if node.method?(:initialize)
+
           parent = node.parent
           module_function_node?(parent) ? check(parent) : check(node)
         end

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
         end
       end
 
+      context 'when `initialize` method' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            def initialize
+            end
+          RUBY
+        end
+      end
+
       context 'when method is private' do
         it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #11504.

This PR makes to allow `initialize` method in `Style/DocumentationMethod` because `initialize` is a special method called from `new`. In some languages they are called constructor to distinguish it from method.

So it would be different from the following intent that this cop wants to detect.

> Checks for missing documentation comment for public methods.
> It can optionally be configured to also require documentation for
> non-public methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
