### PR TITLE
Make `Style/CollectionCompact` aware of `delete_if`

### DIFF
--- a/changelog/new_make_collection_compact_aware_of_delete_if.md
+++ b/changelog/new_make_collection_compact_aware_of_delete_if.md
@@ -1,0 +1,1 @@
+* [#11814](https://github.com/rubocop/rubocop/pull/11814): Make `Style/CollectionCompact` aware of `delete_if`. ([@koic][])

--- a/spec/rubocop/cop/style/collection_compact_spec.rb
+++ b/spec/rubocop/cop/style/collection_compact_spec.rb
@@ -5,11 +5,14 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
     expect_offense(<<~RUBY)
       array.reject { |e| e.nil? }
             ^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `reject { |e| e.nil? }`.
+      array.delete_if { |e| e.nil? }
+            ^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `delete_if { |e| e.nil? }`.
       array.reject! { |e| e.nil? }
             ^^^^^^^^^^^^^^^^^^^^^^ Use `compact!` instead of `reject! { |e| e.nil? }`.
     RUBY
 
     expect_correction(<<~RUBY)
+      array.compact
       array.compact
       array.compact!
     RUBY
@@ -19,11 +22,14 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
     expect_offense(<<~RUBY)
       array.reject(&:nil?)
             ^^^^^^^^^^^^^^ Use `compact` instead of `reject(&:nil?)`.
+      array.delete_if(&:nil?)
+            ^^^^^^^^^^^^^^^^^ Use `compact` instead of `delete_if(&:nil?)`.
       array.reject!(&:nil?)
             ^^^^^^^^^^^^^^^ Use `compact!` instead of `reject!(&:nil?)`.
     RUBY
 
     expect_correction(<<~RUBY)
+      array.compact
       array.compact
       array.compact!
     RUBY
@@ -33,9 +39,12 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
     expect_offense(<<~RUBY)
       array.reject &:nil?
             ^^^^^^^^^^^^^ Use `compact` instead of `reject &:nil?`.
+      array.delete_if &:nil?
+            ^^^^^^^^^^^^^^^^ Use `compact` instead of `delete_if &:nil?`.
     RUBY
 
     expect_correction(<<~RUBY)
+      array.compact
       array.compact
     RUBY
   end
@@ -44,11 +53,14 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
     expect_offense(<<~RUBY)
       hash.reject { |k, v| v.nil? }
            ^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `reject { |k, v| v.nil? }`.
+      hash.delete_if { |k, v| v.nil? }
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `delete_if { |k, v| v.nil? }`.
       hash.reject! { |k, v| v.nil? }
            ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact!` instead of `reject! { |k, v| v.nil? }`.
     RUBY
 
     expect_correction(<<~RUBY)
+      hash.compact
       hash.compact
       hash.compact!
     RUBY
@@ -73,11 +85,14 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
       def foo(params)
         params.reject { |_k, v| v.nil? }
                ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `reject { |_k, v| v.nil? }`.
+        params.delete_if { |_k, v| v.nil? }
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `delete_if { |_k, v| v.nil? }`.
       end
     RUBY
 
     expect_correction(<<~RUBY)
       def foo(params)
+        params.compact
         params.compact
       end
     RUBY
@@ -86,6 +101,7 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
   it 'does not register an offense when using `reject` to not to rejecting nils' do
     expect_no_offenses(<<~RUBY)
       array.reject { |e| e.odd? }
+      array.delete_if { |e| e.odd? }
     RUBY
   end
 
@@ -100,6 +116,7 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
     it 'does not register an offense and corrects when using `reject` on array to reject nils' do
       expect_no_offenses(<<~RUBY)
         reject { |e| e.nil? }
+        delete_if { |e| e.nil? }
         reject! { |e| e.nil? }
       RUBY
     end
@@ -127,6 +144,12 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
       RUBY
     end
 
+    it 'does not register an offense and corrects when using `to_enum.delete_if` on array to reject nils' do
+      expect_no_offenses(<<~RUBY)
+        array.to_enum.delete_if { |e| e.nil? }
+      RUBY
+    end
+
     it 'registers an offense and corrects when using `lazy.reject` on array to reject nils' do
       expect_offense(<<~RUBY)
         array.lazy.reject { |e| e.nil? }
@@ -140,12 +163,19 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
         array.lazy.compact!
       RUBY
     end
+
+    it 'does not register an offense and corrects when using `lazy.delete_if` on array to reject nils' do
+      expect_no_offenses(<<~RUBY)
+        array.lazy.delete_if { |e| e.nil? }
+      RUBY
+    end
   end
 
   context 'Ruby <= 3.0', :ruby30 do
     it 'does not register an offense and corrects when using `to_enum.reject` on array to reject nils' do
       expect_no_offenses(<<~RUBY)
         array.to_enum.reject { |e| e.nil? }
+        array.to_enum.delete_if { |e| e.nil? }
         array.to_enum.reject! { |e| e.nil? }
       RUBY
     end
@@ -153,6 +183,7 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
     it 'does not register an offense and corrects when using `lazy.reject` on array to reject nils' do
       expect_no_offenses(<<~RUBY)
         array.lazy.reject { |e| e.nil? }
+        array.lazy.delete_if { |e| e.nil? }
         array.lazy.reject! { |e| e.nil? }
       RUBY
     end


### PR DESCRIPTION
This PR makes `Style/CollectionCompact` aware of `delete_if`.

Note, `Enumerator` does not have `delete_if`, the following use case are allowed:

```ruby
% ruby -ve '[1, 2, 3].to_enum.delete_if { |e| e.nil? }'
ruby 3.3.0dev (2023-03-17T00:50:41Z master f29c9d6d36) [x86_64-darwin19]
-e:1:in `<main>': undefined method `delete_if' for an instance of Enumerator (NoMethodError)

[1, 2, 3].to_enum.delete_if { |e| e.nil? }
                 ^^^^^^^^^^
```

It doesn't register an offense as well as `to_enum` when `lazy` is used.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
