### PR TITLE
Fix `Lint/Syntax` behavior when `Enabled: false` of `Lint` department

### DIFF
--- a/changelog/fix_lint_syntax_when_enabled_false.md
+++ b/changelog/fix_lint_syntax_when_enabled_false.md
@@ -1,0 +1,1 @@
+* [#11686](https://github.com/rubocop/rubocop/pull/11686): Fix `Lint/Syntax` behavior when `Enabled: false` of `Lint` department. ([@koic][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -304,8 +304,8 @@ module RuboCop
     end
 
     def enable_cop?(qualified_cop_name, cop_options)
-      # If the cop is explicitly enabled, the other checks can be skipped.
-      return true if cop_options['Enabled'] == true
+      # If the cop is explicitly enabled or `Lint/Syntax`, the other checks can be skipped.
+      return true if cop_options['Enabled'] == true || qualified_cop_name == 'Lint/Syntax'
 
       department = department_of(qualified_cop_name)
       cop_enabled = cop_options.fetch('Enabled') { !for_all_cops['DisabledByDefault'] }

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -305,6 +305,38 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         1 file inspected, 1 offense detected
       RESULT
     end
+
+    it '`Lint/Syntax` must be enabled when `Lint` is given `Enabled: false`' do
+      create_file('.rubocop.yml', <<~YAML)
+        Lint:
+          Enabled: false
+      YAML
+
+      create_file('example.rb', <<~RUBY)
+        1 /// 2
+      RUBY
+
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
+      expect(
+        $stdout.string.include?('F:  1:  7: Lint/Syntax: unexpected token tINTEGER')
+      ).to be(true)
+    end
+
+    it '`Lint/Syntax` must be enabled when `DisabledByDefault: true`' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          DisabledByDefault: true
+      YAML
+
+      create_file('example.rb', <<~RUBY)
+        1 /// 2
+      RUBY
+
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
+      expect(
+        $stdout.string.include?('F:  1:  7: Lint/Syntax: unexpected token tINTEGER')
+      ).to be(true)
+    end
   end
 
   describe 'rubocop:disable comment' do


### PR DESCRIPTION
Here's another fix I found in work on #11688.

Ruby code has a syntax error and .rubocop.yml with `Lint` department is disabled:

```ruby
def foobar
  t = {
    a: "foo"  # missing "," syntax error
    b: 'bar'
  }
  return t
end
```

```yaml
# .rubocop.yml
Lint:
  Enabled: false
```

But `Lint/Syntax` must not be disabled:

> There is one exception from the general rule above and that is `Lint/Syntax`, a special cop that checks for syntax errors before the other cops are invoked. It cannot be disabled and its severity (`fatal`) cannot be changed in configuration.

https://docs.rubocop.org/rubocop/1.46/configuration.html#severity

## Before

The syntax is invalid but an offense is not registerd:

```console
$ bundle exec rubocop
(snip)

Inspecting 1 file
.

1 file inspected, no offenses detected
```

## After

`Lint/Syntax` detects invalid syntax as expected:

```console
$ bundle exec rubocop
(snip)

Offenses:

example.rb:4:5: F: Lint/Syntax: unexpected token tIDENTIFIER
(Using Ruby 3.2 parser; configure using TargetRubyVersion parameter, under AllCops)
    b: 'bar'
    ^

1 file inspected, 1 offense detected
```

The `Lint/Syntax` behavior for `DisabledByDefault: true` configuration is also fixed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
