### PR TITLE
Fix an error for `Lint/ConstantResolution`

### DIFF
--- a/changelog/fix_an_error_for_lint_constant_resolution.md
+++ b/changelog/fix_an_error_for_lint_constant_resolution.md
@@ -1,0 +1,1 @@
+* [#11620](https://github.com/rubocop/rubocop/pull/11620): Fix an error for `Lint/ConstantResolution` when using `__ENCODING__`. ([@koic][])

--- a/lib/rubocop/cop/lint/constant_resolution.rb
+++ b/lib/rubocop/cop/lint/constant_resolution.rb
@@ -68,7 +68,7 @@ module RuboCop
         PATTERN
 
         def on_const(node)
-          return if !unqualified_const?(node) || node.parent&.defined_module
+          return if !unqualified_const?(node) || node.parent&.defined_module || node.loc.nil?
 
           add_offense(node)
         end

--- a/spec/rubocop/cop/lint/constant_resolution_spec.rb
+++ b/spec/rubocop/cop/lint/constant_resolution_spec.rb
@@ -118,5 +118,11 @@ RSpec.describe RuboCop::Cop::Lint::ConstantResolution, :config do
         MY_CONST::B
       RUBY
     end
+
+    it 'registers no offense when using `__ENCODING__`' do
+      expect_no_offenses(<<~RUBY)
+        __ENCODING__
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
This PR fixes an error for `Lint/ConstantResolution` when using `__ENCODING__`.

```ruby
__ENCODING__
```

```console
$ rubocop constant_resolution.rb --only Lint/ConstantResolution -d
(snip)

undefined method `expression' for nil:NilClass
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/base.rb:419:in `range_from_node_or_range'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/base.rb:173:in `add_offense'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
