### PR TITLE
Restore a pending test for JRuby

### DIFF
--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1680,9 +1680,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                 ''].join("\n"))
     end
 
-    # FIXME: Remove `broken_on: jruby`, which works around a JRuby 9.2.13.0 regression:
-    # https://github.com/jruby/jruby/issues/6365
-    it 'fails when a configuration file has invalid YAML syntax', broken_on: :jruby do
+    it 'fails when a configuration file has invalid YAML syntax' do
       create_file('example/.rubocop.yml', <<~YAML)
         AllCops:
           Exclude:
@@ -1693,7 +1691,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       # MRI and JRuby return slightly different error messages.
       expect($stderr.string)
         .to match(%r{^\(\S+example/\.rubocop\.yml\):\ (did\ not\ find\ )?
-                  expected\ alphabetic\ or \ numeric\ character}x)
+                  (expected\ alphabetic\ or \ numeric\ character|unexpected\ character)}x)
     end
 
     context 'when a file inherits from a higher level' do


### PR DESCRIPTION
https://github.com/jruby/jruby/issues/6365 has been resolved in JRuby 9.4. This PR restores a pending test for JRuby.

MRI and JRuby return different error messages, the regex is tweaked for the error messages:

## Ruby 3.2.1

```console
% ruby -ryaml -ve "YAML.load('Exclude: **/*_old.rb')"
ruby 3.2.1 (2023-02-08 revision 31819e82c8) [x86_64-darwin19]
/Users/koic/.rbenv/versions/3.2.1/lib/ruby/3.2.0/psych/parser.rb:62:in `_native_parse': (<unknown>):
did not find expected alphabetic or numeric character while scanning an alias at line 1 column 10 (Psych::SyntaxError)
        from /Users/koic/.rbenv/versions/3.2.1/lib/ruby/3.2.0/psych/parser.rb:62:in `parse'
        from /Users/koic/.rbenv/versions/3.2.1/lib/ruby/3.2.0/psych.rb:455:in `parse_stream'
        from /Users/koic/.rbenv/versions/3.2.1/lib/ruby/3.2.0/psych.rb:399:in `parse'
        from /Users/koic/.rbenv/versions/3.2.1/lib/ruby/3.2.0/psych.rb:323:in `safe_load'
        from /Users/koic/.rbenv/versions/3.2.1/lib/ruby/3.2.0/psych.rb:369:in `load'
        from -e:1:in `<main>'
```

## JRuby 9.4.1.0

```console
% ruby -ryaml -ve "YAML.load('Exclude: **/*_old.rb')"
jruby 9.4.1.0 (3.1.0) 2023-02-07 237d5fa5f4 Java HotSpot(TM) 64-Bit Server VM 25.271-b09 on 1.8.0_271-b09 +jit [x86_64-darwin]
Psych::SyntaxError: (<unknown>): unexpected character found *(42) while scanning an alias at line 1 column 11
  _native_parse at org/jruby/ext/psych/PsychParser.java:305
          parse at /Users/koic/.rbenv/versions/jruby-9.4.1.0/lib/ruby/stdlib/psych/parser.rb:62
   parse_stream at /Users/koic/.rbenv/versions/jruby-9.4.1.0/lib/ruby/stdlib/psych.rb:455
          parse at /Users/koic/.rbenv/versions/jruby-9.4.1.0/lib/ruby/stdlib/psych.rb:399
      safe_load at /Users/koic/.rbenv/versions/jruby-9.4.1.0/lib/ruby/stdlib/psych.rb:323
           load at /Users/koic/.rbenv/versions/jruby-9.4.1.0/lib/ruby/stdlib/psych.rb:369
         <main> at -e:1
... 8 levels...
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
