### PR TITLE
Handle `ruby2_keywords` in `Style/DocumentationMethod` cop

### DIFF
--- a/changelog/change_documentation_method_accept_handle_ruby2_keywords.md
+++ b/changelog/change_documentation_method_accept_handle_ruby2_keywords.md
@@ -1,0 +1,1 @@
+* [#11586](https://github.com/rubocop/rubocop/issues/11586): Handle `ruby2_keywords` in `Style/DocumentationMethod` cop. ([@fatkodima][])

--- a/lib/rubocop/cop/style/documentation_method.rb
+++ b/lib/rubocop/cop/style/documentation_method.rb
@@ -101,16 +101,16 @@ module RuboCop
 
         MSG = 'Missing method documentation comment.'
 
-        # @!method module_function_node?(node)
-        def_node_matcher :module_function_node?, <<~PATTERN
-          (send nil? :module_function ...)
+        # @!method modifier_node?(node)
+        def_node_matcher :modifier_node?, <<~PATTERN
+          (send nil? {:module_function :ruby2_keywords} ...)
         PATTERN
 
         def on_def(node)
           return if node.method?(:initialize)
 
           parent = node.parent
-          module_function_node?(parent) ? check(parent) : check(node)
+          modifier_node?(parent) ? check(parent) : check(node)
         end
         alias on_defs on_def
 

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -619,6 +619,16 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
             RUBY
           end
         end
+
+        it 'registers an offense for inline def with ruby2_keywords' do
+          expect_offense(<<~RUBY)
+            module Foo
+              ruby2_keywords def bar
+              ^^^^^^^^^^^^^^^^^^^^^^ Missing method documentation comment.
+              end
+            end
+          RUBY
+        end
       end
 
       context 'with documentation comment' do
@@ -664,6 +674,16 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
               end
             RUBY
           end
+        end
+
+        it 'does not register an offense for inline def with ruby2_keywords' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              # Documentation
+              ruby2_keywords def bar
+              end
+            end
+          RUBY
         end
       end
 


### PR DESCRIPTION
Fixes #11586.