### PR TITLE
Fix an incorrect autocorrect for `Style/AccessModifierDeclarations` when multiple groupable access modifiers are defined

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_access_modifier_declarations.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_access_modifier_declarations.md
@@ -1,0 +1,1 @@
+* [#11530](https://github.com/rubocop/rubocop/pull/11530): Fix an incorrect autocorrect for `Style/AccessModifierDeclarations` when multiple groupable access modifiers are defined. ([@ydah][])

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -129,7 +129,8 @@ module RuboCop
         end
 
         def offense?(node)
-          (group_style? && access_modifier_is_inlined?(node)) ||
+          (group_style? && access_modifier_is_inlined?(node) &&
+            !right_siblings_same_inline_method?(node)) ||
             (inline_style? && access_modifier_is_not_inlined?(node))
         end
 
@@ -147,6 +148,12 @@ module RuboCop
 
         def access_modifier_is_not_inlined?(node)
           !access_modifier_is_inlined?(node)
+        end
+
+        def right_siblings_same_inline_method?(node)
+          node.right_siblings.any? do |sibling|
+            sibling.method?(node.method_name) && !sibling.arguments.empty?
+          end
         end
 
         def message(range)

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -250,6 +250,28 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
 
       include_examples 'always accepted', access_modifier
     end
+
+    it 'offends when multiple groupable access modifiers are defined' do
+      expect_offense(<<~RUBY)
+        class Test
+          private def foo; end
+          private def bar; end
+          ^^^^^^^ `private` should not be inlined in method definitions.
+          def baz; end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Test
+          def baz; end
+        private
+
+        def foo; end
+
+        def bar; end
+        end
+      RUBY
+    end
   end
 
   context 'when `inline` is configured' do


### PR DESCRIPTION
This PR is fix an incorrect autocorrect for `Style/AccessModifierDeclarations` when multiple groupable access modifiers are defined.

## Code to reproduce

```ruby
class Test
  private def foo; end
  private def bar; end
  def baz; end
end
```

## Expected behavior

Automatically corrected as follows:

```ruby
class Test
  def baz; end

  private

  def foo; end

  def bar; end
end
```

## Actual behavior

Automatically corrected as follows:

```ruby
class Test
  def baz; end
private

def bar; end # <--- The order is changing
private # <--- Duplicate

def foo; end # <--- The order is changing
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
