### PR TITLE
Mark `Layout/ClassStructure` as unsafe to autocorrect

### DIFF
--- a/changelog/change_layout_class_structure_autorrect_safety.md
+++ b/changelog/change_layout_class_structure_autorrect_safety.md
@@ -1,0 +1,1 @@
+* [#11904](https://github.com/rubocop/rubocop/pull/11904): Mark `Layout/ClassStructure` as unsafe to autocorrect. ([@nevans][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -467,7 +467,9 @@ Layout/ClassStructure:
   Description: 'Enforces a configured order of definitions within a class body.'
   StyleGuide: '#consistent-classes'
   Enabled: false
+  SafeAutoCorrect: false
   VersionAdded: '0.52'
+  VersionChanged: '<<next>>'
   Categories:
     module_inclusion:
       - include

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -68,6 +68,13 @@ module RuboCop
       #        - extend
       # ----
       #
+      # @safety
+      #   Autocorrection is unsafe because class methods and module inclusion
+      #   can behave differently, based on which methods or constants have
+      #   already been defined.
+      #
+      #   Constants will only be moved when they are assigned with literals.
+      #
       # @example
       #   # bad
       #   # Expect extend be before constant


### PR DESCRIPTION
Autocorrection is unsafe because class instance methods and module inclusion may behave dynamically, based on which methods or constants have been defined.  ~~Constant definitions may also depend upon pre-existing methods or included modules.~~ _Only literal constants are autocorrected: #7808._

### Alternative approach:

`ClassStructure` could be updated to make autocorrection behave differently for `-a` vs `-A`, i.e: method `def`s can be safely re-ordered if all "macros" are anchored to their current position.  But that would be a more complicated PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
