### PR TITLE
[Fix #12005] Fix a false negative for `Lint/Debugger`

### DIFF
--- a/changelog/fix_a_false_negative_for_lint_debugger.md
+++ b/changelog/fix_a_false_negative_for_lint_debugger.md
@@ -1,0 +1,1 @@
+* [#12005](https://github.com/rubocop/rubocop/issues/12005): Fix a false negative for `Lint/Debugger` when using debugger method inside lambda. ([@koic][])

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -10,10 +10,44 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
       RUBY
     end
 
+    it 'does not register an offense for a `custom_debugger` call when used in assignment' do
+      expect_no_offenses(<<~RUBY)
+        x.y = custom_debugger
+      RUBY
+    end
+
     it 'registers an offense for a `custom_debugger` call' do
       expect_offense(<<~RUBY)
         custom_debugger
         ^^^^^^^^^^^^^^^ Remove debugger entry point `custom_debugger`.
+      RUBY
+    end
+
+    it 'registers an offense for a `custom_debugger` call when used in lambda literal' do
+      expect_offense(<<~RUBY)
+        x.y = -> { custom_debugger }
+                   ^^^^^^^^^^^^^^^ Remove debugger entry point `custom_debugger`.
+      RUBY
+    end
+
+    it 'registers an offense for a `custom_debugger` call when used in `lambda`' do
+      expect_offense(<<~RUBY)
+        x.y = lambda { custom_debugger }
+                       ^^^^^^^^^^^^^^^ Remove debugger entry point `custom_debugger`.
+      RUBY
+    end
+
+    it 'registers an offense for a `custom_debugger` call when used in `proc`' do
+      expect_offense(<<~RUBY)
+        x.y = proc { custom_debugger }
+                     ^^^^^^^^^^^^^^^ Remove debugger entry point `custom_debugger`.
+      RUBY
+    end
+
+    it 'registers an offense for a `custom_debugger` call when used in `Proc.new`' do
+      expect_offense(<<~RUBY)
+        x.y = Proc.new { custom_debugger }
+                         ^^^^^^^^^^^^^^^ Remove debugger entry point `custom_debugger`.
       RUBY
     end
 


### PR DESCRIPTION
Fixes #12005.

This PR fixes a false negative for `Lint/Debugger` when using debugger method inside lambda.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
