### PR TITLE
Make `Style/CollectionMethods` aware of `collect_concat`

### DIFF
--- a/changelog/change_make_style_collection_methods_aware_of_collect_concat.md
+++ b/changelog/change_make_style_collection_methods_aware_of_collect_concat.md
@@ -1,0 +1,1 @@
+* [#12197](https://github.com/rubocop/rubocop/pull/12197): Make `Style/CollectionMethods` aware of `collect_concat`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3409,6 +3409,7 @@ Style/CollectionMethods:
   PreferredMethods:
     collect: 'map'
     collect!: 'map!'
+    collect_concat: 'flat_map'
     inject: 'reduce'
     detect: 'find'
     find_all: 'select'

--- a/lib/rubocop/cop/style/collection_methods.rb
+++ b/lib/rubocop/cop/style/collection_methods.rb
@@ -25,6 +25,7 @@ module RuboCop
       #   # bad
       #   items.collect
       #   items.collect!
+      #   items.collect_concat
       #   items.inject
       #   items.detect
       #   items.find_all
@@ -33,6 +34,7 @@ module RuboCop
       #   # good
       #   items.map
       #   items.map!
+      #   items.flat_map
       #   items.reduce
       #   items.find
       #   items.select


### PR DESCRIPTION
This PR makes `Style/CollectionMethods` aware of `collect_concat` because matches the existing `map` and `collect` terminology selection.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
