### PR TITLE
Make `Layout/EndAlignment` aware of pattern matching

### DIFF
--- a/changelog/new_make_layout_end_alignment_aware_of_pattern_matching.md
+++ b/changelog/new_make_layout_end_alignment_aware_of_pattern_matching.md
@@ -1,0 +1,1 @@
+* [#11746](https://github.com/rubocop/rubocop/pull/11746): Make `Layout/EndAlignment` aware of pattern matching. ([@koic][])

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -109,6 +109,7 @@ module RuboCop
             check_other_alignment(node)
           end
         end
+        alias on_case_match on_case
 
         private
 
@@ -169,7 +170,10 @@ module RuboCop
         end
 
         def alignment_node_for_variable_style(node)
-          return node.parent if node.case_type? && node.argument? && same_line?(node, node.parent)
+          if (node.case_type? || node.case_match_type?) && node.argument? &&
+             same_line?(node, node.parent)
+            return node.parent
+          end
 
           assignment = assignment_or_operator_method(node)
 


### PR DESCRIPTION
This PR makes `Layout/EndAlignment` aware of pattern matching.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
