### PR TITLE
Fix a false positive for `Lint/NestedMethodDefinition`

### DIFF
--- a/changelog/fix_false_positive_for_lint_nested_method_definition.md
+++ b/changelog/fix_false_positive_for_lint_nested_method_definition.md
@@ -1,0 +1,1 @@
+* [#11547](https://github.com/rubocop/rubocop/pull/11547): Fix a false positive for `Lint/NestedMethodDefinition` when using Ruby 3.2's `Data.define`. ([@koic][])

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -120,7 +120,7 @@ module RuboCop
 
         def scoping_method_call?(child)
           child.sclass_type? || eval_call?(child) || exec_call?(child) ||
-            class_or_module_or_struct_new_call?(child) || allowed_method_name?(child)
+            class_constructor?(child) || allowed_method_name?(child)
         end
 
         def allowed_method_name?(node)
@@ -139,9 +139,12 @@ module RuboCop
           (block (send _ {:instance_exec :class_exec :module_exec} ...) ...)
         PATTERN
 
-        # @!method class_or_module_or_struct_new_call?(node)
-        def_node_matcher :class_or_module_or_struct_new_call?, <<~PATTERN
-          ({block numblock} (send (const {nil? cbase} {:Class :Module :Struct}) :new ...) ...)
+        # @!method class_constructor?(node)
+        def_node_matcher :class_constructor?, <<~PATTERN
+          ({block numblock} {
+            (send (const {nil? cbase} {:Class :Module :Struct}) :new ...)
+            (send (const {nil? cbase} :Data) :define ...)
+          } ...)
         PATTERN
       end
     end

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -299,6 +299,52 @@ RSpec.describe RuboCop::Cop::Lint::NestedMethodDefinition, :config do
     end
   end
 
+  context 'when Ruby >= 3.2', :ruby32 do
+    it 'does not register offense for nested definition inside `Data.define`' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def self.define
+            Data.define(:name) do
+              def y
+              end
+            end
+          end
+        end
+
+        class Foo
+          def self.define
+            Data.define do
+              def y
+              end
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register offense for nested definition inside `::Data.define`' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def self.define
+            ::Data.define(:name) do
+              def y
+              end
+            end
+          end
+        end
+
+        class Foo
+          def self.define
+            ::Data.define do
+              def y
+              end
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
   context 'when `AllowedMethods: [has_many]`' do
     let(:cop_config) do
       { 'AllowedMethods' => ['has_many'] }


### PR DESCRIPTION
This PR fixes a false positive for `Lint/NestedMethodDefinition` when using Ruby 3.2's `Data.define` Ruby 3.2 introduced `Data.define`. This is similar to `Struct.new` and should be handled in the same way.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
