### PR TITLE
[Fix #11809] Fix an incorrect autocorrect for `Naming/RescuedExceptionsVariableName`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_naming_rescued_exceptions_variable_name.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_naming_rescued_exceptions_variable_name.md
@@ -1,0 +1,1 @@
+* [#11809](https://github.com/rubocop/rubocop/issues/11809): Fix an incorrect autocorrect for `Naming/RescuedExceptionsVariableName` when exception variable is referenced after `rescue` statement. ([@koic][])

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -82,9 +82,7 @@ module RuboCop
           message = message(node)
 
           add_offense(range, message: message) do |corrector|
-            corrector.replace(range, preferred_name)
-
-            correct_node(corrector, node.body, offending_name, preferred_name)
+            autocorrect(corrector, node, range, offending_name, preferred_name)
           end
         end
 
@@ -93,6 +91,16 @@ module RuboCop
         def offense_range(resbody)
           variable = resbody.exception_variable
           variable.source_range
+        end
+
+        def autocorrect(corrector, node, range, offending_name, preferred_name)
+          corrector.replace(range, preferred_name)
+          correct_node(corrector, node.body, offending_name, preferred_name)
+          return unless (kwbegin_node = node.parent.each_ancestor(:kwbegin).first)
+
+          kwbegin_node.right_siblings.each do |child_node|
+            correct_node(corrector, child_node, offending_name, preferred_name)
+          end
         end
 
         def variable_name_matches?(node, name)

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -456,6 +456,27 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
         RUBY
       end
     end
+
+    context 'when the variable is referenced after `rescue` statement' do
+      it 'handles it' do
+        expect_offense(<<~RUBY)
+          begin
+            something
+          rescue StandardError => e1
+                                  ^^ Use `e` instead of `e1`.
+          end
+          foo(e1)
+        RUBY
+
+        expect_correction(<<~RUBY)
+          begin
+            something
+          rescue StandardError => e
+          end
+          foo(e)
+        RUBY
+      end
+    end
   end
 
   context 'with the `PreferredName` setup' do


### PR DESCRIPTION
Fixes #11809.

This PR fixes an incorrect autocorrect for `Naming/RescuedExceptionsVariableName` when exception variable is referenced after `rescue` statement.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
