### PR TITLE
[Fix #12046] Make `ReturnNilInPredicateMethodDefinition` aware of `nil` at the end of method

### DIFF
--- a/changelog/new_make_style_return_nil_in_predicate_method_definition_aware_of_nil.md
+++ b/changelog/new_make_style_return_nil_in_predicate_method_definition_aware_of_nil.md
@@ -1,0 +1,1 @@
+* [#12046](https://github.com/rubocop/rubocop/issues/12046): Make `ReturnNilInPredicateMethodDefinition` aware of `nil` at the end of predicate method definition. ([@koic][])

--- a/spec/rubocop/cop/style/return_nil_in_predicate_method_definition_spec.rb
+++ b/spec/rubocop/cop/style/return_nil_in_predicate_method_definition_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
       expect_offense(<<~RUBY)
         def foo?
           return if condition
-          ^^^^^^ Use `return false` instead of `return` in the predicate method.
+          ^^^^^^ Return `false` instead of `nil` in predicate methods.
 
           bar?
         end
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
       expect_offense(<<~RUBY)
         def foo?
           return nil if condition
-          ^^^^^^^^^^ Use `return false` instead of `return nil` in the predicate method.
+          ^^^^^^^^^^ Return `false` instead of `nil` in predicate methods.
 
           bar?
         end
@@ -36,6 +36,25 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
           return false if condition
 
           bar?
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using `nil` at the end of the predicate method definition' do
+      expect_offense(<<~RUBY)
+        def foo?
+          return true if condition
+
+          nil
+          ^^^ Return `false` instead of `nil` in predicate methods.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          return true if condition
+
+          false
         end
       RUBY
     end
@@ -70,6 +89,18 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
       RUBY
     end
 
+    it 'does not register an offense when using `nil` at the middle of method definition' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          do_something
+
+          nil
+
+          do_something
+        end
+      RUBY
+    end
+
     it 'does not register an offense when not using `return`' do
       expect_no_offenses(<<~RUBY)
         def foo?
@@ -78,9 +109,18 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
       RUBY
     end
 
-    it 'does not register an offense when empty body`' do
+    it 'does not register an offense when empty body' do
       expect_no_offenses(<<~RUBY)
         def foo?
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when empty body with `rescue`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          return false unless condition
+        rescue
         end
       RUBY
     end
@@ -91,7 +131,7 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
       expect_offense(<<~RUBY)
         def self.foo?
           return if condition
-          ^^^^^^ Use `return false` instead of `return` in the predicate method.
+          ^^^^^^ Return `false` instead of `nil` in predicate methods.
 
           bar?
         end
@@ -110,7 +150,7 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
       expect_offense(<<~RUBY)
         def self.foo?
           return nil if condition
-          ^^^^^^^^^^ Use `return false` instead of `return nil` in the predicate method.
+          ^^^^^^^^^^ Return `false` instead of `nil` in predicate methods.
 
           bar?
         end


### PR DESCRIPTION
Fixes #12046.

This PR makes `ReturnNilInPredicateMethodDefinition` aware of `nil` at the end of predicate method definition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
