### PR TITLE
Fix a typo in comment

### DIFF
--- a/lib/rubocop/ext/regexp_node.rb
+++ b/lib/rubocop/ext/regexp_node.rb
@@ -29,7 +29,7 @@ module RuboCop
           @parsed_tree&.each_expression(true) { |e| e.origin = origin }
         end
       # Please remove this `else` branch when support for regexp_parser 1.8 will be dropped.
-      # It's for compatibility with regexp_arser 1.8 and will never be maintained.
+      # It's for compatibility with regexp_parser 1.8 and will never be maintained.
       else
         def assign_properties(*)
           super


### PR DESCRIPTION
This PR is fix a typo in comment

regexp_arser -> regexp_parser

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
