### PR TITLE
[Fix #11704] Fix a false positive for `Lint/UselessMethodDefinition`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_useless_method_definition.md
+++ b/changelog/fix_a_false_positive_for_lint_useless_method_definition.md
@@ -1,0 +1,1 @@
+* [#11704](https://github.com/rubocop/rubocop/issues/11704): Fix a false positive for `Lint/UselessMethodDefinition` when method definition with non access modifier containing only `super` call. ([@koic][])

--- a/spec/rubocop/cop/lint/useless_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/useless_method_definition_spec.rb
@@ -121,6 +121,50 @@ RSpec.describe RuboCop::Cop::Lint::UselessMethodDefinition, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when method definition with `public` access modifier containing only `super` call' do
+    expect_offense(<<~RUBY)
+      public def method
+             ^^^^^^^^^^ Useless method definition detected.
+        super
+      end
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it 'registers an offense and corrects when method definition with `protected` access modifier containing only `super` call' do
+    expect_offense(<<~RUBY)
+      protected def method
+                ^^^^^^^^^^ Useless method definition detected.
+        super
+      end
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it 'registers an offense and corrects when method definition with `private` access modifier containing only `super` call' do
+    expect_offense(<<~RUBY)
+      private def method
+              ^^^^^^^^^^ Useless method definition detected.
+        super
+      end
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it 'registers an offense and corrects when method definition with `module_function` access modifier containing only `super` call' do
+    expect_offense(<<~RUBY)
+      module_function def method
+                      ^^^^^^^^^^ Useless method definition detected.
+        super
+      end
+    RUBY
+
+    expect_correction("\n")
+  end
+
   it 'does not register an offense for method containing additional code to `super`' do
     expect_no_offenses(<<~RUBY)
       def method
@@ -165,6 +209,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessMethodDefinition, :config do
   it 'does not register an offense when method definition contains optional keyword argument' do
     expect_no_offenses(<<~RUBY)
       def method(x: 1)
+        super
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when method definition with generic method macro containing only `super` call' do
+    expect_no_offenses(<<~RUBY)
+      do_something def method
         super
       end
     RUBY


### PR DESCRIPTION
Fixes #11704.

This PR fixes a false positive for `Lint/UselessMethodDefinition` when method definition with non access modifier containing only `super` call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
