### PR TITLE
Fix a false positive for `Style/CollectionCompact`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_collection_compact.md
+++ b/changelog/fix_a_false_positive_for_style_collection_compact.md
@@ -1,0 +1,1 @@
+* [#11799](https://github.com/rubocop/rubocop/pull/11799): Fix a false positive for `Style/CollectionCompact` when using `reject` on hash to reject nils in Ruby 2.3 analysis. ([@koic][])

--- a/lib/rubocop/cop/style/collection_compact.rb
+++ b/lib/rubocop/cop/style/collection_compact.rb
@@ -36,10 +36,13 @@ module RuboCop
       class CollectionCompact < Base
         include RangeHelp
         extend AutoCorrector
+        extend TargetRubyVersion
 
         MSG = 'Use `%<good>s` instead of `%<bad>s`.'
         RESTRICT_ON_SEND = %i[reject reject! select select!].freeze
         TO_ENUM_METHODS = %i[to_enum lazy].freeze
+
+        minimum_target_ruby_version 2.4
 
         # @!method reject_method_with_block_pass?(node)
         def_node_matcher :reject_method_with_block_pass?, <<~PATTERN

--- a/spec/rubocop/cop/style/collection_compact_spec.rb
+++ b/spec/rubocop/cop/style/collection_compact_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config do
+RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
   it 'registers an offense and corrects when using `reject` on array to reject nils' do
     expect_offense(<<~RUBY)
       array.reject { |e| e.nil? }
@@ -154,6 +154,15 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config do
       expect_no_offenses(<<~RUBY)
         array.lazy.reject { |e| e.nil? }
         array.lazy.reject! { |e| e.nil? }
+      RUBY
+    end
+  end
+
+  context 'when Ruby <= 2.3', :ruby23 do
+    it 'does not register an offense when using `reject` on hash to reject nils' do
+      expect_no_offenses(<<~RUBY)
+        hash.reject { |k, v| v.nil? }
+        hash.reject! { |k, v| v.nil? }
       RUBY
     end
   end


### PR DESCRIPTION
This PR fixes a false positive for `Style/CollectionCompact` when using `reject` on hash to reject nils in Ruby 2.3 analysis.
Because `Hash#compact` and `Hash#compact!` have been introduced in Ruby 2.4.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
