### PR TITLE
Fix a false positive for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_false_positive_for_style_redundant_line_continuation.md
+++ b/changelog/fix_false_positive_for_style_redundant_line_continuation.md
@@ -1,0 +1,1 @@
+* [#11752](https://github.com/rubocop/rubocop/pull/11752): Fix a false positive for `Style/RedundantLineContinuation` when using line concatenation and calling a method without parentheses. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -109,9 +109,14 @@ module RuboCop
 
         def argument_newline?(node)
           node = node.children.first if node.root? && node.begin_type?
-          return if !node.send_type? || node.arguments.empty?
 
-          node.loc.selector.line != node.first_argument.loc.line
+          if argument_is_method?(node)
+            argument_newline?(node.first_argument)
+          else
+            return false unless method_call_with_arguments?(node)
+
+            node.loc.selector.line != node.first_argument.loc.line
+          end
         end
 
         def find_node_for_line(line)
@@ -132,6 +137,17 @@ module RuboCop
           else
             source_range.line == line
           end
+        end
+
+        def argument_is_method?(node)
+          return false unless node.send_type?
+          return false unless (first_argument = node.first_argument)
+
+          method_call_with_arguments?(first_argument)
+        end
+
+        def method_call_with_arguments?(node)
+          node.call_type? && !node.arguments.empty?
         end
 
         def start_with_arithmetic_operator?(source_line)

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -150,6 +150,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'does not register an offense when using line concatenation and calling a method without parentheses' do
+    expect_no_offenses(<<~'RUBY')
+      foo do_something \
+        argument
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation and safe navigation calling a method without parentheses' do
+    expect_no_offenses(<<~'RUBY')
+      foo obj&.do_something \
+        argument
+    RUBY
+  end
+
   it 'does not register an offense when line continuations with arithmetic operator' do
     expect_no_offenses(<<~'RUBY')
       1 \


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/11694#issuecomment-1493936758

This PR fixes a false positive for `Style/RedundantLineContinuation` when using line concatenation and calling a method without parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
