### PR TITLE
[Fix #12171] Fix a false positive for `Style/ArrayIntersect`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_array_intersect.md
+++ b/changelog/fix_a_false_positive_for_style_array_intersect.md
@@ -1,0 +1,1 @@
+* [#12171](https://github.com/rubocop/rubocop/issues/12171): Fix a false positive for `Style/ArrayIntersect` when using block argument for `Enumerable#any?`. ([@koic][])

--- a/spec/rubocop/cop/style/array_intersect_spec.rb
+++ b/spec/rubocop/cop/style/array_intersect_spec.rb
@@ -32,6 +32,24 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
       RUBY
     end
 
+    it 'does not register an offense when using `(array1 & array2).any?` with block' do
+      expect_no_offenses(<<~RUBY)
+        (array1 & array2).any? { |x| false }
+      RUBY
+    end
+
+    it 'does not register an offense when using `(array1 & array2).any?` with symbol block' do
+      expect_no_offenses(<<~RUBY)
+        (array1 & array2).any?(&:block)
+      RUBY
+    end
+
+    it 'does not register an offense when using `(array1 & array2).any?` with numbered block' do
+      expect_no_offenses(<<~RUBY)
+        (array1 & array2).any? { do_something(_1) }
+      RUBY
+    end
+
     it 'does not register an offense when using `([1, 2, 3] & [4, 5, 6]).present?`' do
       expect_no_offenses(<<~RUBY)
         ([1, 2, 3] & [4, 5, 6]).present?


### PR DESCRIPTION
Fixes #12171.

This PR fixes a false positive for `Style/ArrayIntersect` when using block argument for `Enumerable#any?`.

Note: This cop is already marked as unsafe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
