### PR TITLE
Fix an error for `Lint/UselessRescue`

### DIFF
--- a/changelog/fix_an_error_for_lint_useless_rescue.md
+++ b/changelog/fix_an_error_for_lint_useless_rescue.md
@@ -1,0 +1,1 @@
+* [#11576](https://github.com/rubocop/rubocop/pull/11576): Fix an error for `Lint/UselessRescue` when `rescue` does not exception variable and `ensure` has empty body. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_rescue.rb
+++ b/lib/rubocop/cop/lint/useless_rescue.rb
@@ -72,8 +72,9 @@ module RuboCop
         def use_exception_variable_in_ensure?(resbody_node)
           return false unless (exception_variable = resbody_node.exception_variable)
           return false unless (ensure_node = resbody_node.each_ancestor(:ensure).first)
+          return false unless (ensure_body = ensure_node.body)
 
-          ensure_node.body.each_descendant(:lvar).map(&:source).include?(exception_variable.source)
+          ensure_body.each_descendant(:lvar).map(&:source).include?(exception_variable.source)
         end
 
         def exception_objects(resbody_node)

--- a/spec/rubocop/cop/lint/useless_rescue_spec.rb
+++ b/spec/rubocop/cop/lint/useless_rescue_spec.rb
@@ -62,6 +62,15 @@ RSpec.describe RuboCop::Cop::Lint::UselessRescue, :config do
     RUBY
   end
 
+  it 'does not register an offense when `rescue` does not exception variable and `ensure` has empty body' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+      rescue => e
+      ensure
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using exception variable in `ensure` clause' do
     expect_no_offenses(<<~RUBY)
       def foo


### PR DESCRIPTION
This PR fixes an error for `Lint/UselessRescue` when `rescue` does not exception variable and `ensure` has empty body:

```ruby
def foo
rescue => e
ensure
end
```

```console
% bundle exec rubocop --only Lint/UselessRescue -d
(snip)

undefined method `each_descendant' for nil:NilClass
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/lint/useless_rescue.rb:78:in `use_exception_variable_in_ensure?'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/lint/useless_rescue.rb:60:in `only_reraising?'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/lint/useless_rescue.rb:54:in `on_rescue'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
