### PR TITLE
Add TargetRailsVersion to default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -156,6 +156,8 @@ AllCops:
     rubocop-capybara: [capybara]
   # Enable/Disable checking the methods extended by Active Support.
   ActiveSupportExtensionsEnabled: false
+  # Used by rubocop-rails to set the version of Rails used by the inspected code
+  TargetRailsVersion: ~
 
 #################### Bundler ###############################
 


### PR DESCRIPTION
After discovering that a valid configuration can't be created programmatically if it includes `TargetRailsVersion` without [patching it in](https://github.com/rubocop/rubocop-rails/blob/master/lib/rubocop/rails/inject.rb#L14) by doing an `instance_variable_set` on the `ConfigLoader`'s `@default_configuration`, it seems appropriate to explicitly list this property even though it's specific to rubocop-rails.

For example, before this commit, running: 

```ruby
RuboCop::Config.create({
  "AllCops" => {
    "TargetRailsVersion" => 5.2
  }
}, "some_path")
```

Will emit this warning:

```
Warning: AllCops does not support TargetRailsVersion parameter.

Supported parameters are:

  - RubyInterpreters
  - Include
  - Exclude
  - DefaultFormatter
  - DisplayCopNames
  - DisplayStyleGuide
  - StyleGuideBaseURL
  - DocumentationBaseURL
  - ExtraDetails
  - StyleGuideCopsOnly
  - EnabledByDefault
  - DisabledByDefault
  - NewCops
  - UseCache
  - MaxFilesInCache
  - CacheRootDirectory
  - AllowSymlinksInCacheRootDirectory
  - TargetRubyVersion
  - SuggestExtensions
  - ActiveSupportExtensionsEnabled
```

Even though this is the domain of a plugin, it seems appropriate to add it since:

1. `ActiveSupportExtensionsEnabled` has similarly been added (perhaps for the same reason?)
2. RuboCop itself (and not rubocop-rails) actually contains the logic handling this setting  in [Config](/lib/rubocop/config.rb#L249-L258)

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
