### PR TITLE
[Fix #12113] Fix a false positive for `Bundler/DuplicatedGroup`

### DIFF
--- a/changelog/fix_a_false_positive_for_bundler_duplicated_group.md
+++ b/changelog/fix_a_false_positive_for_bundler_duplicated_group.md
@@ -1,0 +1,1 @@
+* [#12113](https://github.com/rubocop/rubocop/issues/12113): Fix a false positive for `Bundler/DuplicatedGroup` when groups are duplicated but `source`, `git`, `platforms`, or `path` values are different. ([@koic][])

--- a/lib/rubocop/cop/bundler/duplicated_group.rb
+++ b/lib/rubocop/cop/bundler/duplicated_group.rb
@@ -5,6 +5,24 @@ module RuboCop
     module Bundler
       # A Gem group, or a set of groups, should be listed only once in a Gemfile.
       #
+      # For example, if the values of `source`, `git`, `platforms`, or `path`
+      # surrounding `group` are different, no offense will be registered:
+      #
+      # [source,ruby]
+      # -----
+      # platforms :ruby do
+      #   group :default do
+      #     gem 'openssl'
+      #   end
+      # end
+      #
+      # platforms :jruby do
+      #   group :default do
+      #     gem 'jruby-openssl'
+      #   end
+      # end
+      # -----
+      #
       # @example
       #   # bad
       #   group :development do
@@ -42,6 +60,7 @@ module RuboCop
 
         MSG = 'Gem group `%<group_name>s` already defined on line ' \
               '%<line_of_first_occurrence>d of the Gemfile.'
+        SOURCE_BLOCK_NAMES = %i[source git platforms path].freeze
 
         # @!method group_declarations(node)
         def_node_search :group_declarations, '(send nil? :group ...)'
@@ -61,11 +80,15 @@ module RuboCop
         private
 
         def duplicated_group_nodes
-          groups = group_declarations(processed_source.ast).group_by do |node|
-            group_attributes(node).sort
+          group_declarations = group_declarations(processed_source.ast)
+          group_keys = group_declarations.group_by do |node|
+            source_key = find_source_key(node)
+            group_attributes = group_attributes(node).sort.join
+
+            "#{source_key}#{group_attributes}"
           end
 
-          groups.values.select { |nodes| nodes.size > 1 }
+          group_keys.values.select { |nodes| nodes.size > 1 }
         end
 
         def register_offense(node, group_name, line_of_first_occurrence)
@@ -77,6 +100,16 @@ module RuboCop
             line_of_first_occurrence: line_of_first_occurrence
           )
           add_offense(offense_location, message: message)
+        end
+
+        def find_source_key(node)
+          source_block = node.each_ancestor(:block).find do |block_node|
+            SOURCE_BLOCK_NAMES.include?(block_node.method_name)
+          end
+
+          return unless source_block
+
+          "#{source_block.method_name}#{source_block.send_node.first_argument&.source}"
         end
 
         def group_attributes(node)

--- a/spec/rubocop/cop/bundler/duplicated_group_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_group_spec.rb
@@ -148,5 +148,168 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGroup, :config do
         RUBY
       end
     end
+
+    context 'and a set of groups is duplicated but `source` URLs are different' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY, 'Gemfile')
+          source 'https://rubygems.pkg.github.com/private-org' do
+            group :development do
+              gem 'rubocop'
+            end
+          end
+
+          group :development do
+            gem 'rubocop-rails'
+          end
+        RUBY
+      end
+    end
+
+    context 'and a set of groups is duplicated and `source` URLs are the same' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY, 'Gemfile')
+          source 'https://rubygems.pkg.github.com/private-org' do
+            group :development do
+              gem 'rubocop'
+            end
+          end
+
+          source 'https://rubygems.pkg.github.com/private-org' do
+            group :development do
+            ^^^^^^^^^^^^^^^^^^ Gem group `:development` already defined on line 2 of the Gemfile.
+              gem 'rubocop-rails'
+            end
+          end
+
+          group :development do
+            gem 'rubocop-performance'
+          end
+        RUBY
+      end
+    end
+
+    context 'and a set of groups is duplicated but `git` URLs are different' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY, 'Gemfile')
+          git 'https://github.com/rubocop/rubocop.git' do
+            group :default do
+              gem 'rubocop'
+            end
+          end
+
+          git 'https://github.com/rails/rails.git' do
+            group :default do
+              gem 'activesupport'
+              gem 'actionpack'
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'and a set of groups is duplicated and `git` URLs are the same' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY, 'Gemfile')
+          git 'https://github.com/rails/rails.git' do
+            group :default do
+              gem 'activesupport'
+            end
+          end
+
+          git 'https://github.com/rails/rails.git' do
+            group :default do
+            ^^^^^^^^^^^^^^ Gem group `:default` already defined on line 2 of the Gemfile.
+              gem 'actionpack'
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'and a set of groups is duplicated but `platforms` values are different' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY, 'Gemfile')
+          platforms :ruby do
+            group :default do
+              gem 'openssl'
+            end
+          end
+
+          platforms :jruby do
+            group :default do
+              gem 'jruby-openssl'
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'and a set of groups is duplicated and `platforms` values are the same' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY, 'Gemfile')
+          platforms :ruby do
+            group :default do
+              gem 'ruby-debug'
+            end
+          end
+
+          platforms :ruby do
+            group :default do
+            ^^^^^^^^^^^^^^ Gem group `:default` already defined on line 2 of the Gemfile.
+              gem 'sqlite3'
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'and a set of groups is duplicated but `path` values are different' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY, 'Gemfile')
+          path 'components_admin' do
+            group :default do
+              gem 'admin_ui'
+            end
+          end
+
+          path 'components_public' do
+            group :default do
+              gem 'public_ui'
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'and a set of groups is duplicated and `path` values are the same' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY, 'Gemfile')
+          path 'components' do
+            group :default do
+              gem 'admin_ui'
+            end
+          end
+
+          path 'components' do
+            group :default do
+            ^^^^^^^^^^^^^^ Gem group `:default` already defined on line 2 of the Gemfile.
+              gem 'public_ui'
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when `source` URL argument is not given' do
+      it 'does not crash' do
+        expect_no_offenses(<<-RUBY, 'Gemfile')
+          source do
+            group :development do
+              gem 'rubocop'
+            end
+          end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix #12113.

This PR fixes a false positive for `Bundler/DuplicatedGroup` when groups are duplicated but `source`, `git`, `platforms`,  or `path` values are different.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
