### PR TITLE
Add autocorrection for `Lint/UselessAssignment`

### DIFF
--- a/changelog/new_add_autocorrection_for_lint_useless_assignment.md
+++ b/changelog/new_add_autocorrection_for_lint_useless_assignment.md
@@ -1,0 +1,1 @@
+* [#11597](https://github.com/rubocop/rubocop/issues/11597): Add autocorrection for `Lint/UselessAssignment`. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2454,6 +2454,8 @@ Lint/UselessAssignment:
   StyleGuide: '#underscore-unused-vars'
   Enabled: true
   VersionAdded: '0.11'
+  VersionChanged: '<<next>>'
+  SafeAutoCorrect: false
 
 Lint/UselessElseWithoutRescue:
   Description: 'Checks for useless `else` in `begin..end` without `rescue`.'

--- a/lib/rubocop/cop/variable_force/assignment.rb
+++ b/lib/rubocop/cop/variable_force/assignment.rb
@@ -47,6 +47,10 @@ module RuboCop
           @node.type == REGEXP_NAMED_CAPTURE_TYPE
         end
 
+        def exception_assignment?
+          node.parent&.resbody_type? && node.parent.exception_variable == node
+        end
+
         def operator_assignment?
           return false unless meta_assignment_node
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     create_file('.rubocop.yml', <<~YAML)
       Layout/HashAlignment:
         EnforcedColonStyle: table
+      Lint/UselessAssignment:
+        Enabled: false
       Style/FrozenStringLiteralComment:
         Enabled: false
     YAML
@@ -30,7 +32,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       }
     RUBY
     create_file('example.rb', source)
-    expect(cli.run(['--autocorrect-all'])).to eq(1)
+    expect(cli.run(['--autocorrect-all'])).to eq(0)
     expect(File.read('example.rb')).to eq(source)
   end
 
@@ -46,6 +48,9 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
         ForceEqualSignAlignment: true
 
       Layout/MultilineMethodCallBraceLayout:
+        Enabled: false
+
+      Lint/UselessAssignment:
         Enabled: false
     YAML
 
@@ -112,6 +117,8 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     create_file('.rubocop.yml', <<~YAML)
       Layout/ExtraSpacing:
         ForceEqualSignAlignment: true
+      Lint/UselessAssignment:
+        Enabled: false
     YAML
 
     create_file('example.rb', <<~RUBY)
@@ -138,6 +145,9 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
 
       Layout/HashAlignment:
         EnforcedHashRocketStyle: table
+
+      Lint/UselessAssignment:
+        Enabled: false
     YAML
     source = <<~RUBY
       a = { 1=>2, a => b }
@@ -153,7 +163,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       }
     RUBY
     create_file('example.rb', source)
-    expect(cli.run(['--autocorrect-all'])).to eq(1)
+    expect(cli.run(['--autocorrect-all'])).to eq(0)
 
     # 1=>2 is changed to 1 => 2. The rest is unchanged.
     # SpaceAroundOperators leaves it to HashAlignment when the style is table.
@@ -854,10 +864,12 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
         RUBY
         create_file('example.rb', source)
         create_file('.rubocop.yml', <<~YAML)
+          Lint/UselessAssignment:
+            Enabled: false
           Style/BlockDelimiters:
             EnforcedStyle: #{style}
         YAML
-        expect(cli.run(['--autocorrect-all'])).to eq(1)
+        expect(cli.run(['--autocorrect-all'])).to eq(0)
         # rubocop:disable Style/HashLikeCase
         corrected = case style
                     when :semantic
@@ -1043,7 +1055,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
         BlockB do |_portfolio|
           foo
         end
-      rescue StandardError => e # some problem
+      rescue StandardError # some problem
         bar
       end
 
@@ -1263,7 +1275,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       module Foo
       class Bar
 
-        stuff = [
+        STUFF = [
                   {
                     some: 'hash',
                   },
@@ -1271,7 +1283,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
                     another: 'hash',
                     with: 'more'
                   },
-                ]
+                ].freeze
       end
       end
     RUBY
@@ -1294,7 +1306,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
 
         module Foo
           class Bar
-            stuff = [
+            STUFF = [
               {
                 some: 'hash'
               },
@@ -1302,7 +1314,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
                 another: 'hash',
                 with: 'more'
               }
-            ]
+            ].freeze
           end
         end
       RUBY
@@ -1875,12 +1887,12 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
         EnforcedStyleForMultiline: comma
     YAML
 
-    expect(cli.run(%w[--autocorrect-all])).to eq(1)
+    expect(cli.run(%w[--autocorrect-all])).to eq(0)
     expect($stderr.string).to eq('')
     expect(File.read('example.rb')).to eq(<<~RUBY)
       # frozen_string_literal: true
 
-      result = foo(
+      foo(
         # comment
         <<~SQL.squish)
           SELECT * FROM bar

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -766,9 +766,9 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
               == example.rb ==
               C:  1:  5: [Correctable] Layout/SpaceAroundOperators: Surrounding space missing for operator ==.
               C:  2:  1: [Correctable] Layout/IndentationStyle: Tab detected in indentation.
-              W:  2:  2: Lint/UselessAssignment: Useless assignment to variable - y.
+              W:  2:  2: [Correctable] Lint/UselessAssignment: Useless assignment to variable - y.
 
-              1 file inspected, 3 offenses detected, 2 offenses autocorrectable
+              1 file inspected, 3 offenses detected, 3 offenses autocorrectable
             RESULT
         end
       end
@@ -1946,8 +1946,8 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         expect(cli.run(['--autocorrect', '--format', 'simple', target_file])).to eq(1)
 
         expect($stdout.string.lines.to_a.last)
-          .to eq('1 file inspected, 2 offenses detected, 1 offense corrected' \
-                 "\n")
+          .to eq('1 file inspected, 2 offenses detected, 1 offense corrected, 1 more offense can ' \
+                 "be corrected with `rubocop -A`\n")
       end
     end
 
@@ -1999,7 +1999,10 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         RUBY
 
         expect(cli.run(['--autocorrect', '--format', 'simple', target_file])).to eq(1)
-        expect($stdout.string.lines.to_a.last).to eq("1 file inspected, 2 offenses detected\n")
+        expect($stdout.string.lines.to_a.last).to eq(
+          '1 file inspected, 2 offenses detected, 1 more offense can be corrected with ' \
+          "`rubocop -A`\n"
+        )
       end
     end
   end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         Dir.chdir('other') { expect(cli.run(['--format', 'simple', checked_path])).to eq(1) }
         expect($stdout.string).to eq(<<~RESULT)
           == #{abs('Rakefile')} ==
-          W:  3:  1: Lint/UselessAssignment: Useless assignment to variable - x.
+          W:  3:  1: [Correctable] Lint/UselessAssignment: Useless assignment to variable - x.
 
-          1 file inspected, 1 offense detected
+          1 file inspected, 1 offense detected, 1 offense autocorrectable
         RESULT
       end
     end
@@ -300,9 +300,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
       expect($stdout.string).to eq(<<~RESULT)
         == example.rb ==
-        W:  5:  1: Lint/UselessAssignment: Useless assignment to variable - b.
+        W:  5:  1: [Correctable] Lint/UselessAssignment: Useless assignment to variable - b.
 
-        1 file inspected, 1 offense detected
+        1 file inspected, 1 offense detected, 1 offense autocorrectable
       RESULT
     end
 
@@ -1128,9 +1128,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect($stdout.string)
         .to eq(<<~RESULT)
           == .other/example.rb ==
-          W:  3:  1: Lint/UselessAssignment: Useless assignment to variable - x.
+          W:  3:  1: [Correctable] Lint/UselessAssignment: Useless assignment to variable - x.
 
-          1 file inspected, 1 offense detected
+          1 file inspected, 1 offense detected, 1 offense autocorrectable
         RESULT
     end
 
@@ -1788,7 +1788,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         RUBY
 
         expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
-        expect($stdout.string.lines.to_a.last).to eq("1 file inspected, 2 offenses detected\n")
+        expect($stdout.string.lines.to_a.last).to eq(
+          "1 file inspected, 2 offenses detected, 1 offense autocorrectable\n"
+        )
       end
     end
   end

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        class SomeClass
+          foo = 1
+          puts foo
+          def some_method
+            2
+            bar = 3
+            puts bar
+          end
+        end
+      RUBY
     end
   end
 
@@ -60,6 +72,18 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           def self.some_method
             foo = 2
             ^^^ Useless assignment to variable - `foo`.
+            bar = 3
+            puts bar
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class SomeClass
+          foo = 1
+          puts foo
+          def self.some_method
+            2
             bar = 3
             puts bar
           end
@@ -84,6 +108,19 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        1.times do
+          foo = 1
+          puts foo
+          instance = Object.new
+          def instance.some_method
+            2
+            bar = 3
+            puts bar
+          end
+        end
+      RUBY
     end
   end
 
@@ -96,6 +133,18 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           class SomeClass
             foo = 2
             ^^^ Useless assignment to variable - `foo`.
+            bar = 3
+            puts bar
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        1.times do
+          foo = 1
+          puts foo
+          class SomeClass
+            2
             bar = 3
             puts bar
           end
@@ -120,6 +169,19 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        1.times do
+          foo = 1
+          puts foo
+          array_class = Array
+          class SomeClass < array_class
+            2
+            bar = 3
+            puts bar
+          end
+        end
+      RUBY
     end
   end
 
@@ -138,6 +200,19 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        1.times do
+          foo = 1
+          puts foo
+          instance = Object.new
+          class << instance
+            2
+            bar = 3
+            puts bar
+          end
+        end
+      RUBY
     end
   end
 
@@ -150,6 +225,18 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           module SomeModule
             foo = 2
             ^^^ Useless assignment to variable - `foo`.
+            bar = 3
+            puts bar
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        1.times do
+          foo = 1
+          puts foo
+          module SomeModule
+            2
             bar = 3
             puts bar
           end
@@ -176,6 +263,12 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         bar = 2
         puts bar
       RUBY
+
+      expect_correction(<<~RUBY)
+        1
+        bar = 2
+        puts bar
+      RUBY
     end
   end
 
@@ -184,6 +277,10 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
       expect_offense(<<~RUBY)
         foo ||= 1
         ^^^ Useless assignment to variable - `foo`. Use `||` instead of `||=`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo || 1
       RUBY
     end
   end
@@ -200,6 +297,15 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           puts bar
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          1
+          bar = 2
+          3
+          puts bar
+        end
+      RUBY
     end
   end
 
@@ -213,6 +319,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           ^^^ Useless assignment to variable - `foo`.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          foo = 1
+          puts foo
+          3
+        end
+      RUBY
     end
   end
 
@@ -222,6 +336,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         def some_method
           foo = 1
           ^^^ Useless assignment to variable - `foo`.
+          foo = 3
+          puts foo
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          1
           foo = 3
           puts foo
         end
@@ -281,12 +403,22 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           ^^^ Useless assignment to variable - `foo`.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        1.times do |i; foo|
+          2
+        end
+      RUBY
     end
 
     it 'registers offenses for self assignment in numblock', :ruby27 do
       expect_offense(<<~RUBY)
         do_something { foo += _1 }
                        ^^^ Useless assignment to variable - `foo`. Use `+` instead of `+=`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something { foo + _1 }
       RUBY
     end
   end
@@ -298,6 +430,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           while true
             foo = 1
             ^^^ Useless assignment to variable - `foo`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          while true
+            1
           end
         end
       RUBY
@@ -375,6 +515,20 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           total
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          total = 0
+          foo = 0
+
+          while total < 100
+            total += 1
+            foo = 1
+          end
+
+          total
+        end
+      RUBY
     end
   end
 
@@ -388,6 +542,16 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
             puts foo
             foo = 3
             ^^^ Useless assignment to variable - `foo`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        while true
+          def some_method
+            foo = 1
+            puts foo
+            3
           end
         end
       RUBY
@@ -408,6 +572,17 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        foo = 1
+
+        while foo < 100
+          foo += 1
+          def some_method
+            1
+          end
+        end
+      RUBY
     end
   end
 
@@ -418,6 +593,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           if flag
             foo = 1
             ^^^ Useless assignment to variable - `foo`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method(flag)
+          if flag
+            1
           end
         end
       RUBY
@@ -432,6 +615,17 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           if flag
             foo = 1
             ^^^ Useless assignment to variable - `foo`.
+            foo = 2
+          end
+
+          foo
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method(flag)
+          if flag
+            1
             foo = 2
           end
 
@@ -573,6 +767,17 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method(flag)
+          1
+
+          if flag
+            foo = 2
+            puts foo
+          end
+        end
+      RUBY
     end
   end
 
@@ -583,6 +788,17 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           if flag
             foo = 2
             ^^^ Useless assignment to variable - `foo`.
+          else
+            foo = 3
+            puts foo
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method(flag)
+          if flag
+            2
           else
             foo = 3
             puts foo
@@ -608,6 +824,19 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method(flag)
+          foo = 1
+
+          if flag
+            puts foo
+            2
+          else
+            puts foo
+          end
+        end
+      RUBY
     end
   end
 
@@ -618,6 +847,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         if flag
           foo = 1
           ^^^ Useless assignment to variable - `foo`.
+        else
+          puts foo
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if flag
+          1
         else
           puts foo
         end
@@ -641,6 +878,19 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method(flag_a, flag_b)
+          foo = 1
+
+          if flag_a
+            puts foo
+            2
+          elsif flag_b
+            puts foo
+          end
+        end
+      RUBY
     end
   end
 
@@ -656,6 +906,22 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
             puts foo
             foo = 2
             ^^^ Useless assignment to variable - `foo`.
+          else
+            case
+            when flag_b
+              puts foo
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method(flag_a, flag_b)
+          foo = 1
+
+          if flag_a
+            puts foo
+            2
           else
             case
             when flag_b
@@ -706,6 +972,12 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           ^^^ Useless assignment to variable - `foo`.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method(flag)
+          1 unless foo
+        end
+      RUBY
     end
   end
 
@@ -727,6 +999,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         def some_method
           foo = 1
           ^^^ Useless assignment to variable - `foo`.
+          (foo = do_something_returns_object_or_nil) && do_something
+          foo
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          1
           (foo = do_something_returns_object_or_nil) && do_something
           foo
         end
@@ -795,6 +1075,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           foo
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          foo = 1
+          foo += 2
+          foo
+        end
+      RUBY
     end
   end
 
@@ -818,6 +1106,13 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           ^^^ Useless assignment to variable - `foo`. Use `||` instead of `||=`.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          foo = do_something_returns_object_or_nil
+          foo || 1
+        end
+      RUBY
     end
   end
 
@@ -831,6 +1126,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           some_return_value
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          foo = do_something_returns_object_or_nil
+          foo || 1
+          some_return_value
+        end
+      RUBY
     end
   end
 
@@ -840,6 +1143,13 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         def some_method
           foo, bar = do_something
                ^^^ Useless assignment to variable - `bar`. Use `_` or `_bar` as a variable name to indicate that it won't be used.
+          puts foo
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          foo, _ = do_something
           puts foo
         end
       RUBY
@@ -888,6 +1198,15 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           do_something
           foo = true
           ^^^ Useless assignment to variable - `foo`.
+        rescue
+          do_anything
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          do_something
+          true
         rescue
           do_anything
         end
@@ -983,6 +1302,19 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
 
         puts foo
       RUBY
+
+      expect_correction(<<~RUBY)
+        foo = false
+
+        begin
+          do_something
+        rescue
+          true
+          foo = true
+        end
+
+        puts foo
+      RUBY
     end
   end
 
@@ -1004,6 +1336,21 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
 
         puts foo
       RUBY
+
+      expect_correction(<<~RUBY)
+        foo = false
+
+        begin
+          do_something
+        rescue
+          true
+          foo = true
+        ensure
+          do_anything
+        end
+
+        puts foo
+      RUBY
     end
   end
 
@@ -1018,6 +1365,19 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         ensure
           foo = true
           ^^^ Useless assignment to variable - `foo`.
+          foo = true
+        end
+
+        puts foo
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          do_something
+        rescue
+          do_anything
+        ensure
+          true
           foo = true
         end
 
@@ -1082,6 +1442,23 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
 
         puts foo
       RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          do_something
+          :in_begin
+        rescue FirstError
+          :in_first_rescue
+        rescue SecondError
+          :in_second_rescue
+        else
+          :in_else
+        ensure
+          foo = :in_ensure
+        end
+
+        puts foo
+      RUBY
     end
   end
 
@@ -1093,6 +1470,15 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           do_something
         rescue FirstError => error
                              ^^^^^ Useless assignment to variable - `error`.
+        rescue SecondError
+          p error # => nil
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          do_something
+        rescue FirstError
         rescue SecondError
           p error # => nil
         end
@@ -1120,6 +1506,13 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           super
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method(bar)
+          1
+          super
+        end
+      RUBY
     end
   end
 
@@ -1132,6 +1525,13 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           super(bar)
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method(foo, bar)
+          1
+          super(bar)
+        end
+      RUBY
     end
   end
 
@@ -1140,6 +1540,10 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
       expect_offense(<<~RUBY)
         /(?<foo>\w+)/ =~ 'FOO'
         ^^^^^^^^^^^^ Useless assignment to variable - `foo`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        /(?:\w+)/ =~ 'FOO'
       RUBY
     end
   end
@@ -1150,6 +1554,12 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         def some_method
           /(?<foo>\w+)/ =~ 'FOO'
           ^^^^^^^^^^^^^ Useless assignment to variable - `foo`.
+        end
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        def some_method
+          /(?:\w+)/ =~ 'FOO'
         end
       RUBY
     end
@@ -1198,6 +1608,15 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         def some_method
           foo = 1
           ^^^ Useless assignment to variable - `foo`.
+          1.times do |foo|
+            puts foo
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          1
           1.times do |foo|
             puts foo
           end
@@ -1306,6 +1725,10 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         foo = 1
         ^^^ Useless assignment to variable - `foo`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        1
+      RUBY
     end
   end
 
@@ -1325,6 +1748,11 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         expect_offense(<<~RUBY)
           some_method(foo = 1) do
                       ^^^ Useless assignment to variable - `foo`.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          some_method(1) do
           end
         RUBY
       end
@@ -1378,6 +1806,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
             puts environment
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          def some_method
+            {}
+            another_symbol
+            puts environment
+          end
+        RUBY
       end
     end
 
@@ -1392,6 +1828,15 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
             puts environment
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          def some_method
+            environment = nil
+            another_symbol
+            {}
+            puts environment
+          end
+        RUBY
       end
     end
 
@@ -1401,6 +1846,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           def some_method
             enviromnent = {}
             ^^^^^^^^^^^ Useless assignment to variable - `enviromnent`.
+            another_symbol
+            puts envelope
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def some_method
+            {}
             another_symbol
             puts envelope
           end
@@ -1418,6 +1871,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
             puts self.environment
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          def some_method
+            {}
+            another_symbol
+            puts self.environment
+          end
+        RUBY
       end
     end
 
@@ -1431,6 +1892,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
             puts environment(1)
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          def some_method
+            {}
+            another_symbol
+            puts environment(1)
+          end
+        RUBY
       end
     end
 
@@ -1440,6 +1909,16 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           class SomeClass
             enviromnent = {}
             ^^^^^^^^^^^ Useless assignment to variable - `enviromnent`.
+
+            def some_method(environment)
+              puts environment
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class SomeClass
+            {}
 
             def some_method(environment)
               puts environment

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::Team do
           'bar' +
           "#{baz}"
 
-        i=i+1
+        i+1
 
         def a
           self::b
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::Team do
           'bar' \
           "#{baz}"
 
-        i += 1
+        i + 1
 
         def a
           b


### PR DESCRIPTION
As discussed in https://github.com/rubocop/rubocop/issues/11597, this autocorrection does not take care of responsibilities that should be handled by `Lint/Void`.

- https://github.com/rubocop/rubocop/pull/11848

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
