### PR TITLE
Fix a method name for `Style/RedundantLineContinuation`

### DIFF
--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -88,7 +88,7 @@ module RuboCop
         def require_line_continuation?(range)
           !ends_with_backslash_without_comment?(range.source_line) ||
             string_concatenation?(range.source_line) ||
-            starts_with_plus_or_minus?(processed_source[range.line])
+            start_with_arithmetic_operator?(processed_source[range.line])
         end
 
         def ends_with_backslash_without_comment?(source_line)
@@ -133,7 +133,7 @@ module RuboCop
           end
         end
 
-        def starts_with_plus_or_minus?(source_line)
+        def start_with_arithmetic_operator?(source_line)
           %r{\A\s*[+\-*/%]}.match?(source_line)
         end
       end


### PR DESCRIPTION
This PR is a follow-up of #11694.
Wrong method name was used in the cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
