### PR TITLE
[Fix #12124] Fix false positives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_positives_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#12124](https://github.com/rubocop/rubocop/issues/12124): Fix false positives for `Style/RedundantParentheses` when parentheses in `super` or `yield` call with multiline style argument. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -98,7 +98,9 @@ module RuboCop
         end
 
         def like_method_argument_parentheses?(node)
-          node.send_type? && node.arguments.one? && !node.parenthesized? &&
+          return false if !node.send_type? && !node.super_type? && !node.yield_type?
+
+          node.arguments.one? && !node.parenthesized? &&
             !node.arithmetic_operation? && node.first_argument.begin_type?
         end
 

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -585,6 +585,22 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'accepts parentheses in super call with multiline style argument' do
+    expect_no_offenses(<<~RUBY)
+      super (
+        42
+      )
+    RUBY
+  end
+
+  it 'accepts parentheses in yield call with multiline style argument' do
+    expect_no_offenses(<<~RUBY)
+      yield (
+        42
+      )
+    RUBY
+  end
+
   it 'registers an offense and corrects when method arguments are unnecessarily parenthesized' do
     expect_offense(<<~RUBY)
       foo(


### PR DESCRIPTION
Fixes #12124.

This PR fixes false positives for `Style/RedundantParentheses` when parentheses in `super` or `yield` call with multiline style argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
