### PR TITLE
[Fix #12015] Mark `Style/HashConversion` as unsafe autocorrection

### DIFF
--- a/changelog/change_mark_style_hash_conversion_as_unsafe_autocorrection.md
+++ b/changelog/change_mark_style_hash_conversion_as_unsafe_autocorrection.md
@@ -1,0 +1,1 @@
+* [#12015](https://github.com/rubocop/rubocop/issues/12015): Mark `Style/HashConversion` as unsafe autocorrection. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3916,8 +3916,9 @@ Style/HashConversion:
   Description: 'Avoid Hash[] in favor of ary.to_h or literal hashes.'
   StyleGuide: '#avoid-hash-constructor'
   Enabled: pending
+  SafeAutoCorrect: false
   VersionAdded: '1.10'
-  VersionChanged: '1.11'
+  VersionChanged: '<<next>>'
   AllowSplatArgument: true
 
 Style/HashEachMethods:

--- a/lib/rubocop/cop/style/hash_conversion.rb
+++ b/lib/rubocop/cop/style/hash_conversion.rb
@@ -10,6 +10,16 @@ module RuboCop
       # `Hash[*ary]` can be replaced with `ary.each_slice(2).to_h` but it will be complicated.
       # So, `AllowSplatArgument` option is true by default to allow splat argument for simple code.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because `ArgumentError` occurs
+      #   if the number of elements is odd:
+      #
+      #   [source,ruby]
+      #   ----
+      #   Hash[[[1, 2], [3]]] #=> {1=>2, 3=>nil}
+      #   [[1, 2], [5]].to_h  #=> wrong array length at 1 (expected 2, was 1) (ArgumentError)
+      #   ----
+      #
       # @example
       #   # bad
       #   Hash[ary]


### PR DESCRIPTION
Fixes #12015.

This PR marks `Style/HashConversion` as unsafe autocorrection.

This cop's autocorrection is unsafe because `ArgumentError` occurs if the number of elements is odd:

```ruby
Hash[[[1, 2], [3, 4], [5]]] #=> {1=>2, 3=>4, 5=>nil}
[[1, 2], [3, 4], [5]].to_h  #=> wrong array length at 2 (expected 2, was 1) (ArgumentError)
```

For example, this cannot be avoided when the arguments are variables.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
