### PR TITLE
Fix an error for `Layout/HeredocArgumentClosingParenthesis`

### DIFF
--- a/changelog/fix_error_for_layout_heredoc_argument_closing_parenthesis.md
+++ b/changelog/fix_error_for_layout_heredoc_argument_closing_parenthesis.md
@@ -1,0 +1,1 @@
+* [#11589](https://github.com/rubocop/rubocop/pull/11589): Fix an error for `Layout/HeredocArgumentClosingParenthesis` when heredoc is a branch body in a method argument of a parenthesized argument. ([@koic][])

--- a/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
+++ b/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
@@ -67,8 +67,7 @@ module RuboCop
 
           outermost_send = outermost_send_on_same_line(heredoc_arg)
           return unless outermost_send
-          return unless outermost_send.loc.end
-          return unless heredoc_arg.first_line != outermost_send.loc.end.line
+          return if end_keyword_before_closing_parentesis?(node)
           return if subsequent_closing_parentheses_in_same_line?(outermost_send)
           return if exist_argument_between_heredoc_end_and_closing_parentheses?(node)
 
@@ -159,6 +158,12 @@ module RuboCop
         end
 
         # Closing parenthesis helpers.
+
+        def end_keyword_before_closing_parentesis?(parenthesized_send_node)
+          parenthesized_send_node.ancestors.any? do |ancestor|
+            ancestor.loc.respond_to?(:end) && ancestor.loc.end&.source == 'end'
+          end
+        end
 
         def subsequent_closing_parentheses_in_same_line?(outermost_send)
           last_arg_of_outer_send = outermost_send.last_argument

--- a/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb
@@ -80,6 +80,25 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis, :config 
       expect_no_offenses(<<~RUBY)
         foo(bar do
           baz <<~EOS
+          EOS
+        end)
+      RUBY
+    end
+
+    it 'accepts when heredoc is a branch body in a method argument of a parenthesized argument' do
+      expect_no_offenses(<<~RUBY)
+        foo(unless condition
+          bar(<<~EOS)
+            text
+          EOS
+        end)
+      RUBY
+    end
+
+    it 'accepts when heredoc is a branch body in a nested method argument of a parenthesized argument' do
+      expect_no_offenses(<<~RUBY)
+        foo(unless condition
+          bar(baz(<<~EOS))
             text
           EOS
         end)


### PR DESCRIPTION
This PR fixes the following error for `Layout/HeredocArgumentClosingParenthesis` when heredoc is a branch body in a method argument of a parenthesized argument:

```ruby
foo(unless condition
  bar(<<~STRING)
    text
  STRING
end)
```

```console
% bundle exec rubocop --only Layout/HeredocArgumentClosingParenthesis -a
(snip)

Offenses:

example.rb:5:4: C: [Corrected] Layout/HeredocArgumentClosingParenthesis:
Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
end)
   ^

0 files inspected, 1 offense detected, 1 offense corrected
Infinite loop detected in /Users/koic/src/github.com/koic/rubocop-issues/example.rb
and caused by Layout/HeredocArgumentClosingParenthesis
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/runner.rb:332:in `check_for_infinite_loop'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/runner.rb:315:in `block in iterate_until_no_changes'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
