### PR TITLE
[Fix #11663] Fix an incorrect autocorrect for `Style/BlockDelimiters`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_block_delimiters.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_block_delimiters.md
@@ -1,0 +1,1 @@
+* [#11663](https://github.com/rubocop/rubocop/issues/11663): Fix an incorrect autocorrect for `Style/BlockDelimiters` when multi-line blocks to `{` and `}` with arithmetic operation method chain. ([@koic][])

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -342,6 +342,7 @@ module RuboCop
         end
 
         def proper_block_style?(node)
+          return true if require_braces?(node)
           return special_method_proper_block_style?(node) if special_method?(node.method_name)
 
           case style
@@ -349,6 +350,14 @@ module RuboCop
           when :semantic            then semantic_block_style?(node)
           when :braces_for_chaining then braces_for_chaining_style?(node)
           when :always_braces       then braces_style?(node)
+          end
+        end
+
+        def require_braces?(node)
+          return false unless node.braces?
+
+          node.each_ancestor(:send).any? do |send|
+            send.arithmetic_operation? && node.source_range.end_pos < send.loc.selector.begin_pos
           end
         end
 

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -603,6 +603,26 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
 
+      it 'registers an offense and autocorrects when multi-line blocks to `{` and `}` with method chain' do
+        expect_offense(<<~RUBY)
+          foo bar + baz {
+                        ^ Avoid using `{...}` for multi-line blocks.
+          }.qux.quux
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo bar + baz do
+          end.qux.quux
+        RUBY
+      end
+
+      it 'does not register an offense when multi-line blocks to `{` and `}` with arithmetic operation method chain' do
+        expect_no_offenses(<<~RUBY)
+          foo bar + baz {
+          }.qux + quux
+        RUBY
+      end
+
       it 'does not autocorrect {} if do-end would introduce a syntax error' do
         expect_no_offenses(<<~RUBY)
           my_method :arg1, arg2: proc {


### PR DESCRIPTION
Fixes #11665.

This PR fixes an incorrect autocorrect for `Style/BlockDelimiters` when multi-line blocks to `{` and `}` with arithmetic operation method chain.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
