### PR TITLE
[Fix #12190] Fix a false positive for `Layout/SpaceAroundOperators`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_space_around_operators.md
+++ b/changelog/fix_a_false_positive_for_layout_space_around_operators.md
@@ -1,0 +1,1 @@
+* [#12190](https://github.com/rubocop/rubocop/issues/12190): Fix a false positive for `Layout/SpaceAroundOperators` when aligning operators vertically. ([@koic][])

--- a/lib/rubocop/cop/mixin/preceding_following_alignment.rb
+++ b/lib/rubocop/cop/mixin/preceding_following_alignment.rb
@@ -75,7 +75,7 @@ module RuboCop
       end
 
       def aligned_token?(range, line)
-        aligned_words?(range, line) || aligned_dot?(range, line) || aligned_assignment?(range, line)
+        aligned_words?(range, line) || aligned_assignment?(range, line)
       end
 
       def aligned_operator?(range, line)
@@ -83,13 +83,11 @@ module RuboCop
       end
 
       def aligned_words?(range, line)
-        /\s\S/.match?(line[range.column - 1, 2])
-      end
+        left_edge = range.column
+        return true if /\s\S/.match?(line[left_edge - 1, 2])
 
-      def aligned_dot?(range, line)
-        char = line[range.column]
-
-        char == '.' && char == range.source[0]
+        token = range.source
+        token == line[left_edge, token.length]
       end
 
       def aligned_assignment?(range, line)

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -160,6 +160,13 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
     RUBY
   end
 
+  it 'accepts vertical alignment with operator' do
+    expect_no_offenses(<<~RUBY)
+      down? && !migrated.include?(migration.version.to_i)
+      up?   &&  migrated.include?(migration.version.to_i)
+    RUBY
+  end
+
   it 'accepts an operator called with method syntax' do
     expect_no_offenses('Date.today.+(1).to_s')
   end


### PR DESCRIPTION
Fixes #12190.

This PR fixes a false positive for `Layout/SpaceAroundOperators` when aligning operators vertically.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
