### PR TITLE
[Fix #11802] Improve handling of [] and () with percent symbol arrays

### DIFF
--- a/changelog/fix_improve_handling_of_bracket_and_parentheses_with_percent_symbol_arrays.md
+++ b/changelog/fix_improve_handling_of_bracket_and_parentheses_with_percent_symbol_arrays.md
@@ -1,0 +1,1 @@
+* [#11802](https://github.com/rubocop/rubocop/issues/11802): Improve handling of `[]` and `()` with percent symbol arrays. ([@jasondoc3][])


### PR DESCRIPTION
Addresses https://github.com/rubocop/rubocop/issues/11802, but also accounts for `()`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
