### PR TITLE
Naming/MethodParameterName: Add "pr" to the default allowlist

### DIFF
--- a/changelog/change_naming_method_parameter_name_add_pr_to_the_default.md
+++ b/changelog/change_naming_method_parameter_name_add_pr_to_the_default.md
@@ -1,0 +1,1 @@
+* [#11690](https://github.com/rubocop/rubocop/pull/11690): `Naming/MethodParameterName`: Add "pr" to the default allowlist. ([@issyl0][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2857,6 +2857,7 @@ Naming/MethodParameterName:
     - 'on'
     - os
     - pp
+    - pr
     - to
   # Forbidden names that will register an offense
   ForbiddenNames: []


### PR DESCRIPTION
- I feel like this is likely ubiquitous enough to be short for "pull request" in a bunch of code?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
