### PR TITLE
Server mode: only read $stdin when -s or --stdin argument provided

### DIFF
--- a/changelog/fix_server_mode_only_read_stdin_when_s_or_stdin.md
+++ b/changelog/fix_server_mode_only_read_stdin_when_s_or_stdin.md
@@ -1,0 +1,1 @@
+* [#11857](https://github.com/rubocop/rubocop/pull/11857): Server mode: only read $stdin when -s or --stdin argument provided. ([@naveg][])

--- a/lib/rubocop/server/client_command/exec.rb
+++ b/lib/rubocop/server/client_command/exec.rb
@@ -18,10 +18,11 @@ module RuboCop
         def run
           ensure_server!
           Cache.status_path.delete if Cache.status_path.file?
+          read_stdin = ARGV.include?('-s') || ARGV.include?('--stdin')
           send_request(
             command: 'exec',
             args: ARGV.dup,
-            body: $stdin.tty? ? '' : $stdin.read
+            body: read_stdin ? $stdin.read : ''
           )
           warn stderr unless stderr.empty?
           status

--- a/spec/rubocop/server/client_command/exec_spec.rb
+++ b/spec/rubocop/server/client_command/exec_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Server::ClientCommand::Exec do
+  if RuboCop::Server.support_server?
+    it 'does not read from $stdin when -s/--stdin not specified' do
+      exec_command = described_class.new
+
+      expect(ARGV).to receive(:include?).with('-s').and_return(false)
+      expect(ARGV).to receive(:include?).with('--stdin').and_return(false)
+
+      expect(exec_command).to receive(:ensure_server!).and_return(nil)
+      expect(exec_command).to receive(:send_request).and_return(nil)
+      expect(exec_command).to receive(:stderr).and_return('')
+      expect(exec_command).to receive(:status).and_return(0)
+
+      allow($stdin).to receive(:tty?).and_return(false)
+      expect($stdin).not_to receive(:read)
+
+      exec_command.run
+    end
+
+    it 'reads from $stdin when -s/--stdin specified' do
+      exec_command = described_class.new
+
+      expect(ARGV).to receive(:include?).with('-s').and_return(true)
+
+      expect(exec_command).to receive(:ensure_server!).and_return(nil)
+      expect(exec_command).to receive(:send_request).and_return(nil)
+      expect(exec_command).to receive(:stderr).and_return('')
+      expect(exec_command).to receive(:status).and_return(0)
+
+      allow($stdin).to receive(:tty?).and_return(false)
+      expect($stdin).to receive(:read)
+
+      exec_command.run
+    end
+  end
+end


### PR DESCRIPTION
When using `--server` in a non-tty environment, rubocop hangs reading
STDIN. Avoid this by only reading STDIN when the `-s` or `--stdin`
arguments are provided, in which case text on STDIN is expected.

This change allows `rubocop --server` to be used in non-tty contexts,
such as File Watchers or External Tools in RubyMine.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
