### PR TITLE
Make `Lint/UselessAccessModifier` aware of Ruby 3.2's `Data.define`

### DIFF
--- a/changelog/new_make_useless_access_modifier_aware_of_data_define.md
+++ b/changelog/new_make_useless_access_modifier_aware_of_data_define.md
@@ -1,0 +1,1 @@
+* [#11546](https://github.com/rubocop/rubocop/pull/11546): Make `Lint/UselessAccessModifier` aware of Ruby 3.2's `Data.define`. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -167,9 +167,12 @@ module RuboCop
           ({block numblock} (send _ {:class_eval :instance_eval}) ...)
         PATTERN
 
-        # @!method class_or_module_or_struct_new_call?(node)
-        def_node_matcher :class_or_module_or_struct_new_call?, <<~PATTERN
-          ({block numblock} (send (const {nil? cbase} {:Class :Module :Struct}) :new ...) ...)
+        # @!method class_constructor?(node)
+        def_node_matcher :class_constructor?, <<~PATTERN
+          ({block numblock} {
+            (send (const {nil? cbase} {:Class :Module :Struct}) :new ...)
+            (send (const {nil? cbase} :Data) :define ...)
+          } ...)
         PATTERN
 
         def check_node(node)
@@ -270,7 +273,7 @@ module RuboCop
 
         def eval_call?(child)
           class_or_instance_eval?(child) ||
-            class_or_module_or_struct_new_call?(child) ||
+            class_constructor?(child) ||
             any_context_creating_methods?(child)
         end
 

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -1019,6 +1019,48 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
     end
   end
 
+  context '`def` in `Data.define` block', :ruby32 do
+    %w[protected private].each do |modifier|
+      it "doesn't register an offense if a method is defined in `Data.define` with block" do
+        expect_no_offenses(<<~RUBY)
+          Data.define do
+            #{modifier}
+            def foo
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense if no method is defined in `Data.define` with block' do
+        expect_offense(<<~RUBY, modifier: modifier)
+          Data.define do
+            %{modifier}
+            ^{modifier} Useless `#{modifier}` access modifier.
+          end
+        RUBY
+      end
+
+      it 'registers an offense if no method is defined in `::Data.define` with block' do
+        expect_offense(<<~RUBY, modifier: modifier)
+          ::Data.define do
+            %{modifier}
+            ^{modifier} Useless `#{modifier}` access modifier.
+          end
+        RUBY
+      end
+
+      it 'registers an offense if no method is defined in `Data.define` with numblock' do
+        expect_offense(<<~RUBY, modifier: modifier)
+          Data.define do
+            %{modifier}
+            ^{modifier} Useless `#{modifier}` access modifier.
+            do_something(_1)
+          end
+        RUBY
+      end
+    end
+  end
+
   %w[module class].each do |keyword|
     it_behaves_like('at the top of the body', keyword)
     it_behaves_like('non-repeated visibility modifiers', keyword)


### PR DESCRIPTION
Ruby 3.2 introduced immutable `Data.define`. Since this is similar to `Struct.new`. This `Lint/UselessAccessModifier` will handle `Struct.new` and `Data.define` in the same way.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
