### PR TITLE
[Doc] Tweak the doc for `DisabledByDefault` config

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -483,8 +483,8 @@ are disabled by default.
 
 The cop enabling process can be altered by setting `DisabledByDefault` or
 `EnabledByDefault` (but not both) to `true`. These settings override the default for *all*
-cops to disabled or enabled, regardless of the cops' default values (whether enabled,
-disabled or pending).
+cops to disabled or enabled, except `Lint/Syntax` which is always enabled,
+regardless of the cops' default values (whether enabled, disabled or pending).
 
 [source,yaml]
 ----
@@ -492,7 +492,7 @@ AllCops:
   DisabledByDefault: true
 ----
 
-All cops are then disabled by default. Only cops appearing in user
+All cops except `Lint/Syntax` are then disabled by default. Only cops appearing in user
 configuration files with `Enabled: true` will be enabled; every other cop will
 be disabled without having to explicitly disable them in configuration. It is
 also possible to enable entire departments by adding for example


### PR DESCRIPTION
Follow up #11689.

I read back through the configuration doc and noticed that the description of `DisabledByDefault` behavior was not strict.
This PR updates the doc to consider `Lint/Syntax` which is always enabled.

This makes the description consistent with:

> There is one exception from the general rule above and that is `Lint/Syntax`,
> a special cop that checks for syntax errors before the other cops are invoked.
> It cannot be disabled and its severity (`fatal`) cannot be changed in configuration.

https://docs.rubocop.org/rubocop/1.46/configuration.html#severity

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
