### PR TITLE
[Fix #11685] Fix incorrect directive comment insertion when percent array violates `Layout/LineLength` cop

### DIFF
--- a/changelog/fix_fix_incorrect_directive_comment_insertion_when.md
+++ b/changelog/fix_fix_incorrect_directive_comment_insertion_when.md
@@ -1,0 +1,1 @@
+* [#11685](https://github.com/rubocop/rubocop/issues/11685): Fix incorrect directive comment insertion when percent array violates `Layout/LineLength` cop. ([@nobuyo][])

--- a/spec/rubocop/cli/disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/disable_uncorrectable_spec.rb
@@ -259,6 +259,30 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
           RUBY
         end
       end
+
+      context 'and the offense is inside a percent array' do
+        it 'adds before-and-after disable statement around the percent array' do
+          create_file('.rubocop.yml', <<~YAML)
+            Layout/LineLength:
+              Max: 30
+          YAML
+          create_file('example.rb', <<~RUBY)
+            # frozen_string_literal: true
+
+            ARRAY = %i[AAAAAAAAAAAAAAAAAAAA BBBBBBBBBBBBBBBBBBBB].freeze
+          RUBY
+          expect(exit_code).to eq(0)
+          expect(File.read('example.rb')).to eq(<<~RUBY)
+            # frozen_string_literal: true
+
+            # rubocop:todo Layout/LineLength
+            ARRAY = %i[
+              AAAAAAAAAAAAAAAAAAAA BBBBBBBBBBBBBBBBBBBB
+            ].freeze
+            # rubocop:enable Layout/LineLength
+          RUBY
+        end
+      end
     end
 
     context 'when exist offense for Layout/SpaceInsideArrayLiteralBrackets' do


### PR DESCRIPTION
Fixes #11685.

The problem was that directive comments were inserted inside percent literals and thus had no effect.
So I've added a condition to detect percent array as well as heredoc.

```rb
ARRAY = %i[
# rubocop:todo Layout/LineLength <---- 💥 
AAAAAAAAAAAAAAAAAAAA BBBBBBBBBBBBBBBBBBBB].freeze
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
