### PR TITLE
Add rubocop-sketchup to list of third party extensions.

### DIFF
--- a/docs/modules/ROOT/pages/extensions.adoc
+++ b/docs/modules/ROOT/pages/extensions.adoc
@@ -97,12 +97,14 @@ i18n wrapper function analysis (`gettext` and `rails-i18n`)
 Custom cops and config defaults for Chef Infra Cookbooks
 * https://github.com/utkarsh2102/rubocop-packaging[rubocop-packaging] -
 Upstream best practices and coding conventions for downstream (e.g. Debian packages) compatibility.
-* https://github.com/Shopify/rubocop-sorbet[rubocop-sorbet]
+* https://github.com/Shopify/rubocop-sorbet[rubocop-sorbet] -
 Sorbet-specific analysis
 * https://github.com/DmitryTsepelev/rubocop-graphql[rubocop-graphql] -
 GraphQL-specific analysis
 * https://github.com/dukaev/rubocop-changed[rubocop-changed] -
 Reduced CI time by analyzing only changed files
+* https://github.com/SketchUp/rubocop-sketchup[rubocop-sketchup] -
+SketchUp Ruby API specific analysis
 
 Any extensions missing? Send us a Pull Request!
 


### PR DESCRIPTION
Adding `rubocop-sketchup` to the list of known third party extensions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
