### PR TITLE
[Fix #12007] Fix an error for `Layout/SpaceAroundOperators`

### DIFF
--- a/changelog/fix_an_error_for_layout_space_around_operators.md
+++ b/changelog/fix_an_error_for_layout_space_around_operators.md
@@ -1,0 +1,1 @@
+* [#12007](https://github.com/rubocop/rubocop/issues/12007): Fix an error for `Layout/SpaceAroundOperators` when using unary operator with double colon. ([@koic][])

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -153,7 +153,9 @@ module RuboCop
         private
 
         def regular_operator?(send_node)
-          !send_node.unary_operation? && !send_node.dot? && operator_with_regular_syntax?(send_node)
+          return false if send_node.unary_operation? || send_node.dot? || send_node.double_colon?
+
+          operator_with_regular_syntax?(send_node)
         end
 
         def operator_with_regular_syntax?(send_node)

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -257,6 +257,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
       [].map(&:size)
       a.(b)
       -3
+      foo::~
       arr.collect { |e| -e }
       x = +2
     RUBY


### PR DESCRIPTION
Fixes #12007.

This PR fixes an error for `Layout/SpaceAroundOperators` when using unary operator with double colon.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
