### PR TITLE
[Fix #11834] Fix false positive for variable in inside conditional branch in nested node

### DIFF
--- a/changelog/fix_false_positive_for_when_variable_in_inside.md
+++ b/changelog/fix_false_positive_for_when_variable_in_inside.md
@@ -1,0 +1,1 @@
+* [#11834](https://github.com/rubocop/rubocop/issues/11834): Fix false positive for when variable in inside conditional branch in nested node. ([@alexeyschepin][])

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -68,7 +68,7 @@ module RuboCop
 
         def same_conditions_node_different_branch?(variable, outer_local_variable)
           variable_node = variable_node(variable)
-          return false unless variable_node.conditional?
+          return false unless node_or_its_ascendant_conditional?(variable_node)
 
           outer_local_variable_node =
             find_conditional_node_from_ascendant(outer_local_variable.declaration_node)
@@ -95,6 +95,12 @@ module RuboCop
           return parent if parent.conditional?
 
           find_conditional_node_from_ascendant(parent)
+        end
+
+        def node_or_its_ascendant_conditional?(node)
+          return true if node.conditional?
+
+          !!find_conditional_node_from_ascendant(node)
         end
       end
     end

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -235,6 +235,24 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
   end
 
   context 'when a block local variable has same name as an outer scope variable' \
+          'with different branches of same `if` condition node' \
+          'in a nested node' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        def some_method
+          if condition?
+            foo = 1
+          else
+            bar = [1, 2, 3]
+            bar.each do |foo|
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a block local variable has same name as an outer scope variable' \
           'with different branches of same `case` condition node' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/11834

This PR fixes a false positive offence for a variable in inside a conditional branch in a nested node.
Please suggest better naming for the new method and the new spec. 


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
