### PR TITLE
Fix `find_end_line` for block nodes.

### DIFF
--- a/changelog/fix_find_end_line_for_blocks.md
+++ b/changelog/fix_find_end_line_for_blocks.md
@@ -1,0 +1,1 @@
+* [#11858](https://github.com/rubocop/rubocop/pull/11858): Fix false positives when using source comments in blocks. ([@reitermarkus][])

--- a/lib/rubocop/cop/mixin/comments_help.rb
+++ b/lib/rubocop/cop/mixin/comments_help.rb
@@ -62,7 +62,7 @@ module RuboCop
       # Returns the end line of a node, which might be a comment and not part of the AST
       # End line is considered either the line at which another node starts, or
       # the line at which the parent node ends.
-      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Lint/DuplicateBranch
       def find_end_line(node)
         if node.if_type? && node.else?
           node.loc.else.line
@@ -70,6 +70,8 @@ module RuboCop
           node.else_branch.loc.line
         elsif node.if_type? && node.elsif?
           node.each_ancestor(:if).find(&:if?).loc.end.line
+        elsif node.block_type? || node.numblock_type?
+          node.loc.end.line
         elsif (next_sibling = node.right_sibling) && next_sibling.is_a?(AST::Node)
           next_sibling.loc.line
         elsif (parent = node.parent)
@@ -78,7 +80,7 @@ module RuboCop
           node.loc.end.line
         end
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Lint/DuplicateBranch
     end
   end
 end

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -294,6 +294,15 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
       RUBY
 
       expect_no_offenses(<<~RUBY)
+        something
+
+        something do |e|
+          # comment
+          e.upcase
+        end
+      RUBY
+
+      expect_no_offenses(<<~RUBY)
         something do |e|
           e.upcase # comment
         end
@@ -421,6 +430,34 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
 
     it 'accepts ::Proc.new with 1 numbered parameter' do
       expect_no_offenses('::Proc.new { _1.method }')
+    end
+
+    context 'AllowComments: true' do
+      let(:cop_config) { { 'AllowComments' => true } }
+
+      it 'accepts blocks containing comments' do
+        expect_no_offenses(<<~RUBY)
+          something do
+            # comment
+            _1.upcase
+          end
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          something do
+            _1.upcase # comment
+          end
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          something
+
+          something do
+            # comment
+            _1.upcase
+          end
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
When two block nodes are in the root, e.g.

```ruby
block1 do
  # ...
end

block2 do
  # ...
end
```

calling `find_end_line` on the second will return `1` instead of `7`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
