### PR TITLE
Handle modifier looping conditionals so `Lint/UselessAssignment` doesn't give false positives

### DIFF
--- a/changelog/fix_handle_modifier_looping_conditionals_in.md
+++ b/changelog/fix_handle_modifier_looping_conditionals_in.md
@@ -1,0 +1,1 @@
+* [#3591](https://github.com/rubocop/rubocop/issues/3591): Handle modifier `while` and `until` expressions in `Lint/UselessAssignment`. ([@bfad][])

--- a/lib/rubocop/cop/variable_force/variable.rb
+++ b/lib/rubocop/cop/variable_force/variable.rb
@@ -52,7 +52,7 @@ module RuboCop
             # if/unless keyword. A preceding assignment is needed to put the
             # variable in scope. For this reason we skip to the next assignment
             # here.
-            next if in_modifier_if?(assignment)
+            next if in_modifier_conditional?(assignment)
 
             break if !assignment.branch || assignment.branch == reference.branch
 
@@ -63,10 +63,12 @@ module RuboCop
         end
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
-        def in_modifier_if?(assignment)
+        def in_modifier_conditional?(assignment)
           parent = assignment.node.parent
           parent = parent.parent if parent&.begin_type?
-          parent&.if_type? && parent&.modifier_form?
+          return false if parent.nil?
+
+          (parent.if_type? || parent.while_type? || parent.until_type?) && parent.modifier_form?
         end
 
         def capture_with_block!

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -17,6 +17,22 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when a variable is assigned and assigned again in a modifier loop condition' do
+    it 'accepts with parentheses' do
+      expect_no_offenses(<<~RUBY)
+        a = nil
+        puts a while (a = false)
+      RUBY
+    end
+
+    it 'accepts without parentheses' do
+      expect_no_offenses(<<~RUBY)
+        a = nil
+        puts a until a = true
+      RUBY
+    end
+  end
+
   context 'when a variable is assigned and unreferenced in a method' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
The modifier `if` and `unless` expressions were fixed in [fca7d43][], but it didn't also fix it for the modifier forms of `while` and `until`. This commit builds on that commit so that the following code no longer fails the Lint/UselessAssignment cop:

```
middleware = nil
middleware.call(env) while (middleware = rack_middleware.next)
```

[fca7d43]: https://github.com/rubocop/rubocop/commit/fca7d435b438ea407854adccac11b4a1beb1301d

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
