### PR TITLE
[Fix #11715] Ensure default configuration loads

### DIFF
--- a/changelog/fix_ensure_default_configuration_loads.md
+++ b/changelog/fix_ensure_default_configuration_loads.md
@@ -1,0 +1,1 @@
+* [#11715](https://github.com/rubocop/rubocop/issues/11715): Ensure default configuration loads. ([@koic][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -29,7 +29,7 @@ module RuboCop
     end
 
     # rubocop:disable Metrics/AbcSize
-    def initialize(hash = {}, loaded_path = nil)
+    def initialize(hash = RuboCop::ConfigLoader.default_configuration, loaded_path = nil)
       @loaded_path = loaded_path
       @for_cop = Hash.new do |h, cop|
         cop_name = cop.respond_to?(:cop_name) ? cop.cop_name : cop

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -8,6 +8,14 @@ RSpec.describe RuboCop::Config do
   let(:hash) { {} }
   let(:loaded_path) { 'example/.rubocop.yml' }
 
+  describe '.new' do
+    context 'without arguments' do
+      subject(:configuration) { described_class.new }
+
+      it { expect(configuration['Lint/BooleanSymbol']['SafeAutoCorrect']).to be(false) }
+    end
+  end
+
   describe '#validate', :isolated_environment do
     subject(:configuration) do
       # ConfigLoader.load_file will validate config

--- a/spec/rubocop/cop/mixin/enforce_superclass_spec.rb
+++ b/spec/rubocop/cop/mixin/enforce_superclass_spec.rb
@@ -2,7 +2,7 @@
 
 # rubocop:disable RSpec/FilePath
 RSpec.describe RuboCop::Cop::EnforceSuperclass, :restore_registry do
-  subject(:cop) { cop_class.new }
+  subject(:cop) { cop_class.new(configuration) }
 
   let(:cop_class) { RuboCop::Cop::RSpec::ApplicationRecord }
   let(:msg) { 'Models should subclass `ApplicationRecord`' }


### PR DESCRIPTION
Fixes #11715.

There was an issue where the default configuration was not loaded when instantiating cop with no arguments. This patch ensures default configuration by passing `RuboCop::ConfigLoader.default_configuration` to `RuboCop::Config.new` default argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
