### PR TITLE
Fix a false positive for `Layout/TrailingEmptyLines`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_trailing_empty_lines.md
+++ b/changelog/fix_a_false_positive_for_layout_trailing_empty_lines.md
@@ -1,0 +1,1 @@
+* [#12040](https://github.com/rubocop/rubocop/pull/12040): Fix a false positive for `Layout/TrailingEmptyLines` to prevent the following incorrect autocorrection when inspecting the `%` form string `%\n\n`. ([@koic][])

--- a/lib/rubocop/cop/layout/trailing_empty_lines.rb
+++ b/lib/rubocop/cop/layout/trailing_empty_lines.rb
@@ -51,6 +51,7 @@ module RuboCop
           # there could be good reasons why it needs to end with a certain
           # number of newlines.
           return if ends_in_end?(processed_source)
+          return if end_with_percent_blank_string?(processed_source)
 
           whitespace_at_end = buffer.source[/\s*\Z/]
           blank_lines = whitespace_at_end.count("\n") - 1
@@ -84,6 +85,10 @@ module RuboCop
 
           extra = buffer.source[processed_source.tokens.last.end_pos..]
           extra&.strip&.start_with?('__END__')
+        end
+
+        def end_with_percent_blank_string?(processed_source)
+          processed_source.buffer.source.end_with?("%\n\n")
         end
 
         def message(wanted_blank_lines, blank_lines)

--- a/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
@@ -86,6 +86,14 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
 
       expect_correction("x = 0\n")
     end
+
+    it 'accepts the `%` form string `"%\n\n"` at the end of file' do
+      expect_no_offenses("%\n\n")
+    end
+
+    it 'accepts when assigning the `%` form string `"%\n\n"` to a variable at the end of file' do
+      expect_no_offenses("x = %\n\n")
+    end
   end
 
   context 'when EnforcedStyle is final_blank_line' do
@@ -151,6 +159,14 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
         x = 0
 
       RUBY
+    end
+
+    it 'accepts the `%` form string `"%\n\n"` at the end of file' do
+      expect_no_offenses("%\n\n")
+    end
+
+    it 'accepts when assigning the `%` form string `"%\n\n"` to a variable at the end of file' do
+      expect_no_offenses("x = %\n\n")
     end
   end
 end


### PR DESCRIPTION
This PR fixes a false positive for `Layout/TrailingEmptyLines` to prevent the following incorrect autocorrection when inspecting the `%` form string `%\n\n`.

First, `Layout/TrailingEmptyLines` cop detects an offense upon inspection, but it's valid syntax:

```console
$ echo "x = %\n\n" | be rubocop --stdin example.rb --only Layout/TrailingEmptyLines
Inspecting 1 file
C

Offenses:

example.rb:2:1: C: [Correctable] Layout/TrailingEmptyLines: 2 trailing blank lines detected.

1 file inspected, 1 offense detected, 1 offense autocorrectable
```

Next, `Layout/TrailingEmptyLines` cop autocorrects to an invalid syntax and `Lint/Syntax` occurs:

```
$ echo "x = %\n\n" | be rubocop --stdin example.rb --only Layout/TrailingEmptyLines -a
Inspecting 1 file
F

Offenses:

example.rb:1:5: F: Lint/Syntax: unterminated string meets end of file
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
x = %
^
example.rb:2:1: C: [Corrected] Layout/TrailingEmptyLines: 2 trailing blank lines detected.

1 file inspected, 2 offenses detected, 1 offense corrected
====================
x = %
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
