### PR TITLE
More rubocop optimizations

### DIFF
--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -51,6 +51,8 @@ module RuboCop
         MSG_BEFORE_FOR_ONLY_BEFORE = 'Keep a blank line before `%<modifier>s`.'
         MSG_AFTER_FOR_ONLY_BEFORE = 'Remove a blank line after `%<modifier>s`.'
 
+        RESTRICT_ON_SEND = %i[public protected private module_function].freeze
+
         def initialize(config = nil, options = nil)
           super
 

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -153,9 +153,10 @@ module RuboCop
         MSG = 'Indent the first argument one step more than %<base>s.'
 
         def on_send(node)
+          return unless should_check?(node)
+          return if same_line?(node, node.first_argument)
           return if style != :consistent && enforce_first_argument_with_fixed_indentation? &&
                     !enable_layout_first_method_argument_line_break?
-          return if !node.arguments? || bare_operator?(node) || node.setter_method?
 
           indent = base_indentation(node) + configured_indentation_width
 
@@ -165,6 +166,10 @@ module RuboCop
         alias on_super on_send
 
         private
+
+        def should_check?(node)
+          node.arguments? && !bare_operator?(node) && !node.setter_method?
+        end
 
         def autocorrect(corrector, node)
           AlignmentCorrector.correct(corrector, processed_source, node, column_delta)

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -50,9 +50,9 @@ module RuboCop
 
         def on_send(node)
           # Include "the whole expression".
-          node = node.parent while convertible_block?(node) ||
-                                   node.parent.is_a?(RuboCop::AST::BinaryOperatorNode) ||
-                                   node.parent&.send_type?
+          node = node.parent while node.parent&.send_type? ||
+                                   convertible_block?(node) ||
+                                   node.parent.is_a?(RuboCop::AST::BinaryOperatorNode)
 
           return unless offense?(node) && !part_of_ignored_node?(node)
 
@@ -75,9 +75,8 @@ module RuboCop
         end
 
         def offense?(node)
-          return false if configured_to_not_be_inspected?(node)
-
-          node.multiline? && !too_long?(node) && suitable_as_single_line?(node)
+          node.multiline? && !too_long?(node) && suitable_as_single_line?(node) &&
+            !configured_to_not_be_inspected?(node)
         end
 
         def configured_to_not_be_inspected?(node)

--- a/lib/rubocop/cop/layout/space_before_first_arg.rb
+++ b/lib/rubocop/cop/layout/space_before_first_arg.rb
@@ -34,6 +34,7 @@ module RuboCop
 
         def on_send(node)
           return unless regular_method_call_with_arguments?(node)
+          return if node.parenthesized?
 
           first_arg = node.first_argument.source_range
           first_arg_with_space = range_with_surrounding_space(first_arg, side: :left)
@@ -52,7 +53,6 @@ module RuboCop
         end
 
         def expect_params_after_method_name?(node)
-          return false if node.parenthesized?
           return true if no_space_between_method_name_and_first_argument?(node)
 
           first_arg = node.first_argument

--- a/lib/rubocop/cop/lint/unreachable_loop.rb
+++ b/lib/rubocop/cop/lint/unreachable_loop.rb
@@ -111,9 +111,9 @@ module RuboCop
           return false unless node.block_type? || node.numblock_type?
 
           send_node = node.send_node
-          return false if matches_allowed_pattern?(send_node.source)
-
-          send_node.enumerable_method? || send_node.enumerator_method? || send_node.method?(:loop)
+          loopable = send_node.enumerable_method? || send_node.enumerator_method? ||
+                     send_node.method?(:loop)
+          loopable && !matches_allowed_pattern?(send_node.source)
         end
 
         def check(node)

--- a/lib/rubocop/cop/style/redundant_string_escape.rb
+++ b/lib/rubocop/cop/style/redundant_string_escape.rb
@@ -64,10 +64,10 @@ module RuboCop
         def str_contents_range(node)
           if heredoc?(node)
             node.loc.heredoc_body
+          elsif node.str_type?
+            node.source_range
           elsif begin_loc_present?(node)
             contents_range(node)
-          else
-            node.source_range
           end
         end
 


### PR DESCRIPTION
Tested on rubocop itself. Walked through the slowest cops.
```
$ rubocop --profile
$ rake prof:slow_cops
```

### Before
Time: `117.5s`.
```
==> 1350  (    2.7%)  RuboCop::Cop::Layout::FirstArgumentIndentation#on_send
==> 1211  (    2.4%)  RuboCop::Cop::Layout::RedundantLineBreak#on_send
==> 1062  (    2.1%)  RuboCop::Cop::Style::RedundantStringEscape#on_str
==> 1040  (    2.1%)  RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier#on_send
    1036  (    2.1%)  RuboCop::Cop::RSpec::VariableDefinition#on_send
 ==> 882  (    1.8%)  RuboCop::Cop::Layout::SpaceBeforeFirstArg#on_send
     839  (    1.7%)  RuboCop::Cop::Layout::IndentationConsistency#on_begin
     792  (    1.6%)  RuboCop::Cop::RSpec::EmptyExampleGroup#on_block
     740  (    1.5%)  RuboCop::Cop::Style::RedundantSelf#on_block
     729  (    1.4%)  RuboCop::Cop::RSpec::VariableName#on_send
     727  (    1.4%)  RuboCop::Cop::RSpec::RepeatedDescription#on_block
     685  (    1.4%)  RuboCop::Cop::RSpec::PendingWithoutReason#on_send
     676  (    1.3%)  RuboCop::Cop::RSpec::MultipleExpectations#on_block
 ==> 598  (    1.2%)  RuboCop::Cop::Lint::UnreachableLoop#on_block
     581  (    1.2%)  RuboCop::Cop::MultilineExpressionIndentation#on_send
     578  (    1.1%)  RuboCop::Cop::StringHelp#on_str
     578  (    1.1%)  RuboCop::Cop::Layout::IndentationWidth#on_block
     569  (    1.1%)  RuboCop::Cop::RSpec::DescribedClass#on_block
     513  (    1.0%)  RuboCop::Cop::MethodComplexity#on_def
     479  (    1.0%)  RuboCop::Cop::Lint::DuplicateMethods#on_def
     457  (    0.9%)  RuboCop::Cop::Layout::LineLength#on_potential_breakable_node
     452  (    0.9%)  RuboCop::Cop::StringHelp#on_str
     450  (    0.9%)  RuboCop::Cop::Layout::DotPosition#on_send
     447  (    0.9%)  RuboCop::Cop::Layout::BlockAlignment#on_block
     446  (    0.9%)  RuboCop::Cop::RSpec::Focus#on_send
     431  (    0.9%)  RuboCop::Cop::RSpec::LetSetup#on_block
     419  (    0.8%)  RuboCop::Cop::RSpec::NamedSubject#on_block
     404  (    0.8%)  RuboCop::Cop::RSpec::NoExpectationExample#on_block
     400  (    0.8%)  RuboCop::Cop::MethodComplexity#on_def
     393  (    0.8%)  RuboCop::Cop::Layout::ArgumentAlignment#on_send
     385  (    0.8%)  RuboCop::Cop::Style::ConditionalAssignment#on_send
     384  (    0.8%)  RuboCop::Cop::Lint::Debugger#on_send
     382  (    0.8%)  RuboCop::Cop::RSpec::ScatteredSetup#on_block
     373  (    0.7%)  RuboCop::Cop::RSpec::Capybara::FeatureMethods#on_block
     371  (    0.7%)  RuboCop::Cop::Heredoc#on_str
     365  (    0.7%)  RuboCop::Cop::Style::TrailingCommaInArguments#on_send
     361  (    0.7%)  RuboCop::Cop::RSpec::RepeatedExample#on_block
     358  (    0.7%)  RuboCop::Cop::RSpec::MultipleSubjects#on_block
     353  (    0.7%)  RuboCop::Cop::Layout::EmptyLinesAroundBlockBody#on_block
     350  (    0.7%)  RuboCop::Cop::Lint::DeprecatedOpenSSLConstant#on_send
```

### After
Time: `109.6s` (6% less).
```
     959  (    2.1%)  RuboCop::Cop::RSpec::VariableDefinition#on_send
     837  (    1.9%)  RuboCop::Cop::Layout::IndentationConsistency#on_begin
     806  (    1.8%)  RuboCop::Cop::RSpec::EmptyExampleGroup#on_block
     743  (    1.7%)  RuboCop::Cop::Layout::RedundantLineBreak#on_send
     724  (    1.6%)  RuboCop::Cop::RSpec::PendingWithoutReason#on_send
     721  (    1.6%)  RuboCop::Cop::Style::RedundantSelf#on_block
     713  (    1.6%)  RuboCop::Cop::RSpec::RepeatedDescription#on_block
     674  (    1.5%)  RuboCop::Cop::RSpec::MultipleExpectations#on_block
     658  (    1.5%)  RuboCop::Cop::RSpec::VariableName#on_send
     569  (    1.3%)  RuboCop::Cop::RSpec::DescribedClass#on_block
     565  (    1.3%)  RuboCop::Cop::MultilineExpressionIndentation#on_send
     550  (    1.2%)  RuboCop::Cop::Layout::IndentationWidth#on_block
     523  (    1.2%)  RuboCop::Cop::StringHelp#on_str
     481  (    1.1%)  RuboCop::Cop::MethodComplexity#on_def
     476  (    1.1%)  RuboCop::Cop::Style::RedundantStringEscape#on_str
     431  (    1.0%)  RuboCop::Cop::Lint::DuplicateMethods#on_def
     431  (    1.0%)  RuboCop::Cop::StringHelp#on_str
     429  (    1.0%)  RuboCop::Cop::Layout::LineLength#on_potential_breakable_node
     429  (    1.0%)  RuboCop::Cop::Layout::SpaceBeforeFirstArg#on_send
     426  (    1.0%)  RuboCop::Cop::RSpec::LetSetup#on_block
     421  (    0.9%)  RuboCop::Cop::RSpec::Capybara::FeatureMethods#on_block
     420  (    0.9%)  RuboCop::Cop::RSpec::NoExpectationExample#on_block
     408  (    0.9%)  RuboCop::Cop::Layout::BlockAlignment#on_block
     404  (    0.9%)  RuboCop::Cop::RSpec::Focus#on_send
     402  (    0.9%)  RuboCop::Cop::Style::ConditionalAssignment#on_send
     399  (    0.9%)  RuboCop::Cop::Layout::SpaceAroundKeyword#on_block
     398  (    0.9%)  RuboCop::Cop::RSpec::NamedSubject#on_block
     396  (    0.9%)  RuboCop::Cop::Layout::DotPosition#on_send
     391  (    0.9%)  RuboCop::Cop::Layout::ArgumentAlignment#on_send
     391  (    0.9%)  RuboCop::Cop::RSpec::ScatteredSetup#on_block
     388  (    0.9%)  RuboCop::Cop::Layout::EmptyLinesAroundBlockBody#on_block
     382  (    0.9%)  RuboCop::Cop::Style::TrailingCommaInArguments#on_send
     381  (    0.8%)  RuboCop::Cop::MethodComplexity#on_def
     374  (    0.8%)  RuboCop::Cop::RSpec::MultipleSubjects#on_block
     354  (    0.8%)  RuboCop::Cop::Layout::FirstArgumentIndentation#on_send
     352  (    0.8%)  RuboCop::Cop::RSpec::RepeatedExample#on_block
     352  (    0.8%)  RuboCop::Cop::Heredoc#on_str
     343  (    0.8%)  RuboCop::Cop::Lint::Debugger#on_send
     322  (    0.7%)  RuboCop::Cop::Heredoc#on_str
     313  (    0.7%)  RuboCop::Cop::Layout::ClosingParenthesisIndentation#on_send
```

Not very large improvement, but good enough for mostly conditions swapping.