### PR TITLE
Add rubocop-factory_bot to suggested extensions and extension doc

### DIFF
--- a/changelog/change_add_rubocop_factory_bot_to_suggested_extensions.md
+++ b/changelog/change_add_rubocop_factory_bot_to_suggested_extensions.md
@@ -1,0 +1,1 @@
+* [#11859](https://github.com/rubocop/rubocop/pull/11859): Add rubocop-factory_bot to suggested extensions. ([@ydah][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -154,6 +154,7 @@ AllCops:
     rubocop-rake: [rake]
     rubocop-graphql: [graphql]
     rubocop-capybara: [capybara]
+    rubocop-factory_bot: [factory_bot, factory_bot_rails]
   # Enable/Disable checking the methods extended by Active Support.
   ActiveSupportExtensionsEnabled: false
 

--- a/docs/modules/ROOT/pages/extensions.adoc
+++ b/docs/modules/ROOT/pages/extensions.adoc
@@ -86,6 +86,8 @@ Code style checking for Sequel gem
 Thread-safety analysis
 * https://github.com/rubocop/rubocop-capybara[rubocop-capybara] -
 Capybara-specific analysis
+* https://github.com/rubocop/rubocop-factory_bot[rubocop-factory_bot] -
+factory_bot-specific analysis
 
 ==== Third-party Extensions
 


### PR DESCRIPTION
This PR adds [rubocop-factory_bot](https://github.com/rubocop/rubocop-factory_bot) to the `SuggestExtensions` list and extension doc.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
