### PR TITLE
[Fix #12087] Fix a false positive for `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/fix_false_positives_for_style_arguments_forwarding.md
+++ b/changelog/fix_false_positives_for_style_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#12087](https://github.com/rubocop/rubocop/issues/12087): Fix false positives for `Style/ArgumentsForwarding` when leading argument with rest arguments. ([@koic][])


### PR DESCRIPTION
Fixes #12087, #12089, #12096, and #12100.

This PR fixes false positives for `Style/ArgumentsForwarding` when leading argument with rest arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
