### PR TITLE
[Fix #11202] Fix `--only` flag usage with `--auto-gen-config` and `Layout/LineLength`

### DIFF
--- a/changelog/fix_only_flag_usage_with_auto_gen_config.md
+++ b/changelog/fix_only_flag_usage_with_auto_gen_config.md
@@ -1,0 +1,1 @@
+* [#11202](https://github.com/rubocop/rubocop/issues/11202): Fixed usage of `--only` flag with `--auto-gen-config`. ([@istvanfazakas][])

--- a/lib/rubocop/cli/command/auto_generate_config.rb
+++ b/lib/rubocop/cli/command/auto_generate_config.rb
@@ -16,6 +16,7 @@ module RuboCop
 
         PHASE_1_OVERRIDDEN = '(skipped because the default Layout/LineLength:Max is overridden)'
         PHASE_1_DISABLED = '(skipped because Layout/LineLength is disabled)'
+        PHASE_1_SKIPPED = '(skipped because a list of cops is passed to the `--only` flag)'
 
         def run
           add_formatter
@@ -31,6 +32,8 @@ module RuboCop
             skip_line_length_cop(PHASE_1_DISABLED)
           elsif !same_max_line_length?(@config_store.for_pwd, ConfigLoader.default_configuration)
             skip_line_length_cop(PHASE_1_OVERRIDDEN)
+          elsif options_has_only_flag?
+            skip_line_length_cop(PHASE_1_SKIPPED)
           else
             run_line_length_cop
           end
@@ -55,6 +58,10 @@ module RuboCop
 
         def line_length_cop(config)
           config.for_cop('Layout/LineLength')
+        end
+
+        def options_has_only_flag?
+          @options[:only]
         end
 
         # Do an initial run with only Layout/LineLength so that cops that


### PR DESCRIPTION
**Fixes https://github.com/rubocop/rubocop/issues/11202
This PR fixes the usage of the `--only` flag with the `--auto-gen-config` when the `Layout/LineLength` COP is enabled.
It will only generate the config for the given COPs if we use use the `--only` flag.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
