### PR TITLE
Remove print debug methods from default for `Lint/Debugger`

### DIFF
--- a/changelog/change_remove_print_debug_methods_from_default_for_lint_debugger.md
+++ b/changelog/change_remove_print_debug_methods_from_default_for_lint_debugger.md
@@ -1,0 +1,1 @@
+* [#11564](https://github.com/rubocop/rubocop/pull/11564): Remove print debug methods from default for `Lint/Debugger`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1630,13 +1630,12 @@ Lint/Debugger:
   Description: 'Check for debugger calls.'
   Enabled: true
   VersionAdded: '0.14'
-  VersionChanged: '1.10'
+  VersionChanged: '<<next>>'
   DebuggerMethods:
     # Groups are available so that a specific group can be disabled in
     # a user's configuration, but are otherwise not significant.
     Kernel:
       - binding.irb
-      - p
       - Kernel.binding.irb
     Byebug:
       - byebug
@@ -1646,9 +1645,6 @@ Lint/Debugger:
     Capybara:
       - save_and_open_page
       - save_and_open_screenshot
-    PP:
-      - PP.pp
-      - pp
     debug.rb:
       - binding.b
       - binding.break

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -76,6 +76,10 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
         ^^^^^^^^^^^^^^^^^^ Remove debugger entry point `Kernel.binding.irb`.
       RUBY
     end
+  end
+
+  context 'when print debug method is configured by user' do
+    let(:cop_config) { { 'DebuggerMethods' => %w[p] } }
 
     it 'registers an offense for a p call' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR rolls back the print debug default configuration (#11518) of `Lint/Debugger` based on the following feedback.

- https://github.com/rubocop/rubocop/pull/11557#issuecomment-1423819556
- https://github.com/rubocop/rubocop/pull/11552#issuecomment-1423489150
- https://github.com/rubocop/rubocop/pull/11518#issuecomment-1425847503

It seems like it was a bad idea to mix debugger and print debug methods by default.

This PR updates `Lint/Debugger` cop defaults to handle only debugger methods as per the cop name. OTOH, it leaves the logic in #11557 to prevent false positives when user configures print debug methods. e.g. https://github.com/rubocop/rubocop/issues/11517#issuecomment-1407695703

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
