### PR TITLE
Fix a false positive for `Style/RequireOrder`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_require_order.md
+++ b/changelog/fix_a_false_positive_for_style_require_order.md
@@ -1,0 +1,1 @@
+* [#11902](https://github.com/rubocop/rubocop/pull/11902): Fix a false positive for `Style/RequireOrder` when single-quoted string and double-quoted string are mixed. ([@koic][])

--- a/lib/rubocop/cop/style/require_order.rb
+++ b/lib/rubocop/cop/style/require_order.rb
@@ -106,8 +106,9 @@ module RuboCop
             break unless sibling&.send_type? && sibling&.method?(node.method_name)
             break unless sibling.arguments? && !sibling.receiver
             break unless in_same_section?(sibling, node)
+            break unless node.first_argument.str_type? && sibling.first_argument.str_type?
 
-            node.first_argument.source < sibling.first_argument.source
+            node.first_argument.value < sibling.first_argument.value
           end
         end
 

--- a/spec/rubocop/cop/style/require_order_spec.rb
+++ b/spec/rubocop/cop/style/require_order_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe RuboCop::Cop::Style::RequireOrder, :config do
         require 'b'
       RUBY
     end
+
+    it 'registers no offense when single-quoted string and double-quoted string are mixed' do
+      expect_no_offenses(<<~RUBY)
+        require 'a'
+        require "b"
+      RUBY
+    end
   end
 
   context 'when only one `require`' do


### PR DESCRIPTION
This PR fixes a false positive for `Style/RequireOrder` when single-quoted string and double-quoted string are mixed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
