### PR TITLE
[Fix #11992] Fix an error for built-in language server

### DIFF
--- a/changelog/fix_an_error_for_builtin_lsp.md
+++ b/changelog/fix_an_error_for_builtin_lsp.md
@@ -1,0 +1,1 @@
+* [#11992](https://github.com/rubocop/rubocop/issues/11992): Fix an unexpected `NoMethodError` for built-in language server when an internal error occurs. ([@koic][])

--- a/lib/rubocop/lsp/server.rb
+++ b/lib/rubocop/lsp/server.rb
@@ -36,8 +36,8 @@ module RuboCop
             @routes.handle_unsupported_method(request)
           end
         rescue StandardError => e
-          log("Error #{e.class} #{e.message[0..100]}")
-          log(e.backtrace.inspect)
+          Logger.log("Error #{e.class} #{e.message[0..100]}")
+          Logger.log(e.backtrace.inspect)
         end
       end
 

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -527,4 +527,24 @@ RSpec.describe RuboCop::Lsp::Server, :isolated_environment do
       )
     end
   end
+
+  context 'when an internal error occurs' do
+    before do
+      allow_any_instance_of(RuboCop::Lsp::Routes).to receive(:for).with('initialize').and_raise # rubocop:disable RSpec/AnyInstance
+    end
+
+    let(:requests) do
+      [
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'initialize',
+        params: { probably: "Don't need real params for this test?" }
+      ]
+    end
+
+    it 'logs an internal server error message' do
+      expect(stderr).to start_with('[server] Error RuntimeError')
+      expect(messages.count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #11992.

This PR fixes an unexpected `NoMethodError` for LSP mode when an internal error occurs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
