### PR TITLE
Fix an error for `Style/RequireOrder`

### DIFF
--- a/changelog/fix_an_error_for_style_require_order.md
+++ b/changelog/fix_an_error_for_style_require_order.md
@@ -1,0 +1,1 @@
+* [#11835](https://github.com/rubocop/rubocop/pull/11835): Fix an error for `Style/RequireOrder` when multiple `require` are not sorted. ([@koic][])

--- a/lib/rubocop/cop/style/require_order.rb
+++ b/lib/rubocop/cop/style/require_order.rb
@@ -88,10 +88,7 @@ module RuboCop
           return unless previous_older_sibling
 
           add_offense(node, message: format(MSG, name: node.method_name)) do |corrector|
-            corrector.swap(
-              range_with_comments_and_lines(previous_older_sibling),
-              range_with_comments_and_lines(node.parent.if_type? ? node.parent : node)
-            )
+            autocorrect(corrector, node, previous_older_sibling)
           end
         end
 
@@ -112,6 +109,14 @@ module RuboCop
 
             node.first_argument.source < sibling.first_argument.source
           end
+        end
+
+        def autocorrect(corrector, node, previous_older_sibling)
+          range1 = range_with_comments_and_lines(previous_older_sibling)
+          range2 = range_with_comments_and_lines(node.parent.if_type? ? node.parent : node)
+
+          corrector.remove(range2)
+          corrector.insert_before(range1, range2.source)
         end
 
         def search_node(node)

--- a/spec/rubocop/cop/style/require_order_spec.rb
+++ b/spec/rubocop/cop/style/require_order_spec.rb
@@ -92,6 +92,27 @@ RSpec.describe RuboCop::Cop::Style::RequireOrder, :config do
     end
   end
 
+  context 'when multiple `require` are not sorted' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        require 'd'
+        require 'a'
+        ^^^^^^^^^^^ Sort `require` in alphabetical order.
+        require 'b'
+        ^^^^^^^^^^^ Sort `require` in alphabetical order.
+        require 'c'
+        ^^^^^^^^^^^ Sort `require` in alphabetical order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require 'a'
+        require 'b'
+        require 'c'
+        require 'd'
+      RUBY
+    end
+  end
+
   context 'when both `require` and `require_relative` are in same section' do
     it 'registers no offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR fixes the following error for `Style/RequireOrder` when multiple `require` are not sorted:

```console
$ cat example.rb
require 'd'
require 'a'
require 'b'
require 'c'
```

```console
$ bundle exec rubocop --only Style/RequireOrder -A
Inspecting 1 file
An error occurred while Style/RequireOrder cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/require_order/example.rb:4:0.
To see the complete backtrace run rubocop -d.
C

Offenses:

example.rb:2:1: C: [Corrected] Style/RequireOrder: Sort require in alphabetical order.
require 'a'
^^^^^^^^^^^
example.rb:3:1: C: [Corrected] Style/RequireOrder: Sort require in alphabetical order.
require 'b'
^^^^^^^^^^^
example.rb:4:1: C: [Corrected] Style/RequireOrder: Sort require in alphabetical order.
require 'c'
^^^^^^^^^^^

1 file inspected, 3 offenses detected, 3 offenses corrected

1 error occurred:
An error occurred while Style/RequireOrder cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/require_order/example.rb:4:0.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop/rubocop/issues

Mention the following information in the issue report:
1.50.2 (using Parser 3.2.2.1, rubocop-ast 1.28.1, running on ruby 3.2.1) [x86_64-darwin19]
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
