### PR TITLE
Fix a false positive for `Style/RegexpLiteral`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_regexp_literal.md
+++ b/changelog/fix_a_false_positive_for_style_regexp_literal.md
@@ -1,0 +1,1 @@
+* [#11808](https://github.com/rubocop/rubocop/pull/11808): Fix a false positive for `Style/RegexpLiteral` when using a regexp starts with equal as a method argument. ([@koic][])

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -3,7 +3,16 @@
 module RuboCop
   module Cop
     module Style
-      # Enforces using // or %r around regular expressions.
+      # Enforces using `//` or `%r` around regular expressions.
+      #
+      # NOTE: The following `%r` cases using a regexp starts with a blank or `=`
+      # as a method argument allowed to prevent syntax errors.
+      #
+      # [source,ruby]
+      # ----
+      # do_something %r{ regexp} # `do_something / regexp/` is an invalid syntax.
+      # do_something %r{=regexp} # `do_something /=regexp/` is an invalid syntax.
+      # ----
       #
       # @example EnforcedStyle: slashes (default)
       #   # bad
@@ -151,7 +160,7 @@ module RuboCop
 
         def allowed_omit_parentheses_with_percent_r_literal?(node)
           return false unless node.parent&.call_type?
-          return true if node.content.start_with?(' ')
+          return true if node.content.start_with?(' ', '=')
 
           enforced_style = config.for_cop('Style/MethodCallWithArgsParentheses')['EnforcedStyle']
 

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -537,6 +537,12 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
           ^^^^^^^^^^^ Use `//` around regular expression.
         RUBY
       end
+
+      it 'does not register an offense when using a regexp starts with equal as a method argument' do
+        expect_no_offenses(<<~RUBY)
+          do_something %r/=regexp/
+        RUBY
+      end
     end
 
     context 'when using `%r` regexp with `EnforcedStyle: mixed`' do


### PR DESCRIPTION
This PR fixes a false positive for `Style/RegexpLiteral` when using a regexp starts with equal as a method argument:

```console
$ cat example.rb
do_something %r/=regexp/

$ ruby -c example.rb
Syntax OK
```

The following false positive trigger autocorrection to invalid syntax:

```console
$ bundle exec rubocop -a --only Style/RegexpLiteral
Inspecting 1 file
F

Offenses:

example.rb:1:14: C: [Corrected] Style/RegexpLiteral: Use // around regular expression.
do_something %r/=regexp/
             ^^^^^^^^^^^
example.rb:2:1: F: Lint/Syntax: unexpected token $end
(Using Ruby 3.2 parser; configure using TargetRubyVersion parameter, under AllCops)

1 file inspected, 2 offenses detected, 1 offense corrected

$ git diff .
diff --git a/11808/example.rb b/11808/example.rb
index ae11d97..2221398 100644
--- a/11808/example.rb
+++ b/11808/example.rb
@@ -1 +1 @@
-do_something %r/=regexp/
+do_something /=regexp/

$ ruby -c example.rb
example.rb: example.rb:1: syntax error, unexpected end-of-input (SyntaxError)
do_something /=regexp/
                      ^
```

`=regexp` already has the same problem as blank ` regexp`. Other characters (e.g. `*regexp`) don't seem to have the same problem.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
