### PR TITLE
[Fix #12143] Fix a false positive for `Lint/ToEnumArguments`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_to_enum_arguments.md
+++ b/changelog/fix_a_false_positive_for_lint_to_enum_arguments.md
@@ -1,0 +1,1 @@
+* [#12143](https://github.com/rubocop/rubocop/issues/12143): Fix a false positive for `Lint/ToEnumArguments` when using anonymous keyword arguments forwarding. ([@koic][])

--- a/lib/rubocop/cop/lint/to_enum_arguments.rb
+++ b/lib/rubocop/cop/lint/to_enum_arguments.rb
@@ -74,7 +74,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
         def argument_match?(send_arg, def_arg)
           def_arg_name = def_arg.children[0]
 
@@ -87,12 +87,14 @@ module RuboCop
             send_arg.hash_type? &&
               send_arg.pairs.any? { |pair| passing_keyword_arg?(pair, def_arg_name) }
           when :kwrestarg
-            send_arg.each_child_node(:kwsplat).any? { |child| child.source == def_arg.source }
+            send_arg.each_child_node(:kwsplat, :forwarded_kwrestarg).any? do |child|
+              child.source == def_arg.source
+            end
           when :forward_arg
             send_arg.forwarded_args_type?
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
       end
     end
   end

--- a/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
+++ b/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
@@ -167,4 +167,28 @@ RSpec.describe RuboCop::Cop::Lint::ToEnumArguments, :config do
       RUBY
     end
   end
+
+  context 'anonymous positional arguments forwarding', :ruby32 do
+    it 'does not register an offense when enumerator is created with the correct arguments' do
+      expect_no_offenses(<<~RUBY)
+        def do_something(*)
+          return to_enum(:do_something, *) unless block_given?
+
+          do_something_else
+        end
+      RUBY
+    end
+  end
+
+  context 'anonymous keyword arguments forwarding', :ruby32 do
+    it 'does not register an offense when enumerator is created with the correct arguments' do
+      expect_no_offenses(<<~RUBY)
+        def do_something(**)
+          return to_enum(:do_something, **) unless block_given?
+
+          do_something_else
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #12143.

This PR fixes a false positive for `Lint/ToEnumArguments` when using anonymous keyword arguments forwarding.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
