### PR TITLE
Improve `Naming/MethodName` example `AllowedPatterns`

### DIFF
--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -10,8 +10,8 @@ module RuboCop
       #
       #   Naming/MethodName:
       #     AllowedPatterns:
-      #       - '\A\s*onSelectionBulkChange\s*'
-      #       - '\A\s*onSelectionCleared\s*'
+      #       - '\AonSelectionBulkChange\z'
+      #       - '\AonSelectionCleared\z'
       #
       # Method names matching patterns are always allowed.
       #

--- a/spec/rubocop/cop/naming/method_name_spec.rb
+++ b/spec/rubocop/cop/naming/method_name_spec.rb
@@ -136,8 +136,8 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
         {
           'EnforcedStyle' => enforced_style,
           'AllowedPatterns' => [
-            '\A\s*onSelectionBulkChange\s*',
-            '\A\s*on_selection_cleared\s*'
+            '\AonSelectionBulkChange\z',
+            '\Aon_selection_cleared\z'
           ]
         }
       end


### PR DESCRIPTION
None of the code paths lead to scenarios in which a method name could possibly include leading or trailing whitespace, so there is no reason for the documentation or test patterns to include optional whitespace.

Instead, we can show an example of anchoring on both ends, to exactly match the method name.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
