### PR TITLE
[Fix #11989] Fix an incorrect autocorrect for `Style/RedundantRegexpArgument`

### DIFF
--- a/changelog/fix_an_incorrect_auttocorrect_for_style_redundant_regexp_argument.md
+++ b/changelog/fix_an_incorrect_auttocorrect_for_style_redundant_regexp_argument.md
@@ -1,0 +1,1 @@
+* [#11989](https://github.com/rubocop/rubocop/issues/11989): Fix an incorrect autocorrect for `Style/RedundantRegexpArgument` when using unicode chars. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_regexp_argument.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_argument.rb
@@ -40,7 +40,9 @@ module RuboCop
           byteindex byterindex gsub gsub! partition rpartition scan split start_with? sub sub!
         ].freeze
         DETERMINISTIC_REGEX = /\A(?:#{LITERAL_REGEX})+\Z/.freeze
-        STR_SPECIAL_CHARS = %w[\n \" \' \\\\ \t \b \f \r].freeze
+        STR_SPECIAL_CHARS = %w[
+          \a \c \C \e \f \M \n \" \' \\\\ \t \b \f \r \u \v \x \0 \1 \2 \3 \4 \5 \6 \7
+        ].freeze
 
         def on_send(node)
           return unless (regexp_node = node.first_argument)

--- a/spec/rubocop/cop/style/redundant_regexp_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_argument_spec.rb
@@ -80,6 +80,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpArgument, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using unicode chars' do
+    expect_offense(<<~'RUBY')
+      "foo\nbar\nbaz\n".split(/\u3000/)
+                              ^^^^^^^^ Use string `"\u3000"` as argument instead of regexp `/\u3000/`.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      "foo\nbar\nbaz\n".split("\u3000")
+    RUBY
+  end
+
   it 'registers an offense and corrects when using consecutive backslash escape chars' do
     expect_offense(<<~'RUBY')
       "foo\\\.bar".split(/\\\./)


### PR DESCRIPTION
Fixes #11989.

This PR fixes an incorrect autocorrect for `Style/RedundantRegexpArgument` when using unicode chars.

This is a resolution applying the feedback below:
https://github.com/rubocop/rubocop/pull/11595#discussion_r1231268032

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
