### PR TITLE
Document that disable comments can include a descriptive comment

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -739,11 +739,11 @@ Running `rubocop --autocorrect --disable-uncorrectable` will
 create comments to disable all offenses that can't be automatically
 corrected.
 
-Do not write anything other than cop name in the disabling comment. E.g.:
+You can also include a comment to explain why the cop has been disabled. E.g.:
 
 [source,ruby]
 ----
-# rubocop:disable Layout/LineLength --This is a bad comment that includes other than cop name.
+# rubocop:disable Layout/LineLength This is a comment that explains why Layout/LineLength is disabled.
 ----
 
 == Temporarily enabling cops in source code


### PR DESCRIPTION
Updates the documentation to reflect that disabling comments _can_ include descriptive text after the cop name. This feature was introduced in #3191 and as far as I can tell is still supported. 

_This is only a documentation update, I'll do my best to pick the relevant tasks below 🙇🏻_

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/