### PR TITLE
Fix an error for `Style/Lambda`

### DIFF
--- a/changelog/fix_an_error_for_style_lambda.md
+++ b/changelog/fix_an_error_for_style_lambda.md
@@ -1,0 +1,1 @@
+* [#12115](https://github.com/rubocop/rubocop/pull/12115): Fix an error for `Style/Lambda` when using numbered parameter with a multiline `->` call. ([@koic][])

--- a/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb
+++ b/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb
@@ -14,12 +14,15 @@ module RuboCop
         # Check for unparenthesized args' preceding and trailing whitespaces.
         remove_unparenthesized_whitespace(corrector)
 
-        # Avoid correcting to `lambdado` by inserting whitespace
-        # if none exists before or after the lambda arguments.
-        insert_separating_space(corrector)
+        if block_node.block_type?
+          # Avoid correcting to `lambdado` by inserting whitespace
+          # if none exists before or after the lambda arguments.
+          insert_separating_space(corrector)
+
+          remove_arguments(corrector)
+        end
 
         replace_selector(corrector)
-        remove_arguments(corrector)
 
         replace_delimiters(corrector)
 

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -215,6 +215,23 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
           end
         end
 
+        context 'with a multiline `->` call' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              -> {
+              ^^ Use the `lambda` method for multiline lambdas.
+                _1.do_something
+              }
+            RUBY
+
+            expect_correction(<<~RUBY)
+              lambda {
+                _1.do_something
+              }
+            RUBY
+          end
+        end
+
         context 'with a multiline lambda method call' do
           it 'does not register an offense' do
             expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR fixes the following error for `Style/Lambda` when using numbered parameter with a multiline `->` call:

```console
$ cat example.rb
-> {
  _1.do_something
}

$ bundle exec rubocop example.rb --only Style/Lambda -d
(snip)

An error occurred while Style/Lambda cop was inspecting /Users/koic/src/github.com/koic/rubocop-issues/lambda/example.rb:1:0.
undefined method `loc' for []:Array
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb:96:in `arguments_end_pos'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
