### PR TITLE
Move SafeAutoCorrect: false to correct cop config

### DIFF
--- a/changelog/change_layout_assignment_indentation_and_lint_assignment_in_condition_safe_auto_correct.md
+++ b/changelog/change_layout_assignment_indentation_and_lint_assignment_in_condition_safe_auto_correct.md
@@ -1,0 +1,1 @@
+* [#11542](https://github.com/rubocop/rubocop/pull/11542): Mark `Layout/AssignmentIndentation` as safe and `Lint/AssignmentInCondition` as unsafe for autocorrection. ([@eugeneius][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -406,9 +406,8 @@ Layout/AssignmentIndentation:
                 Checks the indentation of the first line of the
                 right-hand-side of a multi-line assignment.
   Enabled: true
-  SafeAutoCorrect: false
   VersionAdded: '0.49'
-  VersionChanged: '1.40'
+  VersionChanged: '<<next>>'
   # By default the indentation width from `Layout/IndentationWidth` is used,
   # but it can be overridden by setting this parameter.
   IndentationWidth: ~
@@ -1573,7 +1572,9 @@ Lint/AssignmentInCondition:
   Description: "Don't use assignment in conditions."
   StyleGuide: '#safe-assignment-in-condition'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.9'
+  VersionChanged: '<<next>>'
   AllowSafeAssignment: true
 
 Lint/BigDecimalNew:


### PR DESCRIPTION
https://github.com/rubocop/rubocop/pull/11211 added autocorrect for `Lint/AssignmentInCondition`, but marked `Layout/AssignmentIndentation` as unsafe for autocorrection.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/