### PR TITLE
Fix a false positive for `Style/ClassEqualityComparison`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_class_equality_comparison.md
+++ b/changelog/fix_a_false_positive_for_style_class_equality_comparison.md
@@ -1,0 +1,1 @@
+* [#12098](https://github.com/rubocop/rubocop/pull/12098): Fix a false positive for `Style/ClassEqualityComparison` when comparing interpolated string class name for equality. ([@koic][])

--- a/lib/rubocop/cop/style/class_equality_comparison.rb
+++ b/lib/rubocop/cop/style/class_equality_comparison.rb
@@ -69,6 +69,8 @@ module RuboCop
                     matches_allowed_pattern?(def_node.method_name))
 
           class_comparison_candidate?(node) do |receiver_node, class_node|
+            return if class_node.dstr_type?
+
             range = offense_range(receiver_node, node)
             class_argument = (class_name = class_name(class_node, node)) ? "(#{class_name})" : ''
 

--- a/spec/rubocop/cop/style/class_equality_comparison_spec.rb
+++ b/spec/rubocop/cop/style/class_equality_comparison_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
       RUBY
     end
 
+    it 'does not register an offense when comparing interpolated string class name for equality' do
+      expect_no_offenses(<<~'RUBY')
+        var.class.name == "String#{interpolation}"
+      RUBY
+    end
+
     it 'registers an offense but does not correct when comparing local variable for equality' do
       expect_offense(<<~RUBY)
         class_name = 'Model'


### PR DESCRIPTION
This PR fixes a false positive to prevent an incorrect autocorrect for `Style/ClassEqualityComparison` when comparing interpolated string class name for equality.

For example, autocorrect the code below:

```console
$ cat example.rb
var.class.name == "String#{interpolation}"

$ bundle exec rubocop --only Style/ClassEqualityComparison -a
Inspecting 1 file
C

Offenses:

example.rb:1:5: C: [Corrected] Style/ClassEqualityComparison: Use instance_of?("String#{interpolation}") instead of comparing classes.
var.class.name == "String#{interpolation}"
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

The `instance_of?` argument is still a string.

```console
$ cat example.rb
var.instance_of?("String#{interpolation}")
```

But the `instance_of?` argument requires class or module. So the above case cannot be replaced by `instace_of?`.

```console
$ ruby -e "''.instance_of?('String')"
-e:1:in `instance_of?': class or module required (TypeError)

''.instance_of?('String')
                ^^^^^^^^
        from -e:1:in `<main>'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
