### PR TITLE
Support free-spacing mode `Regexp` in `Naming/InclusiveLanguage`

### DIFF
--- a/spec/rubocop/cop/naming/inclusive_language_spec.rb
+++ b/spec/rubocop/cop/naming/inclusive_language_spec.rb
@@ -129,6 +129,48 @@ RSpec.describe RuboCop::Cop::Naming::InclusiveLanguage, :config do
       RUBY
     end
 
+    context 'specified as Array' do
+      let(:cop_config) do
+        { 'FlaggedTerms' => {
+          'master' => { 'AllowedRegex' => ['master\'s degree', 'mastermind'] }
+        } }
+      end
+
+      it 'does not register an offense for an allowed use' do
+        expect_no_offenses(<<~RUBY)
+          # The mastermind had a master's degree.
+        RUBY
+      end
+    end
+
+    context 'specified as a String with regular expression syntax' do
+      let(:cop_config) do
+        { 'FlaggedTerms' => {
+          'master' => { 'AllowedRegex' => 'master(?:card|mind)' }
+        } }
+      end
+
+      it 'does not register an offense for an allowed use' do
+        expect_no_offenses(<<~RUBY)
+          # The mastermind's Mastercard was declined.
+        RUBY
+      end
+    end
+
+    context 'specified as Regexp' do
+      let(:cop_config) do
+        { 'FlaggedTerms' => {
+          'master' => { 'AllowedRegex' => /master(?:card|mind)/ }
+        } }
+      end
+
+      it 'does not register an offense for an allowed use' do
+        expect_no_offenses(<<~RUBY)
+          # The mastermind's Mastercard was declined.
+        RUBY
+      end
+    end
+
     context 'offense after an allowed use' do
       let(:cop_config) do
         { 'FlaggedTerms' => {

--- a/spec/rubocop/cop/naming/inclusive_language_spec.rb
+++ b/spec/rubocop/cop/naming/inclusive_language_spec.rb
@@ -169,6 +169,23 @@ RSpec.describe RuboCop::Cop::Naming::InclusiveLanguage, :config do
           # The mastermind's Mastercard was declined.
         RUBY
       end
+
+      context 'using free-spacing/extended mode' do
+        let(:cop_config) do
+          { 'FlaggedTerms' => {
+            'master' => { 'AllowedRegex' => /master(?:
+              card|
+              mind
+            )/x }
+          } }
+        end
+
+        it 'does not register an offense for an allowed use' do
+          expect_no_offenses(<<~RUBY)
+            # The mastermind's Mastercard was declined.
+          RUBY
+        end
+      end
     end
 
     context 'offense after an allowed use' do


### PR DESCRIPTION
WIP – See #11831.

This edits the way the `Naming/InclusiveLanguage` cop combines its config into `Regexp` to match terms. Specifically, because we would convert given `Regexp` to `String`s via `Regexp#source`, and then simply combine patterns/strings using

```ruby
Regexp.new(strings.join('|'), Regexp::IGNORECASE)
```

we would lose any mode/options information about the `Regexp`, which in the case of ["free-spacing"/"extended" mode](https://docs.ruby-lang.org/en/master/Regexp.html#class-Regexp-label-Free-Spacing+Mode+and+Comments), would mean the `Regexp` could be corrupted by additional spacing being considered part of the pattern.

This changes the approach to normalize patterns as `Regexp`s instead of `String`s, and then simply combine them using `Regexp.union`. To preserve the existing behaviour of always making the patterns case insensitive, we extract the source and options from any given `Regexp`, and construct a new one where we force case insensitivity using

```ruby
Regexp.new(regexp.source, regexp.options | Regexp::IGNORECASE)
```

This way, we preserve all other flags (`/.../x`, but also others like `/.../m`).

Note that it was previously possible to work around this by applying options at the subexpression level, which remains possible (e.g. to force case **sensitivity**).

### TODO

- [ ] Validate approach
- [ ] Rename identifiers accordingly
- [ ] Add more specs for edge cases and covering existing behaviour, to ensure it is preserved.
- [ ] Better document use of `Regexp` in cop documentation (unclear how `AllowedRegexp` works; maybe separate PR?)

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
