### PR TITLE
[Fix #11884] Make `rubocop -V` display rubocop-factory_bot version when using it

### DIFF
--- a/changelog/fix_display_factory_bot_version_when_verbose_version.md
+++ b/changelog/fix_display_factory_bot_version_when_verbose_version.md
@@ -1,0 +1,1 @@
+* [#11884](https://github.com/rubocop/rubocop/issues/11884): Make `rubocop -V` display rubocop-factory_bot version when using it. ([@koic][])

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -9,9 +9,13 @@ module RuboCop
           'rubocop-ast %<rubocop_ast_version>s, ' \
           'running on %<ruby_engine>s %<ruby_version>s)%<server_mode>s [%<ruby_platform>s]'
 
-    CANONICAL_FEATURE_NAMES = { 'Rspec' => 'RSpec', 'Graphql' => 'GraphQL', 'Md' => 'Markdown',
-                                'Thread_safety' => 'ThreadSafety' }.freeze
-    EXTENSION_PATH_NAMES = { 'rubocop-md' => 'markdown' }.freeze
+    CANONICAL_FEATURE_NAMES = {
+      'Rspec' => 'RSpec', 'Graphql' => 'GraphQL', 'Md' => 'Markdown', 'Factory_bot' => 'FactoryBot',
+      'Thread_safety' => 'ThreadSafety'
+    }.freeze
+    EXTENSION_PATH_NAMES = {
+      'rubocop-md' => 'markdown', 'rubocop-factory_bot' => 'factory_bot'
+    }.freeze
 
     # @api private
     def self.version(debug: false, env: nil)

--- a/spec/rubocop/version_spec.rb
+++ b/spec/rubocop/version_spec.rb
@@ -132,6 +132,8 @@ RSpec.describe RuboCop::Version do
           rubocop-graphql
           rubocop-md
           rubocop-thread_safety
+          rubocop-capybara
+          rubocop-factory_bot
         ]
       end
 
@@ -150,7 +152,9 @@ RSpec.describe RuboCop::Version do
           /- rubocop-rspec \d+\.\d+\.\d+/,
           /- rubocop-graphql \d+\.\d+\.\d+/,
           /- rubocop-md \d+\.\d+\.\d+/,
-          /- rubocop-thread_safety \d+\.\d+\.\d+/
+          /- rubocop-thread_safety \d+\.\d+\.\d+/,
+          /- rubocop-capybara \d+\.\d+\.\d+/,
+          /- rubocop-factory_bot \d+\.\d+\.\d+/
         )
       end
     end


### PR DESCRIPTION
Fixes #11884.

This PR makes `rubocop -V` display rubocop-factory_bot version when using it.

Also, the rubocop-capybara version is already displaying up fine, but this PR adds a spec for that because it lacks the spec when extracted rubocop-capybara and rubocop-factory_bot from rubocop-rspec.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
