### PR TITLE
Make `InternalAffairs/RedundantSourceRange` aware of correction methods

### DIFF
--- a/lib/rubocop/cop/correctors/parentheses_corrector.rb
+++ b/lib/rubocop/cop/correctors/parentheses_corrector.rb
@@ -74,7 +74,7 @@ module RuboCop
         def add_heredoc_comma(corrector, node)
           return unless heredoc?(node)
 
-          corrector.insert_after(node.child_nodes.last.source_range, ',')
+          corrector.insert_after(node.child_nodes.last, ',')
         end
 
         def heredoc?(node)

--- a/lib/rubocop/cop/internal_affairs/redundant_source_range.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_source_range.rb
@@ -13,19 +13,46 @@ module RuboCop
       #   # good
       #   node.source
       #
+      #   # bad
+      #   add_offense(node) { |corrector| corrector.replace(node.source_range, prefer) }
+      #   add_offense(node) { |corrector| corrector.insert_before(node.source_range, prefer) }
+      #   add_offense(node) { |corrector| corrector.insert_before_multi(node.source_range, prefer) }
+      #   add_offense(node) { |corrector| corrector.insert_after(node.source_range, prefer) }
+      #   add_offense(node) { |corrector| corrector.insert_after_multi(node.source_range, prefer) }
+      #   add_offense(node) { |corrector| corrector.swap(node.source_range, before, after) }
+      #
+      #   # good
+      #   add_offense(node) { |corrector| corrector.replace(node, prefer) }
+      #   add_offense(node) { |corrector| corrector.insert_before(node, prefer) }
+      #   add_offense(node) { |corrector| corrector.insert_before_multi(node, prefer) }
+      #   add_offense(node) { |corrector| corrector.insert_after(node, prefer) }
+      #   add_offense(node) { |corrector| corrector.insert_after_multi(node, prefer) }
+      #   add_offense(node) { |corrector| corrector.swap(node, before, after) }
+      #
       class RedundantSourceRange < Base
         extend AutoCorrector
 
         MSG = 'Remove the redundant `source_range`.'
-        RESTRICT_ON_SEND = %i[source].freeze
+        RESTRICT_ON_SEND = %i[
+          source
+          replace remove insert_before insert_before_multi insert_after insert_after_multi swap
+        ].freeze
 
         # @!method redundant_source_range(node)
         def_node_matcher :redundant_source_range, <<~PATTERN
-          (send $(send _ :source_range) :source)
+          {
+            (send $(send _ :source_range) :source)
+            (send _ {
+              :replace :insert_before :insert_before_multi :insert_after :insert_after_multi
+            } $(send _ :source_range) _)
+            (send _ :remove $(send _ :source_range))
+            (send _ :swap $(send _ :source_range) _ _)
+          }
         PATTERN
 
         def on_send(node)
           return unless (source_range = redundant_source_range(node))
+          return if source_range.receiver.send_type? && source_range.receiver.method?(:buffer)
 
           selector = source_range.loc.selector
 

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -69,7 +69,7 @@ module RuboCop
 
         def register_offense(node)
           add_offense(node) do |corrector|
-            corrector.replace(node.source_range, to_single_line(node.source).strip)
+            corrector.replace(node, to_single_line(node.source).strip)
           end
           ignore_node(node)
         end

--- a/lib/rubocop/cop/lint/empty_interpolation.rb
+++ b/lib/rubocop/cop/lint/empty_interpolation.rb
@@ -25,7 +25,7 @@ module RuboCop
         def on_interpolation(begin_node)
           return unless begin_node.children.empty?
 
-          add_offense(begin_node) { |corrector| corrector.remove(begin_node.source_range) }
+          add_offense(begin_node) { |corrector| corrector.remove(begin_node) }
         end
       end
     end

--- a/lib/rubocop/cop/mixin/hash_transform_method.rb
+++ b/lib/rubocop/cop/mixin/hash_transform_method.rb
@@ -175,7 +175,7 @@ module RuboCop
         end
 
         def set_new_arg_name(transformed_argname, corrector)
-          corrector.replace(block_node.arguments.source_range, "|#{transformed_argname}|")
+          corrector.replace(block_node.arguments, "|#{transformed_argname}|")
         end
 
         def set_new_body_expression(transforming_body_expr, corrector)

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -167,7 +167,7 @@ module RuboCop
           corrector.insert_before(condition,
                                   "#{'!' if node.unless?}#{replace_condition(node.condition)} && ")
 
-          corrector.remove(node.condition.source_range)
+          corrector.remove(node.condition)
           corrector.remove(range_with_surrounding_space(node.loc.keyword, newlines: false))
           corrector.replace(if_branch.loc.keyword, 'if')
         end
@@ -187,7 +187,7 @@ module RuboCop
           return if end_pos > begin_pos
 
           corrector.replace(range_between(end_pos, begin_pos), '(')
-          corrector.insert_after(condition.last_argument.source_range, ')')
+          corrector.insert_after(condition.last_argument, ')')
         end
 
         def insert_bang(corrector, node, is_modify_form)

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -55,7 +55,7 @@ module RuboCop
           elsif (class_node = parent.parent).body.nil?
             corrector.remove(range_for_empty_class_body(class_node, parent))
           else
-            corrector.insert_after(parent.source_range, ' do')
+            corrector.insert_after(parent, ' do')
           end
         end
 

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -238,7 +238,7 @@ module RuboCop
 
           indent = ' ' * node.loc.column
           corrector.replace(
-            node.source_range,
+            node,
             ['class << self',
              "#{indent}  #{accessor(kind, node.method_name)}",
              "#{indent}end"].join("\n")

--- a/spec/rubocop/cop/internal_affairs/redundant_source_range_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_source_range_spec.rb
@@ -17,4 +17,140 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantSourceRange, :config do
       node.source
     RUBY
   end
+
+  it 'registers an offense when using `corrector.replace(node.source_range, content)`' do
+    expect_offense(<<~RUBY)
+      add_offense do |corrector|
+        corrector.replace(node.source_range, content)
+                               ^^^^^^^^^^^^ Remove the redundant `source_range`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      add_offense do |corrector|
+        corrector.replace(node, content)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `corrector.remove(node.source_range)`' do
+    expect_offense(<<~RUBY)
+      add_offense do |corrector|
+        corrector.remove(node.source_range)
+                              ^^^^^^^^^^^^ Remove the redundant `source_range`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      add_offense do |corrector|
+        corrector.remove(node)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `corrector.insert_before(node.source_range, content)`' do
+    expect_offense(<<~RUBY)
+      add_offense do |corrector|
+        corrector.insert_before(node.source_range, content)
+                                     ^^^^^^^^^^^^ Remove the redundant `source_range`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      add_offense do |corrector|
+        corrector.insert_before(node, content)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `corrector.insert_before_multi(node.source_range, content)`' do
+    expect_offense(<<~RUBY)
+      add_offense do |corrector|
+        corrector.insert_before_multi(node.source_range, content)
+                                           ^^^^^^^^^^^^ Remove the redundant `source_range`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      add_offense do |corrector|
+        corrector.insert_before_multi(node, content)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `corrector.insert_after(node.source_range, content)`' do
+    expect_offense(<<~RUBY)
+      add_offense do |corrector|
+        corrector.insert_after(node.source_range, content)
+                                    ^^^^^^^^^^^^ Remove the redundant `source_range`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      add_offense do |corrector|
+        corrector.insert_after(node, content)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `corrector.insert_after_multi(node.source_range, content)`' do
+    expect_offense(<<~RUBY)
+      add_offense do |corrector|
+        corrector.insert_after_multi(node.source_range, content)
+                                          ^^^^^^^^^^^^ Remove the redundant `source_range`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      add_offense do |corrector|
+        corrector.insert_after_multi(node, content)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `corrector.swap(node.source_range, before, after)`' do
+    expect_offense(<<~RUBY)
+      add_offense do |corrector|
+        corrector.swap(node.source_range, before, after)
+                            ^^^^^^^^^^^^ Remove the redundant `source_range`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      add_offense do |corrector|
+        corrector.swap(node, before, after)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `lvar.source_range`' do
+    expect_offense(<<~RUBY)
+      def foo(corrector, lvar)
+        corrector.insert_after(lvar.source_range, content)
+                                    ^^^^^^^^^^^^ Remove the redundant `source_range`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo(corrector, lvar)
+        corrector.insert_after(lvar, content)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `corrector.replace(node, content)`' do
+    expect_no_offenses(<<~RUBY)
+      add_offense do |corrector|
+        corrector.replace(node, content)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `processed_source.buffer.source_range`' do
+    expect_no_offenses(<<~RUBY)
+      add_offense do |corrector|
+        corrector.insert_before(processed_source.buffer.source_range, preceding_comment)
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR makes `InternalAffairs/RedundantSourceRange` aware of redundant `source_range` for `replace`, `insert_before`, `insert_before_multi`, `insert_after`, `insert_after_multi`, and `swap` methods of `RuboCop::Cop::Corrector`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
