### PR TITLE
Fix an incorrect autocorrect for `Style/RedundantException` when message is not string

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_exception.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_exception.md
@@ -1,0 +1,1 @@
+* [#12177](https://github.com/rubocop/rubocop/pull/12177): Fix an incorrect autocorrect for `Style/RedundantException`. ([@ydah][])

--- a/spec/rubocop/cop/style/redundant_exception_spec.rb
+++ b/spec/rubocop/cop/style/redundant_exception_spec.rb
@@ -4,54 +4,54 @@ RSpec.describe RuboCop::Cop::Style::RedundantException, :config do
   shared_examples 'common behavior' do |keyword, runtime_error|
     it "reports an offense for a #{keyword} with #{runtime_error}" do
       expect_offense(<<~RUBY, keyword: keyword, runtime_error: runtime_error)
-        %{keyword} %{runtime_error}, msg
-        ^{keyword}^^{runtime_error}^^^^^ Redundant `RuntimeError` argument can be removed.
+        %{keyword} %{runtime_error}, "message"
+        ^{keyword}^^{runtime_error}^^^^^^^^^^^ Redundant `RuntimeError` argument can be removed.
       RUBY
 
       expect_correction(<<~RUBY)
-        #{keyword} msg
+        #{keyword} "message"
       RUBY
     end
 
     it "reports an offense for a #{keyword} with #{runtime_error} and ()" do
       expect_offense(<<~RUBY, keyword: keyword, runtime_error: runtime_error)
-        %{keyword}(%{runtime_error}, msg)
-        ^{keyword}^^{runtime_error}^^^^^^ Redundant `RuntimeError` argument can be removed.
+        %{keyword}(%{runtime_error}, "message")
+        ^{keyword}^^{runtime_error}^^^^^^^^^^^^ Redundant `RuntimeError` argument can be removed.
       RUBY
 
       expect_correction(<<~RUBY)
-        #{keyword}(msg)
+        #{keyword}("message")
       RUBY
     end
 
     it "reports an offense for a #{keyword} with #{runtime_error}.new" do
       expect_offense(<<~RUBY, keyword: keyword, runtime_error: runtime_error)
-        %{keyword} %{runtime_error}.new msg
-        ^{keyword}^^{runtime_error}^^^^^^^^ Redundant `RuntimeError.new` call can be replaced with just the message.
+        %{keyword} %{runtime_error}.new "message"
+        ^{keyword}^^{runtime_error}^^^^^^^^^^^^^^ Redundant `RuntimeError.new` call can be replaced with just the message.
       RUBY
 
       expect_correction(<<~RUBY)
-        #{keyword} msg
+        #{keyword} "message"
       RUBY
     end
 
     it "reports an offense for a #{keyword} with #{runtime_error}.new" do
       expect_offense(<<~RUBY, keyword: keyword, runtime_error: runtime_error)
-        %{keyword} %{runtime_error}.new(msg)
-        ^{keyword}^^{runtime_error}^^^^^^^^^ Redundant `RuntimeError.new` call can be replaced with just the message.
+        %{keyword} %{runtime_error}.new("message")
+        ^{keyword}^^{runtime_error}^^^^^^^^^^^^^^^ Redundant `RuntimeError.new` call can be replaced with just the message.
       RUBY
 
       expect_correction(<<~RUBY)
-        #{keyword} msg
+        #{keyword} "message"
       RUBY
     end
 
     it "accepts a #{keyword} with #{runtime_error} if it does not have 2 args" do
-      expect_no_offenses("#{keyword} #{runtime_error}, msg, caller")
+      expect_no_offenses("#{keyword} #{runtime_error}, 'message', caller")
     end
 
     it 'accepts rescue w/ non redundant error' do
-      expect_no_offenses "#{keyword} OtherError, msg"
+      expect_no_offenses "#{keyword} OtherError, 'message'"
     end
   end
 
@@ -59,4 +59,70 @@ RSpec.describe RuboCop::Cop::Style::RedundantException, :config do
   include_examples 'common behavior', 'raise', '::RuntimeError'
   include_examples 'common behavior', 'fail', 'RuntimeError'
   include_examples 'common behavior', 'fail', '::RuntimeError'
+
+  it 'registers an offense for raise with RuntimeError, "#{message}"' do
+    expect_offense(<<~'RUBY')
+      raise RuntimeError, "#{message}"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant `RuntimeError` argument can be removed.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      raise "#{message}"
+    RUBY
+  end
+
+  it 'registers an offense for raise with RuntimeError, `command`' do
+    expect_offense(<<~RUBY)
+      raise RuntimeError, `command`
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant `RuntimeError` argument can be removed.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      raise `command`
+    RUBY
+  end
+
+  it 'registers an offense for raise with RuntimeError, Object.new' do
+    expect_offense(<<~RUBY)
+      raise RuntimeError, Object.new
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant `RuntimeError` argument can be removed.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      raise Object.new.to_s
+    RUBY
+  end
+
+  it 'registers an offense for raise with RuntimeError.new, Object.new and parans' do
+    expect_offense(<<~RUBY)
+      raise RuntimeError.new(Object.new)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant `RuntimeError.new` call can be replaced with just the message.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      raise Object.new.to_s
+    RUBY
+  end
+
+  it 'registers an offense for raise with RuntimeError.new, Object.new no parens' do
+    expect_offense(<<~RUBY)
+      raise RuntimeError.new Object.new
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant `RuntimeError.new` call can be replaced with just the message.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      raise Object.new.to_s
+    RUBY
+  end
+
+  it 'registers an offense for raise with RuntimeError, valiable' do
+    expect_offense(<<~RUBY)
+      raise RuntimeError, valiable
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant `RuntimeError` argument can be removed.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      raise valiable.to_s
+    RUBY
+  end
 end


### PR DESCRIPTION
The following autocorrection is performed, but when the message is not a string, the behavior changes after the autocorrection.

```ruby
# before
raise RuntimeError, Object.new
# => #<RuntimeError: #<Object:0x000000010f369da8>>

# offense
# spec/spec_helper.rb:3:1: C: [Correctable] Style/RedundantException: Redundant RuntimeError argument can be removed.
# raise RuntimeError, Object.new
# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

# after
raise Object.new
# => #<TypeError: exception class/object expected>
```

Therefore, this PR fixes so that the behavior does not change.

```ruby
irb(main):001:0> e = raise Object.new rescue $!
=> #<TypeError: exception class/object expected>
irb(main):002:0> e = raise RuntimeError, Object.new rescue $!
=> #<RuntimeError: #<Object:0x000000010f369da8>>
irb(main):003:0> e = raise Object.new.to_s rescue $!
=> #<RuntimeError: #<Object:0x000000010f3402a0>>
irb(main):004:0> e = raise RuntimeError.new(Object.new) rescue $!
=> #<RuntimeError: #<Object:0x00000001049d3e88>>
irb(main):005:0> e = raise RuntimeError.new Object.new  rescue $!
=> #<RuntimeError: #<Object:0x00000001079dadc0>>
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
