### PR TITLE
Do not try to expand nil Include when inheriting.

### DIFF
--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -46,7 +46,7 @@ module RuboCop
       return unless File.basename(base_config_path).start_with?('.rubocop')
 
       base_dir = File.dirname(base_config_path)
-      hash[key]['Include'] = value['Include'].map do |include_path|
+      hash[key]['Include'] = value['Include']&.map do |include_path|
         PathUtil.relative_path(File.join(base_dir, include_path), Dir.pwd)
       end
     end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -286,6 +286,32 @@ RSpec.describe RuboCop::ConfigLoader do
         expect(configuration_from_file['Style/StringLiterals']['Include']).to eq(['dir/**/*.rb'])
       end
 
+      it 'does not expand a nil Include' do
+        create_file(file_path, <<~YAML)
+          inherit_from: ../.rubocop.yml
+          Style/StringLiterals:
+            Include: ~
+        YAML
+
+        expect(configuration_from_file['Style/StringLiterals']['Include'].nil?).to be(true)
+      end
+
+      it 'gets an Include that is relative to the subdirectory when inheriting from a nil Include' do
+        create_file('.rubocop.yml', <<~YAML)
+          Style/StringLiterals:
+            Include: ~
+        YAML
+
+        create_file(file_path, <<~YAML)
+          inherit_from: ../.rubocop.yml
+          Style/StringLiterals:
+            Include:
+              - dir/**/*.rb
+        YAML
+
+        expect(configuration_from_file['Style/StringLiterals']['Include']).to eq(['dir/**/*.rb'])
+      end
+
       it 'ignores parent AllCops/Exclude if ignore_parent_exclusion is true' do
         sub_file_path = 'vendor/.rubocop.yml'
         create_file(sub_file_path, <<~YAML)


### PR DESCRIPTION
When inheriting from a parent config file that has nullified an Include in any rule, it will currently fail as it will assume that the Include will always be an non-nullable array

Example:

```
# rubocop.yml
Style/StringLiterals:
  Include:
    - dir/**/*.rb

# child_dir/.rubocop.yml
inherit_from: ../.rubocop.yml
Style/StringLiterals:
  Include: ~
```

I'm currently using this pattern to remove a default Include pattern so it resorts back to the AllCops inclusion list, so setting it to `[]` does not accomplish the same effect.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
