### PR TITLE
Tweak offense range highlight for `Naming/HeredocDelimiterNaming`

### DIFF
--- a/lib/rubocop/cop/naming/heredoc_delimiter_naming.rb
+++ b/lib/rubocop/cop/naming/heredoc_delimiter_naming.rb
@@ -31,7 +31,9 @@ module RuboCop
         def on_heredoc(node)
           return if meaningful_delimiters?(node)
 
-          add_offense(node.loc.heredoc_end)
+          range = node.children.empty? ? node : node.loc.heredoc_end
+
+          add_offense(range)
         end
 
         private

--- a/spec/rubocop/cop/naming/heredoc_delimiter_naming_spec.rb
+++ b/spec/rubocop/cop/naming/heredoc_delimiter_naming_spec.rb
@@ -90,6 +90,15 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterNaming, :config do
         RUBY
       end
     end
+
+    context 'when using blank heredoc delimiters' do
+      it 'registers an offense with a non-meaningful delimiter' do
+        expect_offense(<<~RUBY)
+          <<~''
+          ^^^^^ Use meaningful heredoc delimiters.
+        RUBY
+      end
+    end
   end
 
   context 'with a squiggly heredoc' do


### PR DESCRIPTION
Follow https://github.com/rubocop/rubocop/pull/11999#issuecomment-1613469560

This PR tweaks offense range highlight.

```console
$ cat /tmp/heredoc.rb
<<~''
```

## Before

It was registering an offense as expected, but the offense range was not showing:

```console
$ bundle exec rubocop /tmp/heredoc.rb --only Naming/HeredocDelimiterNaming
Inspecting 1 file
C

Offenses:

/tmp/heredoc.rb:1:1: C: Naming/HeredocDelimiterNaming: Use meaningful heredoc delimiters.

1 file inspected, 1 offense detected
```

## After

It registers an offense as expected and shows the offense range:

```console
$ bundle exec rubocop /tmp/heredoc.rb --only Naming/HeredocDelimiterNaming
Inspecting 1 file
C

Offenses:

/tmp/heredoc.rb:1:1: C: Naming/HeredocDelimiterNaming: Use meaningful heredoc delimiters.
<<~''
^^^^^

1 file inspected, 1 offense detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
