### PR TITLE
Fix an error for `Style/NegatedIfElseCondition`

### DIFF
--- a/changelog/fix_an_error_for_style_negated_if_else_condition.md
+++ b/changelog/fix_an_error_for_style_negated_if_else_condition.md
@@ -1,0 +1,1 @@
+* [#11646](https://github.com/rubocop/rubocop/pull/11646): Fix an error for `Style/NegatedIfElseCondition` when using `()` as a condition. ([@koic][])

--- a/spec/rubocop/cop/style/negated_if_else_condition_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_else_condition_spec.rb
@@ -229,6 +229,16 @@ RSpec.describe RuboCop::Cop::Style::NegatedIfElseCondition, :config do
     RUBY
   end
 
+  it 'does not crash when using `()` as a condition' do
+    expect_no_offenses(<<~RUBY)
+      if ()
+        foo
+      else
+        bar
+      end
+    RUBY
+  end
+
   it 'moves comments to correct branches during autocorrect' do
     expect_offense(<<~RUBY)
       if !condition.nil?


### PR DESCRIPTION
This PR fixes an error for `Style/NegatedIfElseCondition` when using `()` as a condition.

```ruby
if ()
else
  do_something
end
```

```console
$ bundle exec rubocop --only Style/NegatedIfElseCondition -d
(snip)

undefined method `begin_type?' for nil:NilClass
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/negated_if_else_condition.rb:76:in `unwrap_begin_nodes'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/negated_if_else_condition.rb:52:in `on_if'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
