### PR TITLE
[Fix #11981] Fix an incorrect autocorrect for `Style/RedundantRegexpArgument`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_regexp_argument.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_regexp_argument.md
@@ -1,0 +1,1 @@
+* [#11981](https://github.com/rubocop/rubocop/issues/11981): Fix an incorrect autocorrect for `Style/RedundantRegexpArgument` when using double quote and single quote characters. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_regexp_argument.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_argument.rb
@@ -48,9 +48,7 @@ module RuboCop
           return if !regexp_node.regopt.children.empty? || regexp_node.content == ' '
           return unless determinist_regexp?(regexp_node)
 
-          new_argument = replacement(regexp_node)
-          quote = new_argument.include?('"') ? "'" : '"'
-          prefer = "#{quote}#{new_argument}#{quote}"
+          prefer = preferred_argument(regexp_node)
           message = format(MSG, prefer: prefer, current: regexp_node.source)
 
           add_offense(regexp_node, message: message) do |corrector|
@@ -62,6 +60,19 @@ module RuboCop
 
         def determinist_regexp?(regexp_node)
           DETERMINISTIC_REGEX.match?(regexp_node.source)
+        end
+
+        def preferred_argument(regexp_node)
+          new_argument = replacement(regexp_node)
+
+          if new_argument.include?('"')
+            new_argument.gsub!("'", "\\\\'")
+            quote = "'"
+          else
+            quote = '"'
+          end
+
+          "#{quote}#{new_argument}#{quote}"
         end
 
         def replacement(regexp_node)

--- a/spec/rubocop/cop/style/redundant_regexp_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_argument_spec.rb
@@ -14,6 +14,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpArgument, :config do
     end
   end
 
+  it 'registers an offense and corrects when using double quote and single quote characters' do
+    expect_offense(<<~RUBY)
+      str.gsub(/"''/, '')
+               ^^^^^ Use string `'"\\'\\''` as argument instead of regexp `/"''/`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      str.gsub('"\\'\\'', '')
+    RUBY
+  end
+
   it 'registers an offense and corrects when using double quote character' do
     expect_offense(<<~RUBY)
       str.gsub(/"/)


### PR DESCRIPTION
Fixes #11981.

This PR fixes an incorrect autocorrect for `Style/RedundantRegexpArgument` when using double quote and single quote characters.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
