### PR TITLE
[Fix #12141] Fix false positive for `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/fix_fix_false_positive_for_style_arguments_forwarding.md
+++ b/changelog/fix_fix_false_positive_for_style_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#12141](https://github.com/rubocop/rubocop/issues/12141): Fix false positive for `Style/ArgumentsForwarding` when method def includes additional kwargs. ([@owst][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -291,7 +291,7 @@ module RuboCop
             return false if any_arg_referenced?
             return false if ruby_32_missing_rest_or_kwest?
             return false unless offensive_block_forwarding?
-            return false if forward_additional_kwargs?
+            return false if additional_kwargs_or_forwarded_kwargs?
 
             no_additional_args? || (target_ruby_version >= 3.0 && no_post_splat_args?)
           end
@@ -337,6 +337,14 @@ module RuboCop
 
             arg_after_splat = arguments[splat_index + 1]
             [nil, :hash, :block_pass].include?(arg_after_splat&.type)
+          end
+
+          def additional_kwargs_or_forwarded_kwargs?
+            additional_kwargs? || forward_additional_kwargs?
+          end
+
+          def additional_kwargs?
+            @def_node.arguments.any? { |a| a.kwarg_type? || a.kwoptarg_type? }
           end
 
           def forward_additional_kwargs?


### PR DESCRIPTION
If additional kwargs are supplied then forward-all (`...`) cannot be used.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
