### PR TITLE
Lint/RedundantHeredocDelimiterQuotes: Add spec for escapes

### DIFF
--- a/lib/rubocop/cop/style/redundant_heredoc_delimiter_quotes.rb
+++ b/lib/rubocop/cop/style/redundant_heredoc_delimiter_quotes.rb
@@ -22,7 +22,8 @@ module RuboCop
       #   EOS
       #
       #   do_something(<<~'EOS')
-      #     escaped character\.
+      #     Preserve \
+      #     newlines
       #   EOS
       #
       class RedundantHeredocDelimiterQuotes < Base

--- a/spec/rubocop/cop/style/redundant_heredoc_delimiter_quotes_spec.rb
+++ b/spec/rubocop/cop/style/redundant_heredoc_delimiter_quotes_spec.rb
@@ -152,4 +152,13 @@ RSpec.describe RuboCop::Cop::Style::RedundantHeredocDelimiterQuotes, :config do
       EDGE　CASE
     RUBY
   end
+
+  it 'does not register an offense when using the heredoc delimiter with backslash' do
+    expect_no_offenses(<<~'RUBY')
+      do_something(<<~'EOS')
+        Preserve \
+        newlines
+      EOS
+    RUBY
+  end
 end


### PR DESCRIPTION
This commit adds a missing spec to highlight how escapes are handled.

Follow-up of https://github.com/rubocop/rubocop/pull/11528.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
