### PR TITLE
[Fix #11604] Make `Naming/VariableNumber` to allow `x86_64` by default

### DIFF
--- a/changelog/change_make_naming_variable_number_to_allow_x86_64_by_default.md
+++ b/changelog/change_make_naming_variable_number_to_allow_x86_64_by_default.md
@@ -1,0 +1,1 @@
+* [#11604](https://github.com/rubocop/rubocop/issues/11604): Make `Naming/VariableNumber` to allow `x86_64` CPU architecture name by default. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2923,6 +2923,7 @@ Naming/VariableNumber:
     - rfc822       # Time#rfc822
     - rfc2822      # Time#rfc2822
     - rfc3339      # DateTime.rfc3339
+    - x86_64       # Allowed by default as an underscore separated CPU architecture name
   AllowedPatterns: []
 
 #################### Security ##############################

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -678,7 +678,7 @@ RSpec.describe RuboCop::ConfigLoader do
           .to contain_exactly('foo.rb', 'test.rb')
         expect(examples_configuration['Include']).to contain_exactly('bar.rb', 'another_test.rb')
         expect(examples_configuration['AllowedIdentifiers'])
-          .to contain_exactly(*%w[capture3 iso8601 rfc1123_date rfc2822 rfc3339 rfc822 iso2])
+          .to contain_exactly(*%w[capture3 iso8601 rfc1123_date rfc2822 rfc3339 rfc822 iso2 x86_64])
       end
     end
 


### PR DESCRIPTION
Fixes #11604.

This PR makes `Naming/VariableNumber` to allow `x86_64` CPU architecture name by default. CPU architecture names such as "x86" and "arm64" are not added as they do not require underscore separators like "x86_64".

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
