### PR TITLE
Add autocorrection for `Style/CombinableLoops`

### DIFF
--- a/changelog/new_add_autocorrection_for_style_combinable_loops.md
+++ b/changelog/new_add_autocorrection_for_style_combinable_loops.md
@@ -1,0 +1,1 @@
+* [#11856](https://github.com/rubocop/rubocop/pull/11856): Add autocorrection for `Style/CombinableLoops`. ([@r7kamura][])

--- a/spec/rubocop/cop/style/combinable_loops_spec.rb
+++ b/spec/rubocop/cop/style/combinable_loops_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe RuboCop::Cop::Style::CombinableLoops, :config do
         items.reverse_each { |item| do_something_else(item, arg) }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Combine this loop with the previous loop.
       RUBY
+
+      expect_correction(<<~RUBY)
+        items.each { |item| do_something(item)
+        do_something_else(item, arg) }
+
+        items.each_with_index { |item| do_something(item)
+        do_something_else(item, arg) }
+
+        items.reverse_each { |item| do_something(item)
+        do_something_else(item, arg) }
+      RUBY
     end
 
     context 'Ruby 2.7' do
@@ -32,6 +43,17 @@ RSpec.describe RuboCop::Cop::Style::CombinableLoops, :config do
           items.reverse_each { do_something(_1) }
           items.reverse_each { do_something_else(_1, arg) }
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Combine this loop with the previous loop.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          items.each { do_something(_1)
+          do_something_else(_1, arg) }
+
+          items.each_with_index { do_something(_1)
+          do_something_else(_1, arg) }
+
+          items.reverse_each { do_something(_1)
+          do_something_else(_1, arg) }
         RUBY
       end
     end
@@ -91,6 +113,11 @@ RSpec.describe RuboCop::Cop::Style::CombinableLoops, :config do
         for item in items do do_something(item) end
         for item in items do do_something_else(item, arg) end
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Combine this loop with the previous loop.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        for item in items do do_something(item)
+        do_something_else(item, arg) end
       RUBY
     end
 


### PR DESCRIPTION
As long as the offense is not a false positive, I believe this autocorrection would be safe.

What I am a little concerned about now is what the outcome should be if there are comments in between 🤔 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
