### PR TITLE
Fix an error for `Style/IfUnlessModifier`

### DIFF
--- a/changelog/fix_an_error_for_style_if_unless_modifier.md
+++ b/changelog/fix_an_error_for_style_if_unless_modifier.md
@@ -1,0 +1,1 @@
+* [#11842](https://github.com/rubocop/rubocop/pull/11842): Fix an error for `Style/IfUnlessModifier` when using multiple `if` modifier in the long one line. ([@koic][])

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -84,7 +84,10 @@ module RuboCop
           return unless (msg = message(node))
 
           add_offense(node.loc.keyword, message: format(msg, keyword: node.keyword)) do |corrector|
+            next if part_of_ignored_node?(node)
+
             autocorrect(corrector, node)
+            ignore_node(node)
           end
         end
 

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -73,6 +73,26 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         end
       end
 
+      context 'when using multiple `if` modifier in the long one line' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            def f
+              return value if items.filter_map { |item| item.do_something if item.something? }
+                                                                          ^^ Modifier form of `if` makes the line too long.
+                           ^^ Modifier form of `if` makes the line too long.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def f
+              if items.filter_map { |item| item.do_something if item.something? }
+                return value
+              end
+            end
+          RUBY
+        end
+      end
+
       context 'when using a method with heredoc argument' do
         it 'accepts' do
           expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR fixes the following error for `Style/IfUnlessModifier` when using multiple `if` modifier in the long one line:

```ruby
return value if items.filter_map { |item| item.loooooooooooooooooooooooooooooooooooooooooooooooooooog if item.something? }
```

```console
$ bundle exec rubocop --only Style/IfUnlessModifier -a -d
(snip)

Scanning /Users/koic/src/github.com/koic/rubocop-issues/if_unless_modifier/example.rb
An error occurred while Style/IfUnlessModifier cop was inspecting /Users/koic/src/github.com/koic/rubocop-issues/if_unless_modifier/example.rb:1:42.
Parser::Source::TreeRewriter detected clobbering
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
