### PR TITLE
Fix an error for `Layout/HeredocArgumentClosingParenthesis`

### DIFF
--- a/changelog/fix_an_error_for_layout_heredoc_argument_closing_parenthesis.md
+++ b/changelog/fix_an_error_for_layout_heredoc_argument_closing_parenthesis.md
@@ -1,0 +1,1 @@
+* [#11579](https://github.com/rubocop/rubocop/pull/11579): Fix an error for `Layout/HeredocArgumentClosingParenthesis` when heredoc is a method argument in a parenthesized block argument. ([@koic][])

--- a/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
+++ b/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
@@ -215,6 +215,7 @@ module RuboCop
         end
 
         def exist_argument_between_heredoc_end_and_closing_parentheses?(node)
+          return true unless node.loc.end
           return false unless (heredoc_end = find_most_bottom_of_heredoc_end(node.arguments))
 
           heredoc_end < node.loc.end.begin_pos &&

--- a/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb
@@ -76,6 +76,16 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis, :config 
       RUBY
     end
 
+    it 'accepts when heredoc is a method argument in a parenthesized block argument' do
+      expect_no_offenses(<<~RUBY)
+        foo(bar do
+          baz <<~EOS
+            text
+          EOS
+        end)
+      RUBY
+    end
+
     it 'accepts correct case with other param after' do
       expect_no_offenses(<<~RUBY)
         foo(<<-SQL, 123)


### PR DESCRIPTION
This PR fixes an error for `Layout/HeredocArgumentClosingParenthesis` when heredoc is a method argument in a parenthesized block argument:

```ruby
foo(bar do
  baz <<~EOS
  EOS
end)
```

```console
% bundle exec rubocop --only Layout/HeredocArgumentClosingParenthesis
(snip)

undefined method `begin_pos' for nil:NilClass
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/layout/
heredoc_argument_closing_parenthesis.rb:220:in `exist_argument_between_heredoc_end_and_closing_parentheses?'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/layout/
heredoc_argument_closing_parenthesis.rb:73:in `on_send'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/commissioner.rb:107:in `public_send'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
