### PR TITLE
[Fix #11607] Fix a false positive for Style/RedundantRegexpEscape

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_regexp_escape.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_regexp_escape.md
@@ -1,0 +1,1 @@
+* [#11607](https://github.com/rubocop/rubocop/issues/11607): Fix a false positive for `Style/RedundantRegexpEscape` when an escaped hyphen follows after an escaped opening square bracket within a character class. ([@SparLaimor][])

--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -74,11 +74,18 @@ module RuboCop
 
         def char_class_begins_or_ends_with_escaped_hyphen?(node, index)
           # The hyphen character is allowed to be escaped within a character class
-          # but it's not necessry to escape hyphen if it's the first or last character
+          # but it's not necessary to escape hyphen if it's the first or last character
           # within the character class. This method checks if that's the case.
           # e.g. "[0-9\\-]" or "[\\-0-9]" would return true
-          contents_range(node).source[index - 1] == '[' ||
-            contents_range(node).source[index + 2] == ']'
+          content = contents_range(node).source
+
+          if content[index + 2] == ']'
+            true
+          elsif content[index - 1] == '['
+            index < 2 || content[index - 2] != '\\'
+          else
+            false
+          end
         end
 
         def delimiter?(node, char)

--- a/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
@@ -137,6 +137,19 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpEscape, :config do
           RUBY
         end
       end
+
+      context "with an escaped opening square bracket before an escaped '-' character" do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~'RUBY')
+            foo = /[\[\-]/
+                      ^^ Redundant escape inside regexp literal
+          RUBY
+
+          expect_correction(<<~'RUBY')
+            foo = /[\[-]/
+          RUBY
+        end
+      end
     end
 
     context "with an escaped '-' character being the first character inside a character class" do
@@ -171,6 +184,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpEscape, :config do
       it 'does not register an offense' do
         expect_no_offenses('foo = %r{[\w\-\#]}')
         expect_no_offenses('foo = /[\w\-\#]/')
+        expect_no_offenses('foo = /[\[\-\]]/')
       end
     end
 


### PR DESCRIPTION
Fixes #11607.

This PR fixes a false positive for `Style/RedundantRegexpEscape` when an escaped hyphen follows after an escaped opening square bracket within a character class.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/

