### PR TITLE
[Fix #11697] Fix `Lint/Syntax` behavior when using `--only` option

### DIFF
--- a/changelog/fix_lint_syntax_when_only_option.md
+++ b/changelog/fix_lint_syntax_when_only_option.md
@@ -1,0 +1,1 @@
+* [#11697](https://github.com/rubocop/rubocop/issues/11697): Fix `Lint/Syntax` behavior when `--only` is not given the cop name. ([@koic][])

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -182,7 +182,10 @@ module RuboCop
           raise OptionArgumentError, message
         end
 
-        @options[:"#{option}"] = list.empty? ? [''] : list.split(',')
+        cop_names = list.empty? ? [''] : list.split(',')
+        cop_names.unshift('Lint/Syntax') if option == 'only' && !cop_names.include?('Lint/Syntax')
+
+        @options[:"#{option}"] = cop_names
       end
     end
 

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -451,6 +451,14 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         expect($stderr.string.include?('Unrecognized cop or department: .')).to be(true)
       end
 
+      it '`Lint/Syntax` must be enabled even if `--only` is given `Style/StringLiterals` only' do
+        create_file('example.rb', '1 /// 2')
+        expect(cli.run(['--only', 'Style/StringLiterals', 'example.rb'])).to eq(1)
+        expect(
+          $stdout.string.include?('example.rb:1:7: F: Lint/Syntax: unexpected token tINTEGER')
+        ).to be(true)
+      end
+
       %w[Syntax Lint/Syntax].each do |name|
         it "only checks syntax if #{name} is given" do
           create_file('example.rb', 'x ')


### PR DESCRIPTION
Fixes #11697.

This PR fixes `Lint/Syntax` behavior when `--only` is not given the cop name. The cop must always be executed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
