### PR TITLE
Add autocorrection for `Style/HashLikeCase`

### DIFF
--- a/changelog/new_add_autocorrection_for_style_hash_like_case.md
+++ b/changelog/new_add_autocorrection_for_style_hash_like_case.md
@@ -1,0 +1,1 @@
+* [#11854](https://github.com/rubocop/rubocop/pull/11854): Add autocorrection for `Style/HashLikeCase`. ([@r7kamura][])

--- a/spec/rubocop/cop/style/hash_like_case_spec.rb
+++ b/spec/rubocop/cop/style/hash_like_case_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe RuboCop::Cop::Style::HashLikeCase, :config do
           'BAR'
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        { 'foo' => 'FOO', 'bar' => 'BAR' }[x]
+      RUBY
     end
 
     it 'registers an offense when using `case-when` with symbol conditions and literal bodies of the same type' do
@@ -25,6 +29,10 @@ RSpec.describe RuboCop::Cop::Style::HashLikeCase, :config do
         when :bar
           'BAR'
         end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        { :foo => 'FOO', :bar => 'BAR' }[x]
       RUBY
     end
 


### PR DESCRIPTION
Implemented autocorrection that replaces case-when with Hash literal lookup.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
