### PR TITLE
Fix an incorrect autocorrect for `Lint/OrAssignmentToConstant`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_or_assignment_to_constant.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_or_assignment_to_constant.md
@@ -1,0 +1,1 @@
+* [#11659](https://github.com/rubocop/rubocop/pull/11659): Fix an incorrect autocorrect for `Lint/OrAssignmentToConstant` when using or-assignment to a constant in method definition. ([@koic][])

--- a/lib/rubocop/cop/lint/or_assignment_to_constant.rb
+++ b/lib/rubocop/cop/lint/or_assignment_to_constant.rb
@@ -31,6 +31,8 @@ module RuboCop
           return unless lhs&.casgn_type?
 
           add_offense(node.loc.operator) do |corrector|
+            next if node.each_ancestor(:def, :defs).any?
+
             corrector.replace(node.loc.operator, '=')
           end
         end

--- a/spec/rubocop/cop/lint/or_assignment_to_constant_spec.rb
+++ b/spec/rubocop/cop/lint/or_assignment_to_constant_spec.rb
@@ -12,6 +12,43 @@ RSpec.describe RuboCop::Cop::Lint::OrAssignmentToConstant, :config do
     RUBY
   end
 
+  it 'registers an offense with or-assignment to a constant in method definition' do
+    expect_offense(<<~RUBY)
+      def foo
+        M::CONST ||= 1
+                 ^^^ Avoid using or-assignment with constants.
+      end
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers an offense with or-assignment to a constant in singleton method definition' do
+    expect_offense(<<~RUBY)
+      def self.foo
+        M::CONST ||= 1
+                 ^^^ Avoid using or-assignment with constants.
+      end
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers an offense with or-assignment to a constant in method definition using `define_method`' do
+    expect_offense(<<~RUBY)
+      define_method :foo do
+        M::CONST ||= 1
+                 ^^^ Avoid using or-assignment with constants.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      define_method :foo do
+        M::CONST = 1
+      end
+    RUBY
+  end
+
   it 'does not register an offense with plain assignment to a constant' do
     expect_no_offenses(<<~RUBY)
       CONST = 1


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for `Lint/OrAssignmentToConstant` when using or-assignment to a constant in method definition.

```ruby
def foo
  M::N ||= 42
end
```

```console
$ ruby -v
ruby 3.2.1 (2023-02-08 revision 31819e82c8) [x86_64-darwin19]
$ ruby -c example.rb
Syntax OK
$ bundle exec rubocop --only Lint/OrAssignmentToConstant -a
(snip)

Offenses:

example.rb:2:8: W: Lint/OrAssignmentToConstant: Avoid using or-assignment with constants.
  M::N ||= 42
       ^^^

1 file inspected, 1 offense detected
```

```ruby
def foo
  M::N = 42
end
```

```console
$ ruby -c example.rb
example.rb: example.rb:2: dynamic constant assignment (SyntaxError)
  M::N = 42
  ^~~~
```

It's reasonable to display the offense, but it wouldn't be reasonable to have this syntax error caused by autocorrection.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
