### PR TITLE
Enable autocorrection for Layout/LineContinuationLeadingSpace

### DIFF
--- a/changelog/change_enable_autocorrection_for_line_continuation_leading_space.md
+++ b/changelog/change_enable_autocorrection_for_line_continuation_leading_space.md
@@ -1,0 +1,1 @@
+* [#11541](https://github.com/rubocop/rubocop/pull/11541): Enable autocorrection for `Layout/LineContinuationLeadingSpace`. ([@eugeneius][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1006,10 +1006,8 @@ Layout/LineContinuationLeadingSpace:
                   Use trailing spaces instead of leading spaces in strings
                   broken over multiple lines (by a backslash).
   Enabled: pending
-  AutoCorrect: false
-  SafeAutoCorrect: false
   VersionAdded: '1.31'
-  VersionChanged: '1.32'
+  VersionChanged: '<<next>>'
   EnforcedStyle: trailing
   SupportedStyles:
     - leading


### PR DESCRIPTION
Autocorrect was implemented in https://github.com/rubocop/rubocop/pull/11091.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/