### PR TITLE
Fix a false positive for `Lint/NestedMethodDefinition` when nested definition inside `*_eval` and `*_exec` method call with a numblock

### DIFF
--- a/changelog/fix_fix_a_false_positive_for_lint-nested_method_definition.md
+++ b/changelog/fix_fix_a_false_positive_for_lint-nested_method_definition.md
@@ -1,0 +1,1 @@
+* [#11740](https://github.com/rubocop/rubocop/pull/11740): Fix a false positive for `Lint/NestedMethodDefinition` when nested definition inside `*_eval` and `*_exec` method call with a numblock. ([@ydah][])

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -131,12 +131,12 @@ module RuboCop
 
         # @!method eval_call?(node)
         def_node_matcher :eval_call?, <<~PATTERN
-          (block (send _ {:instance_eval :class_eval :module_eval} ...) ...)
+          ({block numblock} (send _ {:instance_eval :class_eval :module_eval} ...) ...)
         PATTERN
 
         # @!method exec_call?(node)
         def_node_matcher :exec_call?, <<~PATTERN
-          (block (send _ {:instance_exec :class_exec :module_exec} ...) ...)
+          ({block numblock} (send _ {:instance_exec :class_exec :module_exec} ...) ...)
         PATTERN
       end
     end

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -297,6 +297,34 @@ RSpec.describe RuboCop::Cop::Lint::NestedMethodDefinition, :config do
         end
       RUBY
     end
+
+    it 'does not register offense for nested definition inside instance_eval with a numblock' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def x(obj)
+            obj.instance_eval do
+              @bar = _1
+              def y
+              end
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register offense for nested definition inside instance_exec with a numblock' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def x(obj)
+            obj.instance_exec(3) do
+              @bar = _1
+              def y
+              end
+            end
+          end
+        end
+      RUBY
+    end
   end
 
   context 'when Ruby >= 3.2', :ruby32 do


### PR DESCRIPTION
This PR fix a false positive for `Lint/NestedMethodDefinition` when nested definition inside `*_eval` and `*_exec` method call with a numblock.

```ruby
class Foo
  def x(obj)
    obj.instance_eval do
      @bar = _1
      def y
      end
    end
  end
end

class Foo
  def x(obj)
    obj.instance_exec(3) do
      @bar = _1
      def y
      end
    end
  end
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
