### PR TITLE
Fix a false positive for `Style/SelectByRegexp` when Ruby 2.2 or lower analysis

### DIFF
--- a/changelog/fix_a_false_positive_for_style_select_by_regexp.md
+++ b/changelog/fix_a_false_positive_for_style_select_by_regexp.md
@@ -1,0 +1,1 @@
+* [#11879](https://github.com/rubocop/rubocop/pull/11879): Fix a false positive for `Style/SelectByRegexp` when Ruby 2.2 or lower analysis. ([@koic][])


### PR DESCRIPTION
This PR fixes a false positive for `Style/SelectByRegexp` when using regexp mismatching with Ruby 2.2 or lower because `grep_v` requires Ruby 2.3+.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
