### PR TITLE
Fix an error for `Style/IfInsideElse`

### DIFF
--- a/changelog/fix_an_error_for_style_if_inside_else.md
+++ b/changelog/fix_an_error_for_style_if_inside_else.md
@@ -1,0 +1,1 @@
+* [#11967](https://github.com/rubocop/rubocop/pull/11967): Fix error for `Style/IfInsideElse` when a deep nested multiline `if...then...elsif...else...end`. ([@koic][])

--- a/lib/rubocop/cop/style/if_inside_else.rb
+++ b/lib/rubocop/cop/style/if_inside_else.rb
@@ -59,11 +59,13 @@ module RuboCop
       #   end
       #
       class IfInsideElse < Base
+        include IgnoredNode
         include RangeHelp
         extend AutoCorrector
 
         MSG = 'Convert `if` nested inside `else` to `elsif`.'
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def on_if(node)
           return if node.ternary? || node.unless?
 
@@ -73,9 +75,13 @@ module RuboCop
           return if allow_if_modifier_in_else_branch?(else_branch)
 
           add_offense(else_branch.loc.keyword) do |corrector|
+            next if part_of_ignored_node?(node)
+
             autocorrect(corrector, else_branch)
+            ignore_node(node)
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         private
 

--- a/spec/rubocop/cop/style/if_inside_else_spec.rb
+++ b/spec/rubocop/cop/style/if_inside_else_spec.rb
@@ -143,8 +143,10 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
     expect_correction(<<~RUBY)
       if x
         'x'
-      elsif y
+      else
+        if y
         'y'
+      end
       end
     RUBY
   end
@@ -183,10 +185,12 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
     expect_correction(<<~RUBY)
       if x
         'x'
-      elsif y
+      else
+        if y
         'y'
         elsif z
         'z'
+      end
       end
     RUBY
   end
@@ -229,12 +233,49 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
     expect_correction(<<~RUBY)
       if x
         'x'
-      elsif y
+      else
+        if y
         'y'
         elsif z
         'z'
         else
         'a'
+        end
+      end
+    RUBY
+  end
+
+  it 'handles a deep nested multiline `if...then...elsif...else...end`' do
+    expect_offense(<<~RUBY)
+      if cond
+      else
+        if nested_one
+        ^^ Convert `if` nested inside `else` to `elsif`.
+        else
+          if c
+          ^^ Convert `if` nested inside `else` to `elsif`.
+            if d
+            else
+              if e
+              ^^ Convert `if` nested inside `else` to `elsif`.
+              end
+            end
+          end
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if cond
+      elsif nested_one
+        else
+          if c
+            if d
+            else
+              if e
+              end
+            end
+          end
       end
     RUBY
   end


### PR DESCRIPTION
This PR fixes the following error for `Style/IfInsideElse` when a deep nested multiline `if...then...elsif...else...end`:

```console
$ cat example.rb
if cond
else
  if nested_one
  else
    if c
      if d
      else
        if e
        end
      end
    end
  end
end
```

```console
$ bundle exec rubocop --only Style/IfInsideElse -a
Inspecting 1 file
An error occurred while Style/IfInsideElse cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/if_inside_else/example.rb:6:6.
To see the complete backtrace run rubocop -d.
C

Offenses:

example.rb:3:3: C: [Corrected] Style/IfInsideElse: Convert if nested inside else to elsif.
  if nested_one
  ^^
example.rb:5:5: C: [Corrected] Style/IfInsideElse: Convert if nested inside else to elsif.
    if c
    ^^
example.rb:6:9: C: [Corrected] Style/IfInsideElse: Convert if nested inside else to elsif.
        if e
        ^^

1 file inspected, 3 offenses detected, 3 offenses corrected

1 error occurred:
An error occurred while Style/IfInsideElse cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/if_inside_else/example.rb:6:6.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop/rubocop/issues

Mention the following information in the issue report:
1.50.2 (using Parser 3.2.2.1, rubocop-ast 1.28.1, running on ruby 3.2.1) [x86_64-darwin19]
```

The autocorrection is repeated until all warnings are eliminated, so it is effectively compatible with the previous autocorrection.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
