### PR TITLE
Fix a false negative for `Layout/LeadingCommentSpace`

### DIFF
--- a/changelog/fix_a_false_negative_for_layout_leading_comment_space.md
+++ b/changelog/fix_a_false_negative_for_layout_leading_comment_space.md
@@ -1,0 +1,1 @@
+* [#12136](https://github.com/rubocop/rubocop/pull/12136): Fix a false negative for `Layout/LeadingCommentSpace` when using `#+` or `#-` as they are not RDoc comments. ([@koic][])

--- a/lib/rubocop/cop/layout/leading_comment_space.rb
+++ b/lib/rubocop/cop/layout/leading_comment_space.rb
@@ -57,7 +57,7 @@ module RuboCop
 
         def on_new_investigation
           processed_source.comments.each do |comment|
-            next unless /\A#+[^#\s=+-]/.match?(comment.text)
+            next unless /\A(?!#\+\+|#--)(#+[^#\s=])/.match?(comment.text)
             next if comment.loc.line == 1 && allowed_on_first_line?(comment)
             next if doxygen_comment_style?(comment)
             next if gemfile_ruby_comment?(comment)

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -143,6 +143,20 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
       RUBY
     end
 
+    it 'registers an offense when using `#+` or `#-` as they are not RDoc comments' do
+      expect_offense(<<~RUBY)
+        #+
+        ^^ Missing space after `#`.
+        #-
+        ^^ Missing space after `#`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # +
+        # -
+      RUBY
+    end
+
     it 'registers an offense when starting `:`' do
       expect_offense(<<~RUBY)
         #:nodoc:


### PR DESCRIPTION
This PR fixes a false negative for `Layout/LeadingCommentSpace` when using `#+` or `#-` as they are not RDoc comments.

They are followed by `+` or `-` twice, such as `#++` and `#--`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
