### PR TITLE
[Fix #11730] Fix an error for `Layout/HashAlignment`

### DIFF
--- a/changelog/new_fix_an_error_for_layout_hash_alignment.md
+++ b/changelog/new_fix_an_error_for_layout_hash_alignment.md
@@ -1,0 +1,1 @@
+* [#11730](https://github.com/rubocop/rubocop/issues/11730): Fix an error for `Layout/HashAlignment` when using anonymous keyword rest arguments. ([@koic][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
   s.add_runtime_dependency('rexml', '>= 3.2.5', '< 4.0')
-  s.add_runtime_dependency('rubocop-ast', '>= 1.26.0', '< 2.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 1.28.0', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 2.4.0', '< 3.0')
 end

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -1360,6 +1360,57 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       end
     end
 
+    context 'when using anonymous keyword rest arguments', :ruby32 do
+      context 'and forwarded keyword rest argument after a hash key' do
+        it 'registers an offense on the misaligned key and corrects' do
+          expect_offense(<<~RUBY)
+            def foo(**)
+              bar ab: 1,
+                  c: 2, **
+                  ^^^^ Align the keys and values of a hash literal if they span more than one line.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def foo(**)
+              bar ab: 1,
+                  c:  2, **
+            end
+          RUBY
+        end
+      end
+
+      context 'and aligned keys but forwarded keyword rest argument after' do
+        it 'does not register an offense on the `forwarded_kwrestarg`' do
+          expect_no_offenses(<<~RUBY)
+            def foo(**)
+              bar a: 1,
+                  b: 2, **
+            end
+          RUBY
+        end
+      end
+
+      context 'and a misaligned forwarded keyword rest argument' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            def foo(**)
+              bar a: 1,
+                    **
+                    ^^ Align keyword splats with the rest of the hash if it spans more than one line.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def foo(**)
+              bar a: 1,
+                  **
+            end
+          RUBY
+        end
+      end
+    end
+
     context 'when the only item is a kwsplat' do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #11730.

This PR fixes an error for `Layout/HashAlignment` when using anonymous keyword rest arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
