### PR TITLE
Fix an incorrect autocorrect for `Style/Alias`

### DIFF
--- a/changelog/fix_an_incorrect_for_style_alias.md
+++ b/changelog/fix_an_incorrect_for_style_alias.md
@@ -1,0 +1,1 @@
+* [#12099](https://github.com/rubocop/rubocop/pull/12099): Fix an incorrect autocorrect for `Style/Alias` when `EncforcedStyle: prefer_alias_method` and using `alias` with interpolated symbol argument. ([@koic][])

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -134,9 +134,7 @@ module RuboCop
 
         def correct_alias_to_alias_method(corrector, node)
           replacement =
-            'alias_method ' \
-            ":#{identifier(node.new_identifier)}, " \
-            ":#{identifier(node.old_identifier)}"
+            "alias_method #{identifier(node.new_identifier)}, #{identifier(node.old_identifier)}"
 
           corrector.replace(node, replacement)
         end
@@ -146,10 +144,13 @@ module RuboCop
           corrector.replace(node.old_identifier, node.old_identifier.source[1..])
         end
 
-        # @!method identifier(node)
-        def_node_matcher :identifier, <<~PATTERN
-          (sym $_)
-        PATTERN
+        def identifier(node)
+          if node.sym_type?
+            ":#{node.children.first}"
+          else
+            node.source
+          end
+        end
       end
     end
   end

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -26,6 +26,17 @@ RSpec.describe RuboCop::Cop::Style::Alias, :config do
       RUBY
     end
 
+    it 'registers an offense for `alias` with interpolated symbol argument' do
+      expect_offense(<<~'RUBY')
+        alias :"string#{interpolation}" :symbol
+        ^^^^^ Use `alias_method` instead of `alias`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        alias_method :"string#{interpolation}", :symbol
+      RUBY
+    end
+
     it 'does not register an offense for alias_method' do
       expect_no_offenses('alias_method :ala, :bala')
     end


### PR DESCRIPTION
This PR fixes the following incorrect autocorrection for `Style/Alias` when `EncforcedStyle: prefer_alias_method` and using `alias` with interpolated symbol argument:

```console
$ cat example.rb
alias :"string#{interpolation}" :symbol

$ cat .rubocop.yml
Style/Alias:
  EnforcedStyle: prefer_alias_method
```

```console
$ bundle exec rubocop -a --only Style/Alias
(snip)

Offenses:

example.rb:1:1: C: [Corrected] Style/Alias: Use alias_method instead of alias.
alias :"string#{interpolation}" :symbol
^^^^^
example.rb:1:14: F: Lint/Syntax: unexpected token tCOLON
(Using Ruby 3.2 parser; configure using TargetRubyVersion parameter, under AllCops)
alias_method :, :symbol
             ^

1 file inspected, 2 offenses detected, 1 offense corrected
```

```console
$ cat example.rb
alias_method :, :symbol

$ ruby -c example.rb
example.rb: example.rb:1: syntax error, unexpected ',', expecting literal content or terminator or tSTRING_DBEG or tSTRING_DVAR (SyntaxError)
alias_method :, :symbol
              ^
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
