### PR TITLE
[Fix #11861] Fix a false positive for `Layout/SpaceAfterSemicolon`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_space_after_semicolon.md
+++ b/changelog/fix_a_false_positive_for_layout_space_after_semicolon.md
@@ -1,0 +1,1 @@
+* [#11861](https://github.com/rubocop/rubocop/issues/11861): Fix a false positive for `Layout/SpaceAfterSemicolon` when no space between a semicolon and a closing brace of string interpolation. ([@koic][])

--- a/lib/rubocop/cop/mixin/space_after_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_after_punctuation.rb
@@ -36,7 +36,7 @@ module RuboCop
       end
 
       def allowed_type?(token)
-        %i[tRPAREN tRBRACK tPIPE].include?(token.type)
+        %i[tRPAREN tRBRACK tPIPE tSTRING_DEND].include?(token.type)
       end
 
       def space_forbidden_before_rcurly?

--- a/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterSemicolon, :config do
       it 'accepts a space between a semicolon and a closing brace' do
         expect_no_offenses('test { ; }')
       end
+
+      it 'accepts no space between a semicolon and a closing brace of string interpolation' do
+        expect_no_offenses(<<~'RUBY')
+          "#{ ;}"
+        RUBY
+      end
     end
 
     context 'when EnforcedStyle for SpaceInsideBlockBraces is space' do


### PR DESCRIPTION
Fixes #11861.

This PR fixes a false positive for `Layout/SpaceAfterSemicolon` when no space between a semicolon and a closing brace of string interpolation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
