### PR TITLE
Make LSP server support `rubocop.formatAutocorrectsAll` execute command

### DIFF
--- a/changelog/new_make_lsp_server_support_format_autocorrects_all_execute_command.md
+++ b/changelog/new_make_lsp_server_support_format_autocorrects_all_execute_command.md
@@ -1,0 +1,1 @@
+* [#12078](https://github.com/rubocop/rubocop/pull/12078): Make LSP server support `rubocop.formatAutocorrectsAll` execute command. ([@koic][])

--- a/docs/modules/ROOT/pages/usage/lsp.adoc
+++ b/docs/modules/ROOT/pages/usage/lsp.adoc
@@ -132,6 +132,12 @@ For detailed instructions on setting the parameter, please refer to the configur
 
 NOTE: The `safeAutocorrect` parameter was introduced in RuboCop 1.54.
 
+As execute commands in the `workspace/executeCommand` parameters, it provides `rubocop.formatAutocorrects` for safe autocorrections (`rubocop -a`) and
+`rubocop.formatAutocorrectsAll` for unsafe autocorrections (`rubocop -A`).
+These parameters take precedence over the `initializationOptions:safeAutocorrect` value set in the `initialize` parameter.
+
+NOTE: The `rubocop.formatAutocorrectsAll` execute command was introduced in RuboCop 1.56.
+
 == Lint Mode
 
 LSP client can run lint cops by passing the following `lintMode` parameter in the `initialize` request

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -112,23 +112,29 @@ module RuboCop
       end
 
       handle 'workspace/executeCommand' do |request|
-        if request[:params][:command] == 'rubocop.formatAutocorrects'
-          uri = request[:params][:arguments][0][:uri]
-          @server.write(
-            id: request[:id],
-            method: 'workspace/applyEdit',
-            params: {
-              label: 'Format with RuboCop autocorrects',
-              edit: {
-                changes: {
-                  uri => format_file(uri)
-                }
+        case (command = request[:params][:command])
+        when 'rubocop.formatAutocorrects'
+          label = 'Format with RuboCop autocorrects'
+        when 'rubocop.formatAutocorrectsAll'
+          label = 'Format all with RuboCop autocorrects'
+        else
+          handle_unsupported_method(request, command)
+          return
+        end
+
+        uri = request[:params][:arguments][0][:uri]
+        @server.write(
+          id: request[:id],
+          method: 'workspace/applyEdit',
+          params: {
+            label: label,
+            edit: {
+              changes: {
+                uri => format_file(uri, command: command)
               }
             }
-          )
-        else
-          handle_unsupported_method(request, request[:params][:command])
-        end
+          }
+        )
       end
 
       handle 'textDocument/willSave' do |_request|
@@ -176,14 +182,14 @@ module RuboCop
         }
       end
 
-      def format_file(file_uri)
+      def format_file(file_uri, command: nil)
         unless (text = @text_cache[file_uri])
           Logger.log("Format request arrived before text synchronized; skipping: `#{file_uri}'")
 
           return []
         end
 
-        new_text = @server.format(remove_file_protocol_from(file_uri), text)
+        new_text = @server.format(remove_file_protocol_from(file_uri), text, command: command)
 
         return [] if new_text == text
 

--- a/lib/rubocop/lsp/runtime.rb
+++ b/lib/rubocop/lsp/runtime.rb
@@ -35,9 +35,15 @@ module RuboCop
       #   https://github.com/rubocop/rubocop/blob/v1.52.0/lib/rubocop/cli/command/execute_runner.rb#L95
       # Setting `parallel: true` would break this here:
       #   https://github.com/rubocop/rubocop/blob/v1.52.0/lib/rubocop/runner.rb#L72
-      def format(path, text)
+      def format(path, text, command:)
+        safe_autocorrect = if command
+                             command == 'rubocop.formatAutocorrects'
+                           else
+                             @safe_autocorrect
+                           end
+
         formatting_options = {
-          stdin: text, force_exclusion: true, autocorrect: true, safe_autocorrect: @safe_autocorrect
+          stdin: text, force_exclusion: true, autocorrect: true, safe_autocorrect: safe_autocorrect
         }
         formatting_options[:only] = config_only_options if @lint_mode || @layout_mode
 

--- a/lib/rubocop/lsp/server.rb
+++ b/lib/rubocop/lsp/server.rb
@@ -45,8 +45,8 @@ module RuboCop
         @writer.write(response)
       end
 
-      def format(path, text)
-        @runtime.format(path, text)
+      def format(path, text, command:)
+        @runtime.format(path, text, command: command)
       end
 
       def offenses(path, text)

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -980,7 +980,7 @@ RSpec.describe RuboCop::Lsp::Server, :isolated_environment do
     end
   end
 
-  describe 'execute command formatting' do
+  describe 'execute command safe formatting' do
     let(:requests) do
       [
         {
@@ -1018,6 +1018,59 @@ RSpec.describe RuboCop::Lsp::Server, :isolated_environment do
             changes: {
               'file:///path/to/file.rb': [
                 newText: "puts 'hi'\n",
+                range: {
+                  start: { line: 0, character: 0 }, end: { line: 1, character: 0 }
+                }
+              ]
+            }
+          }
+        }
+      )
+    end
+  end
+
+  describe 'execute command unsafe formatting' do
+    let(:requests) do
+      [
+        {
+          jsonrpc: '2.0',
+          method: 'textDocument/didOpen',
+          params: {
+            textDocument: {
+              languageId: 'ruby',
+              text: 'something.map { |s| s.upcase }',
+              uri: 'file:///path/to/file.rb',
+              version: 0
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          id: 99,
+          method: 'workspace/executeCommand',
+          params: {
+            command: 'rubocop.formatAutocorrectsAll',
+            arguments: [uri: 'file:///path/to/file.rb']
+          }
+        }
+      ]
+    end
+
+    it 'handles requests' do
+      expect(stderr).to eq('')
+      expect(messages.last).to eq(
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'workspace/applyEdit',
+        params: {
+          label: 'Format all with RuboCop autocorrects',
+          edit: {
+            changes: {
+              'file:///path/to/file.rb': [
+                newText: <<~RUBY,
+                  # frozen_string_literal: true
+
+                  something.map(&:upcase)
+                RUBY
                 range: {
                   start: { line: 0, character: 0 }, end: { line: 1, character: 0 }
                 }


### PR DESCRIPTION
This PR makes LSP server support `rubocop.formatAutocorrectsAll` execute command. The user can run `rubocop -A` with the execute command in the editor.

The existing `rubocop.formatAutocorrects` execute command equivalent to `rubocop -a` can be used as follows: https://github.com/rubocop/vscode-rubocop#manually-triggering-a-format-with-autocorrects

The new `rubocop.formatAutocorrectsAll` execute command is the provide execute command for that `rubocop -A`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
