### PR TITLE
[Fix #11677] Fix the severity for `Lint/Syntax`

### DIFF
--- a/changelog/fix_the_severity_for_lint_syntax.md
+++ b/changelog/fix_the_severity_for_lint_syntax.md
@@ -1,0 +1,1 @@
+* [#11677](https://github.com/rubocop/rubocop/issues/11677): Fix the severity for `Lint/Syntax`. ([@koic][])

--- a/lib/rubocop/cop/lint/syntax.rb
+++ b/lib/rubocop/cop/lint/syntax.rb
@@ -33,6 +33,10 @@ module RuboCop
           message << '.' unless message.end_with?('.')
           message
         end
+
+        def find_severity(_range, _severity)
+          :fatal
+        end
       end
     end
   end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
     expect($stderr.string).to eq ''
     expect($stdout.string)
-      .to eq(["#{abs('example.rb')}:3:1: E: Lint/Syntax: unexpected " \
+      .to eq(["#{abs('example.rb')}:3:1: F: Lint/Syntax: unexpected " \
               'token $end (Using Ruby 2.6 parser; configure using ' \
               '`TargetRubyVersion` parameter, under `AllCops`)',
               ''].join("\n"))
@@ -1948,6 +1948,28 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(['--format', 'simple', 'test.rb'])).to eq(2)
         expect(
           $stderr.string.include?('Error: configuration for Lint/Syntax cop found in .rubocop.yml')
+        ).to be(true)
+      end
+    end
+
+    context 'when `Lint` is given `Severity: info`' do
+      let(:code) do
+        <<~RUBY
+          1 /// 2
+        RUBY
+      end
+
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          Lint:
+            Severity: info
+        YAML
+      end
+
+      it '`Lint/Syntax` severity `fatal` cannot be changed by configuration' do
+        expect(cli.run(['--format', 'simple', 'test.rb'])).to eq(1)
+        expect(
+          $stdout.string.include?('F:  1:  7: Lint/Syntax: unexpected token tINTEGER')
         ).to be(true)
       end
     end

--- a/spec/rubocop/cop/lint/syntax_spec.rb
+++ b/spec/rubocop/cop/lint/syntax_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::Lint::Syntax, :config do
         MESSAGE
         offense = offenses.first
         expect(offense.message).to eq(message)
-        expect(offense.severity).to eq(:error)
+        expect(offense.severity).to eq(:fatal)
       end
 
       context 'with --display-cop-names option' do
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Lint::Syntax, :config do
           MESSAGE
           offense = offenses.first
           expect(offense.message).to eq(message)
-          expect(offense.severity).to eq(:error)
+          expect(offense.severity).to eq(:fatal)
         end
       end
 
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::Lint::Syntax, :config do
           MESSAGE
           offense = offenses.first
           expect(offense.message).to eq(message)
-          expect(offense.severity).to eq(:error)
+          expect(offense.severity).to eq(:fatal)
         end
       end
     end


### PR DESCRIPTION
Fixes #11677.

This PR fixes the severity for `Lint/Syntax`. The `Lint/Syntax` severity must always be `fatal`.

> There is one exception from the general rule above and that is `Lint/Syntax`, a special cop that checks for syntax errors before the other cops are invoked. It cannot be disabled and its severity (`fatal`) cannot be changed in configuration.

https://docs.rubocop.org/rubocop/1.46/configuration.html#severity

In addition to #11666, it also fixes the following issues:

```ruby
def foobar
  t = {
    a: "foo"  # missing "," syntax error
    b: 'bar'
  }
  return t
end
```

## Before

The severity that mult be `fatal` (`F`) is unexpectedly `error` (`E`):

```console
$ bundle exec rubocop
(snip)

Inspecting 1 file
E

Offenses:

example.rb:4:5: E: Lint/Syntax: unexpected token tIDENTIFIER
(Using Ruby 3.2 parser; configure using TargetRubyVersion parameter, under AllCops)
    b: 'bar'
    ^

1 file inspected, 1 offense detected
```

## After

It will be `fatal` (`F`) as expected:

```console
$ bundle exec rubocop
(snip)

Inspecting 1 file
F

Offenses:

example.rb:4:5: F: Lint/Syntax: unexpected token tIDENTIFIER
(Using Ruby 3.2 parser; configure using TargetRubyVersion parameter, under AllCops)
    b: 'bar'
    ^

1 file inspected, 1 offense detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
