### PR TITLE
Cache `classname_attribute_value` in junit formatter

### DIFF
--- a/lib/rubocop/formatter/junit_formatter.rb
+++ b/lib/rubocop/formatter/junit_formatter.rb
@@ -62,7 +62,10 @@ module RuboCop
       end
 
       def classname_attribute_value(file)
-        file.gsub(/\.rb\Z/, '').gsub("#{Dir.pwd}/", '').tr('/', '.')
+        @classname_attribute_value_cache ||= Hash.new do |hash, key|
+          hash[key] = key.gsub(/\.rb\Z/, '').gsub("#{Dir.pwd}/", '').tr('/', '.')
+        end
+        @classname_attribute_value_cache[file]
       end
 
       def finished(_inspected_files)


### PR DESCRIPTION
In https://github.com/rubocop/rubocop/issues/11657, I identified inefficiency of junit formatter.

With the https://github.com/ruby/rexml/pull/94 (see there for all the details regarding how I profiled etc), I was able to optimize memory usage quite a lot.

### Before
```
Total allocated: 630.15 MB (8838482 objects)
Total retained:  53.50 MB (445069 objects)

allocated memory by gem
-----------------------------------
 294.26 MB  rexml/lib
 214.78 MB  rubocop/lib
  38.60 MB  rubocop-ast/lib
  31.62 MB  parser-3.2.1.0
  31.43 MB  other
  10.02 MB  lib
   3.11 MB  rubocop-rspec-2.18.1
   1.95 MB  rubocop-performance-1.16.0
   1.83 MB  regexp_parser-2.7.0
   1.61 MB  ast-2.4.2
 405.71 kB  unicode-display_width-2.4.2
 287.16 kB  rubocop-capybara-2.17.1
 244.96 kB  rubocop-rake-0.6.0
   5.00 kB  rubygems

allocated memory by file
-----------------------------------
 123.30 MB  /Users/fatkodima/Desktop/oss/rexml/lib/rexml/text.rb
 101.92 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/formatter/junit_formatter.rb
  61.42 MB  /Users/fatkodima/Desktop/oss/rexml/lib/rexml/namespace.rb
  ....
```

### After (with the changes from linked `rexml` PR)
```
Total allocated: 279.93 MB (3586100 objects) 🔥 🔥 🔥 🚒 
Total retained:  53.56 MB (445438 objects)

allocated memory by gem
-----------------------------------
 127.12 MB  rubocop/lib
  54.44 MB  rexml/lib
  38.60 MB  rubocop-ast/lib
  31.62 MB  parser-3.2.1.0
  10.02 MB  lib
   8.69 MB  other
   3.11 MB  rubocop-rspec-2.18.1
   1.95 MB  rubocop-performance-1.16.0
   1.83 MB  regexp_parser-2.7.0
   1.61 MB  ast-2.4.2
 405.71 kB  unicode-display_width-2.4.2
 287.16 kB  rubocop-capybara-2.17.1
 244.96 kB  rubocop-rake-0.6.0
   5.00 kB  rubygems

allocated memory by file
-----------------------------------
  28.89 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/config.rb
  27.30 MB  /Users/fatkodima/Desktop/oss/rexml/lib/rexml/element.rb
  15.77 MB  /Users/fatkodima/Desktop/oss/rexml/lib/rexml/attribute.rb
  15.11 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/parser-3.2.1.0/lib/parser/source/buffer.rb
  14.34 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/formatter/junit_formatter.rb
  12.59 MB  /Users/fatkodima/Desktop/oss/rubocop-ast/lib/rubocop/ast/node.rb
  12.03 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/registry.rb
....
```