### PR TITLE
[Fix #11947] Fix an error for `Style/ConditionalAssignment`

### DIFF
--- a/changelog/fix_error_for_style_conditional_assignment.md
+++ b/changelog/fix_error_for_style_conditional_assignment.md
@@ -1,0 +1,1 @@
+* [#11947](https://github.com/rubocop/rubocop/issues/11947): Fix an error for `Style/ConditionalAssignment` with an assignment that uses `if` branch bodies, which include a block. ([@koic][])

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -440,6 +440,8 @@ module RuboCop
       module ConditionalCorrectorHelper
         def remove_whitespace_in_branches(corrector, branch, condition, column)
           branch.each_node do |child|
+            next if child.source_range.nil?
+
             white_space = white_space_range(child, column)
             corrector.remove(white_space) if white_space.source.strip.empty?
           end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -835,6 +835,29 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
       RUBY
     end
 
+    it 'registers an offense for an assignment that uses if branch bodies including a block' do
+      expect_offense(<<~RUBY)
+        result = if condition
+        ^^^^^^^^^^^^^^^^^^^^^ Assign variables inside of conditionals
+          foo do
+          end
+        else
+          bar do
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if condition
+          result = foo do
+          end
+        else
+          result = bar do
+          end
+        end
+      RUBY
+    end
+
     it 'registers an offense for assignment to case when then else' do
       expect_offense(<<~RUBY)
         baz = case foo


### PR DESCRIPTION
Fixes #11947.

This PR fixes an error for `Style/ConditionalAssignment` with an assignment that uses `if` branch bodies, which include a block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
