### PR TITLE
Removed the copyright years from license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2012-23 Bozhidar Batsov
+Copyright (c) Bozhidar Batsov
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -248,5 +248,5 @@ RuboCop's changelog is available [here](CHANGELOG.md).
 
 ## Copyright
 
-Copyright (c) 2012-2023 Bozhidar Batsov. See [LICENSE.txt](LICENSE.txt) for
+Copyright (c) Bozhidar Batsov. See [LICENSE.txt](LICENSE.txt) for
 further details.

--- a/docs/modules/ROOT/pages/about/license.adoc
+++ b/docs/modules/ROOT/pages/about/license.adoc
@@ -13,4 +13,4 @@ All the original Ruby code is available under the terms of the MIT license.
 
 == Copyright
 
-Copyright (c) 2012-2023 Bozhidar Batsov and RuboCop contributors.
+Copyright (c) Bozhidar Batsov and RuboCop contributors.


### PR DESCRIPTION
Rails have completely removed the usage of years in all the License files https://github.com/rails/rails/pull/47467. Rubocop can also follow the same pattern so that we can avoid creating supporting PRs to update the years. eg:  #11371 #10340 etc..

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
