### PR TITLE
Make `Style/RedundantArgument` aware of `exit` and `exit!`

### DIFF
--- a/changelog/change_make_redundant_argument_aware_of_exit_and_exit_bang.md
+++ b/changelog/change_make_redundant_argument_aware_of_exit_and_exit_bang.md
@@ -1,0 +1,1 @@
+* [#12064](https://github.com/rubocop/rubocop/pull/12064): Make `Style/RedundantArgument` aware of `exit` and `exit!`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4811,12 +4811,16 @@ Style/RedundantArgument:
   Enabled: pending
   Safe: false
   VersionAdded: '1.4'
-  VersionChanged: '1.40'
+  VersionChanged: '<<next>>'
   Methods:
     # Array#join
     join: ''
     # Array#sum
     sum: 0
+    # Kernel.#exit
+    exit: true
+    # Kernel.#exit!
+    exit!: false
     # String#split
     split: ' '
     # String#chomp

--- a/lib/rubocop/cop/style/redundant_argument.rb
+++ b/lib/rubocop/cop/style/redundant_argument.rb
@@ -35,6 +35,8 @@ module RuboCop
       #   array.join('')
       #   [1, 2, 3].join("")
       #   array.sum(0)
+      #   exit(true)
+      #   exit!(false)
       #   string.split(" ")
       #   "first\nsecond".split(" ")
       #   string.chomp("\n")
@@ -45,6 +47,8 @@ module RuboCop
       #   array.join
       #   [1, 2, 3].join
       #   array.sum
+      #   exit
+      #   exit!
       #   string.split
       #   "first second".split
       #   string.chomp
@@ -55,9 +59,10 @@ module RuboCop
         extend AutoCorrector
 
         MSG = 'Argument %<arg>s is redundant because it is implied by default.'
+        NO_RECEIVER_METHODS = %i[exit exit!].freeze
 
         def on_send(node)
-          return if node.receiver.nil?
+          return if !NO_RECEIVER_METHODS.include?(node.method_name) && node.receiver.nil?
           return if node.arguments.count != 1
           return unless redundant_argument?(node)
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
   s.add_runtime_dependency('rexml', '>= 3.2.5', '< 4.0')
-  s.add_runtime_dependency('rubocop-ast', '>= 1.28.0', '< 2.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 1.28.1', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 2.4.0', '< 3.0')
 end

--- a/spec/rubocop/cop/style/redundant_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_argument_spec.rb
@@ -2,7 +2,12 @@
 
 RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
   let(:cop_config) do
-    { 'Methods' => { 'join' => '', 'sum' => 0, 'split' => ' ', 'chomp' => "\n", 'chomp!' => "\n" } }
+    {
+      'Methods' => {
+        'join' => '', 'sum' => 0, 'exit' => true, 'exit!' => false,
+        'split' => ' ', 'chomp' => "\n", 'chomp!' => "\n"
+      }
+    }
   end
 
   it 'registers an offense and corrects when method called on variable' do
@@ -11,6 +16,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
               ^^^^ Argument '' is redundant because it is implied by default.
       foo.sum(0)
              ^^^ Argument 0 is redundant because it is implied by default.
+      exit(true)
+          ^^^^^^ Argument true is redundant because it is implied by default.
+      exit!(false)
+           ^^^^^^^ Argument false is redundant because it is implied by default.
       foo.split(' ')
                ^^^^^ Argument ' ' is redundant because it is implied by default.
       foo.chomp("\n")
@@ -22,6 +31,8 @@ RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
     expect_correction(<<~RUBY)
       foo.join
       foo.sum
+      exit
+      exit!
       foo.split
       foo.chomp
       foo.chomp!


### PR DESCRIPTION
This PR makes aware of `Style/RedundantArgument` aware of `exit` and `exit!`. It require RuboCop AST 1.28.1+ that includes https://github.com/rubocop/rubocop-ast/pull/262.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
