### PR TITLE
Add examples for `Style/AccessorGrouping`

### DIFF
--- a/lib/rubocop/cop/style/accessor_grouping.rb
+++ b/lib/rubocop/cop/style/accessor_grouping.rb
@@ -22,6 +22,15 @@ module RuboCop
       #     attr_reader :bar, :baz
       #   end
       #
+      #   # good
+      #   class Foo
+      #     # may be intended comment for bar.
+      #     attr_reader :bar
+      #
+      #     may_be_intended_annotation :baz
+      #     attr_reader :baz
+      #   end
+      #
       # @example EnforcedStyle: separated
       #   # bad
       #   class Foo


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/11602#issuecomment-1440585242.

This PR adds examples for `Style/AccessorGrouping`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
