### PR TITLE
Fix `Style/AccessorGrouping` to accept macros separated from accessors by space

### DIFF
--- a/changelog/fix_accessor_grouping_macros_and_accessors_space.md
+++ b/changelog/fix_accessor_grouping_macros_and_accessors_space.md
@@ -1,0 +1,1 @@
+* [#11891](https://github.com/rubocop/rubocop/issues/11891): Fix `Style/AccessorGrouping` to accept macros separated from accessors by space. ([@fatkodima][])

--- a/lib/rubocop/cop/style/accessor_grouping.rb
+++ b/lib/rubocop/cop/style/accessor_grouping.rb
@@ -92,6 +92,7 @@ module RuboCop
           comment_line?(processed_source[node.first_line - 2])
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def groupable_accessor?(node)
           return true unless (previous_expression = node.left_siblings.last)
 
@@ -104,8 +105,11 @@ module RuboCop
 
           return true unless previous_expression.send_type?
 
-          previous_expression.attribute_accessor? || previous_expression.access_modifier?
+          previous_expression.attribute_accessor? ||
+            previous_expression.access_modifier? ||
+            node.first_line - previous_expression.last_line > 1 # there is a space between nodes
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def class_send_elements(class_node)
           class_def = class_node.body

--- a/spec/rubocop/cop/style/accessor_grouping_spec.rb
+++ b/spec/rubocop/cop/style/accessor_grouping_spec.rb
@@ -412,6 +412,26 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when other method is followed by a space and grouped accessors' do
+      expect_offense(<<~RUBY)
+        class Foo
+          other_macro :zoo, :woo
+
+          attr_reader :foo, :bar
+          ^^^^^^^^^^^^^^^^^^^^^^ Use one attribute per `attr_reader`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          other_macro :zoo, :woo
+
+          attr_reader :foo
+          attr_reader :bar
+        end
+      RUBY
+    end
+
     context 'when there are comments for attributes' do
       it 'registers and corrects an offense' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #11891.

I changed this cop to consider some code, which precedes accessors, as annotations if there is no space between them.

