### PR TITLE
[Fix #11820] Fix `Lint/EmptyConditionalBody` false-positives for commented empty `elsif` body

### DIFF
--- a/changelog/fix_lint_empty_conditional_body_false_positives.md
+++ b/changelog/fix_lint_empty_conditional_body_false_positives.md
@@ -1,0 +1,1 @@
+* [#11820](https://github.com/rubocop/rubocop/issues/11820): Fix `Lint/EmptyConditionalBody` false-positives for commented empty `elsif` body. ([@r7kamura][])

--- a/lib/rubocop/cop/mixin/comments_help.rb
+++ b/lib/rubocop/cop/mixin/comments_help.rb
@@ -68,6 +68,8 @@ module RuboCop
           node.loc.else.line
         elsif node.if_type? && node.ternary?
           node.else_branch.loc.line
+        elsif node.if_type? && node.elsif?
+          node.each_ancestor(:if).find(&:if?).loc.end.line
         elsif (next_sibling = node.right_sibling) && next_sibling.is_a?(AST::Node)
           next_sibling.loc.line
         elsif (parent = node.parent)

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -75,6 +75,32 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     RUBY
   end
 
+  it 'does not register an offense for missing 2nd `elsif` body with a comment' do
+    expect_no_offenses(<<~RUBY)
+      if condition1
+        do_something1
+      elsif condition2
+        do_something2
+      elsif condition3
+        # noop
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for missing 3rd `elsif` body with a comment' do
+    expect_no_offenses(<<~RUBY)
+      if condition1
+        do_something1
+      elsif condition2
+        do_something2
+      elsif condition3
+        do_something3
+      elsif condition4
+        # noop
+      end
+    RUBY
+  end
+
   it 'registers an offense for missing `elsif` body' do
     expect_offense(<<~RUBY)
       if condition


### PR DESCRIPTION

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
