### PR TITLE
Only run Yamllint CI if required

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,9 +1,12 @@
 name: Linting
 on:
-  - pull_request
-  - workflow_dispatch
-permissions:  # added using https://github.com/step-security/secure-workflows
-  contents: read
+  pull_request:
+    paths:
+      - '.github/workflows/linting.yml'
+      - '.yamllint.yml'
+      - '**/*.yaml'
+      - '**/*.yml'
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -17,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Yamllint
-        uses: karancode/yamllint-github-action@master
+        uses: karancode/yamllint-github-action@v2.1.1
         with:
           yamllint_comment: true
         env:


### PR DESCRIPTION
- Only run if a YML/YAML file or the config is touched
- Remove duplicate permission setting already set at job level
- Pin GitHub Action to tagged version so Dependabot can control version

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
