### PR TITLE
[Fix #1867] Fix an error when `AllCops:Exclude` is empty in .rubocop.yml

### DIFF
--- a/changelog/fix_an_error_when_allcops_exclude_is_empty.md
+++ b/changelog/fix_an_error_when_allcops_exclude_is_empty.md
@@ -1,0 +1,1 @@
+* [#1867](https://github.com/rubocop/rubocop/issues/1867): Fix an error when `AllCops:Exclude` is empty in .rubocop.yml. ([@koic][])

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -114,7 +114,7 @@ module RuboCop
     end
 
     def combined_exclude_glob_patterns(base_dir)
-      exclude = @config_store.for(base_dir).for_all_cops['Exclude']
+      exclude = @config_store.for(base_dir).for_all_cops['Exclude'] || []
       patterns = exclude.select { |pattern| pattern.is_a?(String) && pattern.end_with?('/**/*') }
                         .map { |pattern| pattern.sub("#{base_dir}/", '') }
       "#{base_dir}/{#{patterns.join(',')}}"

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1097,6 +1097,23 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect($stdout.string).to eq(['', '0 files inspected, no offenses detected', ''].join("\n"))
     end
 
+    it 'works when `AllCops:Exclude` is empty' do
+      create_file('example.rb', ['x = 0', 'puts x'])
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          Exclude:
+      YAML
+
+      expect(cli.run(%w[--format simple])).to eq(1)
+      expect($stdout.string).to eq(<<~STDOUT)
+        == example.rb ==
+        C:  1:  1: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
+
+        1 file inspected, 1 offense detected, 1 offense autocorrectable
+      STDOUT
+      expect($stderr.string).to eq ''
+    end
+
     it 'only reads configuration in explicitly included hidden directories' do
       create_file('.hidden/example.rb', 'x=0')
       # This file contains configuration for an unknown cop. This would cause a


### PR DESCRIPTION
Fixes #1867.

This PR fixes the following error when `AllCops:Exclude` is empty in .rubocop.yml.

```console
$ cat .rubocop.yml
AllCops:
  Exclude:

$ bundle exec rubocop
(snip)

private method `select' called for nil:NilClass
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/rubocop-1.54.1/lib/rubocop/target_finder.rb:118:in `combined_exclude_glob_patterns'
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/rubocop-1.54.1/lib/rubocop/target_finder.rb:85:in `find_files'
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/rubocop-1.54.1/lib/rubocop/target_finder.rb:59:in `target_files_in_dir'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
