### PR TITLE
[Fix #11996] Fix an error for `Style/IfWithSemicolon`

### DIFF
--- a/changelog/fix_an_error_for_style_if_with_semicolon.md
+++ b/changelog/fix_an_error_for_style_if_with_semicolon.md
@@ -1,0 +1,1 @@
+* [#11996](https://github.com/rubocop/rubocop/issues/11996): Fix an error for `Style/IfWithSemicolon` when without branch bodies. ([@koic][])

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -47,7 +47,7 @@ module RuboCop
         def correct_elsif(node)
           <<~RUBY.chop
             if #{node.condition.source}
-              #{node.if_branch.source}
+              #{node.if_branch&.source}
             #{build_else_branch(node.else_branch).chop}
             end
           RUBY
@@ -56,7 +56,7 @@ module RuboCop
         def build_else_branch(second_condition)
           result = <<~RUBY
             elsif #{second_condition.condition.source}
-              #{second_condition.if_branch.source}
+              #{second_condition.if_branch&.source}
           RUBY
 
           if second_condition.else_branch

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -23,17 +23,6 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects for one line if/;/end without else body' do
-    expect_offense(<<~RUBY)
-      if cond; run else; end
-      ^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      cond ? run : nil
-    RUBY
-  end
-
   it 'registers an offense when not using `else` branch' do
     expect_offense(<<~RUBY)
       if cond; run end
@@ -53,6 +42,21 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
   end
 
   context 'when elsif is present' do
+    it 'accepts without branch bodies' do
+      expect_offense(<<~RUBY)
+        if cond; elsif cond2; end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use `if/else` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if cond
+        #{' ' * 2}
+        elsif cond2
+        #{' ' * 2}
+        end
+      RUBY
+    end
+
     it 'accepts without `else` branch' do
       expect_offense(<<~RUBY)
         if cond; run elsif cond2; run2 end


### PR DESCRIPTION
Fixes #11996.

This PR fixes an error for `Style/IfWithSemicolon` when without branch bodies.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
