### PR TITLE
[Fix #11549] Fix an error for third party cops

### DIFF
--- a/changelog/fix_an_error_for_third_party_cops.md
+++ b/changelog/fix_an_error_for_third_party_cops.md
@@ -1,0 +1,1 @@
+* [#11549](https://github.com/rubocop/rubocop/issues/11549): Fix an error for third party cops when inheriting `RuboCop::Cop::Cop`. ([@koic][])


### PR DESCRIPTION
Fixes #11549.

This PR fixes an error for third party cops when inheriting `RuboCop::Cop::Cop`. It makes the same changes to `RuboCop::Cop::Cop` as `RuboCop::Cop::Base` in #10839. Confirmed that rubocop-i18n tests pass again.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
