### PR TITLE
Make `Metrics/ClassLength` aware of singleton class

### DIFF
--- a/changelog/new_make_metrics_class_length_aware_of_singleton_class.md
+++ b/changelog/new_make_metrics_class_length_aware_of_singleton_class.md
@@ -1,0 +1,1 @@
+* [#11776](https://github.com/rubocop/rubocop/pull/11776): Make `Metrics/ClassLength` aware of singleton class. ([@koic][])

--- a/lib/rubocop/cop/metrics/class_length.rb
+++ b/lib/rubocop/cop/metrics/class_length.rb
@@ -42,6 +42,7 @@ module RuboCop
         def on_class(node)
           check_code_length(node)
         end
+        alias on_sclass on_class
 
         def on_casgn(node)
           parent = node.parent

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -10,7 +10,7 @@ module RuboCop
           include Util
 
           FOLDABLE_TYPES = %i[array hash heredoc send csend].freeze
-          CLASSLIKE_TYPES = %i[class module].freeze
+          CLASSLIKE_TYPES = %i[class module sclass].freeze
           private_constant :FOLDABLE_TYPES, :CLASSLIKE_TYPES
 
           def initialize(node, processed_source, count_comments: false, foldable_types: [])

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -207,6 +207,34 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
     end
   end
 
+  context 'when singleton class' do
+    it 'rejects a class with more than 5 lines' do
+      expect_offense(<<~RUBY)
+        class << self
+        ^^^^^^^^^^^^^ Class has too many lines. [6/5]
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+
+    it 'accepts a class with 5 lines' do
+      expect_no_offenses(<<~RUBY)
+        class << self
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+        end
+      RUBY
+    end
+  end
+
   context 'when inspecting a class defined with Class.new' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
@@ -306,6 +306,19 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::CodeLengthCalculator do
         expect(length).to eq(2)
       end
 
+      it 'calculates singleton class length' do
+        source = parse_source(<<~RUBY)
+          class << self
+            a = 1
+            # a = 2
+            a = 3
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source).calculate
+        expect(length).to eq(2)
+      end
+
       it 'does not count blank lines' do
         source = parse_source(<<~RUBY)
           class Test


### PR DESCRIPTION
This PR makes `Metrics/ClassLength` aware of singleton class. It can detect singleton class length with the same matrix as normal class length.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
