### PR TITLE
Fix false negatives for `Layout/EmptyLinesAroundExceptionHandlingKeywords`

### DIFF
--- a/changelog/fix_false_negatives_for_layout_empty_lines_around_exception_handling_keywords.md
+++ b/changelog/fix_false_negatives_for_layout_empty_lines_around_exception_handling_keywords.md
@@ -1,0 +1,1 @@
+* [#11959](https://github.com/rubocop/rubocop/pull/11959): Fix false negatives for `Layout/EmptyLinesAroundExceptionHandlingKeywords` when using Ruby 2.5's `rescue` inside block and Ruby 2.7's numbered block. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_lines_around_exception_handling_keywords.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_exception_handling_keywords.rb
@@ -68,6 +68,8 @@ module RuboCop
           check_body(node.body, node.loc.line)
         end
         alias on_defs on_def
+        alias on_block on_def
+        alias on_numblock on_def
 
         def on_kwbegin(node)
           body, = *node

--- a/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
@@ -97,6 +97,150 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords, 
     RUBY
   end
 
+  it 'registers an offense when there is a blank line above `rescue` keyword in a block', :ruby25 do
+    expect_offense(<<~RUBY)
+      foo do
+        f1
+
+      #{message} before the `rescue`.
+      rescue
+        f2
+      else
+        f3
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo do
+        f1
+      rescue
+        f2
+      else
+        f3
+      end
+    RUBY
+  end
+
+  it 'registers an offense when `rescue` section starts with a blank line in a block', :ruby25 do
+    expect_offense(<<~RUBY)
+      foo do
+        f1
+      rescue
+
+      #{message} after the `rescue`.
+        f2
+      else
+        f3
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo do
+        f1
+      rescue
+        f2
+      else
+        f3
+      end
+    RUBY
+  end
+
+  it 'registers an offense when `rescue` section ends with a blank line in a block', :ruby25 do
+    expect_offense(<<~RUBY)
+      foo do
+        f1
+      rescue
+        f2
+
+      #{message} before the `else`.
+      else
+        f3
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo do
+        f1
+      rescue
+        f2
+      else
+        f3
+      end
+    RUBY
+  end
+
+  it 'registers an offense when there is a blank line above `rescue` keyword in a numbered block', :ruby27 do
+    expect_offense(<<~RUBY)
+      foo do
+        f1(_1)
+
+      #{message} before the `rescue`.
+      rescue
+        f2
+      else
+        f3
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo do
+        f1(_1)
+      rescue
+        f2
+      else
+        f3
+      end
+    RUBY
+  end
+
+  it 'registers an offense when `rescue` section starts with a blank line in a numbered block', :ruby27 do
+    expect_offense(<<~RUBY)
+      foo do
+        f1(_1)
+      rescue
+
+      #{message} after the `rescue`.
+        f2
+      else
+        f3
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo do
+        f1(_1)
+      rescue
+        f2
+      else
+        f3
+      end
+    RUBY
+  end
+
+  it 'registers an offense when `rescue` section ends with a blank line in a numbered block', :ruby27 do
+    expect_offense(<<~RUBY)
+      foo do
+        f1(_1)
+      rescue
+        f2
+
+      #{message} before the `else`.
+      else
+        f3
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo do
+        f1(_1)
+      rescue
+        f2
+      else
+        f3
+      end
+    RUBY
+  end
+
   include_examples 'accepts', 'no empty line', <<~RUBY
     begin
       f1


### PR DESCRIPTION
This PR fixes false negatives for `Layout/EmptyLinesAroundExceptionHandlingKeywords` when using Ruby 2.5's `rescue` inside block and Ruby 2.7's numbered block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
