### PR TITLE
[Fix #11846] Fix a false positive for `Lint/RedundantStringCoercion`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_redundant_string_coercion.md
+++ b/changelog/fix_a_false_positive_for_lint_redundant_string_coercion.md
@@ -1,0 +1,1 @@
+* [#11846](https://github.com/rubocop/rubocop/issues/11846): Fix a false positive for `Lint/RedundantStringCoercion` when using `to_s(argument)` in `puts` argument. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_string_coercion.rb
+++ b/lib/rubocop/cop/lint/redundant_string_coercion.rb
@@ -47,7 +47,7 @@ module RuboCop
           return if node.receiver
 
           node.each_child_node(:send) do |child|
-            next unless child.method?(:to_s)
+            next if !child.method?(:to_s) || child.arguments.any?
 
             register_offense(child, "`#{node.method_name}`")
           end

--- a/spec/rubocop/cop/lint/redundant_string_coercion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_string_coercion_spec.rb
@@ -138,4 +138,10 @@ RSpec.describe RuboCop::Cop::Lint::RedundantStringCoercion, :config do
       obj.print first.to_s, second.to_s
     RUBY
   end
+
+  it 'does not register an offense when using `to_s(argument)` in `puts` argument' do
+    expect_no_offenses(<<~RUBY)
+      puts obj.to_s(argument)
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #11846.

This PR fixes a false positive for `Lint/RedundantStringCoercion` when using `to_s(argument)` in `puts` argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
