### PR TITLE
Don't adjust Includes if base and derived configs are in the same folder

### DIFF
--- a/changelog/fix_don_t_adjust_includes_if_base_and_derived_configs.md
+++ b/changelog/fix_don_t_adjust_includes_if_base_and_derived_configs.md
@@ -1,0 +1,1 @@
+* [#11968](https://github.com/rubocop/rubocop/pull/11968): Don't adjust Includes if base and derived configs are in the same folder. ([@naveg][])

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -33,7 +33,7 @@ module RuboCop
                       inherit_mode: determine_inherit_mode(hash, k))
           end
           hash[k] = v
-          fix_include_paths(base_config.loaded_path, hash, k, v) if v.key?('Include')
+          fix_include_paths(base_config.loaded_path, path, hash, k, v) if v.key?('Include')
         end
       end
     end
@@ -42,10 +42,16 @@ module RuboCop
     # base configuration are relative to the directory where the base configuration file is. For the
     # derived configuration, we need to make those paths relative to where the derived configuration
     # file is.
-    def fix_include_paths(base_config_path, hash, key, value)
+    def fix_include_paths(base_config_path, derived_config_path, hash, key, value)
       return unless File.basename(base_config_path).start_with?('.rubocop')
 
       base_dir = File.dirname(base_config_path)
+      derived_dir = File.dirname(derived_config_path)
+
+      # If the two files are in the same directory, don't adjust anything. This is equivalent to the
+      # configuration being specified in a single file
+      return if base_dir == derived_dir
+
       hash[key]['Include'] = value['Include'].map do |include_path|
         PathUtil.relative_path(File.join(base_dir, include_path), Dir.pwd)
       end


### PR DESCRIPTION
This fixes an issue caused by #11416, where files no longer match when
rubocop is run from a child directory.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
