### PR TITLE
Fix a false negative for `Lint/RedundantSafeNavigation`

### DIFF
--- a/changelog/fix_a_false_negative_for_lint_redundant_safe_navigation.md
+++ b/changelog/fix_a_false_negative_for_lint_redundant_safe_navigation.md
@@ -1,0 +1,1 @@
+* [#11890](https://github.com/rubocop/rubocop/pull/11890): Fix a false negative for `Lint/RedundantSafeNavigation` when `&.` is used for `to_d`. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_safe_navigation.rb
+++ b/lib/rubocop/cop/lint/redundant_safe_navigation.rb
@@ -49,7 +49,7 @@ module RuboCop
       #   do_something if attrs&.not_nil_safe_method(:[])
       #
       class RedundantSafeNavigation < Base
-        include AllowedMethods
+        include NilMethods
         include RangeHelp
         extend AutoCorrector
 
@@ -63,7 +63,7 @@ module RuboCop
         PATTERN
 
         def on_csend(node)
-          return unless check?(node) && allowed_method?(node.method_name)
+          return unless check?(node) && nil_methods.include?(node.method_name)
           return if respond_to_nil_specific_method?(node)
 
           range = range_between(node.loc.dot.begin_pos, node.source_range.end_pos)

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -72,6 +72,21 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when `&.` is used for `to_d`' do
+    expect_offense(<<~RUBY)
+      if foo&.to_d
+            ^^^^^^ Redundant safe navigation detected.
+        do_something_else
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo.to_d
+        do_something_else
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using `&.` outside of conditions' do
     expect_no_offenses(<<~RUBY)
       foo&.respond_to?(:bar)


### PR DESCRIPTION
This PR fixes a false negative for `Lint/RedundantSafeNavigation` when `&.` is used for `to_d`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
