### PR TITLE
Fix a false positive for `Layout/RedundantLineBreak`

### DIFF
--- a/changelog/fix_an_error_for_layout_redundant_line_break.md
+++ b/changelog/fix_an_error_for_layout_redundant_line_break.md
@@ -1,0 +1,1 @@
+* [#12050](https://github.com/rubocop/rubocop/pull/12050): Fix a false positive for `Layout/RedundantLineBreak` when inspecting the `%` form string `%\n\n`. ([@koic][])

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -48,6 +48,10 @@ module RuboCop
 
         MSG = 'Redundant line break detected.'
 
+        def on_lvasgn(node)
+          super unless end_with_percent_blank_string?(processed_source)
+        end
+
         def on_send(node)
           # Include "the whole expression".
           node = node.parent while node.parent&.send_type? ||
@@ -60,6 +64,10 @@ module RuboCop
         end
 
         private
+
+        def end_with_percent_blank_string?(processed_source)
+          processed_source.buffer.source.end_with?("%\n\n")
+        end
 
         def check_assignment(node, _rhs)
           return unless offense?(node)

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -351,6 +351,14 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
               .baz
           RUBY
         end
+
+        it 'does not register an offense when the `%` form string `"%\n\n"` at the end of file' do
+          expect_no_offenses("%\n\n")
+        end
+
+        it 'does not register an offense when assigning the `%` form string `"%\n\n"` to a variable at the end of file' do
+          expect_no_offenses("x = %\n\n")
+        end
       end
     end
 


### PR DESCRIPTION
This PR fixes a false positive for `Layout/RedundantLineBreak` to prevent the following incorrect autocorrection when inspecting the `%` form string `%\n\n`.

First, `Layout/RedundantLineBreak` cop detects an offense upon inspection, but it's valid syntax:

```console
$ echo "x = %\n\n" | be rubocop --stdin example.rb --enable-pending-cops --only Layout/RedundantLineBreak
Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Correctable] Layout/RedundantLineBreak: Redundant line break detected.
x = % ...
^^^^^

1 file inspected, 1 offense detected, 1 offense autocorrectable
```

Next, `Layout/RedundantLineBreak` cop autocorrects to an invalid syntax and `Lint/Syntax` occurs:

```console
% echo "x = %\n\n" | be rubocop --stdin example.rb --enable-pending-cops --only Layout/RedundantLineBreak -a
Inspecting 1 file
F

Offenses:

example.rb:1:1: C: [Corrected] Layout/RedundantLineBreak: Redundant line break detected.
x = % ...
^^^^^
example.rb:1:5: F: Lint/Syntax: unterminated string meets end of file
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
x = %
^

1 file inspected, 2 offenses detected, 1 offense corrected
====================
x = %
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
