### PR TITLE
Simplify `inspect` output

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -284,6 +284,10 @@ module RuboCop
       end
     end
 
+    def inspect # :nodoc:
+      "#<#{self.class.name}:#{object_id} @loaded_path=#{loaded_path}>"
+    end
+
     private
 
     def target_rails_version_from_bundler_lock_file

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -305,6 +305,10 @@ module RuboCop
         @current_original = original
       end
 
+      def inspect # :nodoc:
+        "#<#{self.class.name}:#{object_id} @config=#{@config} @options=#{@options}>"
+      end
+
       private
 
       ### Reserved for Cop::Cop


### PR DESCRIPTION
When debugging errors, cops and configs may be inspected as part of error messages.

Extremely long error messages can be problematic when debugging, as they may exhaust the terminal scrollback buffer, without the visible portion necesarily providing useful information.

Because the config typically contains at least the entire default config, its `inspect` output is unusably long.

Because cops contain many instance variables relating to the file being investigated (which may be long), their `inspect` output is often unusably long.

Simplifying the `inspect` output for such objects makes error output more usable, and is a technique used in other gems, such as Rails.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
