### PR TITLE
Remove redundant `SafeAutoCorrect: false`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3743,7 +3743,6 @@ Style/FileEmpty:
                  Prefer to use `File.empty?('path/to/file')` when checking if a file is empty.
   Enabled: pending
   Safe: false
-  SafeAutoCorrect: false
   VersionAdded: '1.48'
 
 Style/FileRead:
@@ -4571,11 +4570,10 @@ Style/NumericPredicate:
                  Checks for the use of predicate- or comparison methods for
                  numeric comparisons.
   StyleGuide: '#predicate-methods'
-  Safe: false
   # This will change to a new method call which isn't guaranteed to be on the
   # object. Switching these methods has to be done with knowledge of the types
   # of the variables which rubocop doesn't have.
-  SafeAutoCorrect: false
+  Safe: false
   Enabled: true
   VersionAdded: '0.42'
   VersionChanged: '0.59'

--- a/lib/rubocop/cop/style/file_empty.rb
+++ b/lib/rubocop/cop/style/file_empty.rb
@@ -6,9 +6,9 @@ module RuboCop
       # Prefer to use `File.empty?('path/to/file')` when checking if a file is empty.
       #
       # @safety
-      #   This cop's autocorrection is unsafe it because `File.size`, `File.read`,
-      #   and `File.binread` raise `ENOENT` exception when there is no file
-      #   corresponding to the path, while `File.empty?` does not raise an exception.
+      #   This cop is unsafe, because `File.size`, `File.read`, and `File.binread`
+      #   raise `ENOENT` exception when there is no file corresponding to the path,
+      #   while `File.empty?` does not raise an exception.
       #
       # @example
       #   # bad


### PR DESCRIPTION
This PR remove `SafeAutoCorrect: false` from `Style/FileEmpty`, `Style/NumericPredicate` and update the documentation.
It seems that other cops also appear to be choosing one or the other, so I thought it would be best to set only one of them to false for this cop. WDYT?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
