### PR TITLE
[Fix #11800] Mark `Style/InvertibleUnlessCondition` as unsafe

### DIFF
--- a/changelog/fix_mark_style_invertible_unless_condition_as_unsafe.md
+++ b/changelog/fix_mark_style_invertible_unless_condition_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#11800](https://github.com/rubocop/rubocop/issues/11800): Mark `Style/InvertibleUnlessCondition` as unsafe. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4067,7 +4067,9 @@ Style/InverseMethods:
 Style/InvertibleUnlessCondition:
   Description: 'Favor `if` with inverted condition over `unless`.'
   Enabled: false
+  Safe: false
   VersionAdded: '1.44'
+  VersionChanged: '<<next>>'
   # `InverseMethods` are methods that can be inverted in a `unless` condition.
   # The relationship of inverse methods needs to be defined in both directions.
   # Keys and values both need to be defined as symbols.


### PR DESCRIPTION
Fixes #11800.

This PR marks `Style/InvertibleUnlessCondition` as unsafe. `@safety` is already documented:
https://github.com/rubocop/rubocop/blob/v1.50.1/lib/rubocop/cop/style/invertible_unless_condition.rb#L20-L23

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
