### PR TITLE
Restore a pending test for processing a regex with regopt

### DIFF
--- a/spec/rubocop/cop/variable_force_spec.rb
+++ b/spec/rubocop/cop/variable_force_spec.rb
@@ -28,9 +28,7 @@ RSpec.describe RuboCop::Cop::VariableForce do
       end
     end
 
-    # FIXME: Remove `broken_on: jruby` when JRuby incompatible is resolved:
-    # https://github.com/jruby/jruby/issues/7113
-    context 'when processing a regex with regopt', broken_on: :jruby do
+    context 'when processing a regex with regopt' do
       let(:node) { parse_source('/\x82/n =~ "a"').ast }
 
       it 'does not raise an error' do


### PR DESCRIPTION
This PR reverts a pending test of #10432 because https://github.com/jruby/jruby/issues/7113 has been resolved in JRuby 9.3.9.0.

## JRuby 9.3.3.0

`RegexpError` error will occur:

```console
% rbenv local jruby-9.3.3.0
% ruby -e "Regexp.new('\x82', Regexp::NOENCODING)"
RegexpError: invalid multibyte escape: /\x82/
  initialize at org/jruby/RubyRegexp.java:956
         new at org/jruby/RubyClass.java:893
      <main> at -e:1
```

## JRuby 9.3.9.0 and JRuby 9.4.1.0

No errors:

```console
% rbenv local jruby-9.3.9.0
% ruby -e "Regexp.new('\x82', Regexp::NOENCODING)"

% rbenv local jruby-9.4.1.0
% ruby -e "Regexp.new('\x82', Regexp::NOENCODING)"
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
