### PR TITLE
[Fix #11812] Fix a false negative for `Style/Attr`

### DIFF
--- a/changelog/fix_a_false_negative_for_style_attr.md
+++ b/changelog/fix_a_false_negative_for_style_attr.md
@@ -1,0 +1,1 @@
+* [#11812](https://github.com/rubocop/rubocop/issues/11812): Fix a false negative for `Style/Attr` when using `attr` and method definitions. ([@koic][])

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -83,7 +83,7 @@ module RuboCop
       config_store.for_pwd.for_all_cops['AllowSymlinksInCacheRootDirectory']
     end
 
-    attr :path
+    attr_reader :path
 
     def initialize(file, team, options, config_store, cache_root = nil)
       cache_root ||= File.join(options[:cache_root], 'rubocop_cache') if options[:cache_root]

--- a/spec/rubocop/cop/style/attr_spec.rb
+++ b/spec/rubocop/cop/style/attr_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe RuboCop::Cop::Style::Attr, :config do
     RUBY
   end
 
+  it 'registers an offense when using `attr` and method definitions' do
+    expect_offense(<<~RUBY)
+      class SomeClass
+        attr :name
+        ^^^^ Do not use `attr`. Use `attr_reader` instead.
+
+        def foo
+        end
+      end
+    RUBY
+  end
+
   it 'accepts attr when it does not take arguments' do
     expect_no_offenses('func(attr)')
   end


### PR DESCRIPTION
Fixes #11812.

This PR fixes a false negative for `Style/Attr` when using `attr` and method definitions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
