### PR TITLE
[Fix #12162] Fix an error for `Bundler/DuplicatedGroup`

### DIFF
--- a/changelog/fix_an_error_for_bundler_duplicated_group.md
+++ b/changelog/fix_an_error_for_bundler_duplicated_group.md
@@ -1,0 +1,1 @@
+* [#12162](https://github.com/rubocop/rubocop/issues/12162): Fix an error for `Bundler/DuplicatedGroup` when there's a duplicate set of groups and the `group` value contains a splat. ([@koic][])

--- a/lib/rubocop/cop/bundler/duplicated_group.rb
+++ b/lib/rubocop/cop/bundler/duplicated_group.rb
@@ -117,7 +117,7 @@ module RuboCop
             if argument.hash_type?
               argument.pairs.map(&:source).sort.join(', ')
             else
-              argument.value.to_s
+              argument.respond_to?(:value) ? argument.value.to_s : argument.source
             end
           end
         end

--- a/spec/rubocop/cop/bundler/duplicated_group_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_group_spec.rb
@@ -149,6 +149,21 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGroup, :config do
       end
     end
 
+    context 'and a set of groups is duplicated and `group` value is a splat value' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY, 'Gemfile')
+          group(*LIVE_ENVS) do
+            gem 'admin_ui'
+          end
+
+          group(*LIVE_ENVS) do
+          ^^^^^^^^^^^^^^^^^ Gem group `*LIVE_ENVS` already defined on line 1 of the Gemfile.
+            gem 'public_ui'
+          end
+        RUBY
+      end
+    end
+
     context 'and a set of groups is duplicated but `source` URLs are different' do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY, 'Gemfile')


### PR DESCRIPTION
Fixes #12162.

This PR fixes an error for `Bundler/DuplicatedGroup` when there's a duplicate set of groups and the `group` value contains a splat.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
