### PR TITLE
Fix code length calculator for method calls with heredoc

### DIFF
--- a/changelog/fix_code_length_calculator_for_method_calls_with_heredoc.md
+++ b/changelog/fix_code_length_calculator_for_method_calls_with_heredoc.md
@@ -1,0 +1,1 @@
+* [#12001](https://github.com/rubocop/rubocop/issues/12001): Fix code length calculator for method calls with heredoc. ([@fatkodima][])

--- a/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
@@ -290,6 +290,26 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::CodeLengthCalculator do
         length = described_class.new(source.ast, source, foldable_types: %i[method_call]).calculate
         expect(length).to eq(4)
       end
+
+      it 'folds method calls with heredocs if asked' do
+        source = parse_source(<<~RUBY)
+          def test
+            a = 1
+            foo <<~HERE, <<~THERE
+              2
+              3
+              4
+            HERE
+              5
+              6
+              7
+           THERE
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, foldable_types: %i[method_call]).calculate
+        expect(length).to eq(2)
+      end
     end
 
     context 'when class' do


### PR DESCRIPTION
Fixes #12001.

The  problem is that for the code like 
```ruby
other_method <<~ANY
  2
  3
ANY
```

the `.source` method returns just the first line (`other_method <<~ANY`), and so for the example from the linked issue, the total method length included all the lines, but when considering method calls as a single line (`CountAsOne` option), only the first line of the method call was considered and subtracted from the total, leaving all the rest lines from heredoc.

This PR fixes the `CodeLengthCalculator` to correctly calculate sources when the node includes a heredoc in its body.