### PR TITLE
[Fix #11949] Fix a false positive for `Layout/RedundantLineBreak`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_redundant_line_break.md
+++ b/changelog/fix_a_false_positive_for_layout_redundant_line_break.md
@@ -1,0 +1,1 @@
+* [#11949](https://github.com/rubocop/rubocop/issues/11949): Fix a false positive for `Layout/RedundantLineBreak` when using a line broken string. ([@koic][])

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -99,7 +99,7 @@ module RuboCop
         def suitable_as_single_line?(node)
           !comment_within?(node) &&
             node.each_descendant(:if, :case, :kwbegin, :def).none? &&
-            node.each_descendant(:dstr, :str).none?(&:heredoc?) &&
+            node.each_descendant(:dstr, :str).none? { |n| n.heredoc? || n.value.include?("\n") } &&
             node.each_descendant(:begin).none? { |b| !b.single_line? }
         end
 

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -341,6 +341,16 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
               .baz
           RUBY
         end
+
+        it 'does not register an offense with a line broken string argument' do
+          expect_no_offenses(<<~RUBY)
+            foo('
+              xyz
+            ')
+              .bar
+              .baz
+          RUBY
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #11949.

This PR fixes a false positive for `Layout/RedundantLineBreak` when using a line broken string.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
