### PR TITLE
[Fix #12079] Fix an error for `Style/MixinGrouping`

### DIFF
--- a/changelog/fix_an_error_for_style_mixin_grouping.md
+++ b/changelog/fix_an_error_for_style_mixin_grouping.md
@@ -1,0 +1,1 @@
+* [#12079](https://github.com/rubocop/rubocop/issues/12079): Fix an error for `Style/MixinGrouping` when mixin method has no arguments. ([@koic][])

--- a/lib/rubocop/cop/style/mixin_grouping.rb
+++ b/lib/rubocop/cop/style/mixin_grouping.rb
@@ -40,7 +40,7 @@ module RuboCop
         def on_class(node)
           begin_node = node.child_nodes.find(&:begin_type?) || node
           begin_node.each_child_node(:send).select(&:macro?).each do |macro|
-            next unless MIXIN_METHODS.include?(macro.method_name)
+            next if !MIXIN_METHODS.include?(macro.method_name) || macro.arguments.empty?
 
             check(macro)
           end

--- a/spec/rubocop/cop/style/mixin_grouping_spec.rb
+++ b/spec/rubocop/cop/style/mixin_grouping_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe RuboCop::Cop::Style::MixinGrouping, :config do
           end
         RUBY
       end
+
+      it 'does not register an offense when `include` has no arguments' do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            include
+          end
+        RUBY
+      end
     end
 
     context 'when using `extend`' do
@@ -60,6 +68,14 @@ RSpec.describe RuboCop::Cop::Style::MixinGrouping, :config do
           end
         RUBY
       end
+
+      it 'does not register an offense when `extend` has no arguments' do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            extend
+          end
+        RUBY
+      end
     end
 
     context 'when using `prepend`' do
@@ -75,6 +91,14 @@ RSpec.describe RuboCop::Cop::Style::MixinGrouping, :config do
           class Foo
             prepend Qux
             prepend Bar
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when `prepend` has no arguments' do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            prepend
           end
         RUBY
       end


### PR DESCRIPTION
Fixes #12079.

This PR fixes an error for `Style/MixinGrouping` when mixin method has no arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
