### PR TITLE
Fix a crash in `Lint/EmptyConditionalBody`

### DIFF
--- a/changelog/fix_fix_a_crash_in_lint_empty_conditional_body.md
+++ b/changelog/fix_fix_a_crash_in_lint_empty_conditional_body.md
@@ -1,0 +1,1 @@
+* [#11712](https://github.com/rubocop/rubocop/pull/11712): Fix a crash in `Lint/EmptyConditionalBody`. ([@gsamokovarov][])

--- a/lib/rubocop/cop/mixin/comments_help.rb
+++ b/lib/rubocop/cop/mixin/comments_help.rb
@@ -71,7 +71,7 @@ module RuboCop
         elsif (next_sibling = node.right_sibling) && next_sibling.is_a?(AST::Node)
           next_sibling.loc.line
         elsif (parent = node.parent)
-          parent.loc.end ? parent.loc.end.line : parent.loc.line
+          parent.loc.respond_to?(:end) && parent.loc.end ? parent.loc.end.line : parent.loc.line
         else
           node.loc.end.line
         end

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -317,6 +317,19 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     RUBY
   end
 
+  context '>= Ruby 3.1', :ruby31 do
+    it 'registers an offense for multi-line value omission in `unless`' do
+      expect_offense(<<~RUBY)
+        var =
+          unless object.action value:, other:
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid `unless` branches without a body.
+            condition || other_condition # This is the value of `other:`, like so:
+                                         # `other: condition || other_condition`
+          end
+      RUBY
+    end
+  end
+
   context 'when AllowComments is false' do
     let(:cop_config) { { 'AllowComments' => false } }
 


### PR DESCRIPTION
```ruby
var =
  unless object.action value:, other:
    condition || other_condition # This is the value of `other:`, like so:
                                 # `other: condition || other_condition`
  end
```

The code above is tricky, because we may think `condition || other_condition` is the body of the condition, however the code is a valid case for the `Lint/EmptyConditionalBody` rule. It is equivalent to:

```ruby
var =
  unless object.action value:, other: condition || other_condition
  end
```


However, the variable assignment is tricking `CommentsHelp#find_end_line` method into calling an `#end` method of `Parser::Source::Map::Variable` object. `Parser::Source::Map::Variable` **does not respond** to it. Other `Parser::Source::Map` subclasses also do not respond to `#end` methods so we need to check for its existing. `Parser::Source::Map::RescueBody` can be a parent node too.
