### PR TITLE
[Fix #11852] Fix an incorrect autocorrect for `Style/EvalWithLocation`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_eval_with_location.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_eval_with_location.md
@@ -1,0 +1,1 @@
+* [#11852](https://github.com/rubocop/rubocop/issues/11852): Fix an incorrect autocorrect for `Style/EvalWithLocation` when using `eval` without line number and with parenthesized method call. ([@koic][])

--- a/lib/rubocop/cop/style/eval_with_location.rb
+++ b/lib/rubocop/cop/style/eval_with_location.rb
@@ -210,7 +210,7 @@ module RuboCop
         def add_offense_for_missing_line(node, code)
           register_offense(node) do |corrector|
             line_str = missing_line(node, code)
-            corrector.insert_after(node.source_range.end, ", #{line_str}")
+            corrector.insert_after(node.last_argument.source_range.end, ", #{line_str}")
           end
         end
 

--- a/spec/rubocop/cop/style/eval_with_location_spec.rb
+++ b/spec/rubocop/cop/style/eval_with_location_spec.rb
@@ -70,6 +70,21 @@ RSpec.describe RuboCop::Cop::Style::EvalWithLocation, :config do
     RUBY
   end
 
+  it 'registers an offense when using `#eval` without lineno and with parenthesized method call' do
+    expect_offense(<<~RUBY)
+      eval(<<-CODE, binding, __FILE__)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pass a binding, `__FILE__` and `__LINE__` to `eval`.
+        do_something
+      CODE
+    RUBY
+
+    expect_correction(<<~RUBY)
+      eval(<<-CODE, binding, __FILE__, __LINE__ + 1)
+        do_something
+      CODE
+    RUBY
+  end
+
   it 'registers an offense when using `#eval` with an incorrect line number' do
     expect_offense(<<~RUBY)
       eval 'do_something', binding, __FILE__, __LINE__ + 1


### PR DESCRIPTION
Fixes #11852.

This PR fixes an incorrect autocorrect for `Style/EvalWithLocation` when using `eval` without line number and with parenthesized method call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
