### PR TITLE
[Fix #12117] Fix `Style/ArgumentsForwarding` when not always forwarding a block

### DIFF
--- a/changelog/fix_an_error_for_style_arguments_forwarding_when_not_always_forwarding_block.md
+++ b/changelog/fix_an_error_for_style_arguments_forwarding_when_not_always_forwarding_block.md
@@ -1,0 +1,1 @@
+* [#12117](https://github.com/rubocop/rubocop/issues/12117): Fix a false positive for `Style/ArgumentsForwarding` cop when not always forwarding block. ([@owst][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -280,7 +280,7 @@ module RuboCop
 
             if can_forward_all?
               :all
-            elsif target_ruby_version >= 3.2
+            else
               :rest_or_kwrest
             end
           end


### PR DESCRIPTION
With `TargetRubyVersion < 3.2`, if some call sites forwarded the block but others didn't then the cop didn't classify the without-block call site as a forwarding call, and thus didn't notice the discrepancy between those that did forward the block and those that didn't.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
