### PR TITLE
[Fix #12154] Fix incorrect `diagnosticProvider` value of LSP

### DIFF
--- a/changelog/fix_incorrect_diagnostic_provider_value_of_lsp.md
+++ b/changelog/fix_incorrect_diagnostic_provider_value_of_lsp.md
@@ -1,0 +1,1 @@
+* [#12154](https://github.com/rubocop/rubocop/issues/12154): Fix incorrect `diagnosticProvider` value of LSP. ([@koic][])

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -45,7 +45,10 @@ module RuboCop
           result: LanguageServer::Protocol::Interface::InitializeResult.new(
             capabilities: LanguageServer::Protocol::Interface::ServerCapabilities.new(
               document_formatting_provider: true,
-              diagnostic_provider: true,
+              diagnostic_provider: LanguageServer::Protocol::Interface::DiagnosticOptions.new(
+                inter_file_dependencies: false,
+                workspace_diagnostics: false
+              ),
               text_document_sync: LanguageServer::Protocol::Interface::TextDocumentSyncOptions.new(
                 change: LanguageServer::Protocol::Constant::TextDocumentSyncKind::FULL,
                 open_close: true

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Lsp::Server, :isolated_environment do
           capabilities: {
             textDocumentSync: { openClose: true, change: 1 },
             documentFormattingProvider: true,
-            diagnosticProvider: true
+            diagnosticProvider: { interFileDependencies: false, workspaceDiagnostics: false }
           }
         }
       )


### PR DESCRIPTION
Fixes #12154.

This PR fixes incorrect `diagnosticProvider` value of LSP.

`diagnosticProvider` cannot accept true as below. This PR replaces the originally acceptable value.

```typescript
/**
 * The server has support for pull model diagnostics.
 *
 * @since 3.17.0
 */
diagnosticProvider?: DiagnosticOptions | DiagnosticRegistrationOptions;
```

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
