### PR TITLE
[Fix #12187] Fix an incorrect autocorrect for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_sole_nested_conditional.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#12187](https://github.com/rubocop/rubocop/issues/12187): Fix an incorrect autocorrect for `Style/SoleNestedConditional` when comment is in an empty nested `if` body. ([@ymap][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -173,7 +173,9 @@ module RuboCop
         end
 
         def correct_for_comment(corrector, node, if_branch)
-          comments = processed_source.ast_with_comments[if_branch]
+          comments = processed_source.ast_with_comments[if_branch].select do |comment|
+            comment.loc.line < if_branch.condition.first_line
+          end
           comment_text = comments.map(&:text).join("\n") << "\n"
 
           corrector.insert_before(node.loc.keyword, comment_text) unless comments.empty?

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -483,6 +483,23 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when comment is in an empty nested `if` body' do
+    expect_offense(<<~RUBY)
+      if foo
+        if bar
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          # Comments.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo && bar
+          # Comments.
+        end
+    RUBY
+  end
+
   it 'registers an offense and corrects when `if` foo do_something end `if` bar' do
     expect_offense(<<~RUBY)
       if foo


### PR DESCRIPTION
Fixes #12187.

This PR fixes an incorrect autocorrect for `Style/SoleNestedConditional` when comment is in an empty nested `if` body.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
