### PR TITLE
Fix an error for `Lint/EmptyConditionalBody`

### DIFF
--- a/changelog/fix_an_error_for_lint_empty_conditional_body.md
+++ b/changelog/fix_an_error_for_lint_empty_conditional_body.md
@@ -1,0 +1,1 @@
+* [#11625](https://github.com/rubocop/rubocop/pull/11625): Fix an error for `Lint/EmptyConditionalBody` when missing `if` body and using method call for return value. ([@koic][])

--- a/lib/rubocop/cop/lint/empty_conditional_body.rb
+++ b/lib/rubocop/cop/lint/empty_conditional_body.rb
@@ -72,6 +72,8 @@ module RuboCop
           return if cop_config['AllowComments'] && contains_comments?(node)
 
           add_offense(node, message: format(MSG, keyword: node.keyword)) do |corrector|
+            next if node.parent&.call_type?
+
             autocorrect(corrector, node)
           end
         end

--- a/lib/rubocop/cop/mixin/comments_help.rb
+++ b/lib/rubocop/cop/mixin/comments_help.rb
@@ -68,7 +68,7 @@ module RuboCop
           node.loc.else.line
         elsif node.if_type? && node.ternary?
           node.else_branch.loc.line
-        elsif (next_sibling = node.right_sibling)
+        elsif (next_sibling = node.right_sibling) && next_sibling.is_a?(AST::Node)
           next_sibling.loc.line
         elsif (parent = node.parent)
           parent.loc.end ? parent.loc.end.line : parent.loc.line

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -273,6 +273,26 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     expect_correction('')
   end
 
+  it 'registers an offense when missing `if` body and using method call for return value' do
+    expect_offense(<<~RUBY)
+      if condition
+      ^^^^^^^^^^^^ Avoid `if` branches without a body.
+      end.do_something
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers an offense when missing `if` body and using safe navigation method call for return value' do
+    expect_offense(<<~RUBY)
+      if condition
+      ^^^^^^^^^^^^ Avoid `if` branches without a body.
+      end&.do_something
+    RUBY
+
+    expect_no_corrections
+  end
+
   it 'does not register an offense for missing `unless` body with a comment' do
     expect_no_offenses(<<~RUBY)
       unless condition


### PR DESCRIPTION
This PR fixes an error for `Lint/EmptyConditionalBody` when missing `if` body and using method call for return value.

```ruby
if condition
end.do_something
```

```console
% rubocop lint_empty_conditional_body.rb --only Lint/EmptyConditionalBody -d
(snip)

undefined method `loc' for :do_something:Symbol
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/mixin/comments_help.rb:72:in `find_end_line'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/mixin/comments_help.rb:20:in `comments_in_range'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/mixin/comments_help.rb:15:in `contains_comments?'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/lint/empty_conditional_body.rb:72:in `on_if'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
