### PR TITLE
Fix a false positive for `Layout/LineContinuationSpacing`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_line_continuation_spacing.md
+++ b/changelog/fix_a_false_positive_for_layout_line_continuation_spacing.md
@@ -1,0 +1,1 @@
+* [#11599](https://github.com/rubocop/rubocop/pull/11599): Fix a false positive for `Layout/LineContinuationSpacing` when using percent literals. ([@koic][])

--- a/spec/rubocop/cop/layout/line_continuation_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/line_continuation_spacing_spec.rb
@@ -61,6 +61,21 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationSpacing, :config do
       RUBY
     end
 
+    it 'registers an offense when too much space in front of backslash in array literals' do
+      expect_offense(<<~'RUBY')
+        [
+          :foo  \
+              ^^^ Use one space in front of backslash.
+        ]
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        [
+          :foo \
+        ]
+      RUBY
+    end
+
     it 'registers no offense with one space in front of backslash' do
       expect_no_offenses(<<~'RUBY')
         if 2 + 2 \
@@ -77,6 +92,14 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationSpacing, :config do
           is\
           ok
         X
+      RUBY
+    end
+
+    it 'ignores percent literals' do
+      expect_no_offenses(<<~'RUBY')
+        %i[
+          foo  \
+        ]
       RUBY
     end
 
@@ -164,6 +187,21 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationSpacing, :config do
       RUBY
     end
 
+    it 'registers an offense when too much space in front of backslash in array literals' do
+      expect_offense(<<~'RUBY')
+        [
+          :foo  \
+              ^^^ Use zero spaces in front of backslash.
+        ]
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        [
+          :foo\
+        ]
+      RUBY
+    end
+
     it 'ignores heredocs and comments' do
       expect_no_offenses(<<~'RUBY')
         # this \
@@ -171,6 +209,14 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationSpacing, :config do
           is  \
           ok
         X
+      RUBY
+    end
+
+    it 'ignores percent literals' do
+      expect_no_offenses(<<~'RUBY')
+        %i[
+          foo  \
+        ]
       RUBY
     end
 


### PR DESCRIPTION
This PR fixes a false positive for `Layout/LineContinuationSpacing` when using percent literals.

Space with `\` has meaning in percent literals. e.g.:

```ruby
p %i[
    x \
   ]

p %i[
    x\
  ]
```

```console
% ruby example.rb
[:x, :"\n"]
[:"x\n"]
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
