### PR TITLE
[Fix #11482] Avoid comment deletion by `Style/IfUnlessModifier` when the modifier form expression has long comment

### DIFF
--- a/changelog/change_avoid_comment_deletion_by_style_if_unless_modifier.md
+++ b/changelog/change_avoid_comment_deletion_by_style_if_unless_modifier.md
@@ -1,0 +1,1 @@
+* [#11482](https://github.com/rubocop/rubocop/issues/11482): Avoid comment deletion by `Style/IfUnlessModifier` when the modifier form expression has long comment. ([@nobuyo][])

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -107,6 +107,20 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         end
       end
 
+      context 'when the line is too long due to long comment with modifier' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            some_statement if some_quite_long_condition # The condition might have been long, but this comment is longer. In fact, it is too long for Rubocop
+                           ^^ Modifier form of `if` makes the line too long.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            # The condition might have been long, but this comment is longer. In fact, it is too long for Rubocop
+            some_statement if some_quite_long_condition
+          RUBY
+        end
+      end
+
       describe 'IgnoreCopDirectives' do
         let(:spaces) { ' ' * 57 }
         let(:comment) { '# rubocop:disable Style/For' }
@@ -136,9 +150,8 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
 
             expect_correction(<<~RUBY)
               def f
-                if condition
-                  #{body}
-                end #{comment}
+                #{comment}
+                #{body} if condition
               end
             RUBY
           end


### PR DESCRIPTION
This PR fixes #11482.

Now the cop corrects code from:
```rb
# frozen_string_literal: true

some_statement if some_quite_long_condition # The condition might have been long, but this comment is longer. In fact, it is too long for Rubocop
```
to:

```rb
# frozen_string_literal: true

# The condition might have been long, but this comment is longer. In fact, it is too long for Rubocop
some_statement if some_quite_long_condition
```

I think the correction is ok. But the message for the offense is still indicate `if` is bad, not comment.
Any ideas for this?

```console
test.rb:3:16: C: [Corrected] Style/IfUnlessModifier: Modifier form of if makes the line too long.
some_statement if some_quite_long_condition # The condition might have been long, but this comment is longer. In fact, it is too long for Rubocop
               ^^
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
