### PR TITLE
Add good example for Style/HashSyntax EnforcedShorthandSyntax: either

### DIFF
--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -88,6 +88,9 @@ module RuboCop
       #   {foo: foo, bar: bar}
       #
       #   # good
+      #   {foo: foo, bar:}
+      #
+      #   # good
       #   {foo:, bar:}
       #
       # @example EnforcedShorthandSyntax: consistent


### PR DESCRIPTION
It's not obvious that "either" also allows mixed style.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
