### PR TITLE
Add vscode-rubocop to the LSP doc

### DIFF
--- a/docs/modules/ROOT/pages/usage/lsp.adoc
+++ b/docs/modules/ROOT/pages/usage/lsp.adoc
@@ -31,6 +31,12 @@ The language server supports `textDocument/formatting` method and is autocorrect
 
 Here are examples of LSP client configurations.
 
+=== VS Code
+
+https://github.com/rubocop/vscode-rubocop[vscode-rubocop] integrates RuboCop into VS Code.
+
+You can install this VS Code extension from the https://marketplace.visualstudio.com/items?itemName=rubocop.vscode-rubocop[Visual Studio Marketplace].
+
 === Emacs (Eglot)
 
 https://github.com/joaotavora/eglot[Eglot] is a client for Language Server Protocol servers on Emacs.


### PR DESCRIPTION
vscode-rubocop has been released:
https://marketplace.visualstudio.com/items?itemName=rubocop.vscode-rubocop

This PR adds vscode-rubocop to the LSP doc.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
