### PR TITLE
Fix an error for `Style/IfWithBooleanLiteralBranches`

### DIFF
--- a/changelog/fix_an_error_for_style_if_with_boolean_literal_branches.md
+++ b/changelog/fix_an_error_for_style_if_with_boolean_literal_branches.md
@@ -1,0 +1,1 @@
+* [#11647](https://github.com/rubocop/rubocop/pull/11647): Fix an error for `Style/IfWithBooleanLiteralBranches` when using `()` as a condition. ([@koic][])

--- a/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
+++ b/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
@@ -118,6 +118,8 @@ module RuboCop
         end
 
         def return_boolean_value?(condition)
+          return false unless condition
+
           if condition.begin_type?
             return_boolean_value?(condition.children.first)
           elsif condition.or_type?

--- a/spec/rubocop/cop/style/if_with_boolean_literal_branches_spec.rb
+++ b/spec/rubocop/cop/style/if_with_boolean_literal_branches_spec.rb
@@ -611,6 +611,14 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
     end
   end
 
+  it 'does not crash when using `()` as a condition' do
+    expect_no_offenses(<<~RUBY)
+      if ()
+      else
+      end
+    RUBY
+  end
+
   context 'when `AllowedMethods: nonzero?`' do
     let(:cop_config) { { 'AllowedMethods' => ['nonzero?'] } }
 


### PR DESCRIPTION
This PR fixes an error for `Style/IfWithBooleanLiteralBranches` when using `()` as a condition.

```ruby
if ()
else
end
```

```console
$ bundle exec rubocop --only Style/IfWithBooleanLiteralBranches -d
(snip)

undefined method `begin_type?' for nil:NilClass
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb:121:
in `return_boolean_value?'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb:122:
in `return_boolean_value?'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb:75:
in `if_with_boolean_literal_branches?'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb:77:
in `on_if'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
