### PR TITLE
Fix handling of escaped octals in duplicate regexp cop

### DIFF
--- a/changelog/fix_octal_handling_in_duplicate_char_class_element.md
+++ b/changelog/fix_octal_handling_in_duplicate_char_class_element.md
@@ -1,0 +1,1 @@
+* [#11562](https://github.com/rubocop/rubocop/pull/11562): Fixed escaped octal handling and detection in `Lint/DuplicateRegexpCharacterClassElement`. ([@rwstauner][])

--- a/lib/rubocop/cop/lint/duplicate_regexp_character_class_element.rb
+++ b/lib/rubocop/cop/lint/duplicate_regexp_character_class_element.rb
@@ -82,7 +82,7 @@ module RuboCop
 
           range_between(
             children.first.expression.begin_pos,
-            children.last.expression.begin_pos + children.last.te - children.last.ts
+            children.last.expression.begin_pos + children.last.to_s.length
           )
         end
 

--- a/spec/rubocop/cop/lint/duplicate_regexp_character_class_element_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_regexp_character_class_element_spec.rb
@@ -64,6 +64,32 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateRegexpCharacterClassElement, :config
     end
   end
 
+  context 'with repeated character class elements when `"\07\01\078"` (means `"\u0007\u0001\u00078"`)' do
+    it 'registers an offense' do
+      expect_offense(<<~'RUBY')
+        /[\07\01\078]/
+                ^^^ Duplicate element inside regexp character class
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        /[\07\018]/
+      RUBY
+    end
+  end
+
+  context 'with repeated character class elements when `"\177\01\1778"` (means `"\u007f\u0001\u007f8"`)' do
+    it 'registers an offense' do
+      expect_offense(<<~'RUBY')
+        /[\177\01\1778]/
+                 ^^^^ Duplicate element inside regexp character class
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        /[\177\018]/
+      RUBY
+    end
+  end
+
   context 'with a repeated character class element and %r{} literal' do
     it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
This improves the handling of escaped octals (as long as we allow regexp_parser < 2.7)
for the duplicate regexp character class element cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
