### PR TITLE
[Fix #11641] Fix a false negative for `Layout/ExtraSpacing` when there are many comments with extra spaces

### DIFF
--- a/changelog/fix_fix_a_false_negative_for_layout_extra_spacing_when.md
+++ b/changelog/fix_fix_a_false_negative_for_layout_extra_spacing_when.md
@@ -1,0 +1,1 @@
+* [#11641](https://github.com/rubocop/rubocop/issues/11641): Fix a false negative for `Layout/ExtraSpacing` when there are many comments with extra spaces. ([@nobuyo][])

--- a/lib/rubocop/cop/layout/extra_spacing.rb
+++ b/lib/rubocop/cop/layout/extra_spacing.rb
@@ -49,7 +49,7 @@ module RuboCop
 
         private
 
-        def aligned_locations(locs)
+        def aligned_locations(locs) # rubocop:disable Metrics/AbcSize
           return [] if locs.empty?
 
           aligned = Set[locs.first.line, locs.last.line]
@@ -57,6 +57,11 @@ module RuboCop
             col = loc.column
             aligned << loc.line if col == before.column || col == after.column
           end
+
+          # if locs.size > 2 and the size of variable `aligned`
+          # has not increased from its initial value, there are not aligned lines.
+          return [] if locs.size > 2 && aligned.size == 2
+
           aligned
         end
 

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -592,4 +592,44 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       RUBY
     end
   end
+
+  context 'when multiple comments have extra spaces' do
+    it 'registers offenses for all comments' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def require(p)  # rubocop:disable Naming/MethodParameterName
+                        ^ Unnecessary spacing detected.
+          end
+
+          def load(p)  # rubocop:disable Naming/MethodParameterName
+                     ^ Unnecessary spacing detected.
+          end
+
+          def join(*ps)  # rubocop:disable Naming/MethodParameterName
+                       ^ Unnecessary spacing detected.
+          end
+
+          def exist?(*ps)  # rubocop:disable Naming/MethodParameterName
+                         ^ Unnecessary spacing detected.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          def require(p) # rubocop:disable Naming/MethodParameterName
+          end
+
+          def load(p) # rubocop:disable Naming/MethodParameterName
+          end
+
+          def join(*ps) # rubocop:disable Naming/MethodParameterName
+          end
+
+          def exist?(*ps) # rubocop:disable Naming/MethodParameterName
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Closes #11641.

This PR fixes a false negative for `Layout/ExtraSpacing` that caused the first and last comments to be assumed to be aligned when there are many comments with extra spaces.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
