### PR TITLE
[Fix #11822] Fix an error for `Layout/SpaceInsideBlockBraces`

### DIFF
--- a/changelog/fix_an_error_for_layout_space_inside_block_braces.md
+++ b/changelog/fix_an_error_for_layout_space_inside_block_braces.md
@@ -1,0 +1,1 @@
+* [#11822](https://github.com/rubocop/rubocop/issues/11822): Fix an error for `Layout/SpaceInsideBlockBraces` when a method call with a multiline block is used as an argument. ([@koic][])

--- a/lib/rubocop/cop/layout/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_block_braces.rb
@@ -236,6 +236,8 @@ module RuboCop
         end
 
         def offense(begin_pos, end_pos, msg, style_param = 'EnforcedStyle')
+          return if begin_pos > end_pos
+
           range = range_between(begin_pos, end_pos)
           add_offense(range, message: msg) do |corrector|
             case range.source

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -329,6 +329,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       expect_no_offenses('each{puts}')
     end
 
+    it 'accepts when a method call with a multiline block is used as an argument' do
+      expect_no_offenses(<<~RUBY)
+        foo bar { |arg|
+          baz(arg)
+        }
+      RUBY
+    end
+
     context 'with passed in parameters' do
       context 'and space before block parameters allowed' do
         it 'accepts left brace with inner space' do


### PR DESCRIPTION
Fixes #11822.

This PR fixes an error for `Layout/SpaceInsideBlockBraces` when a method call with a multiline block is used as an argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
