### PR TITLE
Allow numeric names in `Naming/ClassAndModuleCamelCase` cop

### DIFF
--- a/changelog/change_allow_numeric_names_for_camelcase_cop.md
+++ b/changelog/change_allow_numeric_names_for_camelcase_cop.md
@@ -1,0 +1,1 @@
+* [#11611](https://github.com/rubocop/rubocop/pull/11611): Allow numeric names in `Naming/ClassAndModuleCamelCase` cop. ([@tejasbubane][])

--- a/lib/rubocop/cop/naming/class_and_module_camel_case.rb
+++ b/lib/rubocop/cop/naming/class_and_module_camel_case.rb
@@ -34,11 +34,18 @@ module RuboCop
 
           allowed = /#{cop_config['AllowedNames'].join('|')}/
           name = node.loc.name.source.gsub(allowed, '')
+          name = remove_grouped_digits(name)
           return unless name.include?('_')
 
           add_offense(node.loc.name)
         end
         alias on_module on_class
+
+        private
+
+        def remove_grouped_digits(name)
+          name.split('_').grep_v(/^\d+$/).join('_')
+        end
       end
     end
   end

--- a/spec/rubocop/cop/naming/class_and_module_camel_case_spec.rb
+++ b/spec/rubocop/cop/naming/class_and_module_camel_case_spec.rb
@@ -35,6 +35,33 @@ RSpec.describe RuboCop::Cop::Naming::ClassAndModuleCamelCase, :config do
     RUBY
   end
 
+  context 'names with digits' do
+    it 'accepts names with grouped digits' do
+      expect_no_offenses(<<~RUBY)
+        class X86_64
+        end
+
+        module ISO_8859_1
+        end
+
+        class CVE_2023_1234
+        end
+      RUBY
+    end
+
+    it 'registers offense when digits with lowercase letters' do
+      expect_offense(<<~RUBY)
+        class X86_64a
+              ^^^^^^^ Use CamelCase for classes and modules.
+        end
+
+        module CVE_x123
+               ^^^^^^^^ Use CamelCase for classes and modules.
+        end
+      RUBY
+    end
+  end
+
   it 'allows module_parent method' do
     expect_no_offenses(<<~RUBY)
       class module_parent::MyClass


### PR DESCRIPTION
Fixes #11611

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/