### PR TITLE
Optimize `Style/WordArray` complex matrix check

### DIFF
--- a/changelog/change_optimize_style_word_array_complex_matrix_check.md
+++ b/changelog/change_optimize_style_word_array_complex_matrix_check.md
@@ -1,0 +1,1 @@
+* [#11588](https://github.com/rubocop/rubocop/pull/11588): Optimize `Style/WordArray` complex matrix check. ([@sambostock][])


### PR DESCRIPTION
One of the checks we do in `Style/WordArray` is to check if an otherwise simple array is a member of a parent array consisting exclusively of arrays, including at least one with "complex" content.

This means that for each sub-array, we navigate up to the parent, and check all of its children, resulting in `n²` array complexity checks.

By maintaining a cache of checked parent array nodes per investigation (i.e. per file), we can reduce this to `n` array complexity checks.

This has a massive impact on performance when investigating files containing large arrays of arrays. A test is added with a timeout that does not pass when using the non-caching implementation **(it would take over a minute; now takes under a second)**.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
