### PR TITLE
[Fix rubocop#11164] Suppress server mode message with -f json

### DIFF
--- a/changelog/fix_fix_rubocop_11164_suppress_server_mode_message.md
+++ b/changelog/fix_fix_rubocop_11164_suppress_server_mode_message.md
@@ -1,1 +1,1 @@
-* [#11164](https://github.com/rubocop/rubocop/issues/11164): [Fix rubocop#11164] Suppress server mode message with -f json. ([@jasondoc3][])
+* [#11164](https://github.com/rubocop/rubocop/issues/11164): Suppress server mode message with `-f json`. ([@jasondoc3][])

--- a/changelog/fix_fix_rubocop_11164_suppress_server_mode_message.md
+++ b/changelog/fix_fix_rubocop_11164_suppress_server_mode_message.md
@@ -1,0 +1,1 @@
+* [#11164](https://github.com/rubocop/rubocop/issues/11164): [Fix rubocop#11164] Suppress server mode message with -f json. ([@jasondoc3][])

--- a/lib/rubocop/server/core.rb
+++ b/lib/rubocop/server/core.rb
@@ -100,7 +100,7 @@ module RuboCop
 
       def use_json_format?
         return true if ARGV.include?('--format=json') || ARGV.include?('--format=j')
-        return false unless (index = ARGV.index('--format'))
+        return false unless (index = ARGV.index('--format') || ARGV.index('-f'))
 
         format = ARGV[index + 1]
 

--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -123,6 +123,34 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
           expect(stdout).not_to start_with 'RuboCop server starting on '
         end
       end
+
+      context 'when `-f json`' do
+        it 'does not display the server start message' do
+          create_file('example.rb', <<~RUBY)
+            puts 0
+          RUBY
+
+          stdout, _stderr, _status = Open3.capture3(
+            'ruby', '-I', '.',
+            rubocop, '--server', '-f', 'json', '--stdin', 'example.rb', stdin_data: 'puts 0'
+          )
+          expect(stdout).not_to start_with 'RuboCop server starting on '
+        end
+      end
+
+      context 'when `-f j`' do
+        it 'does not display the server start message' do
+          create_file('example.rb', <<~RUBY)
+            puts 0
+          RUBY
+
+          stdout, _stderr, _status = Open3.capture3(
+            'ruby', '-I', '.',
+            rubocop, '--server', '-f', 'j', '--stdin', 'example.rb', stdin_data: 'puts 0'
+          )
+          expect(stdout).not_to start_with 'RuboCop server starting on '
+        end
+      end
     end
 
     context 'when using `--server` option after running server and updating configuration' do


### PR DESCRIPTION
A followup to https://github.com/rubocop/rubocop/pull/11167 and https://github.com/rubocop/rubocop/issues/11164. I noticed "RuboCop server starting..." is still printed when running in server mode with `-f json`. It should be suppressed :zipper_mouth_face: 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
