### PR TITLE
[Fix #11803] Update the doc for `Style/RedundantFetchBlock`

### DIFF
--- a/lib/rubocop/cop/style/redundant_fetch_block.rb
+++ b/lib/rubocop/cop/style/redundant_fetch_block.rb
@@ -3,11 +3,13 @@
 module RuboCop
   module Cop
     module Style
-      # Identifies places where `fetch(key) { value }`
-      # can be replaced by `fetch(key, value)`.
+      # Identifies places where `fetch(key) { value }` can be replaced by `fetch(key, value)`.
       #
-      # In such cases `fetch(key, value)` method is faster
-      # than `fetch(key) { value }`.
+      # In such cases `fetch(key, value)` method is faster than `fetch(key) { value }`.
+      #
+      # NOTE: The block string `'value'` in `hash.fetch(:key) { 'value' }` is detected
+      # when frozen string literal magic comment is enabled (i.e. `# frozen_string_literal: true`),
+      # but not when disabled.
       #
       # @safety
       #   This cop is unsafe because it cannot be guaranteed that the receiver


### PR DESCRIPTION
Fixes #11803.

This PR adds a note to the doc for `Style/RedundantFetchBlock` about the difference in behavior between enabled and disabled frozen string magic literal comment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
