### PR TITLE
Fix an incorrect autocorrect for `Style/MultilineTernaryOperator`

### DIFF
--- a/changelog/fix_an_incorrrect_autocorrect_for_style_multiline_ternary_operator.md
+++ b/changelog/fix_an_incorrrect_autocorrect_for_style_multiline_ternary_operator.md
@@ -1,0 +1,1 @@
+* [#12183](https://github.com/rubocop/rubocop/pull/12183): Fix an incorrect autocorrect for `Style/MultilineTernaryOperator` when returning a multiline ternary operator expression with safe navigation method call. ([@koic][])

--- a/lib/rubocop/cop/style/multiline_ternary_operator.rb
+++ b/lib/rubocop/cop/style/multiline_ternary_operator.rb
@@ -39,7 +39,7 @@ module RuboCop
 
         MSG_IF = 'Avoid multi-line ternary operators, use `if` or `unless` instead.'
         MSG_SINGLE_LINE = 'Avoid multi-line ternary operators, use single-line instead.'
-        SINGLE_LINE_TYPES = %i[return break next send].freeze
+        SINGLE_LINE_TYPES = %i[return break next send csend].freeze
 
         def on_if(node)
           return unless offense?(node)

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -176,6 +176,19 @@ RSpec.describe RuboCop::Cop::Style::MultilineTernaryOperator, :config do
     RUBY
   end
 
+  it 'register an offense and corrects when returning a multiline ternary operator expression with safe navigation method call' do
+    expect_offense(<<~RUBY)
+      obj&.do_something cond ?
+                        ^^^^^^ Avoid multi-line ternary operators, use single-line instead.
+                        foo :
+                        bar
+    RUBY
+
+    expect_correction(<<~RUBY)
+      obj&.do_something cond ? foo : bar
+    RUBY
+  end
+
   it 'accepts a single line ternary operator expression' do
     expect_no_offenses('a = cond ? b : c')
   end


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Style/MultilineTernaryOperator` when returning a multiline ternary operator expression with safe navigation method call:

```ruby
$ cat example.rb
obj&.x foo ?
       bar :
       baz
```

## Before

It is autocorrected to invalid syntax as follows:

```console
$ bundle exec rubocop --only Style/MultilineTernaryOperator -a
Inspecting 1 file
F

Offenses:

example.rb:1:8: C: [Corrected] Style/MultilineTernaryOperator: Avoid multi-line ternary operators, use if or unless instead.
obj&.x foo ? ...
       ^^^^^
example.rb:3:1: F: Lint/Syntax: unexpected token kELSE
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
else
^^^^

1 file inspected, 2 offenses detected, 1 offense corrected

$ cat example.rb
obj&.x if foo
  bar
else
  baz
end

$ ruby -c example.rb
example.rb: example.rb:3: syntax error, unexpected `else' (SyntaxError)
```

## After

It will be autocorrected to a valid syntax as shown below:

```console
$ bundle exec rubocop --only Style/MultilineTernaryOperator -a
Inspecting 1 file
C

Offenses:

example.rb:1:8: C: [Corrected] Style/MultilineTernaryOperator: Avoid multi-line ternary operators, use single-line instead.
obj&.x foo ? ...
       ^^^^^

1 file inspected, 1 offense detected, 1 offense corrected

$ cat example.rb
obj&.x foo ? bar : baz
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
