### PR TITLE
Add integration info for Helix Editor

### DIFF
--- a/docs/modules/ROOT/pages/integration_with_other_tools.adoc
+++ b/docs/modules/ROOT/pages/integration_with_other_tools.adoc
@@ -51,6 +51,10 @@ and https://github.com/w0rp/ale[ale].
 
 There is also the https://github.com/ngmy/vim-rubocop[vim-rubocop] plugin.
 
+=== Helix
+
+Helix supports Solargraph natively to provide LSP features. For formatting support, see the https://github.com/helix-editor/helix/wiki/External-binary-formatter-configuration#rubocop[External binary formatter configuration for RuboCop] to use either your bundled or globally installed version of RuboCop.
+
 === Sublime Text
 
 If you're a ST user you might find the


### PR DESCRIPTION
This adds a note about RuboCop integration with the [Helix Editor](https://helix-editor.com/). For more info on the underlying implementation, see here: https://docs.helix-editor.com/languages.html#language-configuration
> `formatter` The  formatter for the language, it will take precedence over the lsp when  defined. The formatter must be able to take the original file as input  from stdin and write the formatted file to stdout

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
