### PR TITLE
CI against JRuby 9.4 instead of JRuby 9.3

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -59,7 +59,7 @@ jobs:
         run: bundle exec rake internal_investigation
 
   jruby:
-    name: JRuby 9.3
+    name: JRuby 9.4
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -67,7 +67,7 @@ jobs:
       - name: set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: jruby-9.3
+          ruby-version: jruby-9.4
           bundler-cache: true
       - name: spec
         run: bundle exec rake spec


### PR DESCRIPTION
JRuby 9.4.1.0 is now available on setup-ruby.
https://github.com/ruby/setup-ruby/releases/tag/v1.136.0

JRuby 9.4 is MRI 3.1 compatible and JRuby 9.3 is MRI 2.6 compatible. JRuby 9.3 is still supported as a RuboCop runtime, but presumably any new JRuby issues found may be fixed in JRuby 9.4. And MRI 2.6 will be dropped from the runtime in the not distant future.

So, JRuby 9.3 will not be retained and will be replaced by JRuby 9.4 because CI latency.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
