### PR TITLE
Require Parser 3.2.2.3 for Ruby 3.3.0dev as a runtime

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,6 @@ gem 'asciidoctor'
 gem 'bump', require: false
 gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'memory_profiler', platform: :mri
-# FIXME: Workaround for Parser 3.2.2.2 or lower with Ruby 3.3.0dev.
-# When the Praser gem releases a new version of Racc that includes the runtime dependencies,
-# it will be able to upgrade the Parser gem dependency and remove the workaround.
-gem 'racc', '>= 1.6.2'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.18.0'

--- a/changelog/change_require_parser_3_2_2_3_or_higher.md
+++ b/changelog/change_require_parser_3_2_2_3_or_higher.md
@@ -1,0 +1,1 @@
+* [#11942](https://github.com/rubocop/rubocop/pull/11942): Require Parser 3.2.2.3 or higher. ([@koic][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('json', '~> 2.3')
   s.add_runtime_dependency('parallel', '~> 1.10')
-  s.add_runtime_dependency('parser', '>= 3.2.0.0')
+  s.add_runtime_dependency('parser', '>= 3.2.2.3')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
   s.add_runtime_dependency('rexml', '>= 3.2.5', '< 4.0')


### PR DESCRIPTION
Follow up https://github.com/whitequark/parser/pull/929#issuecomment-1583040960

For Ruby 3.3.0dev, this PR makes RuboCop require Parser 3.2.2.3 as a runtime dependency.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
