### PR TITLE
Add contribution note for CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log
 
+<!---
+  Do NOT edit this CHANGELOG.md file by hand directly, as it is automatically updated.
+
+  Please add an entry file to the https://github.com/rubocop/rubocop/blob/master/changelog/
+  named `{change_type}_{change_description}.md` if the new code introduces user-observable changes.
+
+  See https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format for details.
+-->
+
 ## master (unreleased)
 
 ## 1.45.1 (2023-02-08)

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -156,8 +156,8 @@ RSpec.describe 'RuboCop Project', type: :feature do
       expect(changelog.end_with?("\n")).to be true
     end
 
-    it 'has either entries, headers, or empty lines' do
-      expect(non_reference_lines).to all(match(/^(\*|#|$)/))
+    it 'has either entries, headers, empty lines, or comments' do
+      expect(non_reference_lines).to all(match(/^(\*|#|$|<!---|-->|  )/))
     end
 
     describe 'entry' do

--- a/spec/tasks/changelog_spec.rb
+++ b/spec/tasks/changelog_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe Changelog do
     described_class.new(content: <<~CHANGELOG, entries: list)
       # Change log
 
+      <!---
+        Do NOT edit this CHANGELOG.md file by hand directly, as it is automatically updated.
+
+        Please add an entry file to the https://github.com/rubocop/rubocop/blob/master/changelog/
+        named `{change_type}_{change_description}.md` if the new code introduces user-observable changes.
+
+        See https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format for details.
+      -->
+
       ## master (unreleased)
 
       ### New features

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -25,7 +25,6 @@ class Changelog
     end
 
     def write
-      FileUtils.mkdir_p(ENTRIES_PATH)
       File.write(path, content)
       path
     end


### PR DESCRIPTION
Occasionally I review direct edit to the CHANGELOG.md:

- https://github.com/rubocop/rubocop/pull/11559#discussion_r1101152654
- https://github.com/rubocop/rubocop/pull/11406#discussion_r1064492125
- https://github.com/rubocop/rubocop/pull/11395#discussion_r1064000369

It might be communicated a little more efficiently if listed in the CHANGELOG.md. And the triple dash for commenting out is used intentionally.
https://stackoverflow.com/questions/4823468/comments-in-markdown/4829998#4829998

It affects when markdown is viewed on GitHub. This is unnecessary note for user viewing the CHANGELOG.md on GitHub.

Also add changelog/.gitkeep to prevent dead link after release.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
