### PR TITLE
Fix `Style/EachForSimpleLoop` handling for blocks with a parameter

### DIFF
--- a/changelog/fix_each_for_simple_loop_block_with_param.md
+++ b/changelog/fix_each_for_simple_loop_block_with_param.md
@@ -1,0 +1,1 @@
+* [#11681](https://github.com/rubocop/rubocop/pull/11681): `Style/EachForSimpleLoop` now does not register offense for blocks with a parameter. ([@j1wilmot][])

--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -46,7 +46,7 @@ module RuboCop
         private
 
         def offending?(node)
-          each_range_with_zero_origin?(node) || each_range_without_block_argument?(node)
+          each_range_without_block_argument?(node)
         end
 
         # @!method each_range(node)
@@ -56,18 +56,6 @@ module RuboCop
               (begin
                 (${irange erange}
                   (int $_) (int $_)))
-              :each)
-            (args ...)
-            ...)
-        PATTERN
-
-        # @!method each_range_with_zero_origin?(node)
-        def_node_matcher :each_range_with_zero_origin?, <<~PATTERN
-          (block
-            (send
-              (begin
-                ({irange erange}
-                  (int 0) (int _)))
               :each)
             (args ...)
             ...)

--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -9,31 +9,52 @@ RSpec.describe RuboCop::Cop::Style::EachForSimpleLoop, :config do
     expect_no_offenses('(0..b).each {}')
   end
 
-  context 'with inline block with parameters' do
-    it 'autocorrects an offense' do
-      expect_offense(<<~RUBY)
-        (0...10).each { |n| }
-        ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
-      RUBY
+  context 'with inline block' do
+    context 'with no parameters' do
+      it 'autocorrects an offense' do
+        expect_offense(<<~RUBY)
+          (0...10).each {}
+          ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        10.times { |n| }
-      RUBY
+        expect_correction(<<~RUBY)
+          10.times {}
+        RUBY
+      end
+    end
+
+    context 'with parameters' do
+      it 'does not register offense' do
+        expect_no_offenses(<<~RUBY)
+          (0...10).each { |n| }
+        RUBY
+      end
     end
   end
 
-  context 'with multiline block with parameters' do
-    it 'autocorrects an offense' do
-      expect_offense(<<~RUBY)
-        (0...10).each do |n|
-        ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
-        end
-      RUBY
+  context 'with multiline' do
+    context 'with no parameters' do
+      it 'autocorrects an offense' do
+        expect_offense(<<~RUBY)
+          (0...10).each do
+          ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
+          end
+        RUBY
 
-      expect_correction(<<~RUBY)
-        10.times do |n|
-        end
-      RUBY
+        expect_correction(<<~RUBY)
+          10.times do
+          end
+        RUBY
+      end
+    end
+
+    context 'with parameters' do
+      it 'does not register offense' do
+        expect_no_offenses(<<~RUBY)
+          (0...10).each do |n|
+          end
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
**Problem:**
The `Style/EachForSimpleLoop` cop [documents](https://github.com/rubocop/rubocop/blob/master/lib/rubocop/cop/style/each_for_simple_loop.rb#L10) that "This check only applies if the block takes no parameters", however that is not how it behaves. Not running for blocks with parameters was also the [original intent](https://github.com/rubocop/rubocop/issues/3018#issuecomment-222643692) when this cop was introduced. The issue is that the `each_range_with_zero_origin` matcher matches against a block that takes arguments when it should not.

**Solution:**
- Add tests to ensure an offense is not generated for blocks with params
- Remove the `each_range_with_zero_origin matcher`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
