### PR TITLE
[Fix #11591] Fix a false positive for `Lint/ToEnumArguments`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_to_enum_arguments.md
+++ b/changelog/fix_a_false_positive_for_lint_to_enum_arguments.md
@@ -1,0 +1,1 @@
+* [#11591](https://github.com/rubocop/rubocop/issues/11591): Fix a false positive for `Lint/ToEnumArguments` when enumerator is not created for `__callee__` and `__callee__` methods. ([@koic][])

--- a/lib/rubocop/cop/lint/to_enum_arguments.rb
+++ b/lib/rubocop/cop/lint/to_enum_arguments.rb
@@ -43,8 +43,12 @@ module RuboCop
           return unless def_node
 
           enum_conversion_call?(node) do |method_node, arguments|
-            add_offense(node) unless method_name?(method_node, def_node.method_name) &&
-                                     arguments_match?(arguments, def_node)
+            next if method_node.call_type? &&
+                    !method_node.method?(:__method__) && !method_node.method?(:__callee__)
+            next if method_name?(method_node, def_node.method_name) &&
+                    arguments_match?(arguments, def_node)
+
+            add_offense(node)
           end
         end
 

--- a/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
+++ b/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
@@ -122,6 +122,23 @@ RSpec.describe RuboCop::Cop::Lint::ToEnumArguments, :config do
     RUBY
   end
 
+  it 'does not register an offense when enumerator is not created for `__method__` and `__callee__` methods' do
+    expect_no_offenses(<<~RUBY)
+      def m(x)
+        return to_enum(never_nullable(value), x)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when enumerator is not created for `__method__` and `__callee__` methods ' \
+     'and using safe navigation operator' do
+    expect_no_offenses(<<~RUBY)
+      def m(x)
+        return to_enum(obj&.never_nullable(value), x)
+      end
+    RUBY
+  end
+
   %w[:m __callee__ __method__].each do |code|
     it "does not register an offense when enumerator is created with `#{code}` and the correct arguments" do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #11591.

THis PR fixes a false positive for `Lint/ToEnumArguments` when enumerator is not created for `__callee__` and `__callee__` methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
