### PR TITLE
[Fix #12024] Fix a false positive for `Lint/RedundantRegexpQuantifiers`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_redundant_regexp_quantifiers.md
+++ b/changelog/fix_a_false_positive_for_lint_redundant_regexp_quantifiers.md
@@ -1,0 +1,1 @@
+* [#12024](https://github.com/rubocop/rubocop/issues/12024): Fix a false positive for `Lint/RedundantRegexpQuantifiers` when interpolation is used in a regexp literal. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_regexp_quantifiers.rb
+++ b/lib/rubocop/cop/lint/redundant_regexp_quantifiers.rb
@@ -5,6 +5,14 @@ module RuboCop
     module Lint
       # Checks for redundant quantifiers inside Regexp literals.
       #
+      # It is always allowed when interpolation is used in a regexp literal,
+      # because it's unknown what kind of string will be expanded as a result:
+      #
+      # [source,ruby]
+      # ----
+      # /(?:a*#{interpolation})?/x
+      # ----
+      #
       # @example
       #   # bad
       #   /(?:x+)+/
@@ -32,6 +40,8 @@ module RuboCop
                                    'with a single `%<replacement>s`.'
 
         def on_regexp(node)
+          return if node.interpolation?
+
           each_redundantly_quantified_pair(node) do |group, child|
             replacement = merged_quantifier(group, child)
             add_offense(

--- a/spec/rubocop/cop/lint/redundant_regexp_quantifiers_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_regexp_quantifiers_spec.rb
@@ -131,6 +131,14 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRegexpQuantifiers, :config do
     end
   end
 
+  context 'with non-redundant quantifiers and interpolation in x-mode' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~'RUBY')
+        foo = /(?:a*#{interpolation})?/x
+      RUBY
+    end
+  end
+
   context 'with deeply nested redundant quantifiers' do
     it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #12024.

This PR fixes a false positive for `Lint/RedundantRegexpQuantifiers` when interpolation is used in a regexp literal.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
