### PR TITLE
Correct Rubocop for `private_class_method` method documentation.

### DIFF
--- a/changelog/fix_correct_rubocop_for_private_class_method_method.md
+++ b/changelog/fix_correct_rubocop_for_private_class_method_method.md
@@ -1,0 +1,1 @@
+* [#11637](https://github.com/rubocop/rubocop/pull/11637): Correct Rubocop for `private_class_method` method documentation. ([@bigzed][])

--- a/lib/rubocop/cop/mixin/def_node.rb
+++ b/lib/rubocop/cop/mixin/def_node.rb
@@ -19,7 +19,7 @@ module RuboCop
 
       # @!method non_public_modifier?(node)
       def_node_matcher :non_public_modifier?, <<~PATTERN
-        (send nil? {:private :protected} ({def defs} ...))
+        (send nil? {:private :protected :private_class_method} ({def defs} ...))
       PATTERN
     end
   end

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -92,6 +92,14 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
           expect_no_offenses('private def method; end')
         end
 
+        it 'does not register an offense with inline `private_class_method`' do
+          expect_no_offenses(<<~RUBY)
+            private_class_method def self.foo
+              puts 'bar'
+            end
+          RUBY
+        end
+
         context 'when required for non-public methods' do
           let(:require_for_non_public_methods) { true }
 
@@ -128,6 +136,15 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
             expect_offense(<<~RUBY)
               private def method; end
                       ^^^^^^^^^^^^^^^ Missing method documentation comment.
+            RUBY
+          end
+
+          it 'register an offense with inline `private_class_method`' do
+            expect_offense(<<~RUBY)
+              private_class_method def self.foo
+                                   ^^^^^^^^^^^^ Missing method documentation comment.
+                puts 'bar'
+              end
             RUBY
           end
         end


### PR DESCRIPTION
The `private_class_method` modifier was not respected when checking whether a method needs documentation. I was able to fix that, but unable to fix the corresponding spec when documentation is present. Rubocop unfortunately still complains.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
