### PR TITLE
Make `Style/RedundantFilterChain` aware of `select.present?`

### DIFF
--- a/changelog/change_make_style_redundant_filter_chain_aware_of_select_present.md
+++ b/changelog/change_make_style_redundant_filter_chain_aware_of_select_present.md
@@ -1,0 +1,1 @@
+* [#12126](https://github.com/rubocop/rubocop/pull/12126): Make `Style/RedundantFilterChain` aware of `select.present?` when `ActiveSupportExtensionsEnabled` config is `true`. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_filter_chain.rb
+++ b/lib/rubocop/cop/style/redundant_filter_chain.rb
@@ -28,6 +28,9 @@ module RuboCop
       #   # good
       #   arr.select { |x| x > 1 }.many?
       #
+      #   # good
+      #   arr.select { |x| x > 1 }.present?
+      #
       # @example AllCops:ActiveSupportExtensionsEnabled: true
       #   # bad
       #   arr.select { |x| x > 1 }.many?
@@ -35,12 +38,18 @@ module RuboCop
       #   # good
       #   arr.many? { |x| x > 1 }
       #
+      #   # bad
+      #   arr.select { |x| x > 1 }.present?
+      #
+      #   # good
+      #   arr.any? { |x| x > 1 }
+      #
       class RedundantFilterChain < Base
         extend AutoCorrector
 
         MSG = 'Use `%<prefer>s` instead of `%<first_method>s.%<second_method>s`.'
 
-        RAILS_METHODS = %i[many?].freeze
+        RAILS_METHODS = %i[many? present?].freeze
         RESTRICT_ON_SEND = (%i[any? empty? none? one?] + RAILS_METHODS).freeze
 
         # @!method select_predicate?(node)
@@ -58,7 +67,8 @@ module RuboCop
           empty?: :none?,
           none?: :none?,
           one?: :one?,
-          many?: :many?
+          many?: :many?,
+          present?: :any?
         }.freeze
         private_constant :REPLACEMENT_METHODS
 

--- a/spec/rubocop/cop/style/redundant_filter_chain_spec.rb
+++ b/spec/rubocop/cop/style/redundant_filter_chain_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantFilterChain, :config do
       RUBY
     end
 
+    it "does not register an offense when using `##{method}` followed by `#present?`" do
+      expect_no_offenses(<<~RUBY)
+        arr.#{method} { |x| x > 1 }.present?
+      RUBY
+    end
+
     it "does not register an offense when using `##{method}` without a block followed by `#any?`" do
       expect_no_offenses(<<~RUBY)
         relation.#{method}(:name).any?
@@ -90,6 +96,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantFilterChain, :config do
 
       expect_correction(<<~RUBY)
         arr.many? { |x| x > 1 }
+      RUBY
+    end
+
+    it 'registers an offense when using `#select` followed by `#present?`' do
+      expect_offense(<<~RUBY)
+        arr.select { |x| x > 1 }.present?
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `any?` instead of `select.present?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        arr.any? { |x| x > 1 }
       RUBY
     end
   end


### PR DESCRIPTION
Resolves: rubocop/rubocop-rails#1048.

This PR makes `Style/RedundantFilterChain` aware of `select.present?` when `AllCops/ActiveSupportExtensionsEnabled: true`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
