### PR TITLE
With `--fail-level A` ignore non-correctable offenses at :info severity

### DIFF
--- a/changelog/fix_with_fail_level_a_ignore_non_correctable_offenses.md
+++ b/changelog/fix_with_fail_level_a_ignore_non_correctable_offenses.md
@@ -1,0 +1,1 @@
+* [#12091](https://github.com/rubocop/rubocop/pull/12091): With `--fail-level A` ignore non-correctable offenses at :info severity. ([@naveg][])

--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -196,7 +196,7 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | Inspect files in order of modification time and stops after first file with offenses.
 
 | `--fail-level`
-| Minimum xref:configuration.adoc#severity[severity] for exit with error code. Full severity name or upper case initial can be given. Normally, autocorrected offenses are ignored. Use `A` or `autocorrect` if you'd like them to trigger failure.
+| Minimum xref:configuration.adoc#severity[severity] for exit with error code. Full severity name or upper case initial can be given. Normally, autocorrected offenses are ignored. Use `A` or `autocorrect` if you'd like any autocorrectable offense to trigger failure, regardless of severity.
 
 | `--force-exclusion`
 | Force excluding files specified in the configuration `Exclude` even if they are explicitly passed as arguments.

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -421,10 +421,10 @@ module RuboCop
     end
 
     def considered_failure?(offense)
-      # For :autocorrect level, any offense - corrected or not - is a failure.
       return false if offense.disabled?
 
-      return true if @options[:fail_level] == :autocorrect
+      # For :autocorrect level, any correctable offense is a failure, regardless of severity
+      return true if @options[:fail_level] == :autocorrect && offense.correctable?
 
       !offense.corrected? && offense.severity >= minimum_severity_to_fail
     end
@@ -461,7 +461,9 @@ module RuboCop
       @minimum_severity_to_fail ||= begin
         # Unless given explicitly as `fail_level`, `:info` severity offenses do not fail
         name = @options[:fail_level] || :refactor
-        RuboCop::Cop::Severity.new(name)
+
+        # autocorrect is a fake level - use the default
+        RuboCop::Cop::Severity.new(name == :autocorrect ? :refactor : name)
       end
     end
 

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1797,6 +1797,29 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       expect_offense_detected
     end
 
+    context 'when the cop has the "info" severity' do
+      before do
+        create_file(target_file, <<~RUBY)
+          Long::Line::Not::Autocorrectable
+        RUBY
+
+        create_file('.rubocop.yml', <<~YAML)
+          Layout/LineLength:
+            Max: 10
+            Severity: info
+        YAML
+      end
+
+      it 'succeeds when option is autocorrect and the offense is not autocorrectable' do
+        expect(cli.run(['--fail-level', 'autocorrect',
+                        '--only', 'Layout/LineLength',
+                        target_file])).to eq(0)
+        expect($stderr.string).to eq('')
+        expect($stdout.string.include?('1 file inspected, 1 offense detected')).to be(true)
+        expect($stdout.string.include?('Layout/LineLength')).to be(true)
+      end
+    end
+
     context 'with --display-only-fail-level-offenses' do
       it 'outputs offense message when fail-level is less than the severity' do
         expect(cli.run(['--fail-level', 'refactor',


### PR DESCRIPTION
The current implementation of `--fail-level autocorrect` fails for all
offenses, no matter what. Notably, this includes non-correctable
offenses with the :info severity.

Change the implementation to only fail:
* Any _correctable_ offense, regardless of severity
* Non-correctable offenses with severity :refactor (the default) or
  higher

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
