### PR TITLE
Fix #11658: registers pry as an offense

### DIFF
--- a/changelog/fix_registers_pry_as_an_offense.md
+++ b/changelog/fix_registers_pry_as_an_offense.md
@@ -1,1 +1,1 @@
-* [#11658](https://github.com/rubocop/rubocop/issues/11658): Fix Lint/Debugger should not allow pry. ([@ThHareau][])
+* [#11658](https://github.com/rubocop/rubocop/issues/11658): Fix `Lint/Debugger` should not allow pry. ([@ThHareau][])

--- a/changelog/fix_registers_pry_as_an_offense.md
+++ b/changelog/fix_registers_pry_as_an_offense.md
@@ -1,0 +1,1 @@
+* [#11658](https://github.com/rubocop/rubocop/issues/11658): Fix Lint/Debugger should not allow pry. ([@ThHareau][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1659,6 +1659,7 @@ Lint/Debugger:
       - Kernel.binding.remote_pry
       - Kernel.binding.pry_remote
       - Pry.rescue
+      - pry
     Rails:
       - debugger
       - Kernel.debugger

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -240,6 +240,20 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
   end
 
   context 'pry' do
+    it 'registers an offense for a pry call' do
+      expect_offense(<<~RUBY)
+        pry
+        ^^^ Remove debugger entry point `pry`.
+      RUBY
+    end
+
+    it 'registers an offense for a pry with an argument call' do
+      expect_offense(<<~RUBY)
+        pry foo
+        ^^^^^^^ Remove debugger entry point `pry foo`.
+      RUBY
+    end
+
     it 'registers an offense for a pry binding call' do
       expect_offense(<<~RUBY)
         binding.pry
@@ -298,10 +312,6 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
           ^^^^^^^^^^^^ Remove debugger entry point `::Pry.rescue`.
         end
       RUBY
-    end
-
-    it 'does not register an offense for a `pry` call without binding' do
-      expect_no_offenses('pry')
     end
 
     it 'does not register an offense for a `rescue` call without Pry' do


### PR DESCRIPTION
Fix for #11658 : `pry` alone is now an offense
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
