### PR TITLE
Add support for `Style/RedundantConditional` when redundant returning of true/false only if/unless block

### DIFF
--- a/changelog/change_add_support_for_style_redundant_conditional.md
+++ b/changelog/change_add_support_for_style_redundant_conditional.md
@@ -1,0 +1,1 @@
+* [#12176](https://github.com/rubocop/rubocop/pull/12176): Add support for `Style/RedundantConditional` when redundant returning of true/false only if/unless block. ([@ydah][])

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -354,7 +354,7 @@ module RuboCop
           # Don't check indentation if the line doesn't start with the body.
           # For example, lines like "else do_something".
           first_char_pos_on_line = body_node.source_range.source_line =~ /\S/
-          true unless body_node.loc.column == first_char_pos_on_line
+          body_node.loc.column != first_char_pos_on_line
         end
 
         def offending_range(body_node, indentation)

--- a/lib/rubocop/cop/layout/space_inside_parens.rb
+++ b/lib/rubocop/cop/layout/space_inside_parens.rb
@@ -168,7 +168,7 @@ module RuboCop
           # follows, and that the rules for space inside don't apply.
           return true if token2.comment?
 
-          true unless same_line?(token1, token2) && !token1.space_after?
+          !(same_line?(token1, token2) && !token1.space_after?)
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_conditional_spec.rb
+++ b/spec/rubocop/cop/style/redundant_conditional_spec.rb
@@ -57,6 +57,36 @@ RSpec.describe RuboCop::Cop::Style::RedundantConditional, :config do
     RUBY
   end
 
+  it 'registers an offense for unless/else with boolean results' do
+    expect_offense(<<~RUBY)
+      unless x == y
+      ^^^^^^^^^^^^^ This conditional expression can just be replaced by `!(x == y)`.
+        true
+      else
+        false
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !(x == y)
+    RUBY
+  end
+
+  it 'registers an offense for unless/else with negated boolean results' do
+    expect_offense(<<~RUBY)
+      unless x == y
+      ^^^^^^^^^^^^^ This conditional expression can just be replaced by `x == y`.
+        false
+      else
+        true
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x == y
+    RUBY
+  end
+
   it 'registers an offense for if/elsif/else with boolean results' do
     expect_offense(<<~RUBY)
       if cond
@@ -118,6 +148,102 @@ RSpec.describe RuboCop::Cop::Style::RedundantConditional, :config do
       else
         3
       end
+    RUBY
+  end
+
+  it 'registers an offense for if with true results' do
+    expect_offense(<<~RUBY)
+      true if x == y
+      ^^^^^^^^^^^^^^ This conditional expression can just be replaced by `x == y`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x == y
+    RUBY
+  end
+
+  it 'registers an offense for if with false results' do
+    expect_offense(<<~RUBY)
+      false if x == y
+      ^^^^^^^^^^^^^^^ This conditional expression can just be replaced by `!(x == y)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !(x == y)
+    RUBY
+  end
+
+  it 'registers an offense for unless with true results' do
+    expect_offense(<<~RUBY)
+      true unless x == y
+      ^^^^^^^^^^^^^^^^^^ This conditional expression can just be replaced by `!(x == y)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !(x == y)
+    RUBY
+  end
+
+  it 'registers an offense for unless with false results' do
+    expect_offense(<<~RUBY)
+      false unless x == y
+      ^^^^^^^^^^^^^^^^^^^ This conditional expression can just be replaced by `x == y`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x == y
+    RUBY
+  end
+
+  it 'registers an offense for if block with true results' do
+    expect_offense(<<~RUBY)
+      if x == y
+      ^^^^^^^^^ This conditional expression can just be replaced by `x == y`.
+        true
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x == y
+    RUBY
+  end
+
+  it 'registers an offense for if block with false results' do
+    expect_offense(<<~RUBY)
+      if x == y
+      ^^^^^^^^^ This conditional expression can just be replaced by `!(x == y)`.
+        false
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !(x == y)
+    RUBY
+  end
+
+  it 'registers an offense for unless block with true results' do
+    expect_offense(<<~RUBY)
+      unless x == y
+      ^^^^^^^^^^^^^ This conditional expression can just be replaced by `!(x == y)`.
+        true
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !(x == y)
+    RUBY
+  end
+
+  it 'registers an offense for unless block with false results' do
+    expect_offense(<<~RUBY)
+      unless x == y
+      ^^^^^^^^^^^^^ This conditional expression can just be replaced by `x == y`.
+        false
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x == y
     RUBY
   end
 end


### PR DESCRIPTION
Although detected  https://github.com/rubocop/rubocop-rspec/pull/1692#discussion_r1288432020 , the following cases could also be supported. WDYT?

```ruby
# bad
true if x == y

# bad
if x == y
  true
end
```


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
