### PR TITLE
[Fix #11893] Fix a false positive for `Lint/InheritException`

### DIFF
--- a/changelog/fix_false_positive_for_lint_inherit_exception.md
+++ b/changelog/fix_false_positive_for_lint_inherit_exception.md
@@ -1,0 +1,1 @@
+* [#11893](https://github.com/rubocop/rubocop/issues/11893): Fix a false positive for `Lint/InheritException` when inheriting `Exception` with omitted namespace. ([@koic][])

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -58,6 +58,7 @@ module RuboCop
 
         def on_class(node)
           return unless node.parent_class && exception_class?(node.parent_class)
+          return if inherit_exception_class_with_omitted_namespace?(node)
 
           message = message(node.parent_class)
 
@@ -85,6 +86,12 @@ module RuboCop
 
         def exception_class?(class_node)
           class_node.const_name == 'Exception'
+        end
+
+        def inherit_exception_class_with_omitted_namespace?(class_node)
+          return false if class_node.parent_class.namespace&.cbase_type?
+
+          class_node.left_siblings.any? { |sibling| exception_class?(sibling.identifier) }
         end
 
         def preferred_base_class

--- a/spec/rubocop/cop/lint/inherit_exception_spec.rb
+++ b/spec/rubocop/cop/lint/inherit_exception_spec.rb
@@ -29,10 +29,59 @@ RSpec.describe RuboCop::Cop::Lint::InheritException, :config do
         end
       end
 
+      context 'when inheriting `Exception`' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            module Foo
+              class C < Exception; end # This `Exception` is the same as `::Exception`.
+                        ^^^^^^^^^ Inherit from `RuntimeError` instead of `Exception`.
+              class Exception < RuntimeError; end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            module Foo
+              class C < RuntimeError; end # This `Exception` is the same as `::Exception`.
+              class Exception < RuntimeError; end
+            end
+          RUBY
+        end
+      end
+
+      context 'when inheriting `::Exception`' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            module Foo
+              class Exception < RuntimeError; end
+              class C < ::Exception; end
+                        ^^^^^^^^^^^ Inherit from `RuntimeError` instead of `Exception`.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            module Foo
+              class Exception < RuntimeError; end
+              class C < RuntimeError; end
+            end
+          RUBY
+        end
+      end
+
       context 'when inheriting a standard lib exception class that is not a subclass of `StandardError`' do
         it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)
             class C < Interrupt; end
+          RUBY
+        end
+      end
+
+      context 'when inheriting `Exception` with omitted namespace' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              class Exception < RuntimeError; end # This `Exception` is the same as `Foo::Exception`.
+              class C < Exception; end
+            end
           RUBY
         end
       end
@@ -65,10 +114,59 @@ RSpec.describe RuboCop::Cop::Lint::InheritException, :config do
         end
       end
 
+      context 'when inheriting `Exception`' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            module Foo
+              class C < Exception; end # This `Exception` is the same as `::Exception`.
+                        ^^^^^^^^^ Inherit from `StandardError` instead of `Exception`.
+              class Exception < RuntimeError; end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            module Foo
+              class C < StandardError; end # This `Exception` is the same as `::Exception`.
+              class Exception < RuntimeError; end
+            end
+          RUBY
+        end
+      end
+
+      context 'when inheriting `::Exception`' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            module Foo
+              class Exception < RuntimeError; end
+              class C < ::Exception; end
+                        ^^^^^^^^^^^ Inherit from `StandardError` instead of `Exception`.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            module Foo
+              class Exception < RuntimeError; end
+              class C < StandardError; end
+            end
+          RUBY
+        end
+      end
+
       context 'when inheriting a standard lib exception class that is not a subclass of `StandardError`' do
         it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)
             class C < Interrupt; end
+          RUBY
+        end
+      end
+
+      context 'when inheriting `Exception` with omitted namespace' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              class Exception < StandardError; end # This `Exception` is the same as `Foo::Exception`.
+              class C < Exception; end
+            end
           RUBY
         end
       end


### PR DESCRIPTION
Fixes #11893.

This PR fixes a false positive for `Lint/InheritException` when inheriting `Exception` with omitted namespace.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
