### PR TITLE
[Fix #11919] Fix an error for `Lint/UselessAssignment`

### DIFF
--- a/changelog/fix_error_for_lint_useless_assignment.md
+++ b/changelog/fix_error_for_lint_useless_assignment.md
@@ -1,0 +1,1 @@
+* [#11919](https://github.com/rubocop/rubocop/issues/11919): Fix an error for `Lint/UselessAssignment` when a variable is assigned and unreferenced in `for`. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_assignment.rb
+++ b/lib/rubocop/cop/lint/useless_assignment.rb
@@ -136,7 +136,8 @@ module RuboCop
         def autocorrect(corrector, assignment)
           if assignment.exception_assignment?
             remove_exception_assignment_part(corrector, assignment.node)
-          elsif assignment.multiple_assignment? || assignment.rest_assignment?
+          elsif assignment.multiple_assignment? || assignment.rest_assignment? ||
+                assignment.for_assignment?
             rename_variable_with_underscore(corrector, assignment.node)
           elsif assignment.operator_assignment?
             remove_trailing_character_from_operator(corrector, assignment.node)

--- a/lib/rubocop/cop/variable_force/assignment.rb
+++ b/lib/rubocop/cop/variable_force/assignment.rb
@@ -69,6 +69,12 @@ module RuboCop
           meta_assignment_node.type == REST_ASSIGNMENT_TYPE
         end
 
+        def for_assignment?
+          return false unless meta_assignment_node
+
+          meta_assignment_node.for_type?
+        end
+
         def operator
           assignment_node = meta_assignment_node || @node
           assignment_node.loc.operator.source
@@ -78,7 +84,8 @@ module RuboCop
           unless instance_variable_defined?(:@meta_assignment_node)
             @meta_assignment_node = operator_assignment_node ||
                                     multiple_assignment_node ||
-                                    rest_assignment_node
+                                    rest_assignment_node ||
+                                    for_assignment_node
           end
 
           @meta_assignment_node
@@ -106,6 +113,12 @@ module RuboCop
         def rest_assignment_node
           return nil unless node.parent
           return nil unless node.parent.type == REST_ASSIGNMENT_TYPE
+
+          node.parent
+        end
+
+        def for_assignment_node
+          return nil unless node.parent&.for_type?
 
           node.parent
         end

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -255,6 +255,31 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when a variable is assigned and unreferenced in `for`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        for item in items
+            ^^^^ Useless assignment to variable - `item`. Did you mean `items`?
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        for _ in items
+        end
+      RUBY
+    end
+  end
+
+  context 'when a variable is assigned and referenced in `for`' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        for item in items
+          do_something(item)
+        end
+      RUBY
+    end
+  end
+
   context 'when a variable is assigned and unreferenced in top level' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/variable_force/assignment_spec.rb
+++ b/spec/rubocop/cop/variable_force/assignment_spec.rb
@@ -129,6 +129,21 @@ RSpec.describe RuboCop::Cop::VariableForce::Assignment do
         expect(assignment.meta_assignment_node.type).to eq(:splat)
       end
     end
+
+    context 'when it is `for` assignment' do
+      let(:source) do
+        <<~RUBY
+          def some_method
+            for item in items
+            end
+          end
+        RUBY
+      end
+
+      it 'returns splat node' do
+        expect(assignment.meta_assignment_node.type).to eq(:for)
+      end
+    end
   end
 
   describe '#operator' do


### PR DESCRIPTION
Fixes #11919.

This PR fixes an error for `Lint/UselessAssignment` when a variable is assigned and unreferenced in `for`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
