### PR TITLE
[Fix #11844] Fix a false positive for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_line_continuation.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_line_continuation.md
@@ -1,0 +1,1 @@
+* [#11844](https://github.com/rubocop/rubocop/issues/11844): Fix a false positive for `Style/RedundantLineContinuation` when using line concatenation for assigning a return value and without argument parentheses. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -70,6 +70,10 @@ module RuboCop
 
         MSG = 'Redundant line continuation.'
         ALLOWED_STRING_TOKENS = %i[tSTRING tSTRING_CONTENT].freeze
+        ARGUMENT_TYPES = %i[
+          kFALSE kNIL kSELF kTRUE tCONSTANT tCVAR tFLOAT tGVAR tIDENTIFIER tINTEGER tIVAR
+          tLBRACK tLCURLY tLPAREN_ARG tSTRING tSTRING_BEG tSYMBOL tXSTRING_BEG
+        ].freeze
 
         def on_new_investigation
           return unless processed_source.ast
@@ -124,7 +128,7 @@ module RuboCop
         #   do_something \
         #     argument
         def method_with_argument?(current_token, next_token)
-          current_token.type == :tIDENTIFIER && next_token.type == :tIDENTIFIER
+          current_token.type == :tIDENTIFIER && ARGUMENT_TYPES.include?(next_token.type)
         end
 
         def argument_newline?(node)

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -191,10 +191,138 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
-  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses' do
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of method call' do
     expect_no_offenses(<<~'RUBY')
       foo = do_something \
         argument
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of local variable' do
+    expect_no_offenses(<<~'RUBY')
+      argument = 42
+
+      foo = do_something \
+        argument
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of instance variable' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        @argument
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of class variable' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        @@argument
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of global variable' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        $argument
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of constant' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        ARGUMENT
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of string literal' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        'argument'
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of interpolated string literal' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        "argument#{x}"
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of xstring literal' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        `argument`
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of symbol literal' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        :argument
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of regexp literal' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        (1..9)
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of integer literal' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        42
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of float literal' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        42.0
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of true literal' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        true
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of false literal' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        false
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of nil literal' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        nil
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of self' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        self
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of array literal' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        []
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of hash literal' do
+    expect_no_offenses(<<~'RUBY')
+      foo = do_something \
+        {}
     RUBY
   end
 


### PR DESCRIPTION
Fixes #11844.

This PR fixes a false positive for `Style/RedundantLineContinuation` when using line concatenation for assigning a return value and without argument parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
