### PR TITLE
[Fix #11511] Fix a false negative for `Style/YodaCondition`

### DIFF
--- a/changelog/fix_a_false_negative_for_style_yoda_condition.md
+++ b/changelog/fix_a_false_negative_for_style_yoda_condition.md
@@ -1,0 +1,1 @@
+* [#11511](https://github.com/rubocop/rubocop/issues/11511): Fix a false negative for `Style/YodaCondition` when using constant. ([@koic][])

--- a/lib/rubocop/cop/layout/space_around_keyword.rb
+++ b/lib/rubocop/cop/layout/space_around_keyword.rb
@@ -241,7 +241,7 @@ module RuboCop
         end
 
         def accept_namespace_operator?(range)
-          ACCEPT_NAMESPACE_OPERATOR == range.source
+          range.source == ACCEPT_NAMESPACE_OPERATOR
         end
 
         def safe_navigation_call?(range, pos)

--- a/lib/rubocop/server/client_command/exec.rb
+++ b/lib/rubocop/server/client_command/exec.rb
@@ -41,7 +41,7 @@ module RuboCop
         end
 
         def incompatible_version?
-          RuboCop::Version::STRING != Cache.version_path.read
+          Cache.version_path.read != RuboCop::Version::STRING
         end
 
         def stderr

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe RuboCop::Cop::Style::YodaCondition, :config do
       expect_no_offenses('foo == "bar"')
     end
 
+    it 'accepts constant on right' do
+      expect_no_offenses('foo == BAR')
+    end
+
     it 'accepts interpolated string on left' do
       expect_no_offenses('"#{interpolation}" == foo')
     end
@@ -135,6 +139,17 @@ RSpec.describe RuboCop::Cop::Style::YodaCondition, :config do
 
       expect_correction(<<~RUBY)
         bar > 42
+      RUBY
+    end
+
+    it 'registers an offense constant on left of comparison' do
+      expect_offense(<<~RUBY)
+        FOO < bar
+        ^^^^^^^^^ Reverse the order of the operands `FOO < bar`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        bar > FOO
       RUBY
     end
 


### PR DESCRIPTION
Fixes #11511.

This PR fixes a false negative for `Style/YodaCondition` when using constant.
Yoda conditions targets constant but only handles literal. This patch makes constant aware.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
