### PR TITLE
[Fix #12172] Fix a false positive for `Style/EmptyCaseCondition`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_empty_case_condition.md
+++ b/changelog/fix_a_false_positive_for_style_empty_case_condition.md
@@ -1,0 +1,1 @@
+* [#12172](https://github.com/rubocop/rubocop/issues/12172): Fix a false positive for `Style/EmptyCaseCondition` when using `return`, `break`, `next` or method call before empty case condition. ([@koic][])

--- a/lib/rubocop/cop/style/empty_case_condition.rb
+++ b/lib/rubocop/cop/style/empty_case_condition.rb
@@ -40,9 +40,13 @@ module RuboCop
         extend AutoCorrector
 
         MSG = 'Do not use empty `case` condition, instead use an `if` expression.'
+        NOT_SUPPORTED_PARENT_TYPES = %i[return break next send csend].freeze
 
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_case(case_node)
-          return if case_node.condition
+          if case_node.condition || NOT_SUPPORTED_PARENT_TYPES.include?(case_node.parent&.type)
+            return
+          end
 
           branch_bodies = [*case_node.when_branches.map(&:body), case_node.else_branch].compact
 
@@ -52,6 +56,7 @@ module RuboCop
 
           add_offense(case_node.loc.keyword) { |corrector| autocorrect(corrector, case_node) }
         end
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         private
 

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -240,22 +240,22 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition, :config do
     context 'when used as an argument of a method without comment' do
       let(:source) do
         <<~RUBY
-          do_some_work case
-                       ^^^^ Do not use empty `case` condition, instead use an `if` expression.
-                       when object.nil?
-                         Object.new
-                       else
-                         object
-                       end
+          case
+          ^^^^ Do not use empty `case` condition, instead use an `if` expression.
+          when object.nil?
+            Object.new
+          else
+            object
+          end
         RUBY
       end
       let(:corrected_source) do
         <<~RUBY
-          do_some_work if object.nil?
-                         Object.new
-                       else
-                         object
-                       end
+          if object.nil?
+            Object.new
+          else
+            object
+          end
         RUBY
       end
 
@@ -266,67 +266,23 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition, :config do
       let(:source) do
         <<~RUBY
           # example.rb
-          do_some_work case
-                       ^^^^ Do not use empty `case` condition, instead use an `if` expression.
-                       when object.nil?
-                         Object.new
-                       else
-                         object
-                       end
+          case
+          ^^^^ Do not use empty `case` condition, instead use an `if` expression.
+          when object.nil?
+            Object.new
+          else
+            object
+          end
         RUBY
       end
       let(:corrected_source) do
         <<~RUBY
           # example.rb
-          do_some_work if object.nil?
-                         Object.new
-                       else
-                         object
-                       end
-        RUBY
-      end
-
-      it_behaves_like 'detect/correct empty case, accept non-empty case'
-    end
-
-    context 'when using `when ... then` in `case` in `return`' do
-      let(:source) do
-        <<~RUBY
-          return case
-                 ^^^^ Do not use empty `case` condition, instead use an `if` expression.
-                 when object.nil? then Object.new
-                 else object
-                 end
-        RUBY
-      end
-      let(:corrected_source) do
-        <<~RUBY
-          return if object.nil?
-           Object.new
-                 else object
-                 end
-        RUBY
-      end
-
-      it_behaves_like 'detect/correct empty case, accept non-empty case'
-    end
-
-    context 'when using `when ... then` in `case` in a method call' do
-      let(:source) do
-        <<~RUBY
-          do_some_work case
-                       ^^^^ Do not use empty `case` condition, instead use an `if` expression.
-                       when object.nil? then Object.new
-                       else object
-                       end
-        RUBY
-      end
-      let(:corrected_source) do
-        <<~RUBY
-          do_some_work if object.nil?
-           Object.new
-                       else object
-                       end
+          if object.nil?
+            Object.new
+          else
+            object
+          end
         RUBY
       end
 
@@ -383,6 +339,71 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition, :config do
               else
                 return 2 if foo
               end
+        RUBY
+      end
+    end
+
+    context 'when using `return` before empty case condition' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          return case
+                 when foo
+                   1
+                 else
+                   2
+                 end
+        RUBY
+      end
+    end
+
+    context 'when using `break` before empty case condition' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          break case
+                when foo
+                  1
+                else
+                  2
+                end
+        RUBY
+      end
+    end
+
+    context 'when using `next` before empty case condition' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          next case
+               when foo
+                 1
+               else
+                 2
+               end
+        RUBY
+      end
+    end
+
+    context 'when using method call before empty case condition' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          do_something case
+                       when foo
+                         1
+                       else
+                         2
+                       end
+        RUBY
+      end
+    end
+
+    context 'when using safe navigation method call before empty case condition' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          obj&.do_something case
+                            when foo
+                              1
+                            else
+                              2
+                            end
         RUBY
       end
     end


### PR DESCRIPTION
Fixes #12172.

This PR fixes a false positive for `Style/EmptyCaseCondition` when using `return`, `break`, `next` or method call before empty case condition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
