### PR TITLE
Fix `Style/RedundantSelfAssignmentBranch` to handle heredocs

### DIFF
--- a/changelog/fix_style_redundant_self_assignment_branch_to_handle_heredocs.md
+++ b/changelog/fix_style_redundant_self_assignment_branch_to_handle_heredocs.md
@@ -1,0 +1,1 @@
+* [#12133](https://github.com/rubocop/rubocop/pull/12133): Fix `Style/RedundantSelfAssignmentBranch` to handle heredocs. ([@r7kamura][])

--- a/lib/rubocop/cop/style/redundant_self_assignment_branch.rb
+++ b/lib/rubocop/cop/style/redundant_self_assignment_branch.rb
@@ -75,6 +75,11 @@ module RuboCop
           add_offense(offense_branch) do |corrector|
             assignment_value = opposite_branch ? opposite_branch.source : 'nil'
             replacement = "#{assignment_value} #{keyword} #{if_node.condition.source}"
+            if opposite_branch.respond_to?(:heredoc?) && opposite_branch.heredoc?
+              replacement += opposite_branch.loc.heredoc_end.with(
+                begin_pos: opposite_branch.source_range.end_pos
+              ).source
+            end
 
             corrector.replace(if_node, replacement)
           end

--- a/spec/rubocop/cop/style/redundant_self_assignment_branch_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_assignment_branch_spec.rb
@@ -93,6 +93,25 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelfAssignmentBranch, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when self-assigning redundant if branch with heredoc' do
+    expect_offense(<<~RUBY)
+      foo = if condition
+              foo
+              ^^^ Remove the self-assignment branch.
+            else
+              <<~TEXT
+                bar
+              TEXT
+            end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo = <<~TEXT unless condition
+                bar
+              TEXT
+    RUBY
+  end
+
   it 'does not register an offense when self-assigning redundant else branch and multiline if branch' do
     expect_no_offenses(<<~RUBY)
       foo = if condition


### PR DESCRIPTION
There is a bug in the autocorrection of `Style/RedundantSelfAssignmentBranch`, which causes the following replacement if `opposite_branch` is a heredoc.

Before:

```ruby
foo =
  if some_condition
    foo
  else
    <<~TEXT
      bar
    TEXT
  end
```

After:

```ruby
foo =
  <<~TEXT unless some_condition
```

So in this pull request, I will modify it to make up for the missing parts in the case of heredoc.

This implementation is roughly the same as other methods of dealing with heredocs, for example, in `Style/FileWrite`:

https://github.com/rubocop/rubocop/blob/dd299948479c15cc7dd254a339631d241938b20b/lib/rubocop/cop/style/file_write.rb#L108-L121

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
