### PR TITLE
Style/AccessorGrouping: Fix sibling detection for methods with type sigs

### DIFF
--- a/changelog/fix_style_accessor_grouping_fix_sibling_detection_for.md
+++ b/changelog/fix_style_accessor_grouping_fix_sibling_detection_for.md
@@ -1,0 +1,1 @@
+* [#11675](https://github.com/rubocop/rubocop/pull/11675): `Style/AccessorGrouping`: Fix sibling detection for methods with type sigs. ([@issyl0][])

--- a/lib/rubocop/cop/style/accessor_grouping.rb
+++ b/lib/rubocop/cop/style/accessor_grouping.rb
@@ -70,7 +70,7 @@ module RuboCop
 
         def check(send_node)
           return if previous_line_comment?(send_node) || !groupable_accessor?(send_node)
-          return unless (grouped_style? && sibling_accessors(send_node).size > 1) ||
+          return unless (grouped_style? && groupable_sibling_accessors(send_node).size > 1) ||
                         (separated_style? && send_node.arguments.size > 1)
 
           message = message(send_node)
@@ -127,12 +127,12 @@ module RuboCop
           style == :separated
         end
 
-        def sibling_accessors(send_node)
+        def groupable_sibling_accessors(send_node)
           send_node.parent.each_child_node(:send).select do |sibling|
             sibling.attribute_accessor? &&
               sibling.method?(send_node.method_name) &&
               node_visibility(sibling) == node_visibility(send_node) &&
-              !previous_line_comment?(sibling)
+              groupable_accessor?(sibling) && !previous_line_comment?(sibling)
           end
         end
 
@@ -143,7 +143,7 @@ module RuboCop
 
         def preferred_accessors(node)
           if grouped_style?
-            accessors = sibling_accessors(node)
+            accessors = groupable_sibling_accessors(node)
             group_accessors(node, accessors) if node.loc == accessors.first.loc
           else
             separate_accessors(node)

--- a/spec/rubocop/cop/style/accessor_grouping_spec.rb
+++ b/spec/rubocop/cop/style/accessor_grouping_spec.rb
@@ -141,6 +141,47 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
       RUBY
     end
 
+    it 'does not register an offense for grouped accessors below a typechecked accessor method' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          extend T::Sig
+
+          sig { returns(Integer) }
+          attr_reader :one
+
+          attr_reader :two, :three
+        end
+      RUBY
+    end
+
+    it 'registers an offense for grouped accessors distinct from a typechecked accessor method' do
+      expect_offense(<<~RUBY)
+        class Foo
+          extend T::Sig
+
+          sig { returns(Integer) }
+          attr_reader :one
+
+          attr_reader :two, :three
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes.
+
+          attr_reader :four
+          ^^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          extend T::Sig
+
+          sig { returns(Integer) }
+          attr_reader :one
+
+          attr_reader :two, :three, :four
+        end
+      RUBY
+    end
+
     it 'registers an offense for accessors with method definitions' do
       expect_offense(<<~RUBY)
         class Foo


### PR DESCRIPTION
- Over in `Homebrew/brew`, trying to enable this cop after 008506d59f094140636269aa588e32fb69001018 was released, we were seeing the following offenses which were incorrect since we can't combine attrs that follow on from typed ones.

```
  sig { returns(Pathname) }
  attr_reader :cached_location

  attr_reader :cache, :meta, :name, :version
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes
```

- This commit ensures that sibling accessors are groupable before raising an offense that they should be grouped.
- Also add more tests to ensure the offense detection and subsequent autocorrection still works.
- Follow up to #11650.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
