### PR TITLE
[Fix #11998] Fix an error when inspecting blank heredoc delimiter

### DIFF
--- a/changelog/fix_an_error_when_inspecting_blank_heredoc_delimiter.md
+++ b/changelog/fix_an_error_when_inspecting_blank_heredoc_delimiter.md
@@ -1,0 +1,1 @@
+* [#11998](https://github.com/rubocop/rubocop/issues/11998): Fix an error when inspecting blank heredoc delimiter. ([@koic][])

--- a/lib/rubocop/cop/mixin/heredoc.rb
+++ b/lib/rubocop/cop/mixin/heredoc.rb
@@ -26,11 +26,15 @@ module RuboCop
       end
 
       def delimiter_string(node)
-        node.source.match(OPENING_DELIMITER).captures[1]
+        return '' unless (match = node.source.match(OPENING_DELIMITER))
+
+        match.captures[1]
       end
 
       def heredoc_type(node)
-        node.source.match(OPENING_DELIMITER).captures[0]
+        return '' unless (match = node.source.match(OPENING_DELIMITER))
+
+        match.captures[0]
       end
     end
   end

--- a/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
+++ b/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
@@ -173,6 +173,14 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
           RUBY
         end
       end
+
+      context 'when using blank heredoc delimiters' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            <<''
+          RUBY
+        end
+      end
     end
 
     context 'with a squiggly heredoc' do

--- a/spec/rubocop/cop/style/redundant_heredoc_delimiter_quotes_spec.rb
+++ b/spec/rubocop/cop/style/redundant_heredoc_delimiter_quotes_spec.rb
@@ -161,4 +161,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantHeredocDelimiterQuotes, :config do
       EOS
     RUBY
   end
+
+  it 'does not register an offense when using the blank heredoc delimiter' do
+    expect_no_offenses(<<~RUBY)
+      <<''
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #11998.

This PR fixes an error when inspecting blank heredoc delimiter.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
