### PR TITLE
Style/AccessorGrouping: Fix detection of Sorbet `sig {}` blocks

### DIFF
--- a/changelog/fix_style_accessor_grouping_fix_detection_of_sorbet.md
+++ b/changelog/fix_style_accessor_grouping_fix_detection_of_sorbet.md
@@ -1,0 +1,1 @@
+* [#11650](https://github.com/rubocop/rubocop/pull/11650): `Style/AccessorGrouping`: Fix detection of Sorbet `sig {}` blocks. ([@issyl0][])

--- a/spec/rubocop/cop/style/accessor_grouping_spec.rb
+++ b/spec/rubocop/cop/style/accessor_grouping_spec.rb
@@ -127,11 +127,16 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
     it 'does not register an offense for accessors with other methods' do
       expect_no_offenses(<<~RUBY)
         class Foo
+          extend T::Sig
+
           annotation_method :one
           attr_reader :one
 
           annotation_method :two
           attr_reader :two
+
+          sig { returns(Integer) }
+          attr_reader :three
         end
       RUBY
     end


### PR DESCRIPTION
- Sorbet `sig { returns(Integer) }` annotations above `attr_reader` methods should be ignored after ~9921cdcd03b1883a9ce66de769c457da4c3317b7~ df7c4cd1f4e2f0cb912feb69eea2fd9f9ab5e5b7, per the docs, but they weren't being (see the test I added here for evidence).
- Sorbet `sig {}` constructs are blocks (hence the braces), not `send_type?` directly.
- Hence, we now check if the previous expression is a block and if so, descend into its child nodes until we find a `send_type`, then use that to determine if the accessor is groupable.
- Relates to https://github.com/rubocop/rubocop/issues/11596, but that issue is already closed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
