### PR TITLE
Make `Style/RedundantParentheses` aware of redundant method arg parentheses

### DIFF
--- a/changelog/change_make_style_redundant_parentheses_aware_of_method_arg_parentheses.md
+++ b/changelog/change_make_style_redundant_parentheses_aware_of_method_arg_parentheses.md
@@ -1,0 +1,1 @@
+* [#11739](https://github.com/rubocop/rubocop/pull/11739): Make `Style/RedundantParentheses` aware of redundant method argument parentheses. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -98,7 +98,7 @@ module RuboCop
         end
 
         def like_method_argument_parentheses?(node)
-          node.send_type? && node.arguments.one? &&
+          node.send_type? && node.arguments.one? && !node.parenthesized? &&
             !node.arithmetic_operation? && node.first_argument.begin_type?
         end
 

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -183,6 +183,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'registers an offense for parens around method arguments of a method call with an argument' do
+    expect_offense(<<~RUBY)
+      x.y((z))
+          ^^^ Don't use parentheses around a method call.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.y(z)
+    RUBY
+  end
+
   it 'registers an offense for parens around an interpolated expression' do
     expect_offense(<<~RUBY)
       "\#{(foo)}"


### PR DESCRIPTION
This PR makes `Style/RedundantParentheses` aware of redundant method argument parentheses.

The following is an example:

```ruby
x.y.((z))
```

## Before

```console
$ bundle exec rubocop --only Style/RedundantParentheses -a
Inspecting 1 file
.

1 file inspected, no offenses detected
```

## After

```console
$ bundle exec rubocop --only Style/RedundantParentheses -a
Inspecting 1 file
C

Offenses:

example.rb:1:6: C: [Corrected] Style/RedundantParentheses: Don't use parentheses around a method call.
x.y.((z))
     ^^^

1 file inspected, 1 offense detected, 1 offense corrected

$ cat example.rb
x.y.(z)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
