### PR TITLE
[Fix #11986] Fix a false positive for `Lint/MixedCaseRange`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_mixed_case_range.md
+++ b/changelog/fix_a_false_positive_for_lint_mixed_case_range.md
@@ -1,0 +1,1 @@
+* [#11986](https://github.com/rubocop/rubocop/issues/11986): Fix a false positive for `Lint/MixedCaseRange` when the number of characters at the start or end of range is other than 1. ([@koic][])

--- a/lib/rubocop/cop/lint/mixed_case_range.rb
+++ b/lib/rubocop/cop/lint/mixed_case_range.rb
@@ -84,6 +84,8 @@ module RuboCop
         end
 
         def unsafe_range?(range_start, range_end)
+          return false if range_start.length != 1 || range_end.length != 1
+
           range_for(range_start) != range_for(range_end)
         end
 

--- a/spec/rubocop/cop/lint/mixed_case_range_spec.rb
+++ b/spec/rubocop/cop/lint/mixed_case_range_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe RuboCop::Cop::Lint::MixedCaseRange, :config do
     RUBY
   end
 
+  it 'does not register an offense when the number of characters at the start of range is other than 1' do
+    expect_no_offenses(<<~RUBY)
+      foo = 'aa'..'z'
+    RUBY
+  end
+
+  it 'does not register an offense when the number of characters at the end of range is other than 1' do
+    expect_no_offenses(<<~RUBY)
+      foo = 'a'..'zz'
+    RUBY
+  end
+
   context 'ruby > 2.6', :ruby27 do
     it 'does not register an offense for a beginless range' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #11986.

This PR fixes a false positive for `Lint/MixedCaseRange` when the number of characters at the start or end of range is other than 1.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
