### PR TITLE
Fix an error for `Metrics/MethodLength`

### DIFF
--- a/changelog/fix_an_error_for_metrics_method_length.md
+++ b/changelog/fix_an_error_for_metrics_method_length.md
@@ -1,0 +1,1 @@
+* [#12011](https://github.com/rubocop/rubocop/pull/12011): Fix an error for `Metrics/MethodLength` when using a heredoc in a block without block arguments. ([@koic][])

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -190,7 +190,7 @@ module RuboCop
           def source_from_node_with_heredoc(node)
             last_line = -1
             node.each_descendant do |descendant|
-              next unless descendant.loc
+              next unless descendant.source
 
               descendant_last_line =
                 if heredoc_node?(descendant)

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -187,6 +187,18 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
     RUBY
   end
 
+  it 'does not crash when using a heredoc in a block without block arguments' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        do_something do
+          <<~HEREDOC
+            text
+          HEREDOC
+        end
+      end
+    RUBY
+  end
+
   context 'when CountComments is enabled' do
     before { cop_config['CountComments'] = true }
 


### PR DESCRIPTION
This PR fixes the following error for `Metrics/MethodLength` when using a heredoc in a block without block arguments:

```console
$ cd path/to/rubocop-ast
$ bundle exec rubocop -d --only Metrics/MethodLength lib/rubocop/ast/node_pattern/compiler/sequence_subcompiler.rb
(snip)

Scanning /Users/koic/src/github.com/rubocop/rubocop-ast/lib/rubocop/ast/node_pattern/compiler/sequence_subcompiler.rb
An error occurred while Metrics/MethodLength cop was inspecting /Users/koic/src/github.com/rubocop/rubocop-ast/lib/
rubocop/ast/node_pattern/compiler/sequence_subcompiler.rb:88:10.
undefined method `last_line' for nil
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/parser-3.2.2.3/lib/parser/source/map.rb:118:
in `last_line'
/Users/koic/src/github.com/rubocop/rubocop-ast/lib/rubocop/ast/node.rb:266:in `last_line'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/metrics/utils/code_length_calculator.rb:199:
in `block in source_from_node_with_heredoc'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
