### PR TITLE
[Fix #11706] Fix infinite loop when `--disable-uncorrectable` option and there is a multi-line percent array violates `Layout/LineLength`

### DIFF
--- a/changelog/fix_fix_infinite_loop_when_disable_uncorrectable.md
+++ b/changelog/fix_fix_infinite_loop_when_disable_uncorrectable.md
@@ -1,0 +1,1 @@
+* [#11706](https://github.com/rubocop/rubocop/issues/11706): Fix infinite loop when `--disable-uncorrectable` option and there is a multi-line percent array violates `Layout/LineLength`. ([@nobuyo][])

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -82,7 +82,7 @@ module RuboCop
           node.array_type? && node.percent_literal?
         end
 
-        percent_array.map(&:source_range).find { |range| range.crossing?(offense_range) }
+        percent_array.map(&:source_range).find { |range| range.overlaps?(offense_range) }
       end
 
       def range_of_first_line(range)

--- a/spec/rubocop/cli/disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/disable_uncorrectable_spec.rb
@@ -261,11 +261,14 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
       end
 
       context 'and the offense is inside a percent array' do
-        it 'adds before-and-after disable statement around the percent array' do
+        before do
           create_file('.rubocop.yml', <<~YAML)
             Layout/LineLength:
               Max: 30
           YAML
+        end
+
+        it 'adds before-and-after disable statement around the percent array' do
           create_file('example.rb', <<~RUBY)
             # frozen_string_literal: true
 
@@ -278,6 +281,28 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
             # rubocop:todo Layout/LineLength
             ARRAY = %i[
               AAAAAAAAAAAAAAAAAAAA BBBBBBBBBBBBBBBBBBBB
+            ].freeze
+            # rubocop:enable Layout/LineLength
+          RUBY
+        end
+
+        it 'adds before-and-after disable statement around the multi-line percent array' do
+          create_file('example.rb', <<~RUBY)
+            # frozen_string_literal: true
+
+            ARRAY = %i[
+              AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+              AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+            ].freeze
+          RUBY
+          expect(exit_code).to eq(0)
+          expect(File.read('example.rb')).to eq(<<~RUBY)
+            # frozen_string_literal: true
+
+            # rubocop:todo Layout/LineLength
+            ARRAY = %i[
+              AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+              AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
             ].freeze
             # rubocop:enable Layout/LineLength
           RUBY


### PR DESCRIPTION
Fixes #11706, follows up #11701.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
