### PR TITLE
Support safe or unsafe autocorrect config for LSP

### DIFF
--- a/changelog/new_support_safe_autocorrect_config_for_lsp.md
+++ b/changelog/new_support_safe_autocorrect_config_for_lsp.md
@@ -1,0 +1,1 @@
+* [#12000](https://github.com/rubocop/rubocop/pull/12000): Support safe or unsafe autocorrect config for LSP. ([@koic][])

--- a/docs/modules/ROOT/pages/usage/lsp.adoc
+++ b/docs/modules/ROOT/pages/usage/lsp.adoc
@@ -47,7 +47,26 @@ See Eglot's official documentation for more information.
 
 == Autocorrection
 
-The language server supports `textDocument/formatting` method and is autocorrectable. The autocorrection is safe.
+The language server supports `textDocument/formatting` method and is autocorrectable. The autocorrection is safe by default (`rubocop -a`).
+
+LSP client can switch to unsafe autocorrection (`rubocop -A`) by passing the following `safeAutocorrect` parameter in the `initialize` request.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 42,
+  "method": "initialize",
+  "params": {
+    "initializationOptions": {
+      "safeAutocorrect": false
+    }
+  }
+}
+```
+
+For detailed instructions on setting the parameter, please refer to the configuration methods of your LSP client.
+
+NOTE: The `safeAutocorrect` parameter was introduced in RuboCop 1.54.
 
 == Run as a Language Server
 

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -36,6 +36,8 @@ module RuboCop
       end
 
       handle 'initialize' do |request|
+        @server.configure(safe_autocorrect: safe_autocorrect?(request))
+
         @server.write(
           id: request[:id],
           result: LanguageServer::Protocol::Interface::InitializeResult.new(
@@ -161,6 +163,12 @@ module RuboCop
       end
 
       private
+
+      def safe_autocorrect?(request)
+        safe_autocorrect = request.dig(:params, :initializationOptions, :safeAutocorrect)
+
+        safe_autocorrect.nil? || safe_autocorrect == true
+      end
 
       def format_file(file_uri)
         unless (text = @text_cache[file_uri])

--- a/lib/rubocop/lsp/runtime.rb
+++ b/lib/rubocop/lsp/runtime.rb
@@ -14,9 +14,12 @@ module RuboCop
     # Runtime for Language Server Protocol of RuboCop.
     # @api private
     class Runtime
+      attr_writer :safe_autocorrect
+
       def initialize(config_store)
         @config_store = config_store
         @logged_paths = []
+        @safe_autocorrect = true
       end
 
       # This abuses the `--stdin` option of rubocop and reads the formatted text
@@ -32,7 +35,7 @@ module RuboCop
       #   https://github.com/rubocop/rubocop/blob/v1.52.0/lib/rubocop/runner.rb#L72
       def format(path, text)
         formatting_options = {
-          stdin: text, force_exclusion: true, autocorrect: true, safe_autocorrect: true
+          stdin: text, force_exclusion: true, autocorrect: true, safe_autocorrect: @safe_autocorrect
         }
 
         redirect_stdout { run_rubocop(formatting_options, path) }

--- a/lib/rubocop/lsp/server.rb
+++ b/lib/rubocop/lsp/server.rb
@@ -53,6 +53,10 @@ module RuboCop
         @runtime.offenses(path, text)
       end
 
+      def configure(safe_autocorrect: true)
+        @runtime.safe_autocorrect = safe_autocorrect
+      end
+
       def stop(&block)
         at_exit(&block) if block
         exit


### PR DESCRIPTION
This PR supports safe or unsafe autocorrect config for LSP.

The autocorrection is still safe by default (`rubocop -a`).

LSP client can switch to unsafe autocorrection (`rubocop -A`) by passing the following `safeAutocorrect` parameter in the `initialize` request.

```json
{
  "jsonrpc": "2.0",
  "id": 42,
  "method": "initialize",
  "params": {
    "initializationOptions": {
      "safeAutocorrect": false
    }
  }
}
```

Some users may want to set unsafe autocorrection as the default for the LSP, understanding the risks involved.

However, considering that the default should be safe, unsafe is an option.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
