### PR TITLE
[Fix #12085] Fix an error for `Lint/SuppressedException`

### DIFF
--- a/changelog/fix_error_for_lint_suppressed_exception.md
+++ b/changelog/fix_error_for_lint_suppressed_exception.md
@@ -1,0 +1,1 @@
+* [#12085](https://github.com/rubocop/rubocop/issues/12085): Fix an error for `Lint/SuppressedException` when `AllowNil: true` is set and endless method definition is used. ([@koic][])

--- a/lib/rubocop/cop/lint/suppressed_exception.rb
+++ b/lib/rubocop/cop/lint/suppressed_exception.rb
@@ -119,7 +119,7 @@ module RuboCop
           ancestor = node.each_ancestor(:kwbegin, :def, :defs, :block, :numblock).first
           return false unless ancestor
 
-          end_line = ancestor.loc.end.line
+          end_line = ancestor.loc.end&.line || ancestor.loc.last_line
           processed_source[node.first_line...end_line].any? { |line| comment_line?(line) }
         end
 

--- a/spec/rubocop/cop/lint/suppressed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/suppressed_exception_spec.rb
@@ -140,7 +140,8 @@ RSpec.describe RuboCop::Cop::Lint::SuppressedException, :config do
   end
 
   context 'with AllowComments set to true' do
-    let(:cop_config) { { 'AllowComments' => true } }
+    let(:cop_config) { { 'AllowComments' => true, 'AllowNil' => allow_nil } }
+    let(:allow_nil) { true }
 
     it 'does not register an offense for empty rescue with comment' do
       expect_no_offenses(<<~RUBY)
@@ -239,6 +240,31 @@ RSpec.describe RuboCop::Cop::Lint::SuppressedException, :config do
             rescue
               # do nothing
             end
+          RUBY
+        end
+      end
+    end
+
+    context 'with AllowNil set to true' do
+      let(:allow_nil) { true }
+
+      context 'when using endless method definition', :ruby30 do
+        it 'does not register an offense for inline nil rescue' do
+          expect_no_offenses(<<~RUBY)
+            def some_method = other_method(42) rescue nil
+          RUBY
+        end
+      end
+    end
+
+    context 'with AllowNil set to false' do
+      let(:allow_nil) { false }
+
+      context 'when using endless method definition', :ruby30 do
+        it 'registers an offense for inline nil rescue' do
+          expect_offense(<<~RUBY)
+            def some_method = other_method(42) rescue nil
+                                               ^^^^^^^^^^ Do not suppress exceptions.
           RUBY
         end
       end


### PR DESCRIPTION
Fixes #12085.

This PR fixes an error for `Lint/SuppressedException` when `AllowNil: true` is set and endless method definition is used.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
