### PR TITLE
[Fix #12105] Adjust target ruby gem requirement matcher and version parsing to support multiple version constraints

### DIFF
--- a/changelog/fix_target_ruby_gem_requirement_support_multiple_version_constraints.md
+++ b/changelog/fix_target_ruby_gem_requirement_support_multiple_version_constraints.md
@@ -1,0 +1,1 @@
+* [#12105](https://github.com/rubocop/rubocop/issues/12105): Fix target ruby `Gem::Requirement` matcher and version parsing to support multiple version constraints. ([@ItsEcholot][])

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -380,6 +380,62 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
             create_file(gemspec_file_path, content)
             expect(target_ruby.version).to eq default_version
           end
+
+          it 'sets first known ruby version that satisfies range requirement' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = Gem::Requirement.new('>= 2.3.1', '< 3.0.0')
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq default_version
+          end
+
+          it 'sets first known ruby version that satisfies range requirement in array notation' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = Gem::Requirement.new(['>= 2.3.1', '< 3.0.0'])
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq default_version
+          end
+
+          it 'sets first known ruby version that satisfies range requirement with frozen strings' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = Gem::Requirement.new('>= 2.3.1'.freeze, '< 3.0.0'.freeze)
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq default_version
+          end
+
+          it 'sets first known ruby version that satisfies range requirement in array notation with frozen strings' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = Gem::Requirement.new(['>= 2.3.1'.freeze, '< 3.0.0'.freeze])
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq default_version
+          end
         end
 
         context 'when file contains `required_ruby_version` as an array' do


### PR DESCRIPTION
This PR adjusts the `gem_requirement` matcher to support multiple version constraints if `Gem::Requirement` is used as a value for `required_ruby_version` in the gemspec. It also allows version constraints in `Gem::Requirement` where the string was frozen with `.freeze`.

More information can be found in the linked issue #12105.

Example which is now supported with this PR:
```ruby
Gem::Specification.new do |s|
  s.required_ruby_version = Gem::Requirement.new(['>= 2.3.1'.freeze, '< 3.0.0'.freeze])
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
