### PR TITLE
Correct typos with cSpell

### DIFF
--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -777,7 +777,7 @@ end
 
 | Categories
 | `{"module_inclusion"=>["include", "prepend", "extend"]}`
-| 
+|
 
 | ExpectedOrder
 | `module_inclusion`, `constants`, `public_class_methods`, `initializer`, `public_methods`, `protected_methods`, `private_methods`

--- a/docs/modules/ROOT/pages/v1_upgrade_notes.adoc
+++ b/docs/modules/ROOT/pages/v1_upgrade_notes.adoc
@@ -156,9 +156,9 @@ _Legacy:_ interface allowed for a `node`, with an optional `location` (symbol or
 
 _Current:_ pass a range (or node as a shortcut for `node.loc.expression`), no `location:`. No abuse tolerated.
 
-==== de-dupping changes
+==== deduping changes
 
-Both de-dup on `range` and won't process the duplicated offenses at all.
+Both dedupe on `range` and won't process the duplicated offenses at all.
 
 _Legacy:_ if offenses on same `node` but different `range`: considered as multiple offenses but a single autocorrect call.
 

--- a/docs/modules/ROOT/partials/cops_layout_footer.adoc
+++ b/docs/modules/ROOT/partials/cops_layout_footer.adoc
@@ -24,7 +24,7 @@ that are already short enough, and only considered multiline
 because of their last element.
 
 Each cop can be configured independently allowing for more fine-grained
-control ovwer what is considered good ok in the codebase.
+control over what is considered good ok in the codebase.
 
 === Examples
 

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -138,10 +138,10 @@ module RuboCop
       def correction_lambda
         return unless support_autocorrect?
 
-        dedup_on_node(@v0_argument) { autocorrect(@v0_argument) }
+        dedupe_on_node(@v0_argument) { autocorrect(@v0_argument) }
       end
 
-      def dedup_on_node(node)
+      def dedupe_on_node(node)
         @corrected_nodes ||= {}.compare_by_identity
         yield unless @corrected_nodes.key?(node)
       ensure

--- a/lib/rubocop/cop/correctors/percent_literal_corrector.rb
+++ b/lib/rubocop/cop/correctors/percent_literal_corrector.rb
@@ -66,10 +66,10 @@ module RuboCop
         end
       end
 
-      def line_breaks(node, source, previous_line_num, base_line_num, node_indx)
+      def line_breaks(node, source, previous_line_num, base_line_num, node_index)
         source_in_lines = source.split("\n")
         if first_line?(node, previous_line_num)
-          node_indx.zero? && node.first_line == base_line_num ? '' : ' '
+          node_index.zero? && node.first_line == base_line_num ? '' : ' '
         else
           process_lines(node, previous_line_num, base_line_num, source_in_lines)
         end

--- a/lib/rubocop/cop/internal_affairs/example_heredoc_delimiter.rb
+++ b/lib/rubocop/cop/internal_affairs/example_heredoc_delimiter.rb
@@ -52,7 +52,7 @@ module RuboCop
         # @return [void]
         def autocorrect(corrector, node)
           [
-            heredoc_openning_delimiter_range_from(node),
+            heredoc_opening_delimiter_range_from(node),
             heredoc_closing_delimiter_range_from(node)
           ].each do |range|
             corrector.replace(range, EXPECTED_HEREDOC_DELIMITER)
@@ -90,7 +90,7 @@ module RuboCop
 
         # @param node [RuboCop::AST::StrNode]
         # @return [Parser::Source::Range]
-        def heredoc_openning_delimiter_range_from(node)
+        def heredoc_opening_delimiter_range_from(node)
           match_data = node.source.match(Heredoc::OPENING_DELIMITER)
           node.source_range.begin.adjust(
             begin_pos: match_data.begin(2),

--- a/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
+++ b/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
@@ -67,7 +67,7 @@ module RuboCop
 
           outermost_send = outermost_send_on_same_line(heredoc_arg)
           return unless outermost_send
-          return if end_keyword_before_closing_parentesis?(node)
+          return if end_keyword_before_closing_parenthesis?(node)
           return if subsequent_closing_parentheses_in_same_line?(outermost_send)
           return if exist_argument_between_heredoc_end_and_closing_parentheses?(node)
 
@@ -159,7 +159,7 @@ module RuboCop
 
         # Closing parenthesis helpers.
 
-        def end_keyword_before_closing_parentesis?(parenthesized_send_node)
+        def end_keyword_before_closing_parenthesis?(parenthesized_send_node)
           parenthesized_send_node.ancestors.any? do |ancestor|
             ancestor.loc.respond_to?(:end) && ancestor.loc.end&.source == 'end'
           end

--- a/lib/rubocop/cop/layout/space_inside_parens.rb
+++ b/lib/rubocop/cop/layout/space_inside_parens.rb
@@ -91,7 +91,7 @@ module RuboCop
             if !left_parens?(token1, token2) && !right_parens?(token1, token2)
               correct_missing_space(token1, token2)
             else
-              correct_extaneus_space_between_consecutive_parens(token1, token2)
+              correct_extraneous_space_between_consecutive_parens(token1, token2)
             end
           end
         end
@@ -112,7 +112,7 @@ module RuboCop
           end
         end
 
-        def correct_extaneus_space_between_consecutive_parens(token1, token2)
+        def correct_extraneous_space_between_consecutive_parens(token1, token2)
           return if range_between(token1.end_pos, token2.begin_pos).source != ' '
 
           range = range_between(token1.end_pos, token2.begin_pos)

--- a/lib/rubocop/cop/lint/deprecated_class_methods.rb
+++ b/lib/rubocop/cop/lint/deprecated_class_methods.rb
@@ -38,7 +38,7 @@ module RuboCop
           attr clone dup exists? freeze gethostbyaddr gethostbyname iterator?
         ].freeze
 
-        PREFERRED_METHDOS = {
+        PREFERRED_METHODS = {
           clone: 'to_h',
           dup: 'to_h',
           exists?: 'exist?',
@@ -97,11 +97,11 @@ module RuboCop
 
             "#{preferred_attr_method} #{node.first_argument.source}"
           elsif dir_env_file_const?(node.receiver)
-            prefer = PREFERRED_METHDOS[node.method_name]
+            prefer = PREFERRED_METHODS[node.method_name]
 
             prefer ? "#{node.receiver.source}.#{prefer}" : 'ENV'
           else
-            PREFERRED_METHDOS[node.method_name]
+            PREFERRED_METHODS[node.method_name]
           end
         end
 

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -59,10 +59,10 @@ module RuboCop
                                                    shuffle slice sort sort_by squeeze strip sub
                                                    succ swapcase tr tr_s transform_values
                                                    unicode_normalize uniq upcase].freeze
-        METHODS_REPLACABLE_BY_EACH = %i[collect map].freeze
+        METHODS_REPLACEABLE_BY_EACH = %i[collect map].freeze
 
         NONMUTATING_METHODS = (NONMUTATING_METHODS_WITH_BANG_VERSION +
-                               METHODS_REPLACABLE_BY_EACH).freeze
+                               METHODS_REPLACEABLE_BY_EACH).freeze
 
         def on_block(node)
           return unless node.body && !node.body.begin_type?
@@ -133,7 +133,11 @@ module RuboCop
           method_name = node.method_name
           return unless NONMUTATING_METHODS.include?(method_name)
 
-          suggestion = METHODS_REPLACABLE_BY_EACH.include?(method_name) ? 'each' : "#{method_name}!"
+          suggestion = if METHODS_REPLACEABLE_BY_EACH.include?(method_name)
+                         'each'
+                       else
+                         "#{method_name}!"
+                       end
           add_offense(node,
                       message: format(NONMUTATING_MSG, method: method_name, suggest: suggestion))
         end

--- a/lib/rubocop/cop/style/double_negation.rb
+++ b/lib/rubocop/cop/style/double_negation.rb
@@ -103,12 +103,12 @@ module RuboCop
         def find_def_node_from_ascendant(node)
           return unless (parent = node.parent)
           return parent if parent.def_type? || parent.defs_type?
-          return node.parent.child_nodes.first if define_mehod?(parent)
+          return node.parent.child_nodes.first if define_method?(parent)
 
           find_def_node_from_ascendant(node.parent)
         end
 
-        def define_mehod?(node)
+        def define_method?(node)
           return false unless node.block_type?
 
           child = node.child_nodes.first

--- a/lib/rubocop/cop/style/hash_except.rb
+++ b/lib/rubocop/cop/style/hash_except.rb
@@ -122,7 +122,7 @@ module RuboCop
         end
 
         def safe_to_register_offense?(block, except_key)
-          extracted = extract_body_if_nagated(block.body)
+          extracted = extract_body_if_negated(block.body)
           if extracted.method?('in?') || extracted.method?('include?') || \
              extracted.method?('exclude?')
             return true
@@ -132,7 +132,7 @@ module RuboCop
           except_key.sym_type? || except_key.str_type?
         end
 
-        def extract_body_if_nagated(body)
+        def extract_body_if_negated(body)
           return body unless body.method?('!')
 
           body.receiver
@@ -161,7 +161,7 @@ module RuboCop
 
         def except_key(node)
           key_argument = node.argument_list.first.source
-          body = extract_body_if_nagated(node.body)
+          body = extract_body_if_negated(node.body)
           lhs, _method_name, rhs = *body
           return if [lhs, rhs].map(&:source).none?(key_argument)
 

--- a/lib/rubocop/cop/style/redundant_regexp_character_class.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_character_class.rb
@@ -63,7 +63,7 @@ module RuboCop
             next if expr.type != :set || expr.expressions.size != 1
             next if expr.negative?
             next if %i[set posixclass nonposixclass].include?(expr.expressions.first.type)
-            next if multiple_codepoins?(expr.expressions.first)
+            next if multiple_codepoints?(expr.expressions.first)
 
             yield expr
           end
@@ -80,7 +80,7 @@ module RuboCop
           !non_redundant
         end
 
-        def multiple_codepoins?(expression)
+        def multiple_codepoints?(expression)
           expression.respond_to?(:codepoints) && expression.codepoints.count >= 2
         end
 

--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -107,7 +107,7 @@ module RuboCop
             end
           end
         # Please remove this `else` branch when support for regexp_parser 1.8 will be dropped.
-        # It's for compatibility with regexp_arser 1.8 and will never be maintained.
+        # It's for compatibility with regexp_parser 1.8 and will never be maintained.
         else
           def each_escape(node)
             node.parsed_tree&.traverse&.reduce(0) do |char_class_depth, (event, expr)|

--- a/lib/rubocop/ext/regexp_parser.rb
+++ b/lib/rubocop/ext/regexp_parser.rb
@@ -28,7 +28,7 @@ module RuboCop
               @expression ||= origin.adjust(begin_pos: ts, end_pos: ts + full_length)
             end
           # Please remove this `else` branch when support for regexp_parser 1.8 will be dropped.
-          # It's for compatibility with regexp_arser 1.8 and will never be maintained.
+          # It's for compatibility with regexp_parser 1.8 and will never be maintained.
           else
             attr_accessor :source
 

--- a/lib/rubocop/server/helper.rb
+++ b/lib/rubocop/server/helper.rb
@@ -11,7 +11,7 @@
 #
 module RuboCop
   module Server
-    # This module has a helper memthod for `RuboCop::Server::SocketReader`.
+    # This module has a helper method for `RuboCop::Server::SocketReader`.
     # @api private
     module Helper
       def self.redirect(stdin: $stdin, stdout: $stdout, stderr: $stderr, &_block)

--- a/lib/rubocop/server/server_command/exec.rb
+++ b/lib/rubocop/server/server_command/exec.rb
@@ -21,7 +21,7 @@ module RuboCop
           # We must pass the --color option to preserve this behavior.
           @args.unshift('--color') unless %w[--color --no-color].any? { |f| @args.include?(f) }
           status = RuboCop::CLI.new.run(@args)
-          # This status file is read by `rubocop --server` (`RuboCop::Server::Clientcommand::Exec`).
+          # This status file is read by `rubocop --server` (`RuboCop::Server::ClientCommand::Exec`).
           # so that they use the correct exit code.
           # Status is 1 when there are any issues, and 0 otherwise.
           Cache.write_status_file(status)

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -416,7 +416,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         RUBY
       end
 
-      context 'when --only does not contain Layout/Linelength' do
+      context 'when --only does not contain Layout/LineLength' do
         it 'generates TODO only for the mentioned cop' do
           $stdout = StringIO.new
           expect(cli.run(['--auto-gen-config', '--only', 'Style/Documentation'])).to eq(0)
@@ -644,7 +644,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
     end
 
     context 'when existing config file has a YAML document start header' do
-      it 'inserts `inherit_from` key after hearder' do
+      it 'inserts `inherit_from` key after header' do
         create_file('example1.rb', <<~RUBY)
           def foo; end
         RUBY

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -173,14 +173,14 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       end
 
       describe '--server-status' do
-        context 'when server is not runnning' do
+        context 'when server is not running' do
           it 'displays server status' do
             output = `ruby -I . "#{rubocop}" --server-status`
             expect(output).to match(/RuboCop server is not running./)
           end
         end
 
-        context 'when server is runnning' do
+        context 'when server is running' do
           before do
             `ruby -I . "#{rubocop}" --start-server`
           end
@@ -812,7 +812,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
     context 'when a cop name is not specified' do
       it 'displays how to use `--only` option' do
-        expect(cli.run(%w[--except -a Lint/NumberConverion])).to eq(2)
+        expect(cli.run(%w[--except -a Lint/NumberConversion])).to eq(2)
         expect($stderr.string).to eq(<<~MESSAGE)
           --except argument should be [COP1,COP2,...].
         MESSAGE

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -576,7 +576,7 @@ RSpec.describe RuboCop::ConfigLoader do
         end.not_to output(/overrides the same parameter/).to_stdout
       end
 
-      it 'overwrites the Exclude from the parent when the cop overridesthe global inherit_mode' do
+      it 'overwrites the Exclude from the parent when the cop overrides the global inherit_mode' do
         expect do
           excludes = configuration_from_file['Style/Dir']['Exclude']
           expect(excludes).to eq([File.expand_path('spec/requests/group_invite_spec.rb')])
@@ -1001,7 +1001,7 @@ RSpec.describe RuboCop::ConfigLoader do
       end
     end
 
-    context 'when a file inherits and overrides with non-namedspaced cops' do
+    context 'when a file inherits and overrides with non-namespaced cops' do
       let(:file_path) { '.rubocop.yml' }
 
       before do

--- a/spec/rubocop/cop/layout/argument_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/argument_alignment_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe RuboCop::Cop::Layout::ArgumentAlignment, :config do
       RUBY
     end
 
-    it 'registers an offense and correct multi-line parametersindented too far' do
+    it 'registers an offense and correct multi-line parameters indented too far' do
       expect_offense(<<~RUBY)
         create :transaction, :closed,
                  account:          account,

--- a/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
       end
     end
 
-    it 'registers autocorrects empty line whetn args start on definition line' do
+    it 'registers autocorrects empty line when args start on definition line' do
       expect_offense(<<~RUBY)
         bar(qux,
 

--- a/spec/rubocop/cop/layout/end_of_line_spec.rb
+++ b/spec/rubocop/cop/layout/end_of_line_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
     it 'can inspect non-UTF-8 encoded source with proper encoding comment' do
       # Weird place to have a test on working with non-utf-8 encodings.
       # Encodings are not specific to the EndOfLine cop, so the test is better
-      # be moved somewhere more general ?
+      # be moved somewhere more general?
       # Also working with encodings is actually the responsibility of
       # 'whitequark/parser' gem, not Rubocop itself so these test really belongs there(?)
 

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     context 'false' do
       let(:allow_comments) { false }
 
-      it 'regsiters offense' do
+      it 'registers offense' do
         expect_offense(<<~RUBY)
           object.method(argument)  # this is a comment
                                  ^ Unnecessary spacing detected.

--- a/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementLineBreak, :config do
   context 'last element can be multiline' do
     let(:cop_config) { { 'AllowMultilineFinalElement' => true } }
 
-    it 'ignores last argument that is a multine Hash' do
+    it 'ignores last argument that is a multiline Hash' do
       expect_no_offenses(<<~RUBY)
         [a, b, {
           c: d

--- a/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementLineBreak, :config do
   context 'last element can be multiline' do
     let(:cop_config) { { 'AllowMultilineFinalElement' => true } }
 
-    it 'ignores last argument that is a multine Hash' do
+    it 'ignores last argument that is a multiline Hash' do
       expect_no_offenses(<<~RUBY)
         h = {a: b, c: {
           d: e

--- a/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak, :config do
   context 'last element can be multiline' do
     let(:cop_config) { { 'AllowMultilineFinalElement' => true } }
 
-    it 'ignores last argument that is a multine Hash' do
+    it 'ignores last argument that is a multiline Hash' do
       expect_no_offenses(<<~RUBY)
         foo(bar, {
           a: b

--- a/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak, :config do
   context 'last element can be multiline' do
     let(:cop_config) { { 'AllowMultilineFinalElement' => true } }
 
-    it 'ignores last argument that value is a multine Hash' do
+    it 'ignores last argument that value is a multiline Hash' do
       expect_no_offenses(<<~RUBY)
         def foo(bar, baz = {
           a: b
@@ -107,7 +107,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak, :config do
       RUBY
     end
 
-    it 'registers and corrects parameters that value is a multiline hashe and is not the last parameter' do
+    it 'registers and corrects parameters that value is a multiline hashes and is not the last parameter' do
       expect_offense(<<~RUBY)
         def foo(bar, baz = {
                 ^^^ Add a line break before the first parameter of a multi-line method parameter list.

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -310,8 +310,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       context 'with a trailing RuboCop directive' do
         it 'registers an offense for the line' do
           expect_offense(<<~RUBY)
-            #{'a' * 80} # rubcop:disable Layout/SomeCop
-            #{' ' * 80}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [112/80]
+            #{'a' * 80} # rubocop:disable Layout/SomeCop
+            #{' ' * 80}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [113/80]
           RUBY
         end
       end
@@ -1086,7 +1086,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       end
 
       context 'when over limit' do
-        it 'adds offense and autocorrects it by breaking the semicolonbefore the hash' do
+        it 'adds offense and autocorrects it by breaking the semicolon before the hash' do
           expect_offense(<<~RUBY)
             {foo: 1, bar: "2"}; a = 400000000000 + 500000000000000
                                                     ^^^^^^^^^^^^^^ Line is too long. [54/40]
@@ -1100,7 +1100,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       end
 
       context 'when over limit and semicolon at end of line' do
-        it 'adds offense and autocorrects it by breaking the first semicolonbefore the hash' do
+        it 'adds offense and autocorrects it by breaking the first semicolon before the hash' do
           expect_offense(<<~RUBY)
             {foo: 1, bar: "2"}; a = 400000000000 + 500000000000000;
                                                     ^^^^^^^^^^^^^^^ Line is too long. [55/40]
@@ -1114,7 +1114,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       end
 
       context 'when over limit and many spaces around semicolon' do
-        it 'adds offense and autocorrects it by breaking the semicolonbefore the hash' do
+        it 'adds offense and autocorrects it by breaking the semicolon before the hash' do
           expect_offense(<<~RUBY)
             {foo: 1, bar: "2"}  ;   a = 400000000000 + 500000000000000
                                                     ^^^^^^^^^^^^^^^^^^ Line is too long. [58/40]
@@ -1128,7 +1128,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       end
 
       context 'when over limit and many semicolons' do
-        it 'adds offense and autocorrects it by breaking the semicolonbefore the hash' do
+        it 'adds offense and autocorrects it by breaking the semicolon before the hash' do
           expect_offense(<<~RUBY)
             {foo: 1, bar: "2"}  ;;; a = 400000000000 + 500000000000000
                                                     ^^^^^^^^^^^^^^^^^^ Line is too long. [58/40]
@@ -1142,7 +1142,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       end
 
       context 'when over limit and one semicolon at the end' do
-        it 'adds offense and does not autocorrectbefore the hash' do
+        it 'adds offense and does not autocorrect before the hash' do
           expect_offense(<<~RUBY)
             a = 400000000000 + 500000000000000000000;
                                                     ^ Line is too long. [41/40]
@@ -1153,7 +1153,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       end
 
       context 'when over limit and many semicolons at the end' do
-        it 'adds offense and does not autocorrectbefore the hash' do
+        it 'adds offense and does not autocorrect before the hash' do
           expect_offense(<<~RUBY)
             a = 400000000000 + 500000000000000000000;;;;;;;
                                                     ^^^^^^^ Line is too long. [47/40]

--- a/spec/rubocop/cop/layout/multiline_array_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_array_line_breaks_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineArrayLineBreaks, :config do
     end
   end
 
-  context 'ignore laste element' do
+  context 'ignore last element' do
     let(:cop_config) { { 'AllowMultilineFinalElement' => true } }
 
     it 'ignores last value that is a multiline hash' do

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects a do/end block with a mult-line body' do
+  it 'registers an offense and corrects a do/end block with a multi-line body' do
     expect_offense(<<~RUBY)
       test do |foo| bar
                     ^^^ Block body expression is on the same line as the block start.

--- a/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
       RUBY
     end
 
-    it 'registers an offense and corrects a lambda for extra spacebefore first parameter' do
+    it 'registers an offense and corrects a lambda for extra space before first parameter' do
       expect_offense(<<~RUBY)
         ->(  x ) { puts x }
            ^ Extra space before first block parameter detected.
@@ -302,7 +302,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
       RUBY
     end
 
-    it 'registers an offense and corrects a lambda for multiple spacesafter last parameter' do
+    it 'registers an offense and corrects a lambda for multiple spaces after last parameter' do
       expect_offense(<<~RUBY)
         ->( x, y   ) { puts x }
                  ^^ Extra space after last block parameter detected.

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -799,7 +799,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
       RUBY
     end
 
-    it 'registers an offense and corrects a hash rocket with an extra spaceon multiple line' do
+    it 'registers an offense and corrects a hash rocket with an extra space on multiple line' do
       expect_offense(<<~RUBY)
         {
           1 =>  2

--- a/spec/rubocop/cop/lint/float_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/float_comparison_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RuboCop::Cop::Lint::FloatComparison, :config do
     RUBY
   end
 
-  it 'registers an offense when comparing with arightmetic operator on floats' do
+  it 'registers an offense when comparing with arithmetic operator on floats' do
     expect_offense(<<~RUBY)
       x == 0.1 + y
       ^^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression, :config do
     expect_no_offenses('assert_equal (0..1.9), acceleration.domain')
   end
 
-  it 'does not register an offesne when heredoc has a space between the same string as the method name and `(`' do
+  it 'does not register an offense when heredoc has a space between the same string as the method name and `(`' do
     expect_no_offenses(<<~RUBY)
       foo(
         <<~EOS

--- a/spec/rubocop/cop/lint/require_parentheses_spec.rb
+++ b/spec/rubocop/cop/lint/require_parentheses_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::Lint::RequireParentheses, :config do
     expect_no_offenses('foo && bar ? baz : qux')
   end
 
-  it 'accepts missing parentheses when using ternary operator in square bracksts' do
+  it 'accepts missing parentheses when using ternary operator in square brackets' do
     expect_no_offenses('do_something[foo && bar ? baz : qux]')
   end
 

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -367,7 +367,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
     end
   end
 
-  context 'when using ActiveSupport behavior when Rails is not eabled' do
+  context 'when using ActiveSupport behavior when Rails is not enabled' do
     it 'reports offenses and corrects' do
       expect_offense(<<~RUBY)
         module SomeModule

--- a/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
           var&.dont_count_me
           var = 2
           var&.bar
-          var&.dont_count_me_eother
+          var&.dont_count_me_either
         end
       RUBY
     end

--- a/spec/rubocop/cop/naming/constant_name_spec.rb
+++ b/spec/rubocop/cop/naming/constant_name_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe RuboCop::Cop::Naming::ConstantName, :config do
     RUBY
   end
 
-  it 'registers an offense for camel case in const namewhen using frozen range assignment' do
+  it 'registers an offense for camel case in const name when using frozen range assignment' do
     expect_offense(<<~RUBY)
       TopCase = (1..5).freeze
       ^^^^^^^ Use SCREAMING_SNAKE_CASE for constants.
     RUBY
   end
 
-  it 'registers an offense for camel case in const namewhen using frozen object assignment' do
+  it 'registers an offense for camel case in const name when using frozen object assignment' do
     expect_offense(<<~RUBY)
       TopCase = 5.freeze
       ^^^^^^^ Use SCREAMING_SNAKE_CASE for constants.

--- a/spec/rubocop/cop/style/block_comments_spec.rb
+++ b/spec/rubocop/cop/style/block_comments_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::Style::BlockComments, :config do
     RUBY
   end
 
-  it 'autocorrects a block comment into a regular comment (without trailingnewline)' do
+  it 'autocorrects a block comment into a regular comment (without trailing newline)' do
     expect_offense(<<~RUBY)
       =begin
       ^^^^^^ Do not use block comments.

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
       RUBY
     end
 
-    it 'registers an offense assigning any variable type to if elsewith multiple assignment' do
+    it 'registers an offense assigning any variable type to if else with multiple assignment' do
       expect_offense(<<~RUBY, variable: variable)
         %{variable}, %{variable} = if foo
         ^{variable}^^^{variable}^^^^^^^^^ Assign variables inside of conditionals

--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::EachForSimpleLoop, :config do
-  it 'does not register offense if range startpoint is not constant' do
+  it 'does not register offense if range starting point is not constant' do
     expect_no_offenses('(a..10).each {}')
   end
 

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
       RUBY
     end
 
-    it 'registers an offense and corrects when using springf with second argument that uses an operator' do
+    it 'registers an offense and corrects when using sprintf with second argument that uses an operator' do
       expect_offense(<<~RUBY)
         format(something, a + 42)
         ^^^^^^ Favor `String#%` over `format`.

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1466,7 +1466,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
-      context 'when hash roket syntax' do
+      context 'when hash rocket syntax' do
         let(:enforced_style) { 'hash_rockets' }
 
         it 'does not register an offense' do

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
     end
   end
 
-  context 'using `defined?` in the condtion' do
+  context 'using `defined?` in the condition' do
     it 'registers for argument value is defined' do
       expect_offense(<<~RUBY)
         value = :custom

--- a/spec/rubocop/cop/style/ip_addresses_spec.rb
+++ b/spec/rubocop/cop/style/ip_addresses_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe RuboCop::Cop::Style::IpAddresses, :config do
       expect_no_offenses('"2001:db8::1xyz"')
     end
 
-    context 'the unspecified address :: (shortform of 0:0:0:0:0:0:0:0)' do
+    context 'the unspecified address :: (short-form of 0:0:0:0:0:0:0:0)' do
       it 'does not register an offense' do
         expect_no_offenses('"::"')
       end

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation, :config do
     RUBY
   end
 
-  it 'registers multiple offenses when there are chained concatenationscombined with << calls' do
+  it 'registers multiple offenses when there are chained concatenations combined with << calls' do
     expect_offense(<<~'RUBY')
       top = "test#{x}" <<
                        ^^ Use `\` instead of `+` or `<<` to concatenate those strings.

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -469,7 +469,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     end
 
     context 'anonymous rest arguments in 3.2', :ruby32 do
-      it 'does not regiester an offense when method calls to have parens' do
+      it 'does not register an offense when method calls to have parens' do
         expect_no_offenses(<<~RUBY)
           def foo(*)
             foo(*)
@@ -480,7 +480,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     end
 
     context 'anonymous keyword rest arguments in 3.2', :ruby32 do
-      it 'does not regiester an offense when method calls to have parens' do
+      it 'does not register an offense when method calls to have parens' do
         expect_no_offenses(<<~RUBY)
           def foo(**)
             foo(**)

--- a/spec/rubocop/cop/style/mixin_grouping_spec.rb
+++ b/spec/rubocop/cop/style/mixin_grouping_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe RuboCop::Cop::Style::MixinGrouping, :config do
           end
         RUBY
 
-        # empty line left by prpend Qux
+        # empty line left by prepend Qux
         expect_correction(<<~RUBY)
           class Foo
             prepend Qux, Bar

--- a/spec/rubocop/cop/style/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/style/multiple_comparison_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison, :config do
   end
 
   it 'registers an offense and corrects when `a` is compared three times, once on the ' \
-     'righthand side' do
+     'right hand side' do
     expect_offense(<<~RUBY)
       a = "a"
       if a == "a" || "b" == a || a == "c"

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -536,7 +536,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
         RUBY
       end
 
-      it 'accepts operating on a constant and an interger' do
+      it 'accepts operating on a constant and an integer' do
         expect_no_offenses(<<~RUBY)
           CONST = FOO + 2
         RUBY

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -151,11 +151,11 @@ RSpec.describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
 
     it 'does not register an offense for preferred delimiters with only a closing delimiter' do
-      expect_no_offenses('%w(only closing delimiter charapter\))')
+      expect_no_offenses('%w(only closing delimiter character\))')
     end
 
     it 'does not register an offense for preferred delimiters with not a pairing delimiter' do
-      expect_no_offenses('%w|\|not pairirng delimiter|')
+      expect_no_offenses('%w|\|not pairing delimiter|')
     end
 
     it 'registers an offense for other delimiters' do

--- a/spec/rubocop/cop/style/quoted_symbols_spec.rb
+++ b/spec/rubocop/cop/style/quoted_symbols_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe RuboCop::Cop::Style::QuotedSymbols, :config do
       RUBY
     end
 
-    context 'hash with hashrocket style' do
+    context 'hash with hash rocket style' do
       it 'accepts properly quoted symbols' do
         expect_no_offenses(<<~RUBY)
           { :'a' => value }
@@ -269,7 +269,7 @@ RSpec.describe RuboCop::Cop::Style::QuotedSymbols, :config do
       RUBY
     end
 
-    context 'hash with hashrocket style' do
+    context 'hash with hash rocket style' do
       it 'accepts properly quoted symbols' do
         expect_no_offenses(<<~RUBY)
           { :"a" => value }

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -433,7 +433,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
-      it 'does not register an offense when the branches contains arguments fowarding', :ruby27 do
+      it 'does not register an offense when the branches contains arguments forwarding', :ruby27 do
         expect_no_offenses(<<~RUBY)
           def do_something(foo, ...)
             if foo

--- a/spec/rubocop/cop/style/rescue_standard_error_spec.rb
+++ b/spec/rubocop/cop/style/rescue_standard_error_spec.rb
@@ -335,7 +335,7 @@ RSpec.describe RuboCop::Cop::Style::RescueStandardError, :config do
         RUBY
       end
 
-      it 'accepts rescuing a single error other than StandardErrorassigned to a variable' do
+      it 'accepts rescuing a single error other than StandardError assigned to a variable' do
         expect_no_offenses(<<~RUBY)
           begin
             foo

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
     expect_no_offenses('foo.baz + bar if foo')
   end
 
-  it 'allows chained method calls during assignment safe guardedby an object check' do
+  it 'allows chained method calls during assignment safe guarded by an object check' do
     expect_no_offenses('foo.baz = bar if foo')
   end
 
@@ -1182,7 +1182,7 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
       expect_no_offenses('foo.bar if baz.respond_to?(:bar)')
     end
 
-    it 'allows method calls safeguarded by a respond_to check on adifferent variable and method' do
+    it 'allows method calls safeguarded by a respond_to check on a different variable and method' do
       expect_no_offenses('foo.bar if baz.respond_to?(:foo)')
     end
 

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -327,7 +327,7 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
       RUBY
     end
 
-    it 'autocorrects non-preffered builtin names' do
+    it 'autocorrects non-preferred builtin names' do
       expect_offense(<<~RUBY)
         puts $:
              ^^ Prefer `$LOAD_PATH` over `$:`.

--- a/spec/rubocop/cop/style/string_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/string_concatenation_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation, :config do
     RUBY
   end
 
-  it 'correctly handles nested concatenable parts' do
+  it 'correctly handles nested concatenatable parts' do
     expect_offense(<<~RUBY)
       (user.vip? ? greeting + ', ' : '') + user.name + ' <' + user.email + '>'
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -432,7 +432,7 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
             expect(runner.run([])).to be false
           end
 
-          it 'ommits unsafe correctable `Style/FrozenStringLiteral`' do
+          it 'omits unsafe correctable `Style/FrozenStringLiteral`' do
             runner.run([])
             expect(formatter_output).to eq <<~RESULT
               Inspecting 1 file
@@ -475,7 +475,7 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
             expect(runner.run([])).to be false
           end
 
-          it 'ommits uncorrectable `Layout/LineLength`' do
+          it 'omits uncorrectable `Layout/LineLength`' do
             runner.run([])
             expect(formatter_output).to eq <<~RESULT
               Inspecting 1 file

--- a/spec/rubocop/server/cache_spec.rb
+++ b/spec/rubocop/server/cache_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe RuboCop::Server::Cache do
         end
       end
 
-      context 'when cache root path is not specified path and `XDG_CACHE_HOME` environment variable is spacified' do
+      context 'when cache root path is not specified path and `XDG_CACHE_HOME` environment variable is specified' do
         let(:cache_path) { File.join('/tmp/cache-root-directory', 'rubocop_cache', 'server') }
 
         around do |example|


### PR DESCRIPTION
Took a pass over the repo with https://github.com/streetsidesoftware/cspell

I've left this as a single large comming for now, but I can rebase out any parts that aren't desired.

I ignore those in the CHANGELOG and relnotes since I assume that they represented commit messages, so they shouldn't be corrected

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
