### PR TITLE
[Fix #12061] Support regex in StringLiteralsInInterpolation

### DIFF
--- a/changelog/fix_support_regex_in_string_literals_in_interpolation.md
+++ b/changelog/fix_support_regex_in_string_literals_in_interpolation.md
@@ -1,0 +1,1 @@
+* [#12061](https://github.com/rubocop/rubocop/issues/12061): Support regex in StringLiteralsInInterpolation. ([@jonas054][])

--- a/lib/rubocop/cop/mixin/string_help.rb
+++ b/lib/rubocop/cop/mixin/string_help.rb
@@ -30,8 +30,10 @@ module RuboCop
       private
 
       def inside_interpolation?(node)
-        # A :begin node inside a :dstr or :dsym node is an interpolation.
-        node.ancestors.drop_while { |a| !a.begin_type? }.any? { |a| a.dstr_type? || a.dsym_type? }
+        # A :begin node inside a :dstr, :dsym, or :regexp node is an interpolation.
+        node.ancestors
+            .drop_while { |a| !a.begin_type? }
+            .any? { |a| a.dstr_type? || a.dsym_type? || a.regexp_type? }
       end
     end
   end

--- a/lib/rubocop/cop/style/string_literals_in_interpolation.rb
+++ b/lib/rubocop/cop/style/string_literals_in_interpolation.rb
@@ -3,22 +3,42 @@
 module RuboCop
   module Cop
     module Style
-      # Checks that quotes inside the string interpolation
+      # Checks that quotes inside string, symbol, and regexp interpolations
       # match the configured preference.
       #
       # @example EnforcedStyle: single_quotes (default)
       #   # bad
-      #   result = "Tests #{success ? "PASS" : "FAIL"}"
+      #   string = "Tests #{success ? "PASS" : "FAIL"}"
+      #   symbol = :"Tests #{success ? "PASS" : "FAIL"}"
+      #   heredoc = <<~TEXT
+      #     Tests #{success ? "PASS" : "FAIL"}
+      #   TEXT
+      #   regexp = /Tests #{success ? "PASS" : "FAIL"}/
       #
       #   # good
-      #   result = "Tests #{success ? 'PASS' : 'FAIL'}"
+      #   string = "Tests #{success ? 'PASS' : 'FAIL'}"
+      #   symbol = :"Tests #{success ? 'PASS' : 'FAIL'}"
+      #   heredoc = <<~TEXT
+      #     Tests #{success ? 'PASS' : 'FAIL'}
+      #   TEXT
+      #   regexp = /Tests #{success ? 'PASS' : 'FAIL'}/
       #
       # @example EnforcedStyle: double_quotes
       #   # bad
-      #   result = "Tests #{success ? 'PASS' : 'FAIL'}"
+      #   string = "Tests #{success ? 'PASS' : 'FAIL'}"
+      #   symbol = :"Tests #{success ? 'PASS' : 'FAIL'}"
+      #   heredoc = <<~TEXT
+      #     Tests #{success ? 'PASS' : 'FAIL'}
+      #   TEXT
+      #   regexp = /Tests #{success ? 'PASS' : 'FAIL'}/
       #
       #   # good
-      #   result = "Tests #{success ? "PASS" : "FAIL"}"
+      #   string = "Tests #{success ? "PASS" : "FAIL"}"
+      #   symbol = :"Tests #{success ? "PASS" : "FAIL"}"
+      #   heredoc = <<~TEXT
+      #     Tests #{success ? "PASS" : "FAIL"}
+      #   TEXT
+      #   regexp = /Tests #{success ? "PASS" : "FAIL"}/
       class StringLiteralsInInterpolation < Base
         include ConfigurableEnforcedStyle
         include StringLiteralsHelp
@@ -28,6 +48,11 @@ module RuboCop
         def autocorrect(corrector, node)
           StringLiteralCorrector.correct(corrector, node, style)
         end
+
+        # Cop classes that include the StringHelp module usually ignore regexp
+        # nodes. Not so for this cop, which is why we override the on_regexp
+        # definition with an empty one.
+        def on_regexp(node); end
 
         private
 

--- a/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
       SOURCE
     end
 
+    it 'registers an offense for double quotes within a regexp' do
+      expect_offense(<<~'RUBY')
+        /foo#{"sar".sub("s", 'b')}/
+              ^^^^^ Prefer single-quoted strings inside interpolations.
+                        ^^^ Prefer single-quoted strings inside interpolations.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        /foo#{'sar'.sub('s', 'b')}/
+      RUBY
+    end
+
     it 'accepts double quotes on a static string' do
       expect_no_offenses('"A"')
     end


### PR DESCRIPTION
Interpolation can occur in strings, symbols, and regular expressions, so update code to support regex and extend code examples in documentation comments.