### PR TITLE
[Fix #10081] Fix Cop::Cop monkey patch on CopHelper

### DIFF
--- a/changelog/fix_fix_cop__cop_monkey_patch_on_cop_helper.md
+++ b/changelog/fix_fix_cop__cop_monkey_patch_on_cop_helper.md
@@ -1,0 +1,1 @@
+* [#10081](https://github.com/rubocop/rubocop/issues/10081): Fix Cop::Cop monkey patch on CopHelper. ([@alepore][])

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -76,18 +76,13 @@ module CopHelper
   end
 end
 
-module RuboCop
-  module Cop
-    # Monkey-patch Cop for tests to provide easy access to messages and
-    # highlights.
-    class Cop
-      def messages
-        offenses.sort.map(&:message)
-      end
+# Monkey-patch Cop for tests to provide easy access to messages and highlights.
+RuboCop::Cop::Cop.class_eval do
+  def messages
+    offenses.sort.map(&:message)
+  end
 
-      def highlights
-        offenses.sort.map { |o| o.location.source }
-      end
-    end
+  def highlights
+    offenses.sort.map { |o| o.location.source }
   end
 end


### PR DESCRIPTION
Rewrites the monkey patch on `CopHelper` to work with `zeitwerk`, otherwise the helper is impossible to use because it raises "TypeError: superclass mismatch for class Cop"

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
