### PR TITLE
[Fix #12044] Make LSP server support `layoutMode` parameter

### DIFF
--- a/changelog/new_make_lsp_support_layout_only_parameter.md
+++ b/changelog/new_make_lsp_support_layout_only_parameter.md
@@ -1,0 +1,1 @@
+* [#12044](https://github.com/rubocop/rubocop/issues/12044): Make LSP server support `layoutMode` option to run layout cops. ([@koic][])

--- a/docs/modules/ROOT/pages/usage/lsp.adoc
+++ b/docs/modules/ROOT/pages/usage/lsp.adoc
@@ -131,6 +131,29 @@ For detailed instructions on setting the parameter, please refer to the configur
 
 NOTE: The `safeAutocorrect` parameter was introduced in RuboCop 1.54.
 
+== Layout Mode
+
+LSP client can run layout cops by passing the following `layoutMode` parameter in the `initialize` request.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 42,
+  "method": "initialize",
+  "params": {
+    "initializationOptions": {
+      "layoutMode": true
+    }
+  }
+}
+```
+
+Furthermore, enabling autocorrect in a LSP client at the time of saving equates to the effect of `rubocop -x` option.
+
+For detailed instructions on setting the parameter, please refer to the configuration methods of your LSP client.
+
+NOTE: The `layoutMode` parameter was introduced in RuboCop 1.55.
+
 == Run as a Language Server
 
 Run `rubocop --lsp` command from LSP client.

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -36,7 +36,9 @@ module RuboCop
       end
 
       handle 'initialize' do |request|
-        @server.configure(safe_autocorrect: safe_autocorrect?(request))
+        initialization_options = extract_initialization_options_from(request)
+
+        @server.configure(initialization_options)
 
         @server.write(
           id: request[:id],
@@ -164,10 +166,13 @@ module RuboCop
 
       private
 
-      def safe_autocorrect?(request)
+      def extract_initialization_options_from(request)
         safe_autocorrect = request.dig(:params, :initializationOptions, :safeAutocorrect)
 
-        safe_autocorrect.nil? || safe_autocorrect == true
+        {
+          safe_autocorrect: safe_autocorrect.nil? || safe_autocorrect == true,
+          layout_mode: request.dig(:params, :initializationOptions, :layoutMode) == true
+        }
       end
 
       def format_file(file_uri)

--- a/lib/rubocop/lsp/runtime.rb
+++ b/lib/rubocop/lsp/runtime.rb
@@ -14,12 +14,13 @@ module RuboCop
     # Runtime for Language Server Protocol of RuboCop.
     # @api private
     class Runtime
-      attr_writer :safe_autocorrect
+      attr_writer :safe_autocorrect, :layout_mode
 
       def initialize(config_store)
         @config_store = config_store
         @logged_paths = []
         @safe_autocorrect = true
+        @layout_mode = false
       end
 
       # This abuses the `--stdin` option of rubocop and reads the formatted text
@@ -37,6 +38,7 @@ module RuboCop
         formatting_options = {
           stdin: text, force_exclusion: true, autocorrect: true, safe_autocorrect: @safe_autocorrect
         }
+        formatting_options[:only] = ['Layout'] if @layout_mode
 
         redirect_stdout { run_rubocop(formatting_options, path) }
 
@@ -47,6 +49,7 @@ module RuboCop
         diagnostic_options = {
           stdin: text, force_exclusion: true, formatters: ['json'], format: 'json'
         }
+        diagnostic_options[:only] = ['Layout'] if @layout_mode
 
         json = redirect_stdout { run_rubocop(diagnostic_options, path) }
         results = JSON.parse(json, symbolize_names: true)

--- a/lib/rubocop/lsp/server.rb
+++ b/lib/rubocop/lsp/server.rb
@@ -53,8 +53,9 @@ module RuboCop
         @runtime.offenses(path, text)
       end
 
-      def configure(safe_autocorrect: true)
-        @runtime.safe_autocorrect = safe_autocorrect
+      def configure(options)
+        @runtime.safe_autocorrect = options[:safe_autocorrect]
+        @runtime.layout_mode = options[:layout_mode]
       end
 
       def stop(&block)

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -317,6 +317,231 @@ RSpec.describe RuboCop::Lsp::Server, :isolated_environment do
     end
   end
 
+  describe 'format without `layoutMode` option' do
+    let(:requests) do
+      [
+        {
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'initialize',
+          params: {
+            probably: "Don't need real params for this test?"
+          }
+        },
+        {
+          jsonrpc: '2.0',
+          method: 'textDocument/didOpen',
+          params: {
+            textDocument: {
+              languageId: 'ruby',
+              text: <<~RUBY,
+                puts "hi"
+                  puts 'bye'
+              RUBY
+              uri: 'file:///path/to/file.rb',
+              version: 0
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          method: 'textDocument/didChange',
+          params: {
+            contentChanges: [
+              {
+                text: <<~RUBY
+                  puts "hi"
+                    puts 'bye'
+                RUBY
+              }
+            ],
+            textDocument: {
+              uri: 'file:///path/to/file.rb',
+              version: 10
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          id: 20,
+          method: 'textDocument/formatting',
+          params: {
+            options: { insertSpaces: true, tabSize: 2 },
+            textDocument: { uri: 'file:///path/to/file.rb' }
+          }
+        }
+      ]
+    end
+
+    it 'handles requests' do
+      expect(stderr).to eq('')
+      format_result = messages.last
+      expect(format_result).to eq(
+        jsonrpc: '2.0',
+        id: 20,
+        result: [
+          newText: <<~RUBY,
+            puts 'hi'
+            puts 'bye'
+          RUBY
+          range: {
+            start: { line: 0, character: 0 }, end: { line: 3, character: 0 }
+          }
+        ]
+      )
+    end
+  end
+
+  describe 'format with `layoutMode: true`' do
+    let(:requests) do
+      [
+        {
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'initialize',
+          params: {
+            probably: "Don't need real params for this test?",
+            initializationOptions: {
+              layoutMode: true
+            }
+          }
+        },
+        {
+          jsonrpc: '2.0',
+          method: 'textDocument/didOpen',
+          params: {
+            textDocument: {
+              languageId: 'ruby',
+              text: <<~RUBY,
+                puts "hi"
+                  puts 'bye'
+              RUBY
+              uri: 'file:///path/to/file.rb',
+              version: 0
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          method: 'textDocument/didChange',
+          params: {
+            contentChanges: [
+              {
+                text: <<~RUBY
+                  puts "hi"
+                    puts 'bye'
+                RUBY
+              }
+            ],
+            textDocument: {
+              uri: 'file:///path/to/file.rb',
+              version: 10
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          id: 20,
+          method: 'textDocument/formatting',
+          params: {
+            options: { insertSpaces: true, tabSize: 2 },
+            textDocument: { uri: 'file:///path/to/file.rb' }
+          }
+        }
+      ]
+    end
+
+    it 'handles requests' do
+      expect(stderr).to eq('')
+      format_result = messages.last
+      expect(format_result).to eq(
+        jsonrpc: '2.0',
+        id: 20,
+        result: [
+          newText: <<~RUBY,
+            puts "hi"
+            puts 'bye'
+          RUBY
+          range: {
+            start: { line: 0, character: 0 }, end: { line: 3, character: 0 }
+          }
+        ]
+      )
+    end
+  end
+
+  describe 'format with `layoutMode: false`' do
+    let(:requests) do
+      [
+        {
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'initialize',
+          params: {
+            probably: "Don't need real params for this test?",
+            initializationOptions: {
+              layoutMode: false
+            }
+          }
+        },
+        {
+          jsonrpc: '2.0',
+          method: 'textDocument/didOpen',
+          params: {
+            textDocument: {
+              languageId: 'ruby',
+              text: <<~RUBY,
+                puts "hi"
+                  puts 'bye'
+              RUBY
+              uri: 'file:///path/to/file.rb',
+              version: 0
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          method: 'textDocument/didChange',
+          params: {
+            contentChanges: [
+              {
+                text: <<~RUBY
+                  puts "hi"
+                    puts 'bye'
+                RUBY
+              }
+            ],
+            textDocument: {
+              uri: 'file:///path/to/file.rb',
+              version: 10
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          id: 20,
+          method: 'textDocument/formatting',
+          params: {
+            options: { insertSpaces: true, tabSize: 2 },
+            textDocument: { uri: 'file:///path/to/file.rb' }
+          }
+        }
+      ]
+    end
+
+    it 'handles requests' do
+      expect(stderr).to eq('')
+      format_result = messages.last
+      expect(format_result).to eq(
+        jsonrpc: '2.0',
+        id: 20,
+        result: [
+          newText: <<~RUBY,
+            puts 'hi'
+            puts 'bye'
+          RUBY
+          range: {
+            start: { line: 0, character: 0 }, end: { line: 3, character: 0 }
+          }
+        ]
+      )
+    end
+  end
+
   describe 'no op commands' do
     let(:requests) do
       [


### PR DESCRIPTION
Fixes #12044.

LSP client can run layout cops by passing the following `layoutMode` parameter in the `initialize` request.

```json
{
  "jsonrpc": "2.0",
  "id": 42,
  "method": "initialize",
  "params": {
    "initializationOptions": {
      "layoutMode": true
    }
  }
}
```

Furthermore, enabling autocorrect in a LSP client at the time of saving equates to the effect of `rubocop -x` option.

For detailed instructions on setting the parameter, please refer to the configuration methods of your LSP client.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
