### PR TITLE
Fix false negatives for `Style/ParallelAssignment`

### DIFF
--- a/changelog/fix_false_negatives_for_style_parallel_assignment.md
+++ b/changelog/fix_false_negatives_for_style_parallel_assignment.md
@@ -1,0 +1,1 @@
+* [#11789](https://github.com/rubocop/rubocop/pull/11789): Fix false negatives for `Style/ParallelAssignment` when Ruby 2.7+. ([@koic][])

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -531,7 +531,23 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
     RUBY
   end
 
-  it 'corrects when the expression uses a modifier rescue statement' do
+  it 'corrects when the expression uses a modifier rescue statement', :ruby26 do
+    expect_offense(<<~RUBY)
+      a, b = 1, 2 rescue foo
+      ^^^^^^^^^^^ Do not use parallel assignment.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        a = 1
+        b = 2
+      rescue
+        foo
+      end
+    RUBY
+  end
+
+  it 'corrects when the expression uses a modifier rescue statement', :ruby27 do
     expect_offense(<<~RUBY)
       a, b = 1, 2 rescue foo
       ^^^^^^^^^^^ Do not use parallel assignment.
@@ -587,8 +603,7 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
     RUBY
   end
 
-  it 'corrects when the expression uses a modifier rescue statement ' \
-     'as the only thing inside of a method' do
+  it 'corrects when the expression uses a modifier rescue statement as the only thing inside of a method', :ruby26 do
     expect_offense(<<~RUBY)
       def foo
         a, b = 1, 2 rescue foo
@@ -606,7 +621,47 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
     RUBY
   end
 
-  it 'corrects when the expression uses a modifier rescue statement inside of a method' do
+  it 'corrects when the expression uses a modifier rescue statement as the only thing inside of a method', :ruby27 do
+    expect_offense(<<~RUBY)
+      def foo
+        a, b = 1, 2 rescue foo
+        ^^^^^^^^^^^ Do not use parallel assignment.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        a = 1
+        b = 2
+      rescue
+        foo
+      end
+    RUBY
+  end
+
+  it 'corrects when the expression uses a modifier rescue statement inside of a method', :ruby26 do
+    expect_offense(<<~RUBY)
+      def foo
+        a, b = %w(1 2) rescue foo
+        ^^^^^^^^^^^^^^ Do not use parallel assignment.
+        something_else
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        begin
+          a = '1'
+          b = '2'
+        rescue
+          foo
+        end
+        something_else
+      end
+    RUBY
+  end
+
+  it 'corrects when the expression uses a modifier rescue statement inside of a method', :ruby27 do
     expect_offense(<<~RUBY)
       def foo
         a, b = %w(1 2) rescue foo
@@ -699,7 +754,23 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
       RUBY
     end
 
-    it 'works with rescue' do
+    it 'works with rescue', :ruby26 do
+      expect_offense(<<~RUBY)
+        a, b = 1, 2 rescue foo
+        ^^^^^^^^^^^ Do not use parallel assignment.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+           a = 1
+           b = 2
+        rescue
+           foo
+        end
+      RUBY
+    end
+
+    it 'works with rescue', :ruby27 do
       expect_offense(<<~RUBY)
         a, b = 1, 2 rescue foo
         ^^^^^^^^^^^ Do not use parallel assignment.


### PR DESCRIPTION
This PR fix false negatives for `Style/ParallelAssignment` when Ruby 2.7+. Because AST changed between Ruby 2.6 and Ruby 2.7 as follows:

```console
$ ruby-parse --26 -e "a, b = 1, 2 rescue foo"
(rescue
  (masgn
    (mlhs
      (lvasgn :a)
      (lvasgn :b))
    (array
      (int 1)
      (int 2)))
  (resbody nil nil
    (send nil :foo)) nil)
```

```console
$ ruby-parse --27 -e "a, b = 1, 2 rescue foo"
(masgn
  (mlhs
    (lvasgn :a)
    (lvasgn :b))
  (rescue
    (array
      (int 1)
      (int 2))
    (resbody nil nil
      (send nil :foo)) nil))
```

This PR makes `Style/ParallelAssignment` to handle both AST.

Refer: https://github.com/ruby/ruby/commit/53b3be5d58a9bf1efce229b3dce723f96e820c79

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
