### PR TITLE
[Fix #11905] Fix an error for `Lint/UselessAssignment`

### DIFF
--- a/changelog/fix_an_error_for_lint_useless_assignment.md
+++ b/changelog/fix_an_error_for_lint_useless_assignment.md
@@ -1,0 +1,1 @@
+* [#11905](https://github.com/rubocop/rubocop/issues/11905): Fix an error for `Lint/UselessAssignment` when a variable is assigned with rest assignment and unreferenced. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_assignment.rb
+++ b/lib/rubocop/cop/lint/useless_assignment.rb
@@ -132,10 +132,11 @@ module RuboCop
           node.receiver.nil? && !node.arguments?
         end
 
+        # rubocop:disable Metrics/AbcSize
         def autocorrect(corrector, assignment)
           if assignment.exception_assignment?
             remove_exception_assignment_part(corrector, assignment.node)
-          elsif assignment.multiple_assignment?
+          elsif assignment.multiple_assignment? || assignment.rest_assignment?
             rename_variable_with_underscore(corrector, assignment.node)
           elsif assignment.operator_assignment?
             remove_trailing_character_from_operator(corrector, assignment.node)
@@ -146,6 +147,7 @@ module RuboCop
             remove_local_variable_assignment_part(corrector, assignment.node)
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         def remove_exception_assignment_part(corrector, node)
           corrector.remove(

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -40,6 +40,7 @@ module RuboCop
       OPERATOR_ASSIGNMENT_TYPES = (LOGICAL_OPERATOR_ASSIGNMENT_TYPES + [:op_asgn]).freeze
 
       MULTIPLE_ASSIGNMENT_TYPE = :masgn
+      REST_ASSIGNMENT_TYPE = :splat
 
       VARIABLE_REFERENCE_TYPE = :lvar
 

--- a/lib/rubocop/cop/variable_force/assignment.rb
+++ b/lib/rubocop/cop/variable_force/assignment.rb
@@ -63,6 +63,12 @@ module RuboCop
           meta_assignment_node.type == MULTIPLE_ASSIGNMENT_TYPE
         end
 
+        def rest_assignment?
+          return false unless meta_assignment_node
+
+          meta_assignment_node.type == REST_ASSIGNMENT_TYPE
+        end
+
         def operator
           assignment_node = meta_assignment_node || @node
           assignment_node.loc.operator.source
@@ -70,7 +76,9 @@ module RuboCop
 
         def meta_assignment_node
           unless instance_variable_defined?(:@meta_assignment_node)
-            @meta_assignment_node = operator_assignment_node || multiple_assignment_node
+            @meta_assignment_node = operator_assignment_node ||
+                                    multiple_assignment_node ||
+                                    rest_assignment_node
           end
 
           @meta_assignment_node
@@ -93,6 +101,13 @@ module RuboCop
           return nil unless node.parent.type == MULTIPLE_LEFT_HAND_SIDE_TYPE
 
           grandparent_node
+        end
+
+        def rest_assignment_node
+          return nil unless node.parent
+          return nil unless node.parent.type == REST_ASSIGNMENT_TYPE
+
+          node.parent
         end
       end
     end

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1169,6 +1169,25 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when a variable is assigned with rest assignment and unreferenced' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        def some_method
+          foo, *bar = do_something
+                ^^^ Useless assignment to variable - `bar`.
+          puts foo
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          foo, *_ = do_something
+          puts foo
+        end
+      RUBY
+    end
+  end
+
   context 'when a variable is assigned in loop body and referenced in post while condition' do
     it 'accepts' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/variable_force/assignment_spec.rb
+++ b/spec/rubocop/cop/variable_force/assignment_spec.rb
@@ -115,6 +115,20 @@ RSpec.describe RuboCop::Cop::VariableForce::Assignment do
         expect(assignment.meta_assignment_node.type).to eq(:masgn)
       end
     end
+
+    context 'when it is rest assignment' do
+      let(:source) do
+        <<~RUBY
+          def some_method
+            *foo = [1, 2]
+          end
+        RUBY
+      end
+
+      it 'returns splat node' do
+        expect(assignment.meta_assignment_node.type).to eq(:splat)
+      end
+    end
   end
 
   describe '#operator' do


### PR DESCRIPTION
Fixes #11905.

This PR fixes an error for `Lint/UselessAssignment` when a variable is assigned with rest assignment and unreferenced.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
