### PR TITLE
Allow parentheses in single-line match patterns

### DIFF
--- a/changelog/fix_allow_parentheses_in_single_line_match_patterns.md
+++ b/changelog/fix_allow_parentheses_in_single_line_match_patterns.md
@@ -1,0 +1,1 @@
+* [#12055](https://github.com/rubocop/rubocop/pull/12055): Allow parentheses in single-line match patterns when using the `omit_parentheses` style of `Style/MethodCallWithArgsParentheses`. ([@gsamokovarov][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -124,9 +124,10 @@ module RuboCop
             node.parent&.class_type? && node.parent&.single_line?
           end
 
-          def call_with_ambiguous_arguments?(node)
+          def call_with_ambiguous_arguments?(node) # rubocop:disable Metrics/PerceivedComplexity
             call_with_braced_block?(node) ||
               call_as_argument_or_chain?(node) ||
+              call_in_match_pattern?(node) ||
               hash_literal_in_arguments?(node) ||
               node.descendants.any? do |n|
                 n.forwarded_args_type? || ambiguous_literal?(n) || logical_operator?(n) ||
@@ -142,6 +143,10 @@ module RuboCop
             node.parent &&
               ((node.parent.send_type? && !assigned_before?(node.parent, node)) ||
               node.parent.csend_type? || node.parent.super_type? || node.parent.yield_type?)
+          end
+
+          def call_in_match_pattern?(node)
+            node.parent&.match_pattern_type?
           end
 
           def hash_literal_in_arguments?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -961,6 +961,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    it 'accepts parens in singe-line pattern matching', :ruby30 do
+      expect_no_offenses(<<~RUBY)
+        execute(query) => {elapsed:, sql_count:}
+      RUBY
+    end
+
     context 'allowing parenthesis in chaining' do
       let(:cop_config) do
         {


### PR DESCRIPTION
```ruby
execute(query) => {elapsed:, sql_count:}

# (match-pattern
#   (send nil :execute
#     (send nil :query))
#   (hash-pattern
#     (match-var :elapsed)
#     (match-var :sql_count)))
```

is a single-line pattern-match. The current version of the `omit_parentheses` style in `Style/MethodCallWithArgsParentheses` forces us to omit the parens in the call, making it a call with an options hash that has a string key and a value omitted hash as an value:

```ruby
execute query => {elapsed:, sql_count:}

# (send nil :execute
#   (kwargs
#     (pair
#       (send nil :query)
#       (hash
#         (pair
#           (sym :elapsed)
#           (send nil :elapsed))
#         (pair
#           (sym :sql_count)
#           (send nil :sql_count))))))
```

This is yet another ambiguity and we need to allow the parentheses when we pattern match the value of a call.