### PR TITLE
[Fix #12106] Fix a false negative for `Style/RedundantReturn`

### DIFF
--- a/changelog/fix_a_false_negative_for_style_redundant_return.md
+++ b/changelog/fix_a_false_negative_for_style_redundant_return.md
@@ -1,0 +1,1 @@
+* [#12106](https://github.com/rubocop/rubocop/issues/12106): Fix a false negative for `Style/RedundantReturn` when returning value with guard clause and `return` is used. ([@koic][])

--- a/lib/rubocop/config_finder.rb
+++ b/lib/rubocop/config_finder.rb
@@ -46,14 +46,14 @@ module RuboCop
 
         file = File.join(Dir.home, DOTFILE)
 
-        return file if File.exist?(file)
+        file if File.exist?(file)
       end
 
       def find_user_xdg_config
         xdg_config_home = expand_path(ENV.fetch('XDG_CONFIG_HOME', '~/.config'))
         xdg_config = File.join(xdg_config_home, 'rubocop', XDG_CONFIG)
 
-        return xdg_config if File.exist?(xdg_config)
+        xdg_config if File.exist?(xdg_config)
       end
 
       def expand_path(path)

--- a/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
@@ -137,7 +137,7 @@ module RuboCop
             return node if node
           end
 
-          return last_heredoc_argument(n.receiver) if n.respond_to?(:receiver)
+          last_heredoc_argument(n.receiver) if n.respond_to?(:receiver)
         end
 
         def last_heredoc_argument_node(node)

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -354,7 +354,7 @@ module RuboCop
           # Don't check indentation if the line doesn't start with the body.
           # For example, lines like "else do_something".
           first_char_pos_on_line = body_node.source_range.source_line =~ /\S/
-          return true unless body_node.loc.column == first_char_pos_on_line
+          true unless body_node.loc.column == first_char_pos_on_line
         end
 
         def offending_range(body_node, indentation)

--- a/lib/rubocop/cop/layout/space_inside_parens.rb
+++ b/lib/rubocop/cop/layout/space_inside_parens.rb
@@ -168,7 +168,7 @@ module RuboCop
           # follows, and that the rules for space inside don't apply.
           return true if token2.comment?
 
-          return true unless same_line?(token1, token2) && !token1.space_after?
+          true unless same_line?(token1, token2) && !token1.space_after?
         end
       end
     end

--- a/lib/rubocop/cop/lint/struct_new_override.rb
+++ b/lib/rubocop/cop/lint/struct_new_override.rb
@@ -32,25 +32,25 @@ module RuboCop
         # @!method struct_new(node)
         def_node_matcher :struct_new, <<~PATTERN
           (send
-            (const ${nil? cbase} :Struct) :new ...)
+            (const {nil? cbase} :Struct) :new ...)
         PATTERN
 
         def on_send(node)
-          return unless struct_new(node) do
-            node.arguments.each_with_index do |arg, index|
-              # Ignore if the first argument is a class name
-              next if index.zero? && arg.str_type?
+          return unless struct_new(node)
 
-              # Ignore if the argument is not a member name
-              next unless STRUCT_MEMBER_NAME_TYPES.include?(arg.type)
+          node.arguments.each_with_index do |arg, index|
+            # Ignore if the first argument is a class name
+            next if index.zero? && arg.str_type?
 
-              member_name = arg.value
+            # Ignore if the argument is not a member name
+            next unless STRUCT_MEMBER_NAME_TYPES.include?(arg.type)
 
-              next unless STRUCT_METHOD_NAMES.include?(member_name.to_sym)
+            member_name = arg.value
 
-              message = format(MSG, member_name: member_name.inspect, method_name: member_name.to_s)
-              add_offense(arg, message: message)
-            end
+            next unless STRUCT_METHOD_NAMES.include?(member_name.to_sym)
+
+            message = format(MSG, member_name: member_name.inspect, method_name: member_name.to_s)
+            add_offense(arg, message: message)
           end
         end
       end

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -370,7 +370,8 @@ module RuboCop
         def special_method_proper_block_style?(node)
           method_name = node.method_name
           return true if allowed_method?(method_name) || matches_allowed_pattern?(method_name)
-          return node.braces? if braces_required_method?(method_name)
+
+          node.braces? if braces_required_method?(method_name)
         end
 
         def braces_required_method?(method_name)

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -22,9 +22,14 @@ module RuboCop
       #     return something
       #   end
       #
-      #   # good
+      #   # bad
       #   def test
       #     return something if something_else
+      #   end
+      #
+      #   # good
+      #   def test
+      #     something if something_else
       #   end
       #
       #   # good
@@ -136,7 +141,7 @@ module RuboCop
         end
 
         def check_if_node(node)
-          return if node.modifier_form? || node.ternary?
+          return if node.ternary?
 
           check_branch(node.if_branch)
           check_branch(node.else_branch)

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -152,10 +152,25 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
     RUBY
   end
 
-  it 'accepts return in a non-final position' do
-    expect_no_offenses(<<~RUBY)
+  it 'registers an offense when returning value with guard clause and `return` is used' do
+    expect_offense(<<~RUBY)
       def func
         return something if something_else
+        ^^^^^^ Redundant `return` detected.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def func
+        something if something_else
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when returning value with guard clause and `return` is not used' do
+    expect_no_offenses(<<~RUBY)
+      def func
+        something if something_else
       end
     RUBY
   end


### PR DESCRIPTION
Fixes #12106.

This PR fixes a false negative for `Style/RedundantReturn` when returning value with guard clause and `return` is used.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
