### PR TITLE
[Fix #12097] Mark unsafe autocorrect for `Style/ClassEqualityComparison`

### DIFF
--- a/changelog/change_mark_style_class_equality_comparison_as_unsafe_autocorrection.md
+++ b/changelog/change_mark_style_class_equality_comparison_as_unsafe_autocorrection.md
@@ -1,0 +1,1 @@
+* [#12097](https://github.com/rubocop/rubocop/issues/12097): Mark unsafe autocorrect for `Style/ClassEqualityComparison`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3354,7 +3354,9 @@ Style/ClassEqualityComparison:
   Description: 'Enforces the use of `Object#instance_of?` instead of class comparison for equality.'
   StyleGuide: '#instance-of-vs-class-comparison'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.93'
+  VersionChanged: '<<next>>'
   AllowedMethods:
     - ==
     - equal?

--- a/lib/rubocop/cop/style/class_equality_comparison.rb
+++ b/lib/rubocop/cop/style/class_equality_comparison.rb
@@ -8,6 +8,11 @@ module RuboCop
       # `==`, `equal?`, and `eql?` custom method definitions are allowed by default.
       # These are customizable with `AllowedMethods` option.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because there is no guarantee that
+      #   the constant `Foo` exists when autocorrecting `var.class.name == 'Foo'` to
+      #   `var.instance_of?(Foo)`.
+      #
       # @example
       #   # bad
       #   var.class == Date


### PR DESCRIPTION
Fixes #12097.

This PR marks unsafe autocorrect for `Style/ClassEqualityComparison` because there is no guarantee that the constant `Foo` exists when autocorrecting `var.class.name == 'Foo'` to `var.instance_of?(Foo)`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
