### PR TITLE
Documentation: Clarify reference to TargetRubyVersion

### DIFF
--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -37,7 +37,7 @@ The following table is the runtime support matrix.
 
 RuboCop targets Ruby 2.0+ code analysis since RuboCop 1.30. It restored code analysis support that had been removed earlier by mistake, together with dropping runtime support for unsupported Ruby versions.
 
-NOTE: The compatibility xref:configuration.adoc#setting-the-target-ruby-version[target Ruby version mentioned here] is about code analysis (what RuboCop can analyze), not runtime (is RuboCop capable of running on some Ruby or not).
+NOTE: The compatibility xref:configuration.adoc#setting-the-target-ruby-version[setting `TargetRubyVersion`] is about code analysis (what RuboCop can analyze), not runtime (is RuboCop capable of running on some Ruby or not).
 
 == Forward Compatibility
 


### PR DESCRIPTION
Due to the structural and grammatical similarity of terms it isn't clear that "here" refers to the link and not the section of the page being read. This makes the assumption explicit, which will help those unfamiliar with the reference.

When used in an anchor tag' text "here" commonly refers to what is in the anchor's href target.

However, less familiar RuboCop users may not know that there is a setting literally called `TargetRubyVersion`, while the preceeding sentence uses the exact same language "target ruby version", and is not directly referring to the setting.  This can result in the reference to "here" being ambiguous.

Better to be explicit.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
