### PR TITLE
Remove `bundler` from the default `AllowedGems` of `Gemspec/DevelopmentDependencies`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 gem 'asciidoctor'
 gem 'bump', require: false
+gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'memory_profiler', platform: :mri
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'

--- a/changelog/change_remove_bundler_from_default_allowed_gems.md
+++ b/changelog/change_remove_bundler_from_default_allowed_gems.md
@@ -1,0 +1,1 @@
+* [#11539](https://github.com/rubocop/rubocop/pull/11539): Remove `bundler` from default `AllowedGems` of `Gemspec/DevelopmentDependencies`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -271,8 +271,7 @@ Gemspec/DevelopmentDependencies:
     - Gemfile
     - gems.rb
     - gemspec
-  AllowedGems:
-    - bundler
+  AllowedGems: []
   Include:
     - '**/*.gemspec'
     - '**/Gemfile'

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -40,6 +40,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rubocop-ast', '>= 1.24.1', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 2.4.0', '< 3.0')
-
-  s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
 end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/11469#issuecomment-1400134564.

This PR removes `bundler` from default `AllowedGems` of `Gemspec/DevelopmentDependencies` It is a oversight of RuboCop development and should not be configured globally in config/default.yml.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
