### PR TITLE
[Fix #11974] Fix an error for `Style/RedundantCurrentDirectoryInPath`

### DIFF
--- a/changelog/fix_an_error_for_style_redundant_current_directory_in_path.md
+++ b/changelog/fix_an_error_for_style_redundant_current_directory_in_path.md
@@ -1,0 +1,1 @@
+* [#11974](https://github.com/rubocop/rubocop/issues/11974): Fix an error for `Style/RedundantCurrentDirectoryInPath` when using string interpolation in `require_relative`. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_current_directory_in_path.rb
+++ b/lib/rubocop/cop/style/redundant_current_directory_in_path.rb
@@ -22,7 +22,7 @@ module RuboCop
 
         def on_send(node)
           return unless node.method?(:require_relative)
-          return unless node.first_argument.str_content.start_with?(CURRENT_DIRECTORY_PATH)
+          return unless node.first_argument.str_content&.start_with?(CURRENT_DIRECTORY_PATH)
           return unless (index = node.first_argument.source.index(CURRENT_DIRECTORY_PATH))
 
           begin_pos = node.first_argument.source_range.begin.begin_pos + index

--- a/spec/rubocop/cop/style/redundant_current_directory_in_path_spec.rb
+++ b/spec/rubocop/cop/style/redundant_current_directory_in_path_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantCurrentDirectoryInPath, :config do
     RUBY
   end
 
+  it "registers an offense when using a current directory path with string interpolation in `require_relative '...'`" do
+    expect_offense(<<~'RUBY')
+      require_relative './path/#{to}/feature'
+                        ^^ Remove the redundant current directory path.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      require_relative 'path/#{to}/feature'
+    RUBY
+  end
+
   it 'registers an offense when using a current directory path in `require_relative %q(...)`' do
     expect_offense(<<~RUBY)
       require_relative %q(./path/to/feature)
@@ -32,6 +43,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantCurrentDirectoryInPath, :config do
   it 'does not register an offense when not using a current directory path in `require_relative`' do
     expect_no_offenses(<<~RUBY)
       require_relative 'path/to/feature'
+    RUBY
+  end
+
+  it 'does not register an offense when not using a current directory path with string interpolation in `require_relative`' do
+    expect_no_offenses(<<~'RUBY')
+      require_relative "path/#{to}/feature"
     RUBY
   end
 


### PR DESCRIPTION
Fixes #11974.

This PR fixes an error for `Style/RedundantCurrentDirectoryInPath` when using string interpolation in `require_relative`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
