### PR TITLE
Make `Style/ClassStructure` aware of singleton class

### DIFF
--- a/changelog/new_make_layout_class_structure_aware_of_singleton_class.md
+++ b/changelog/new_make_layout_class_structure_aware_of_singleton_class.md
@@ -1,0 +1,1 @@
+* [#11773](https://github.com/rubocop/rubocop/pull/11773): Make `Layout/ClassStructure` aware of singleton class. ([@koic][])

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -23,6 +23,14 @@ module RuboCop
     class << self
       include FileFinder
 
+      PENDING_BANNER = <<~BANNER
+        The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.
+
+        Please also note that you can opt-in to new cops by default by adding this to your config:
+          AllCops:
+            NewCops: enable
+      BANNER
+
       attr_accessor :debug, :ignore_parent_exclusion, :disable_pending_cops, :enable_pending_cops,
                     :ignore_unrecognized_cops
       attr_writer :default_configuration
@@ -164,14 +172,6 @@ module RuboCop
 
         ConfigFinder.project_root
       end
-
-      PENDING_BANNER = <<~BANNER
-        The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.
-
-        Please also note that you can opt-in to new cops by default by adding this to your config:
-          AllCops:
-            NewCops: enable
-      BANNER
 
       def warn_on_pending_cops(pending_cops)
         warn Rainbow(PENDING_BANNER).yellow

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -159,6 +159,7 @@ module RuboCop
             previous = index
           end
         end
+        alias on_sclass on_class
 
         private
 

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -545,4 +545,27 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
       RUBY
     end
   end
+
+  context 'when singleton class' do
+    context 'simple example' do
+      specify do
+        expect_offense <<~RUBY
+          class << self
+            CONST = 'wrong place'
+            include AnotherModule
+            ^^^^^^^^^^^^^^^^^^^^^ `module_inclusion` is supposed to appear before `constants`.
+            extend SomeModule
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class << self
+            include AnotherModule
+            extend SomeModule
+            CONST = 'wrong place'
+          end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
It is necessary to consider how to handle module better, but singleton class (`class << self`) can be handled in the same way as class. Because they are both `class`.

Also this PR fixes the following new offense:

```console
$ bundle exec rubocop
(snip)

Offenses:

lib/rubocop/config_loader.rb:168:7: C: [Correctable] Layout/ClassStructure: constants is supposed to appear before public_methods.
      PENDING_BANNER = <<~BANNER
      ^^^^^^^^^^^^^^^^^^^^^^^^^^

1481 files inspected, 1 offense detected, 1 offe
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
