### PR TITLE
Revert "Workaround for Style/RedundantBegin when using JRuby 9.2"

### DIFF
--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -121,18 +121,12 @@ module RuboCop
 
           if rescued_exceptions.any?
             rescued_exceptions.each_with_object([]) do |exception, converted|
-              # FIXME: Workaround `rubocop:disable` comment for JRuby.
-              #        https://github.com/jruby/jruby/issues/6642
-              # rubocop:disable Style/RedundantBegin
-              begin
-                RuboCop::Util.silence_warnings do
-                  # Avoid printing deprecation warnings about constants
-                  converted << Kernel.const_get(exception.source)
-                end
-              rescue NameError
-                converted << nil
+              RuboCop::Util.silence_warnings do
+                # Avoid printing deprecation warnings about constants
+                converted << Kernel.const_get(exception.source)
               end
-              # rubocop:enable Style/RedundantBegin
+            rescue NameError
+              converted << nil
             end
           else
             # treat an empty `rescue` as `rescue StandardError`


### PR DESCRIPTION
## Summary

Revert https://github.com/rubocop/rubocop/commit/1533ece5b3d41ee8a1a2f154f23b7c1297e53a85

Current RuboCop (1.52) requires Ruby 2.7+ and JRuby 9.4+. So JRuby 9.2 has been dropped from runtime version.

## Additional Information

https://github.com/jruby/jruby/issues/6642 has been resolved in JRuby 9.4:

```ruby
# example.rb
require 'ripper'

class RipperParser < Ripper
  def on_parse_error(message)
    raise message
  end
end

RipperParser.new(<<~RUBY).parse
  foo do
    bar do
  end
rescue NameError
  converted << nil
end
RUBY
```

```console
$ ruby -v
jruby 9.4.2.0 (3.1.0) 2023-03-08 90d2913fda Java HotSpot(TM) 64-Bit Server VM 25.271-b09 on 1.8.0_271-b09 +jit [x86_64-darwin]
$ ruby example.rb # No errors
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
