### PR TITLE
Use cop name to check if cop inside registry is enabled

### DIFF
--- a/changelog/fix_use_cop_name_inside_registry_enabled_check.md
+++ b/changelog/fix_use_cop_name_inside_registry_enabled_check.md
@@ -1,0 +1,1 @@
+* [#11657](https://github.com/rubocop/rubocop/issues/11657): Use cop name to check if cop inside registry is enabled. Previously, it was able to cause large memory usage during linting. ([@fatkodima][])

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -197,7 +197,9 @@ module RuboCop
       def enabled?(cop, config)
         return true if options[:only]&.include?(cop.cop_name)
 
-        cfg = config.for_cop(cop)
+        # We need to use `cop_name` in this case, because `for_cop` uses caching
+        # which expects cop names or cop classes as keys.
+        cfg = config.for_cop(cop.cop_name)
 
         cop_enabled = cfg.fetch('Enabled') == true || enabled_pending_cop?(cfg, config)
 

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -160,8 +160,8 @@ module RuboCop
       def roundup_relevant_cops(processed_source)
         cops.select do |cop|
           next true if processed_source.comment_config.cop_opted_in?(cop)
-          next false unless @registry.enabled?(cop, @config)
           next false if cop.excluded_file?(processed_source.file_path)
+          next false unless @registry.enabled?(cop, @config)
 
           support_target_ruby_version?(cop) && support_target_rails_version?(cop)
         end


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/11657.

Previously, `@for_cop` cache https://github.com/rubocop/rubocop/blob/951507a2cd70518aeca2351b405a301534be195b/lib/rubocop/config.rb#L34-L40
always received only cop names (strings) or cop classes, but after https://github.com/rubocop/rubocop/pull/11603/files#diff-1c2f3a3b82c13964ec1f4f0ce72bb04f429cc9258514611cd6b6d735ec8aea6aR163 it started to receive cop instances, and so this cache became needlessly bigger and bigger.