### PR TITLE
Fix an error for `Lint/RefinementImportMethods`

### DIFF
--- a/changelog/fix_an_error_for_refinement_import_methods.md
+++ b/changelog/fix_an_error_for_refinement_import_methods.md
@@ -1,0 +1,1 @@
+* [#11608](https://github.com/rubocop/rubocop/pull/11608): Fix an error for `Lint/RefinementImportMethods` when using `include` on the top level. ([@koic][])

--- a/lib/rubocop/cop/lint/refinement_import_methods.rb
+++ b/lib/rubocop/cop/lint/refinement_import_methods.rb
@@ -41,7 +41,8 @@ module RuboCop
 
         def on_send(node)
           return if node.receiver
-          return unless node.parent.block_type? && node.parent.method?(:refine)
+          return unless (parent = node.parent)
+          return unless parent.block_type? && parent.method?(:refine)
 
           add_offense(node.loc.selector, message: format(MSG, current: node.method_name))
         end

--- a/spec/rubocop/cop/lint/refinement_import_methods_spec.rb
+++ b/spec/rubocop/cop/lint/refinement_import_methods_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe RuboCop::Cop::Lint::RefinementImportMethods, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when using `include` on the top level' do
+      expect_no_offenses(<<~RUBY)
+        include Foo
+      RUBY
+    end
   end
 
   context 'Ruby <= 3.0', :ruby30 do


### PR DESCRIPTION
This PR fixes an error for `Lint/RefinementImportMethods` when using `include` on the top level.

```ruby
include Foo
```

```console
% bundle exec rubocop --only Lint/RefinementImportMethods -d
(snip)

undefined method `block_type?' for nil:NilClass
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/lint/refinement_import_methods.rb:44:in `on_send'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/commissioner.rb:143:in `public_send'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
