### PR TITLE
Add new `Bundler/DuplicatedGroup` cop

### DIFF
--- a/changelog/new_add_new_bundler_duplicated_group_cop.md
+++ b/changelog/new_add_new_bundler_duplicated_group_cop.md
@@ -1,1 +1,1 @@
-* Add new `Bundler/DuplicatedGroup` cop. ([@OwlKing][])
+* [#12074](https://github.com/rubocop/rubocop/pull/12074): Add new `Bundler/DuplicatedGroup` cop. ([@OwlKing][])

--- a/changelog/new_add_new_bundler_duplicated_group_cop.md
+++ b/changelog/new_add_new_bundler_duplicated_group_cop.md
@@ -1,0 +1,1 @@
+* Add new `Bundler/DuplicatedGroup` cop. ([@OwlKing][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -173,6 +173,16 @@ Bundler/DuplicatedGem:
     - '**/Gemfile'
     - '**/gems.rb'
 
+Bundler/DuplicatedGroup:
+  Description: 'Checks for duplicate group entries in Gemfile.'
+  Enabled: true
+  Severity: warning
+  VersionAdded: '<<next>>'
+  Include:
+    - '**/*.gemfile'
+    - '**/Gemfile'
+    - '**/gems.rb'
+
 Bundler/GemComment:
   Description: 'Add a comment describing each gem.'
   Enabled: false

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -162,6 +162,7 @@ require_relative 'rubocop/cop/correctors/string_literal_corrector'
 require_relative 'rubocop/cop/correctors/unused_arg_corrector'
 
 require_relative 'rubocop/cop/bundler/duplicated_gem'
+require_relative 'rubocop/cop/bundler/duplicated_group'
 require_relative 'rubocop/cop/bundler/gem_comment'
 require_relative 'rubocop/cop/bundler/gem_filename'
 require_relative 'rubocop/cop/bundler/gem_version'

--- a/lib/rubocop/cop/bundler/duplicated_group.rb
+++ b/lib/rubocop/cop/bundler/duplicated_group.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Bundler
-      # A Gem group should be listed only once in a Gemfile.
+      # A Gem group, or a set of groups should be listed only once in a Gemfile.
       # @example
       #   # bad
       #   group :development do
@@ -14,10 +14,11 @@ module RuboCop
       #     gem 'rubocop-rails'
       #   end
       #
-      #   # bad
+      #   # bad (same set of groups declared twice)
       #   group :development, :test do
       #     gem 'rubocop'
       #   end
+      #
       #   group :test, :development do
       #     gem 'rspec'
       #   end

--- a/lib/rubocop/cop/bundler/duplicated_group.rb
+++ b/lib/rubocop/cop/bundler/duplicated_group.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Bundler
+      # A Gem group should be listed only once in a Gemfile.
+      # @example
+      #   # bad
+      #   group :development do
+      #     gem 'rubocop'
+      #   end
+      #
+      #   group :development do
+      #     gem 'rubocop-rails'
+      #   end
+      #
+      #   # bad
+      #   group :development, :test do
+      #     gem 'rubocop'
+      #   end
+      #   group :test, :development do
+      #     gem 'rspec'
+      #   end
+      #
+      #   # good
+      #   group :development do
+      #     gem 'rubocop'
+      #   end
+      #
+      #   group :development, :test do
+      #     gem 'rspec'
+      #   end
+      #
+      #   # good
+      #   gem 'rubocop', groups: [:development, :test]
+      #   gem 'rspec', groups: [:development, :test]
+      #
+      class DuplicatedGroup < Base
+        include RangeHelp
+
+        MSG = 'Gem group `%<group_name>s` already defined on line ' \
+              '%<line_of_first_occurrence>d of the Gemfile.'
+
+        def on_new_investigation
+          return if processed_source.blank?
+
+          duplicated_group_nodes.each do |nodes|
+            nodes[1..].each do |node|
+              register_offense(node, node.arguments.map(&:value).join(', '), nodes.first.first_line)
+            end
+          end
+        end
+
+        private
+
+        # @!method group_declarations(node)
+        def_node_search :group_declarations, '(send nil? :group ...)'
+
+        def duplicated_group_nodes
+          group_declarations(processed_source.ast)
+            .group_by { |node| node.arguments.map(&:value).map(&:to_s).sort }
+            .values
+            .select { |nodes| nodes.size > 1 }
+        end
+
+        def register_offense(node, group_name, line_of_first_occurrence)
+          line_range = node.loc.column...node.loc.last_column
+          offense_location = source_range(processed_source.buffer, node.first_line, line_range)
+          message = format(
+            MSG,
+            group_name: group_name,
+            line_of_first_occurrence: line_of_first_occurrence
+          )
+          add_offense(offense_location, message: message)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/bundler/duplicated_group_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_group_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Bundler::DuplicatedGroup, :config do
+  let(:cop_config) { { 'Include' => ['**/Gemfile'] } }
+
+  context 'when investigating Ruby files' do
+    it 'does not register any offenses' do
+      expect_no_offenses(<<~RUBY, 'foo.rb')
+        # cop will not read these contents
+        group :development
+        group :development
+      RUBY
+    end
+  end
+
+  context 'when investigating Gemfiles' do
+    context 'and the file is empty' do
+      it 'does not register any offenses' do
+        expect_no_offenses('', 'Gemfile')
+      end
+    end
+
+    context 'and no duplicate groups are present' do
+      it 'does not register any offenses' do
+        expect_no_offenses(<<~RUBY, 'Gemfile')
+          group :development do
+            gem 'rubocop'
+          end
+          group :test do
+            gem 'flog'
+          end
+        RUBY
+      end
+    end
+
+    context 'and a group is duplicated' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY, 'Gemfile')
+          group :development do
+            gem 'rubocop'
+          end
+          group :development do
+          ^^^^^^^^^^^^^^^^^^ Gem group `development` already defined on line 1 of the Gemfile.
+            gem 'rubocop-rails'
+          end
+        RUBY
+      end
+    end
+
+    context 'and a group is duplicated using different argument types' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY, 'Gemfile')
+          group :development do
+            gem 'rubocop'
+          end
+          group 'development' do
+          ^^^^^^^^^^^^^^^^^^^ Gem group `development` already defined on line 1 of the Gemfile.
+            gem 'rubocop-rails'
+          end
+        RUBY
+      end
+    end
+
+    context 'and a group is present in different sets of groups' do
+      it 'does not register any offenses' do
+        expect_no_offenses(<<~RUBY, 'Gemfile')
+          group :development do
+            gem 'rubocop'
+          end
+          group :development, :test do
+            gem 'rspec'
+          end
+          group :ci, :development do
+            gem 'flog'
+          end
+        RUBY
+      end
+    end
+
+    context 'and a set of groups is duplicated' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY, 'Gemfile')
+          group :test, :development do
+            gem 'rubocop'
+          end
+          group :development, :test do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Gem group `development, test` already defined on line 1 of the Gemfile.
+            gem 'rubocop-rails'
+          end
+        RUBY
+      end
+    end
+  end
+end


### PR DESCRIPTION
New cop validating each gem group (or a set of groups) is only defined once. 

```ruby
# bad
group :development do
  gem 'rubocop'
end

group :development do
  gem 'rubocop-rails'
end

# bad
group :development, :test do
  gem 'rubocop'
end

group :test, :development do
  gem 'rspec'
end

# good
group :development do
  gem 'rubocop'
end

group :development, :test do
  gem 'rspec'
end

# good
gem 'rubocop', groups: [:development, :test]
gem 'rspec', groups: [:development, :test]
```

This has been suggested many years ago here https://github.com/rubocop/rubocop/issues/3600 but I couldn't find any attempts at implementing it. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
