### PR TITLE
[Fix #11508] Fix a false positive for `Style/OperatorMethodCall`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_operator_method_call.md
+++ b/changelog/fix_a_false_positive_for_style_operator_method_call.md
@@ -1,0 +1,1 @@
+* [#11508](https://github.com/rubocop/rubocop/issues/11508): Fix a false positive for `Style/OperatorMethodCall` when using multiple arguments for operator method. ([@koic][])

--- a/lib/rubocop/cop/style/operator_method_call.rb
+++ b/lib/rubocop/cop/style/operator_method_call.rb
@@ -25,7 +25,7 @@ module RuboCop
 
         def on_send(node)
           return unless (dot = node.loc.dot)
-          return if node.receiver.const_type?
+          return if node.receiver.const_type? || !node.arguments.one?
 
           _lhs, _op, rhs = *node
           return if !rhs || method_call_with_parenthesized_arg?(rhs) || anonymous_forwarding?(rhs)

--- a/spec/rubocop/cop/style/operator_method_call_spec.rb
+++ b/spec/rubocop/cop/style/operator_method_call_spec.rb
@@ -97,6 +97,12 @@ RSpec.describe RuboCop::Cop::Style::OperatorMethodCall, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when using multiple arguments' do
+      expect_no_offenses(<<~RUBY)
+        foo.#{operator_method}(bar, baz)
+      RUBY
+    end
   end
 
   it 'registers an offense when using `foo.+({})`' do


### PR DESCRIPTION
Fixes #11508.

This PR fixes a false positive for `Style/OperatorMethodCall` when using multiple arguments for operator method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
