### PR TITLE
[Fix #12020] Fix an error for `Layout/SpaceAfterComma` with `Layout/SpaceBeforeSemicolon`

### DIFF
--- a/changelog/fix_an_error_for_layout_space_after_comma.md
+++ b/changelog/fix_an_error_for_layout_space_after_comma.md
@@ -1,0 +1,1 @@
+* [#12020](https://github.com/rubocop/rubocop/issues/12020): This PR fixes an infinite loop error for `Layout/SpaceAfterComma` with `Layout/SpaceBeforeSemicolon` when autocorrection conflicts. ([@koic][])

--- a/lib/rubocop/cop/layout/space_after_comma.rb
+++ b/lib/rubocop/cop/layout/space_after_comma.rb
@@ -24,7 +24,15 @@ module RuboCop
         end
 
         def kind(token)
-          'comma' if token.comma?
+          'comma' if token.comma? && !before_semicolon?(token)
+        end
+
+        private
+
+        def before_semicolon?(token)
+          tokens = processed_source.tokens
+
+          tokens[tokens.index(token) + 1].semicolon?
         end
       end
     end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1653,6 +1653,18 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       RUBY
   end
 
+  it 'corrects `Layout/SpaceAfterComma` with `Layout/SpaceBeforeSemicolon`' do
+    create_file('example.rb', <<~RUBY)
+      foo { |a, ; x|
+      }
+    RUBY
+    expect(cli.run(%w[-a --only Layout/SpaceAfterComma,Layout/SpaceBeforeSemicolon])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      foo { |a,; x|
+      }
+    RUBY
+  end
+
   it 'can correct SpaceAfterComma and HashSyntax offenses' do
     create_file('example.rb', "I18n.t('description',:property_name => property.name)")
     expect(cli.run(%w[-D --autocorrect-all --format emacs


### PR DESCRIPTION
Fixes #12020.

This PR fixes an infinite loop error for `Layout/SpaceAfterComma` with `Layout/SpaceBeforeSemicolon` when autocorrection conflicts.

The use of semicolon after comma (`,;`) is limited, so making it difficult to default the presence or absence of space between the semicolon and the comma. This PR aims to prevent an infinite loop error occurrences by always allowing the absence of space after comma when it is followed by semicolon.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
