### PR TITLE
Remove superfluous test setup

### DIFF
--- a/spec/rubocop/cli/suggest_extensions_spec.rb
+++ b/spec/rubocop/cli/suggest_extensions_spec.rb
@@ -78,7 +78,6 @@ RSpec.describe 'RuboCop::CLI SuggestExtensions', :isolated_environment do # rubo
       end
     end
 
-    let(:cop_class) { RuboCop::Cop::Base }
     let(:loaded_features) { %w[] }
 
     let(:lockfile) do
@@ -138,15 +137,6 @@ RSpec.describe 'RuboCop::CLI SuggestExtensions', :isolated_environment do # rubo
       end
 
       context 'that are dependencies' do
-        let(:gemfile) do
-          create_file('Gemfile', <<~RUBY)
-            gem 'rspec'
-            gem 'rake'
-            gem 'rubocop-rspec'
-            gem 'rubocop-rake'
-          RUBY
-        end
-
         before do
           create_file('Gemfile.lock', <<~TEXT)
             GEM
@@ -175,14 +165,6 @@ RSpec.describe 'RuboCop::CLI SuggestExtensions', :isolated_environment do # rubo
       end
 
       context 'that some are dependencies' do
-        let(:gemfile) do
-          create_file('Gemfile', <<~RUBY)
-            gem 'rspec'
-            gem 'rake'
-            gem 'rubocop-rake'
-          RUBY
-        end
-
         before do
           create_file('Gemfile.lock', <<~TEXT)
             GEM
@@ -252,15 +234,6 @@ RSpec.describe 'RuboCop::CLI SuggestExtensions', :isolated_environment do # rubo
               rubocop-rake (~> 0.5)
               rubocop-rspec (~> 2.0.0)
           TEXT
-        end
-
-        let(:gemfile) do
-          create_file('Gemfile', <<~RUBY)
-            gem 'rspec'
-            gem 'rake'
-            gem 'rubocop-rspec'
-            gem 'rubocop-rake'
-          RUBY
         end
 
         let(:loaded_features) { %w[rubocop-rspec rubocop-rake] }

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -294,7 +294,6 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation, :config do
   end
 
   context 'when `Layout/AccessModifierIndentation EnforcedStyle: outdent`' do
-    let(:allow_for_alignment) { true }
     let(:indentation_width) { 2 }
     let(:config) do
       RuboCop::Config.new(

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -291,10 +291,6 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       { 'AllowForAlignment' => allow_alignment,
         'AllowBeforeTrailingComments' => allow_comments }
     end
-    let(:src_with_extra) do
-      ['  object.method(argument)  # this is a comment',
-       '                         ^ Unnecessary spacing detected.']
-    end
 
     context 'true' do
       let(:allow_comments) { true }

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
         'Layout/SpaceAroundOperators' => {
           'AllowForAlignment' => allow_for_alignment,
           'EnforcedStyleForExponentOperator' => exponent_operator_style
+        },
+        'Layout/ExtraSpacing' => {
+          'Enabled' => force_equal_sign_alignment,
+          'ForceEqualSignAlignment' => force_equal_sign_alignment
         }
       )
   end
@@ -16,6 +20,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
   let(:hash_style) { 'key' }
   let(:allow_for_alignment) { true }
   let(:exponent_operator_style) { nil }
+  let(:force_equal_sign_alignment) { false }
 
   it 'accepts operator surrounded by tabs' do
     expect_no_offenses("a\t+\tb")
@@ -971,9 +976,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
   end
 
   describe 'when Layout/ExtraSpacing has `ForceEqualSignAlignment` configured to true' do
-    let(:other_cops) do
-      { 'Layout/ExtraSpacing' => { 'Enabled' => true, 'ForceEqualSignAlignment' => true } }
-    end
+    let(:force_equal_sign_alignment) { true }
 
     it 'allows variables to be aligned' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/lint/unified_integer_spec.rb
+++ b/spec/rubocop/cop/lint/unified_integer_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe RuboCop::Cop::Lint::UnifiedInteger, :config do
         end
 
         context 'when explicitly specified as toplevel constant' do
-          let(:source) { "1.is_a?(::#{klass})" }
-
           it 'registers an offense' do
             expect_offense(<<~RUBY, klass: klass)
               1.is_a?(::%{klass})

--- a/spec/rubocop/cop/naming/variable_number_spec.rb
+++ b/spec/rubocop/cop/naming/variable_number_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
-  let(:cop_config) { { 'CheckMethodNames' => true, 'CheckSymbols' => true } }
-
   shared_examples 'offense' do |style, variable, style_to_allow_offenses|
     it "registers an offense for #{variable} in #{style}" do
       expect_offense(<<~RUBY, variable: variable)

--- a/spec/rubocop/cop/range_help_spec.rb
+++ b/spec/rubocop/cop/range_help_spec.rb
@@ -21,10 +21,6 @@ RSpec.describe RuboCop::Cop::RangeHelp do
     parse_source(source)
   end
 
-  let(:source) do
-    raise NotImplementedError
-  end
-
   describe 'source indicated by #range_with_surrounding_comma' do
     subject do
       r = instance.send(:range_with_surrounding_comma, input_range, side)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -639,8 +639,6 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   end
 
   context 'pin operator', :ruby31 do
-    let(:target_ruby_version) { 3.1 }
-
     shared_examples 'redundant parentheses' do |variable, description|
       it "registers an offense and corrects #{description}" do
         expect_offense(<<~RUBY, variable: variable)

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
-  let(:redundant_parens_enabled) { false }
-
   shared_examples 'safe assignment disabled' do |style, message|
     let(:cop_config) { { 'EnforcedStyle' => style, 'AllowSafeAssignment' => false } }
 

--- a/spec/rubocop/cop/visibility_help_spec.rb
+++ b/spec/rubocop/cop/visibility_help_spec.rb
@@ -25,10 +25,6 @@ RSpec.describe RuboCop::Cop::VisibilityHelp do
       parse_source(source)
     end
 
-    let(:source) do
-      raise NotImplementedError
-    end
-
     context 'without visibility block' do
       let(:source) do
         <<~RUBY

--- a/spec/rubocop/formatter/offense_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/offense_count_formatter_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
 
   let(:output) { StringIO.new }
   let(:options) { { display_style_guide: false } }
-  let(:file_count) { files.size }
 
   let(:files) do
     %w[lib/rubocop.rb spec/spec_helper.rb exe/rubocop].map do |path|

--- a/spec/support/multiline_literal_brace_layout_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_examples.rb
@@ -5,8 +5,6 @@ RSpec.shared_examples_for 'multiline literal brace layout' do
 
   let(:prefix) { '' } # A prefix before the opening brace.
   let(:suffix) { '' } # A suffix for the line after the closing brace.
-  let(:open) { nil } # The opening brace.
-  let(:close) { nil } # The closing brace.
   let(:a) { 'a' } # The first element.
   let(:b) { 'b' } # The second element.
   let(:b_comment) { '' } # Comment after the second element.

--- a/spec/support/multiline_literal_brace_layout_trailing_comma_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_trailing_comma_examples.rb
@@ -3,20 +3,8 @@
 RSpec.shared_examples_for 'multiline literal brace layout trailing comma' do
   let(:prefix) { '' } # A prefix before the opening brace.
   let(:suffix) { '' } # A suffix for the line after the closing brace.
-  let(:open) { nil } # The opening brace.
-  let(:close) { nil } # The closing brace.
   let(:a) { 'a' } # The first element.
   let(:b) { 'b' } # The second element.
-
-  # same line message for symmetrical style (use [...] to abbreviate).
-  let(:same_line_message) do
-    'Closing brace must be on the same line as the last element when opening [...]'
-  end
-
-  # same line message for same_line style
-  let(:always_same_line_message) do
-    'Closing brace must be on the same line as the last element.'
-  end
 
   context 'symmetrical style' do
     let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }


### PR DESCRIPTION
- Drops a number of unused `let`s.
- In one case, I attempted to recreate what appeared to be the intent of the spec. Happy to do something different if preferred as it seems like the test passes with or without the configuration overridden.
- Generally just test-driving a release of my [`rspectre`](https://github.com/dgollahon/rspectre) tool on popular repos

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
