### PR TITLE
Suppress a Ruby warning when using Ruby 3.3.0dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,9 @@ gem 'test-queue'
 gem 'yard', '~> 0.9'
 
 group :test do
+  # FIXME: This `bigdecimal` dependency can be removed when https://github.com/jnunemaker/crack/pull/75
+  # is merged and released. It's a workaround until then.
+  gem 'bigdecimal', platform: :mri
   gem 'webmock', require: false
 end
 


### PR DESCRIPTION
Follow up https://github.com/ruby/ruby/commit/1c93288f8bbf667cb95eb7137b2fe64213894b77.

This PR suppresses the following warning when using Ruby 3.3.0dev

```consle
$ cd path/to/rubocop
$ ruby -v
ruby 3.3.0dev (2023-08-22T14:46:32Z master 7127f39bac) [x86_64-darwin22]
$ bundle exec rake spec
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/crack-0.4.5/lib/crack/xml.rb:9:
 warning: bigdecimal will be not part of the default gems since Ruby 3.4.0. Add it to your Gemfile.
```

crack is a dependency for the testing tool WebMock, so it will be added to the Gemfile:

```console
$ cat Gemfile.lock
(snip)
    webmock (3.18.1)
      addressable (>= 2.8.0)
      crack (>= 0.3.2)
      hashdiff (>= 0.4.0, < 2.0.0)
```

The `bigdecimal` dependency can be removed when https://github.com/jnunemaker/crack/pull/75 is merged and released. It's a workaround until then.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
