### PR TITLE
Fix a false positive for `Layout/RedundantLineBreak`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_redundant_line_break.md
+++ b/changelog/fix_a_false_positive_for_layout_redundant_line_break.md
@@ -1,0 +1,1 @@
+* [#12155](https://github.com/rubocop/rubocop/pull/12155): Fix false positive for `Layout/RedundantLineBreak` when using a modified singleton method definition. ([@koic][])

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -106,7 +106,7 @@ module RuboCop
 
         def suitable_as_single_line?(node)
           !comment_within?(node) &&
-            node.each_descendant(:if, :case, :kwbegin, :def).none? &&
+            node.each_descendant(:if, :case, :kwbegin, :def, :defs).none? &&
             node.each_descendant(:dstr, :str).none? { |n| n.heredoc? || n.value.include?("\n") } &&
             node.each_descendant(:begin).none? { |b| !b.single_line? }
         end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2456,6 +2456,30 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Layout/RedundantLineBreak` and `Style/SingleLineMethods` offenses' do
+    create_file('.rubocop.yml', <<~YAML)
+      AllCops:
+        TargetRubyVersion: 2.7
+      Layout/RedundantLineBreak:
+        Enabled: true
+      Layout/SingleLineMethods:
+        Enabled: true
+    YAML
+
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~RUBY)
+      x def self.y; z end
+    RUBY
+
+    expect(cli.run(['-a', '--only', 'Layout/RedundantLineBreak,Style/SingleLineMethods'])).to eq(0)
+
+    expect(source_file.read).to eq(<<~RUBY)
+      x def self.y;#{' '}
+          z#{' '}
+        end
+    RUBY
+  end
+
   it 'corrects `Layout/DotPosition` and `Layout/SingleLineBlockChain` offenses' do
     source_file = Pathname('example.rb')
     create_file(source_file, <<~RUBY)

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -100,6 +100,14 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
         RUBY
       end
 
+      it 'accepts a modified singleton method definition' do
+        expect_no_offenses(<<~RUBY)
+          x def self.y
+              z
+            end
+        RUBY
+      end
+
       it 'accepts a method call on a single line' do
         expect_no_offenses(<<~RUBY)
           my_method(1, 2, "x")


### PR DESCRIPTION
This PR fixes false positive for `Layout/RedundantLineBreak` to prevent the following infinite loop error:

```console
$ echo 'x def self.y; z end' | be rubocop --stdin example.rb -a --only Layout/RedundantLineBreak,Style/SingleLineMethods
Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Corrected] Layout/RedundantLineBreak: Redundant line break detected.
x def self.y;  ...
^^^^^^^^^^^^^^
example.rb:1:3: C: [Corrected] Style/SingleLineMethods: Avoid single-line method definitions.
x def self.y; z end
  ^^^^^^^^^^^^^^^^^

0 files inspected, 2 offenses detected, 2 offenses corrected
Infinite loop detected in /Users/koic/src/github.com/rubocop/rubocop/example.rb and caused by Style/SingleLineMethods -> Layout/RedundantLineBreak
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/runner.rb:332:in `check_for_infinite_loop'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
