### PR TITLE
[Fix #11953] Fix a false negative for `Lint/DuplicateHashKey`

### DIFF
--- a/changelog/fix_a_false_negative_for_lint_duplicate_hash_key.md
+++ b/changelog/fix_a_false_negative_for_lint_duplicate_hash_key.md
@@ -1,0 +1,1 @@
+* [#11953](https://github.com/rubocop/rubocop/issues/11953): Fix a false negative for `Lint/DuplicateHashKey` when there is a duplicated constant key in the hash literal. ([@koic][])

--- a/lib/rubocop/cop/lint/duplicate_hash_key.rb
+++ b/lib/rubocop/cop/lint/duplicate_hash_key.rb
@@ -4,6 +4,7 @@ module RuboCop
   module Cop
     module Lint
       # Checks for duplicated keys in hash literals.
+      # This cop considers both primitive types and constants for the hash keys.
       #
       # This cop mirrors a warning in Ruby 2.2.
       #
@@ -24,7 +25,7 @@ module RuboCop
         MSG = 'Duplicated key in hash literal.'
 
         def on_hash(node)
-          keys = node.keys.select(&:recursive_basic_literal?)
+          keys = node.keys.select { |key| key.recursive_basic_literal? || key.const_type? }
 
           return unless duplicates?(keys)
 

--- a/spec/rubocop/cop/lint/duplicate_hash_key_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_hash_key_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateHashKey, :config do
     end
   end
 
+  context 'when there is a duplicated constant key in the hash literal' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        hash = { 'otherkey' => 'value', KEY => 'value', KEY => 'hi' }
+                                                        ^^^ Duplicated key in hash literal.
+      RUBY
+    end
+  end
+
   context 'when there are two duplicated keys in a hash' do
     it 'registers two offenses' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #11953.

This PR fixes a false negative for `Lint/DuplicateHashKey` when there is a duplicated constant key in the hash literal.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
