### PR TITLE
Fix an incorrect autocorrect for `Layout/ClassStructure` using heredoc inside method

### DIFF
--- a/changelog/fix_autocorrect_class_structure_method_with_heredoc.md
+++ b/changelog/fix_autocorrect_class_structure_method_with_heredoc.md
@@ -1,0 +1,1 @@
+* [#11621](https://github.com/rubocop/rubocop/issues/11621): Fix an incorrect autocorrect for `Layout/ClassStructure` using heredoc inside method. ([@fatkodima][])

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -285,8 +285,10 @@ module RuboCop
         end
 
         def end_position_for(node)
-          heredoc = find_heredoc(node)
-          return heredoc.location.heredoc_end.end_pos + 1 if heredoc
+          if node.casgn_type?
+            heredoc = find_heredoc(node)
+            return heredoc.location.heredoc_end.end_pos + 1 if heredoc
+          end
 
           end_line = buffer.line_for_position(node.loc.expression.end_pos)
           buffer.line_range(end_line).end_pos

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -387,6 +387,37 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when public class method with heredoc after instance method' do
+    expect_offense(<<~RUBY)
+      class Foo
+        def instance_method
+          'instance method'
+        end
+
+        def self.class_method
+        ^^^^^^^^^^^^^^^^^^^^^ `public_class_methods` is supposed to appear before `public_methods`.
+          <<~EOS
+            class method
+          EOS
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo
+        def self.class_method
+          <<~EOS
+            class method
+          EOS
+        end
+        def instance_method
+          'instance method'
+        end
+
+      end
+    RUBY
+  end
+
   context 'when def modifier is used' do
     it 'registers an offense and corrects public method with modifier declared after private method with modifier' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #11621.