### PR TITLE
Remove unnecessary `Symbol#to_s` used for Ruby 2.6- compatibility

### DIFF
--- a/lib/rubocop/cop/style/combinable_loops.rb
+++ b/lib/rubocop/cop/style/combinable_loops.rb
@@ -78,8 +78,7 @@ module RuboCop
         private
 
         def collection_looping_method?(node)
-          # TODO: Remove `Symbol#to_s` after supporting only Ruby >= 2.7.
-          method_name = node.method_name.to_s
+          method_name = node.method_name
           method_name.start_with?('each') || method_name.end_with?('_each')
         end
 


### PR DESCRIPTION
I found a comment that mentions compatibility with Ruby 2.6-. Since this cop already requires Ruby 2.7 or higher at its gemspec, I think it's safe to remove this `to_s`.

- https://github.com/rubocop/rubocop/pull/11791

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
