### PR TITLE
[Fix #11862] Fix an incorrect autocorrect for `Style/GuardClause`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_guard_clause.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_guard_clause.md
@@ -1,0 +1,1 @@
+* [#11862](https://github.com/rubocop/rubocop/issues/11862): Fix an incorrect autocorrect for `Style/GuardClause` when using `raise` in `else` branch in a one-liner with `then`. ([@koic][])

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -187,6 +187,8 @@ module RuboCop
           if_branch = node.if_branch
           else_branch = node.else_branch
 
+          corrector.replace(node.loc.begin, "\n") if node.loc.begin&.is?('then')
+
           if if_branch&.send_type? && heredoc?(if_branch.last_argument)
             autocorrect_heredoc_argument(corrector, node, if_branch, else_branch, guard)
           elsif else_branch&.send_type? && heredoc?(else_branch.last_argument)

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -165,6 +165,18 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
     expect_no_corrections
   end
 
+  it 'registers an offense when using `raise` in `else` branch in a one-liner with `then`' do
+    expect_offense(<<~RUBY)
+      if something then work else raise('message') end
+      ^^ Use a guard clause (`raise('message') unless something`) instead of wrapping the code inside a conditional expression.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      raise('message') unless something#{trailing_whitespace}
+       work#{trailing_whitespace * 3}
+    RUBY
+  end
+
   it 'registers an offense when using `and return` in `then` branch' do
     expect_offense(<<~RUBY)
       def func


### PR DESCRIPTION
Fixes #11862.

This PR fixes an incorrect autocorrect for `Style/GuardClause` when using `raise` in `else` branch in a one-liner with `then`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
