### PR TITLE
Style/GuardClause could prevent useless else after multiline guard

### DIFF
--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -195,6 +195,31 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
     expect_no_corrections
   end
 
+  it 'registers an offense when using if / else with multiple lines' do
+    expect_offense(<<~RUBY)
+      def func
+        if something
+        ^^ Unnecessary 'else' after 'return'
+          work1
+          return work2
+        else
+          work3
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def func
+        if something
+          work1
+          return work2
+        end
+
+        work3
+      end
+    RUBY
+  end
+
   it 'accepts a method which body does not end with if / unless' do
     expect_no_offenses(<<~RUBY)
       def func


### PR DESCRIPTION
eslint has `no-else-return` https://eslint.org/docs/latest/rules/no-else-return

I think Rubocop's `Style/GuardClause` rule could apply a similar style enforcement

---

I have committed a failing test to exemplify what I envision, and will open this PR as Draft. I would like to know if maintainers would support such functionality before I spend the time implementing it.

Thanks!