### PR TITLE
Fix false negatives for `Style/RedundantRegexpArgument`

### DIFF
--- a/changelog/fix_false_negatives_for_style_redundant_regexp_argument.md
+++ b/changelog/fix_false_negatives_for_style_redundant_regexp_argument.md
@@ -1,0 +1,1 @@
+* [#12010](https://github.com/rubocop/rubocop/pull/12010): Fix false negatives for `Style/RedundantRegexpArgument` when using safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_regexp_argument.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_argument.rb
@@ -57,6 +57,7 @@ module RuboCop
             corrector.replace(regexp_node, prefer)
           end
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/style/redundant_regexp_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_argument_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpArgument, :config do
         'foo'.#{method}("f")
       RUBY
     end
+
+    it "registers an offense and corrects when the method with safe navigation operator is `#{method}`" do
+      expect_offense(<<~RUBY, method: method)
+        'foo'&.#{method}(/f/)
+               _{method} ^^^ Use string `"f"` as argument instead of regexp `/f/`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        'foo'&.#{method}("f")
+      RUBY
+    end
   end
 
   it 'registers an offense and corrects when using double quote and single quote characters' do


### PR DESCRIPTION
This PR fixes false negatives for `Style/RedundantRegexpArgument` when using safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
