### PR TITLE
[Fix #11849] Fix an error for `Style/ConditionalAssignment`

### DIFF
--- a/changelog/fix_an_error_for_style_conditional_assignment.md
+++ b/changelog/fix_an_error_for_style_conditional_assignment.md
@@ -1,0 +1,1 @@
+* [#11849](https://github.com/rubocop/rubocop/issues/11849): Fix an error for `Style/ConditionalAssignment` when `EnforcedStyle: assign_inside_condition` and using empty `case` condition. ([@koic][])

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -350,7 +350,7 @@ module RuboCop
         end
 
         def ternary_condition?(node)
-          [node, node.children.first].any? { |n| n.if_type? && n.ternary? }
+          [node, node.children.first].compact.any? { |n| n.if_type? && n.ternary? }
         end
 
         def lhs_all_match?(branches)

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -852,6 +852,27 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
       RUBY
     end
 
+    it 'registers an offense when empty `case` condition' do
+      expect_offense(<<~RUBY)
+        var = case
+        ^^^^^^^^^^ Assign variables inside of conditionals
+        when foo
+          bar
+        else
+          baz
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        case
+        when foo
+          var = bar
+        else
+          var = baz
+        end
+      RUBY
+    end
+
     context 'for loop' do
       it 'ignores pseudo assignments in a for loop' do
         expect_no_offenses('for i in [1, 2, 3]; puts i; end')


### PR DESCRIPTION
Fixes #11849.

This PR fixes an error for `Style/ConditionalAssignment` when `EnforcedStyle: assign_inside_condition` and using empty `case` condition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
