### PR TITLE
Drop Ruby 2.6 runtime support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,30 +40,6 @@ rubocop_steps: &rubocop_steps
         ruby -I lib -r bundler/setup -r rubocop -e 'exit 0'
 
 jobs:
-
-  # Ruby 2.6
-  ruby-2.6-spec:
-    docker:
-      - image: cimg/ruby:2.6
-    environment:
-      <<: *common_env
-    steps:
-      *spec_steps
-  ruby-2.6-ascii_spec:
-    docker:
-      - image: cimg/ruby:2.6
-    environment:
-      <<: *common_env
-    steps:
-      *ascii_spec_steps
-  ruby-2.6-rubocop:
-    docker:
-      - image: cimg/ruby:2.6
-    environment:
-      <<: *common_env
-    steps:
-      *rubocop_steps
-
   # Ruby 2.7
   ruby-2.7-spec:
     docker:
@@ -213,7 +189,7 @@ jobs:
       - run:
           name: Upload coverage results to Code Climate
           command: |
-            ./tmp/cc-test-reporter sum-coverage tmp/codeclimate.*.json --parts 5 --output tmp/codeclimate.total.json
+            ./tmp/cc-test-reporter sum-coverage tmp/codeclimate.*.json --parts 4 --output tmp/codeclimate.total.json
             ./tmp/cc-test-reporter upload-coverage --input tmp/codeclimate.total.json
 
   # Miscellaneous tasks
@@ -236,11 +212,6 @@ workflows:
     jobs:
       - documentation-checks
       - cc-setup
-      - ruby-2.6-spec:
-          requires:
-            - cc-setup
-      - ruby-2.6-ascii_spec
-      - ruby-2.6-rubocop
       - ruby-2.7-spec:
           requires:
             - cc-setup
@@ -269,7 +240,6 @@ workflows:
 
       - cc-upload-coverage:
           requires:
-            - ruby-2.6-spec
             - ruby-2.7-spec
             - ruby-3.0-spec
             - ruby-3.1-spec

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         # [ubuntu, macos, windows]
         os: [windows]
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', 'head']
+        ruby: ['2.7', '3.0', '3.1', '3.2', 'head']
         include:
           - os: windows
             ruby: mingw

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,6 @@ pull_request_rules:
       - label=auto-merge
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
-      - "status-success=windows 2.6"
       - "status-success=windows 2.7"
       - "status-success=windows 3.0"
       - "status-success=windows 3.1"
@@ -19,9 +18,6 @@ pull_request_rules:
       - "status-success=ci/circleci: jruby-9.2-ascii_spec"
       - "status-success=ci/circleci: jruby-9.2-rubocop"
       - "status-success=ci/circleci: jruby-9.2-spec"
-      - "status-success=ci/circleci: ruby-2.6-ascii_spec"
-      - "status-success=ci/circleci: ruby-2.6-rubocop"
-      - "status-success=ci/circleci: ruby-2.6-spec"
       - "status-success=ci/circleci: ruby-2.7-ascii_spec"
       - "status-success=ci/circleci: ruby-2.7-rubocop"
       - "status-success=ci/circleci: ruby-2.7-spec"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - 'tmp/**/*'
     - '.git/**/*'
     - 'bin/*'
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   SuggestExtensions: false
 
 Naming/PredicateName:

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ You can read a lot more about RuboCop in its [official docs](https://docs.ruboco
 
 RuboCop officially supports the following runtime Ruby implementations:
 
-* MRI 2.6+
-* JRuby 9.3+
+* MRI 2.7+
+* JRuby 9.4+
 
 Targets Ruby 2.0+ code analysis.
 

--- a/changelog/change_drop_ruby_26.md
+++ b/changelog/change_drop_ruby_26.md
@@ -1,0 +1,1 @@
+* [#10791](https://github.com/rubocop/rubocop/pull/10791): **(Breaking)** Drop runtime support for Ruby 2.6 and JRuby 9.3 (CRuby 2.6 compatible). ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -140,7 +140,7 @@ AllCops:
   # or gems.locked file. (Although the Ruby version is specified in the Gemfile
   # or gems.rb file, RuboCop reads the final value from the lock file.) If the
   # Ruby version is still unresolved, RuboCop will use the oldest officially
-  # supported Ruby version (currently Ruby 2.6).
+  # supported Ruby version (currently Ruby 2.7).
   TargetRubyVersion: ~
   # Determines if a notification for extension libraries should be shown when
   # rubocop is run. Keys are the name of the extension, and values are an array

--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -4,8 +4,8 @@ RuboCop targets Ruby 2.0+ code analysis.footnote:[As defined by its reference im
 
 RuboCop officially runtime supports MRI (a.k.a. CRuby) and JRuby.
 
-- MRI 2.6+
-- JRuby 9.3+
+- MRI 2.7+
+- JRuby 9.4+
 
 The oldest supported JRuby version is derived from the oldest compatible MRI version.
 
@@ -14,7 +14,7 @@ NOTE: RuboCop might be working with other Ruby implementations as well, but it's
 == Support Matrix
 
 RuboCop generally aims to follow MRI's own support policy - meaning RuboCop would support all officially supported MRI releases.footnote:[Typically the last 3 releases.] To give people extra time for a smooth transition, we've customarily provided support for about one year after EOL of MRI version.
-This means that if Ruby 2.6 reaches its EOL in Spring 2022, it would be supported by RuboCop (at least) until Spring 2023.footnote:[At the core team's discretion this policy might be waived aside for MRI releases causing significant maintenance overhead.]
+This means that if Ruby 2.7 reaches its EOL in Spring 2023, it would be supported by RuboCop (at least) until Spring 2024.footnote:[At the core team's discretion this policy might be waived aside for MRI releases causing significant maintenance overhead.]
 
 The following table is the runtime support matrix.
 
@@ -28,7 +28,7 @@ The following table is the runtime support matrix.
 | 2.3 | 0.81
 | 2.4 | 1.12
 | 2.5 | 1.28
-| 2.6 | -
+| 2.6 | 1.50
 | 2.7 | -
 | 3.0 | -
 | 3.1 | -

--- a/lib/rubocop/config_obsoletion.rb
+++ b/lib/rubocop/config_obsoletion.rb
@@ -68,11 +68,11 @@ module RuboCop
     # Cop rules are keyed by the name of the original cop
     def load_cop_rules(rules)
       rules.flat_map do |rule_type, data|
-        data.map do |cop_name, configuration|
+        data.filter_map do |cop_name, configuration|
           next unless configuration # allow configurations to be disabled with `CopName: ~`
 
           COP_RULE_CLASSES[rule_type].new(@config, cop_name, configuration)
-        end.compact
+        end
       end
     end
 

--- a/lib/rubocop/cop/correctors/alignment_corrector.rb
+++ b/lib/rubocop/cop/correctors/alignment_corrector.rb
@@ -54,7 +54,7 @@ module RuboCop
         def inside_string_ranges(node)
           return [] unless node.is_a?(Parser::AST::Node)
 
-          node.each_node(:str, :dstr, :xstr).map { |n| inside_string_range(n) }.compact
+          node.each_node(:str, :dstr, :xstr).filter_map { |n| inside_string_range(n) }
         end
 
         def inside_string_range(node)

--- a/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
+++ b/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
@@ -59,12 +59,12 @@ module RuboCop
         def method_directives(node)
           comments = processed_source.ast_with_comments[node]
 
-          comments.map do |comment|
+          comments.filter_map do |comment|
             match = comment.text.match(REGEXP)
             next unless match
 
             { node: comment, method_name: match[:method_name], args: match[:args] }
-          end.compact
+          end
         end
 
         def too_many_directives(node)

--- a/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
+++ b/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
@@ -228,9 +228,9 @@ module RuboCop
         end
 
         def find_most_bottom_of_heredoc_end(arguments)
-          arguments.map do |argument|
+          arguments.filter_map do |argument|
             argument.loc.heredoc_end.end_pos if argument.loc.respond_to?(:heredoc_end)
-          end.compact.max
+          end.max
         end
 
         # Internal trailing comma helpers.

--- a/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
+++ b/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
@@ -65,13 +65,13 @@ module RuboCop
         def on_when(node)
           regexp_conditions = node.conditions.select(&:regexp_type?)
 
-          @valid_ref = regexp_conditions.map { |condition| check_regexp(condition) }.compact.max
+          @valid_ref = regexp_conditions.filter_map { |condition| check_regexp(condition) }.max
         end
 
         def on_in_pattern(node)
           regexp_patterns = regexp_patterns(node)
 
-          @valid_ref = regexp_patterns.map { |pattern| check_regexp(pattern) }.compact.max
+          @valid_ref = regexp_patterns.filter_map { |pattern| check_regexp(pattern) }.max
         end
 
         def on_nth_ref(node)

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -386,7 +386,7 @@ module RuboCop
         def allowed_statements?(branches)
           return false unless branches.all?
 
-          statements = branches.map { |branch| tail(branch) }.compact
+          statements = branches.filter_map { |branch| tail(branch) }
 
           lhs_all_match?(statements) && statements.none?(&:masgn_type?) &&
             assignment_types_match?(*statements)

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -93,7 +93,7 @@ module RuboCop
         def contains_delimiter?(node, delimiters)
           delimiters_regexp = Regexp.union(delimiters)
 
-          node.children.map { |n| string_source(n) }.compact.any?(delimiters_regexp)
+          node.children.filter_map { |n| string_source(n) }.any?(delimiters_regexp)
         end
 
         def string_source(node)

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -234,9 +234,9 @@ module RuboCop
         end
 
         def matching_styles(global)
-          STYLE_VARS_MAP.map do |style, vars|
+          STYLE_VARS_MAP.filter_map do |style, vars|
             style if vars.values.flatten(1).include? global
-          end.compact
+          end
         end
 
         def english_name_replacement(preferred_name, node)

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -112,7 +112,7 @@ module RuboCop
       end
 
       def external_dependency_checksum
-        keys = cops.map(&:external_dependency_checksum).compact
+        keys = cops.filter_map(&:external_dependency_checksum)
         Digest::SHA1.hexdigest(keys.join)
       end
 

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -6,7 +6,7 @@ require 'tempfile'
 module CopHelper
   extend RSpec::SharedContext
 
-  let(:ruby_version) { 2.6 }
+  let(:ruby_version) { RuboCop::TargetRuby::DEFAULT_VERSION }
   let(:rails_version) { false }
 
   def inspect_source(source, file = nil)

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -5,7 +5,7 @@ module RuboCop
   # @api private
   class TargetRuby
     KNOWN_RUBIES = [2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3].freeze
-    DEFAULT_VERSION = 2.6
+    DEFAULT_VERSION = 2.7
 
     OBSOLETE_RUBIES = {
       1.9 => '0.41',
@@ -14,7 +14,8 @@ module RuboCop
       2.2 => '0.68',
       2.3 => '0.81',
       2.4 => '1.12',
-      2.5 => '1.28'
+      2.5 => '1.28',
+      2.6 => '1.50'
     }.freeze
     private_constant :KNOWN_RUBIES, :OBSOLETE_RUBIES
 

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -43,7 +43,7 @@ module RuboCop
         env.config_store.unvalidated.for_pwd.loaded_features.sort
       end
 
-      features.map do |loaded_feature|
+      features.filter_map do |loaded_feature|
         next unless (match = loaded_feature.match(/rubocop-(?<feature>.*)/))
 
         # Get the expected name of the folder containing the extension code.
@@ -61,7 +61,7 @@ module RuboCop
         next unless (feature_version = feature_version(feature))
 
         "  - #{loaded_feature} #{feature_version}"
-      end.compact
+      end
     end
 
     # Returns feature version in one of two ways:

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.name = 'rubocop'
   s.version = RuboCop::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
   s.description = <<-DESCRIPTION
     RuboCop is a Ruby code style checking and code formatting tool.

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -169,13 +169,13 @@ RSpec.describe 'RuboCop Project', type: :feature do
 
       describe 'link to related issue' do
         let(:issues) do
-          entries.map do |entry|
+          entries.filter_map do |entry|
             entry.match(%r{
               (?<=^\*\s)
               \[(?<ref>(?:(?<repo>rubocop/[a-z_-]+)?\#(?<number>\d+))|.*)\]
               \((?<url>[^)]+)\)
             }x)
-          end.compact
+          end
         end
 
         it 'has a reference' do

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -763,7 +763,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
   it 'corrects Style/Next and Style/SafeNavigation offenses' do
     create_file('.rubocop.yml', <<~YAML)
       AllCops:
-        TargetRubyVersion: 2.6
+        TargetRubyVersion: 2.7
     YAML
     source = <<~RUBY
       until x
@@ -1696,7 +1696,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
     create_file('.rubocop.yml', <<~YAML)
       AllCops:
-        TargetRubyVersion: 2.6
+        TargetRubyVersion: 2.7
       Style/Semicolon:
         AutoCorrect: false
     YAML
@@ -1729,7 +1729,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
     create_file('.rubocop.yml', <<~YAML)
       AllCops:
-        TargetRubyVersion: 2.6
+        TargetRubyVersion: 2.7
     YAML
     create_file('example.rb', src)
     exit_status = cli.run(%w[-a -f simple --only Lint/BooleanSymbol,Lint/PercentStringArray])

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect($stderr.string).to eq ''
     expect($stdout.string)
       .to eq(["#{abs('example.rb')}:3:1: F: Lint/Syntax: unexpected " \
-              'token $end (Using Ruby 2.6 parser; configure using ' \
+              'token $end (Using Ruby 2.7 parser; configure using ' \
               '`TargetRubyVersion` parameter, under `AllCops`)',
               ''].join("\n"))
   end
@@ -1058,7 +1058,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       create_file('file.rb', 'x=0') # Included by default
       create_file('example', 'x=0')
       create_file('regexp', 'x=0')
-      create_file('vendor/bundle/ruby/2.6.0/gems/backports-3.6.8/.irbrc', 'x=0')
+      create_file('vendor/bundle/ruby/2.7.0/gems/backports-3.6.8/.irbrc', 'x=0')
       create_file('.dot1/file.rb', 'x=0') # Hidden but explicitly included
       create_file('.dot2/file.rb', 'x=0') # Hidden, excluded by default
       create_file('.dot3/file.rake', 'x=0') # Hidden, not included by wildcard

--- a/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
+++ b/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
     expect_offense(<<~RUBY, 'bar.gemspec')
       Gem::Specification.new do |spec|
         spec.required_ruby_version = ''
-                                     ^^ `required_ruby_version` and `TargetRubyVersion` (2.6, which may be specified in .rubocop.yml) should be equal.
+                                     ^^ `required_ruby_version` and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
       end
     RUBY
   end
@@ -180,7 +180,7 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
     expect_offense(<<~RUBY, 'bar.gemspec')
       Gem::Specification.new do |spec|
         spec.required_ruby_version = []
-                                     ^^ `required_ruby_version` and `TargetRubyVersion` (2.6, which may be specified in .rubocop.yml) should be equal.
+                                     ^^ `required_ruby_version` and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
       end
     RUBY
   end

--- a/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
+++ b/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference, :config do
+# Run test with Ruby 2.6 because this cop cannot handle invalid syntax in Ruby 2.7+.
+RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference, :config, :ruby26 do
   describe 'circular argument references in ordinal arguments' do
     context 'when the method contains a circular argument reference' do
       it 'registers an offense' do

--- a/spec/rubocop/cop/lint/syntax_spec.rb
+++ b/spec/rubocop/cop/lint/syntax_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::Lint::Syntax, :config do
         expect(offenses.size).to eq(1)
         message = <<~MESSAGE.chomp
           unexpected token $end
-          (Using Ruby 2.6 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
+          (Using Ruby 2.7 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
         MESSAGE
         offense = offenses.first
         expect(offense.message).to eq(message)
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::Lint::Syntax, :config do
           expect(offenses.size).to eq(1)
           message = <<~MESSAGE.chomp
             Lint/Syntax: unexpected token $end
-            (Using Ruby 2.6 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
+            (Using Ruby 2.7 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
           MESSAGE
           offense = offenses.first
           expect(offense.message).to eq(message)
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::Lint::Syntax, :config do
           expect(offenses.size).to eq(1)
           message = <<~MESSAGE.chomp
             unexpected token $end
-            (Using Ruby 2.6 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
+            (Using Ruby 2.7 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
           MESSAGE
           offense = offenses.first
           expect(offense.message).to eq(message)

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -325,13 +325,13 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
               <<-HEREDOC
                 Gem::Specification.new do |s|
                   s.name = 'test'
-                  s.required_ruby_version = '> 2.6.8'
+                  s.required_ruby_version = '> 2.7.8'
                   s.licenses = ['MIT']
                 end
               HEREDOC
 
             create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 2.6
+            expect(target_ruby.version).to eq 2.7
           end
 
           it 'sets target_ruby from approximate version' do
@@ -339,13 +339,13 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
               <<-HEREDOC
                 Gem::Specification.new do |s|
                   s.name = 'test'
-                  s.required_ruby_version = '~> 2.6.0'
+                  s.required_ruby_version = '~> 2.7.0'
                   s.licenses = ['MIT']
                 end
               HEREDOC
 
             create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 2.6
+            expect(target_ruby.version).to eq 2.7
           end
         end
 
@@ -391,13 +391,13 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
               <<-HEREDOC
                 Gem::Specification.new do |s|
                   s.name = 'test'
-                  s.required_ruby_version = ['<=2.7.4', '>=2.6.5']
+                  s.required_ruby_version = ['<=3.0.4', '>=2.7.5']
                   s.licenses = ['MIT']
                 end
               HEREDOC
 
             create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 2.6
+            expect(target_ruby.version).to eq 2.7
           end
 
           it 'sets target_ruby from required_ruby_version with many requirements' do
@@ -405,13 +405,13 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
               <<-HEREDOC
                 Gem::Specification.new do |s|
                   s.name = 'test'
-                  s.required_ruby_version = ['<=3.0.0', '>2.5.8', '~>2.6.1']
+                  s.required_ruby_version = ['<=3.1.0', '>2.6.8', '~>2.7.1']
                   s.licenses = ['MIT']
                 end
               HEREDOC
 
             create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 2.6
+            expect(target_ruby.version).to eq 2.7
           end
         end
 

--- a/spec/rubocop/version_spec.rb
+++ b/spec/rubocop/version_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Version do
       before do
         create_file('.rubocop.yml', <<~YAML)
           AllCops:
-            TargetRubyVersion: 2.6
+            TargetRubyVersion: 2.7
         YAML
       end
 

--- a/tasks/spec_runner.rake
+++ b/tasks/spec_runner.rake
@@ -102,7 +102,7 @@ module RuboCop
 
         unless @failures.blank?
           puts "==> Failed Examples\n\n"
-          puts @completed.map(&:failed_examples).compact.sort.join("\n")
+          puts @completed.filter_map(&:failed_examples).sort.join("\n")
           puts
         end
 


### PR DESCRIPTION
This PR drops Ruby 2.6 runtime support. The next release will be the time to drop Ruby 2.6 support:

- https://www.ruby-lang.org/en/downloads/branches/
- https://docs.rubocop.org/rubocop/compatibility.html#support-matrix

CRuby 2.6 compatible JRuby 9.3 will be dropped and CRuby 2.7 compatible JRuby 9.4+ is required.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
