### PR TITLE
Add `base64` to runtime dependency

### DIFF
--- a/changelog/change_add_base64_to_runtime_dependency.md
+++ b/changelog/change_add_base64_to_runtime_dependency.md
@@ -1,0 +1,1 @@
+* [#12094](https://github.com/rubocop/rubocop/pull/12094): Add `base64` gem to runtime dependency to suppress Ruby 3.3's warning. ([@koic][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
+  s.add_runtime_dependency('base64', '~> 0.1.1')
   s.add_runtime_dependency('json', '~> 2.3')
   s.add_runtime_dependency('language_server-protocol', '>= 3.17.0')
   s.add_runtime_dependency('parallel', '~> 1.10')


### PR DESCRIPTION
This PR add `base64` to runtime dependency to suppress the following Ruby 3.3's warning:

```console
$ ruby -v
ruby 3.3.0dev (2023-08-03T00:11:08Z master 4b6c584023) [x86_64-darwin22]

$ bundle exec rubocop
base64 is not part of the default gems since Ruby 3.4.0. Add it to your Gemfile.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
