### PR TITLE
Add options to the actions-codespell configuration to check hidden files and file name

### DIFF
--- a/.github/workflows/spell_checking.yml
+++ b/.github/workflows/spell_checking.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: codespell-project/actions-codespell@v1
         with:
+          check_filenames: true
+          check_hidden: true
           ignore_words_file: codespell.txt
   misspell:
     name: Check spelling of all files in commit with misspell


### PR DESCRIPTION
How about checking about codespell for hidden files (those starting with ".") and file name as well?

- https://github.com/codespell-project/actions-codespell#parameter-check_filenames
- https://github.com/codespell-project/actions-codespell#parameter-check_hidden

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
