### PR TITLE
[Fix #11880] Fix a false positive for `Style/ExactRegexpMatch`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_exact_regexp_match.md
+++ b/changelog/fix_a_false_positive_for_style_exact_regexp_match.md
@@ -1,0 +1,1 @@
+* [#11880](https://github.com/rubocop/rubocop/issues/11880): Fix a false positive for `Style/ExactRegexpMatch` when using literal with quantifier in regexp. ([@koic][])

--- a/lib/rubocop/cop/style/exact_regexp_match.rb
+++ b/lib/rubocop/cop/style/exact_regexp_match.rb
@@ -41,8 +41,7 @@ module RuboCop
           return unless (regexp = exact_regexp_match(node))
 
           parsed_regexp = Regexp::Parser.parse(regexp)
-          tokens = parsed_regexp.map(&:token)
-          return unless tokens[0] == :bos && tokens[1] == :literal && tokens[2] == :eos
+          return unless exact_match_pattern?(parsed_regexp)
 
           prefer = "#{node.receiver.source} #{new_method(node)} '#{parsed_regexp[1].text}'"
 
@@ -52,6 +51,13 @@ module RuboCop
         end
 
         private
+
+        def exact_match_pattern?(parsed_regexp)
+          tokens = parsed_regexp.map(&:token)
+          return false unless tokens[0] == :bos && tokens[1] == :literal && tokens[2] == :eos
+
+          !parsed_regexp[1].quantifier
+        end
 
         def new_method(node)
           node.method?(:!~) ? '!=' : '=='

--- a/spec/rubocop/cop/style/exact_regexp_match_spec.rb
+++ b/spec/rubocop/cop/style/exact_regexp_match_spec.rb
@@ -62,6 +62,12 @@ RSpec.describe RuboCop::Cop::Style::ExactRegexpMatch, :config do
     RUBY
   end
 
+  it 'does not register an offense when using `string === /\A0+\z/` (literal with quantifier)' do
+    expect_no_offenses(<<~'RUBY')
+      string === /\A0+\z/
+    RUBY
+  end
+
   it 'does not register an offense when using `string =~ /\Astring.*\z/` (any pattern)' do
     expect_no_offenses(<<~'RUBY')
       string =~ /\Astring.*\z/


### PR DESCRIPTION
Fixes #11880.

This PR fixes a false positive for `Style/ExactRegexpMatch` when using literal with quantifier in regexp.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
