### PR TITLE
[Fix #11626] Fix a false positive for `Style/ZeroLengthPredicate`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_zero_length_predicate.md
+++ b/changelog/fix_a_false_positive_for_style_zero_length_predicate.md
@@ -1,0 +1,1 @@
+* [#11626](https://github.com/rubocop/rubocop/issues/11626): Fix a false positive for `Style/ZeroLengthPredicate` when using `File.new(path).size.zero?`. ([@koic][])

--- a/spec/rubocop/cop/style/zero_length_predicate_spec.rb
+++ b/spec/rubocop/cop/style/zero_length_predicate_spec.rb
@@ -403,44 +403,106 @@ RSpec.describe RuboCop::Cop::Style::ZeroLengthPredicate, :config do
 
   context 'when inspecting a StringIO object' do
     context 'when initialized with a string' do
-      it 'does not register an offense' do
+      it 'does not register an offense using `size == 0`' do
         expect_no_offenses(<<~RUBY)
           StringIO.new('foo').size == 0
         RUBY
       end
 
-      it 'does not register an offense with top-level ::StringIO' do
+      it 'does not register an offense with top-level ::StringIO using `size == 0`' do
         expect_no_offenses(<<~RUBY)
           ::StringIO.new('foo').size == 0
+        RUBY
+      end
+
+      it 'does not register an offense using `size.zero?`' do
+        expect_no_offenses(<<~RUBY)
+          StringIO.new('foo').size.zero?
+        RUBY
+      end
+
+      it 'does not register an offense with top-level ::StringIO using `size.zero?`' do
+        expect_no_offenses(<<~RUBY)
+          ::StringIO.new('foo').size.zero?
         RUBY
       end
     end
 
     context 'when initialized without arguments' do
-      it 'does not register an offense' do
+      it 'does not register an offense using `size == 0`' do
         expect_no_offenses(<<~RUBY)
           StringIO.new.size == 0
         RUBY
       end
 
-      it 'does not register an offense with top-level ::StringIO' do
+      it 'does not register an offense with top-level ::StringIO using `size == 0`' do
         expect_no_offenses(<<~RUBY)
           ::StringIO.new.size == 0
+        RUBY
+      end
+
+      it 'does not register an offense using `size.zero?`' do
+        expect_no_offenses(<<~RUBY)
+          StringIO.new.size.zero?
+        RUBY
+      end
+
+      it 'does not register an offense with top-level ::StringIO using `size.zero?`' do
+        expect_no_offenses(<<~RUBY)
+          ::StringIO.new.size.zero?
         RUBY
       end
     end
   end
 
+  context 'when inspecting a File object' do
+    it 'does not register an offense using `size == 0`' do
+      expect_no_offenses(<<~RUBY)
+        File.new('foo').size == 0
+      RUBY
+    end
+
+    it 'does not register an offense with top-level ::File using `size == 0`' do
+      expect_no_offenses(<<~RUBY)
+        ::File.new('foo').size == 0
+      RUBY
+    end
+
+    it 'does not register an offense using `size.zero?`' do
+      expect_no_offenses(<<~RUBY)
+        File.new('foo').size.zero?
+      RUBY
+    end
+
+    it 'does not register an offense with top-level ::File using `size.zero?`' do
+      expect_no_offenses(<<~RUBY)
+        ::File.new('foo').size.zero?
+      RUBY
+    end
+  end
+
   context 'when inspecting a Tempfile object' do
-    it 'does not register an offense' do
+    it 'does not register an offense using `size == 0`' do
       expect_no_offenses(<<~RUBY)
         Tempfile.new('foo').size == 0
       RUBY
     end
 
-    it 'does not register an offense with top-level ::Tempfile' do
+    it 'does not register an offense with top-level ::Tempfile using `size == 0`' do
       expect_no_offenses(<<~RUBY)
         ::Tempfile.new('foo').size == 0
+      RUBY
+    end
+
+    it 'does not register an offense using `size.zero?`' do
+      expect_no_offenses(<<~RUBY)
+        Tempfile.new('foo').size.zero?
+      RUBY
+    end
+
+    it 'does not register an offense with top-level ::Tempfile using `size.zero?`' do
+      expect_no_offenses(<<~RUBY)
+        ::Tempfile.new('foo').size.zero?
       RUBY
     end
   end


### PR DESCRIPTION
Fixes #11626.

This PR fixes a false positive for `Style/ZeroLengthPredicate` when using `File.new(path).size.zero?`.
The same goes for the existing `Tempfile` and `StringIO`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
