### PR TITLE
[Fix #11899] Fix an incorrect autocorrect for `Style/SingleLineMethods`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_single_line_methods.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_single_line_methods.md
@@ -1,0 +1,1 @@
+* [#11899](https://github.com/rubocop/rubocop/issues/11899): Fix an incorrect autocorrect for `Style/SingleLineMethods` when using Ruby 3.0 and `Style/EndlessMethod` is disabled. ([@koic][])

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -135,7 +135,7 @@ module RuboCop
 
         def disallow_endless_method_style?
           endless_method_config = config.for_cop('Style/EndlessMethod')
-          return false unless endless_method_config['Enabled']
+          return true unless endless_method_config['Enabled']
 
           endless_method_config['EnforcedStyle'] == 'disallow'
         end

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
     end
   end
 
-  context 'when `Style/EndlessMethod` is disabled' do
+  context 'when `Style/EndlessMethod` is disabled', :ruby30 do
     before { config['Style/EndlessMethod'] = { 'Enabled' => false } }
 
     it 'corrects to an normal method' do


### PR DESCRIPTION
Fixes #11899.

This PR fixes an incorrect autocorrect for `Style/SingleLineMethods` when using Ruby 3.0 and `Style/EndlessMethod` is disabled.

This is an overlooked bug due to the lack of `:ruby30` in the target test code.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
