### PR TITLE
[Fix #11596] Make `Style/AccessorGrouping` aware of method call before accessor

### DIFF
--- a/changelog/change_make_style_accessor_grouping_aware_of_method_call_before_accessor_method.md
+++ b/changelog/change_make_style_accessor_grouping_aware_of_method_call_before_accessor_method.md
@@ -1,0 +1,1 @@
+* [#11596](https://github.com/rubocop/rubocop/issues/11596): Make `Style/AccessorGrouping` aware of method call before accessor. ([@koic][])

--- a/spec/rubocop/cop/style/accessor_grouping_spec.rb
+++ b/spec/rubocop/cop/style/accessor_grouping_spec.rb
@@ -124,6 +124,45 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
       RUBY
     end
 
+    it 'does not register an offense for accessors with other methods' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          annotation_method :one
+          attr_reader :one
+
+          annotation_method :two
+          attr_reader :two
+        end
+      RUBY
+    end
+
+    it 'registers an offense for accessors with method definitions' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def foo
+          end
+          attr_reader :one
+          ^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes.
+
+          def bar
+          end
+          attr_reader :two
+          ^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          def foo
+          end
+          attr_reader :one, :two
+
+          def bar
+          end
+        end
+      RUBY
+    end
+
     it 'registers offense and corrects if at least two separate accessors without comments' do
       expect_offense(<<~RUBY)
         class Foo


### PR DESCRIPTION
Fixes #11596.

This PR makes `Style/AccessorGrouping` aware of method call before accessor.

If there is a method call before the accessor method it is always allowed as it might be intended like Sorbet . Note, it respects user's intentions, not just Sorbet. Because (annotation) comments are already allowed, so (annotation) methods can be generalized as well.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
