### PR TITLE
Add autocorrection for `Lint/Void`

### DIFF
--- a/changelog/new_add_autocorrection_for_lint_void.md
+++ b/changelog/new_add_autocorrection_for_lint_void.md
@@ -1,0 +1,1 @@
+* [#11848](https://github.com/rubocop/rubocop/pull/11848): Add autocorrection for `Lint/Void`. ([@r7kamura][])

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -569,7 +569,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
   context 'space_inside_bracket cops' do
     let(:source) do
       <<~RUBY
-        [ a[b], c[ d ], [1, 2] ]
+        puts [ a[b], c[ d ], [1, 2] ]
         foo[[ 3, 4 ], [5, 6] ]
       RUBY
     end
@@ -608,7 +608,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
         <<~RUBY
           # frozen_string_literal: true
 
-          [ a[b], c[d], [ 1, 2 ] ]
+          puts [ a[b], c[d], [ 1, 2 ] ]
           foo[[ 3, 4 ], [ 5, 6 ]]
         RUBY
       end
@@ -624,7 +624,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
         <<~RUBY
           # frozen_string_literal: true
 
-          [a[ b ], c[ d ], [1, 2]]
+          puts [a[ b ], c[ d ], [1, 2]]
           foo[ [3, 4], [5, 6] ]
         RUBY
       end
@@ -640,7 +640,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
         <<~RUBY
           # frozen_string_literal: true
 
-          [ a[b], c[d], [ 1, 2 ]]
+          puts [ a[b], c[d], [ 1, 2 ]]
           foo[[ 3, 4 ], [ 5, 6 ]]
         RUBY
       end
@@ -656,7 +656,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
         <<~RUBY
           # frozen_string_literal: true
 
-          [ a[ b ], c[ d ], [ 1, 2 ]]
+          puts [ a[ b ], c[ d ], [ 1, 2 ]]
           foo[ [ 3, 4 ], [ 5, 6 ] ]
         RUBY
       end
@@ -1784,8 +1784,8 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
 
   it 'handles different SpaceInsideBlockBraces and SpaceInsideHashLiteralBraces' do
     create_file('example.rb', <<~RUBY)
-      {foo: bar,
-       bar: baz,}
+      puts({foo: bar,
+       bar: baz,})
       foo.each {bar;}
     RUBY
     create_file('.rubocop.yml', <<~YAML)
@@ -1796,13 +1796,13 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       Style/TrailingCommaInHashLiteral:
         EnforcedStyleForMultiline: consistent_comma
     YAML
-    expect(cli.run(%w[--autocorrect-all])).to eq(1)
+    expect(cli.run(%w[--autocorrect-all])).to eq(0)
     expect($stderr.string).to eq('')
     expect(File.read('example.rb')).to eq(<<~RUBY)
       # frozen_string_literal: true
 
-      {foo: bar,
-       bar: baz,}
+      puts({foo: bar,
+            bar: baz,})
       foo.each { bar }
     RUBY
   end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
           ^{op} Operator `#{op}` used in void context.
         a %{op} b
       RUBY
+
+      expect_correction(<<~RUBY)
+        a
+        b
+        a
+        b
+        a #{op} b
+      RUBY
     end
 
     it "accepts void op #{op} if on last line" do
@@ -37,6 +45,12 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         ^{op} Operator `#{op}@` used in void context.
         %{op}b
       RUBY
+
+      expect_correction(<<~RUBY)
+        b
+        b
+        #{op}b
+      RUBY
     end
   end
 
@@ -48,6 +62,12 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         %{op}b
         ^{op} Operator `#{op}` used in void context.
         %{op}b
+      RUBY
+
+      expect_correction(<<~RUBY)
+        b
+        b
+        #{op}b
       RUBY
     end
   end
@@ -73,6 +93,11 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         ^{var} Variable `#{var}` used in void context.
         top
       RUBY
+
+      expect_correction(<<~RUBY)
+        #{var} = 5
+        top
+      RUBY
     end
   end
 
@@ -83,6 +108,11 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         ^{lit} Literal `#{lit}` used in void context.
         top
       RUBY
+
+      expect_correction(<<~RUBY)
+        #{''}
+        top
+      RUBY
     end
   end
 
@@ -90,6 +120,10 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     expect_offense(<<~RUBY)
       self; top
       ^^^^ `self` used in void context.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ; top
     RUBY
   end
 
@@ -99,6 +133,11 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       ^^^^^^^^^^^ `defined?(x)` used in void context.
       top
     RUBY
+
+    expect_correction(<<~RUBY)
+
+      top
+    RUBY
   end
 
   it 'registers an offense for void `-> { bar }` if not on last line' do
@@ -106,6 +145,12 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       def foo
         -> { bar }
         ^^^^^^^^^^ `-> { bar }` used in void context.
+        top
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
         top
       end
     RUBY
@@ -137,6 +182,12 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         top
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        top
+      end
+    RUBY
   end
 
   it 'does not register an offense for void `lambda { bar }` if on last line' do
@@ -165,6 +216,12 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         top
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        top
+      end
+    RUBY
   end
 
   it 'does not register an offense for void `proc { bar }` if on last line' do
@@ -190,6 +247,12 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       def foo
         Proc.new { bar }
         ^^^^^^^^^^^^^^^^ `Proc.new { bar }` used in void context.
+        top
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
         top
       end
     RUBY
@@ -226,6 +289,13 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         end
         "done"
       RUBY
+
+      expect_correction(<<~RUBY)
+        [1,2,3].each do |n|
+          n.to_s
+        end
+        "done"
+      RUBY
     end
 
     context 'Ruby 2.7', :ruby27 do
@@ -233,6 +303,13 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         expect_offense(<<~RUBY)
           [1,2,3].map do
           ^^^^^^^^^^^^^^ Method `#map` used in void context. Did you mean `#each`?
+            _1.to_s
+          end
+          "done"
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [1,2,3].each do
             _1.to_s
           end
           "done"
@@ -246,12 +323,22 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         ^^^^^^ Method `#sort` used in void context. Did you mean `#sort!`?
         top(x)
       RUBY
+
+      expect_correction(<<~RUBY)
+        x.sort!
+        top(x)
+      RUBY
     end
 
     it 'registers an offense for chained methods' do
       expect_offense(<<~RUBY)
         x.sort.flatten
         ^^^^^^^^^^^^^^ Method `#flatten` used in void context. Did you mean `#flatten!`?
+        top(x)
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.sort.flatten!
         top(x)
       RUBY
     end
@@ -285,6 +372,12 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         42
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def something
+        42
+      end
+    RUBY
   end
 
   it 'registers two offenses for void literals in an initialize method' do
@@ -294,6 +387,11 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         ^^ Literal `42` used in void context.
         42
         ^^ Literal `42` used in void context.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def initialize
       end
     RUBY
   end
@@ -307,6 +405,11 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         ^^ Literal `42` used in void context.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def foo=(rhs)
+      end
+    RUBY
   end
 
   it 'registers two offenses for void literals in a `#each` method' do
@@ -318,6 +421,11 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         ^^ Literal `42` used in void context.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      array.each do |_item|
+      end
+    RUBY
   end
 
   it 'handles `#each` block with single expression' do
@@ -325,6 +433,11 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       array.each do |_item|
         42
         ^^ Literal `42` used in void context.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array.each do |_item|
       end
     RUBY
   end
@@ -336,6 +449,11 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
           _1
           ^^ Variable `_1` used in void context.
           42
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo.tap do
         end
       RUBY
     end
@@ -356,6 +474,11 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         ^^ Literal `42` used in void context.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo.tap do |x|
+      end
+    RUBY
   end
 
   it 'registers two offenses for void literals in a `for`' do
@@ -367,6 +490,11 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         ^^ Literal `42` used in void context.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      for _item in array do
+      end
+    RUBY
   end
 
   it 'handles explicit begin blocks' do
@@ -374,6 +502,12 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       begin
        1
        ^ Literal `1` used in void context.
+       2
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
        2
       end
     RUBY

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe RuboCop::Cop::Team do
       source = <<~'RUBY'
         foo.map{ |a| a.nil? }
 
-        'foo' +
-          'bar' +
-          "#{baz}"
+        puts 'foo' +
+             'bar' +
+             "#{baz}"
 
         i=i+1
 
@@ -36,9 +36,9 @@ RSpec.describe RuboCop::Cop::Team do
 
         foo.map(&:nil?)
 
-        'foo' \
-          'bar' \
-          "#{baz}"
+        puts 'foo' \
+             'bar' \
+             "#{baz}"
 
         i += 1
 


### PR DESCRIPTION
To complement the `Lint/UselessAssignment` autocorrection proposed in #11840, I thought it would be nice to have `Lint/Void` autocorrection as well.

- https://github.com/rubocop/rubocop/pull/11840

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
