### PR TITLE
[Fix #11521] Fix a false positive for `Lint/FormatParameterMismatch`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_format_parameter_mismatch.md
+++ b/changelog/fix_a_false_positive_for_lint_format_parameter_mismatch.md
@@ -1,0 +1,1 @@
+* [#11521](https://github.com/rubocop/rubocop/issues/11521): Fix a false positive for `Lint/FormatParameterMismatch` when using `Kernel.format` with the interpolated number of decimal places fields match. ([@koic][])

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -80,7 +80,10 @@ module RuboCop
           num_of_format_args, num_of_expected_fields = count_matches(node)
 
           return false if num_of_format_args == :unknown
-          return false if num_of_expected_fields.zero? && node.child_nodes.first.dstr_type?
+
+          first_arg = node.first_argument
+          return false if num_of_expected_fields.zero? &&
+                          (first_arg.dstr_type? || first_arg.array_type?)
 
           matched_arguments_count?(num_of_expected_fields, num_of_format_args)
         end

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -325,6 +325,10 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch, :config do
       expect_no_offenses('format("#{foo}", "bar", "baz")')
     end
 
+    it 'does not register an offense when using `Kernel.format` with the interpolated number of decimal places fields match' do
+      expect_no_offenses('Kernel.format("%.#{number_of_decimal_places}f", num)')
+    end
+
     it 'registers an offense for String#% when the fields do not match' do
       expect_offense(<<~'RUBY')
         "%s %s" % ["#{foo}", 1, 2]


### PR DESCRIPTION
Fixes #11521.

This PR fixes a false positive for `Lint/FormatParameterMismatch` when using `Kernel.format` with the interpolated number of decimal places fields match.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
