### PR TITLE
Exclude `**/*.jb` from `Lint/TopLevelReturnWithArgument`

### DIFF
--- a/changelog/change_exclude_non_standard_ruby_files_from.md
+++ b/changelog/change_exclude_non_standard_ruby_files_from.md
@@ -1,0 +1,1 @@
+* [#11826](https://github.com/rubocop/rubocop/pull/11826): Exclude `**/*.jb` from `Lint/TopLevelReturnWithArgument`. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2343,6 +2343,9 @@ Lint/TopLevelReturnWithArgument:
   Description: 'Detects top level return statements with argument.'
   Enabled: true
   VersionAdded: '0.89'
+  # These codes are `eval`-ed in method and their return values may be used.
+  Exclude:
+    - '**/*.jb'
 
 Lint/TrailingCommaInAttributeDeclaration:
   Description: 'Checks for trailing commas in attribute declarations.'


### PR DESCRIPTION
Since non-standard Ruby files such as `*.jb` and so on are expected to be used via `eval` or equivalent, it would be better to exclude them from this Cop's inspection to reduce false positives.

See also the following discussion for more information:

- https://github.com/rubocop/rubocop/pull/11825#issuecomment-1527002005

The patterns specified in `Exclude` are based from `default_configuration['AllCops']['Include']`, excluding the following patterns:

- `**/*.rb`
- `**/*.rbw`
- `**/*.rbx`
- `**/*.ruby`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
