### PR TITLE
[Fix #12168]: Fix bug in `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/fix_fix_12168_fix_bug_in_style_arguments_forwarding.md
+++ b/changelog/fix_fix_12168_fix_bug_in_style_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#12168](https://github.com/rubocop/rubocop/issues/12168): Fix bug in `Style/ArgumentsForwarding` when there are repeated send nodes. ([@owst][])

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -441,6 +441,31 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
         end
       RUBY
     end
+
+    it 'registers an offense when args are forwarded at several call sites' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs, &block)
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+          baz(*args, **kwargs, &block)
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+
+          if something?
+            baz(*args, **kwargs, &block)
+                ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(...)
+          baz(...)
+
+          if something?
+            baz(...)
+          end
+        end
+      RUBY
+    end
   end
 
   context 'TargetRubyVersion >= 3.0', :ruby30 do
@@ -504,6 +529,31 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       expect_correction(<<~RUBY)
         def foo(m, ...)
           bar(m, ...)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when args are forwarded at several call sites' do
+      expect_offense(<<~RUBY)
+        def foo(m, *args, **kwargs, &block)
+                   ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+          baz(m, *args, **kwargs, &block)
+                 ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+
+          if something?
+            baz(m, *args, **kwargs, &block)
+                   ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(m, ...)
+          baz(m, ...)
+
+          if something?
+            baz(m, ...)
+          end
         end
       RUBY
     end
@@ -1082,6 +1132,56 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
           bar(*, **, &block)
           bar(*, &block)
           bar(**, &block)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when args are forwarded at several call sites' do
+      expect_offense(<<~RUBY)
+        def foo(bar, *args)
+                     ^^^^^ Use anonymous positional arguments forwarding (`*`).
+          baz(*args)
+              ^^^^^ Use anonymous positional arguments forwarding (`*`).
+
+          if something?
+            baz(*args)
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(bar, *)
+          baz(*)
+
+          if something?
+            baz(*)
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when kwargs are forwarded at several call sites' do
+      expect_offense(<<~RUBY)
+        def foo(bar, **kwargs)
+                     ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
+          baz(**kwargs)
+              ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
+
+          if something?
+            baz(**kwargs)
+                ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(bar, **)
+          baz(**)
+
+          if something?
+            baz(**)
+          end
         end
       RUBY
     end


### PR DESCRIPTION
We were using nodes as Hash keys, which is not supported - the metadata (source location) is not used to distinguish nodes. Thus the two occurrences of the same send (method name and args) were collapsed into one, causing only one of two offense sites to be reported.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
