### PR TITLE
Mark `Lint/TopLevelReturnWithArgument` as unsafe

### DIFF
--- a/changelog/change_mark_lint_top_level_return_with_argument_as_unsafe.md
+++ b/changelog/change_mark_lint_top_level_return_with_argument_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#11825](https://github.com/rubocop/rubocop/pull/11825): Mark `Lint/TopLevelReturnWithArgument` as unsafe. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2342,7 +2342,9 @@ Lint/ToJSON:
 Lint/TopLevelReturnWithArgument:
   Description: 'Detects top level return statements with argument.'
   Enabled: true
+  Safe: false
   VersionAdded: '0.89'
+  VersionChanged: '<<next>>'
 
 Lint/TrailingCommaInAttributeDeclaration:
   Description: 'Checks for trailing commas in attribute declarations.'

--- a/lib/rubocop/cop/lint/top_level_return_with_argument.rb
+++ b/lib/rubocop/cop/lint/top_level_return_with_argument.rb
@@ -7,6 +7,10 @@ module RuboCop
       # top-level return statement with an argument, then the argument is
       # always ignored. This is detected automatically since Ruby 2.7.
       #
+      # @safety
+      #   This cop is unsafe because it may cause false positives where the Ruby code is used
+      #   through `eval` or equivalent.
+      #
       # @example
       #
       #   # Detected since Ruby 2.7


### PR DESCRIPTION
For example, the following code may be written in jb:

```ruby
# example.jb
return {} if article.nil?

{
  id: article.id,
  name: article.name
}
```

This cop detects offenses in this case, but in practice this `{}` is used as the correct return value, so it is a false positive. jb is [officially supported by RuboCop](https://github.com/rubocop/rubocop/blob/b980e7cd1b691aa9121b77b6bc4456146eb326e8/config/default.yml#L11-L62), and one can well assume that RuboCop will inspect other Ruby files that are used in this way. Therefore, I think it is reasonable to assume that this cop is unsafe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
