### PR TITLE
Fix an error for `InternalAffairs/LocationLineEqualityComparison` when inside block

### DIFF
--- a/lib/rubocop/cop/internal_affairs/location_line_equality_comparison.rb
+++ b/lib/rubocop/cop/internal_affairs/location_line_equality_comparison.rb
@@ -51,7 +51,9 @@ module RuboCop
 
         def extract_receiver(node)
           receiver = node.receiver
-          receiver = receiver.receiver if receiver.method?(:loc) || receiver.method?(:source_range)
+          if receiver.send_type? && (receiver.method?(:loc) || receiver.method?(:source_range))
+            receiver = receiver.receiver
+          end
           receiver.source
         end
       end

--- a/spec/rubocop/cop/internal_affairs/location_line_equality_comparison_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/location_line_equality_comparison_spec.rb
@@ -56,6 +56,21 @@ RSpec.describe RuboCop::Cop::InternalAffairs::LocationLineEqualityComparison, :c
     RUBY
   end
 
+  it 'registers an offense and corrects when using `first_line` inside block' do
+    expect_offense(<<~RUBY)
+      nodes.select do |node|
+        node.first_line == nodes.first.first_line
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `same_line?(node, nodes.first)`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      nodes.select do |node|
+        same_line?(node, nodes.first)
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using `same_line?`' do
     expect_no_offenses(<<~RUBY)
       same_line?(node, node.parent)


### PR DESCRIPTION
This PR if fix an error for `InternalAffairs/LocationLineEqualityComparison` when inside block.

Code to reproduce:
```ruby
nodes.select do |node|
  node.first_line == nodes.first.first_line
end
```

Log:
```
An error occurred while InternalAffairs/LocationLineEqualityComparison cop was inspecting /ydah/rubocop-rspec/a.rb:2:2.
undefined method `method?' for s(:lvar, :node):RuboCop::AST::Node
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cop/internal_affairs/location_line_equality_comparison.rb:54:in `extract_receiver'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cop/internal_affairs/location_line_equality_comparison.rb:41:in `on_send'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cop/commissioner.rb:107:in `public_send'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cop/commissioner.rb:107:in `block (2 levels) in trigger_responding_cops'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cop/commissioner.rb:171:in `with_cop_error_handling'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cop/commissioner.rb:106:in `block in trigger_responding_cops'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cop/commissioner.rb:105:in `each'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cop/commissioner.rb:105:in `trigger_responding_cops'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cop/commissioner.rb:69:in `on_send'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-ast-1.29.0/lib/rubocop/ast/traversal.rb:158:in `on_block'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cop/commissioner.rb:71:in `on_block'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-ast-1.29.0/lib/rubocop/ast/traversal.rb:20:in `walk'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cop/commissioner.rb:87:in `investigate'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cop/team.rb:156:in `investigate_partial'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cop/team.rb:98:in `investigate'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:345:in `block in inspect_file'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:344:in `each'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:344:in `flat_map'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:344:in `inspect_file'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:287:in `block in do_inspection_loop'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:321:in `block in iterate_until_no_changes'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:314:in `loop'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:314:in `iterate_until_no_changes'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:283:in `do_inspection_loop'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:164:in `block in file_offenses'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:189:in `file_offense_cache'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:163:in `file_offenses'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:154:in `process_file'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:135:in `block in each_inspected_file'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:134:in `each'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:134:in `reduce'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:134:in `each_inspected_file'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:120:in `inspect_files'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/runner.rb:73:in `run'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cli/command/execute_runner.rb:26:in `block in execute_runner'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cli/command/execute_runner.rb:52:in `with_redirect'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cli/command/execute_runner.rb:25:in `execute_runner'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cli/command/execute_runner.rb:17:in `run'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cli/command.rb:11:in `run'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cli/environment.rb:18:in `run'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cli.rb:118:in `run_command'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cli.rb:125:in `execute_runners'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cli.rb:51:in `block in run'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cli.rb:77:in `profile_if_needed'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/lib/rubocop/cli.rb:43:in `run'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/exe/rubocop:19:in `block in <top (required)>'
/ydah/.rbenv/versions/3.2.2/lib/ruby/3.2.0/benchmark.rb:311:in `realtime'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-1.54.0/exe/rubocop:19:in `<top (required)>'
/ydah/.rbenv/versions/3.2.2/bin/rubocop:25:in `load'
/ydah/.rbenv/versions/3.2.2/bin/rubocop:25:in `<top (required)>'
/ydah/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `load'
/ydah/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `kernel_load'
/ydah/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli/exec.rb:23:in `run'
/ydah/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli.rb:492:in `exec'
/ydah/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/ydah/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/ydah/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/ydah/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli.rb:34:in `dispatch'
/ydah/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/ydah/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli.rb:28:in `start'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.10/libexec/bundle:45:in `block in <top (required)>'
/ydah/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
/ydah/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.10/libexec/bundle:33:in `<top (required)>'
/ydah/.rbenv/versions/3.2.2/bin/bundle:25:in `load'
/ydah/.rbenv/versions/3.2.2/bin/bundle:25:in `<main>'
```

RuboCop version:
```
rubocop -V
1.54.0 (using Parser 3.2.2.3, rubocop-ast 1.29.0, running on ruby 3.2.2) [x86_64-darwin21]
  - rubocop-performance 1.18.0
  - rubocop-rake 0.6.0
  - rubocop-rspec 2.22.0
```

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
