### PR TITLE
[Fix #12151] Make `Layout/EmptyLineAfterGuardClause` allow `:nocov:` directive

### DIFF
--- a/changelog/new_make_layout_empty_line_after_guard_clause_allow_nocov_direcive.md
+++ b/changelog/new_make_layout_empty_line_after_guard_clause_allow_nocov_direcive.md
@@ -1,0 +1,1 @@
+* [#12151](https://github.com/rubocop/rubocop/issues/12151): Make `Layout/EmptyLineAfterGuardClause` allow `:nocov:` directive after guard clause. ([@koic][])

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -327,6 +327,18 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
+  it 'accepts using guard clause is after `:nocov:` comment' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        # :nocov:
+        return if condition
+        # :nocov:
+
+        bar
+      end
+    RUBY
+  end
+
   it 'accepts a guard clause inside oneliner block' do
     expect_no_offenses(<<~RUBY)
       def foo


### PR DESCRIPTION
Resolves #12151.

This PR makes `Layout/EmptyLineAfterGuardClause` allow `:nocov:` directive after guard clause.

SimpleCov excludes code from the coverage report by wrapping it in `# :nocov:`: https://github.com/simplecov-ruby/simplecov#ignoringskipping-code

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
