### PR TITLE
[Fix #12182] Fix an error for `Lint/UselessAssignment`

### DIFF
--- a/changelog/fix_an_error_for_lint_useless_assignment.md
+++ b/changelog/fix_an_error_for_lint_useless_assignment.md
@@ -1,0 +1,1 @@
+* [#12182](https://github.com/rubocop/rubocop/issues/12182): Fix an error for `Lint/UselessAssignment` when variables are assigned using chained assignment and remain unreferenced. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_assignment.rb
+++ b/lib/rubocop/cop/lint/useless_assignment.rb
@@ -51,11 +51,12 @@ module RuboCop
           scope.variables.each_value { |variable| check_for_unused_assignments(variable) }
         end
 
+        # rubocop:disable Metrics/AbcSize
         def check_for_unused_assignments(variable)
           return if variable.should_be_unused?
 
           variable.assignments.each do |assignment|
-            next if assignment.used?
+            next if assignment.used? || part_of_ignored_node?(assignment.node)
 
             message = message_for_useless_assignment(assignment)
 
@@ -68,8 +69,11 @@ module RuboCop
             add_offense(location, message: message) do |corrector|
               autocorrect(corrector, assignment)
             end
+
+            ignore_node(assignment.node)
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         def message_for_useless_assignment(assignment)
           variable = assignment.variable

--- a/spec/fixtures/html_formatter/expected.html
+++ b/spec/fixtures/html_formatter/expected.html
@@ -367,7 +367,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
       <div class="infobox">
         <div class="total">
           3 files inspected,
-          23 offenses detected:
+          22 offenses detected:
         </div>
         <ul class="offenses-list">
           
@@ -388,7 +388,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
             
             <li>
               <a href="#offense_app/models/book.rb">
-                app/models/book.rb - 7 offenses
+                app/models/book.rb - 6 offenses
               </a>
             </li>
           
@@ -596,7 +596,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
       
       <div class="offense-box" id="offense_app/models/book.rb">
         <div class="box-title-placeholder"><h3>&nbsp;</h3></div>
-        <div class="box-title"><h3>app/models/book.rb - 7 offenses</h3></div>
+        <div class="box-title"><h3>app/models/book.rb - 6 offenses</h3></div>
         <div class="offense-reports">
           
           <div class="report">
@@ -640,17 +640,6 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
             </div>
             
             <pre><code>    <span class="highlight warning">foo</span> = bar = baz</code></pre>
-            
-          </div>
-          
-          <div class="report">
-            <div class="meta">
-              <span class="location">Line #3</span> –
-              <span class="severity warning">warning:</span>
-              <span class="message">Lint/UselessAssignment: Useless assignment to variable - <code>bar</code>. Did you mean <code>baz</code>?</span>
-            </div>
-            
-            <pre><code>    foo = <span class="highlight warning">bar</span> = baz</code></pre>
             
           </div>
           

--- a/spec/fixtures/markdown_formatter/expected.md
+++ b/spec/fixtures/markdown_formatter/expected.md
@@ -1,6 +1,6 @@
 # RuboCop Inspection Report
 
-4 files inspected, 23 offenses detected:
+4 files inspected, 22 offenses detected:
 
 ### app/controllers/application_controller.rb - (2 offenses)
   * **Line # 1 - convention:** Style/Documentation: Missing top-level documentation comment for `class ApplicationController`.
@@ -100,7 +100,7 @@
         def book_params ...
     ```
 
-### app/models/book.rb - (7 offenses)
+### app/models/book.rb - (6 offenses)
   * **Line # 1 - convention:** Style/Documentation: Missing top-level documentation comment for `class Book`.
 
     ```rb
@@ -120,12 +120,6 @@
     ```
 
   * **Line # 3 - warning:** Lint/UselessAssignment: Useless assignment to variable - `foo`.
-
-    ```rb
-        foo = bar = baz
-    ```
-
-  * **Line # 3 - warning:** Lint/UselessAssignment: Useless assignment to variable - `bar`. Did you mean `baz`?
 
     ```rb
         foo = bar = baz

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1198,6 +1198,23 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when variables are assigned using chained assignment and remain unreferenced' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        def some_method
+          foo = bar = do_something
+          ^^^ Useless assignment to variable - `foo`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          bar = do_something
+        end
+      RUBY
+    end
+  end
+
   context 'when a variable is reassigned with multiple assignment ' \
           'while referencing itself in rhs and referenced' do
     it 'accepts' do


### PR DESCRIPTION
Fixes #12182.

This PR fixes an error for `Lint/UselessAssignment` when variables are assigned with chained assignment and unreferenced.

As we added to spec/rubocop/cli/autocorrect_spec.rb, detection and autocorrection will eventually be possible as before.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
