### PR TITLE
[Fix #12068] Fix a false positive for `Style/ReturnNilInPredicateMethodDefinition`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_return_nil_in_predicate_method_definition.md
+++ b/changelog/fix_a_false_positive_for_style_return_nil_in_predicate_method_definition.md
@@ -1,0 +1,1 @@
+* [#12068](https://github.com/rubocop/rubocop/pull/12068): Fix a false positive for `Style/ReturnNilInPredicateMethodDefinition` when the last method argument in method definition is `nil`. ([@koic][])

--- a/lib/rubocop/cop/style/return_nil_in_predicate_method_definition.rb
+++ b/lib/rubocop/cop/style/return_nil_in_predicate_method_definition.rb
@@ -77,6 +77,8 @@ module RuboCop
         private
 
         def nil_node_at_the_end_of_method_body(body)
+          return body if body.nil_type?
+          return unless body.begin_type?
           return unless (last_child = body.children.last)
 
           last_child if last_child.is_a?(AST::Node) && last_child.nil_type?

--- a/spec/rubocop/cop/style/return_nil_in_predicate_method_definition_spec.rb
+++ b/spec/rubocop/cop/style/return_nil_in_predicate_method_definition_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
       RUBY
     end
 
-    it 'registers an offense when using `nil` at the end of the predicate method definition' do
+    it 'registers an offense when using `nil` at the end of the predicate method definition and using guard condition' do
       expect_offense(<<~RUBY)
         def foo?
           return true if condition
@@ -59,12 +59,17 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
       RUBY
     end
 
-    it 'does not register an offense when using `return false`' do
-      expect_no_offenses(<<~RUBY)
+    it 'registers an offense when using `nil` at the end of the predicate method definition' do
+      expect_offense(<<~RUBY)
         def foo?
-          return false if condition
+          nil
+          ^^^ Return `false` instead of `nil` in predicate methods.
+        end
+      RUBY
 
-          bar?
+      expect_correction(<<~RUBY)
+        def foo?
+          false
         end
       RUBY
     end
@@ -97,6 +102,40 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
           nil
 
           do_something
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the last safe navigation method argument in method definition is `nil`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          bar&.baz(nil)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the last method argument in method definition is `nil`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          bar.baz(nil)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when assigning `nil` to a variable in predicate method definition' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          bar = nil
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using `return false`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          return false if condition
+
+          bar?
         end
       RUBY
     end


### PR DESCRIPTION
Fixes #12068.

This PR fixes a false positive for `Style/ReturnNilInPredicateMethodDefinition` when the last method argument in method definition is `nil`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
