### PR TITLE
[Fix #11792] Fix an error for `Lint/DuplicateMatchPattern`

### DIFF
--- a/changelog/fix_an_error_for_lint_duplicate_match_pattern.md
+++ b/changelog/fix_an_error_for_lint_duplicate_match_pattern.md
@@ -1,0 +1,1 @@
+* [#11792](https://github.com/rubocop/rubocop/issues/11792): Fix an error for `Lint/DuplicateMatchPattern` when using hash pattern with `if` guard. ([@koic][])

--- a/lib/rubocop/cop/lint/duplicate_match_pattern.rb
+++ b/lib/rubocop/cop/lint/duplicate_match_pattern.rb
@@ -107,7 +107,7 @@ module RuboCop
 
         def pattern_identity(pattern)
           pattern_source = if pattern.hash_pattern_type? || pattern.match_alt_type?
-                             pattern.children.map(&:source).sort
+                             pattern.children.map(&:source).sort.to_s
                            else
                              pattern.source
                            end

--- a/spec/rubocop/cop/lint/duplicate_match_pattern_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_match_pattern_spec.rb
@@ -214,4 +214,12 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMatchPattern, :config, :ruby27 do
       end
     RUBY
   end
+
+  it 'does not crash when using hash pattern with `if` guard' do
+    expect_no_offenses(<<~RUBY)
+      case x
+      in { key: value } if condition
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #11792.

This PR fixes an error for `Lint/DuplicateMatchPattern` when using hash pattern with `if` guard.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
