### PR TITLE
[Fix #11732] Make `Style/MapToHash` and `Style/MapToSet` aware of symbol proc

### DIFF
--- a/changelog/new_make_style_map_to_hash_and_map_to_set_aware_of_symbol_proc.md
+++ b/changelog/new_make_style_map_to_hash_and_map_to_set_aware_of_symbol_proc.md
@@ -1,0 +1,1 @@
+* [#11732](https://github.com/rubocop/rubocop/issues/11732): Make `Style/MapToHash` and `Style/MapToSet` aware of symbol proc. ([@koic][])

--- a/lib/rubocop/cop/style/map_to_hash.rb
+++ b/lib/rubocop/cop/style/map_to_hash.rb
@@ -39,7 +39,10 @@ module RuboCop
 
         # @!method map_to_h?(node)
         def_node_matcher :map_to_h?, <<~PATTERN
-          $(send (block $(send _ {:map :collect}) ...) :to_h)
+          {
+            $(send (block $(send _ {:map :collect}) ...) :to_h)
+            $(send $(send _ {:map :collect} (block_pass sym)) :to_h)
+          }
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/style/map_to_set.rb
+++ b/lib/rubocop/cop/style/map_to_set.rb
@@ -32,7 +32,10 @@ module RuboCop
 
         # @!method map_to_set?(node)
         def_node_matcher :map_to_set?, <<~PATTERN
-          $(send (block $(send _ {:map :collect}) ...) :to_set)
+          {
+            $(send (block $(send _ {:map :collect}) ...) :to_set)
+            $(send $(send _ {:map :collect} (block_pass sym)) :to_set)
+          }
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/style/map_to_hash_spec.rb
+++ b/spec/rubocop/cop/style/map_to_hash_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe RuboCop::Cop::Style::MapToHash, :config do
         end
       end
 
+      context "for `#{method}.to_h` with symbol proc" do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            foo.#{method}(&:do_something).to_h
+                ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo.to_h(&:do_something)
+          RUBY
+        end
+      end
+
       context 'when the receiver is an array' do
         it 'registers an offense and corrects' do
           expect_offense(<<~RUBY, method: method)

--- a/spec/rubocop/cop/style/map_to_set_spec.rb
+++ b/spec/rubocop/cop/style/map_to_set_spec.rb
@@ -28,6 +28,19 @@ RSpec.describe RuboCop::Cop::Style::MapToSet, :config do
       end
     end
 
+    context "for `#{method}.to_set` with symbol proc" do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY, method: method)
+          foo.#{method}(&:do_something).to_set
+              ^{method} Pass a block to `to_set` instead of calling `#{method}.to_set`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo.to_set(&:do_something)
+        RUBY
+      end
+    end
+
     context 'when the receiver is an array' do
       it 'registers an offense and corrects' do
         expect_offense(<<~RUBY, method: method)


### PR DESCRIPTION
Fixes #11732.

This PR makes `Style/MapToHash` and `Style/MapToSet` aware of symbol proc.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
