### PR TITLE
[Fix #12134] Fix a false positive for `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_method_call_with_args_parentheses.md
+++ b/changelog/fix_a_false_positive_for_style_method_call_with_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#12134](https://github.com/rubocop/rubocop/issues/12134): Fix a false positive for `Style/MethodCallWithArgsParentheses` when parentheses are used in one-line `in` pattern matching. ([@koic][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -146,7 +146,9 @@ module RuboCop
           end
 
           def call_in_match_pattern?(node)
-            node.parent&.match_pattern_type?
+            return false unless (parent = node.parent)
+
+            parent.match_pattern_type? || parent.match_pattern_p_type?
           end
 
           def hash_literal_in_arguments?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -961,7 +961,22 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'accepts parens in singe-line pattern matching', :ruby30 do
+    # Ruby 2.7's one-line `in` pattern node type is `match-pattern`.
+    it 'accepts parens in one-line `in` pattern matching', :ruby27 do
+      expect_no_offenses(<<~RUBY)
+        execute(query) in {elapsed:, sql_count:}
+      RUBY
+    end
+
+    # Ruby 3.0's one-line `in` pattern node type is `match-pattern-p`.
+    it 'accepts parens in one-line `in` pattern matching', :ruby30 do
+      expect_no_offenses(<<~RUBY)
+        execute(query) in {elapsed:, sql_count:}
+      RUBY
+    end
+
+    # Ruby 3.0's one-line `=>` pattern node type is `match-pattern`.
+    it 'accepts parens in one-line `=>` pattern matching', :ruby30 do
       expect_no_offenses(<<~RUBY)
         execute(query) => {elapsed:, sql_count:}
       RUBY


### PR DESCRIPTION
Fixes #12134.

This PR fixes a false positive for `Style/MethodCallWithArgsParentheses` when parentheses are used in one-line `in` pattern matching.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
