### PR TITLE
Fix Gemspec/DevelopmentDependencies not trigger when add_development_…

### DIFF
--- a/changelog/fix_gemspec_development_dependencies_not_trigger.md
+++ b/changelog/fix_gemspec_development_dependencies_not_trigger.md
@@ -1,0 +1,1 @@
+* [#11872](https://github.com/rubocop/rubocop/pull/11872): Fix `Gemspec/DevelopmentDependencies` not trigger when add_development_dependency has more then one arguments. ([@Bhacaz][])

--- a/lib/rubocop/cop/gemspec/development_dependencies.rb
+++ b/lib/rubocop/cop/gemspec/development_dependencies.rb
@@ -75,7 +75,7 @@ module RuboCop
 
         # @!method add_development_dependency?(node)
         def_node_matcher :add_development_dependency?, <<~PATTERN
-          (send _ :add_development_dependency (str #forbidden_gem? ...))
+          (send _ :add_development_dependency (str #forbidden_gem? ...) _? _?)
         PATTERN
 
         # @!method gem?(node)

--- a/spec/rubocop/cop/gemspec/development_dependencies_spec.rb
+++ b/spec/rubocop/cop/gemspec/development_dependencies_spec.rb
@@ -23,6 +23,28 @@ RSpec.describe RuboCop::Cop::Gemspec::DevelopmentDependencies, :config do
       RUBY
     end
 
+    it 'registers an offense when using `#add_development_dependency` in a gemspec a single version argument' do
+      expect_offense(<<~RUBY, 'example.gemspec', preferred_file: enforced_style)
+        Gem::Specification.new do |spec|
+          spec.name = 'example'
+          spec.add_development_dependency 'foo', '>= 1.0'
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify development dependencies in %{preferred_file}.
+          spec.add_development_dependency 'allowed', '>= 1.0'
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using `#add_development_dependency` in a gemspec with two version' do
+      expect_offense(<<~RUBY, 'example.gemspec', preferred_file: enforced_style)
+        Gem::Specification.new do |spec|
+          spec.name = 'example'
+          spec.add_development_dependency 'foo', '>= 1.0', '< 2.0'
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify development dependencies in %{preferred_file}.
+          spec.add_development_dependency 'allowed', '>= 1.0', '< 2.0'
+        end
+      RUBY
+    end
+
     it 'registers no offenses when specifying dependencies in Gemfile' do
       expect_no_offenses(<<~RUBY, 'Gemfile')
         gem 'example'


### PR DESCRIPTION
…dependency has more then one arguments

I was wondering why this cop was not triggered in my gemspec, to finally found that, the node matcher didn't match if an argument (or more) is passed. 

```ruby
# triggered 
spec.add_development_dependency 'foo'

# not triggered
spec.add_development_dependency 'foo', '>= 1.0'
```

There was a [comment](https://github.com/rubocop/rubocop/pull/11469#issuecomment-1403541120) in the PR that introduce this cop which had no response and I didn't found any related issues about this behaviour.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
