### PR TITLE
[Fix #12195] Fix a false negative for `Layout/SpaceAfterNot`

### DIFF
--- a/changelog/fix_a_false_negative_for_layout_space_after_not.md
+++ b/changelog/fix_a_false_negative_for_layout_space_after_not.md
@@ -1,0 +1,1 @@
+* [#12195](https://github.com/rubocop/rubocop/issues/12195): Fix a false negative for `Layout/SpaceAfterNot` when a newline is present after `!`. ([@ymap][])

--- a/lib/rubocop/cop/layout/space_after_not.rb
+++ b/lib/rubocop/cop/layout/space_after_not.rb
@@ -31,7 +31,7 @@ module RuboCop
         private
 
         def whitespace_after_operator?(node)
-          node.receiver.loc.column - node.loc.column > 1
+          node.receiver.source_range.begin_pos - node.source_range.begin_pos > 1
         end
       end
     end

--- a/spec/rubocop/cop/layout/space_after_not_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_not_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterNot, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects newline after !' do
+    expect_offense(<<~RUBY)
+      !
+      ^ Do not leave space between `!` and its argument.
+      something
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !something
+    RUBY
+  end
+
   it 'accepts no space after !' do
     expect_no_offenses('!something')
   end


### PR DESCRIPTION
Fixes #12195.

This PR fixes a false negative for `Layout/SpaceAfterNot` when a newline is present after `!`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
