### PR TITLE
Don't flag default keyword arguments in `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/fix_don_t_default_keyword_arguments_in.md
+++ b/changelog/fix_don_t_default_keyword_arguments_in.md
@@ -1,0 +1,1 @@
+* [#11522](https://github.com/rubocop/rubocop/pull/11522): Don't flag default keyword arguments in `Style/ArgumentsForwarding`. ([@splattael][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -84,6 +84,7 @@ module RuboCop
         def on_def(node)
           return unless node.body
           return unless (rest_args_name, args = use_rest_arguments?(node.arguments))
+          return if args.any?(&:default?)
 
           node.each_descendant(:send) do |send_node|
             kwargs_name, block_name = extract_argument_names_from(args)

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     end
 
     it 'does not register an offense when assigning the restarg outside forwarding method arguments' do
-      expect_no_offenses(<<~'RUBY')
+      expect_no_offenses(<<~RUBY)
         def foo(*args, &block)
           var = args
           foo(*args, &block)
@@ -188,7 +188,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     end
 
     it 'does not register an offense when body of method definition is empty' do
-      expect_no_offenses(<<~'RUBY')
+      expect_no_offenses(<<~RUBY)
         def foo(*args, &block)
         end
       RUBY
@@ -245,6 +245,22 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
         expect_correction(<<~RUBY)
           def foo(...)
             bar(...)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense with default positional arguments' do
+        expect_no_offenses(<<~RUBY)
+          def foo(arg=1, *args)
+            bar(*args)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense with default keyword arguments' do
+        expect_no_offenses(<<~RUBY)
+          def foo(*args, arg: 1)
+            bar(*args)
           end
         RUBY
       end


### PR DESCRIPTION
This PR fixes the following false positive for :policeman: `Style/ArgumentsForwarding` with `AllowOnlyRestArgument: false`:

```ruby
        def migrate_in(*args, coordinator: coordinator_for_tracking_database)
          with_migration_context do
            coordinator.perform_in(*args)
          end
        end
```

It was flagged with:

```
lib/gitlab/database/migrations/background_migration_helpers.rb:203:24: C: [Correctable] Style/ArgumentsForwarding: Use arguments forwarding.
        def migrate_in(*args, coordinator: coordinator_for_tracking_database)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/gitlab/database/migrations/background_migration_helpers.rb:205:36: C: [Correctable] Style/ArgumentsForwarding: Use arguments forwarding.
            coordinator.perform_in(*args)
                                   ^^^^^
```

When auto-corrected, the default argument is dropped which leads potentially to broken logic.

See https://gitlab.com/gitlab-org/gitlab/-/merge_requests/110350#note_1255162281.

Now, method definitions with default keyword arguments are skipped.

For completeness, this PR also adds a spec for default positional arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
