### PR TITLE
[Fix #11556] Fix a false positive for `Lint/Debugger`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_debugger.md
+++ b/changelog/fix_a_false_positive_for_lint_debugger.md
@@ -1,0 +1,1 @@
+* [#11556](https://github.com/rubocop/rubocop/issues/11556): Fix a false positive for `Lint/Debugger` when `p` is an argument of method call. ([@koic][])

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -70,6 +70,9 @@ module RuboCop
         def on_send(node)
           return unless debugger_method?(node)
 
+          # Basically, debugger methods are not used as a method argument without arguments.
+          return if node.arguments.empty? && node.each_ancestor(:send, :csend).any?
+
           add_offense(node)
         end
 

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -110,6 +110,30 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
         Foo.p
       RUBY
     end
+
+    it 'does not register an offense when `p` is an argument of method call' do
+      expect_no_offenses(<<~RUBY)
+        let(:p) { foo }
+
+        it { expect(do_something(p)).to eq bar }
+      RUBY
+    end
+
+    it 'does not register an offense when `p` is an argument of safe navigation method call' do
+      expect_no_offenses(<<~RUBY)
+        let(:p) { foo }
+
+        it { expect(obj&.do_something(p)).to eq bar }
+      RUBY
+    end
+
+    it 'does not register an offense when `p` is a keyword argument of method call' do
+      expect_no_offenses(<<~RUBY)
+        let(:p) { foo }
+
+        it { expect(do_something(k: p)).to eq bar }
+      RUBY
+    end
   end
 
   context 'byebug' do


### PR DESCRIPTION
Fixes #11556.

This PR fixes a false positive for `Lint/Debugger` when `p` is an argument of method call. Basically, debugger methods are not used as a method argument without arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
