### PR TITLE
Mark some cops as unsafe

### DIFF
--- a/changelog/change_mark_some_cops_as_unsafe.md
+++ b/changelog/change_mark_some_cops_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#11871](https://github.com/rubocop/rubocop/pull/11871): Mark `Style/DataInheritance` as unsafe autocorrect, `Style/OpenStructUse` as unsafe, and `Security/CompoundHash` as unsafe. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2948,7 +2948,9 @@ Naming/VariableNumber:
 Security/CompoundHash:
   Description: 'When overwriting Object#hash to combine values, prefer delegating to Array#hash over writing a custom implementation.'
   Enabled: pending
+  Safe: false
   VersionAdded: '1.28'
+  VersionChanged: '<<next>>'
 
 Security/Eval:
   Description: 'The use of eval represents a serious security risk.'
@@ -3521,7 +3523,9 @@ Style/DataInheritance:
   Description: 'Checks for inheritance from Data.define.'
   StyleGuide: '#no-extend-data-define'
   Enabled: pending
+  SafeAutoCorrect: false
   VersionAdded: '1.49'
+  VersionChanged: '<<next>>'
 
 Style/DateTime:
   Description: 'Use Time over DateTime.'
@@ -4628,7 +4632,9 @@ Style/OpenStructUse:
     - https://docs.ruby-lang.org/en/3.0.0/OpenStruct.html#class-OpenStruct-label-Caveats
 
   Enabled: pending
+  Safe: false
   VersionAdded: '1.23'
+  VersionChanged: '<<next>>'
 
 Style/OperatorMethodCall:
   Description: 'Checks for redundant dot before operator method call.'


### PR DESCRIPTION
This PR marks `Style/DataInheritance` as unsafe autocorrect, `Style/OpenStructUse` as unsafe, and `Security/CompoundHash` as unsafe.

This PR adds a project spec as the below and marks `Style/DataInheritance` as unsafe autocorrect:

```console
$ bundle exec rspec spec/project_spec.rb
(snip)

Failures:

  1) RuboCop Project default configuration file does not detect missing `Safe: false` and `SafeAutoCorrect: false`
     Failure/Error:
       expect(unsafe).to(
         be(true),
         "`#{cop_name}` cop should be set `Safe: false` or `SafeAutoCorrect: false` " \
         'because `@safety` YARD tag exists.'
       )

       `Style/DataInheritance` cop should be set `Safe: false` or `SafeAutoCorrect: false` because `@safety` YARD tag exists.
     # ./spec/project_spec.rb:155:in `block (4 levels) in <top (required)>'
     # ./spec/project_spec.rb:151:in `each'
     # ./spec/project_spec.rb:151:in `block (3 levels) in <top (required)>'

Finished in 0.25698 seconds (files took 1.13 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/project_spec.rb:136 # RuboCop Project default configuration file does not detect missing `Safe: false` and `SafeAutoCorrect: false`
```

`Style/OpenStructUse` and `Security/CompoundHash` are also the same.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
