### PR TITLE
[Fix #12128] Make `Style/GuardClause` aware of `define_method`

### DIFF
--- a/changelog/change_make_style_guard_clause_aware_of_define_method.md
+++ b/changelog/change_make_style_guard_clause_aware_of_define_method.md
@@ -1,0 +1,1 @@
+* [#12128](https://github.com/rubocop/rubocop/issues/12128): Make `Style/GuardClause` aware of `define_method`. ([@koic][])

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -55,6 +55,25 @@ module RuboCop
       #   foo || raise('exception') if something
       #   ok
       #
+      #   # bad
+      #   define_method(:test) do
+      #     if something
+      #       work
+      #     end
+      #   end
+      #
+      #   # good
+      #   define_method(:test) do
+      #     return unless something
+      #
+      #     work
+      #   end
+      #
+      #   # also good
+      #   define_method(:test) do
+      #     work if something
+      #   end
+      #
       # @example AllowConsecutiveConditionals: false (default)
       #   # bad
       #   def test
@@ -109,6 +128,13 @@ module RuboCop
           check_ending_body(body)
         end
         alias on_defs on_def
+
+        def on_block(node)
+          return unless node.method?(:define_method) || node.method?(:define_singleton_method)
+
+          on_def(node)
+        end
+        alias on_numblock on_block
 
         def on_if(node)
           return if accepted_form?(node)

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -79,6 +79,120 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
         end
       RUBY
     end
+
+    it 'reports an offense if `define_method` block body is if / unless without else' do
+      expect_offense(<<~RUBY)
+        define_method(:func) do
+          if _1
+          ^^ Use a guard clause (`return unless _1`) instead of wrapping the code inside a conditional expression.
+            #{body}
+          end
+        end
+
+        define_method(:func) do
+          unless _1
+          ^^^^^^ Use a guard clause (`return if _1`) instead of wrapping the code inside a conditional expression.
+            #{body}
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        define_method(:func) do
+          return unless _1
+            #{body}
+         #{trailing_whitespace}
+        end
+
+        define_method(:func) do
+          return if _1
+            #{body}
+         #{trailing_whitespace}
+        end
+      RUBY
+    end
+
+    it 'reports an offense if `define_singleton_method` block body is if / unless without else' do
+      expect_offense(<<~RUBY)
+        define_singleton_method(:func) do
+          if _1
+          ^^ Use a guard clause (`return unless _1`) instead of wrapping the code inside a conditional expression.
+            #{body}
+          end
+        end
+
+        define_singleton_method(:func) do
+          unless _1
+          ^^^^^^ Use a guard clause (`return if _1`) instead of wrapping the code inside a conditional expression.
+            #{body}
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        define_singleton_method(:func) do
+          return unless _1
+            #{body}
+         #{trailing_whitespace}
+        end
+
+        define_singleton_method(:func) do
+          return if _1
+            #{body}
+         #{trailing_whitespace}
+        end
+      RUBY
+    end
+
+    it 'reports an offense if `define_method` numblock body is if / unless without else' do
+      expect_offense(<<~RUBY)
+        define_method(:func) do
+          if something
+          ^^ Use a guard clause (`return unless something`) instead of wrapping the code inside a conditional expression.
+            #{body}
+          end
+        end
+
+        define_method(:func) do
+          unless something
+          ^^^^^^ Use a guard clause (`return if something`) instead of wrapping the code inside a conditional expression.
+            #{body}
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        define_method(:func) do
+          return unless something
+            #{body}
+         #{trailing_whitespace}
+        end
+
+        define_method(:func) do
+          return if something
+            #{body}
+         #{trailing_whitespace}
+        end
+      RUBY
+    end
+
+    it 'accepts an offense if block body ends with if / unless without else' do
+      expect_no_offenses(<<~RUBY)
+        foo do
+          test
+          if something
+            #{body}
+          end
+        end
+
+        foo do
+          test
+          unless something
+            #{body}
+          end
+        end
+      RUBY
+    end
   end
 
   it_behaves_like('reports offense', 'work')
@@ -88,6 +202,18 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
   it 'does not report an offense if body is if..elsif..end' do
     expect_no_offenses(<<~RUBY)
       def func
+        if something
+          a
+        elsif something_else
+          b
+        end
+      end
+    RUBY
+  end
+
+  it 'does not report an offense if block body is if..elsif..end' do
+    expect_no_offenses(<<~RUBY)
+      define_method(:func) do
         if something
           a
         elsif something_else


### PR DESCRIPTION
Fixes #12128.

This PR makes `Style/GuardClause` aware of `define_method`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
