### PR TITLE
Fix a false positive for `Lint/RedundantRequireStatement`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_redundant_require_statement.md
+++ b/changelog/fix_a_false_positive_for_lint_redundant_require_statement.md
@@ -1,0 +1,1 @@
+* [#11931](https://github.com/rubocop/rubocop/pull/11931): Fix a false positive for `Lint/RedundantRequireStatement` when using `PP.pp`. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_require_statement.rb
+++ b/lib/rubocop/cop/lint/redundant_require_statement.rb
@@ -49,6 +49,11 @@ module RuboCop
             (str #redundant_feature?))
         PATTERN
 
+        # @!method pp_const?(node)
+        def_node_matcher :pp_const?, <<~PATTERN
+          (const {nil? cbase} :PP)
+        PATTERN
+
         def on_send(node)
           return unless redundant_require_statement?(node)
 
@@ -72,16 +77,16 @@ module RuboCop
           feature_name == 'enumerator' ||
             (target_ruby_version >= 2.1 && feature_name == 'thread') ||
             (target_ruby_version >= 2.2 && RUBY_22_LOADED_FEATURES.include?(feature_name)) ||
-            (target_ruby_version >= 2.5 && feature_name == 'pp' && !use_pretty_print_method?) ||
+            (target_ruby_version >= 2.5 && feature_name == 'pp' && !need_to_require_pp?) ||
             (target_ruby_version >= 2.7 && feature_name == 'ruby2_keywords') ||
             (target_ruby_version >= 3.1 && feature_name == 'fiber') ||
             (target_ruby_version >= 3.2 && feature_name == 'set')
         end
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
-        def use_pretty_print_method?
+        def need_to_require_pp?
           processed_source.ast.each_descendant(:send).any? do |node|
-            PRETTY_PRINT_METHODS.include?(node.method_name)
+            pp_const?(node.receiver) || PRETTY_PRINT_METHODS.include?(node.method_name)
           end
         end
       end

--- a/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
@@ -128,6 +128,22 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
     end
 
     context 'when requiring `pp`' do
+      it 'does not register an offense and corrects when using `PP.pp`' do
+        expect_no_offenses(<<~RUBY)
+          require 'pp'
+
+          PP.pp
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `::PP.pp`' do
+        expect_no_offenses(<<~RUBY)
+          require 'pp'
+
+          ::PP.pp
+        RUBY
+      end
+
       it 'does not register an offense and corrects when using `pretty_inspect`' do
         expect_no_offenses(<<~RUBY)
           require 'pp'


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/issues/11099#issuecomment-1577117258

This PR fixes a false positive for `Lint/RedundantRequireStatement` when using `PP.pp`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
