### PR TITLE
[Fix: #12109] Fix an error for `Style/ArgumentsForwarding` cop when forwarding kwargs/block arg and an additional arg

### DIFF
--- a/changelog/fix_an_error_for_style_arguments_forwarding_cop_when_forwarding_kwargs_block.md
+++ b/changelog/fix_an_error_for_style_arguments_forwarding_cop_when_forwarding_kwargs_block.md
@@ -1,0 +1,1 @@
+* [#12109](https://github.com/rubocop/rubocop/issues/12109): Fix an error for `Style/ArgumentsForwarding` cop when forwarding kwargs/block arg and an additional arg. ([@ydah][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -80,6 +80,7 @@ module RuboCop
         minimum_target_ruby_version 2.7
 
         FORWARDING_LVAR_TYPES = %i[splat kwsplat block_pass].freeze
+        ADDITIONAL_ARG_TYPES = %i[lvar arg].freeze
 
         FORWARDING_MSG = 'Use shorthand syntax `...` for arguments forwarding.'
         ARGS_MSG = 'Use anonymous positional arguments forwarding (`*`).'
@@ -212,7 +213,7 @@ module RuboCop
         end
 
         def arguments_range(node, first_node)
-          arguments = node.arguments
+          arguments = node.arguments.reject { |arg| ADDITIONAL_ARG_TYPES.include?(arg.type) }
 
           start_node = first_node || arguments.first
 
@@ -332,9 +333,9 @@ module RuboCop
           end
 
           def no_post_splat_args?
-            splat_index = arguments.index(forwarded_rest_arg)
-            arg_after_splat = arguments[splat_index + 1]
+            return true unless (splat_index = arguments.index(forwarded_rest_arg))
 
+            arg_after_splat = arguments[splat_index + 1]
             [nil, :hash, :block_pass].include?(arg_after_splat&.type)
           end
 

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -519,6 +519,38 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
         end
       RUBY
     end
+
+    it 'registers an offense when forwarding kwargs/block arg' do
+      expect_offense(<<~RUBY)
+        def foo(**kwargs, &block)
+                ^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+          baz(**kwargs, &block)
+              ^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(...)
+          baz(...)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when forwarding kwargs/block arg and an additional arg' do
+      expect_offense(<<~RUBY)
+        def foo(x, **kwargs, &block)
+                   ^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+          baz(x, **kwargs, &block)
+                 ^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(x, ...)
+          baz(x, ...)
+        end
+      RUBY
+    end
   end
 
   context 'TargetRubyVersion >= 3.1', :ruby31 do


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop/issues/12109

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
