### PR TITLE
[Fix #11723] Fix a false positive for `Style/IfUnlessModifier`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_if_unless_modifier.md
+++ b/changelog/fix_a_false_positive_for_style_if_unless_modifier.md
@@ -1,0 +1,1 @@
+* [#11723](https://github.com/rubocop/rubocop/issues/11723): Fix a false positive for `Style/IfUnlessModifier` when using one-line pattern matching as a `if` condition. ([@koic][])

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -362,6 +362,50 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
     RUBY
   end
 
+  shared_examples 'one-line pattern matching' do
+    it 'does not register an offense when using match var in body' do
+      expect_no_offenses(<<~RUBY)
+        if [42] in [x]
+          x
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using some match var in body' do
+      expect_no_offenses(<<~RUBY)
+        if { x: 1, y: 2 } in { x:, y: }
+          a && y
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when not using match var in body' do
+      expect_no_offenses(<<~RUBY)
+        if [42] in [x]
+          y
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when not using any match var in body' do
+      expect_no_offenses(<<~RUBY)
+        if { x: 1, y: 2 } in { x:, y: }
+          a && b
+        end
+      RUBY
+    end
+  end
+
+  # The node type for one-line `in` pattern matching in Ruby 2.7 is `match_pattern`.
+  context 'using `match_pattern` as a one-line pattern matching', :ruby27 do
+    include_examples 'one-line pattern matching'
+  end
+
+  # The node type for one-line `in` pattern matching in Ruby 3.0 is `match_pattern_p`.
+  context 'using `match_pattern_p` as a one-line pattern matching', :ruby30 do
+    include_examples 'one-line pattern matching'
+  end
+
   context 'multiline `if` that fits on one line and using hash value omission syntax', :ruby31 do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #11723.

This PR fixes a false positive for `Style/IfUnlessModifier` when using one-line pattern matching as a `if` condition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
