### PR TITLE
Fix an incorrect autocorrect for `Lint/NonAtomicFileOperation`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_non_atomic_file_operation.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_non_atomic_file_operation.md
@@ -1,0 +1,1 @@
+* [#12148](https://github.com/rubocop/rubocop/pull/12148): Fix an incorrect autocorrect for `Lint/NonAtomicFileOperation` when using `FileUtils.remove_dir`, `FileUtils.remove_entry`, or `FileUtils.remove_entry_secure`. ([@koic][])

--- a/lib/rubocop/cop/lint/non_atomic_file_operation.rb
+++ b/lib/rubocop/cop/lint/non_atomic_file_operation.rb
@@ -51,10 +51,12 @@ module RuboCop
         MAKE_FORCE_METHODS = %i[makedirs mkdir_p mkpath].freeze
         MAKE_METHODS = %i[mkdir].freeze
         REMOVE_FORCE_METHODS = %i[rm_f rm_rf].freeze
-        REMOVE_METHODS = %i[remove remove_dir remove_entry remove_entry_secure
-                            delete unlink remove_file rm rmdir safe_unlink].freeze
-        RESTRICT_ON_SEND = (MAKE_METHODS + MAKE_FORCE_METHODS + REMOVE_METHODS +
-          REMOVE_FORCE_METHODS).freeze
+        REMOVE_METHODS = %i[remove delete unlink remove_file rm rmdir safe_unlink].freeze
+        RECURSIVE_REMOVE_METHODS = %i[remove_dir remove_entry remove_entry_secure].freeze
+        RESTRICT_ON_SEND = (
+          MAKE_METHODS + MAKE_FORCE_METHODS + REMOVE_METHODS + RECURSIVE_REMOVE_METHODS +
+          REMOVE_FORCE_METHODS
+        ).freeze
 
         # @!method send_exist_node(node)
         def_node_search :send_exist_node, <<~PATTERN
@@ -140,6 +142,8 @@ module RuboCop
             'mkdir_p'
           elsif REMOVE_METHODS.include?(node.method_name)
             'rm_f'
+          elsif RECURSIVE_REMOVE_METHODS.include?(node.method_name)
+            'rm_rf'
           else
             node.method_name
           end


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Lint/NonAtomicFileOperation` when using `FileUtils.remove_dir`, `FileUtils.remove_entry`, or `FileUtils.remove_entry_secure`. The behavior of these methods is closer to `FileUtils.rm_rf` than `FileUtils.rm`, since it also deletes the directory specified as an argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
