### PR TITLE
Fix checking if token with large offset begins its line

### DIFF
--- a/changelog/fix_line_begins_check_for_large_offset.md
+++ b/changelog/fix_line_begins_check_for_large_offset.md
@@ -1,0 +1,1 @@
+* [#11582](https://github.com/rubocop/rubocop/issues/11582): Fix checking if token with large offset begins its line. ([@fatkodima][])

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -3,6 +3,7 @@
 module RuboCop
   module Cop
     # This module contains a collection of useful utility methods.
+    # rubocop:disable Metrics/ModuleLength
     module Util
       include PathUtil
 
@@ -92,13 +93,20 @@ module RuboCop
         sexp.each_child_node { |elem| on_node(syms, elem, excludes, &block) }
       end
 
+      # Arbitrarily chosen value, should be enough to cover
+      # the most nested source code in real world projects.
+      MAX_LINE_BEGINS_REGEX_INDEX = 50
       LINE_BEGINS_REGEX_CACHE = Hash.new do |hash, index|
-        hash[index] = /^\s{#{index}}\S/
+        hash[index] = /^\s{#{index}}\S/ if index <= MAX_LINE_BEGINS_REGEX_INDEX
       end
-      private_constant :LINE_BEGINS_REGEX_CACHE
+      private_constant :MAX_LINE_BEGINS_REGEX_INDEX, :LINE_BEGINS_REGEX_CACHE
 
       def begins_its_line?(range)
-        range.source_line.match?(LINE_BEGINS_REGEX_CACHE[range.column])
+        if (regex = LINE_BEGINS_REGEX_CACHE[range.column])
+          range.source_line.match?(regex)
+        else
+          range.source_line.index(/\S/) == range.column
+        end
       end
 
       # Returns, for example, a bare `if` node if the given node is an `if`
@@ -190,5 +198,6 @@ module RuboCop
         source == target || (source.is_a?(Array) && source.include?(target))
       end
     end
+    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1640,4 +1640,11 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
       end
     end
   end
+
+  it 'does not register an offense for blocks with a very large offset' do
+    expect_no_offenses(<<~RUBY)
+      foo {
+      #{' ' * 100_001}}
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #11582.

50 is pretty reasonable number, I think. For bigger offsets we just fallback to the previous behavior.