### PR TITLE
[Fix #11765] Fix an error for `Style/MultilineMethodSignature`

### DIFF
--- a/changelog/fix_an_error_for_style_multiline_method_signature.md
+++ b/changelog/fix_an_error_for_style_multiline_method_signature.md
@@ -1,0 +1,1 @@
+* [#11765](https://github.com/rubocop/rubocop/issues/11765): Fix an error for `Style/MultilineMethodSignature` when line break after `def` keyword. ([@koic][])

--- a/lib/rubocop/cop/style/multiline_method_signature.rb
+++ b/lib/rubocop/cop/style/multiline_method_signature.rb
@@ -28,14 +28,17 @@ module RuboCop
           return unless node.arguments?
           return if opening_line(node) == closing_line(node)
           return if correction_exceeds_max_line_length?(node)
+          return unless (begin_of_arguments = node.arguments.loc.begin)
 
-          add_offense(node) { |corrector| autocorrect(corrector, node) }
+          add_offense(node) do |corrector|
+            autocorrect(corrector, node, begin_of_arguments)
+          end
         end
         alias on_defs on_def
 
         private
 
-        def autocorrect(corrector, node)
+        def autocorrect(corrector, node, begin_of_arguments)
           arguments = node.arguments
           joined_arguments = arguments.map(&:source).join(', ')
           last_line_source_of_arguments = last_line_source_of_arguments(arguments)
@@ -47,7 +50,7 @@ module RuboCop
           end
 
           corrector.remove(arguments_range(node))
-          corrector.insert_after(arguments.loc.begin, joined_arguments)
+          corrector.insert_after(begin_of_arguments, joined_arguments)
         end
 
         def last_line_source_of_arguments(arguments)

--- a/spec/rubocop/cop/style/multiline_method_signature_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_signature_spec.rb
@@ -36,6 +36,23 @@ RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects when closing paren is on the following line' \
+         'and line break after `def` keyword' do
+        expect_offense(<<~RUBY)
+          def
+          ^^^ Avoid multi-line method signatures.
+          foo(bar
+              )
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def
+          foo(bar)
+          end
+        RUBY
+      end
+
       context 'when method signature is on a single line' do
         it 'does not register an offense for parameterized method' do
           expect_no_offenses(<<~RUBY)
@@ -50,6 +67,13 @@ RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
             end
           RUBY
         end
+      end
+
+      it 'does not register an offense when line break after `def` keyword' do
+        expect_no_offenses(<<~RUBY)
+          def
+          method_name arg; end
+        RUBY
       end
     end
 


### PR DESCRIPTION
Fixes #11765.

This PR fixes an error for `Style/MultilineMethodSignature` when line break after `def` keyword.

It seems preferable that the following cases can be detected by a new different cop:

```ruby
def
method_name arg; end
```

This is probably not a common line break, the new cop will be able to handle `class`, `module`, class method definitions, and others as well.
And this `Style/MultilineMethodSignature` cop is disabled by default, but I have a feeling that the new cop can be enabled by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
