### PR TITLE
[Fix #10766] Use the path given by `--cache-root` to be the parent for  `rubocop_cache` dir like other ways to specify it

### DIFF
--- a/changelog/change_use_the_path_given_by_cache_root_to_be_the_parent.md
+++ b/changelog/change_use_the_path_given_by_cache_root_to_be_the_parent.md
@@ -1,0 +1,1 @@
+* [#10766](https://github.com/rubocop/rubocop/issues/10766): Use the path given by `--cache-root` to be the parent for `rubocop_cache` dir like other ways to specify it. ([@nobuyo][])

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -86,7 +86,7 @@ module RuboCop
     attr :path
 
     def initialize(file, team, options, config_store, cache_root = nil)
-      cache_root ||= options[:cache_root]
+      cache_root ||= File.join(options[:cache_root], 'rubocop_cache') if options[:cache_root]
       cache_root ||= ResultCache.cache_root(config_store)
       @allow_symlinks_in_cache_location =
         ResultCache.allow_symlinks_in_cache_location?(config_store)

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
       it 'takes the cache_root from the options' do
         cache2 = described_class.new(file, team, { cache_root: 'some/path' }, config_store)
 
-        expect(cache2.path).to start_with('some/path')
+        expect(cache2.path).to start_with('some/path/rubocop_cache')
       end
     end
 
@@ -362,6 +362,14 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
           cacheroot = described_class.cache_root(config_store)
           expect(cacheroot).to eq(File.join(Dir.home, '.cache', 'rubocop_cache'))
         end
+
+        it 'contains the root in path only once' do
+          cache = described_class.new(file, team, options, config_store)
+          expect(cache.path).to start_with(File.join(Dir.home, '.cache', 'rubocop_cache'))
+
+          count = cache.path.scan(/rubocop_cache/).count
+          expect(count).to eq(1)
+        end
       end
 
       context 'and XDG_CACHE_HOME is set' do
@@ -377,6 +385,16 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
         it 'contains the given path and UID' do
           cacheroot = described_class.cache_root(config_store)
           expect(cacheroot).to eq(File.join(ENV.fetch('XDG_CACHE_HOME'), puid, 'rubocop_cache'))
+        end
+
+        it 'contains the root in path only once' do
+          cache = described_class.new(file, team, options, config_store)
+          expect(cache.path).to start_with(
+            File.join(ENV.fetch('XDG_CACHE_HOME'), puid, 'rubocop_cache')
+          )
+
+          count = cache.path.scan(/rubocop_cache/).count
+          expect(count).to eq(1)
         end
       end
     end
@@ -402,6 +420,14 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
         it 'contains the root from RUBOCOP_CACHE_ROOT' do
           cacheroot = described_class.cache_root(config_store)
           expect(cacheroot).to eq(File.join('/tmp/cache-from-env', 'rubocop_cache'))
+        end
+
+        it 'contains the root in path only once' do
+          cache = described_class.new(file, team, options, config_store)
+          expect(cache.path).to start_with(File.join('/tmp/cache-from-env', 'rubocop_cache'))
+
+          count = cache.path.scan(/rubocop_cache/).count
+          expect(count).to eq(1)
         end
       end
     end


### PR DESCRIPTION
Fixes #10766. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
