### PR TITLE
[Fix #11725] Fix an error when accessing cache directory

### DIFF
--- a/changelog/fix_an_error_when_accessing_cache_directory.md
+++ b/changelog/fix_an_error_when_accessing_cache_directory.md
@@ -1,0 +1,1 @@
+* [#11725](https://github.com/rubocop/rubocop/issues/11725): Fix an error when insufficient permissions to server cache dir are granted. ([@koic][])

--- a/lib/rubocop/server/cache.rb
+++ b/lib/rubocop/server/cache.rb
@@ -116,7 +116,7 @@ module RuboCop
 
         def pid_running?
           Process.kill(0, pid_path.read.to_i) == 1
-        rescue Errno::ESRCH, Errno::ENOENT
+        rescue Errno::ESRCH, Errno::ENOENT, Errno::EACCES
           false
         end
 

--- a/spec/rubocop/server/cache_spec.rb
+++ b/spec/rubocop/server/cache_spec.rb
@@ -283,6 +283,15 @@ RSpec.describe RuboCop::Server::Cache do
         end
         expect(described_class.pid_running?).to be(false)
       end
+
+      it 'works properly when insufficient permissions to server cache dir are granted' do
+        expect(described_class).to receive(:pid_path).and_wrap_original do |method|
+          result = method.call
+          described_class.dir.chmod(0o644) # Make insufficient permissions.
+          result
+        end
+        expect(described_class.pid_running?).to be(false)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #11725.

This PR fixes an error when insufficient permissions to server cache dir are granted.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
