### PR TITLE
Fix missing parentheses in shorthand hash syntax as argument calls

### DIFF
--- a/changelog/fix_parentheses_in_shorthand_hash_syntax_as.md
+++ b/changelog/fix_parentheses_in_shorthand_hash_syntax_as.md
@@ -1,0 +1,1 @@
+* [#11516](https://github.com/rubocop/rubocop/pull/11516): Fix missing parentheses in shorthand hash syntax as argument calls. ([@gsamokovarov][])

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1385,6 +1385,21 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'registers an offense in arguments as method calls with hash omissions' do
+        expect_offense(<<~RUBY)
+          if condition?
+            raise LongLongLongLongError.new 'A long, long, long, long, really long message', foo: foo
+                                                                                                  ^^^ Omit the hash value.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if condition?
+            raise LongLongLongLongError.new('A long, long, long, long, really long message', foo:)
+          end
+        RUBY
+      end
+
       context 'when hash roket syntax' do
         let(:enforced_style) { 'hash_rockets' }
 


### PR DESCRIPTION
Previously, `Style/HashSyntax` would autocorrect the code:

```ruby
raise Errors.new 'No!', foo: foo
```
to 👇:

```ruby
raise Errors.new 'No!', foo:
```

While it may lead to valid code _in this case_, parentheses around `Error.new` are required in edge cases like condition that we can inline to a modifier form after we apply the shorthand hash syntax.

In this example:

```ruby
if condition?
  raise Error.new 'A long error message...', foo: foo
end
```

we would autocorrect to invalid Ruby code:

```ruby
raise Error.new 'A long error message...', foo: if condition?
```

Putting parentheses in method calls that return value as an argument in another call is the safest autocorrection in this case. I'm starting to wonder whether we always put the parentheses in them method calls as it's generally safer to autocorrect.

