### PR TITLE
Actually run temporarily enabled cops

### DIFF
--- a/changelog/fix_actually_run_temporarily_enabled_cops.md
+++ b/changelog/fix_actually_run_temporarily_enabled_cops.md
@@ -1,0 +1,1 @@
+* [#11603](https://github.com/rubocop/rubocop/pull/11603): Actually run temporarily enabled cops. ([@tdeo][])

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -42,6 +42,10 @@ module RuboCop
       disabled_line_ranges.none? { |range| range.include?(line_number) }
     end
 
+    def cop_opted_in?(cop)
+      opt_in_cops.include?(cop.cop_name)
+    end
+
     def cop_disabled_line_ranges
       @cop_disabled_line_ranges ||= analyze
     end
@@ -72,6 +76,19 @@ module RuboCop
       end
 
       extras
+    end
+
+    def opt_in_cops
+      @opt_in_cops ||= begin
+        cops = Set.new
+        each_directive do |directive|
+          next unless directive.enabled?
+          next if directive.all_cops?
+
+          cops.merge(directive.cop_names)
+        end
+        cops
+      end
     end
 
     def analyze # rubocop:todo Metrics/AbcSize

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -69,7 +69,7 @@ module CopHelper
   end
 
   def _investigate(cop, processed_source)
-    team = RuboCop::Cop::Team.new([cop], nil, raise_error: true)
+    team = RuboCop::Cop::Team.new([cop], configuration, raise_error: true)
     report = team.investigate(processed_source)
     @last_corrector = report.correctors.first || RuboCop::Cop::Corrector.new(processed_source)
     report.offenses.reject(&:disabled?)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
   end
 
   describe 'for a disabled cop' do
-    it 'reports no offense when enabled on part of a file' do
+    it 'reports an offense when explicitly enabled on part of a file' do
       create_file('.rubocop.yml', <<~YAML)
         AllCops:
           SuggestExtensions: false
@@ -292,18 +292,17 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
         a = 1
         # rubocop:enable Lint/UselessAssignment
-        b = a
-        b += 1
+        b = 2
         # rubocop:disable Lint/UselessAssignment
-        c = 2
+        c = 3
       RUBY
 
-      expect(cli.run(['--format', 'offenses', 'example.rb'])).to eq(0)
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
       expect($stdout.string).to eq(<<~RESULT)
+        == example.rb ==
+        W:  5:  1: Lint/UselessAssignment: Useless assignment to variable - b.
 
-        --
-        0  Total in 0 files
-
+        1 file inspected, 1 offense detected
       RESULT
     end
   end

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -256,25 +256,6 @@ RSpec.describe RuboCop::Cop::Team do
         expect(cops[1].name).to eq('Lint/Void')
       end
     end
-
-    context 'when some classes are disabled with config' do
-      let(:disabled_config) do
-        %w[
-          Lint/Void
-          Layout/LineLength
-        ].each_with_object(RuboCop::Config.new) do |cop_name, accum|
-          accum[cop_name] = { 'Enabled' => false }
-        end
-      end
-      let(:config) { RuboCop::ConfigLoader.merge_with_default(disabled_config, '') }
-      let(:cop_names) { cops.map(&:name) }
-
-      it 'does not return instances of the classes' do
-        expect(cops.empty?).to be(false)
-        expect(cop_names.include?('Lint/Void')).to be(false)
-        expect(cop_names.include?('Layout/LineLength')).to be(false)
-      end
-    end
   end
 
   describe '#forces' do


### PR DESCRIPTION
A follow-up on https://github.com/rubocop/rubocop/pull/10987, I was trying to use the temporarily cop enablement feature, and realized that it wasn't working as intended. Although rubocop does not complain about unneeded directives in such case, it turns out those temporarily enabled cops weren't reporting any offense.

I think I overlooked 2 things in the original implementation:
- the fact that `Team.mobilize_cops` was going to exclude those cops from the beginning and never invoke them
- the [test](https://github.com/rubocop/rubocop/pull/10987/files#diff-46b3c2cf6f8085fc01a6be8ddf84f83b741c9065ecb04cd0cb3409ee29bf9379R282) that I wrote was checking that the temporarily enabled cop wasn't reported as an unneeded directive, but not that it was actually reporting offenses, this is now fixed.


A few points that I'd like to hear your opinions about:

- I'm not super happy with the implementation in `RuboCop::Team` which instantiates a new `Registry`, but changing the class methods to pass the whole registry to `initialize` looked fishy as there seems to be backward-compatible reasons, happy to hear other suggestions.

- Do you think I should keep the removed test in `team_spec` for disabled cops, as this would now cover a private method (`roundup_relevant_cops`) or trust the other test cases to make sure the implementation is correct?

- I generated a bugfix changelog since the behavior is already in the docs, but since the original implementation actually had no effect, should this be considered a new feature?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
