### PR TITLE
Add spec for `Style/RescueModifier`

### DIFF
--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -18,10 +18,17 @@ RSpec.describe RuboCop::Cop::Style::RescueModifier, :config do
     RUBY
   end
 
-  it 'registers an offense for modifier rescue around parallel assignment' do
+  it 'registers an offense for modifier rescue around parallel assignment', :ruby26 do
     expect_offense(<<~RUBY)
       a, b = 1, 2 rescue nil
       ^^^^^^^^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
+    RUBY
+  end
+
+  it 'registers an offense for modifier rescue around parallel assignment', :ruby27 do
+    expect_offense(<<~RUBY)
+      a, b = 1, 2 rescue nil
+             ^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
     RUBY
   end
 


### PR DESCRIPTION
The following syntax changes in Ruby 2.7, so the offense highlight range of `Style/RescueModifier` was changed.
https://github.com/ruby/ruby/commit/53b3be5d58a9bf1efce229b3dce723f96e820c79

For the role of `Style/RescueModifier`, it seems reasonable to have different offense highlight ranges between Ruby 2.6 and 2.7 against these syntax. So just adding a test should be enough I think.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
