### PR TITLE
Add dev docs on preventing correction clobbering

### DIFF
--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -347,6 +347,34 @@ The corrector allows you to `insert_after`, `insert_before`, `wrap` or
 Range can be determined on `node.location` where it brings specific
 ranges for expression or other internal information that the node holds.
 
+==== Preventing Clobbering
+
+The corrector detects and prevents correcting overlapping nodes, to prevent one correction from clobbering another.
+Supporting nested corrections is done by taking multiple passes, and skipping corrections for nested nodes.
+This can be implemented using the `IgnoredNode` module:
+
+[source,diff]
+----
+ extend AutoCorrector
++include IgnoredNode
+
+ def on_send(node)
+   return unless some_condition?(node)
+
+   add_offense(node) do |corrector|
++    next if part_of_ignored_node?(node)
++
+     corrector.replace(node, "...")
+   end
++
++  ignore_node(node)
+ end
+----
+
+This works because the correcting a file is implemented by repeating investigation and correction until the file no longer requires correction, meaning all nested nodes will eventually be processed.
+
+Note that `expect_correction` in `Cop` specs only asserts the result after one pass.
+
 === Configuration
 
 Each cop can hold a configuration and you can refer to `cop_config` in the


### PR DESCRIPTION
It may not be obvious to contributors how to resolve the problem of correction clobbering, requiring investigation to find a solution.

This documents the problem and typical solution, for better discoverability.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* ~Added tests.~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
