### PR TITLE
Add `MinComparisonsCount` config option to `Style/MultipleComparison`

### DIFF
--- a/changelog/new_add_comparisons_threshold_to_multiple_comparison.md
+++ b/changelog/new_add_comparisons_threshold_to_multiple_comparison.md
@@ -1,0 +1,1 @@
+* [#11873](https://github.com/rubocop/rubocop/pull/11873): Add `ComparisonsThreshold` config option to `Style/MultipleComparison`. ([@fatkodima][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4383,6 +4383,7 @@ Style/MultipleComparison:
   VersionAdded: '0.49'
   VersionChanged: '1.1'
   AllowMethodComparison: true
+  ComparisonsThreshold: 2
 
 Style/MutableConstant:
   Description: 'Do not assign mutable objects to constants.'

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -40,6 +40,15 @@ module RuboCop
       #
       #   # good
       #   foo if [b.lightweight, b.heavyweight].include?(a)
+      #
+      # @example ComparisonsThreshold: 2 (default)
+      #   # bad
+      #   foo if a == 'a' || a == 'b'
+      #
+      # @example ComparisonsThreshold: 3
+      #   # good
+      #   foo if a == 'a' || a == 'b'
+      #
       class MultipleComparison < Base
         extend AutoCorrector
 
@@ -58,6 +67,7 @@ module RuboCop
           return unless node == root_of_or_node
           return unless nested_variable_comparison?(root_of_or_node)
           return if @allowed_method_comparison
+          return if @compared_elements.size < comparisons_threshold
 
           add_offense(node) do |corrector|
             elements = @compared_elements.join(', ')
@@ -150,6 +160,10 @@ module RuboCop
 
         def allow_method_comparison?
           cop_config.fetch('AllowMethodComparison', true)
+        end
+
+        def comparisons_threshold
+          cop_config.fetch('ComparisonsThreshold', 2)
         end
       end
     end

--- a/spec/rubocop/cop/style/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/style/multiple_comparison_spec.rb
@@ -222,4 +222,32 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison, :config do
       RUBY
     end
   end
+
+  context 'when `ComparisonsThreshold`: 2' do
+    let(:cop_config) { { 'ComparisonsThreshold' => 2 } }
+
+    it 'registers an offense and corrects when `a` is compared twice' do
+      expect_offense(<<~RUBY)
+        a = "a"
+        foo if a == "a" || a == "b"
+               ^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a = "a"
+        foo if ["a", "b"].include?(a)
+      RUBY
+    end
+  end
+
+  context 'when `ComparisonsThreshold`: 3' do
+    let(:cop_config) { { 'ComparisonsThreshold' => 3 } }
+
+    it 'does not register an offense when `a` is compared twice' do
+      expect_no_offenses(<<~RUBY)
+        a = "a"
+        foo if a == "a" || a == "b"
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
I want to use `Style/MultipleComparison`, but only when at least 3 comparisons are made. It enforces this style when there are 2. Personally, I do not see much benefit for myself from this in most of the cases. So I made this value configurable, while preserving the original value of 2.