### PR TITLE
Fix an error for `Style/YodaCondition`

### DIFF
--- a/changelog/fix_an_error_for_style_yoda_condition.md
+++ b/changelog/fix_an_error_for_style_yoda_condition.md
@@ -1,0 +1,1 @@
+* [#12009](https://github.com/rubocop/rubocop/pull/12009): Fix an error for `Style/YodaCondition` when equality check method is used without the first argument. ([@koic][])

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -118,16 +118,18 @@ module RuboCop
           node.comparison_method? && !noncommutative_operator?(node)
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def valid_yoda?(node)
-          lhs = node.receiver
-          rhs = node.first_argument
+          return true unless (rhs = node.first_argument)
 
+          lhs = node.receiver
           return true if (constant_portion?(lhs) && constant_portion?(rhs)) ||
                          (!constant_portion?(lhs) && !constant_portion?(rhs)) ||
                          interpolation?(lhs)
 
           enforce_yoda? ? constant_portion?(lhs) : constant_portion?(rhs)
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def message(node)
           format(MSG, source: node.source)

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -324,6 +324,10 @@ RSpec.describe RuboCop::Cop::Style::YodaCondition, :config do
       expect_no_offenses('bar === "foo"')
     end
 
+    it 'accepts equality check method is used without the first argument' do
+      expect_no_offenses('foo.==')
+    end
+
     it 'registers an offense for string literal on right' do
       expect_offense(<<~RUBY)
         bar == "foo"


### PR DESCRIPTION
This PR fixes an error for `Style/YodaCondition` when equality check method is used without the first argument:

```ruby
foo.==
```

```console
% rubocop /tmp/example.rb --only Style/YodaCondition -d
(snip)

For /tmp: An error occurred while Style/YodaCondition cop was inspecting /tmp/example.rb:1:0.
undefined method `literal?' for nil:NilClass
An error occurred while Style/YodaCondition cop was inspecting /tmp/example.rb:1:0.
undefined method `literal?' for nil
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/rubocop-1.53.1/lib/
rubocop/cop/style/yoda_condition.rb:144:in `constant_portion?'
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/rubocop-1.53.1/lib/
rubocop/cop/style/yoda_condition.rb:126:in `valid_yoda?'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
