### PR TITLE
Make `Style/TrailingBodyOnClass` aware of singleton class

### DIFF
--- a/changelog/new_make_style_trailing_body_on_class_aware_of_singleton_class.md
+++ b/changelog/new_make_style_trailing_body_on_class_aware_of_singleton_class.md
@@ -1,0 +1,1 @@
+* [#11775](https://github.com/rubocop/rubocop/pull/11775): Make `Style/TrailingBodyOnClass` aware of singleton class. ([@koic][])

--- a/lib/rubocop/cop/style/trailing_body_on_class.rb
+++ b/lib/rubocop/cop/style/trailing_body_on_class.rb
@@ -34,6 +34,7 @@ module RuboCop
             )
           end
         end
+        alias on_sclass on_class
       end
     end
   end

--- a/spec/rubocop/cop/style/trailing_body_on_class_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_class_spec.rb
@@ -35,6 +35,26 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnClass, :config do
     RUBY
   end
 
+  it 'registers an offense when body trails after singleton class definition' do
+    expect_offense(<<~RUBY)
+      class << self; body
+                     ^^^^ Place the first line of class body on its own line.
+      end
+      class << self; def bar; end
+                     ^^^^^^^^^^^^ Place the first line of class body on its own line.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class << self#{trailing_whitespace}
+        body
+      end
+      class << self#{trailing_whitespace}
+        def bar; end
+      end
+    RUBY
+  end
+
   it 'registers offense with multi-line class' do
     expect_offense(<<~RUBY)
       class Foo; body


### PR DESCRIPTION
This PR makes `Style/TrailingBodyOnClass` aware of singleton class. So, singleton class can be handled in the same way as class.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
