### PR TITLE
[Fix #12071] Fix `Style/SymbolArray` false positives when using square brackets or interpolation in a symbol literal within a percent style array

### DIFF
--- a/changelog/fix_style_symbol_array_false_positives.md
+++ b/changelog/fix_style_symbol_array_false_positives.md
@@ -1,0 +1,1 @@
+* [#12071](https://github.com/rubocop/rubocop/issues/12071): Fix `Style/SymbolArray` false positives when using square brackets or interpolation in a symbol literal in a percent style array. ([@jasondoc3][])

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -69,9 +69,9 @@ module RuboCop
 
         def complex_content?(node)
           node.children.any? do |sym|
-            content, = *sym
-            content = content.to_s
-            content_without_delimiter_pairs = content.gsub(/(\[\])|(\(\))/, '')
+            content = *sym
+            content = content.map { |c| c.is_a?(AST::Node) ? c.source : c }.join
+            content_without_delimiter_pairs = content.gsub(/(\[[^\s\[\]]*\])|(\([^\s\(\)]*\))/, '')
 
             content.include?(' ') || DELIMITERS.any? do |delimiter|
               content_without_delimiter_pairs.include?(delimiter)

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -88,7 +88,11 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
     end
 
     it 'does not register an offense for array containing delimiters without spaces' do
-      expect_no_offenses('%i[one two [] ()]')
+      expect_no_offenses('%i[zero (one) [two] three[4] five[six] seven(8) nine(ten) ([]) [] ()]')
+    end
+
+    it 'does not register an offense for a percent array with interpolations' do
+      expect_no_offenses('%I[one_#{two} three #{four}_five six#{seven}eight [nine_#{ten}]]')
     end
 
     it 'does not register an offense if symbol contains whitespace' do
@@ -145,6 +149,28 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
       RUBY
     end
 
+    it 'registers an offense for a %i array containing whitespace between brackets' do
+      expect_offense(<<~'RUBY')
+        %i[one two \[three\ four\ five\]]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `[:one, :two, :'[three four five]']` for an array of symbols.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [:one, :two, :'[three four five]']
+      RUBY
+    end
+
+    it 'registers an offense for a %i array containing brackets between brackets' do
+      expect_offense(<<~'RUBY')
+        %i[one two \[\[\]]
+        ^^^^^^^^^^^^^^^^^^ Use `[:one, :two, :'[[]']` for an array of symbols.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [:one, :two, :'[[]']
+      RUBY
+    end
+
     it 'registers an offense for a %i array containing ( )' do
       expect_offense(<<~'RUBY')
         %i(one \( \) two)
@@ -153,6 +179,28 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
 
       expect_correction(<<~RUBY)
         [:one, :'(', :')', :two]
+      RUBY
+    end
+
+    it 'registers an offense for a %i array containing parentheses between parentheses' do
+      expect_offense(<<~'RUBY')
+        %i(one two \(\(\))
+        ^^^^^^^^^^^^^^^^^^ Use `[:one, :two, :'(()']` for an array of symbols.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [:one, :two, :'(()']
+      RUBY
+    end
+
+    it 'registers an offense for a %i array containing whitespace between parentheses' do
+      expect_offense(<<~'RUBY')
+        %i(one two \(three\ four\ five\))
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `[:one, :two, :'(three four five)']` for an array of symbols.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [:one, :two, :'(three four five)']
       RUBY
     end
 


### PR DESCRIPTION
Fixes #12071. Some false positives offenses were introduced in https://github.com/rubocop/rubocop/pull/12037.

For example, `%I[#{one}_two three]` and `%i[one[2] three]` are currently returning offenses when they should not be.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
