### PR TITLE
Fix a false negative for `Style/YodaExpression`

### DIFF
--- a/changelog/fix_a_false_negative_for_style_yoda_expression.md
+++ b/changelog/fix_a_false_negative_for_style_yoda_expression.md
@@ -1,0 +1,1 @@
+* [#11520](https://github.com/rubocop/rubocop/pull/11520): Fix a false negative for `Style/YodaExpression` when using constant. ([@koic][])

--- a/lib/rubocop/cop/style/yoda_expression.rb
+++ b/lib/rubocop/cop/style/yoda_expression.rb
@@ -24,12 +24,14 @@ module RuboCop
       #   1 + x
       #   10 * y
       #   1 & z
+      #   1 + CONST
       #
       #   # good
       #   60 * 24
       #   x + 1
       #   y * 10
       #   z & 1
+      #   CONST + 1
       #
       #   # good
       #   1 | x
@@ -50,8 +52,7 @@ module RuboCop
 
           lhs = node.receiver
           rhs = node.first_argument
-          return if !lhs.numeric_type? || rhs.numeric_type?
-
+          return unless yoda_expression_constant?(lhs, rhs)
           return if offended_ancestor?(node)
 
           message = format(MSG, source: rhs.source)
@@ -63,6 +64,14 @@ module RuboCop
         end
 
         private
+
+        def yoda_expression_constant?(lhs, rhs)
+          constant_portion?(lhs) && !constant_portion?(rhs)
+        end
+
+        def constant_portion?(node)
+          node.numeric_type? || node.const_type?
+        end
 
         def supported_operators
           Array(cop_config['SupportedOperators'])

--- a/spec/rubocop/cop/style/yoda_expression_spec.rb
+++ b/spec/rubocop/cop/style/yoda_expression_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Style::YodaExpression, :config do
   let(:cop_config) { { 'SupportedOperators' => ['*', '+'] } }
 
-  it 'registers an offense when using simple offended example' do
+  it 'registers an offense when numeric literal on left' do
     expect_offense(<<~RUBY)
       1 + x
       ^^^^^ Non-literal operand (`x`) should be first.
@@ -14,7 +14,18 @@ RSpec.describe RuboCop::Cop::Style::YodaExpression, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects when using complex offended example' do
+  it 'registers an offense when constant on left' do
+    expect_offense(<<~RUBY)
+      CONST + x
+      ^^^^^^^^^ Non-literal operand (`x`) should be first.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x + CONST
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using complex use of numeric literals' do
     expect_offense(<<~RUBY)
       2 + (1 + x)
       ^^^^^^^^^^^ Non-literal operand (`(1 + x)`) should be first.
@@ -25,16 +36,32 @@ RSpec.describe RuboCop::Cop::Style::YodaExpression, :config do
     RUBY
   end
 
-  it 'accepts numeric on the right' do
-    expect_no_offenses(<<~RUBY)
-      1 + 2
-      1 + 2.2
+  it 'registers an offense and corrects when using complex use of constants' do
+    expect_offense(<<~RUBY)
+      TWO + (ONE + x)
+      ^^^^^^^^^^^^^^^ Non-literal operand (`(ONE + x)`) should be first.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (x + ONE) + TWO
     RUBY
   end
 
-  it 'accepts non integer' do
+  it 'accepts numeric literal on the right' do
     expect_no_offenses(<<~RUBY)
-      x + 1
+      x + 42
+    RUBY
+  end
+
+  it 'accepts constant on the right' do
+    expect_no_offenses(<<~RUBY)
+      x + FORTY_TWO
+    RUBY
+  end
+
+  it 'accepts neither numeric literal nor constant' do
+    expect_no_offenses(<<~RUBY)
+      x + y
     RUBY
   end
 


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/11512#issuecomment-1408044549.

This PR fixes a false negative for `Style/YodaExpression` when using constant.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
