### PR TITLE
Make `Lint/RedundantStringCoercion` aware of print method arguments

### DIFF
--- a/changelog/new_make_lint_redundant_string_coercion_aware_of_print_method_arguments.md
+++ b/changelog/new_make_lint_redundant_string_coercion_aware_of_print_method_arguments.md
@@ -1,0 +1,1 @@
+* [#11779](https://github.com/rubocop/rubocop/pull/11779): Make `Lint/RedundantStringCoercion` aware of print method arguments. ([@koic][])

--- a/spec/rubocop/cop/lint/redundant_string_coercion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_string_coercion_spec.rb
@@ -54,4 +54,88 @@ RSpec.describe RuboCop::Cop::Lint::RedundantStringCoercion, :config do
   it 'does not explode on empty interpolation' do
     expect_no_offenses('"this is #{} silly"')
   end
+
+  it 'registers an offense and corrects `to_s` in `print` arguments' do
+    expect_offense(<<~RUBY)
+      print first.to_s, second.to_s
+                  ^^^^ Redundant use of `Object#to_s` in `print`.
+                               ^^^^ Redundant use of `Object#to_s` in `print`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      print first, second
+    RUBY
+  end
+
+  it 'registers an offense and corrects `to_s` in `print` arguments without receiver' do
+    expect_offense(<<~RUBY)
+      print to_s, to_s
+            ^^^^ Use `self` instead of `Object#to_s` in `print`.
+                  ^^^^ Use `self` instead of `Object#to_s` in `print`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      print self, self
+    RUBY
+  end
+
+  it 'registers an offense and corrects `to_s` in `puts` arguments' do
+    expect_offense(<<~RUBY)
+      puts first.to_s, second.to_s
+                 ^^^^ Redundant use of `Object#to_s` in `puts`.
+                              ^^^^ Redundant use of `Object#to_s` in `puts`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      puts first, second
+    RUBY
+  end
+
+  it 'registers an offense and corrects `to_s` in `warn` arguments' do
+    expect_offense(<<~RUBY)
+      warn first.to_s, second.to_s
+                 ^^^^ Redundant use of `Object#to_s` in `warn`.
+                              ^^^^ Redundant use of `Object#to_s` in `warn`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      warn first, second
+    RUBY
+  end
+
+  it 'registers an offense and corrects `to_s` in `puts` arguments without receiver' do
+    expect_offense(<<~RUBY)
+      puts to_s, to_s
+           ^^^^ Use `self` instead of `Object#to_s` in `puts`.
+                 ^^^^ Use `self` instead of `Object#to_s` in `puts`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      puts self, self
+    RUBY
+  end
+
+  it 'does not register an offense when not using `to_s` in `print` arguments' do
+    expect_no_offenses(<<~RUBY)
+      print obj.do_something
+    RUBY
+  end
+
+  it 'does not register an offense when not using `to_s` in `puts` arguments' do
+    expect_no_offenses(<<~RUBY)
+      puts obj.do_something
+    RUBY
+  end
+
+  it 'does not register an offense when using `to_s` in `p` arguments' do
+    expect_no_offenses(<<~RUBY)
+      p first.to_s, second.to_s
+    RUBY
+  end
+
+  it 'does not register an offense when using `to_s` in `print` arguments with receiver' do
+    expect_no_offenses(<<~RUBY)
+      obj.print first.to_s, second.to_s
+    RUBY
+  end
 end

--- a/spec/rubocop/runner_formatter_invocation_spec.rb
+++ b/spec/rubocop/runner_formatter_invocation_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
         %i[started file_started file_finished finished output]
           .each do |message|
           allow(formatter).to receive(message) do
-            puts message.to_s unless message == :output
+            puts message unless message == :output
           end
         end
         formatter


### PR DESCRIPTION
This PR makes `Lint/RedundantStringCoercion` aware of print method arguments. The name of this cop is "RedundantStringCoercion", so it makes more sense to extend the feature than to provide a new cop I think.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
