### PR TITLE
[#11836] should not offense single-quoted symbol containing double quotes in `Lint/SymbolConversion`

### DIFF
--- a/changelog/fix_should_not_offence_single_quoted_symbol_containing_double_quotes.md
+++ b/changelog/fix_should_not_offence_single_quoted_symbol_containing_double_quotes.md
@@ -1,0 +1,1 @@
+* [#11836](https://github.com/rubocop/rubocop/issues/11836): Should not offense single-quoted symbol containing double quotes in `Lint/SymbolConversion` . ([@KessaPassa][])

--- a/lib/rubocop/cop/lint/symbol_conversion.rb
+++ b/lib/rubocop/cop/lint/symbol_conversion.rb
@@ -124,7 +124,7 @@ module RuboCop
           source == value ||
             # `Symbol#inspect` uses double quotes, but allow single-quoted
             # symbols to work as well.
-            source.tr("'", '"') == value
+            source.gsub('"', '\"').tr("'", '"') == value
         end
 
         def requires_quotes?(sym_node)

--- a/spec/rubocop/cop/lint/symbol_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/symbol_conversion_spec.rb
@@ -42,9 +42,21 @@ RSpec.describe RuboCop::Cop::Lint::SymbolConversion, :config do
     RUBY
   end
 
-  it 'does not register an offense for a symbol that requires quotes' do
+  it 'does not register an offense for a symbol that requires double quotes' do
     expect_no_offenses(<<~RUBY)
       :"foo-bar"
+    RUBY
+  end
+
+  it 'does not register an offense for a symbol that requires single quotes' do
+    expect_no_offenses(<<~RUBY)
+      :'foo-bar'
+    RUBY
+  end
+
+  it 'does not register an offense for a symbol that requires single quotes, when it includes double quotes' do
+    expect_no_offenses(<<~RUBY)
+      :'foo-bar""'
     RUBY
   end
 


### PR DESCRIPTION
Fixies https://github.com/rubocop/rubocop/issues/11836
This PR should not offense single-quoted symbol containing double quotes in `Lint/SymbolConversion`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
