### PR TITLE
Cache similar name suggestions in `Lint/RedundantCopDisableDirective` cop

### DIFF
--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -284,12 +284,18 @@ module RuboCop
             .all? { |intervening| /\A\s*,\s*\Z/.match?(intervening) }
         end
 
+        SIMILAR_COP_NAMES_CACHE = Hash.new do |hash, cop_name|
+          hash[:all_cop_names] = Registry.global.names unless hash.key?(:all_cop_names)
+          hash[cop_name] = NameSimilarity.find_similar_name(cop_name, hash[:all_cop_names])
+        end
+        private_constant :SIMILAR_COP_NAMES_CACHE
+
         def describe(cop)
           return 'all cops' if cop == 'all'
           return "`#{remove_department_marker(cop)}` department" if department_marker?(cop)
           return "`#{cop}`" if all_cop_names.include?(cop)
 
-          similar = NameSimilarity.find_similar_name(cop, all_cop_names)
+          similar = SIMILAR_COP_NAMES_CACHE[cop]
           similar ? "`#{cop}` (did you mean `#{similar}`?)" : "`#{cop}` (unknown cop)"
         end
 


### PR DESCRIPTION
Measured in Gitlab's codebase. They have a few old-named (yet to be renamed) cops disabled in the codebase.

### Before
Execution time: `225s`
```
  Mode: wall(1000)
  Samples: 224700 (0.73% miss rate)
  GC: 10689 (4.76%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
 ==> 31853  (14.2%)       31853  (14.2%)     DidYouMean::Jaro.distance
     15008   (6.7%)        9356   (4.2%)     Parser::Lexer#advance
      5485   (2.4%)        5485   (2.4%)     (sweeping)
      5118   (2.3%)        5118   (2.3%)     (marking)
     10074   (4.5%)        4588   (2.0%)     RuboCop::AST::Descendence#each_child_node
      4430   (2.0%)        4430   (2.0%)     Parser::Source::Buffer#slice
      5470   (2.4%)        4252   (1.9%)     Parser::Source::Buffer#line_index_for_position
      4860   (2.2%)        3668   (1.6%)     RuboCop::Cop::Base#initialize
      4586   (2.0%)        3544   (1.6%)     AST::Node#initialize
     34103  (15.2%)        3326   (1.5%)     RuboCop::AST::ProcessedSource.from_file
     12652   (5.6%)        3038   (1.4%)     RuboCop::Cop::Base#relevant_file?
      3002   (1.3%)        3000   (1.3%)     RuboCop::Cop::Base.badge
      3477   (1.5%)        2793   (1.2%)     RuboCop::AST::Descendence#visit_descendants
      3445   (1.5%)        2738   (1.2%)     RuboCop::Cop::Base#complete_investigation
      3343   (1.5%)        2732   (1.2%)     RuboCop::Cop::Base#cop_config
      3817   (1.7%)        2712   (1.2%)     RuboCop::PathUtil.match_path?
      2614   (1.2%)        2614   (1.2%)     Parser::Source::Range#initialize
      2367   (1.1%)        2367   (1.1%)     RuboCop::AST::SendNode#first_argument_index
      2263   (1.0%)        2263   (1.0%)     RuboCop::Cop::Base#begin_investigation
      2355   (1.0%)        2218   (1.0%)     RuboCop::Cop::Team#validate_config
      2119   (0.9%)        2119   (0.9%)     RuboCop::Cop::AutocorrectLogic#autocorrect_requested?
      1899   (0.8%)        1899   (0.8%)     RuboCop::Cop::Base#reset_investigation
      1794   (0.8%)        1794   (0.8%)     RuboCop::Cop::Base#on_investigation_end
      1780   (0.8%)        1780   (0.8%)     RuboCop::Cop::Base#on_new_investigation
      1438   (0.6%)        1438   (0.6%)     RuboCop::AST::MethodDispatchNode#receiver
      1422   (0.6%)        1372   (0.6%)     Set#include?
      2238   (1.0%)        1329   (0.6%)     RuboCop::Cop::Base#callbacks_needed
      2446   (1.1%)        1328   (0.6%)     RuboCop::Config#clusivity_config_for_badge?
      1405   (0.6%)        1318   (0.6%)     RuboCop::Cop::Base#cop_name
      1937   (0.9%)        1297   (0.6%)     RuboCop::Cop::Team.forces_for
```

### After
Execution time: `191s` 🔥 
```
  Mode: wall(1000)
  Samples: 191341 (0.60% miss rate)
  GC: 10022 (5.24%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     15289   (8.0%)        9637   (5.0%)     Parser::Lexer#advance
      5153   (2.7%)        5153   (2.7%)     (sweeping)
      4792   (2.5%)        4792   (2.5%)     (marking)
      4521   (2.4%)        4521   (2.4%)     Parser::Source::Buffer#slice
      9940   (5.2%)        4418   (2.3%)     RuboCop::AST::Descendence#each_child_node
      5516   (2.9%)        4291   (2.2%)     Parser::Source::Buffer#line_index_for_position
      4774   (2.5%)        3596   (1.9%)     RuboCop::Cop::Base#initialize
      4504   (2.4%)        3475   (1.8%)     AST::Node#initialize
     12416   (6.5%)        3027   (1.6%)     RuboCop::Cop::Base#relevant_file?
      3679   (1.9%)        2989   (1.6%)     RuboCop::AST::Descendence#visit_descendants
      3510   (1.8%)        2815   (1.5%)     RuboCop::Cop::Base#complete_investigation
      2756   (1.4%)        2755   (1.4%)     RuboCop::Cop::Base.badge
      3876   (2.0%)        2718   (1.4%)     RuboCop::PathUtil.match_path?
      3147   (1.6%)        2629   (1.4%)     RuboCop::Cop::Base#cop_config
      2628   (1.4%)        2628   (1.4%)     Parser::Source::Range#initialize
      2603   (1.4%)        2603   (1.4%)     RuboCop::AST::SendNode#first_argument_index
     33320  (17.4%)        2346   (1.2%)     RuboCop::AST::ProcessedSource.from_file
      2484   (1.3%)        2342   (1.2%)     RuboCop::Cop::Team#validate_config
      2228   (1.2%)        2228   (1.2%)     RuboCop::Cop::Base#begin_investigation
      2050   (1.1%)        2050   (1.1%)     RuboCop::Cop::AutocorrectLogic#autocorrect_requested?
      1873   (1.0%)        1873   (1.0%)     RuboCop::Cop::Base#reset_investigation
      1768   (0.9%)        1768   (0.9%)     RuboCop::Cop::Base#on_investigation_end
      1734   (0.9%)        1734   (0.9%)     RuboCop::Cop::Base#on_new_investigation
      1554   (0.8%)        1554   (0.8%)     RuboCop::AST::MethodDispatchNode#receiver
      2025   (1.1%)        1381   (0.7%)     RuboCop::Cop::Team.forces_for
      2410   (1.3%)        1375   (0.7%)     RuboCop::Cop::Base#callbacks_needed
      1360   (0.7%)        1360   (0.7%)     RuboCop::AST::Node#parent
      2389   (1.2%)        1331   (0.7%)     RuboCop::Config#clusivity_config_for_badge?
      1367   (0.7%)        1330   (0.7%)     Set#include?
      1386   (0.7%)        1302   (0.7%)     RuboCop::Cop::Base#cop_name
```