### PR TITLE
Fix an error for `Style/LambdaCall`

### DIFF
--- a/changelog/fix_an_error_for_style_lambda_call.md
+++ b/changelog/fix_an_error_for_style_lambda_call.md
@@ -1,0 +1,1 @@
+* [#12102](https://github.com/rubocop/rubocop/pull/12102): Fix an error for `Style/LambdaCall` when using nested lambda call `x.().()`. ([@koic][])

--- a/lib/rubocop/cop/style/lambda_call.rb
+++ b/lib/rubocop/cop/style/lambda_call.rb
@@ -20,6 +20,7 @@ module RuboCop
       #  lambda.(x, y)
       class LambdaCall < Base
         include ConfigurableEnforcedStyle
+        include IgnoredNode
         extend AutoCorrector
 
         MSG = 'Prefer the use of `%<prefer>s` over `%<current>s`.'
@@ -33,8 +34,12 @@ module RuboCop
             current = node.source
 
             add_offense(node, message: format(MSG, prefer: prefer, current: current)) do |corrector|
+              next if part_of_ignored_node?(node)
+
               opposite_style_detected
               corrector.replace(node, prefer)
+
+              ignore_node(node)
             end
           else
             correct_style_detected

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
       RUBY
     end
 
+    it 'registers an offense for x.().()' do
+      expect_offense(<<~RUBY)
+        x.(a, b).(c)
+        ^^^^^^^^^^^^ Prefer the use of `x.(a, b).call(c)` over `x.(a, b).(c)`.
+        ^^^^^^^^ Prefer the use of `x.call(a, b)` over `x.(a, b)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.(a, b).call(c)
+      RUBY
+    end
+
     it 'registers an offense for correct + opposite' do
       expect_offense(<<~RUBY)
         x.call(a, b)


### PR DESCRIPTION
This PR fixes an error for `Style/LambdaCall` when using nested lambda call `x.().()`:

```console
$ cat example.rb
x.(a, b).(c)

$ buncle exec rubocop example.rb --only Style/LambdaCall -a -d
(snip)

An error occurred while Style/LambdaCall cop was inspecting /Users/koic/src/github.com/koic/rubocop-issues/lambda_call/example.rb:1:0.
Parser::Source::TreeRewriter detected clobbering
/Users/koic/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/parser-3.2.2.3/lib/parser/source/tree_rewriter.rb:427:in `trigger_policy'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
