### PR TITLE
Make `Metrics/BlockNesting` aware of numbered parameter

### DIFF
--- a/changelog/new_make_metrics_block_nesting_aware_of_numbered_parameter.md
+++ b/changelog/new_make_metrics_block_nesting_aware_of_numbered_parameter.md
@@ -1,0 +1,1 @@
+* [#11750](https://github.com/rubocop/rubocop/pull/11750): Make `Metrics/BlockNesting` aware of numbered parameter. ([@koic][])

--- a/lib/rubocop/cop/metrics/block_nesting.rb
+++ b/lib/rubocop/cop/metrics/block_nesting.rb
@@ -44,7 +44,7 @@ module RuboCop
         def consider_node?(node)
           return true if NESTING_BLOCKS.include?(node.type)
 
-          count_blocks? && node.block_type?
+          count_blocks? && (node.block_type? || node.numblock_type?)
         end
 
         def message(max)

--- a/spec/rubocop/cop/metrics/block_nesting_spec.rb
+++ b/spec/rubocop/cop/metrics/block_nesting_spec.rb
@@ -227,6 +227,30 @@ RSpec.describe RuboCop::Cop::Metrics::BlockNesting, :config do
         end
       RUBY
     end
+
+    context 'when numbered parameter', :ruby27 do
+      it 'accepts nested multiline blocks' do
+        expect_no_offenses(<<~RUBY)
+          if a
+            if b
+              [1, 2].each do
+                puts _1
+              end
+            end
+          end
+        RUBY
+      end
+
+      it 'accepts nested inline blocks' do
+        expect_no_offenses(<<~RUBY)
+          if a
+            if b
+              [1, 2].each { puts _1 }
+            end
+          end
+        RUBY
+      end
+    end
   end
 
   context 'when CountBlocks is true' do
@@ -257,6 +281,36 @@ RSpec.describe RuboCop::Cop::Metrics::BlockNesting, :config do
             end
           end
         RUBY
+      end
+    end
+
+    context 'when numbered parameter', :ruby27 do
+      context 'nested multiline block' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            if a
+              if b
+                [1, 2].each do
+                ^^^^^^^^^^^^^^ Avoid more than 2 levels of block nesting.
+                  puts _1
+                end
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'nested inline block' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            if a
+              if b
+                [1, 2].each { puts _1 }
+                ^^^^^^^^^^^^^^^^^^^^^^^ Avoid more than 2 levels of block nesting.
+              end
+            end
+          RUBY
+        end
       end
     end
   end


### PR DESCRIPTION
This PR makes `Metrics/BlockNesting` aware of numbered parameter.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
