### PR TITLE
Fix an incorrect autocorrect for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_an_incorrect_for_style_sole_nested_conditional.md
+++ b/changelog/fix_an_incorrect_for_style_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#11944](https://github.com/rubocop/rubocop/pull/11944): Fix an incorrect autocorrect for `Style/SoleNestedConditional` with `Style/MethodCallWithArgsParentheses`. ([@koic][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -186,7 +186,9 @@ module RuboCop
           begin_pos = condition.first_argument.source_range.begin_pos
           return if end_pos > begin_pos
 
-          corrector.replace(range_between(end_pos, begin_pos), '(')
+          range = range_between(end_pos, begin_pos)
+          corrector.remove(range)
+          corrector.insert_after(range, '(')
           corrector.insert_after(condition.last_argument, ')')
         end
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -408,6 +408,34 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `EnforcedStyle: require_parentheses` of `Style/MethodCallWithArgsParentheses` with ' \
+     '`Style/SoleNestedConditional`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/MethodCallWithArgsParentheses:
+        EnforcedStyle: require_parentheses
+    YAML
+    create_file('example.rb', <<~RUBY)
+      if items.include? item
+        if condition
+          do_something
+        end
+      end
+    RUBY
+    expect(
+      cli.run(
+        [
+          '--autocorrect',
+          '--only', 'Style/MethodCallWithArgsParentheses,Style/SoleNestedConditional'
+        ]
+      )
+    ).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      if items.include?(item) && condition
+          do_something
+        end
+    RUBY
+  end
+
   it 'corrects `Style/IfUnlessModifier` with `Style/SoleNestedConditional`' do
     source = <<~RUBY
       def foo


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Style/SoleNestedConditional` with `Style/MethodCallWithArgsParentheses`.

```ruby
if items.include? item
  if condition
    do_something
  end
end
```

## Before

```console
$ bundle exec rubocop -a --only Style/MethodCallWithArgsParentheses,Style/SoleNestedConditional
Inspecting 1 file
F

Offenses:

example.rb:1:4: C: [Corrected] Style/MethodCallWithArgsParentheses: Use parentheses for method calls with arguments.
if items.include? item
   ^^^^^^^^^^^^^^^^^^^
example.rb:1:24: F: Lint/Syntax: unexpected token tRPAREN
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
if items.include?(item)) && condition
                       ^
example.rb:2:3: C: [Corrected] Style/SoleNestedConditional: Consider merging nested conditions into outer if conditions.
  if condition
  ^^
example.rb:3:3: F: Lint/Syntax: unexpected token kEND
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
  end
  ^^^

1 file inspected, 4 offenses detected, 2 offenses corrected
```

Syntax error with redundant closing parentheses.

```console
if items.include?(item)) && condition
    do_something
  end
```

## After

Valid syntax.

```console
if items.include?(item) && condition
    do_something
  end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
