### PR TITLE
Fix `LoadError` on Windows when loading RuboCop from symlinks

### DIFF
--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -202,6 +202,10 @@ module RuboCop
       lib_root = File.join(File.dirname(__FILE__), '..')
       exe_root = File.join(lib_root, '..', 'exe')
 
+      # Make sure to use an absolute path to prevent errors on Windows
+      # when traversing the relative paths with symlinks.
+      exe_root = File.absolute_path(exe_root)
+
       # These are all the files we have `require`d plus everything in the
       # exe directory. A change to any of them could affect the cop output
       # so we include them in the cache hash.


### PR DESCRIPTION
There is a particular edge case when RuboCop is loaded from a fully symlinked environment. This is the default for Bazel which creates a tree of symlinks for every dependency, mimicking the real file tree structure.

In such a setup, RuboCop would fail to load with an error. Resolving the path to an absolute one fixes it.

```
No such file or directory - //?/D:/_bazel/external/bundle/ruby/3.0.0/gems/rubocop-1.36.0/lib/rubocop/../../exe
...
//?/D:/_bazel/external/bundle/ruby/3.0.0/gems/rubocop-1.36.0/lib/rubocop/result_cache.rb:208:in `each'
```

I am not sure what is the best way to write a test for this, I could use some guidance.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
