### PR TITLE
[Fix #11914] Fix an incorrect examples for `Style/ClassEqualityComparion`

### DIFF
--- a/lib/rubocop/cop/style/class_equality_comparison.rb
+++ b/lib/rubocop/cop/style/class_equality_comparison.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # Enforces the use of `Object#instance_of?` instead of class comparison
       # for equality.
-      # `==`, `equal?`, and `eql?` methods are allowed by default.
+      # `==`, `equal?`, and `eql?` custom method definitions are allowed by default.
       # These are customizable with `AllowedMethods` option.
       #
       # @example
@@ -18,53 +18,31 @@ module RuboCop
       #   # good
       #   var.instance_of?(Date)
       #
-      # @example AllowedMethods: [] (default)
+      # @example AllowedMethods: ['==', 'equal?', 'eql?'] (default)
       #   # good
-      #   var.instance_of?(Date)
+      #   def ==(other)
+      #     self.class == other.class && name == other.name
+      #   end
       #
-      #   # bad
-      #   var.class == Date
-      #   var.class.equal?(Date)
-      #   var.class.eql?(Date)
-      #   var.class.name == 'Date'
-      #   var.class.to_s == 'Date'
-      #   var.class.inspect == 'Date'
+      #   def equal?(other)
+      #     self.class.equal?(other.class) && name.equal?(other.name)
+      #   end
       #
-      # @example AllowedMethods: [`==`]
-      #   # good
-      #   var.instance_of?(Date)
-      #   var.class == Date
-      #   var.class.name == 'Date'
-      #   var.class.to_s == 'Date'
-      #   var.class.inspect == 'Date'
-      #
-      #   # bad
-      #   var.class.equal?(Date)
-      #   var.class.eql?(Date)
+      #   def eql?(other)
+      #     self.class.eql?(other.class) && name.eql?(other.name)
+      #   end
       #
       # @example AllowedPatterns: [] (default)
-      #   # good
-      #   var.instance_of?(Date)
-      #
       #   # bad
-      #   var.class == Date
-      #   var.class.equal?(Date)
-      #   var.class.eql?(Date)
-      #   var.class.name == 'Date'
-      #   var.class.to_s == 'Date'
-      #   var.class.inspect == 'Date'
+      #   def eq(other)
+      #     self.class.eq(other.class) && name.eq(other.name)
+      #   end
       #
       # @example AllowedPatterns: ['eq']
       #   # good
-      #   var.instance_of?(Date)
-      #   var.class.equal?(Date)
-      #   var.class.eql?(Date)
-      #
-      #   # bad
-      #   var.class == Date
-      #   var.class.name == 'Date'
-      #   var.class.to_s == 'Date'
-      #   var.class.inspect == 'Date'
+      #   def eq(other)
+      #     self.class.eq(other.class) && name.eq(other.name)
+      #   end
       #
       class ClassEqualityComparison < Base
         include RangeHelp


### PR DESCRIPTION
Fixes #11914.

This PR fixes an incorrect examples for `Style/ClassEqualityComparison`.

The original `IgnoredMethods` (later renamed `AllowedMethods`) was introduced by #8833. OTOH, #10809 seems to have mis-documented #8833.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
