### PR TITLE
[Fix #11554] Fix an error for `Style/RedundantCondition`

### DIFF
--- a/changelog/fix_an_error_for_style_redundant_condition.md
+++ b/changelog/fix_an_error_for_style_redundant_condition.md
@@ -1,0 +1,1 @@
+* [#11554](https://github.com/rubocop/rubocop/issues/11554): Fix an error for `Style/RedundantCondition` when the branches contains empty hash literal argument. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -167,8 +167,8 @@ module RuboCop
         def argument_with_operator?(argument)
           return true if ARGUMENT_WITH_OPERATOR_TYPES.include?(argument.type)
           return false unless argument.hash_type?
+          return false unless (node = argument.children.first)
 
-          node = argument.children.first
           node.kwsplat_type? || node.forwarded_kwrestarg_type?
         end
 

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -352,6 +352,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects when the branches contains empty hash literal argument' do
+        expect_offense(<<~RUBY)
+          if foo
+          ^^^^^^ Use double pipes `||` instead.
+            bar(foo)
+          else
+            bar({})
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bar(foo || {})
+        RUBY
+      end
+
       it 'does not register an offense when the branches contains splat argument' do
         expect_no_offenses(<<~RUBY)
           if foo


### PR DESCRIPTION
Fixes #11554.

This PR fixes an error for `Style/RedundantCondition` when the branches contains empty hash literal argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
