### PR TITLE
Fix octal handling in `Style/RedundantRegexpCharacterClass`

### DIFF
--- a/changelog/fix_octal_handling_in_regexp_char_classes_.md
+++ b/changelog/fix_octal_handling_in_regexp_char_classes_.md
@@ -1,0 +1,1 @@
+* [#11559](https://github.com/rubocop/rubocop/pull/11559): Fixed false positives and negatives in `Style/RedundantRegexpCharacterClass` when using octal escapes (e.g. "\0"). ([@jaynetics][])

--- a/lib/rubocop/cop/style/redundant_regexp_character_class.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_character_class.rb
@@ -74,7 +74,7 @@ module RuboCop
 
           non_redundant =
             whitespace_in_free_space_mode?(node, class_elem) ||
-            backslash_b?(class_elem) || backslash_zero?(class_elem) ||
+            backslash_b?(class_elem) || octal_requiring_char_class?(class_elem) ||
             requires_escape_outside_char_class?(class_elem)
 
           !non_redundant
@@ -104,11 +104,10 @@ module RuboCop
           elem == '\b'
         end
 
-        def backslash_zero?(elem)
-          # See https://github.com/rubocop/rubocop/issues/11067 for details - in short "\0" != "0" -
-          # the former means an Unicode code point `"\u0000"`, the latter a number character `"0"`.
-          # Similarly "\032" means "\u001A". Other numbers starting with "\0" can also be mentioned.
-          elem == '\0'
+        def octal_requiring_char_class?(elem)
+          # The octal escapes \1 to \7 only work inside a character class
+          # because they would be a backreference outside it.
+          elem.match?(/\A\\[1-7]\z/)
         end
 
         def requires_escape_outside_char_class?(elem)


### PR DESCRIPTION
regexp_parser v2.7.0 introduced a fix that makes it correctly detect octal escapes (e.g. "\141", which equals "a") inside character classes, e.g. `/[\141]/`.

Previously, these were incorrectly interpreted and chunked, c.f. https://github.com/ammar/regexp_parser/issues/86

The incorrect chunking made your build green. This is because `\032` emitted `\0`, which was checked for specifically in `#backslash_zero?`.

The fix in regexp_parser v2.7.0, however, made this spec red.

The correct output by rubocop would be to detect this case as a redundant use of a char class, because it is.

The same goes for the original example "\0":

```ruby
[/\0/.match?("\0"), /[\0]/.match?("\0")] # => [true, true]
```

For `\1` to `\7`, putting them in a char class is not redundant but actually required, because they would otherwise be treated as backreferences.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
