### PR TITLE
Make `Style/Semicolon` aware of string interpolation

### DIFF
--- a/changelog/new_make_semicolon_aware_of_string_interpolation.md
+++ b/changelog/new_make_semicolon_aware_of_string_interpolation.md
@@ -1,0 +1,1 @@
+* [#11866](https://github.com/rubocop/rubocop/pull/11866): Make `Style/Semicolon` aware of redundant semicolons in string interpolation braces. ([@koic][])

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -90,8 +90,11 @@ module RuboCop
             0
           elsif exist_semicolon_before_right_curly_brace?(tokens)
             -3
-          elsif exist_semicolon_after_left_curly_brace?(tokens)
+          elsif exist_semicolon_after_left_curly_brace?(tokens) ||
+                exist_semicolon_after_left_string_interpolation_brace?(tokens)
             2
+          elsif exist_semicolon_before_right_string_interpolation_brace?(tokens)
+            -4
           end
         end
 
@@ -101,6 +104,14 @@ module RuboCop
 
         def exist_semicolon_after_left_curly_brace?(tokens)
           tokens[1]&.left_curly_brace? && tokens[2]&.semicolon?
+        end
+
+        def exist_semicolon_before_right_string_interpolation_brace?(tokens)
+          tokens[-3]&.type == :tSTRING_DEND && tokens[-4]&.semicolon?
+        end
+
+        def exist_semicolon_after_left_string_interpolation_brace?(tokens)
+          tokens[1]&.type == :tSTRING_DBEG && tokens[2]&.semicolon?
         end
 
         def register_semicolon(line, column, after_expression, token_before_semicolon = nil)

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -150,6 +150,28 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
     RUBY
   end
 
+  it 'registers an offense when a semicolon at before a closing brace of string interpolation' do
+    expect_offense(<<~'RUBY')
+      "#{foo;}"
+            ^ Do not use semicolons to terminate expressions.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      "#{foo}"
+    RUBY
+  end
+
+  it 'registers an offense when a semicolon at after a opening brace of string interpolation' do
+    expect_offense(<<~'RUBY')
+      "#{;foo}"
+         ^ Do not use semicolons to terminate expressions.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      "#{foo}"
+    RUBY
+  end
+
   it 'registers an offense for range (`1..42`) with semicolon' do
     expect_offense(<<~RUBY)
       1..42;


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/issues/11861.

> I would probably expect rubocop to get rid of that semicolon, but that's a bonus.

This PR makes `Style/Semicolon` aware of redundant semicolons in string interpolation braces.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
