### PR TITLE
[Fix #12082] Fix an error for `Lint/UselessAssignment`

### DIFF
--- a/changelog/fix_an_error_for_lint_useless_assignment.md
+++ b/changelog/fix_an_error_for_lint_useless_assignment.md
@@ -1,0 +1,1 @@
+* [#12082](https://github.com/rubocop/rubocop/issues/12082): Fix an error for `Lint/UselessAssignment` when a variable is assigned and unreferenced in `for` with multiple variables. ([@koic][])

--- a/lib/rubocop/cop/variable_force/assignment.rb
+++ b/lib/rubocop/cop/variable_force/assignment.rb
@@ -119,9 +119,7 @@ module RuboCop
         end
 
         def for_assignment_node
-          return nil unless node.parent&.for_type?
-
-          node.parent
+          node.ancestors.find(&:for_type?)
         end
 
         def find_multiple_assignment_node(grandparent_node)

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -270,6 +270,23 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when a variable is assigned and unreferenced in `for` with multiple variables' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        for i, j in items
+               ^ Useless assignment to variable - `j`.
+          do_something(i)
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        for i, _ in items
+          do_something(i)
+        end
+      RUBY
+    end
+  end
+
   context 'when a variable is assigned and referenced in `for`' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #12082.

This PR fixes an error for `Lint/UselessAssignment` when a variable is assigned and unreferenced in `for` with multiple variables.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
