### PR TITLE
Remove a redundant `SafeAutoCorrect: false` config

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2484,10 +2484,9 @@ Lint/UselessRuby2Keywords:
 Lint/UselessSetterCall:
   Description: 'Checks for useless setter call to a local variable.'
   Enabled: true
-  SafeAutoCorrect: false
+  Safe: false
   VersionAdded: '0.13'
   VersionChanged: '1.2'
-  Safe: false
 
 Lint/UselessTimes:
   Description: 'Checks for useless `Integer#times` calls.'

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -133,6 +133,18 @@ RSpec.describe 'RuboCop Project', type: :feature do
       end
     end
 
+    it 'does not include unnecessary `SafeAutoCorrect: false`' do
+      cop_names.each do |cop_name|
+        next unless config.dig(cop_name, 'Safe') == false
+
+        safe_autocorrect = config.dig(cop_name, 'SafeAutoCorrect')
+
+        expect(safe_autocorrect).not_to(
+          be(false), "`#{cop_name}` has unnecessary `SafeAutoCorrect: false` config."
+        )
+      end
+    end
+
     it 'is expected that all cops documented with `@safety` are `Safe: false` or `SafeAutoCorrect: false`' do
       require 'yard'
 


### PR DESCRIPTION
This PR adds a spec to detect a redundant `SafeAutoCorrect: false` config and remove the detected redundant config:

```console
% bundle exec rspec  spec/project_spec.rb
(snip)

Failures:

  1) RuboCop Project default configuration file does not include unnecessary `SafeAutoCorrect: false`
     Failure/Error:
       expect(safe_autocorrect).not_to(
         be(false), "`#{cop_name}` has unnecessary `SafeAutoCorrect: false` config."
       )

       `Lint/UselessSetterCall` has unnecessary `SafeAutoCorrect: false` config.
# ./spec/project_spec.rb:142:in `block (4 levels) in <top (required)>'
# ./spec/project_spec.rb:137:in `each'
# ./spec/project_spec.rb:137:in `block (3 levels) in <top (required)>'

Finished in 2.48 seconds (files took 1.19 seconds to load)
205 examples, 1 failure

Failed examples:
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
