### PR TITLE
[Fix #11758] Fix a false positive for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_a_false_positive_for_redundant_line_continuation.md
+++ b/changelog/fix_a_false_positive_for_redundant_line_continuation.md
@@ -1,0 +1,1 @@
+* [#11758](https://github.com/rubocop/rubocop/issues/11758): Fix a false positive for `Style/RedundantLineContinuation` when line continuations for string. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -134,6 +134,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'does not register an offense when line continuations for double quoted string' do
+    expect_no_offenses(<<~'RUBY')
+      foo = "foo \
+        bar"
+    RUBY
+  end
+
+  it 'does not register an offense when line continuations for single quoted string' do
+    expect_no_offenses(<<~'RUBY')
+      foo = 'foo \
+        bar'
+    RUBY
+  end
+
   it 'does not register an offense when line continuations inside comment' do
     expect_no_offenses(<<~'RUBY')
       # foo \


### PR DESCRIPTION
Fixes #11758.

This PR fixes a false positive for `Style/RedundantLineContinuation` when line continuations for string.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
