### PR TITLE
[Fix #12192] Fix a false positive for `Layout/RedundantLineBreak`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_redundant_line_break.md
+++ b/changelog/fix_a_false_positive_for_layout_redundant_line_break.md
@@ -1,0 +1,1 @@
+* [#12192](https://github.com/rubocop/rubocop/issues/12192): Fix a false positive for `Layout/RedundantLineBreak` when using quoted symbols with a single newline. ([@ymap][])

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -108,7 +108,7 @@ module RuboCop
           !comment_within?(node) &&
             node.each_descendant(:if, :case, :kwbegin, :def, :defs).none? &&
             node.each_descendant(:dstr, :str).none? { |n| n.heredoc? || n.value.include?("\n") } &&
-            node.each_descendant(:begin).none? { |b| !b.single_line? }
+            node.each_descendant(:begin, :sym).none? { |b| !b.single_line? }
         end
 
         def convertible_block?(node)

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -382,6 +382,13 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
         RUBY
       end
 
+      it 'accepts a quoted symbol with a single newline' do
+        expect_no_offenses(<<~RUBY)
+          foo(:"
+          ")
+        RUBY
+      end
+
       context 'with a longer max line length' do
         let(:max_line_length) { 82 }
 


### PR DESCRIPTION
Fixes #12192.

This PR fixes a false positive for `Layout/RedundantLineBreak` when using quoted symbols with a single newline.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
