### PR TITLE
[Fix #11994] Fix an error for `Layout/LineEndStringConcatenationIndentation`

### DIFF
--- a/changelog/fix_an_error_for_layout_line_end_string_concatenation_indentation.md
+++ b/changelog/fix_an_error_for_layout_line_end_string_concatenation_indentation.md
@@ -1,0 +1,1 @@
+* [#11994](https://github.com/rubocop/rubocop/issues/11994): Fix an error for `Layout/LineEndStringConcatenationIndentation` when inspecting the `%` from string `%\n\n`. ([@koic][])

--- a/lib/rubocop/cop/layout/line_end_string_concatenation_indentation.rb
+++ b/lib/rubocop/cop/layout/line_end_string_concatenation_indentation.rb
@@ -84,6 +84,8 @@ module RuboCop
           return unless strings_concatenated_with_backslash?(node)
 
           children = node.children
+          return if children.empty?
+
           if style == :aligned && !always_indented?(node)
             check_aligned(children, 1)
           else

--- a/spec/rubocop/cop/layout/line_end_string_concatenation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/line_end_string_concatenation_indentation_spec.rb
@@ -157,6 +157,10 @@ RSpec.describe RuboCop::Cop::Layout::LineEndStringConcatenationIndentation, :con
         TEXT
       RUBY
     end
+
+    it 'accepts the `%` form string `"%\n\n"`' do
+      expect_no_offenses("%\n\n")
+    end
   end
 
   context 'when EnforcedStyle is aligned' do


### PR DESCRIPTION
Fixes #11994.

This PR fixes an error for `Layout/LineEndStringConcatenationIndentation` when inspecting the `%` form string `%\n\n`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
