### PR TITLE
Add support for cases starting with an empty comment line in `InternalAffairs/CopDescription` cop

### DIFF
--- a/lib/rubocop/cop/layout/closing_heredoc_indentation.rb
+++ b/lib/rubocop/cop/layout/closing_heredoc_indentation.rb
@@ -3,7 +3,6 @@
 module RuboCop
   module Cop
     module Layout
-      #
       # Checks the indentation of here document closings.
       #
       # @example

--- a/lib/rubocop/cop/lint/erb_new_arguments.rb
+++ b/lib/rubocop/cop/lint/erb_new_arguments.rb
@@ -3,8 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      #
-      # This cop emulates the following Ruby warnings in Ruby 2.6.
+      # Emulates the following Ruby warnings in Ruby 2.6.
       #
       # [source,console]
       # ----

--- a/lib/rubocop/cop/lint/identity_comparison.rb
+++ b/lib/rubocop/cop/lint/identity_comparison.rb
@@ -3,7 +3,6 @@
 module RuboCop
   module Cop
     module Lint
-      #
       # Prefer `equal?` over `==` when comparing `object_id`.
       #
       # `Object#equal?` is provided to compare objects for identity, and in contrast

--- a/lib/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler.rb
+++ b/lib/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler.rb
@@ -3,8 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      #
-      # This cop checks for `IO.select` that is incompatible with Fiber Scheduler since Ruby 3.0.
+      # Checks for `IO.select` that is incompatible with Fiber Scheduler since Ruby 3.0.
       #
       # When an array of IO objects waiting for an exception (the third argument of `IO.select`)
       # is used as an argument, there is no alternative API, so offenses are not registered.

--- a/lib/rubocop/cop/lint/ordered_magic_comments.rb
+++ b/lib/rubocop/cop/lint/ordered_magic_comments.rb
@@ -3,7 +3,6 @@
 module RuboCop
   module Cop
     module Lint
-      #
       # Checks the proper ordering of magic comments and whether
       # a magic comment is not placed before a shebang.
       #

--- a/lib/rubocop/cop/lint/send_with_mixin_argument.rb
+++ b/lib/rubocop/cop/lint/send_with_mixin_argument.rb
@@ -3,8 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      #
-      # This cop checks for `send`, `public_send`, and `__send__` methods
+      # Checks for `send`, `public_send`, and `__send__` methods
       # when using mix-in.
       #
       # `include` and `prepend` methods were private methods until Ruby 2.0,

--- a/lib/rubocop/cop/style/begin_block.rb
+++ b/lib/rubocop/cop/style/begin_block.rb
@@ -3,8 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      #
-      # This cop checks for BEGIN blocks.
+      # Checks for BEGIN blocks.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -3,8 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      #
-      # This cop looks for uses of Perl-style global variables.
+      # Looks for uses of Perl-style global variables.
       # Correcting to global variables in the 'English' library
       # will add a require statement to the top of the file if
       # enabled by RequireEnglish config.

--- a/spec/rubocop/cop/internal_affairs/cop_description_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/cop_description_spec.rb
@@ -106,6 +106,38 @@ RSpec.describe RuboCop::Cop::InternalAffairs::CopDescription, :config do
     end
   end
 
+  it 'registers an offense if the description starts with an empty comment line' do
+    expect_offense(<<~RUBY)
+      module RuboCop
+        module Cop
+          module Lint
+            #
+      ^^^^^^^ Description should not start with an empty comment line.
+            # Checks some problem
+            #
+            # ...
+            class Foo < Base
+            end
+          end
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module RuboCop
+        module Cop
+          module Lint
+            # Checks some problem
+            #
+            # ...
+            class Foo < Base
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
   context 'There is no description comment' do
     it 'does not register offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR add support for cases starting with an empty comment line in `InternalAffairs/CopDescription` cop. Corresponds to a case that begins with an empty comment line as follows:

```ruby
# bad
#
# Checks ...
class SomeCop < Base
  ...
end

# good
# Checks ...
class SomeCop < Base
  ...
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
