### PR TITLE
Use unification to match `File.open` block param with `#read` receiver

### DIFF
--- a/lib/rubocop/cop/style/file_read.rb
+++ b/lib/rubocop/cop/style/file_read.rb
@@ -63,7 +63,7 @@ module RuboCop
 
         # @!method block_read?(node)
         def_node_matcher :block_read?, <<~PATTERN
-          (block _ (args (arg $_)) (send (lvar $_) :read))
+          (block _ (args (arg _name)) (send (lvar _name) :read))
         PATTERN
 
         def on_send(node)
@@ -100,7 +100,7 @@ module RuboCop
         def file_open_read?(node)
           return true if send_read?(node)
 
-          block_read?(node) { |block_arg, read_lvar| block_arg == read_lvar }
+          block_read?(node)
         end
 
         def read_method(mode)


### PR DESCRIPTION
I might find other node patterns to clean up, so feel free to hold off on merging this PR (as it is admittedly a pretty a small change).

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
