### PR TITLE
[Fix #11631] Fix an incorrect autocorrect for `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_arguments_forwarding.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#11631](https://github.com/rubocop/rubocop/issues/11631): Fix an incorrect autocorrect for `Style/ArgumentsForwarding` when using arguments forwarding for `.()` call. ([@koic][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -124,9 +124,9 @@ module RuboCop
 
         def register_offense_to_forwarding_method_arguments(forwarding_method)
           add_offense(arguments_range(forwarding_method)) do |corrector|
-            range = range_between(
-              forwarding_method.loc.selector.end_pos, forwarding_method.source_range.end_pos
-            )
+            begin_pos = forwarding_method.loc.selector&.end_pos || forwarding_method.loc.dot.end_pos
+            range = range_between(begin_pos, forwarding_method.source_range.end_pos)
+
             corrector.replace(range, '(...)')
           end
         end

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -109,6 +109,22 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
+    it 'registers an offense when using restarg and block arg for `.()` call' do
+      expect_offense(<<~RUBY)
+        def foo(*args, &block)
+                ^^^^^^^^^^^^^ Use arguments forwarding.
+          bar.(*args, &block)
+               ^^^^^^^^^^^^^ Use arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(...)
+          bar.(...)
+        end
+      RUBY
+    end
+
     it 'does not register an offense when using arguments forwarding' do
       expect_no_offenses(<<~RUBY)
         def foo(...)


### PR DESCRIPTION
Fixes #11631.

This PR fixes an incorrect autocorrect for `Style/ArgumentsForwarding` when using arguments forwarding for `.()` call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
