### PR TITLE
Output the "server restarting" message to stderr

### DIFF
--- a/changelog/fix_output_the_server_restarting_message_to_stderr.md
+++ b/changelog/fix_output_the_server_restarting_message_to_stderr.md
@@ -1,0 +1,1 @@
+* [#12038](https://github.com/rubocop/rubocop/pull/12038): Output the "server restarting" message to stderr. ([@knu][])

--- a/lib/rubocop/server/client_command/exec.rb
+++ b/lib/rubocop/server/client_command/exec.rb
@@ -32,7 +32,7 @@ module RuboCop
 
         def ensure_server!
           if incompatible_version?
-            puts 'RuboCop version incompatibility found, RuboCop server restarting...'
+            warn 'RuboCop version incompatibility found, RuboCop server restarting...'
             ClientCommand::Stop.new.run
           elsif check_running_server
             return

--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
         RuboCop::Server::Cache.write_version_file('0.99.9')
 
         expect(`ruby -I . "#{rubocop}" --server-status`).to match(/RuboCop server .* is running/)
-        expect(`ruby -I . "#{rubocop}" #{options}`).to start_with(
+        _stdout, stderr, _status = Open3.capture3("ruby -I . \"#{rubocop}\" #{options}")
+        expect(stderr).to start_with(
           'RuboCop version incompatibility found, RuboCop server restarting...'
         )
       end


### PR DESCRIPTION
When using Rubocop with `--autocorrect --stderr`, the standard output should not contain anything other than the autocorrected source.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
