### PR TITLE
Add autocorrection for `Lint/TopLevelReturnWithArgument`

### DIFF
--- a/changelog/new_add_autocorrection_for_top_level_return_with_argument.md
+++ b/changelog/new_add_autocorrection_for_top_level_return_with_argument.md
@@ -1,0 +1,1 @@
+* [#11824](https://github.com/rubocop/rubocop/pull/11824): Add autocorrection for `Lint/TopLevelReturnWithArgument`. ([@r7kamura][])

--- a/spec/rubocop/cop/lint/top_level_return_with_argument_spec.rb
+++ b/spec/rubocop/cop/lint/top_level_return_with_argument_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe RuboCop::Cop::Lint::TopLevelReturnWithArgument, :config do
         return 1, 2, 3
         ^^^^^^^^^^^^^^ Top level return with argument detected.
       RUBY
+
+      expect_correction(<<~RUBY)
+        return
+      RUBY
     end
 
     it 'expects multiple offenses from the return with arguments statements' do
@@ -25,6 +29,14 @@ RSpec.describe RuboCop::Cop::Lint::TopLevelReturnWithArgument, :config do
 
         return 1, 2, 3
         ^^^^^^^^^^^^^^ Top level return with argument detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        return
+
+        return
+
+        return
       RUBY
     end
   end
@@ -53,6 +65,16 @@ RSpec.describe RuboCop::Cop::Lint::TopLevelReturnWithArgument, :config do
 
         bar
       RUBY
+
+      expect_correction(<<~RUBY)
+        foo
+
+        [1, 2, 3, 4, 5].each { |n| return n }
+
+        return
+
+        bar
+      RUBY
     end
   end
 
@@ -65,6 +87,14 @@ RSpec.describe RuboCop::Cop::Lint::TopLevelReturnWithArgument, :config do
 
         return 1, 2, 3
         ^^^^^^^^^^^^^^ Top level return with argument detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def method
+          return 'Hello World'
+        end
+
+        return
       RUBY
     end
   end
@@ -99,6 +129,18 @@ RSpec.describe RuboCop::Cop::Lint::TopLevelReturnWithArgument, :config do
           return "Hello World" if 1 == 1
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        foo
+        return if 1 == 1
+        bar
+        return
+        return
+
+        def method
+          return "Hello World" if 1 == 1
+        end
+      RUBY
     end
   end
 
@@ -109,6 +151,14 @@ RSpec.describe RuboCop::Cop::Lint::TopLevelReturnWithArgument, :config do
 
         if a == b; warn 'hey'; return 42; end
                                ^^^^^^^^^ Top level return with argument detected.
+
+        bar
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo
+
+        if a == b; warn 'hey'; return; end
 
         bar
       RUBY


### PR DESCRIPTION
I have added an autocorrection that simply removes the argument part from top-level `return`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
