### PR TITLE
Fix an error for `Gemspec/DependencyVersion`

### DIFF
--- a/changelog/fix_an_error_for_gemspec_dependency_version.md
+++ b/changelog/fix_an_error_for_gemspec_dependency_version.md
@@ -1,0 +1,1 @@
+* [#11691](https://github.com/rubocop/rubocop/pull/11691): Fix an error for `Gemspec/DependencyVersion` when method called on gem name argument for `add_dependency`. ([@koic][])

--- a/lib/rubocop/cop/gemspec/dependency_version.rb
+++ b/lib/rubocop/cop/gemspec/dependency_version.rb
@@ -94,7 +94,7 @@ module RuboCop
         private
 
         def allowed_gem?(node)
-          allowed_gems.include?(node.first_argument.value)
+          allowed_gems.include?(node.first_argument.str_content)
         end
 
         def allowed_gems

--- a/spec/rubocop/cop/gemspec/dependency_version_spec.rb
+++ b/spec/rubocop/cop/gemspec/dependency_version_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe RuboCop::Cop::Gemspec::DependencyVersion, :config do
         RUBY
       end
 
+      it 'registers an offense when adding dependency without version specification and method called on gem name argument' do
+        expect_offense(<<~RUBY)
+          Gem::Specification.new do |spec|
+            spec.add_dependency('parser'.freeze)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependency version specification is required.
+          end
+        RUBY
+      end
+
       it 'registers an offense when adding dependency using git option without version specification' do
         expect_offense(<<~RUBY)
           Gem::Specification.new do |spec|


### PR DESCRIPTION
This PR fixes the following error for `Gemspec/DependencyVersion` when `add_dependency` without version argument and method called on gem name argument:

```ruby
Gem::Specification.new do |spec|
  spec.add_dependency('parser'.freeze)
end
```

```console
$ bundle exec rubocop --only Gemspec/DependencyVersion -d
(snip)

undefined method `value' for s(:send,
  s(:str, "parser"), :freeze):RuboCop::AST::SendNode
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/gemspec/dependency_version.rb:97:in `allowed_gem?'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/gemspec/dependency_version.rb:84:in `on_send'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/commissioner.rb:143:in `public_send'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
