### PR TITLE
[Fix #11672] Fix an error for `Layout/BlockEndNewline`

### DIFF
--- a/changelog/fix_an_error_for_layout_block_end_newline.md
+++ b/changelog/fix_an_error_for_layout_block_end_newline.md
@@ -1,0 +1,1 @@
+* [#11672](https://github.com/rubocop/rubocop/issues/11672): Fix an error for `Layout/BlockEndNewline` when multiline block `}` is not on its own line and it is used as multiple arguments. ([@koic][])

--- a/spec/rubocop/cop/layout/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/layout/block_end_newline_spec.rb
@@ -13,18 +13,11 @@ RSpec.describe RuboCop::Cop::Layout::BlockEndNewline, :config do
     RUBY
   end
 
-  it 'registers an offense when multiline blocks with newlines before the `; end`' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when multiline blocks with newlines before the `; end`' do
+    expect_no_offenses(<<~RUBY)
       test do
         foo
       ; end
-        ^^^ Expression at 3, 3 should be on its own line.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      test do
-        foo
-      end
     RUBY
   end
 
@@ -83,6 +76,25 @@ RSpec.describe RuboCop::Cop::Layout::BlockEndNewline, :config do
       test {
         foo
       }.bar.baz
+    RUBY
+  end
+
+  it 'registers an offense and corrects when multiline block `}` is not on its own line ' \
+     'and it is used as multiple arguments' do
+    expect_offense(<<~RUBY)
+      foo(one {
+        x }, two {
+          ^ Expression at 2, 5 should be on its own line.
+        y })
+          ^ Expression at 3, 5 should be on its own line.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo(one {
+        x
+      }, two {
+        y
+      })
     RUBY
   end
 


### PR DESCRIPTION
Fixes #11672.

This PR fixes an error for `Layout/BlockEndNewline` when multiline block `}` is not on its own line and it is used as multiple arguments.

And the following case is handled by `Style/Semicolon`:

```ruby
test do
  foo
; end
```

So make it out of the responsibility of `Layout/BlockEndNewline`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
