### PR TITLE
Fix shadowing of FileFinder stop_dir in isolated tests.

### DIFF
--- a/lib/rubocop/file_finder.rb
+++ b/lib/rubocop/file_finder.rb
@@ -6,12 +6,8 @@ module RuboCop
   # Common methods for finding files.
   # @api private
   module FileFinder
-    def self.root_level=(level)
-      @root_level = level
-    end
-
-    def self.root_level?(path, stop_dir)
-      (@root_level || stop_dir) == path.to_s
+    class << self
+      attr_accessor :root_level
     end
 
     def find_file_upwards(filename, start_dir, stop_dir = nil)
@@ -34,7 +30,8 @@ module RuboCop
         file = dir + filename
         yield(file.to_s) if file.exist?
 
-        break if FileFinder.root_level?(dir, stop_dir)
+        dir = dir.to_s
+        break if dir == stop_dir || dir == FileFinder.root_level
       end
     end
   end

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -11,6 +11,8 @@ RSpec.shared_context 'isolated environment' do # rubocop:disable Metrics/BlockLe
       # Make sure to expand all symlinks in the path first. Otherwise we may
       # get mismatched pathnames when loading config files later on.
       tmpdir = File.realpath(tmpdir)
+      # Make upwards search for .rubocop.yml files stop at this directory.
+      RuboCop::FileFinder.root_level = tmpdir
 
       virtual_home = File.expand_path(File.join(tmpdir, 'home'))
       Dir.mkdir(virtual_home)
@@ -20,9 +22,6 @@ RSpec.shared_context 'isolated environment' do # rubocop:disable Metrics/BlockLe
       base_dir = example.metadata[:project_inside_home] ? virtual_home : tmpdir
       root = example.metadata[:root]
       working_dir = root ? File.join(base_dir, 'work', root) : File.join(base_dir, 'work')
-
-      # Make upwards search for .rubocop.yml files stop at this directory.
-      RuboCop::FileFinder.root_level = working_dir
 
       begin
         FileUtils.mkdir_p(working_dir)

--- a/spec/isolated_environment_spec.rb
+++ b/spec/isolated_environment_spec.rb
@@ -10,8 +10,15 @@ RSpec.describe 'isolated environment', :isolated_environment, type: :feature do
   # directory is under the user's home directory. On any platform we don't want
   # a .rubocop.yml file in the temporary directory to affect the outcome of
   # rspec.
+  #
+  # For this test, we shift the root_level down to the work directory so we
+  # can place a file above the root_level and ensure it is not loaded.
   it 'is not affected by a config file above the work directory' do
-    create_file('../.rubocop.yml', ['inherit_from: missing_file.yml'])
+    ignored_path = File.expand_path(File.join(RuboCop::FileFinder.root_level, '.rubocop.yml'))
+    create_file(ignored_path, ['inherit_from: missing_file.yml'])
+
+    RuboCop::FileFinder.root_level = File.join(RuboCop::FileFinder.root_level, 'work')
+
     create_file('ex.rb', ['# frozen_string_literal: true'])
     # A return value of 0 means that the erroneous config file was not read.
     expect(cli.run([])).to eq(0)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -9,12 +9,14 @@ RSpec.describe RuboCop::ConfigLoader do
     described_class.debug = true
     # Force reload of default configuration
     described_class.default_configuration = nil
+    RuboCop::ConfigFinder.project_root = nil
   end
 
   after do
     described_class.debug = false
     # Remove custom configuration
     described_class.default_configuration = nil
+    RuboCop::ConfigFinder.project_root = nil
   end
 
   let(:default_config) { described_class.default_configuration }

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe RuboCop::Cop::Team do
   describe '#inspect_file', :isolated_environment do
     include FileHelper
 
-    let(:file_path) { '/tmp/example.rb' }
+    let(:file_path) { 'example.rb' }
     let(:source) do
       source = RuboCop::ProcessedSource.from_file(file_path, ruby_version)
       source.config = config
@@ -175,7 +175,7 @@ RSpec.describe RuboCop::Cop::Team do
 
       let(:error_message) do
         'An error occurred while Style/NumericLiterals cop was inspecting ' \
-          '/tmp/example.rb:1:0.'
+          'example.rb:1:0.'
       end
 
       it 'records Team#errors' do
@@ -198,7 +198,7 @@ RSpec.describe RuboCop::Cop::Team do
         RUBY
       end
 
-      let(:file_path) { '/tmp/Gemfile' }
+      let(:file_path) { 'Gemfile' }
 
       let(:buggy_correction) { ->(_corrector) do raise cause end }
       let(:options) { { autocorrect: true } }
@@ -207,7 +207,7 @@ RSpec.describe RuboCop::Cop::Team do
 
       let(:error_message) do
         'An error occurred while Bundler/OrderedGems cop was inspecting ' \
-          '/tmp/Gemfile.'
+          'Gemfile.'
       end
 
       it 'records Team#errors' do

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -510,18 +510,16 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
     end
 
     it 'can exclude symlinks as well as directories' do
-      Dir.mktmpdir do |tmpdir|
-        create_empty_file(File.join(tmpdir, 'ruby5.rb'))
-        create_link('link', tmpdir)
+      create_empty_file(File.join(Dir.home, 'ruby5.rb'))
+      create_link('link', Dir.home)
 
-        config = instance_double(RuboCop::Config)
-        exclude_property = { 'Exclude' => [File.expand_path('link/**/*')] }
-        allow(config).to receive(:for_all_cops).and_return(exclude_property)
-        allow(config_store).to receive(:for).and_return(config)
+      config = instance_double(RuboCop::Config)
+      exclude_property = { 'Exclude' => [File.expand_path('link/**/*')] }
+      allow(config).to receive(:for_all_cops).and_return(exclude_property)
+      allow(config_store).to receive(:for).and_return(config)
 
-        expect(found_basenames.include?('ruby5.rb')).to be(false)
-        expect(found_basenames.include?('ruby3.rb')).to be(true)
-      end
+      expect(found_basenames.include?('ruby5.rb')).to be(false)
+      expect(found_basenames.include?('ruby3.rb')).to be(true)
     end
   end
 

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -6,6 +6,8 @@ module FileHelper
   def create_file(file_path, content)
     file_path = File.expand_path(file_path)
 
+    ensure_descendant(file_path)
+
     dir_path = File.dirname(file_path)
     FileUtils.mkdir_p dir_path
 
@@ -30,9 +32,18 @@ module FileHelper
   def create_link(link_path, target_path)
     link_path = File.expand_path(link_path)
 
+    ensure_descendant(link_path)
+
     dir_path = File.dirname(link_path)
     FileUtils.mkdir_p dir_path
 
     FileUtils.symlink(target_path, link_path)
+  end
+
+  def ensure_descendant(path, base = RuboCop::FileFinder.root_level)
+    return unless base
+    return if path.start_with?(base) && path != base
+
+    raise "Test file #{path} is outside of isolated_environment root #{base}"
   end
 end


### PR DESCRIPTION
Previously, stop_dir was ignored when FileFinde.root_level was present.

Tests that should have relied on stop_dir being set correctly, instead passed because the root_level happened to be the same as the stop_dir because of how the test was constructed.

Shift where FileFinder.root_level is set so that we use root_level only for protecting the test environment tmpdir. It is now set to the actual root of the tmpdir, above which nothing should be written in isolated environment tests.

This is a partial extraction of fixes in #12147, which had to fix too many problems like this and became too large.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [x] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
