### PR TITLE
Set target version for Layout/HeredocIndentation

### DIFF
--- a/changelog/fix_set_target_version_for_layout_heredoc_indentation.md
+++ b/changelog/fix_set_target_version_for_layout_heredoc_indentation.md
@@ -1,0 +1,1 @@
+* [#12185](https://github.com/rubocop/rubocop/pull/12185): Set target version for `Layout/HeredocIndentation`. ([@tagliala][])

--- a/lib/rubocop/cop/layout/heredoc_indentation.rb
+++ b/lib/rubocop/cop/layout/heredoc_indentation.rb
@@ -25,6 +25,9 @@ module RuboCop
         include Alignment
         include Heredoc
         extend AutoCorrector
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.3
 
         TYPE_MSG = 'Use %<indentation_width>d spaces for indentation in a ' \
                    'heredoc by using `<<~` instead of `%<current_indent_type>s`.'

--- a/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
@@ -251,5 +251,17 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
     end
   end
 
-  [nil, "'", '"', '`'].each { |quote| include_examples 'all heredoc type', quote }
+  context 'when Ruby >= 2.3', :ruby23 do
+    [nil, "'", '"', '`'].each { |quote| include_examples 'all heredoc type', quote }
+  end
+
+  context 'when Ruby <= 2.2', :ruby22 do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        <<-RUBY2
+        foo
+        RUBY2
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
The squiggly heredoc syntax was introduced in Ruby 2.3. Therefore, this
linter should not flag any offenses for Ruby < 2.3 code.

Additionally, this linter is considered to be safe for autocorrection,
meaning that it is likely to break compatibility with older Ruby
versions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
