### PR TITLE
Replace regex with `Bundler::LockfileParser`

### DIFF
--- a/changelog/change_replace_regex_with_BundlerLockfileParser.md
+++ b/changelog/change_replace_regex_with_BundlerLockfileParser.md
@@ -1,0 +1,1 @@
+* [#12180](https://github.com/rubocop/rubocop/pull/12180): Replace regex with `Bundler::LockfileParser`. ([@amomchilov][])


### PR DESCRIPTION
Depends on #12186, see the difference: https://github.com/amomchilov/rubocop/compare/add-requires_gem-api...parse-lockfile-with-bundler

Now that we have a Hash of all of the target's gems, we can just use that `target_rails_version_from_bundler_lock_file`, and remove the manual regex parsing.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] ~Added tests.~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
