### PR TITLE
[Fix #11682] Fix a false positive for `Lint/UselessRescue`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_useless_rescue.md
+++ b/changelog/fix_a_false_positive_for_lint_useless_rescue.md
@@ -1,0 +1,1 @@
+* [#11682](https://github.com/rubocop/rubocop/issues/11682): Fix a false positive for `Lint/UselessRescue` when using `Thread#raise` in `rescue` clause. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_rescue.rb
+++ b/lib/rubocop/cop/lint/useless_rescue.rb
@@ -56,11 +56,13 @@ module RuboCop
 
         private
 
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
         def only_reraising?(resbody_node)
           return false if use_exception_variable_in_ensure?(resbody_node)
 
           body = resbody_node.body
-          return false if body.nil? || !body.send_type? || !body.method?(:raise)
+
+          return false if body.nil? || !body.send_type? || !body.method?(:raise) || body.receiver
           return true unless body.arguments?
           return false if body.arguments.size > 1
 
@@ -68,6 +70,7 @@ module RuboCop
 
           exception_objects(resbody_node).include?(exception_name)
         end
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
         def use_exception_variable_in_ensure?(resbody_node)
           return false unless (exception_variable = resbody_node.exception_variable)

--- a/spec/rubocop/cop/lint/useless_rescue_spec.rb
+++ b/spec/rubocop/cop/lint/useless_rescue_spec.rb
@@ -108,6 +108,16 @@ RSpec.describe RuboCop::Cop::Lint::UselessRescue, :config do
     RUBY
   end
 
+  it 'does not register an offense when using `Thread#raise` in `rescue` clause' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        do_something
+      rescue
+        Thread.current.raise
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using modifier `rescue`' do
     expect_no_offenses(<<~RUBY)
       do_something rescue nil


### PR DESCRIPTION
Fixes #11682.

This PR fixes a false positive for `Lint/UselessRescue` when using `Thread#raise` in `rescue` clause. In fact, any method call with a receiver will not be "useless rescue", not just `Thread#raise`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
