### PR TITLE
Fix a broken shorthand syntax autocorrection

### DIFF
--- a/changelog/fix_a_broken_shorthand_syntax_autocorrection.md
+++ b/changelog/fix_a_broken_shorthand_syntax_autocorrection.md
@@ -1,0 +1,1 @@
+* [#11565](https://github.com/rubocop/rubocop/pull/11565): Fix a broken shorthand syntax autocorrection. ([@gsamokovarov][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -95,19 +95,19 @@ module RuboCop
           use_modifier_form_without_parenthesized_method_call?(method_dispatch_node)
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
       def def_node_that_require_parentheses(node)
         last_pair = node.parent.pairs.last
         return unless last_pair.key.source == last_pair.value.source
         return unless (dispatch_node = find_ancestor_method_dispatch_node(node))
-        return if node.respond_to?(:parenthesized?) && !node.parenthesized?
+        return if dispatch_node.parenthesized?
         return unless last_expression?(dispatch_node) || method_dispatch_as_argument?(dispatch_node)
 
         def_node = node.each_ancestor(:send, :csend, :super, :yield).first
 
         DefNode.new(def_node) unless def_node && def_node.arguments.empty?
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
       def find_ancestor_method_dispatch_node(node)
         return unless (ancestor = node.parent.parent)

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1090,6 +1090,28 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'registers an offense in chained calls' do
+        expect_offense(<<~RUBY)
+          create(:foo, bar: bar).baz
+                            ^^^ Omit the hash value.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          create(:foo, bar:).baz
+        RUBY
+      end
+
+      it 'registers an offense in chained calls with dispatch keywords' do
+        expect_offense(<<~RUBY)
+          yield(:foo, bar: bar).baz
+                           ^^^ Omit the hash value.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          yield(:foo, bar:).baz
+        RUBY
+      end
+
       it 'registers an offense when without parentheses call expr follows after nested method call' do
         # Add parentheses to prevent syntax errors shown in the URL: https://bugs.ruby-lang.org/issues/18396
         expect_offense(<<~RUBY)


### PR DESCRIPTION
Calls like `foo(bar: bar).baz` were autocorrected to `foo(bar:)).baz`. Notice the extra parentheses. I have broken this in #11516.