### PR TITLE
[Fix #11962] Fix an error for `Style/RedundantStringEscape`

### DIFF
--- a/changelog/fix_an_error_for_style_redundant_string_escape.md
+++ b/changelog/fix_an_error_for_style_redundant_string_escape.md
@@ -1,0 +1,1 @@
+* [#11962](https://github.com/rubocop/rubocop/issues/11962): Fix an error for `Style/RedundantStringEscape` when an escaped double quote precedes interpolation in a symbol literal. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_string_escape.rb
+++ b/lib/rubocop/cop/style/redundant_string_escape.rb
@@ -157,6 +157,8 @@ module RuboCop
             return delimiter?(node.parent, char)
           end
 
+          return true unless node.loc.begin
+
           delimiters = [node.loc.begin.source[-1], node.loc.end.source[0]]
 
           delimiters.include?(char)

--- a/spec/rubocop/cop/style/redundant_string_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_string_escape_spec.rb
@@ -283,6 +283,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantStringEscape, :config do
     it 'does not register an offense with escaped double quote' do
       expect_no_offenses('"\""')
     end
+
+    it 'does not register an offense when an escaped double quote precedes interpolation in a symbol literal' do
+      expect_no_offenses(<<~'RUBY')
+        :"\"#{value}"
+      RUBY
+    end
   end
 
   context 'with a single quoted string' do


### PR DESCRIPTION
Fixes #11962.

This PR fixes an error for `Style/RedundantStringEscape` when an escaped double quote precedes interpolation in a symbol literal.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
