### PR TITLE
Fix a false positive for `Lint/UselessAccessModifier` when using same access modifier inside and outside the `included` block

### DIFF
--- a/changelog/fix_fix_a_false_positive_for_lint_useless_access_modifier.md
+++ b/changelog/fix_fix_a_false_positive_for_lint_useless_access_modifier.md
@@ -1,0 +1,1 @@
+* [#11638](https://github.com/rubocop/rubocop/pull/11638): Fix a false positive for `Lint/UselessAccessModifier` when using same access modifier inside and outside the `included` block. ([@ydah][])


### PR DESCRIPTION
This PR is fix a false positive for `Lint/UselessAccessModifier` when using same access modifier inside and outside the `included` block.

If an included block is used within a class, as shown below, I think it should not be a violation even if the same access modifier is used inside and outside the `included` block.

```ruby
class SomeClass
  included do
    private
    def foo; end
  end
  private
  def bar; end
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
