### PR TITLE
[Fix #11615] Fix false negative and positive for `Lint/MissingSuper`

### DIFF
--- a/changelog/fix_a_false_negative_for_lint_missing_super.md
+++ b/changelog/fix_a_false_negative_for_lint_missing_super.md
@@ -1,0 +1,1 @@
+* [#11615](https://github.com/rubocop/rubocop/issues/11615): Fix a false negative for `Lint/MissingSuper` when no `super` call with `Class.new` block. ([@koic][])

--- a/changelog/fix_a_false_positive_for_lint_missing_super.md
+++ b/changelog/fix_a_false_positive_for_lint_missing_super.md
@@ -1,0 +1,1 @@
+* [#11615](https://github.com/rubocop/rubocop/issues/11615): Fix a false negative for `Lint/MissingSuper` when using `Class.new` without parent class argument. ([@koic][])

--- a/lib/rubocop/cop/lint/missing_super.rb
+++ b/lib/rubocop/cop/lint/missing_super.rb
@@ -110,8 +110,8 @@ module RuboCop
         end
 
         def inside_class_with_stateful_parent?(node)
-          if (class_node = node.each_ancestor(:class).first)
-            class_node&.parent_class && !stateless_class?(class_node.parent_class)
+          if (class_node = node.parent) && class_node.class_type?
+            class_node.parent_class && !stateless_class?(class_node.parent_class)
           elsif (block_node = node.each_ancestor(:block, :numblock).first)
             return false unless (super_class = class_new_block(block_node))
 

--- a/spec/rubocop/cop/lint/missing_super_spec.rb
+++ b/spec/rubocop/cop/lint/missing_super_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe RuboCop::Cop::Lint::MissingSuper, :config do
       RUBY
     end
 
+    it 'does not register an offense for the `Class.new` without parent class argument' do
+      expect_no_offenses(<<~RUBY)
+        class Child < Parent
+          Class.new do
+            def initialize
+            end
+          end
+        end
+      RUBY
+    end
+
     it 'does not register an offense for the constructor-like method defined outside of a class' do
       expect_no_offenses(<<~RUBY)
         module M

--- a/spec/rubocop/cop/lint/missing_super_spec.rb
+++ b/spec/rubocop/cop/lint/missing_super_spec.rb
@@ -50,6 +50,72 @@ RSpec.describe RuboCop::Cop::Lint::MissingSuper, :config do
     end
   end
 
+  context '`Class.new` block' do
+    it 'registers an offense when no `super` call' do
+      expect_offense(<<~RUBY)
+        Class.new(Parent) do
+          def initialize
+          ^^^^^^^^^^^^^^ Call `super` to initialize state of the parent class.
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for the `Class.new` without parent class argument' do
+      expect_no_offenses(<<~RUBY)
+        Class.new do
+          def initialize
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for the `Class.new` with stateless parent class argument' do
+      expect_no_offenses(<<~RUBY)
+        Class.new(Object) do
+          def initialize
+          end
+        end
+      RUBY
+    end
+  end
+
+  context '`Class.new` numbered block', :ruby27 do
+    it 'registers an offense when no `super` call' do
+      expect_offense(<<~RUBY)
+        Class.new(Parent) do
+          def initialize
+          ^^^^^^^^^^^^^^ Call `super` to initialize state of the parent class.
+          end
+
+          do_something(_1)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for the `Class.new` without parent class argument' do
+      expect_no_offenses(<<~RUBY)
+        Class.new do
+          def initialize
+          end
+
+          do_something(_1)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for the `Class.new` with stateless parent class argument' do
+      expect_no_offenses(<<~RUBY)
+        Class.new(Object) do
+          def initialize
+          end
+
+          do_something(_1)
+        end
+      RUBY
+    end
+  end
+
   context 'callbacks' do
     it 'registers no offense when module callback without `super` call' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/11615.

This PR fixes two bugs reported in #11615:

- Fix a false negative when no `super` call with `Class.new` block.
- Fix a false positive when using `Class.new` without parent class argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
