### PR TITLE
Fix typo in Style/ReturnNilInPredicateMethodDefinition docs

### DIFF
--- a/lib/rubocop/cop/style/return_nil_in_predicate_method_definition.rb
+++ b/lib/rubocop/cop/style/return_nil_in_predicate_method_definition.rb
@@ -31,7 +31,7 @@ module RuboCop
       #     do_something?
       #   end
       #
-      # @example AllowedMethod: ['foo?']
+      # @example AllowedMethods: ['foo?']
       #   # good
       #   def foo?
       #     return if condition
@@ -39,7 +39,7 @@ module RuboCop
       #     do_something?
       #   end
       #
-      # @example AllowedPattern: [/foo/]
+      # @example AllowedPatterns: [/foo/]
       #   # good
       #   def foo?
       #     return if condition


### PR DESCRIPTION
This PR fixes a couple of small typos in the `Style/ReturnNilInPredicateMethodDefinition` docs: `AllowedMethod` and `AllowedPattern` should both be pluralized.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
