### PR TITLE
Fix an infinite loop error for `Layout/ArrayAlignment`

### DIFF
--- a/changelog/fix_infinite_loop_error_for_layout_array_alignment.md
+++ b/changelog/fix_infinite_loop_error_for_layout_array_alignment.md
@@ -1,0 +1,1 @@
+* [#11537](https://github.com/rubocop/rubocop/pull/11537): Fix an infinite loop error for `Layout/ArrayAlignment` when using assigning unbracketed array elements. ([@koic][])

--- a/lib/rubocop/cop/layout/array_alignment.rb
+++ b/lib/rubocop/cop/layout/array_alignment.rb
@@ -76,7 +76,7 @@ module RuboCop
         end
 
         def target_method_lineno(node)
-          node.loc.line
+          node.bracketed? ? node.loc.line : node.parent.loc.line
         end
       end
     end

--- a/spec/rubocop/cop/layout/array_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/array_alignment_spec.rb
@@ -202,6 +202,39 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment, :config do
       RUBY
     end
 
+    it 'accepts when assigning aligned bracketed array elements' do
+      expect_no_offenses(<<~RUBY)
+        var = [
+          first,
+          second
+        ]
+      RUBY
+    end
+
+    it 'accepts when assigning aligned unbracketed array elements' do
+      expect_no_offenses(<<~RUBY)
+        var =
+          first,
+          second
+      RUBY
+    end
+
+    it 'registers an offense when assigning not aligned unbracketed array elements' do
+      expect_offense(<<~RUBY)
+        var =
+             first,
+             ^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
+            second
+            ^^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var =
+          first,
+          second
+      RUBY
+    end
+
     it 'accepts single line array' do
       expect_no_offenses('array = [ a, b ]')
     end


### PR DESCRIPTION
Fixes https://github.com/testdouble/standard/issues/517.

This PR fixes an infinite loop error for `Layout/ArrayAlignment` when using assigning unbracketed array elements.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
