### PR TITLE
[Fix #8506] Add AllowedParentClasses config to Lint/MissingSuper.

### DIFF
--- a/changelog/change_merge_pull_request_11936_from.md
+++ b/changelog/change_merge_pull_request_11936_from.md
@@ -1,0 +1,1 @@
+* [#8506](https://github.com/rubocop/rubocop/issues/8506): Add `AllowedParentClasses` config to `Lint/MissingSuper`. ([@iMacTia][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1988,6 +1988,7 @@ Lint/MissingSuper:
                   Checks for the presence of constructors and lifecycle callbacks
                   without calls to `super`.
   Enabled: true
+  AllowedParentClasses: []
   VersionAdded: '0.89'
   VersionChanged: '1.4'
 

--- a/spec/rubocop/cop/lint/missing_super_spec.rb
+++ b/spec/rubocop/cop/lint/missing_super_spec.rb
@@ -207,4 +207,17 @@ RSpec.describe RuboCop::Cop::Lint::MissingSuper, :config do
       RUBY
     end
   end
+
+  context 'with custom AllowedParentClasses config' do
+    let(:cop_config) { { 'AllowedParentClasses' => %w[Array] } }
+
+    it 'does not register an offense for a class with custom stateless parent class' do
+      expect_no_offenses(<<~RUBY)
+        class Child < Array
+          def initialize
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Add `AllowedParentClasses ` config to `Lint/MissingSuper`.

The default value of `%w[BasicObject Object]` is kept for backwards compatibility, but users can now add to that list using the `AllowedParentClasses ` config value.

It's important to note that the value of `AllowedParentClasses ` will be ADDED to the default value.
This is because I don't foresee scenarios where users would want to remove `BasicObject` or `Object` from this list, and removes the requirement for always specifying them.
I'm open to feedback on this assumption and happy to change it into a full replacement, I simply went with the most logical approach in my opinion.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
