### PR TITLE
Make LSP server support `lintMode` parameter

### DIFF
--- a/changelog/new_make_lsp_support_lint_mode_parameter.md
+++ b/changelog/new_make_lsp_support_lint_mode_parameter.md
@@ -1,0 +1,1 @@
+* [#12056](https://github.com/rubocop/rubocop/pull/12056): Make LSP server support `lintMode` option to run lint cops. ([@koic][])

--- a/docs/modules/ROOT/pages/usage/lsp.adoc
+++ b/docs/modules/ROOT/pages/usage/lsp.adoc
@@ -132,6 +132,30 @@ For detailed instructions on setting the parameter, please refer to the configur
 
 NOTE: The `safeAutocorrect` parameter was introduced in RuboCop 1.54.
 
+== Lint Mode
+
+LSP client can run lint cops by passing the following `lintMode` parameter in the `initialize` request
+if you only want to enable the feature as a linter like `ruby -w`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 42,
+  "method": "initialize",
+  "params": {
+    "initializationOptions": {
+      "lintMode": true
+    }
+  }
+}
+```
+
+Furthermore, enabling autocorrect in a LSP client at the time of saving equates to the effect of `rubocop -l` option.
+
+For detailed instructions on setting the parameter, please refer to the configuration methods of your LSP client.
+
+NOTE: The `lintMode` parameter was introduced in RuboCop 1.55.
+
 == Layout Mode
 
 LSP client can run layout cops by passing the following `layoutMode` parameter in the `initialize` request

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -171,6 +171,7 @@ module RuboCop
 
         {
           safe_autocorrect: safe_autocorrect.nil? || safe_autocorrect == true,
+          lint_mode: request.dig(:params, :initializationOptions, :lintMode) == true,
           layout_mode: request.dig(:params, :initializationOptions, :layoutMode) == true
         }
       end

--- a/lib/rubocop/lsp/server.rb
+++ b/lib/rubocop/lsp/server.rb
@@ -55,6 +55,7 @@ module RuboCop
 
       def configure(options)
         @runtime.safe_autocorrect = options[:safe_autocorrect]
+        @runtime.lint_mode = options[:lint_mode]
         @runtime.layout_mode = options[:layout_mode]
       end
 


### PR DESCRIPTION
This PR will provide `lintMode` (`rubocop -l`) as well as `layoutMode` (`rubocop -x`) . I think it's probably less demanding than LSP integration for formatters only, but this PR can provide it in advance.

LSP client can run lint cops by passing the following `lintMode` parameter in the `initialize` request if you only want to enable the feature as a linter like `ruby -w`:

```json
{
  "jsonrpc": "2.0",
  "id": 42,
  "method": "initialize",
  "params": {
    "initializationOptions": {
      "lintMode": true
    }
  }
}
```

Furthermore, enabling autocorrect in a LSP client at the time of saving equates to the effect of `rubocop -l` option.

For detailed instructions on setting the parameter, please refer to the configuration methods of your LSP client.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
