### PR TITLE
Fix false positives for `Style/SymbolArray`

### DIFF
--- a/changelog/fix_false_positives_for_style_symbol_array.md
+++ b/changelog/fix_false_positives_for_style_symbol_array.md
@@ -1,0 +1,1 @@
+* [#12119](https://github.com/rubocop/rubocop/pull/12119): Fix false positives for `Style/SymbolArray` when `%i` array containing unescaped `[`, `]`, `(`, or `)`. ([@koic][])

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -69,6 +69,8 @@ module RuboCop
 
         def complex_content?(node)
           node.children.any? do |sym|
+            return false if DELIMITERS.include?(sym.source)
+
             content = *sym
             content = content.map { |c| c.is_a?(AST::Node) ? c.source : c }.join
             content_without_delimiter_pairs = content.gsub(/(\[[^\s\[\]]*\])|(\([^\s\(\)]*\))/, '')

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
-    it 'registers an offense for a %i array containing [ ]' do
+    it 'registers an offense for a %i array containing escaped [ ]' do
       expect_offense(<<~'RUBY')
         %i[one \[ \] two]
         ^^^^^^^^^^^^^^^^^ Use `[:one, :'[', :']', :two]` for an array of symbols.
@@ -146,6 +146,12 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
 
       expect_correction(<<~RUBY)
         [:one, :'[', :']', :two]
+      RUBY
+    end
+
+    it 'does not register an offense for a %i array containing unescaped [ ]' do
+      expect_no_offenses(<<~RUBY)
+        %i(one [ ] two)
       RUBY
     end
 
@@ -171,7 +177,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
       RUBY
     end
 
-    it 'registers an offense for a %i array containing ( )' do
+    it 'registers an offense for a %i array containing escaped ( )' do
       expect_offense(<<~'RUBY')
         %i(one \( \) two)
         ^^^^^^^^^^^^^^^^^ Use `[:one, :'(', :')', :two]` for an array of symbols.
@@ -179,6 +185,12 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
 
       expect_correction(<<~RUBY)
         [:one, :'(', :')', :two]
+      RUBY
+    end
+
+    it 'does not register an offense for a %i array containing unescaped ( )' do
+      expect_no_offenses(<<~RUBY)
+        %i[one ( ) two]
       RUBY
     end
 


### PR DESCRIPTION
This PR fixes false positives for `Style/SymbolArray` when `%i` array containing unescaped `[`, `]`, `(`, or `)`.

I noticed the following false positive in the RuboCop AST repository:

```console
$ cd path/to/rubocop-ast
$ bundle exec rubocop --only Style/SymbolArray
(snip)

spec/rubocop/ast/node_pattern/lexer_spec.rb:36:9: C: [Correctable] Style/SymbolArray:
Use [:'(', :array, :sym, :'$', :int, :+, :x, :')'] for an array of symbols.
        %i[( array sym $ int + x )]
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^

163 files inspected, 1 offense detected, 1 offense autocorrectable
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
