### PR TITLE
[Fix #11535] Fix a false positive for `Style/NumberedParametersLimit`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_numbered_parameters_limit.md
+++ b/changelog/fix_a_false_positive_for_style_numbered_parameters_limit.md
@@ -1,0 +1,1 @@
+* [#11535](https://github.com/rubocop/rubocop/issues/11535): Fix a false positive for `Style/NumberedParametersLimit` when only `_2` or higher numbered parameter is used. ([@koic][])

--- a/spec/rubocop/cop/style/numbered_parameters_limit_spec.rb
+++ b/spec/rubocop/cop/style/numbered_parameters_limit_spec.rb
@@ -54,6 +54,31 @@ RSpec.describe RuboCop::Cop::Style::NumberedParametersLimit, :config do
     context 'when Max is 1' do
       let(:max) { 1 }
 
+      it 'does not register an offense when only numbered parameter `_1` is used once' do
+        expect_no_offenses(<<~RUBY)
+          foo { do_something(_1) }
+        RUBY
+      end
+
+      it 'does not register an offense when only numbered parameter `_1` is used twice' do
+        expect_no_offenses(<<~RUBY)
+          foo { do_something(_1, _1) }
+        RUBY
+      end
+
+      it 'does not register an offense when only numbered parameter `_9` is used once' do
+        expect_no_offenses(<<~RUBY)
+          foo { do_something(_9) }
+        RUBY
+      end
+
+      it 'does not register an offense when using numbered parameter with underscored local variable' do
+        expect_no_offenses(<<~RUBY)
+          _lvar = 42
+          foo { do_something(_2, _lvar) }
+        RUBY
+      end
+
       it 'uses the right offense message' do
         expect_offense(<<~RUBY)
           foo { do_something(_1, _2, _3, _4, _5) }


### PR DESCRIPTION
Fixes #11535.

This PR fixes a false positive for `Style/NumberedParametersLimit` when only `_2` or higher numbered parameter is used.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
