### PR TITLE
Fix incorrect shorthand autocorrections in calls inside parentheses

### DIFF
--- a/changelog/fix_incorrect_shorthand_autocorrections_in_calls.md
+++ b/changelog/fix_incorrect_shorthand_autocorrections_in_calls.md
@@ -1,0 +1,1 @@
+* [#11643](https://github.com/rubocop/rubocop/pull/11643): Fix incorrect shorthand autocorrections in calls inside parentheses. ([@gsamokovarov][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -95,19 +95,20 @@ module RuboCop
           use_modifier_form_without_parenthesized_method_call?(method_dispatch_node)
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def def_node_that_require_parentheses(node)
         last_pair = node.parent.pairs.last
         return unless last_pair.key.source == last_pair.value.source
         return unless (dispatch_node = find_ancestor_method_dispatch_node(node))
         return if dispatch_node.parenthesized?
+        return if dispatch_node.parent && parentheses?(dispatch_node.parent)
         return if last_expression?(dispatch_node) && !method_dispatch_as_argument?(dispatch_node)
 
         def_node = node.each_ancestor(:send, :csend, :super, :yield).first
 
         DefNode.new(def_node) unless def_node && def_node.arguments.empty?
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       def find_ancestor_method_dispatch_node(node)
         return unless (ancestor = node.parent.parent)

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1438,6 +1438,21 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'registers an offense in calls without parentheses but inside parentheses' do
+        expect_offense(<<~RUBY)
+          (create :foo, bar: bar)
+                             ^^^ Omit the hash value.
+
+          pass
+        RUBY
+
+        expect_correction(<<~RUBY)
+          (create :foo, bar:)
+
+          pass
+        RUBY
+      end
+
       context 'when hash roket syntax' do
         let(:enforced_style) { 'hash_rockets' }
 


### PR DESCRIPTION
If you happen to have a method call without parentheses that is inside outer parentheses like the following example:

```ruby
(create :integration_shop, account: account)
pass
```

We would have still thought that we need to add parentheses to the `create` call during `Style/HashSyntax` autocorrection like so:

```ruby
(create(:integration_shop, account:))
pass
```

While this is not a problem in isolation, it can lead to invalid Ruby autocorrections when `Style/HashSyntax` is used in combination with `Style/RedundantParentheses` (enabled by default) and `Style/MethodCallWithArgsParentheses` (disabled by default) with `EnforcedStyle: omit_parentheses`:

```yaml
AllCops:
  TargetRubyVersion: 3.1
Style/HashSyntax:
  EnforcedShorthandSyntax: always
Style/RedundantParentheses:
  Enabled: true
Style/MethodCallWithArgsParentheses:
  Enabled: true
  EnforcedStyle: omit_parentheses
```

I have two problematic examples:

**1.**

```ruby
receipt = create :receipt, account: account, integration_shop: (create :integration_shop, account: account)
pass
```

Autocorrects to broken Ruby like so:

```ruby
receipt = create :receipt, account:, integration_shop: create :integration_shop, account:
pass
```

This happens because `Style/HashSyntax` puts parentheses in `(create(:integration_shop, account:))`, which then gets autocorrected by `Style/MethodCallWithArgsParentheses` to `(create :integration_shop, account:)` that finally gets processed by `Style/RedundantParentheses` to `create :integration_shop, account:`.

**2.**

```ruby
bank_transaction_ids = (MatchBankTransactionsToCosts.execute object, bank_account: bank_account).keys
pass
```

Gets autocorrected to:

```ruby
bank_transaction_ids = MatchBankTransactionsToCosts.execute object, bank_account:.keys
pass
```

The reason is the same, the unforunate play between `Style/HashSyntax`, `Style/MethodsAcceptingSymbol` with `EnforcedStyle: omit_parentheses` and `Style/RedundantParentheses`.

An fix is not to parenthesize the calls with value omission if they are inside parentheses. That's one of the drawbacks of omitting parentheses, sometimes folks decide to put them in funny places like around a method call.