### PR TITLE
Revert "Have `fix_include_path` make paths relative to Dir.pwd"

### DIFF
--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -33,7 +33,7 @@ module RuboCop
                       inherit_mode: determine_inherit_mode(hash, k))
           end
           hash[k] = v
-          fix_include_paths(base_config.loaded_path, hash, k, v) if v.key?('Include')
+          fix_include_paths(base_config.loaded_path, hash, path, k, v) if v.key?('Include')
         end
       end
     end
@@ -42,12 +42,13 @@ module RuboCop
     # base configuration are relative to the directory where the base configuration file is. For the
     # derived configuration, we need to make those paths relative to where the derived configuration
     # file is.
-    def fix_include_paths(base_config_path, hash, key, value)
+    def fix_include_paths(base_config_path, hash, path, key, value)
       return unless File.basename(base_config_path).start_with?('.rubocop')
 
       base_dir = File.dirname(base_config_path)
+      derived_dir = File.dirname(path)
       hash[key]['Include'] = value['Include'].map do |include_path|
-        PathUtil.relative_path(File.join(base_dir, include_path), Dir.pwd)
+        PathUtil.relative_path(File.join(base_dir, include_path), derived_dir)
       end
     end
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe RuboCop::ConfigLoader do
       end
 
       it 'gets an Include that is relative to the subdirectory' do
-        expect(configuration_from_file['Style/StringLiterals']['Include']).to eq(['dir/**/*.rb'])
+        expect(configuration_from_file['Style/StringLiterals']['Include']).to eq(['**/*.rb'])
       end
 
       it 'ignores parent AllCops/Exclude if ignore_parent_exclusion is true' do
@@ -341,7 +341,7 @@ RSpec.describe RuboCop::ConfigLoader do
       end
 
       it 'gets an Include that is relative to the subdirectory' do
-        expect(configuration_from_file['Style/StringLiterals']['Include']).to eq(['src/**/*.rb'])
+        expect(configuration_from_file['Style/StringLiterals']['Include']).to eq(['../src/**/*.rb'])
       end
     end
 

--- a/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
 
   context 'when investigating Ruby files' do
     it 'does not register any offenses' do
-      expect_no_offenses(<<~RUBY, '/foo.rb')
+      expect_no_offenses(<<~RUBY, 'foo.rb')
         # cop will not read these contents
         gem('rubocop')
         gem('rubocop')

--- a/spec/rubocop/cop/bundler/gem_comment_spec.rb
+++ b/spec/rubocop/cop/bundler/gem_comment_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
 
   context 'when investigating Ruby files' do
     it 'does not register any offenses' do
-      expect_no_offenses(<<~RUBY, '/foo.rb')
+      expect_no_offenses(<<~RUBY, 'foo.rb')
         gem('rubocop')
       RUBY
     end

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
     end
 
     context 'when the file doesn\'t match the Include configuration' do
-      let(:file) { '/bar.rb' }
+      let(:file) { 'bar.rb' }
 
       it { is_expected.to be(false) }
     end


### PR DESCRIPTION
Reverts rubocop/rubocop#11416

As discussed in #11968 