### PR TITLE
[Fix #11762] Fix an incorrect autocorrect for `Style/ClassEqualityComparison`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_class_equality_comparison.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_class_equality_comparison.md
@@ -1,0 +1,1 @@
+* [#11762](https://github.com/rubocop/rubocop/issues/11762): Fix an incorrect autocorrect for `Style/ClassEqualityComparison`  when comparing a variable or return value for equality. ([@koic][])

--- a/spec/rubocop/cop/style/class_equality_comparison_spec.rb
+++ b/spec/rubocop/cop/style/class_equality_comparison_spec.rb
@@ -69,6 +69,43 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
         var.instance_of?(Date)
       RUBY
     end
+
+    it 'registers an offense and corrects when comparing local variable for equality' do
+      expect_offense(<<~RUBY)
+        class_name = 'Model'
+        var.class.name == class_name
+            ^^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_of?` instead of comparing classes.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense and corrects when comparing instance variable for equality' do
+      expect_offense(<<~RUBY)
+        var.class.name == @class_name
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_of?` instead of comparing classes.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense and corrects when comparing method call for equality' do
+      expect_offense(<<~RUBY)
+        var.class.name == class_name
+            ^^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_of?` instead of comparing classes.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense and corrects when comparing safe navigation method call for equality' do
+      expect_offense(<<~RUBY)
+        var.class.name == obj&.class_name
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_of?` instead of comparing classes.
+      RUBY
+
+      expect_no_corrections
+    end
   end
 
   context 'when using `Class#to_s`' do
@@ -205,8 +242,8 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
       expect_offense(<<~RUBY)
         module Foo
           def bar?(value)
-            bar.class.name == @class_name
-                ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(@class_name)` instead of comparing classes.
+            bar.class.name == Model
+                ^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Model)` instead of comparing classes.
           end
         end
       RUBY
@@ -214,7 +251,7 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
       expect_correction(<<~RUBY)
         module Foo
           def bar?(value)
-            bar.instance_of?(@class_name)
+            bar.instance_of?(Model)
           end
         end
       RUBY


### PR DESCRIPTION
Fixes #11762.

This PR fixes an incorrect autocorrect for `Style/ClassEqualityComparison` when comparing a variable or return value for equality.

when a variable or return value of a method is used, it cannot be suggested and safe autocorrected because the type is not known. So this PR tweaks the cop that doesn't suggest `instance_of` argument at those times and doesn't autocorrect. Anyway, detection is possible.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
