### PR TITLE
Enhance Layout/EmptyLineBetweenDefs to include macros

### DIFF
--- a/changelog/change_fix_11738_enhances_empty_line_between_defs_to.md
+++ b/changelog/change_fix_11738_enhances_empty_line_between_defs_to.md
@@ -1,0 +1,1 @@
+* [#11738](https://github.com/rubocop/rubocop/issues/11738): Enhances empty_line_between_defs to treat configured macros like defs. ([@catwomey][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -577,6 +577,8 @@ Layout/EmptyLineBetweenDefs:
   EmptyLineBetweenMethodDefs: true
   EmptyLineBetweenClassDefs: true
   EmptyLineBetweenModuleDefs: true
+  # `DefLikeMacros` takes the name of any macro that you want to treat like a def.
+  DefLikeMacros: []
   # `AllowAdjacentOneLineDefs` means that single line method definitions don't
   # need an empty line between them. `true` by default.
   AllowAdjacentOneLineDefs: true

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -641,4 +641,80 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       end
     end
   end
+
+  context 'DefLikeMacros: [\'foo\']' do
+    let(:cop_config) { { 'DefLikeMacros' => ['foo'] } }
+
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        foo 'first foo' do
+          #foo body
+        end
+        foo 'second foo' do
+        ^^^^^^^^^^^^^^^^^^^ Expected 1 empty line between block definitions; found 0.
+          #foo body
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo 'first foo' do
+          #foo body
+        end
+
+        foo 'second foo' do
+          #foo body
+        end
+      RUBY
+    end
+
+    it 'registers offense if next to method' do
+      expect_offense(<<~RUBY)
+        def foo_first_foo
+          #foo body
+        end
+        foo 'second foo' do
+        ^^^^^^^^^^^^^^^^^^^ Expected 1 empty line between block definitions; found 0.
+          #foo body
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo_first_foo
+          #foo body
+        end
+
+        foo 'second foo' do
+          #foo body
+        end
+      RUBY
+    end
+
+    it 'does not register offense' do
+      expect_no_offenses(<<~RUBY)
+        foo 'first foo' do
+          #foo body
+        end
+
+        foo 'second foo' do
+          #foo body
+        end
+      RUBY
+    end
+
+    it 'does not register offense for non registered macro names' do
+      expect_no_offenses(<<~RUBY)
+        bar "bar" do
+          #bar body
+        end
+        foo 'first foo' do
+          #foo body
+        end
+
+        sig {void}
+        foo 'second foo' do
+          #foo body
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/rubocop/rubocop/issues/11738

This pr enhances the Layout/EmptyLineBetweenDefs cop to treat macros in the `EmptyLineBetweenMacros` config as if they were defs.  See the issue for more detail

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
