### PR TITLE
Fix an error for `Style/Documentation`

### DIFF
--- a/changelog/fix_an_error_for_style_documentation.md
+++ b/changelog/fix_an_error_for_style_documentation.md
@@ -1,0 +1,1 @@
+* [#11661](https://github.com/rubocop/rubocop/pull/11661): Fix an error for `Style/Documentation` when namespace is a variable. ([@koic][])

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -178,13 +178,19 @@ module RuboCop
         def identifier(node)
           # Get the fully qualified identifier for a class/module
           nodes = [node, *node.each_ancestor(:class, :module)]
-          nodes.reverse_each.flat_map { |n| qualify_const(n.identifier) }.join('::')
+          identifier = nodes.reverse_each.flat_map { |n| qualify_const(n.identifier) }.join('::')
+
+          identifier.sub('::::', '::')
         end
 
         def qualify_const(node)
-          return if node.nil? || node.cbase_type? || node.self_type? || node.send_type?
+          return if node.nil?
 
-          [qualify_const(node.namespace), node.short_name].compact
+          if node.cbase_type? || node.self_type? || node.call_type? || node.variable?
+            node.source
+          else
+            [qualify_const(node.namespace), node.short_name].compact
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
   it 'registers an offense for non-empty cbase class' do
     expect_offense(<<~RUBY)
       class ::MyClass
-      ^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class MyClass`.
+      ^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class ::MyClass`.
         def method
         end
       end
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
   it 'registers an offense for non-empty class nested under self' do
     expect_offense(<<~RUBY)
       class self::MyClass
-      ^^^^^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class MyClass`.
+      ^^^^^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class self::MyClass`.
         def method
         end
       end
@@ -40,7 +40,70 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
   it 'registers an offense for non-empty class nested under method call' do
     expect_offense(<<~RUBY)
       class my_method::MyClass
-      ^^^^^^^^^^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class MyClass`.
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class my_method::MyClass`.
+        def method
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for non-empty class nested under safe navigation method call' do
+    expect_offense(<<~RUBY)
+      class obj&.my_method::MyClass
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class obj&.my_method::MyClass`.
+        def method
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for non-empty class nested under local variable' do
+    expect_offense(<<~RUBY)
+      m = Module.new
+      module m::N
+      ^^^^^^^^^^^ Missing top-level documentation comment for `module m::N`.
+        def method
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for non-empty class nested under instance variable' do
+    expect_offense(<<~RUBY)
+      module @m::N
+      ^^^^^^^^^^^^ Missing top-level documentation comment for `module @m::N`.
+        def method
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for non-empty class nested under class variable' do
+    expect_offense(<<~RUBY)
+      module @@m::N
+      ^^^^^^^^^^^^^ Missing top-level documentation comment for `module @@m::N`.
+        def method
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for non-empty class nested under global variable' do
+    expect_offense(<<~RUBY)
+      module $m::N
+      ^^^^^^^^^^^^ Missing top-level documentation comment for `module $m::N`.
+        def method
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for non-empty class nested under local variables' do
+    expect_offense(<<~RUBY)
+      m = Module.new
+      n = Module.new
+      module m::n::M
+      ^^^^^^^^^^^^^^ Missing top-level documentation comment for `module m::n::M`.
         def method
         end
       end


### PR DESCRIPTION
This PR fixes an error for `Style/Documentation` when namespace is a variable.

```ruby
m = Module.new
module n::N
  def method
  end
end
```

```console
% rubocop documentation.rb --only Style/Documentation -d
(snip)

undefined method `namespace' for s(:lvar, :m):RuboCop::AST::Node
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/documentation.rb:187:in `qualify_const'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/documentation.rb:187:in `qualify_const'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/documentation.rb:181:in `block in identifier'
```

It also complements missing cbase and namespaces in offense messages. e.g.:

```diff
 class ::MyClass
-^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class MyClass`.
+^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class ::MyClass`.
```

```diff
 class self::MyClass
-^^^^^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class MyClass`.
+^^^^^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class self::MyClass`.
```

```diff
 class my_method::MyClass
-^^^^^^^^^^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class MyClass`.
+^^^^^^^^^^^^^^^^^^^^^^^^ Missing top-level documentation comment for `class my_method::MyClass`.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
