### PR TITLE
[Fix #12014] Fix an error for `Lint/UselessAssignment`

### DIFF
--- a/changelog/fix_an_error_for_lint_useless_assignment.md
+++ b/changelog/fix_an_error_for_lint_useless_assignment.md
@@ -1,0 +1,1 @@
+* [#12014](https://github.com/rubocop/rubocop/pull/12014): Fix an error for `Lint/UselessAssignment` when part of a multiple assignment is enclosed in parentheses. ([@koic][])

--- a/lib/rubocop/cop/variable_force/assignment.rb
+++ b/lib/rubocop/cop/variable_force/assignment.rb
@@ -102,10 +102,11 @@ module RuboCop
         end
 
         def multiple_assignment_node
-          grandparent_node = node.parent&.parent
-          return nil unless grandparent_node
+          return nil unless (grandparent_node = node.parent&.parent)
+          if (node = find_multiple_assignment_node(grandparent_node))
+            return node
+          end
           return nil unless grandparent_node.type == MULTIPLE_ASSIGNMENT_TYPE
-          return nil unless node.parent.type == MULTIPLE_LEFT_HAND_SIDE_TYPE
 
           grandparent_node
         end
@@ -121,6 +122,16 @@ module RuboCop
           return nil unless node.parent&.for_type?
 
           node.parent
+        end
+
+        def find_multiple_assignment_node(grandparent_node)
+          return unless grandparent_node.type == MULTIPLE_LEFT_HAND_SIDE_TYPE
+          return if grandparent_node.children.any?(&:splat_type?)
+
+          parent = grandparent_node.parent
+          return parent if parent.type == MULTIPLE_ASSIGNMENT_TYPE
+
+          find_multiple_assignment_node(parent)
         end
       end
     end

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1194,6 +1194,42 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when part of a multiple assignment is enclosed in parentheses' do
+    it 'registers an offense when the variable in parentheses is not used' do
+      expect_offense(<<~RUBY)
+        def some_method
+          foo, (bar, baz) = do_something
+                     ^^^ Useless assignment to variable - `baz`. Use `_` or `_baz` as a variable name to indicate that it won't be used.
+          puts foo, bar
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          foo, (bar, _) = do_something
+          puts foo, bar
+        end
+      RUBY
+    end
+
+    it 'registers an offense when the variable in nested parentheses is not used' do
+      expect_offense(<<~RUBY)
+        def some_method
+          foo, (bar, (baz, qux)) = do_something
+                           ^^^ Useless assignment to variable - `qux`. Use `_` or `_qux` as a variable name to indicate that it won't be used.
+          puts foo, bar, baz
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          foo, (bar, (baz, _)) = do_something
+          puts foo, bar, baz
+        end
+      RUBY
+    end
+  end
+
   context 'when a variable is assigned with rest assignment and unreferenced' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #12014.

This PR fixes an error for `Lint/UselessAssignment` when part of a multiple assignment is enclosed in parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
