### PR TITLE
Make `InternalAffairs/RedundantMethodDispatchNode` aware of `method?`

### DIFF
--- a/lib/rubocop/cop/internal_affairs/redundant_method_dispatch_node.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_method_dispatch_node.rb
@@ -14,6 +14,12 @@ module RuboCop
       #   node.method_name
       #
       #   # bad
+      #   node.send_node.method?(:method_name)
+      #
+      #   # good
+      #   node.method?(:method_name)
+      #
+      #   # bad
       #   node.send_node.receiver
       #
       #   # good
@@ -24,11 +30,14 @@ module RuboCop
         extend AutoCorrector
 
         MSG = 'Remove the redundant `send_node`.'
-        RESTRICT_ON_SEND = %i[method_name receiver].freeze
+        RESTRICT_ON_SEND = %i[method_name method? receiver].freeze
 
         # @!method dispatch_method(node)
         def_node_matcher :dispatch_method, <<~PATTERN
-          (send $(send _ :send_node) _)
+          {
+            (send $(send _ :send_node) {:method_name :receiver})
+            (send $(send _ :send_node) :method? _)
+          }
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -54,7 +54,7 @@ module RuboCop
         alias on_defs on_def
 
         def on_block(node)
-          return unless node.send_node.method?(:define_method)
+          return unless node.method?(:define_method)
 
           check_code_length(node)
         end

--- a/lib/rubocop/cop/style/combinable_loops.rb
+++ b/lib/rubocop/cop/style/combinable_loops.rb
@@ -93,8 +93,9 @@ module RuboCop
         end
 
         def same_collection_looping_block?(node, sibling)
-          (sibling&.block_type? || sibling&.numblock_type?) &&
-            sibling.send_node.method?(node.method_name) &&
+          return false if sibling.nil? || (!sibling.block_type? && !sibling.numblock_type?)
+
+          sibling.method?(node.method_name) &&
             sibling.receiver == node.receiver &&
             sibling.send_node.arguments == node.send_node.arguments
         end

--- a/lib/rubocop/cop/style/for.rb
+++ b/lib/rubocop/cop/style/for.rb
@@ -80,7 +80,7 @@ module RuboCop
         private
 
         def suspect_enumerable?(node)
-          node.multiline? && node.send_node.method?(:each) && !node.send_node.arguments?
+          node.multiline? && node.method?(:each) && !node.send_node.arguments?
         end
       end
     end

--- a/spec/rubocop/cop/internal_affairs/redundant_method_dispatch_node_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_method_dispatch_node_spec.rb
@@ -12,6 +12,28 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantMethodDispatchNode, :conf
     RUBY
   end
 
+  it 'registers an offense when using `node.send_node.method?(:method_name)`' do
+    expect_offense(<<~RUBY)
+      node.send_node.method?(:method_name)
+          ^^^^^^^^^^ Remove the redundant `send_node`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node.method?(:method_name)
+    RUBY
+  end
+
+  it 'registers an offense when using `node.send_node.method?(node.method_name)`' do
+    expect_offense(<<~RUBY)
+      node.send_node.method?(node.method_name)
+          ^^^^^^^^^^ Remove the redundant `send_node`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node.method?(node.method_name)
+    RUBY
+  end
+
   it 'does not register an offense when using `node.method_name`' do
     expect_no_offenses(<<~RUBY)
       node.method_name


### PR DESCRIPTION
This PR makes `InternalAffairs/RedundantMethodDispatchNode` aware of `method?`:

```ruby
# bad
node.send_node.method?(:method_name)

# good
node.method?(:method_name)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
