### PR TITLE
Add autocorrection for `Lint/AmbiguousBlockAssociation`

### DIFF
--- a/changelog/new_add_autocorrection_for_lint_ambiguous_block_association.md
+++ b/changelog/new_add_autocorrection_for_lint_ambiguous_block_association.md
@@ -1,0 +1,1 @@
+* [#11819](https://github.com/rubocop/rubocop/pull/11819): Add autocorrection for `Lint/AmbiguousBlockAssociation`. ([@r7kamura][])

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -52,6 +52,8 @@ module RuboCop
       #   expect { do_something }.to not_change { object.attribute }
       #
       class AmbiguousBlockAssociation < Base
+        extend AutoCorrector
+
         include AllowedMethods
         include AllowedPattern
 
@@ -68,7 +70,9 @@ module RuboCop
 
           message = message(node)
 
-          add_offense(node, message: message)
+          add_offense(node, message: message) do |corrector|
+            wrap_in_parentheses(corrector, node)
+          end
         end
         alias on_csend on_send
 
@@ -88,6 +92,13 @@ module RuboCop
           block_param = send_node.last_argument
 
           format(MSG, param: block_param.source, method: block_param.send_node.source)
+        end
+
+        def wrap_in_parentheses(corrector, node)
+          range = node.loc.selector.end.join(node.first_argument.source_range.begin)
+
+          corrector.replace(range, '(')
+          corrector.insert_after(node.last_argument, ')')
         end
       end
     end

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
           some_method a { |el| puts el }
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `a { |el| puts el }` to make sure that the block will be associated with the `a` method call.
         RUBY
+
+        expect_correction(<<~RUBY)
+          some_method(a { |el| puts el })
+        RUBY
       end
     end
 
@@ -46,6 +50,10 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
           Foo.some_method a { |el| puts el }
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `a { |el| puts el }` to make sure that the block will be associated with the `a` method call.
         RUBY
+
+        expect_correction(<<~RUBY)
+          Foo.some_method(a { |el| puts el })
+        RUBY
       end
 
       context 'when using safe navigation operator' do
@@ -53,6 +61,10 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
           expect_offense(<<~RUBY)
             Foo&.some_method a { |el| puts el }
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `a { |el| puts el }` to make sure that the block will be associated with the `a` method call.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            Foo&.some_method(a { |el| puts el })
           RUBY
         end
       end
@@ -64,6 +76,10 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
           expect { order.expire }.to change { order.events }
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `change { order.events }` to make sure that the block will be associated with the `change` method call.
         RUBY
+
+        expect_correction(<<~RUBY)
+          expect { order.expire }.to(change { order.events })
+        RUBY
       end
     end
 
@@ -73,6 +89,10 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
           Hash[some_method a { |el| el }]
                ^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `a { |el| el }` to make sure that the block will be associated with the `a` method call.
         RUBY
+
+        expect_correction(<<~RUBY)
+          Hash[some_method(a { |el| el })]
+        RUBY
       end
     end
 
@@ -81,6 +101,10 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
         expect_offense(<<~RUBY)
           foo = some_method a { |el| puts el }
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `a { |el| puts el }` to make sure that the block will be associated with the `a` method call.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo = some_method(a { |el| puts el })
         RUBY
       end
     end
@@ -99,6 +123,10 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
       expect_offense(<<~RUBY)
         expect { order.expire }.to update { order.events }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `update { order.events }` to make sure that the block will be associated with the `update` method call.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect { order.expire }.to(update { order.events })
       RUBY
     end
   end
@@ -120,6 +148,10 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
       expect_offense(<<~RUBY)
         expect { order.expire }.to update { order.events }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `update { order.events }` to make sure that the block will be associated with the `update` method call.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect { order.expire }.to(update { order.events })
       RUBY
     end
   end


### PR DESCRIPTION
This autocorrection assumes the current code behavior is correct and fills in the missing parentheses. So this is a safe autocorrection because the behavior does not change before and after the change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
