### PR TITLE
Fix an error for `Style/AccessModifierDeclarations` when if a non method definition was included

### DIFF
--- a/changelog/fix_an_error_for_style_access_modifier_declarations.md
+++ b/changelog/fix_an_error_for_style_access_modifier_declarations.md
@@ -1,0 +1,1 @@
+* [#11548](https://github.com/rubocop/rubocop/pull/11548): Fix an error for `Style/AccessModifierDeclarations` when if a non method definition was included. ([@ydah][])

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -152,7 +152,7 @@ module RuboCop
 
         def right_siblings_same_inline_method?(node)
           node.right_siblings.any? do |sibling|
-            sibling.method?(node.method_name) && !sibling.arguments.empty?
+            sibling.send_type? && sibling.method?(node.method_name) && !sibling.arguments.empty?
           end
         end
 

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -258,12 +258,14 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
           private def bar; end
           ^^^^^^^ `private` should not be inlined in method definitions.
           def baz; end
+          QUX = ['qux']
         end
       RUBY
 
       expect_correction(<<~RUBY)
         class Test
           def baz; end
+          QUX = ['qux']
         private
 
         def foo; end


### PR DESCRIPTION
This PR is fix an error for `Style/AccessModifierDeclarations` when if a non method definition was included.

## Code to reproduce
```ruby
class Test
  private def foo; end
  private def bar; end
  def baz; end
  QUX = ['qux']
end
```

## Occurring Error
```
Failures:

  1) RuboCop::Cop::Style::AccessModifierDeclarations when `group` is configured offends when multiple groupable access modifiers are defined
     Failure/Error: sibling.method?(node.method_name) && !sibling.arguments.empty?

     NoMethodError:
       undefined method `method?' for s(:casgn, nil, :QUX,
         s(:array)):RuboCop::AST::CasgnNode
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
