### PR TITLE
[Fix #11787] Fix a false positive for `Lint/DuplicateMatchPattern`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_duplicate_match_pattern.md
+++ b/changelog/fix_a_false_positive_for_lint_duplicate_match_pattern.md
@@ -1,0 +1,1 @@
+* [#11787](https://github.com/rubocop/rubocop/issues/11787): Fix a false positive for `Lint/DuplicateMatchPattern` when repeated `in` patterns but different `if` guard is used. ([@koic][])

--- a/lib/rubocop/cop/lint/duplicate_match_pattern.rb
+++ b/lib/rubocop/cop/lint/duplicate_match_pattern.rb
@@ -71,6 +71,22 @@ module RuboCop
       #     second_method
       #   end
       #
+      #   # bad - repeated the same patterns and guard conditions
+      #   case x
+      #   in foo if bar
+      #     first_method
+      #   in foo if bar
+      #     second_method
+      #   end
+      #
+      #   # good
+      #   case x
+      #   in foo if bar
+      #     first_method
+      #   in foo if baz
+      #     second_method
+      #   end
+      #
       class DuplicateMatchPattern < Base
         extend TargetRubyVersion
 
@@ -90,11 +106,15 @@ module RuboCop
         private
 
         def pattern_identity(pattern)
-          if pattern.hash_pattern_type? || pattern.match_alt_type?
-            pattern.children.map(&:source).sort
-          else
-            pattern.source
-          end
+          pattern_source = if pattern.hash_pattern_type? || pattern.match_alt_type?
+                             pattern.children.map(&:source).sort
+                           else
+                             pattern.source
+                           end
+
+          return pattern_source unless (guard = pattern.parent.children[1])
+
+          pattern_source + guard.source
         end
       end
     end

--- a/spec/rubocop/cop/lint/duplicate_match_pattern_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_match_pattern_spec.rb
@@ -168,4 +168,50 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMatchPattern, :config, :ruby27 do
       end
     RUBY
   end
+
+  it 'register an offense for repeated `in` patterns and the same `if` guard is used' do
+    expect_offense(<<~RUBY)
+      case x
+      in foo if condition
+        first_method
+      in foo if condition
+         ^^^ Duplicate `in` pattern detected.
+        third_method
+      end
+    RUBY
+  end
+
+  it 'register an offense for repeated `in` patterns and the same `unless` guard is used' do
+    expect_offense(<<~RUBY)
+      case x
+      in foo unless condition
+        first_method
+      in foo unless condition
+         ^^^ Duplicate `in` pattern detected.
+        third_method
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for repeated `in` patterns but different `if` guard is used' do
+    expect_no_offenses(<<~RUBY)
+      case x
+      in foo if condition1
+        first_method
+      in foo if condition2
+        third_method
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for repeated `in` patterns but different `unless` guard is used' do
+    expect_no_offenses(<<~RUBY)
+      case x
+      in foo unless condition1
+        first_method
+      in foo unless condition2
+        third_method
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #11787

This PR fixes a false positive for `Lint/DuplicateMatchPattern` when repeated `in` patterns but different `if` guard is used.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
