### PR TITLE
[Fix #11699] Make `Style/ClassEqualityComparison` aware of `to_s` and `inspect`

### DIFF
--- a/changelog/new_make_style_class_equality_comparison_aware_of_class_to_s_and_inspect.md
+++ b/changelog/new_make_style_class_equality_comparison_aware_of_class_to_s_and_inspect.md
@@ -1,0 +1,1 @@
+* [#11699](https://github.com/rubocop/rubocop/issues/11699): Make `Style/ClassEqualityComparison` aware of `Class#to_s` and `Class#inspect` for class equality comparison. ([@koic][])

--- a/spec/rubocop/cop/style/class_equality_comparison_spec.rb
+++ b/spec/rubocop/cop/style/class_equality_comparison_spec.rb
@@ -36,37 +36,109 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects when comparing single quoted class name for equality' do
-    expect_offense(<<~RUBY)
-      var.class.name == 'Date'
-          ^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
-    RUBY
+  context 'when using `Class#name`' do
+    it 'registers an offense and corrects when comparing single quoted class name for equality' do
+      expect_offense(<<~RUBY)
+        var.class.name == 'Date'
+            ^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      var.instance_of?(Date)
-    RUBY
+      expect_correction(<<~RUBY)
+        var.instance_of?(Date)
+      RUBY
+    end
+
+    it 'registers an offense and corrects when comparing `Module#name` for equality' do
+      expect_offense(<<~RUBY)
+        var.class.name == Date.name
+            ^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var.instance_of?(Date)
+      RUBY
+    end
+
+    it 'registers an offense and corrects when comparing double quoted class name for equality' do
+      expect_offense(<<~RUBY)
+        var.class.name == "Date"
+            ^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var.instance_of?(Date)
+      RUBY
+    end
   end
 
-  it 'registers an offense and corrects when comparing `Module#name` for equality' do
-    expect_offense(<<~RUBY)
-      var.class.name == Date.name
-          ^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
-    RUBY
+  context 'when using `Class#to_s`' do
+    it 'registers an offense and corrects when comparing single quoted class name for equality' do
+      expect_offense(<<~RUBY)
+        var.class.to_s == 'Date'
+            ^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      var.instance_of?(Date)
-    RUBY
+      expect_correction(<<~RUBY)
+        var.instance_of?(Date)
+      RUBY
+    end
+
+    it 'registers an offense and corrects when comparing `Module#name` for equality' do
+      expect_offense(<<~RUBY)
+        var.class.to_s == Date.to_s
+            ^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var.instance_of?(Date)
+      RUBY
+    end
+
+    it 'registers an offense and corrects when comparing double quoted class name for equality' do
+      expect_offense(<<~RUBY)
+        var.class.to_s == "Date"
+            ^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var.instance_of?(Date)
+      RUBY
+    end
   end
 
-  it 'registers an offense and corrects when comparing double quoted class name for equality' do
-    expect_offense(<<~RUBY)
-      var.class.name == "Date"
-          ^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
-    RUBY
+  context 'when using `Class#inspect`' do
+    it 'registers an offense and corrects when comparing single quoted class name for equality' do
+      expect_offense(<<~RUBY)
+        var.class.inspect == 'Date'
+            ^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      var.instance_of?(Date)
-    RUBY
+      expect_correction(<<~RUBY)
+        var.instance_of?(Date)
+      RUBY
+    end
+
+    it 'registers an offense and corrects when comparing `Module#name` for equality' do
+      expect_offense(<<~RUBY)
+        var.class.inspect == Date.inspect
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var.instance_of?(Date)
+      RUBY
+    end
+
+    it 'registers an offense and corrects when comparing double quoted class name for equality' do
+      expect_offense(<<~RUBY)
+        var.class.inspect == "Date"
+            ^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var.instance_of?(Date)
+      RUBY
+    end
   end
 
   it 'does not register an offense when using `instance_of?`' do


### PR DESCRIPTION
Fixes #11699.

This PR makes `Style/ClassEqualityComparison` aware of `Class#to_s` and `Class#inspect` for class equality comparison. `Class#to_s` and `Class#inspect` are aliases for `Class#name`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
