### PR TITLE
Fix parentheses in value omissions for multiple assignments

### DIFF
--- a/changelog/fix_parentheses_in_value_omissions_for_multiple.md
+++ b/changelog/fix_parentheses_in_value_omissions_for_multiple.md
@@ -1,0 +1,1 @@
+* [#11575](https://github.com/rubocop/rubocop/pull/11575): Fix parentheses in value omissions for multiple assignments. ([@gsamokovarov][])

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1154,6 +1154,22 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'registers an offense when expression follows multiple assignments' do
+        expect_offense(<<~RUBY)
+          foo = bar = do_stuff arg, opt1: opt1,
+                                          ^^^^ Omit the hash value.
+                                    opt2: opt2
+                                          ^^^^ Omit the hash value.
+          pass
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo = bar = do_stuff(arg, opt1:,
+                                    opt2:)
+          pass
+        RUBY
+      end
+
       it 'registers an offense when one line `if` condition follows (with parentheses)' do
         expect_offense(<<~RUBY)
           foo(value: value) if bar


### PR DESCRIPTION
I'm on a quest to run the `EnforcedShorthandSyntax: always` style on a big codebase. One of the latest thins I found was a value omission in multiple assignments. Not the best idea, but it is a real "production" code usage, I guess. Here is an estimation of the code:

```ruby
foo = foo = do_stuff arg, opt1: opt1,
                          opt2: opt2

something.each { pass }
```

The multiple assignment in the code above tricks the current version of the parentheses detection code and we don't put the parens when autocorrecting:

```ruby
foo = foo = do_stuff arg, opt1:,
                          opt2:

something.each { pass }
```

While not a syntax error, Ruby is treating it like:

```ruby
foo = foo = do_stuff arg, opt1:,
                          opt2: something.each { pass }
```

We do need to put the parentheses for end result like:

```ruby
foo = foo = do_stuff(arg, opt1:,
                          opt2:)

something.each { pass }
```