### PR TITLE
[Docs] Add Emacs (LSP Mode) to the LSP doc

### DIFF
--- a/docs/modules/ROOT/pages/usage/lsp.adoc
+++ b/docs/modules/ROOT/pages/usage/lsp.adoc
@@ -45,6 +45,15 @@ If you run into problems, first use "M-x eglot-reconnect" to reconnect to the la
 
 See Eglot's official documentation for more information.
 
+=== Emacs (LSP Mode)
+
+https://github.com/emacs-lsp/lsp-mode[LSP Mode] is an Emacs client/library for the Language Server Protocol.
+
+You can get the new `lsp-mode` package from https://melpa.org/#/lsp-mode[MELPA].
+
+See LSP Mode official documentation for more information:
+https://emacs-lsp.github.io/lsp-mode/page/lsp-rubocop/
+
 === Vim and Neovim (coc.nvim)
 
 https://github.com/neoclide/coc.nvim[coc.nvim] is an extension host for Vim and Neovim, powered by Node.js.


### PR DESCRIPTION
Follow up https://github.com/emacs-lsp/lsp-mode/pull/4090.

Emacs LSP Mode supports the built-in language server. So, This PR adds Emacs LSP Mode to the LSP doc.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
