### PR TITLE
Fix a false negative for `Lint/MissingSuper`

### DIFF
--- a/changelog/fix_a_false_negative_for_lint_missing_super.md
+++ b/changelog/fix_a_false_negative_for_lint_missing_super.md
@@ -1,0 +1,1 @@
+* [#11654](https://github.com/rubocop/rubocop/pull/11654): Fix a false positive for `Lint/MissingSuper` when no `super` call and when defining some method. ([@koic][])

--- a/lib/rubocop/cop/lint/missing_super.rb
+++ b/lib/rubocop/cop/lint/missing_super.rb
@@ -110,12 +110,12 @@ module RuboCop
         end
 
         def inside_class_with_stateful_parent?(node)
-          if (class_node = node.parent) && class_node.class_type?
-            class_node.parent_class && !stateless_class?(class_node.parent_class)
-          elsif (block_node = node.each_ancestor(:block, :numblock).first)
+          if (block_node = node.each_ancestor(:block, :numblock).first)
             return false unless (super_class = class_new_block(block_node))
 
             !stateless_class?(super_class)
+          elsif (class_node = node.each_ancestor(:class).first)
+            class_node.parent_class && !stateless_class?(class_node.parent_class)
           else
             false
           end

--- a/spec/rubocop/cop/lint/missing_super_spec.rb
+++ b/spec/rubocop/cop/lint/missing_super_spec.rb
@@ -12,6 +12,19 @@ RSpec.describe RuboCop::Cop::Lint::MissingSuper, :config do
       RUBY
     end
 
+    it 'registers an offense when no `super` call and when defining some method' do
+      expect_offense(<<~RUBY)
+        class Child < Parent
+          def initialize
+          ^^^^^^^^^^^^^^ Call `super` to initialize state of the parent class.
+          end
+
+          def do_something
+          end
+        end
+      RUBY
+    end
+
     it 'does not register an offense for the class without parent class' do
       expect_no_offenses(<<~RUBY)
         class Child


### PR DESCRIPTION
Follow part of https://github.com/rubocop/rubocop/pull/11619#issuecomment-1452021939.

This PR fixes a false positive for `Lint/MissingSuper` when no `super` call and when defining some method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
