### PR TITLE
Fix a false negative for `Layout/ExtraSpacing`

### DIFF
--- a/changelog/fix_a_false_negative_for_layout_extra_spacing.md
+++ b/changelog/fix_a_false_negative_for_layout_extra_spacing.md
@@ -1,0 +1,1 @@
+* [#12043](https://github.com/rubocop/rubocop/pull/12043): Fix a false negative for `Layout/ExtraSpacing` when some characters are vertically aligned. ([@koic][])

--- a/lib/rubocop/cop/mixin/preceding_following_alignment.rb
+++ b/lib/rubocop/cop/mixin/preceding_following_alignment.rb
@@ -75,9 +75,7 @@ module RuboCop
       end
 
       def aligned_token?(range, line)
-        aligned_words?(range, line) ||
-          aligned_char?(range, line) ||
-          aligned_assignment?(range, line)
+        aligned_words?(range, line) || aligned_dot?(range, line) || aligned_assignment?(range, line)
       end
 
       def aligned_operator?(range, line)
@@ -88,8 +86,10 @@ module RuboCop
         /\s\S/.match?(line[range.column - 1, 2])
       end
 
-      def aligned_char?(range, line)
-        line[range.column] == range.source[0]
+      def aligned_dot?(range, line)
+        char = line[range.column]
+
+        char == '.' && char == range.source[0]
       end
 
       def aligned_assignment?(range, line)

--- a/lib/rubocop/string_interpreter.rb
+++ b/lib/rubocop/string_interpreter.rb
@@ -32,9 +32,9 @@ module RuboCop
 
       def interpret_string_escape(escape)
         case escape[1]
-        when 'u' then interpret_unicode(escape)
-        when 'x' then interpret_hex(escape)
-        when /\d/       then interpret_octal(escape)
+        when 'u'  then interpret_unicode(escape)
+        when 'x'  then interpret_hex(escape)
+        when /\d/ then interpret_octal(escape)
         else
           escape[1] # literal escaped char, like \\
         end

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -267,6 +267,21 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
         end
       end
     end
+
+    it 'registers an offense and corrects when a character is vertically aligned' do
+      expect_offense(<<~RUBY)
+        d_is_vertically_aligned  do
+                               ^ Unnecessary spacing detected.
+          _______________________d
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        d_is_vertically_aligned do
+          _______________________d
+        end
+      RUBY
+    end
   end
 
   context 'when AllowForAlignment is false' do

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
     create_empty_file('dir1/ruby2.rb')
     create_empty_file('dir1/file.txt')
     create_empty_file('dir1/file')
-    create_file('dir1/executable',  '#!/usr/bin/env ruby')
+    create_file('dir1/executable', '#!/usr/bin/env ruby')
     create_empty_file('dir2/ruby3.rb')
     create_empty_file('.hidden/ruby4.rb')
   end


### PR DESCRIPTION
This PR fixes a false negative for `Layout/ExtraSpacing` when some character are vertically aligned.

For example, there is a wasted space before the `do` keyword.

```ruby
d_is_vertically_aligned  do
  _______________________d
end
```

The `d` char is accidentally vertically aligned and cannot be detected:

```console
$ bundle exec rubocop --only Layout/ExtraSpacing
(snip)

1 file inspected, no offenses detected
```

Looking at the test code, it looks like this is to allow vertical alignment of dots in method calls:

```ruby
y, m = (year * 12 + (mon - 1) + n).divmod(12)
m,   = (m + 1)                    .divmod(1)
```

https://github.com/rubocop/rubocop/blob/v1.54.1/spec/rubocop/cop/layout/extra_spacing_spec.rb#L172-L177

Therefore, this PR tweaks the alignment logic to be closer to the expected behavior.

And it also suppresses the following new offenses found with this tweak:

```console
$ bundle exec rubocop
(snip)

lib/rubocop/string_interpreter.rb:37:18: C: [Correctable] Layout/ExtraSpacing: Unnecessary spacing detected.
        when /\d/       then interpret_octal(escape)
                 ^^^^^^
spec/rubocop/target_finder_spec.rb:74:35: C: [Correctable] Layout/ExtraSpacing: Unnecessary spacing detected.
    create_file('dir1/executable',  '#!/usr/bin/env ruby')
                                  ^

1513 files inspected, 3 offenses detected, 3 offenses autocorrectable
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
