### PR TITLE
Fix typo in DeprecatedAttributeAssignment cop

### DIFF
--- a/docs/modules/ROOT/pages/cops_gemspec.adoc
+++ b/docs/modules/ROOT/pages/cops_gemspec.adoc
@@ -97,7 +97,7 @@ end
 | 1.40
 |===
 
-Checks that deprecated attribute attributes are not set in a gemspec file.
+Checks that deprecated attributes are not set in a gemspec file.
 Removing deprecated attributes allows the user to receive smaller packed gems.
 
 === Examples

--- a/lib/rubocop/cop/gemspec/deprecated_attribute_assignment.rb
+++ b/lib/rubocop/cop/gemspec/deprecated_attribute_assignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Gemspec
-      # Checks that deprecated attribute attributes are not set in a gemspec file.
+      # Checks that deprecated attributes are not set in a gemspec file.
       # Removing deprecated attributes allows the user to receive smaller packed gems.
       #
       # @example


### PR DESCRIPTION
[ci skip]

Hello, I'm not a native English speaker, this looks like a typo but I'm not sure
 
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
