### PR TITLE
[Fix #11908] Support `AllowedReceivers` for `Style/CollectionMethods`

### DIFF
--- a/changelog/new_support_allowed_receivers_for_style_collection_compact.md
+++ b/changelog/new_support_allowed_receivers_for_style_collection_compact.md
@@ -1,0 +1,1 @@
+* [#11908](https://github.com/rubocop/rubocop/issues/11908): Support `AllowedReceivers` for `Style/CollectionMethods`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3363,6 +3363,7 @@ Style/CollectionCompact:
   Safe: false
   VersionAdded: '1.2'
   VersionChanged: '1.3'
+  AllowedReceivers: []
 
 # Align with the style guide.
 Style/CollectionMethods:

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -69,6 +69,7 @@ require_relative 'rubocop/cop/mixin/alignment'
 require_relative 'rubocop/cop/mixin/allowed_identifiers'
 require_relative 'rubocop/cop/mixin/allowed_methods'
 require_relative 'rubocop/cop/mixin/allowed_pattern'
+require_relative 'rubocop/cop/mixin/allowed_receivers'
 require_relative 'rubocop/cop/mixin/auto_corrector' # rubocop:todo Naming/InclusiveLanguage
 require_relative 'rubocop/cop/mixin/check_assignment'
 require_relative 'rubocop/cop/mixin/check_line_breakable'

--- a/lib/rubocop/cop/mixin/allowed_receivers.rb
+++ b/lib/rubocop/cop/mixin/allowed_receivers.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # This module encapsulates the ability to allow certain receivers in a cop.
+    module AllowedReceivers
+      def allowed_receiver?(receiver)
+        receiver_name = receiver_name(receiver)
+
+        allowed_receivers.include?(receiver_name)
+      end
+
+      def receiver_name(receiver)
+        if receiver.receiver && !receiver.receiver.const_type?
+          return receiver_name(receiver.receiver)
+        end
+
+        if receiver.send_type?
+          if receiver.receiver
+            "#{receiver_name(receiver.receiver)}.#{receiver.method_name}"
+          else
+            receiver.method_name.to_s
+          end
+        else
+          receiver.source
+        end
+      end
+
+      def allowed_receivers
+        cop_config.fetch('AllowedReceivers', [])
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/style/collection_compact.rb
+++ b/lib/rubocop/cop/style/collection_compact.rb
@@ -35,7 +35,12 @@ module RuboCop
       #   # good
       #   hash.compact!
       #
+      # @example AllowedReceivers: ['params']
+      #   # good
+      #   params.reject(&:nil?)
+      #
       class CollectionCompact < Base
+        include AllowedReceivers
         include RangeHelp
         extend AutoCorrector
         extend TargetRubyVersion
@@ -76,6 +81,7 @@ module RuboCop
 
         def on_send(node)
           return unless (range = offense_range(node))
+          return if allowed_receiver?(node.receiver)
           if (target_ruby_version <= 3.0 || node.method?(:delete_if)) && to_enum_method?(node)
             return
           end

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -28,6 +28,7 @@ module RuboCop
       #   execute(sql).keys.each { |v| p v }
       #   execute(sql).values.each { |v| p v }
       class HashEachMethods < Base
+        include AllowedReceivers
         include Lint::UnusedArgument
         extend AutoCorrector
 
@@ -115,28 +116,6 @@ module RuboCop
 
         def kv_range(outer_node)
           outer_node.receiver.loc.selector.join(outer_node.loc.selector)
-        end
-
-        def allowed_receiver?(receiver)
-          receiver_name = receiver_name(receiver)
-
-          allowed_receivers.include?(receiver_name)
-        end
-
-        def receiver_name(receiver)
-          if receiver.send_type?
-            if receiver.receiver
-              "#{receiver_name(receiver.receiver)}.#{receiver.method_name}"
-            else
-              receiver.method_name.to_s
-            end
-          else
-            receiver.source
-          end
-        end
-
-        def allowed_receivers
-          cop_config.fetch('AllowedReceivers', [])
         end
       end
     end

--- a/spec/rubocop/cop/style/collection_compact_spec.rb
+++ b/spec/rubocop/cop/style/collection_compact_spec.rb
@@ -197,4 +197,27 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
       RUBY
     end
   end
+
+  context "when `AllowedReceivers: ['params']`" do
+    let(:cop_config) { { 'AllowedReceivers' => ['params'] } }
+
+    it 'does not register an offense when receiver is `params` method' do
+      expect_no_offenses(<<~RUBY)
+        params.reject { |param| param.nil? }
+      RUBY
+    end
+
+    it 'does not register an offense when method chained receiver is `params` method' do
+      expect_no_offenses(<<~RUBY)
+        params.merge(key: value).delete_if { |_k, v| v.nil? }
+      RUBY
+    end
+
+    it 'registers an offense when receiver is not allowed name' do
+      expect_offense(<<~RUBY)
+        foo.reject { |param| param.nil? }
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `reject { |param| param.nil? }`.
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #11908.

This PR supports `AllowedReceivers` for `Style/CollectionMethods`. For example, by setting `AllowedReceivers: ['params']` in RuboCop Rails or user configuration, the following false positive for `params` can be prevented:

```ruby
def selection_params(current, last_category = nil, params = {})
  params.merge(
    category_id: current.is_a?(Category) ? current.to_param : last_category.to_param,
    site_id: current.is_a?(Site) ? current.to_param : nil,
  ).delete_if { |_k, v| v.nil? }
end
```

The configuration to `params` is not set in the RuboCop core due to Rails specific issues. So if this approach is accepted, I will add it to RuboCop Rails's default configuration.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
