### PR TITLE
Fix incorrect Style/HashSyntax autocorrection for assignment methods

### DIFF
--- a/changelog/fix_incorrect_style_hash_syntax_autocorrection_for.md
+++ b/changelog/fix_incorrect_style_hash_syntax_autocorrection_for.md
@@ -1,0 +1,1 @@
+* [#11673](https://github.com/rubocop/rubocop/pull/11673): Fix incorrect `Style/HashSyntax` autocorrection for assignment methods. ([@gsamokovarov][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -100,6 +100,7 @@ module RuboCop
         last_pair = node.parent.pairs.last
         return unless last_pair.key.source == last_pair.value.source
         return unless (dispatch_node = find_ancestor_method_dispatch_node(node))
+        return if dispatch_node.assignment_method?
         return if dispatch_node.parenthesized?
         return if dispatch_node.parent && parentheses?(dispatch_node.parent)
         return if last_expression?(dispatch_node) && !method_dispatch_as_argument?(dispatch_node)

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1154,6 +1154,19 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'registers an offense when expression follows attribute assignment' do
+        expect_offense(<<~RUBY)
+          object.attr = {foo: foo}
+                              ^^^ Omit the hash value.
+          pass
+        RUBY
+
+        expect_correction(<<~RUBY)
+          object.attr = {foo:}
+          pass
+        RUBY
+      end
+
       it 'registers an offense when expression follows multiple assignments' do
         expect_offense(<<~RUBY)
           foo = bar = do_stuff arg, opt1: opt1,


### PR DESCRIPTION
In Ruby 3.1 and above, code like:

```ruby
object.attr = {foo: foo}
                    ^^^ Omit the hash value.
pass
```

was incorrectly autocorrected to:

```ruby
object.attr({foo:})
pass
```

The autocorrected code is valid Ruby, but is semantically different. This may and will lead to subtle bugs in user codebases.