### PR TITLE
[Fix #11517] Make `Lint/Debugger` aware of some debug methods

### DIFF
--- a/changelog/change_make_lint_debugger_aware_of_some_debug_methods.md
+++ b/changelog/change_make_lint_debugger_aware_of_some_debug_methods.md
@@ -1,0 +1,1 @@
+* [#11517](https://github.com/rubocop/rubocop/issues/11517): Make `Lint/Debugger` aware of `p`, `PP.pp`, and `pp` methods. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1639,6 +1639,7 @@ Lint/Debugger:
     # a user's configuration, but are otherwise not significant.
     Kernel:
       - binding.irb
+      - p
       - Kernel.binding.irb
     Byebug:
       - byebug
@@ -1648,6 +1649,9 @@ Lint/Debugger:
     Capybara:
       - save_and_open_page
       - save_and_open_screenshot
+    PP:
+      - PP.pp
+      - pp
     debug.rb:
       - binding.b
       - binding.break


### PR DESCRIPTION
Fixes #11517.

This PR makes `Lint/Debugger` aware of `p`, `PP.pp`, and `pp` methods. These are used for debugging purposes basically. OTOH, `puts` is not included in the config because it is used for the intended standard output.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
