### PR TITLE
[Fix #11567] Fix `Layout/EndAlignment` false negative

### DIFF
--- a/changelog/fix_fix_layout_end_alignment_false_negative.md
+++ b/changelog/fix_fix_layout_end_alignment_false_negative.md
@@ -1,0 +1,1 @@
+* [#11567](https://github.com/rubocop/rubocop/issues/11567): Fix `Layout/EndAlignment` false negative. ([@j-miyake][])

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -82,6 +82,10 @@ module RuboCop
           check_other_alignment(node)
         end
 
+        def on_sclass(node)
+          check_other_alignment(node)
+        end
+
         def on_module(node)
           check_other_alignment(node)
         end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2823,4 +2823,79 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       end
     RUBY
   end
+
+  it 'corrects `Layout/EndAlignment` when `end` is not aligned with beginning of a singleton class definition ' \
+     'and EnforcedStyleAlignWith is set to `keyword` style' do
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~RUBY)
+      class << self
+        end
+      puts 1; class << self
+        end
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/EndAlignment:
+        EnforcedStyleAlignWith: keyword
+    YAML
+
+    status = cli.run(%w[--autocorrect --only Layout/EndAlignment])
+    expect(status).to eq(0)
+    expect(source_file.read).to eq(<<~RUBY)
+      class << self
+      end
+      puts 1; class << self
+              end
+    RUBY
+  end
+
+  it 'corrects `Layout/EndAlignment` when `end` is not aligned with beginning of a singleton class definition ' \
+     'and EnforcedStyleAlignWith is set to `variable` style' do
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~RUBY)
+      class << self
+        end
+      puts 1; class << self
+        end
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/EndAlignment:
+        EnforcedStyleAlignWith: variable
+    YAML
+
+    status = cli.run(%w[--autocorrect --only Layout/EndAlignment])
+    expect(status).to eq(0)
+    expect(source_file.read).to eq(<<~RUBY)
+      class << self
+      end
+      puts 1; class << self
+              end
+    RUBY
+  end
+
+  it 'corrects `Layout/EndAlignment` when `end` is not aligned with start of line ' \
+     'and EnforcedStyleAlignWith is set to `start_of_line` style' do
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~RUBY)
+      class << self
+        end
+      puts 1; class << self
+        end
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/EndAlignment:
+        EnforcedStyleAlignWith: start_of_line
+    YAML
+
+    status = cli.run(%w[--autocorrect --only Layout/EndAlignment])
+    expect(status).to eq(0)
+    expect(source_file.read).to eq(<<~RUBY)
+      class << self
+      end
+      puts 1; class << self
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -5,26 +5,35 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
 
   include_examples 'aligned', "\xef\xbb\xbfclass", 'Test', 'end'
 
-  include_examples 'aligned', 'class',  'Test',      'end'
-  include_examples 'aligned', 'module', 'Test',      'end'
-  include_examples 'aligned', 'if',     'test',      'end'
-  include_examples 'aligned', 'unless', 'test',      'end'
-  include_examples 'aligned', 'while',  'test',      'end'
-  include_examples 'aligned', 'until',  'test',      'end'
-  include_examples 'aligned', 'case',   'a when b',  'end'
+  include_examples 'aligned', 'class',          'Test',      'end'
+  include_examples 'aligned', 'class << self;', 'Test',      'end'
+  include_examples 'aligned', 'module',         'Test',      'end'
+  include_examples 'aligned', 'if',             'test',      'end'
+  include_examples 'aligned', 'unless',         'test',      'end'
+  include_examples 'aligned', 'while',          'test',      'end'
+  include_examples 'aligned', 'until',          'test',      'end'
+  include_examples 'aligned', 'case',           'a when b',  'end'
 
   include_examples 'misaligned', <<~RUBY, false
     puts 1; class Test
       end
       ^^^ `end` at 2, 2 is not aligned with `class` at 1, 8.
 
-    module Test
+    class Test
       end
-      ^^^ `end` at 2, 2 is not aligned with `module` at 1, 0.
+      ^^^ `end` at 2, 2 is not aligned with `class` at 1, 0.
 
-    puts 1; class Test
+    puts 1; class << self
       end
       ^^^ `end` at 2, 2 is not aligned with `class` at 1, 8.
+
+    class << self
+      end
+      ^^^ `end` at 2, 2 is not aligned with `class` at 1, 0.
+
+    puts 1; module Test
+      end
+      ^^^ `end` at 2, 2 is not aligned with `module` at 1, 8.
 
     module Test
       end
@@ -71,13 +80,14 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       ^^^ `end` at 2, 2 is not aligned with `case` at 1, 0.
   RUBY
 
-  include_examples 'aligned', 'puts 1; class',  'Test',     '        end'
-  include_examples 'aligned', 'puts 1; module', 'Test',     '        end'
-  include_examples 'aligned', 'puts 1; if',     'Test',     '        end'
-  include_examples 'aligned', 'puts 1; unless', 'Test',     '        end'
-  include_examples 'aligned', 'puts 1; while',  'Test',     '        end'
-  include_examples 'aligned', 'puts 1; until',  'Test',     '        end'
-  include_examples 'aligned', 'puts 1; case',   'a when b', '        end'
+  include_examples 'aligned', 'puts 1; class',          'Test',     '        end'
+  include_examples 'aligned', 'puts 1; class << self;', 'Test',     '        end'
+  include_examples 'aligned', 'puts 1; module',         'Test',     '        end'
+  include_examples 'aligned', 'puts 1; if',             'Test',     '        end'
+  include_examples 'aligned', 'puts 1; unless',         'Test',     '        end'
+  include_examples 'aligned', 'puts 1; while',          'Test',     '        end'
+  include_examples 'aligned', 'puts 1; until',          'Test',     '        end'
+  include_examples 'aligned', 'puts 1; case',           'a when b', '        end'
 
   it 'can handle ternary if' do
     expect_no_offenses('a = cond ? x : y')
@@ -90,13 +100,14 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
   context 'when EnforcedStyleAlignWith is start_of_line' do
     let(:cop_config) { { 'EnforcedStyleAlignWith' => 'start_of_line', 'AutoCorrect' => true } }
 
-    include_examples 'aligned', 'puts 1; class',  'Test',     'end'
-    include_examples 'aligned', 'puts 1; module', 'Test',     'end'
-    include_examples 'aligned', 'puts 1; if',     'test',     'end'
-    include_examples 'aligned', 'puts 1; unless', 'test',     'end'
-    include_examples 'aligned', 'puts 1; while',  'test',     'end'
-    include_examples 'aligned', 'puts 1; until',  'test',     'end'
-    include_examples 'aligned', 'puts 1; case',   'a when b', 'end'
+    include_examples 'aligned', 'puts 1; class',          'Test',     'end'
+    include_examples 'aligned', 'puts 1; class << self;', 'Test',     'end'
+    include_examples 'aligned', 'puts 1; module',         'Test',     'end'
+    include_examples 'aligned', 'puts 1; if',             'test',     'end'
+    include_examples 'aligned', 'puts 1; unless',         'test',     'end'
+    include_examples 'aligned', 'puts 1; while',          'test',     'end'
+    include_examples 'aligned', 'puts 1; until',          'test',     'end'
+    include_examples 'aligned', 'puts 1; case',           'a when b', 'end'
 
     include_examples 'misaligned', <<~RUBY, false
       puts 1; class Test
@@ -235,6 +246,10 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
              end
              ^^^ `end` at 2, 7 is not aligned with `module` at 1, 0.
 
+      class << self
+        end
+        ^^^ `end` at 2, 2 is not aligned with `class` at 1, 0.
+
       if test
         end
         ^^^ `end` at 2, 2 is not aligned with `if` at 1, 0.
@@ -256,13 +271,14 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
         ^^^ `end` at 2, 2 is not aligned with `case` at 1, 0.
     RUBY
 
-    include_examples 'aligned', 'class',  'Test',      'end'
-    include_examples 'aligned', 'module', 'Test',      'end'
-    include_examples 'aligned', 'if',     'test',      'end'
-    include_examples 'aligned', 'unless', 'test',      'end'
-    include_examples 'aligned', 'while',  'test',      'end'
-    include_examples 'aligned', 'until',  'test',      'end'
-    include_examples 'aligned', 'case',   'a when b',  'end'
+    include_examples 'aligned', 'class',          'Test',     'end'
+    include_examples 'aligned', 'class << self;', 'Test',     'end'
+    include_examples 'aligned', 'module',         'Test',     'end'
+    include_examples 'aligned', 'if',             'test',     'end'
+    include_examples 'aligned', 'unless',         'test',     'end'
+    include_examples 'aligned', 'while',          'test',     'end'
+    include_examples 'aligned', 'until',          'test',     'end'
+    include_examples 'aligned', 'case',           'a when b', 'end'
 
     include_examples 'misaligned', <<~RUBY, :start_of_line
       puts 1; class Test
@@ -272,6 +288,10 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       puts 1; module Test
       end
       ^^^ `end` at 2, 0 is not aligned with `module` at 1, 8.
+
+      puts 1; class << self
+      end
+      ^^^ `end` at 2, 0 is not aligned with `class` at 1, 8.
 
       puts 1; if test
       end
@@ -294,13 +314,14 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       ^^^ `end` at 2, 0 is not aligned with `case` at 1, 8.
     RUBY
 
-    include_examples 'aligned', 'puts 1; class',  'Test',     '        end'
-    include_examples 'aligned', 'puts 1; module', 'Test',     '        end'
-    include_examples 'aligned', 'puts 1; if',     'Test',     '        end'
-    include_examples 'aligned', 'puts 1; unless', 'Test',     '        end'
-    include_examples 'aligned', 'puts 1; while',  'Test',     '        end'
-    include_examples 'aligned', 'puts 1; until',  'Test',     '        end'
-    include_examples 'aligned', 'puts 1; case',   'a when b', '        end'
+    include_examples 'aligned', 'puts 1; class',          'Test',     '        end'
+    include_examples 'aligned', 'puts 1; class << self;', 'Test',     '        end'
+    include_examples 'aligned', 'puts 1; module',         'Test',     '        end'
+    include_examples 'aligned', 'puts 1; if',             'Test',     '        end'
+    include_examples 'aligned', 'puts 1; unless',         'Test',     '        end'
+    include_examples 'aligned', 'puts 1; while',          'Test',     '        end'
+    include_examples 'aligned', 'puts 1; until',          'Test',     '        end'
+    include_examples 'aligned', 'puts 1; case',           'a when b', '        end'
 
     it 'register an offense when using `+` operator method and `end` is not aligned' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #11567

This PR adds the singleton class definition to the inspection targets of `Layout/EndAlignment`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
