### PR TITLE
Enable anonymous forwarding in Style/ArgumentsForwarding for Ruby 3.2+

### DIFF
--- a/changelog/new_enable_anonymous_forwarding_in_style_arguments_forwarding.md
+++ b/changelog/new_enable_anonymous_forwarding_in_style_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#11794](https://github.com/rubocop/rubocop/pull/11794): Add support to `Style/ArgumentsForwarding` for anonymous arg/kwarg forwarding in Ruby 3.2. ([@owst][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3072,6 +3072,7 @@ Style/ArgumentsForwarding:
   StyleGuide: '#arguments-forwarding'
   Enabled: pending
   AllowOnlyRestArgument: true
+  UseAnonymousForwarding: true
   VersionAdded: '1.1'
 
 Style/ArrayCoercion:

--- a/config/obsoletion.yml
+++ b/config/obsoletion.yml
@@ -224,6 +224,11 @@ changed_parameters:
       - AllowedMethods
       - AllowedPatterns
     severity: warning
+  - cops: Style/ArgumentsForwarding
+    parameters: AllowOnlyRestArgument
+    reason: "`AllowOnlyRestArgument` has no effect with TargetRubyVersion >= 3.2."
+    severity: warning
+    minimum_ruby_version: 3.2
 
 # Enforced styles that have been removed or replaced
 changed_enforced_styles:

--- a/lib/rubocop/config_obsoletion/parameter_rule.rb
+++ b/lib/rubocop/config_obsoletion/parameter_rule.rb
@@ -19,7 +19,7 @@ module RuboCop
       end
 
       def violated?
-        config[cop]&.key?(parameter)
+        applies_to_current_ruby_version? && config[cop]&.key?(parameter)
       end
 
       def warning?
@@ -27,6 +27,14 @@ module RuboCop
       end
 
       private
+
+      def applies_to_current_ruby_version?
+        minimum_ruby_version = metadata['minimum_ruby_version']
+
+        return true unless minimum_ruby_version
+
+        config.target_ruby_version >= minimum_ruby_version
+      end
 
       def alternative
         metadata['alternative']

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -10,8 +10,9 @@ module RuboCop
       #
       # In Ruby 3.2, anonymous args/kwargs forwarding has been added.
       #
-      # This cop identifies places where `use_args(*args)`/`use_kwargs(**kwargs)`
-      # can be replaced by `use_args(*)`/`use_kwargs(**)`.
+      # This cop also identifies places where `use_args(*args)`/`use_kwargs(**kwargs)` can be
+      # replaced by `use_args(*)`/`use_kwargs(**)`; if desired, this functionality can be disabled
+      # by setting UseAnonymousForwarding: false.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -81,7 +81,7 @@ module RuboCop
 
         FORWARDING_LVAR_TYPES = %i[splat kwsplat block_pass].freeze
 
-        FORWARDING_MSG = 'Use arguments forwarding.'
+        FORWARDING_MSG = 'Use shorthand syntax `...` for arguments forwarding.'
         ARGS_MSG = 'Use anonymous positional arguments forwarding.'
         KWARGS_MSG = 'Use anonymous keyword arguments forwarding.'
 

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -8,6 +8,11 @@ module RuboCop
       # This cop identifies places where `do_something(*args, &block)`
       # can be replaced by `do_something(...)`.
       #
+      # In Ruby 3.2, anonymous args/kwargs forwarding has been added.
+      #
+      # This cop identifies places where `use_args(*args)`/`use_kwargs(**kwargs)`
+      # can be replaced by `use_args(*)`/`use_kwargs(**)`.
+      #
       # @example
       #   # bad
       #   def foo(*args, &block)
@@ -24,7 +29,27 @@ module RuboCop
       #     bar(...)
       #   end
       #
-      # @example AllowOnlyRestArgument: true (default)
+      # @example UseAnonymousForwarding: true (default, only relevant for Ruby >= 3.2)
+      #   # bad
+      #   def foo(*args, **kwargs)
+      #     args_only(*args)
+      #     kwargs_only(**kwargs)
+      #   end
+      #
+      #   # good
+      #   def foo(*, **)
+      #     args_only(*)
+      #     kwargs_only(**)
+      #   end
+      #
+      # @example UseAnonymousForwarding: false (only relevant for Ruby >= 3.2)
+      #   # good
+      #   def foo(*args, **kwargs)
+      #     args_only(*args)
+      #     kwargs_only(**kwargs)
+      #   end
+      #
+      # @example AllowOnlyRestArgument: true (default, only relevant for Ruby < 3.2)
       #   # good
       #   def foo(*args)
       #     bar(*args)
@@ -34,7 +59,7 @@ module RuboCop
       #     bar(**kwargs)
       #   end
       #
-      # @example AllowOnlyRestArgument: false
+      # @example AllowOnlyRestArgument: false (only relevant for Ruby < 3.2)
       #   # bad
       #   # The following code can replace the arguments with `...`,
       #   # but it will change the behavior. Because `...` forwards block also.
@@ -53,77 +78,133 @@ module RuboCop
 
         minimum_target_ruby_version 2.7
 
-        MSG = 'Use arguments forwarding.'
+        FORWARDING_LVAR_TYPES = %i[splat kwsplat block_pass].freeze
 
-        # @!method use_rest_arguments?(node)
-        def_node_matcher :use_rest_arguments?, <<~PATTERN
-          (args ({restarg kwrestarg} $_) $...)
-        PATTERN
-
-        # @!method only_rest_arguments?(node, name)
-        def_node_matcher :only_rest_arguments?, <<~PATTERN
-          {
-            (send _ _ (splat (lvar %1)))
-            (send _ _ (hash (kwsplat (lvar %1))))
-          }
-        PATTERN
-
-        # @!method forwarding_method_arguments?(node, rest_name, block_name, kwargs_name)
-        def_node_matcher :forwarding_method_arguments?, <<~PATTERN
-          {
-            (send _ _
-              (splat (lvar %1))
-              (block-pass {(lvar %2) nil?}))
-            (send _ _
-              (splat (lvar %1))
-              (hash (kwsplat (lvar %3)))
-              (block-pass {(lvar %2) nil?}))
-          }
-        PATTERN
+        FORWARDING_MSG = 'Use arguments forwarding.'
+        ARGS_MSG = 'Use anonymous positional arguments forwarding.'
+        KWARGS_MSG = 'Use anonymous keyword arguments forwarding.'
 
         def on_def(node)
           return unless node.body
-          return unless (rest_args_name, args = use_rest_arguments?(node.arguments))
-          return if args.any?(&:default?)
 
-          node.each_descendant(:send) do |send_node|
-            kwargs_name, block_name = extract_argument_names_from(args)
+          forwardable_args = extract_forwardable_args(node.arguments)
 
-            next unless forwarding_method?(send_node, rest_args_name, kwargs_name, block_name) &&
-                        all_lvars_as_forwarding_method_arguments?(node, send_node)
+          send_classifications = classify_send_nodes(
+            node,
+            node.each_descendant(:send).to_a,
+            non_splat_or_block_pass_lvar_references(node.body),
+            forwardable_args
+          )
 
-            register_offense_to_forwarding_method_arguments(send_node)
-            register_offense_to_method_definition_arguments(node)
+          return if send_classifications.empty?
+
+          if only_forwards_all?(send_classifications)
+            add_forward_all_offenses(node, send_classifications)
+          elsif target_ruby_version >= 3.2
+            add_post_ruby_32_offenses(node, send_classifications, forwardable_args)
           end
         end
+
         alias on_defs on_def
 
         private
 
-        def extract_argument_names_from(args)
-          kwargs_name = args.first.source.delete('**') if args.first&.kwrestarg_type?
-          block_arg_name = args.last.source.delete('&') if args.last&.blockarg_type?
-
-          [kwargs_name, block_arg_name].map { |name| name&.to_sym }
+        def extract_forwardable_args(args)
+          [args.find(&:restarg_type?), args.find(&:kwrestarg_type?), args.find(&:blockarg_type?)]
         end
 
-        def forwarding_method?(node, rest_arg, kwargs, block_arg)
-          return only_rest_arguments?(node, rest_arg) unless allow_only_rest_arguments?
-
-          forwarding_method_arguments?(node, rest_arg, block_arg, kwargs)
+        def only_forwards_all?(send_classifications)
+          send_classifications.each_value.all? { |c, _, _| c == :all }
         end
 
-        def all_lvars_as_forwarding_method_arguments?(def_node, forwarding_method)
-          lvars = def_node.body.each_descendant(:lvar, :lvasgn)
+        def add_forward_all_offenses(node, send_classifications)
+          send_classifications.each_key do |send_node|
+            register_forward_all_offense_on_forwarding_method(send_node)
+          end
 
-          begin_pos = forwarding_method.source_range.begin_pos
-          end_pos = forwarding_method.source_range.end_pos
-
-          lvars.all? { |lvar| lvar.source_range.begin_pos.between?(begin_pos, end_pos) }
+          register_forward_all_offense_on_method_def(node)
         end
 
-        def register_offense_to_forwarding_method_arguments(forwarding_method)
-          add_offense(arguments_range(forwarding_method)) do |corrector|
+        def add_post_ruby_32_offenses(def_node, send_classifications, forwardable_args)
+          return unless use_anonymous_forwarding?
+
+          rest_arg, kwrest_arg, _block_arg = *forwardable_args
+
+          send_classifications.each do |send_node, (_c, forward_rest, forward_kwrest)|
+            if forward_rest
+              register_forward_args_offense(def_node.arguments, rest_arg)
+              register_forward_args_offense(send_node, forward_rest)
+            end
+
+            if forward_kwrest
+              register_forward_kwargs_offense(!forward_rest, def_node.arguments, kwrest_arg)
+              register_forward_kwargs_offense(!forward_rest, send_node, forward_kwrest)
+            end
+          end
+        end
+
+        def non_splat_or_block_pass_lvar_references(body)
+          body.each_descendant(:lvar, :lvasgn).filter_map do |lvar|
+            parent = lvar.parent
+
+            next if lvar.lvar_type? && FORWARDING_LVAR_TYPES.include?(parent.type)
+
+            lvar.children.first
+          end.uniq
+        end
+
+        def classify_send_nodes(def_node, send_nodes, referenced_lvars, forwardable_args)
+          send_nodes.to_h do |send_node|
+            classification_and_forwards = classification_and_forwards(
+              def_node,
+              send_node,
+              referenced_lvars,
+              forwardable_args
+            )
+
+            [send_node, classification_and_forwards]
+          end.compact
+        end
+
+        def classification_and_forwards(def_node, send_node, referenced_lvars, forwardable_args)
+          classifier = SendNodeClassifier.new(
+            def_node,
+            send_node,
+            referenced_lvars,
+            forwardable_args,
+            target_ruby_version: target_ruby_version,
+            allow_only_rest_arguments: allow_only_rest_arguments?
+          )
+
+          classification = classifier.classification
+
+          return unless classification
+
+          [classification, classifier.forwarded_rest_arg, classifier.forwarded_kwrest_arg]
+        end
+
+        def register_forward_args_offense(def_arguments_or_send, rest_arg_or_splat)
+          add_offense(rest_arg_or_splat, message: ARGS_MSG) do |corrector|
+            unless parentheses?(def_arguments_or_send)
+              add_parentheses(def_arguments_or_send, corrector)
+            end
+
+            corrector.replace(rest_arg_or_splat, '*')
+          end
+        end
+
+        def register_forward_kwargs_offense(add_parens, def_arguments_or_send, kwrest_arg_or_splat)
+          add_offense(kwrest_arg_or_splat, message: KWARGS_MSG) do |corrector|
+            if add_parens && !parentheses?(def_arguments_or_send)
+              add_parentheses(def_arguments_or_send, corrector)
+            end
+
+            corrector.replace(kwrest_arg_or_splat, '**')
+          end
+        end
+
+        def register_forward_all_offense_on_forwarding_method(forwarding_method)
+          add_offense(arguments_range(forwarding_method), message: FORWARDING_MSG) do |corrector|
             begin_pos = forwarding_method.loc.selector&.end_pos || forwarding_method.loc.dot.end_pos
             range = range_between(begin_pos, forwarding_method.source_range.end_pos)
 
@@ -131,8 +212,8 @@ module RuboCop
           end
         end
 
-        def register_offense_to_method_definition_arguments(method_definition)
-          add_offense(arguments_range(method_definition)) do |corrector|
+        def register_forward_all_offense_on_method_def(method_definition)
+          add_offense(arguments_range(method_definition), message: FORWARDING_MSG) do |corrector|
             arguments_range = range_with_surrounding_space(
               method_definition.arguments.source_range, side: :left
             )
@@ -148,6 +229,97 @@ module RuboCop
 
         def allow_only_rest_arguments?
           cop_config.fetch('AllowOnlyRestArgument', true)
+        end
+
+        def use_anonymous_forwarding?
+          cop_config.fetch('UseAnonymousForwarding', false)
+        end
+
+        # Classifies send nodes for possible rest/kwrest/all (including block) forwarding.
+        class SendNodeClassifier
+          extend NodePattern::Macros
+
+          # @!method find_forwarded_rest_arg(node, rest_name)
+          def_node_search :find_forwarded_rest_arg, '(splat (lvar %1))'
+
+          # @!method find_forwarded_kwrest_arg(node, kwrest_name)
+          def_node_search :find_forwarded_kwrest_arg, '(kwsplat (lvar %1))'
+
+          # @!method find_forwarded_block_arg(node, block_name)
+          def_node_search :find_forwarded_block_arg, '(block_pass {(lvar %1) nil?})'
+
+          def initialize(def_node, send_node, referenced_lvars, forwardable_args, **config)
+            @def_node = def_node
+            @send_node = send_node
+            @referenced_lvars = referenced_lvars
+            @rest_arg, @kwrest_arg, @block_arg = *forwardable_args
+            @rest_arg_name, @kwrest_arg_name, @block_arg_name =
+              *forwardable_args.map { |a| a&.name }
+            @config = config
+          end
+
+          def forwarded_rest_arg
+            return nil if referenced_rest_arg?
+
+            find_forwarded_rest_arg(@send_node, @rest_arg_name).first
+          end
+
+          def forwarded_kwrest_arg
+            return nil if referenced_kwrest_arg?
+
+            find_forwarded_kwrest_arg(@send_node, @kwrest_arg_name).first
+          end
+
+          def forwarded_block_arg
+            return nil if referenced_block_arg?
+
+            find_forwarded_block_arg(@send_node, @block_arg_name).first
+          end
+
+          def classification
+            return nil unless forwarded_rest_arg || forwarded_kwrest_arg
+
+            if referenced_none? && (forwarded_exactly_all? || pre_ruby_32_allow_forward_all?)
+              :all
+            elsif target_ruby_version >= 3.2
+              :rest_or_kwrest
+            end
+          end
+
+          private
+
+          def referenced_rest_arg?
+            @referenced_lvars.include?(@rest_arg_name)
+          end
+
+          def referenced_kwrest_arg?
+            @referenced_lvars.include?(@kwrest_arg_name)
+          end
+
+          def referenced_block_arg?
+            @referenced_lvars.include?(@block_arg_name)
+          end
+
+          def referenced_none?
+            !(referenced_rest_arg? || referenced_kwrest_arg? || referenced_block_arg?)
+          end
+
+          def forwarded_exactly_all?
+            @send_node.arguments.size == 3 &&
+              forwarded_rest_arg &&
+              forwarded_kwrest_arg &&
+              forwarded_block_arg
+          end
+
+          def target_ruby_version
+            @config.fetch(:target_ruby_version)
+          end
+
+          def pre_ruby_32_allow_forward_all?
+            target_ruby_version < 3.2 &&
+              @def_node.arguments.none?(&:default?) &&
+              (@block_arg ? forwarded_block_arg : !@config.fetch(:allow_only_rest_arguments))
+          end
         end
       end
     end

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -82,8 +82,8 @@ module RuboCop
         FORWARDING_LVAR_TYPES = %i[splat kwsplat block_pass].freeze
 
         FORWARDING_MSG = 'Use shorthand syntax `...` for arguments forwarding.'
-        ARGS_MSG = 'Use anonymous positional arguments forwarding.'
-        KWARGS_MSG = 'Use anonymous keyword arguments forwarding.'
+        ARGS_MSG = 'Use anonymous positional arguments forwarding: `*`.'
+        KWARGS_MSG = 'Use anonymous keyword arguments forwarding: `**`.'
 
         def on_def(node)
           return unless node.body

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -82,8 +82,8 @@ module RuboCop
         FORWARDING_LVAR_TYPES = %i[splat kwsplat block_pass].freeze
 
         FORWARDING_MSG = 'Use shorthand syntax `...` for arguments forwarding.'
-        ARGS_MSG = 'Use anonymous positional arguments forwarding: `*`.'
-        KWARGS_MSG = 'Use anonymous keyword arguments forwarding: `**`.'
+        ARGS_MSG = 'Use anonymous positional arguments forwarding (`*`).'
+        KWARGS_MSG = 'Use anonymous keyword arguments forwarding (`**`).'
 
         def on_def(node)
           return unless node.body

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -399,6 +399,45 @@ RSpec.describe RuboCop::ConfigObsoletion do
       end
     end
 
+    context 'when the configuration includes deprecated parameters for the TargetRubyVersion' do
+      let(:hash) do
+        {
+          'AllCops' => { 'TargetRubyVersion' => target_ruby_version },
+          **cop_config
+        }
+      end
+      let(:warning_message) { config_obsoletion.warnings.join("\n") }
+
+      context 'with Style/ArgumentsForwarding AllowOnlyRestArgument' do
+        let(:cop_config) do
+          { 'Style/ArgumentsForwarding' => { 'AllowOnlyRestArgument' => false } }
+        end
+
+        context 'with TargetRubyVersion 3.2' do
+          let(:target_ruby_version) { 3.2 }
+
+          it 'prints a warning message' do
+            expected_message = <<~OUTPUT.chomp
+              obsolete parameter `AllowOnlyRestArgument` (for `Style/ArgumentsForwarding`) found in example/.rubocop.yml
+              `AllowOnlyRestArgument` has no effect with TargetRubyVersion >= 3.2.
+            OUTPUT
+
+            expect { config_obsoletion.reject_obsolete! }.not_to raise_error
+            expect(warning_message).to eq(expected_message)
+          end
+        end
+
+        context 'with TargetRubyVersion 3.1' do
+          let(:target_ruby_version) { 3.1 }
+
+          it 'does not print a warning message' do
+            expect { config_obsoletion.reject_obsolete! }.not_to raise_error
+            expect(warning_message).to eq('')
+          end
+        end
+      end
+    end
+
     context 'when the configuration includes any deprecated parameters' do
       let(:hash) do
         {

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -44,6 +44,43 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
+    it 'registers an offense when using restarg, kwargs and block arg with another method call' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs, &block)
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+          bar(*args, **kwargs, &block)
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+          baz(1, 2, 3)
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(...)
+          bar(...)
+          baz(1, 2, 3)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using restarg, kwargs and block arg twice' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs, &block)
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+          bar(*args, **kwargs, &block)
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+          baz(*args, **kwargs, &block)
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(...)
+          bar(...)
+          baz(...)
+        end
+      RUBY
+    end
+
     it 'registers an offense when passing restarg and block arg in defs' do
       expect_offense(<<~RUBY)
         def self.foo(*args, &block)
@@ -314,6 +351,540 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
           bar(...)
         end
       RUBY
+    end
+  end
+
+  context 'TargetRubyVersion >= 3.2', :ruby32 do
+    it 'registers an offense when using restarg/kwrestarg forwarding without block arg' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs)
+                ^^^^^ Use anonymous positional arguments forwarding.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+          bar(*args, **kwargs)
+              ^^^^^ Use anonymous positional arguments forwarding.
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, **)
+          bar(*, **)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using separate arg/kwarg forwarding' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs)
+                ^^^^^ Use anonymous positional arguments forwarding.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+          args_only(*args)
+                    ^^^^^ Use anonymous positional arguments forwarding.
+          kwargs_only(**kwargs)
+                      ^^^^^^^^ Use anonymous keyword arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, **)
+          args_only(*)
+          kwargs_only(**)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using arg/kwarg forwarding with an additional arg/kwarg' do
+      expect_offense(<<~RUBY)
+        def foo(arg, *args, kwarg:, **kwargs)
+                     ^^^^^ Use anonymous positional arguments forwarding.
+                                    ^^^^^^^^ Use anonymous keyword arguments forwarding.
+          args_only(*args)
+                    ^^^^^ Use anonymous positional arguments forwarding.
+          kwargs_only(**kwargs)
+                      ^^^^^^^^ Use anonymous keyword arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(arg, *, kwarg:, **)
+          args_only(*)
+          kwargs_only(**)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using arg/kwarg forwarding with additional forwarded arg/kwarg' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs)
+                ^^^^^ Use anonymous positional arguments forwarding.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+          args_only(:another_arg, *args)
+                                  ^^^^^ Use anonymous positional arguments forwarding.
+          args_only(*args, :another_arg)
+                    ^^^^^ Use anonymous positional arguments forwarding.
+          kwargs_only(another: :kwarg, **kwargs)
+                                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+          kwargs_only(**kwargs, another: :kwarg)
+                      ^^^^^^^^ Use anonymous keyword arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, **)
+          args_only(:another_arg, *)
+          args_only(*, :another_arg)
+          kwargs_only(another: :kwarg, **)
+          kwargs_only(**, another: :kwarg)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using arg/kwarg forwarding when leading extra arg/kwarg' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs)
+                ^^^^^ Use anonymous positional arguments forwarding.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+          args_only(1, *args)
+                       ^^^^^ Use anonymous positional arguments forwarding.
+          kwargs_only(foo: :bar, **kwargs)
+                                 ^^^^^^^^ Use anonymous keyword arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, **)
+          args_only(1, *)
+          kwargs_only(foo: :bar, **)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using arg/kwarg forwarding with trailing extra arg/kwarg' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs)
+                ^^^^^ Use anonymous positional arguments forwarding.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+          args_only(*args, 1)
+                    ^^^^^ Use anonymous positional arguments forwarding.
+          kwargs_only(**kwargs, foo: :bar)
+                      ^^^^^^^^ Use anonymous keyword arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, **)
+          args_only(*, 1)
+          kwargs_only(**, foo: :bar)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using arg/kwarg forwarding with surrounding extra arg/kwarg' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs)
+                ^^^^^ Use anonymous positional arguments forwarding.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+          args_only(1, *args, 2)
+                       ^^^^^ Use anonymous positional arguments forwarding.
+          kwargs_only(foo: :bar, **kwargs, bar: :baz)
+                                 ^^^^^^^^ Use anonymous keyword arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, **)
+          args_only(1, *, 2)
+          kwargs_only(foo: :bar, **, bar: :baz)
+        end
+      RUBY
+    end
+
+    it 'registers an offense only for kwrestarg when using the restarg outside forwarding' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs)
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+          args.do_something
+          bar(*args, **kwargs)
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*args, **)
+          args.do_something
+          bar(*args, **)
+        end
+      RUBY
+    end
+
+    it 'registers an offense only for kwrestarg when restarg is overwritten' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs)
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+          args = new_args
+          bar(*args, **kwargs)
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*args, **)
+          args = new_args
+          bar(*args, **)
+        end
+      RUBY
+    end
+
+    it 'registers an offense only for restarg when using the kwrestarg outside forwarding' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs)
+                ^^^^^ Use anonymous positional arguments forwarding.
+          kwargs.do_something
+          bar(*args, **kwargs)
+              ^^^^^ Use anonymous positional arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, **kwargs)
+          kwargs.do_something
+          bar(*, **kwargs)
+        end
+      RUBY
+    end
+
+    it 'registers an offense only for restarg when kwrestarg is overwritten' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs)
+                ^^^^^ Use anonymous positional arguments forwarding.
+          kwargs = new_kwargs
+          bar(*args, **kwargs)
+              ^^^^^ Use anonymous positional arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, **kwargs)
+          kwargs = new_kwargs
+          bar(*, **kwargs)
+        end
+      RUBY
+    end
+
+    it 'registers an offense for restarg and kwrestarg when using block outside forwarding' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs, &block)
+                ^^^^^ Use anonymous positional arguments forwarding.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+          block = new_block
+          bar(*args, **kwargs, &block)
+              ^^^^^ Use anonymous positional arguments forwarding.
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, **, &block)
+          block = new_block
+          bar(*, **, &block)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using restarg and block arg' do
+      expect_offense(<<~RUBY)
+        def foo(*args, &block)
+                ^^^^^ Use anonymous positional arguments forwarding.
+          bar(*args, &block)
+              ^^^^^ Use anonymous positional arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, &block)
+          bar(*, &block)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using restarg, kwrestarg and block arg' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs, &block)
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+          bar(*args, **kwargs, &block)
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(...)
+          bar(...)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using restarg, kwargs and block arg with another method call' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs, &block)
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+          bar(*args, **kwargs, &block)
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+          baz(1, 2, 3)
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(...)
+          bar(...)
+          baz(1, 2, 3)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using restarg, kwargs and block arg twice' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs, &block)
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+          bar(*args, **kwargs, &block)
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+          baz(*args, **kwargs, &block)
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(...)
+          bar(...)
+          baz(...)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when passing restarg and block arg in defs' do
+      expect_offense(<<~RUBY)
+        def self.foo(*args, &block)
+                     ^^^^^ Use anonymous positional arguments forwarding.
+          bar(*args, &block)
+              ^^^^^ Use anonymous positional arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def self.foo(*, &block)
+          bar(*, &block)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when the parentheses of restarg arguments are omitted' do
+      expect_offense(<<~RUBY)
+        def foo *args
+                ^^^^^ Use anonymous positional arguments forwarding.
+          bar *args
+              ^^^^^ Use anonymous positional arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*)
+          bar(*)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when the parentheses of kwrestarg arguments are omitted' do
+      expect_offense(<<~RUBY)
+        def foo **kwargs
+                ^^^^^^^^ Use anonymous keyword arguments forwarding.
+          bar **kwargs
+              ^^^^^^^^ Use anonymous keyword arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(**)
+          bar(**)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when the parentheses of restarg/kwrestarg arguments are omitted' do
+      expect_offense(<<~RUBY)
+        def foo *args, **kwargs
+                ^^^^^ Use anonymous positional arguments forwarding.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+          bar *args, **kwargs
+              ^^^^^ Use anonymous positional arguments forwarding.
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, **)
+          bar(*, **)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when forwarding to a method in block' do
+      expect_offense(<<~RUBY)
+        def foo(*args, &block)
+                ^^^^^ Use anonymous positional arguments forwarding.
+          do_something do
+            bar(*args, &block)
+                ^^^^^ Use anonymous positional arguments forwarding.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, &block)
+          do_something do
+            bar(*, &block)
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when delegating' do
+      expect_offense(<<~RUBY)
+        def foo(*args, &block)
+                ^^^^^ Use anonymous positional arguments forwarding.
+          obj.bar(*args, &block)
+                  ^^^^^ Use anonymous positional arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, &block)
+          obj.bar(*, &block)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using restarg and block arg for `.()` call' do
+      expect_offense(<<~RUBY)
+        def foo(*args, &block)
+                ^^^^^ Use anonymous positional arguments forwarding.
+          bar.(*args, &block)
+               ^^^^^ Use anonymous positional arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, &block)
+          bar.(*, &block)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when only forwarding a restarg' do
+      expect_offense(<<~RUBY)
+        def foo(*args, &block)
+                ^^^^^ Use anonymous positional arguments forwarding.
+          bar(*args)
+              ^^^^^ Use anonymous positional arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, &block)
+          bar(*)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using arguments forwarding' do
+      expect_no_offenses(<<~RUBY)
+        def foo(...)
+          bar(...)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when different argument names are used' do
+      expect_no_offenses(<<~RUBY)
+        def foo(*args, &block)
+          bar(*arguments, &block)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when assigning the restarg outside forwarding method arguments' do
+      expect_no_offenses(<<~RUBY)
+        def foo(*args, &block)
+          var = args
+          foo(*args, &block)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when referencing the restarg outside forwarding method arguments' do
+      expect_no_offenses(<<~RUBY)
+        def foo(*args, &block)
+          args
+          foo(*args, &block)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when body of method definition is empty' do
+      expect_no_offenses(<<~RUBY)
+        def foo(*args, &block)
+        end
+      RUBY
+    end
+
+    context 'UseAnonymousForwarding: false' do
+      let(:cop_config) { { 'UseAnonymousForwarding' => false } }
+
+      it 'does not register an offense when using only rest arg' do
+        expect_no_offenses(<<~RUBY)
+          def foo(*args)
+            bar(*args)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using rest and block arg' do
+        expect_no_offenses(<<~RUBY)
+          def foo(*args, &block)
+            bar(*args, &block)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using only kwrest arg' do
+        expect_no_offenses(<<~RUBY)
+          def foo(**kwargs)
+            bar(**kwargs)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using kwrest and block arg' do
+        expect_no_offenses(<<~RUBY)
+          def foo(**kwargs, &block)
+            bar(**kwargs, &block)
+          end
+        RUBY
+      end
+
+      it 'registers an offense when using restarg, kwrestarg and block arg' do
+        expect_offense(<<~RUBY)
+          def foo(*args, **kwargs, &block)
+                  ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+            bar(*args, **kwargs, &block)
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(...)
+            bar(...)
+          end
+        RUBY
+      end
     end
   end
 end

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -358,11 +358,11 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg/kwrestarg forwarding without block arg' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
           bar(*args, **kwargs)
-              ^^^^^ Use anonymous positional arguments forwarding: `*`.
-                     ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+              ^^^^^ Use anonymous positional arguments forwarding (`*`).
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
         end
       RUBY
 
@@ -376,12 +376,12 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using separate arg/kwarg forwarding' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
           args_only(*args)
-                    ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                    ^^^^^ Use anonymous positional arguments forwarding (`*`).
           kwargs_only(**kwargs)
-                      ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                      ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
         end
       RUBY
 
@@ -396,12 +396,12 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using arg/kwarg forwarding with an additional arg/kwarg' do
       expect_offense(<<~RUBY)
         def foo(arg, *args, kwarg:, **kwargs)
-                     ^^^^^ Use anonymous positional arguments forwarding: `*`.
-                                    ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                     ^^^^^ Use anonymous positional arguments forwarding (`*`).
+                                    ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
           args_only(*args)
-                    ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                    ^^^^^ Use anonymous positional arguments forwarding (`*`).
           kwargs_only(**kwargs)
-                      ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                      ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
         end
       RUBY
 
@@ -416,16 +416,16 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using arg/kwarg forwarding with additional forwarded arg/kwarg' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
           args_only(:another_arg, *args)
-                                  ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                                  ^^^^^ Use anonymous positional arguments forwarding (`*`).
           args_only(*args, :another_arg)
-                    ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                    ^^^^^ Use anonymous positional arguments forwarding (`*`).
           kwargs_only(another: :kwarg, **kwargs)
-                                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                                       ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
           kwargs_only(**kwargs, another: :kwarg)
-                      ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                      ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
         end
       RUBY
 
@@ -442,12 +442,12 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using arg/kwarg forwarding when leading extra arg/kwarg' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
           args_only(1, *args)
-                       ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                       ^^^^^ Use anonymous positional arguments forwarding (`*`).
           kwargs_only(foo: :bar, **kwargs)
-                                 ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                                 ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
         end
       RUBY
 
@@ -462,12 +462,12 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using arg/kwarg forwarding with trailing extra arg/kwarg' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
           args_only(*args, 1)
-                    ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                    ^^^^^ Use anonymous positional arguments forwarding (`*`).
           kwargs_only(**kwargs, foo: :bar)
-                      ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                      ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
         end
       RUBY
 
@@ -482,12 +482,12 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using arg/kwarg forwarding with surrounding extra arg/kwarg' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
           args_only(1, *args, 2)
-                       ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                       ^^^^^ Use anonymous positional arguments forwarding (`*`).
           kwargs_only(foo: :bar, **kwargs, bar: :baz)
-                                 ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                                 ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
         end
       RUBY
 
@@ -502,10 +502,10 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense only for kwrestarg when using the restarg outside forwarding' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
           args.do_something
           bar(*args, **kwargs)
-                     ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
         end
       RUBY
 
@@ -520,10 +520,10 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense only for kwrestarg when restarg is overwritten' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
           args = new_args
           bar(*args, **kwargs)
-                     ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
         end
       RUBY
 
@@ -538,10 +538,10 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense only for restarg when using the kwrestarg outside forwarding' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
           kwargs.do_something
           bar(*args, **kwargs)
-              ^^^^^ Use anonymous positional arguments forwarding: `*`.
+              ^^^^^ Use anonymous positional arguments forwarding (`*`).
         end
       RUBY
 
@@ -556,10 +556,10 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense only for restarg when kwrestarg is overwritten' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
           kwargs = new_kwargs
           bar(*args, **kwargs)
-              ^^^^^ Use anonymous positional arguments forwarding: `*`.
+              ^^^^^ Use anonymous positional arguments forwarding (`*`).
         end
       RUBY
 
@@ -574,12 +574,12 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense for restarg and kwrestarg when using block outside forwarding' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs, &block)
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
           block = new_block
           bar(*args, **kwargs, &block)
-              ^^^^^ Use anonymous positional arguments forwarding: `*`.
-                     ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+              ^^^^^ Use anonymous positional arguments forwarding (`*`).
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
         end
       RUBY
 
@@ -594,9 +594,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg and block arg' do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
           bar(*args, &block)
-              ^^^^^ Use anonymous positional arguments forwarding: `*`.
+              ^^^^^ Use anonymous positional arguments forwarding (`*`).
         end
       RUBY
 
@@ -663,9 +663,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when passing restarg and block arg in defs' do
       expect_offense(<<~RUBY)
         def self.foo(*args, &block)
-                     ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                     ^^^^^ Use anonymous positional arguments forwarding (`*`).
           bar(*args, &block)
-              ^^^^^ Use anonymous positional arguments forwarding: `*`.
+              ^^^^^ Use anonymous positional arguments forwarding (`*`).
         end
       RUBY
 
@@ -679,9 +679,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when the parentheses of restarg arguments are omitted' do
       expect_offense(<<~RUBY)
         def foo *args
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
           bar *args
-              ^^^^^ Use anonymous positional arguments forwarding: `*`.
+              ^^^^^ Use anonymous positional arguments forwarding (`*`).
         end
       RUBY
 
@@ -695,9 +695,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when the parentheses of kwrestarg arguments are omitted' do
       expect_offense(<<~RUBY)
         def foo **kwargs
-                ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
           bar **kwargs
-              ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+              ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
         end
       RUBY
 
@@ -711,11 +711,11 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when the parentheses of restarg/kwrestarg arguments are omitted' do
       expect_offense(<<~RUBY)
         def foo *args, **kwargs
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
           bar *args, **kwargs
-              ^^^^^ Use anonymous positional arguments forwarding: `*`.
-                     ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
+              ^^^^^ Use anonymous positional arguments forwarding (`*`).
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
         end
       RUBY
 
@@ -729,10 +729,10 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when forwarding to a method in block' do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
           do_something do
             bar(*args, &block)
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
           end
         end
       RUBY
@@ -749,9 +749,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when delegating' do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
           obj.bar(*args, &block)
-                  ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                  ^^^^^ Use anonymous positional arguments forwarding (`*`).
         end
       RUBY
 
@@ -765,9 +765,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg and block arg for `.()` call' do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
           bar.(*args, &block)
-               ^^^^^ Use anonymous positional arguments forwarding: `*`.
+               ^^^^^ Use anonymous positional arguments forwarding (`*`).
         end
       RUBY
 
@@ -781,9 +781,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when only forwarding a restarg' do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
-                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
           bar(*args)
-              ^^^^^ Use anonymous positional arguments forwarding: `*`.
+              ^^^^^ Use anonymous positional arguments forwarding (`*`).
         end
       RUBY
 

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg and block arg' do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
-                ^^^^^^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           bar(*args, &block)
-              ^^^^^^^^^^^^^ Use arguments forwarding.
+              ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
         end
       RUBY
 
@@ -31,9 +31,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg, kwargs and block arg' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs, &block)
-                ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           bar(*args, **kwargs, &block)
-              ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
         end
       RUBY
 
@@ -47,9 +47,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg, kwargs and block arg with another method call' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs, &block)
-                ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           bar(*args, **kwargs, &block)
-              ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           baz(1, 2, 3)
         end
       RUBY
@@ -65,11 +65,11 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg, kwargs and block arg twice' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs, &block)
-                ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           bar(*args, **kwargs, &block)
-              ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           baz(*args, **kwargs, &block)
-              ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
         end
       RUBY
 
@@ -84,9 +84,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when passing restarg and block arg in defs' do
       expect_offense(<<~RUBY)
         def self.foo(*args, &block)
-                     ^^^^^^^^^^^^^ Use arguments forwarding.
+                     ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           bar(*args, &block)
-              ^^^^^^^^^^^^^ Use arguments forwarding.
+              ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
         end
       RUBY
 
@@ -100,9 +100,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when the parentheses of arguments are omitted' do
       expect_offense(<<~RUBY)
         def foo *args, &block
-                ^^^^^^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           bar *args, &block
-              ^^^^^^^^^^^^^ Use arguments forwarding.
+              ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
         end
       RUBY
 
@@ -119,10 +119,10 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when forwarding to a method in block' do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
-                ^^^^^^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           do_something do
             bar(*args, &block)
-                ^^^^^^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           end
         end
       RUBY
@@ -139,9 +139,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when delegating' do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
-                ^^^^^^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           obj.bar(*args, &block)
-                  ^^^^^^^^^^^^^ Use arguments forwarding.
+                  ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
         end
       RUBY
     end
@@ -149,9 +149,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg and block arg for `.()` call' do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
-                ^^^^^^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           bar.(*args, &block)
-               ^^^^^^^^^^^^^ Use arguments forwarding.
+               ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
         end
       RUBY
 
@@ -273,9 +273,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       it 'registers an offense when using only rest arg' do
         expect_offense(<<~RUBY)
           def foo(*args)
-                  ^^^^^ Use arguments forwarding.
+                  ^^^^^ Use shorthand syntax `...` for arguments forwarding.
             bar(*args)
-                ^^^^^ Use arguments forwarding.
+                ^^^^^ Use shorthand syntax `...` for arguments forwarding.
           end
         RUBY
 
@@ -289,9 +289,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       it 'registers an offense when using only kwrest arg' do
         expect_offense(<<~RUBY)
           def foo(**kwargs)
-                  ^^^^^^^^ Use arguments forwarding.
+                  ^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
             bar(**kwargs)
-                ^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           end
         RUBY
 
@@ -324,9 +324,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg and anonymous block arg' do
       expect_offense(<<~RUBY)
         def foo(*args, &)
-                ^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           bar(*args, &)
-              ^^^^^^^^ Use arguments forwarding.
+              ^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
         end
       RUBY
 
@@ -340,9 +340,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg, kwargs, and anonymous block arg' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs, &)
-                ^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           bar(*args, **kwargs, &)
-              ^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+              ^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
         end
       RUBY
 
@@ -610,9 +610,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg, kwrestarg and block arg' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs, &block)
-                ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           bar(*args, **kwargs, &block)
-              ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
         end
       RUBY
 
@@ -626,9 +626,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg, kwargs and block arg with another method call' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs, &block)
-                ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           bar(*args, **kwargs, &block)
-              ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           baz(1, 2, 3)
         end
       RUBY
@@ -644,11 +644,11 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg, kwargs and block arg twice' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs, &block)
-                ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           bar(*args, **kwargs, &block)
-              ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           baz(*args, **kwargs, &block)
-              ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
         end
       RUBY
 
@@ -873,9 +873,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       it 'registers an offense when using restarg, kwrestarg and block arg' do
         expect_offense(<<~RUBY)
           def foo(*args, **kwargs, &block)
-                  ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+                  ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
             bar(*args, **kwargs, &block)
-                ^^^^^^^^^^^^^^^^^^^^^^^ Use arguments forwarding.
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           end
         RUBY
 

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -358,11 +358,11 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg/kwrestarg forwarding without block arg' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
           bar(*args, **kwargs)
-              ^^^^^ Use anonymous positional arguments forwarding.
-                     ^^^^^^^^ Use anonymous keyword arguments forwarding.
+              ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
         end
       RUBY
 
@@ -376,12 +376,12 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using separate arg/kwarg forwarding' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
           args_only(*args)
-                    ^^^^^ Use anonymous positional arguments forwarding.
+                    ^^^^^ Use anonymous positional arguments forwarding: `*`.
           kwargs_only(**kwargs)
-                      ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                      ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
         end
       RUBY
 
@@ -396,12 +396,12 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using arg/kwarg forwarding with an additional arg/kwarg' do
       expect_offense(<<~RUBY)
         def foo(arg, *args, kwarg:, **kwargs)
-                     ^^^^^ Use anonymous positional arguments forwarding.
-                                    ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                     ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                                    ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
           args_only(*args)
-                    ^^^^^ Use anonymous positional arguments forwarding.
+                    ^^^^^ Use anonymous positional arguments forwarding: `*`.
           kwargs_only(**kwargs)
-                      ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                      ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
         end
       RUBY
 
@@ -416,16 +416,16 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using arg/kwarg forwarding with additional forwarded arg/kwarg' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
           args_only(:another_arg, *args)
-                                  ^^^^^ Use anonymous positional arguments forwarding.
+                                  ^^^^^ Use anonymous positional arguments forwarding: `*`.
           args_only(*args, :another_arg)
-                    ^^^^^ Use anonymous positional arguments forwarding.
+                    ^^^^^ Use anonymous positional arguments forwarding: `*`.
           kwargs_only(another: :kwarg, **kwargs)
-                                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
           kwargs_only(**kwargs, another: :kwarg)
-                      ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                      ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
         end
       RUBY
 
@@ -442,12 +442,12 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using arg/kwarg forwarding when leading extra arg/kwarg' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
           args_only(1, *args)
-                       ^^^^^ Use anonymous positional arguments forwarding.
+                       ^^^^^ Use anonymous positional arguments forwarding: `*`.
           kwargs_only(foo: :bar, **kwargs)
-                                 ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                                 ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
         end
       RUBY
 
@@ -462,12 +462,12 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using arg/kwarg forwarding with trailing extra arg/kwarg' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
           args_only(*args, 1)
-                    ^^^^^ Use anonymous positional arguments forwarding.
+                    ^^^^^ Use anonymous positional arguments forwarding: `*`.
           kwargs_only(**kwargs, foo: :bar)
-                      ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                      ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
         end
       RUBY
 
@@ -482,12 +482,12 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using arg/kwarg forwarding with surrounding extra arg/kwarg' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
           args_only(1, *args, 2)
-                       ^^^^^ Use anonymous positional arguments forwarding.
+                       ^^^^^ Use anonymous positional arguments forwarding: `*`.
           kwargs_only(foo: :bar, **kwargs, bar: :baz)
-                                 ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                                 ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
         end
       RUBY
 
@@ -502,10 +502,10 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense only for kwrestarg when using the restarg outside forwarding' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
           args.do_something
           bar(*args, **kwargs)
-                     ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
         end
       RUBY
 
@@ -520,10 +520,10 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense only for kwrestarg when restarg is overwritten' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
           args = new_args
           bar(*args, **kwargs)
-                     ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
         end
       RUBY
 
@@ -538,10 +538,10 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense only for restarg when using the kwrestarg outside forwarding' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
           kwargs.do_something
           bar(*args, **kwargs)
-              ^^^^^ Use anonymous positional arguments forwarding.
+              ^^^^^ Use anonymous positional arguments forwarding: `*`.
         end
       RUBY
 
@@ -556,10 +556,10 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense only for restarg when kwrestarg is overwritten' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs)
-                ^^^^^ Use anonymous positional arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
           kwargs = new_kwargs
           bar(*args, **kwargs)
-              ^^^^^ Use anonymous positional arguments forwarding.
+              ^^^^^ Use anonymous positional arguments forwarding: `*`.
         end
       RUBY
 
@@ -574,12 +574,12 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense for restarg and kwrestarg when using block outside forwarding' do
       expect_offense(<<~RUBY)
         def foo(*args, **kwargs, &block)
-                ^^^^^ Use anonymous positional arguments forwarding.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
           block = new_block
           bar(*args, **kwargs, &block)
-              ^^^^^ Use anonymous positional arguments forwarding.
-                     ^^^^^^^^ Use anonymous keyword arguments forwarding.
+              ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
         end
       RUBY
 
@@ -594,9 +594,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg and block arg' do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
-                ^^^^^ Use anonymous positional arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
           bar(*args, &block)
-              ^^^^^ Use anonymous positional arguments forwarding.
+              ^^^^^ Use anonymous positional arguments forwarding: `*`.
         end
       RUBY
 
@@ -663,9 +663,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when passing restarg and block arg in defs' do
       expect_offense(<<~RUBY)
         def self.foo(*args, &block)
-                     ^^^^^ Use anonymous positional arguments forwarding.
+                     ^^^^^ Use anonymous positional arguments forwarding: `*`.
           bar(*args, &block)
-              ^^^^^ Use anonymous positional arguments forwarding.
+              ^^^^^ Use anonymous positional arguments forwarding: `*`.
         end
       RUBY
 
@@ -679,9 +679,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when the parentheses of restarg arguments are omitted' do
       expect_offense(<<~RUBY)
         def foo *args
-                ^^^^^ Use anonymous positional arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
           bar *args
-              ^^^^^ Use anonymous positional arguments forwarding.
+              ^^^^^ Use anonymous positional arguments forwarding: `*`.
         end
       RUBY
 
@@ -695,9 +695,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when the parentheses of kwrestarg arguments are omitted' do
       expect_offense(<<~RUBY)
         def foo **kwargs
-                ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
           bar **kwargs
-              ^^^^^^^^ Use anonymous keyword arguments forwarding.
+              ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
         end
       RUBY
 
@@ -711,11 +711,11 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when the parentheses of restarg/kwrestarg arguments are omitted' do
       expect_offense(<<~RUBY)
         def foo *args, **kwargs
-                ^^^^^ Use anonymous positional arguments forwarding.
-                       ^^^^^^^^ Use anonymous keyword arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
           bar *args, **kwargs
-              ^^^^^ Use anonymous positional arguments forwarding.
-                     ^^^^^^^^ Use anonymous keyword arguments forwarding.
+              ^^^^^ Use anonymous positional arguments forwarding: `*`.
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding: `**`.
         end
       RUBY
 
@@ -729,10 +729,10 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when forwarding to a method in block' do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
-                ^^^^^ Use anonymous positional arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
           do_something do
             bar(*args, &block)
-                ^^^^^ Use anonymous positional arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
           end
         end
       RUBY
@@ -749,9 +749,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when delegating' do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
-                ^^^^^ Use anonymous positional arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
           obj.bar(*args, &block)
-                  ^^^^^ Use anonymous positional arguments forwarding.
+                  ^^^^^ Use anonymous positional arguments forwarding: `*`.
         end
       RUBY
 
@@ -765,9 +765,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when using restarg and block arg for `.()` call' do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
-                ^^^^^ Use anonymous positional arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
           bar.(*args, &block)
-               ^^^^^ Use anonymous positional arguments forwarding.
+               ^^^^^ Use anonymous positional arguments forwarding: `*`.
         end
       RUBY
 
@@ -781,9 +781,9 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     it 'registers an offense when only forwarding a restarg' do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
-                ^^^^^ Use anonymous positional arguments forwarding.
+                ^^^^^ Use anonymous positional arguments forwarding: `*`.
           bar(*args)
-              ^^^^^ Use anonymous positional arguments forwarding.
+              ^^^^^ Use anonymous positional arguments forwarding: `*`.
         end
       RUBY
 


### PR DESCRIPTION
Adds support for anonymous [rest/kwrest argument forwarding](https://rubyreferences.github.io/rubychanges/3.2.html#anonymous-arguments-passing-improvements) on Ruby 3.2+ and also rewrites the existing functionality for "forwarding all" (`...`)

Some questions I'd like to answer before fleshing this PR out any further:
1. Should this be a new cop? (I _think_ no, due to the overlap, but e.g. `Naming/BlockForwarding` seems relevant)
1. Should there be configuration to enable/disable anonymous forwarding? (I think yes but haven't done it yet - config name suggestions very welcome)
1. Is there an existing mechanism to alert for now-unnecessary options in later Ruby versions (specifically `AllowOnlyRestArgument` isn't needed in Ruby 3.2+)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
