### PR TITLE
[Fix #12138] Fix a false positive for `Layout/LineContinuationLeadingSpace`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_line_continuation_leading_space.md
+++ b/changelog/fix_a_false_positive_for_layout_line_continuation_leading_space.md
@@ -1,0 +1,1 @@
+* [#12138](https://github.com/rubocop/rubocop/issues/12138): Fix a false positive for `Layout/LineContinuationLeadingSpace` when a backslash is part of a multiline string literal. ([@ymap][])

--- a/spec/rubocop/cop/layout/line_continuation_leading_space_spec.rb
+++ b/spec/rubocop/cop/layout/line_continuation_leading_space_spec.rb
@@ -106,6 +106,13 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
       RUBY
     end
 
+    it 'registers no offense for multiline string with backslash' do
+      expect_no_offenses(<<~'RUBY')
+        '"this text is too" \
+        " long"'
+      RUBY
+    end
+
     describe 'interpolated strings' do
       it 'registers no offense on interpolated string alone' do
         expect_no_offenses(<<~'RUBY')
@@ -280,6 +287,13 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
           'this text is too' \
           ' long'
         )
+      RUBY
+    end
+
+    it 'registers no offense for multiline string with backslash' do
+      expect_no_offenses(<<~'RUBY')
+        '"this text is too " \
+        "long"'
       RUBY
     end
 


### PR DESCRIPTION
Fixes rubocop#12138.

This PR fixes a false positive for `Layout/LineContinuationLeadingSpace` when a backslash is part of a multiline string literal.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
