### PR TITLE
Fix error when trying to display error message

### DIFF
--- a/changelog/fix_error_handling_in_bundler_standalone_mode.md
+++ b/changelog/fix_error_handling_in_bundler_standalone_mode.md
@@ -1,0 +1,1 @@
+* [#11742](https://github.com/rubocop/rubocop/pull/11742): Fix error handling in bundler standalone mode. ([@composerinteralia][])

--- a/lib/rubocop/cli/command/execute_runner.rb
+++ b/lib/rubocop/cli/command/execute_runner.rb
@@ -76,11 +76,16 @@ module RuboCop
           warn <<~WARNING
             Errors are usually caused by RuboCop bugs.
             Please, report your problems to RuboCop's issue tracker.
-            #{Gem.loaded_specs['rubocop'].metadata['bug_tracker_uri']}
-
+            #{bug_tracker_uri}
             Mention the following information in the issue report:
             #{RuboCop::Version.version(debug: true)}
           WARNING
+        end
+
+        def bug_tracker_uri
+          return unless Gem.loaded_specs.key?('rubocop')
+
+          "#{Gem.loaded_specs['rubocop'].metadata['bug_tracker_uri']}\n"
         end
 
         def maybe_print_corrected_source


### PR DESCRIPTION
When RuboCop errors, it prints a message that includes the issue tracker URL. It pulls this URL from the gem spec metadata.

Relying on the gem spec can cause problems in bundler standalone mode, where everything is set up by the standalone file and `Gem.loaded_specs` is not populated with the bundled gems.

```
$ bundle init
$ bundle add rubocop --skip-install
$ bundle install --standalone
$ ruby -r ./bundle/bundler/setup.rb -e 'require "rubocop"; Gem.loaded_specs["bundler"].metadata['bug_tracker_uri']'
undefined method `metadata' for nil:NilClass (NoMethodError)
```

This means that if RuboCop errors, instead of a helpful error message we get a cryptic error that masks the underlying problem. We've seen this a number of times at GitHub (although mostly when developing our own internal cops and not from bugs in RuboCop itself).

This commit makes the error reporting more resilient by skipping the issue tracker URL when the rubocop spec is unavailable. Leaving out the URL in this case seems OK to me, since it's basically falling back to the error message before https://github.com/rubocop/rubocop/commit/ef74a1886aa9174aa8c7fcb5441e00f3843fb7e8. Hard-coding the URL is another option, although there's some risk of it falling out of sync some day.

I didn't find any existing test coverage for this code (perhaps because it only gets run if something else is broken), so I haven't added any additional coverage here.


-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests. (See note above. Open to suggestions!)
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
