### PR TITLE
Fix a false positive for `Lint/NestedMethodDefinition`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_nested_method_definition.md
+++ b/changelog/fix_a_false_positive_for_lint_nested_method_definition.md
@@ -1,0 +1,1 @@
+* [#11545](https://github.com/rubocop/rubocop/pull/11545): Fix the following false positive for `Lint/NestedMethodDefinition` when using numbered parameter. ([@koic][])

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -108,7 +108,7 @@ module RuboCop
           return unless def_ancestor
 
           within_scoping_def =
-            node.each_ancestor(:block, :sclass).any? do |ancestor|
+            node.each_ancestor(:block, :numblock, :sclass).any? do |ancestor|
               scoping_method_call?(ancestor)
             end
 
@@ -141,7 +141,7 @@ module RuboCop
 
         # @!method class_or_module_or_struct_new_call?(node)
         def_node_matcher :class_or_module_or_struct_new_call?, <<~PATTERN
-          (block (send (const {nil? cbase} {:Class :Module :Struct}) :new ...) ...)
+          ({block numblock} (send (const {nil? cbase} {:Class :Module :Struct}) :new ...) ...)
         PATTERN
       end
     end

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -267,6 +267,38 @@ RSpec.describe RuboCop::Cop::Lint::NestedMethodDefinition, :config do
     RUBY
   end
 
+  it 'does not register offense for nested definition inside `Module.new` with block' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        def self.define
+          Module.new do |m|
+            def y
+            end
+
+            do_something(m)
+          end
+        end
+      end
+    RUBY
+  end
+
+  context 'when Ruby >= 2.7', :ruby27 do
+    it 'does not register offense for nested definition inside `Module.new` with numblock' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def self.define
+            Module.new do
+              def y
+              end
+
+              do_something(_1)
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
   context 'when `AllowedMethods: [has_many]`' do
     let(:cop_config) do
       { 'AllowedMethods' => ['has_many'] }


### PR DESCRIPTION
This PR fixes the following false positive for `Lint/NestedMethodDefinition` when using numbered parameter:

```ruby
class Foo
  def self.define
    Module.new do
      def y
      end

      do_something(_1)
    end
  end
end
```

```console
% bundle exec rubocop
(snip)

Offenses:

example.rb:4:7: W: Lint/NestedMethodDefinition: Method definitions must not be nested. Use lambda instead.
      def y ...
      ^^^^^

1 file inspected, 1 offense detected
```

Since there is no warning for block parameter:

```ruby
class Foo
  def self.define
    Module.new do |m|
      def y
      end

      do_something(m)
    end
  end
end
```

So, numbered parameter should behave the same.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
