### PR TITLE
Fix `Style/CombinableLoops` when one of the loops is empty

### DIFF
--- a/changelog/fix_combinable_loops_when_one_of_the_loops_is_empty.md
+++ b/changelog/fix_combinable_loops_when_one_of_the_loops_is_empty.md
@@ -1,0 +1,1 @@
+* [#12063](https://github.com/rubocop/rubocop/pull/12063): Fix `Style/CombinableLoops` when one of the loops is empty. ([@fatkodima][])

--- a/lib/rubocop/cop/style/combinable_loops.rb
+++ b/lib/rubocop/cop/style/combinable_loops.rb
@@ -67,6 +67,7 @@ module RuboCop
           return unless node.parent&.begin_type?
           return unless collection_looping_method?(node)
           return unless same_collection_looping_block?(node, node.left_sibling)
+          return unless node.body && node.left_sibling.body
 
           add_offense(node) do |corrector|
             combine_with_left_sibling(corrector, node)

--- a/spec/rubocop/cop/style/combinable_loops_spec.rb
+++ b/spec/rubocop/cop/style/combinable_loops_spec.rb
@@ -147,5 +147,12 @@ RSpec.describe RuboCop::Cop::Style::CombinableLoops, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when one of the loops is empty' do
+      expect_no_offenses(<<~RUBY)
+        items.each {}
+        items.each {}
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
`Style/CombinableLoops` raises an error when one of the loops is empty:
```
An error occurred while Style/CombinableLoops cop was inspecting example.rb:2:0.
undefined method `source' for nil:NilClass
rubocop/lib/rubocop/cop/style/combinable_loops.rb:108:in `combine_with_left_sibling'
rubocop/lib/rubocop/cop/style/combinable_loops.rb:72:in `block in on_block'
rubocop/lib/rubocop/cop/base.rb:377:in `correct'
rubocop/lib/rubocop/cop/base.rb:181:in `add_offense'
rubocop/lib/rubocop/cop/style/combinable_loops.rb:71:in `on_block'
rubocop/lib/rubocop/cop/commissioner.rb:107:in `public_send'
```

Example (where this error was caught): https://github.com/rails/rails/blob/04c97aec8aa696165e98f46ecec2b13410629be0/activerecord/test/cases/batches_test.rb#L717-L718