### PR TITLE
Add rubocop-capybara to suggested extensions and extension doc

### DIFF
--- a/changelog/change_add_rubocop_capybara_to_suggested_extensions.md
+++ b/changelog/change_add_rubocop_capybara_to_suggested_extensions.md
@@ -1,0 +1,1 @@
+* [#11623](https://github.com/rubocop/rubocop/pull/11623): Add rubocop-capybara to suggested extensions and extension doc. ([@ydah][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -153,6 +153,7 @@ AllCops:
     rubocop-sequel: [sequel]
     rubocop-rake: [rake]
     rubocop-graphql: [graphql]
+    rubocop-capybara: [capybara]
   # Enable/Disable checking the methods extended by Active Support.
   ActiveSupportExtensionsEnabled: false
 

--- a/docs/modules/ROOT/pages/extensions.adoc
+++ b/docs/modules/ROOT/pages/extensions.adoc
@@ -84,6 +84,8 @@ Rake-specific analysis
 Code style checking for Sequel gem
 * https://github.com/rubocop/rubocop-thread_safety[rubocop-thread_safety] -
 Thread-safety analysis
+* https://github.com/rubocop/rubocop-capybara[rubocop-capybara] -
+Capybara-specific analysis
 
 ==== Third-party Extensions
 


### PR DESCRIPTION
This PR adds [rubocop-capybara](https://github.com/rubocop/rubocop-capybara) to the `SuggestExtensions` list and extension doc.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
