### PR TITLE
Make `Style/MapToHash` and `Style/MapToSet` aware of numblock

### DIFF
--- a/changelog/new_make_style_map_to_hash_and_map_to_set_aware_of_numblock.md
+++ b/changelog/new_make_style_map_to_hash_and_map_to_set_aware_of_numblock.md
@@ -1,0 +1,1 @@
+* [#11737](https://github.com/rubocop/rubocop/pull/11737): Make `Style/MapToHash` and `Style/MapToSet` aware of numbered parameters. ([@koic][])

--- a/lib/rubocop/cop/style/map_to_hash.rb
+++ b/lib/rubocop/cop/style/map_to_hash.rb
@@ -40,7 +40,7 @@ module RuboCop
         # @!method map_to_h?(node)
         def_node_matcher :map_to_h?, <<~PATTERN
           {
-            $(send (block $(send _ {:map :collect}) ...) :to_h)
+            $(send ({block numblock} $(send _ {:map :collect}) ...) :to_h)
             $(send $(send _ {:map :collect} (block_pass sym)) :to_h)
           }
         PATTERN

--- a/lib/rubocop/cop/style/map_to_set.rb
+++ b/lib/rubocop/cop/style/map_to_set.rb
@@ -33,7 +33,7 @@ module RuboCop
         # @!method map_to_set?(node)
         def_node_matcher :map_to_set?, <<~PATTERN
           {
-            $(send (block $(send _ {:map :collect}) ...) :to_set)
+            $(send ({block numblock} $(send _ {:map :collect}) ...) :to_set)
             $(send $(send _ {:map :collect} (block_pass sym)) :to_set)
           }
         PATTERN

--- a/spec/rubocop/cop/style/map_to_hash_spec.rb
+++ b/spec/rubocop/cop/style/map_to_hash_spec.rb
@@ -29,6 +29,34 @@ RSpec.describe RuboCop::Cop::Style::MapToHash, :config do
         end
       end
 
+      context 'when using numbered parameters', :ruby27 do
+        context "for `#{method}.to_h` with block arity 1" do
+          it 'registers an offense and corrects' do
+            expect_offense(<<~RUBY, method: method)
+              foo.#{method} { [_1, _1 * 2] }.to_h
+                  ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              foo.to_h { [_1, _1 * 2] }
+            RUBY
+          end
+        end
+
+        context "for `#{method}.to_h` with block arity 2" do
+          it 'registers an offense and corrects' do
+            expect_offense(<<~RUBY, method: method)
+              foo.#{method} { [_1.to_s, _2.to_i] }.to_h
+                  ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              foo.to_h { [_1.to_s, _2.to_i] }
+            RUBY
+          end
+        end
+      end
+
       context "for `#{method}.to_h` with symbol proc" do
         it 'registers an offense and corrects' do
           expect_offense(<<~RUBY, method: method)

--- a/spec/rubocop/cop/style/map_to_set_spec.rb
+++ b/spec/rubocop/cop/style/map_to_set_spec.rb
@@ -28,6 +28,34 @@ RSpec.describe RuboCop::Cop::Style::MapToSet, :config do
       end
     end
 
+    context 'when using numbered parameters', :ruby27 do
+      context "for `#{method}.to_set` with block arity 1" do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            foo.#{method} { [_1, _1 * 2] }.to_set
+                ^{method} Pass a block to `to_set` instead of calling `#{method}.to_set`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo.to_set { [_1, _1 * 2] }
+          RUBY
+        end
+      end
+
+      context "for `#{method}.to_set` with block arity 2" do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            foo.#{method} { [_1.to_s, _2.to_i] }.to_set
+                ^{method} Pass a block to `to_set` instead of calling `#{method}.to_set`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo.to_set { [_1.to_s, _2.to_i] }
+          RUBY
+        end
+      end
+    end
+
     context "for `#{method}.to_set` with symbol proc" do
       it 'registers an offense and corrects' do
         expect_offense(<<~RUBY, method: method)


### PR DESCRIPTION
I noticed it when working on https://github.com/rubocop/rubocop/pull/11735.

This PR makes `Style/MapToHash` and `Style/MapToSet` aware of numbered parameters.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
