### PR TITLE
Allow legacy cop names in upcoming changelog entries

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -239,14 +239,21 @@ RSpec.describe 'RuboCop Project', type: :feature do
     include_examples 'has Changelog format'
 
     context 'future entries' do
-      let(:all_cop_names) do
+      let(:allowed_cop_names) do
+        existing_cop_names.to_set.union(legacy_cop_names)
+      end
+
+      let(:existing_cop_names) do
         RuboCop::Cop::Cop
           .registry
           .without_department(:Test)
           .without_department(:Test2)
           .cops
           .map(&:cop_name)
-          .to_set
+      end
+
+      let(:legacy_cop_names) do
+        RuboCop::ConfigObsoletion.legacy_cop_names
       end
 
       dir = File.expand_path('../changelog', __dir__)
@@ -279,7 +286,7 @@ RSpec.describe 'RuboCop Project', type: :feature do
           it 'has valid cop name with backticks', :aggregate_failures do
             entries.each do |entry|
               entry.scan(%r{\b[A-Z]\w+(?:/[A-Z]\w+)+\b}) do |cop_name|
-                expect(all_cop_names.include?(cop_name))
+                expect(allowed_cop_names.include?(cop_name))
                   .to be(true), "Invalid cop name #{cop_name}."
                 expect(entry.include?("`#{cop_name}`"))
                   .to be(true), "Missing backticks for #{cop_name}."


### PR DESCRIPTION
Sometimes cops are renamed or removed so it should be allowed to use this name in changelog entries.

A follow-up of https://github.com/rubocop/rubocop/pull/11525.

### Verification

Tested by using a removed or renamed cop name in changelog entry like `Gemspec/DateAssignment`:

```diff
diff --git a/changelog/fix_a_false_negative_for_style_yoda_expression.md b/changelog/fix_a_false_negative_for_style_yoda_expression.md
index 874f0b535..3071b22de 100644
--- a/changelog/fix_a_false_negative_for_style_yoda_expression.md
+++ b/changelog/fix_a_false_negative_for_style_yoda_expression.md
@@ -1 +1 @@
-* [#11520](https://github.com/rubocop/rubocop/pull/11520): Fix a false negative for `Style/YodaExpression` when using constant. ([@koic][])
+* [#11520](https://github.com/rubocop/rubocop/pull/11520): Fix a false negative for `Gemspec/DateAssignment` when using constant. ([@koic][])
```

### Before

```
$ bundle exec rspec spec/project_spec.rb -e changelog/fix_a_false_negative_for_style_yoda_expression.md
Run options: include {:full_description=>/changelog\/fix_a_false_negative_for_style_yoda_expression\.md/}

Randomized with seed 41476
....F...........

Failures:

  1) RuboCop Project Changelog future entries For /home/peter/devel/rubocop/changelog/fix_a_false_negative_for_style_yoda_expression.md has valid cop name with backticks
     Failure/Error:
       expect(all_cop_names.include?(cop_name))
         .to be(true), "Invalid cop name #{cop_name}."

       Invalid cop name Gemspec/DateAssignment.
     # ./spec/project_spec.rb:282:in `block (8 levels) in <top (required)>'
     # ./spec/project_spec.rb:281:in `scan'
     # ./spec/project_spec.rb:281:in `block (7 levels) in <top (required)>'
     # ./spec/project_spec.rb:280:in `each'
     # ./spec/project_spec.rb:280:in `block (6 levels) in <top (required)>'

Finished in 0.0829 seconds (files took 2.53 seconds to load)
16 examples, 1 failure

Failed examples:

rspec ./spec/project_spec.rb[1:3:4:7:8] # RuboCop Project Changelog future entries For /home/peter/devel/rubocop/changelog/fix_a_false_negative_for_style_yoda_expression.md has valid cop name with backticks

Randomized with seed 41476
```

### After

```
bundle exec spec/project_spec.rb -e changelog/fix_a_false_negative_for_style_yoda_expression.md
Run options: include {:full_description=>/changelog\/fix_a_false_negative_for_style_yoda_expression\.md/}

Randomized with seed 41008
................

Finished in 0.06386 seconds (files took 2.41 seconds to load)
16 examples, 0 failures

Randomized with seed 41008
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
