### PR TITLE
Fix a false positive for `Lint/Debugger` when methods containing different method chains

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_debugger.md
+++ b/changelog/fix_a_false_positive_for_lint_debugger.md
@@ -1,0 +1,1 @@
+* [#11552](https://github.com/rubocop/rubocop/pull/11552): Fix a false positive for `Lint/Debugger` when methods containing different method chains. ([@ydah][])

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -76,6 +76,40 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
         ^^^^^^^^^^^^^^^^^^ Remove debugger entry point `Kernel.binding.irb`.
       RUBY
     end
+
+    it 'registers an offense for a p call' do
+      expect_offense(<<~RUBY)
+        p 'foo'
+        ^^^^^^^ Remove debugger entry point `p 'foo'`.
+      RUBY
+    end
+
+    it 'registers an offense for a p call with foo method argument' do
+      expect_offense(<<~RUBY)
+        foo(p 'foo')
+            ^^^^^^^ Remove debugger entry point `p 'foo'`.
+      RUBY
+    end
+
+    it 'registers an offense for a p call with p method argument' do
+      expect_offense(<<~RUBY)
+        p(p 'foo')
+          ^^^^^^^ Remove debugger entry point `p 'foo'`.
+        ^^^^^^^^^^ Remove debugger entry point `p(p 'foo')`.
+      RUBY
+    end
+
+    it 'does not register an offense for a p.do_something call' do
+      expect_no_offenses(<<~RUBY)
+        p.do_something
+      RUBY
+    end
+
+    it 'does not register an offense for a p with Foo call' do
+      expect_no_offenses(<<~RUBY)
+        Foo.p
+      RUBY
+    end
   end
 
   context 'byebug' do


### PR DESCRIPTION
This PR is fix a false positive for `Lint/Debugger` when methods containing different method chains.

## Motivation
I don't think that methods such as `p.do_something` for example should be an offense of this cop. I think it would be better to make it a violation only if it is an exact match, including the method chain, but what do you think?

## This PR will result in the following

```ruby
# bad
p 'foo'
foo(p 'foo')
p(p 'foo')

# good
p.do_something # <--- Before the change, it is a bad code
Foo.p
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
