### PR TITLE
Fix a false positive for `Lint/IncompatibleIoSelectWithFiberScheduler`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_incompatible_io_select_with_fiber_scheduler.md
+++ b/changelog/fix_a_false_positive_for_lint_incompatible_io_select_with_fiber_scheduler.md
@@ -1,0 +1,1 @@
+* [#11830](https://github.com/rubocop/rubocop/pull/11830): Fix a false positive for `Lint/IncompatibleIoSelectWithFiberScheduler`. ([@koic][])

--- a/spec/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler_spec.rb
+++ b/spec/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler_spec.rb
@@ -164,6 +164,12 @@ RSpec.describe RuboCop::Cop::Lint::IncompatibleIoSelectWithFiberScheduler, :conf
     RUBY
   end
 
+  it 'does not register an offense when using `IO.select` with read and excepts arguments' do
+    expect_no_offenses(<<~RUBY)
+      IO.select([rp], [], [excepts])
+    RUBY
+  end
+
   it 'does not register an offense when using `Enumerable#select`' do
     expect_no_offenses(<<~RUBY)
       collection.select { |item| item.do_something? }


### PR DESCRIPTION
This PR fixes a false positive for `Lint/IncompatibleIoSelectWithFiberScheduler` when using excepts argument.

AFAIK, `IO.wait_readable` and `IO.wait_writable` cannot replace IO objects waiting for exceptions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
