### PR TITLE
Fix offences in calls inside blocks with braces for Style/MethodCallWithArgsParentheses

### DIFF
--- a/changelog/fix_offences_in_calls_inside_blocks_with_braces.md
+++ b/changelog/fix_offences_in_calls_inside_blocks_with_braces.md
@@ -1,0 +1,1 @@
+* [#11898](https://github.com/rubocop/rubocop/pull/11898): Fix offences in calls inside blocks with braces for `Style/MethodCallWithArgsParentheses` with `omit_parentheses` enforced style. ([@gsamokovarov][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -135,8 +135,7 @@ module RuboCop
           end
 
           def call_with_braced_block?(node)
-            (node.send_type? || node.super_type?) &&
-              ((node.parent&.block_type? || node.parent&.numblock_type?) && node.parent&.braces?)
+            (node.send_type? || node.super_type?) && node.block_node&.braces?
           end
 
           def call_as_argument_or_chain?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -695,6 +695,28 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    it 'register an offense in calls inside braced blocks' do
+      expect_offense(<<~RUBY)
+        client.images(page: page) { |resource| Image.new(resource) }
+                                                        ^^^^^^^^^^ Omit parentheses for method calls with arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        client.images(page: page) { |resource| Image.new resource }
+      RUBY
+    end
+
+    it 'register an offense in calls inside braced numblocks', :ruby27 do
+      expect_offense(<<~RUBY)
+        client.images(page: page) { Image.new(_1) }
+                                             ^^^^ Omit parentheses for method calls with arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        client.images(page: page) { Image.new _1 }
+      RUBY
+    end
+
     it 'accepts parens in single-line inheritance' do
       expect_no_offenses(<<-RUBY)
         class Point < Struct.new(:x, :y); end


### PR DESCRIPTION
For the `omit_parentheses` enforced style, I noticed that calls with parentheses in calls **inside** braced blocks were not linted in a code base of mine, so I investigated. It turned out I had a bad detection of the callers that the braced blocks are attached to, they do **need** the parentheses for the call to be syntactically correct. However, the detection leaked into the calls inside the braces that **don't need** the parentheses.

Example:

```ruby
client.images.map { Image.new _1 }
```

```lisp
(numblock
  (send
    (send
      (send nil :client) :images) :map) 1
  (send
    (const nil :Image) :new
    (lvar :_1)))
```

Here, `(send (const nil :Image) :new (lvar :_1)))`, was considered a **call with braced block**, because the detection used to check for the parent node being a block node. This is not correct. I have used the mechanism defined in `RuboCop::AST::MethodDispatchNode#block_mode` to properly detect only the send node the block is attached to and not other sends in the body.