### PR TITLE
Workaround for Parser 3.2.2.2 or lower with Ruby 3.3.0dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,10 @@ gem 'asciidoctor'
 gem 'bump', require: false
 gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'memory_profiler', platform: :mri
+# FIXME: Workaround for Parser 3.2.2.2 or lower with Ruby 3.3.0dev.
+# When the Praser gem releases a new version of Racc that includes the runtime dependencies,
+# it will be able to upgrade the Parser gem dependency and remove the workaround.
+gem 'racc', '>= 1.6.2'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.18.0'


### PR DESCRIPTION
Follow up https://github.com/ruby/ruby/pull/7877.

Ruby 3.3.0dev is set to promote Racc to a bundled gem. Therefore, this PR provides a workaround for Parser 3.2.2.2 or lower with Ruby 3.3.0dev to prevents the following Ruby 3.3.0dev CI matrix error:

```console
bundle exec rake internal_investigation

rake aborted!
LoadError: cannot load such file -- racc/parser
<internal:/usr/local/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:37:in `require'
<internal:/usr/local/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:37:in `require'
/usr/local/bundle/gems/parser-3.2.2.1/lib/parser.rb:12:in `<top (required)>'
<internal:/usr/local/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:37:in `require'
<internal:/usr/local/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:37:in `require'
/usr/local/bundle/gems/rubocop-ast-1.29.0/lib/rubocop/ast.rb:3:in `<top (required)>'
/usr/local/bundle/gems/rubocop-ast-1.29.0/lib/rubocop-ast.rb:3:in `require_relative'
/usr/local/bundle/gems/rubocop-ast-1.29.0/lib/rubocop-ast.rb:3:in `<top (required)>'
```

https://app.circleci.com/pipelines/github/rubocop/rubocop/9387/workflows/c308ef87-1373-4c0a-b90d-a22ea57860e3/jobs/279345

I opened PR https://github.com/whitequark/parser/pull/929 to add Racc as a runtime dependency to the Parser gem. When the Praser gem releases a new version of Racc that includes the runtime dependencies, it will be able to upgrade the Parser gem dependency and remove the workaround.

RuboCop's support for Ruby 3.3.0dev is experimental and additions of Racc to the runtime have not been made, as I believe the solution proposed in https://github.com/whitequark/parser/pull/929 is the best.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
