### PR TITLE
Remove unnecessary paths for .github/workflows/linting.yml

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,8 +2,6 @@ name: Linting
 on:
   pull_request:
     paths:
-      - '.github/workflows/linting.yml'
-      - '.yamllint.yml'
       - '**/*.yaml'
       - '**/*.yml'
   workflow_dispatch:


### PR DESCRIPTION
This PR removes paths considered redundant for GHA in YAML Lint.
The following paths are not needed as they are included in "**/*.yml".
- '.github/workflows/linting.yml'
- '.yamllint.yml'

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
