### PR TITLE
Fix an error for `Lint/NumberConversion`

### DIFF
--- a/changelog/fix_an_error_for_lint_number_conversion.md
+++ b/changelog/fix_an_error_for_lint_number_conversion.md
@@ -1,0 +1,1 @@
+* [#11946](https://github.com/rubocop/rubocop/pull/11946): Fix an error for `Lint/NumberConversion` when using multiple number conversion methods. ([@koic][])

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -74,6 +74,7 @@ module RuboCop
         extend AutoCorrector
         include AllowedMethods
         include AllowedPattern
+        include IgnoredNode
 
         CONVERSION_METHOD_CLASS_MAPPING = {
           to_i: "#{Integer.name}(%<number_object>s, 10)",
@@ -116,7 +117,11 @@ module RuboCop
               corrected_method: correct_method(node, receiver)
             )
             add_offense(node, message: message) do |corrector|
+              next if part_of_ignored_node?(node)
+
               corrector.replace(node, correct_method(node, node.receiver))
+
+              ignore_node(node)
             end
           end
         end

--- a/spec/rubocop/cop/lint/number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/number_conversion_spec.rb
@@ -202,6 +202,28 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
       RUBY
     end
 
+    it 'registers an offense when using multiple number conversion methods' do
+      expect_offense(<<~RUBY)
+        case foo.to_f
+             ^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using `foo.to_f`, use stricter `Float(foo)`.
+        ^^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using `case foo.to_f[...]
+        when 0.0
+          bar
+        else
+          baz
+        end.to_i
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Integer(case foo.to_f
+        when 0.0
+          bar
+        else
+          baz
+        end, 10)
+      RUBY
+    end
+
     it 'does not register an offense when using `Integer` constructor' do
       expect_no_offenses(<<~RUBY)
         Integer(var, 10).to_f


### PR DESCRIPTION
This PR fixes the following error for `Lint/NumberConversion` when using multiple number conversion methods:

```console
$ cat example.rb
case foo.to_f
when 0.0
bar
else
baz
end.to_i

$ bundle exec rubocop --only Lint/NumberConversion -A -d
(snip)

An error occurred while Lint/NumberConversion cop was inspecting /Users/koic/src/github.com/koic/rubocop-issues/number_conversion/example.rb:1:5.
Parser::Source::TreeRewriter detected clobbering
/Users/koic/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/parser-3.2.2.3/lib/parser/source/tree_rewriter.rb:427:in `trigger_policy'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
