### PR TITLE
Fix an error for `Naming/ConstantName`

### DIFF
--- a/changelog/fix_a_false_positive_for_naming_constant_name.md
+++ b/changelog/fix_a_false_positive_for_naming_constant_name.md
@@ -1,0 +1,1 @@
+* [#11865](https://github.com/rubocop/rubocop/pull/11865): Fix an error for `Naming/ConstantName` when assigning a constant from an empty branch of `else`. ([@koic][])

--- a/lib/rubocop/cop/naming/constant_name.rb
+++ b/lib/rubocop/cop/naming/constant_name.rb
@@ -76,7 +76,7 @@ module RuboCop
         end
 
         def contains_constant?(node)
-          node.branches.any?(&:const_type?)
+          node.branches.compact.any?(&:const_type?)
         end
       end
     end

--- a/spec/rubocop/cop/naming/constant_name_spec.rb
+++ b/spec/rubocop/cop/naming/constant_name_spec.rb
@@ -114,6 +114,15 @@ RSpec.describe RuboCop::Cop::Naming::ConstantName, :config do
     RUBY
   end
 
+  it 'does not register an offense when assigning a constant from an empty branch of `else`' do
+    expect_no_offenses(<<~RUBY)
+      CONST = if condition
+        foo
+      else
+      end
+    RUBY
+  end
+
   context 'when a rhs is a conditional expression' do
     context 'when conditional branches contain only constants' do
       it 'does not check names' do


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/8422#issuecomment-1540027264.

This PR fixes an error for `Naming/ConstantName` when assigning a constant from an empty branch of `else`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
