### PR TITLE
[Fix #12111] Fix an error for `Bundler/DuplicatedGroup`

### DIFF
--- a/changelog/fix_an_error_for_bundler_duplicated_group.md
+++ b/changelog/fix_an_error_for_bundler_duplicated_group.md
@@ -1,0 +1,1 @@
+* [#12111](https://github.com/rubocop/rubocop/issues/12111): Fix an error for `Bundler/DuplicatedGroup` group declaration has keyword option. ([@koic][])

--- a/spec/rubocop/cop/bundler/duplicated_group_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_group_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGroup, :config do
             gem 'rubocop'
           end
           group :development do
-          ^^^^^^^^^^^^^^^^^^ Gem group `development` already defined on line 1 of the Gemfile.
+          ^^^^^^^^^^^^^^^^^^ Gem group `:development` already defined on line 1 of the Gemfile.
             gem 'rubocop-rails'
           end
         RUBY
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGroup, :config do
             gem 'rubocop'
           end
           group 'development' do
-          ^^^^^^^^^^^^^^^^^^^ Gem group `development` already defined on line 1 of the Gemfile.
+          ^^^^^^^^^^^^^^^^^^^ Gem group `'development'` already defined on line 1 of the Gemfile.
             gem 'rubocop-rails'
           end
         RUBY
@@ -77,6 +77,64 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGroup, :config do
       end
     end
 
+    context 'and same groups with different keyword names' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY, 'Gemfile')
+          group :test, foo: true do
+            gem 'activesupport'
+          end
+
+          group :test, bar: true do
+            gem 'rspec'
+          end
+        RUBY
+      end
+    end
+
+    context 'and same groups with different keyword values' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY, 'Gemfile')
+          group :test, foo: true do
+            gem 'activesupport'
+          end
+
+          group :test, foo: false do
+            gem 'rspec'
+          end
+        RUBY
+      end
+    end
+
+    context 'and same groups with same keyword option and the option order is the same' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY, 'Gemfile')
+          group :test, foo: true, bar: true do
+            gem 'activesupport'
+          end
+
+          group :test, foo: true, bar: true do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Gem group `:test, foo: true, bar: true` already defined on line 1 of the Gemfile.
+            gem 'rspec'
+          end
+        RUBY
+      end
+    end
+
+    context 'and same groups with same keyword option and the option order is different' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY, 'Gemfile')
+          group :test, foo: true, bar: true do
+            gem 'activesupport'
+          end
+
+          group :test, bar: true, foo: true do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Gem group `:test, bar: true, foo: true` already defined on line 1 of the Gemfile.
+            gem 'rspec'
+          end
+        RUBY
+      end
+    end
+
     context 'and a set of groups is duplicated' do
       it 'registers an offense' do
         expect_offense(<<-RUBY, 'Gemfile')
@@ -84,7 +142,7 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGroup, :config do
             gem 'rubocop'
           end
           group :development, :test do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^ Gem group `development, test` already defined on line 1 of the Gemfile.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Gem group `:development, :test` already defined on line 1 of the Gemfile.
             gem 'rubocop-rails'
           end
         RUBY


### PR DESCRIPTION
Fixes #12111.

This PR fixes an error for `Bundler/DuplicatedGroup` group declaration has keyword option.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
