### PR TITLE
Fix an error for `Style/IdenticalConditionalBranches`

### DIFF
--- a/changelog/fix_an_error_for_style_identical_conditional_branches.md
+++ b/changelog/fix_an_error_for_style_identical_conditional_branches.md
@@ -1,0 +1,1 @@
+* [#11958](https://github.com/rubocop/rubocop/pull/11958): Fix error for `Style/IdenticalConditionalBranches` when using empty parentheses in the `if` branch. ([@koic][])

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -158,13 +158,16 @@ module RuboCop
           return false unless expressions.size >= 1 && unique_expressions.one?
 
           unique_expression = unique_expressions.first
-          return true unless unique_expression.assignment?
+          return true unless unique_expression&.assignment?
 
           lhs = unique_expression.child_nodes.first
           node.condition.child_nodes.none? { |n| n.source == lhs.source if n.variable? }
         end
 
-        def check_expressions(node, expressions, insert_position) # rubocop:disable Metrics/MethodLength
+        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+        def check_expressions(node, expressions, insert_position)
+          return if expressions.any?(&:nil?)
+
           inserted_expression = false
 
           expressions.each do |expression|
@@ -184,6 +187,7 @@ module RuboCop
             end
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
         def last_child_of_parent?(node)
           return true unless (parent = node.parent)

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -509,11 +509,31 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
     end
   end
 
-  context 'with empty brace' do
-    it 'does not raise any error' do
+  context 'with empty parentheses' do
+    it 'does not raise any error when using empty brace in the both parentheses' do
       expect_no_offenses(<<~RUBY)
         if condition
           ()
+        else
+          ()
+        end
+      RUBY
+    end
+
+    it 'does not raise any error when using empty parentheses in the `if` branch' do
+      expect_no_offenses(<<~RUBY)
+        if condition
+          ()
+        else
+          foo
+        end
+      RUBY
+    end
+
+    it 'does not raise any error when using empty parentheses in the `else` branch' do
+      expect_no_offenses(<<~RUBY)
+        if condition
+          foo
         else
           ()
         end


### PR DESCRIPTION
This PR fixes the following error for `Style/IdenticalConditionalBranches` when using empty parentheses in the `if` branch:

```console
$ cat example.rb
if condition
  ()
else
  foo
end

$ bundle exec rubocop --only Style/IdenticalConditionalBranches -d
(snip)

An error occurred while Style/IdenticalConditionalBranches cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/identical_conditional_branches/example.rb:1:0.
undefined method `assignment?' for nil:NilClass
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/identical_conditional_branches.rb:161:in `duplicated_expressions?'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/identical_conditional_branches.rb:146:in `check_branches'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/identical_conditional_branches.rb:120:in `on_if'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
