### PR TITLE
Fix `Lint/Void` cop for `__ENCODING__` constant

### DIFF
--- a/changelog/fix_lint_void_cop_for_encoding_constant.md
+++ b/changelog/fix_lint_void_cop_for_encoding_constant.md
@@ -1,0 +1,1 @@
+* [#12002](https://github.com/rubocop/rubocop/pull/12002): Fix `Lint/Void` cop for `__ENCODING__` constant. ([@fatkodima][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -113,9 +113,15 @@ module RuboCop
         def check_var(node)
           return unless node.variable? || node.const_type?
 
-          add_offense(node.loc.name,
-                      message: format(VAR_MSG, var: node.loc.name.source)) do |corrector|
-            autocorrect_void_var(corrector, node)
+          if node.const_type? && node.special_keyword?
+            add_offense(node, message: format(VAR_MSG, var: node.source)) do |corrector|
+              autocorrect_void_expression(corrector, node)
+            end
+          else
+            add_offense(node.loc.name,
+                        message: format(VAR_MSG, var: node.loc.name.source)) do |corrector|
+              autocorrect_void_expression(corrector, node)
+            end
           end
         end
 
@@ -123,7 +129,7 @@ module RuboCop
           return if !node.literal? || node.xstr_type? || node.range_type?
 
           add_offense(node, message: format(LIT_MSG, lit: node.source)) do |corrector|
-            autocorrect_void_literal(corrector, node)
+            autocorrect_void_expression(corrector, node)
           end
         end
 
@@ -131,7 +137,7 @@ module RuboCop
           return unless node.self_type?
 
           add_offense(node, message: SELF_MSG) do |corrector|
-            autocorrect_void_self(corrector, node)
+            autocorrect_void_expression(corrector, node)
           end
         end
 
@@ -179,18 +185,6 @@ module RuboCop
               "\n"
             )
           end
-        end
-
-        def autocorrect_void_var(corrector, node)
-          corrector.remove(range_with_surrounding_space(range: node.loc.name, side: :left))
-        end
-
-        def autocorrect_void_literal(corrector, node)
-          corrector.remove(range_with_surrounding_space(range: node.source_range, side: :left))
-        end
-
-        def autocorrect_void_self(corrector, node)
-          corrector.remove(range_with_surrounding_space(range: node.source_range, side: :left))
         end
 
         def autocorrect_void_expression(corrector, node)

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -560,4 +560,20 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       end
     RUBY
   end
+
+  it 'registers offense when using special __ENCODING__' do
+    expect_offense(<<~RUBY)
+      def foo
+        __ENCODING__
+        ^^^^^^^^^^^^ Variable `__ENCODING__` used in void context.
+        42
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        42
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #12002.

`__ENCODING__` is parsed as a constant without a name (`s(:const, s(:const, nil, :Encoding), :UTF_8)`), hence is an error. Other constants, like `__FILE__` or `__LINE__` are parsed as `str` and `int` nodes respectively, so these are identified as literals and are already processed correctly.