### PR TITLE
Fix an incorrect autocorrect for `Layout/ClassStructure` when definitions that need to be sorted are defined alternately

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_layout_class_structure.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_layout_class_structure.md
@@ -1,0 +1,1 @@
+* [#11529](https://github.com/rubocop/rubocop/pull/11529): Fix an incorrect autocorrect for `Layout/ClassStructure` when definitions that need to be sorted are defined alternately. ([@ydah][])

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -134,6 +134,7 @@ module RuboCop
       #
       class ClassStructure < Base
         include VisibilityHelp
+        include CommentsHelp
         extend AutoCorrector
 
         HUMANIZED_NODE_TYPE = {
@@ -163,7 +164,7 @@ module RuboCop
 
         # Autocorrect by swapping between two nodes autocorrecting them
         def autocorrect(corrector, node)
-          previous = node.left_siblings.find do |sibling|
+          previous = node.left_siblings.reverse.find do |sibling|
             !ignore_for_autocorrect?(node, sibling)
           end
           return unless previous
@@ -281,21 +282,6 @@ module RuboCop
           return false unless node.method?(:private_constant)
 
           node.arguments.any? { |arg| (arg.sym_type? || arg.str_type?) && arg.value == name }
-        end
-
-        def source_range_with_comment(node)
-          begin_pos, end_pos =
-            if (node.def_type? && !node.method?(:initialize)) ||
-               (node.send_type? && node.def_modifier?)
-              start_node = find_visibility_start(node) || node
-              end_node = find_visibility_end(node) || node
-              [begin_pos_with_comment(start_node),
-               end_position_for(end_node) + 1]
-            else
-              [begin_pos_with_comment(node), end_position_for(node)]
-            end
-
-          Parser::Source::Range.new(buffer, begin_pos, end_pos)
         end
 
         def end_position_for(node)

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -404,9 +404,9 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
         class A
           public def bar
           end
-
           private def foo
           end
+
         end
       RUBY
     end
@@ -427,9 +427,37 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
         class A
           def bar
           end
-
           private def foo
           end
+
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when definitions that need to be sorted are defined alternately' do
+      expect_offense(<<~RUBY)
+        class A
+          private def foo; end
+
+          def bar; end
+          ^^^^^^^^^^^^ `public_methods` is supposed to appear before `private_methods`.
+
+          private def baz; end
+
+          def qux; end
+          ^^^^^^^^^^^^ `public_methods` is supposed to appear before `private_methods`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class A
+          def bar; end
+          def qux; end
+          private def foo; end
+
+
+          private def baz; end
+
         end
       RUBY
     end
@@ -451,10 +479,10 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
         class A
           def bar
           end
-
           def foo
           end
           private :foo
+
         end
       RUBY
     end


### PR DESCRIPTION
This PR is fix an incorrect autocorrect for `Layout/ClassStructure` when definitions that need to be sorted are defined alternately.

## Code to reproduce

```ruby
class A
  private def foo; end

  def bar; end

  private def baz; end

  def qux; end
end
```

## Expected behavior

Automatically corrected as follows:

```ruby
class A
  def bar; end

  def qux; end

  private def foo; end

  private def baz; end
end
```

## Actual behavior

Automatically corrected as follows:

```ruby
class A
  def qux; end

  def bar; end

  def qux; end # <------ Duplicate

  private def foo; end

  private def baz; end
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
