### PR TITLE
[Fix #12199] Fix false negatives for `Layout/MultilineMethodCallIndentation`

### DIFF
--- a/changelog/fix_false_negatives_for_layout_multiline_method_call_indentation.md
+++ b/changelog/fix_false_negatives_for_layout_multiline_method_call_indentation.md
@@ -1,0 +1,1 @@
+* [#12199](https://github.com/rubocop/rubocop/issues/12199): Fix false negatives for `Layout/MultilineMethodCallIndentation` when using safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -75,7 +75,7 @@ module RuboCop
         def right_hand_side(send_node)
           dot = send_node.loc.dot
           selector = send_node.loc.selector
-          if send_node.dot? && selector && same_line?(dot, selector)
+          if (send_node.dot? || send_node.safe_navigation?) && selector && same_line?(dot, selector)
             dot.join(selector)
           elsif selector
             selector
@@ -179,7 +179,7 @@ module RuboCop
         # a.b
         #  .c
         def semantic_alignment_base(node, rhs)
-          return unless rhs.source.start_with?('.')
+          return unless rhs.source.start_with?('.', '&.')
 
           node = semantic_alignment_node(node)
           return unless node&.loc&.selector

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -20,16 +20,17 @@ module RuboCop
         range = offending_range(node, lhs, rhs, style)
         check(range, node, lhs, rhs)
       end
+      alias on_csend on_send
 
       private
 
-      # In a chain of method calls, we regard the top send node as the base
+      # In a chain of method calls, we regard the top call node as the base
       # for indentation of all lines following the first. For example:
       # a.
       #   b c { block }.            <-- b is indented relative to a
       #   d                         <-- d is indented relative to a
       def left_hand_side(lhs)
-        while lhs.parent&.send_type? && lhs.parent.loc.dot && !lhs.parent.assignment_method?
+        while lhs.parent&.call_type? && lhs.parent.loc.dot && !lhs.parent.assignment_method?
           lhs = lhs.parent
         end
         lhs

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -219,6 +219,113 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           .b
       RUBY
     end
+
+    context 'when using safe navigation operator' do
+      it 'registers an offense and corrects no indentation of second line' do
+        expect_offense(<<~RUBY)
+          a&.
+          b
+          ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a&.
+            b
+        RUBY
+      end
+
+      it 'registers an offense and corrects 3 spaces indentation of 2nd line' do
+        expect_offense(<<~RUBY)
+          a&.
+             b
+             ^ Use 2 (not 3) spaces for indenting an expression spanning multiple lines.
+          c&.
+             d
+             ^ Use 2 (not 3) spaces for indenting an expression spanning multiple lines.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a&.
+            b
+          c&.
+            d
+        RUBY
+      end
+
+      it 'registers an offense and corrects extra indentation of third line' do
+        expect_offense(<<~RUBY)
+          a&.
+            b&.
+              c
+              ^ Use 2 (not 4) spaces for indenting an expression spanning multiple lines.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a&.
+            b&.
+            c
+        RUBY
+      end
+
+      it 'registers an offense and corrects the emacs ruby-mode 1.1 ' \
+         'indentation of an expression in an array' do
+        expect_offense(<<~RUBY)
+          [
+           a&.
+           b
+           ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
+          ]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [
+           a&.
+             b
+          ]
+        RUBY
+      end
+
+      it 'registers an offense and corrects extra indentation of 3rd line in typical RSpec code' do
+        expect_offense(<<~RUBY)
+          expect { Foo.new }&.
+            to change { Bar.count }&.
+                from(1)&.to(2)
+                ^^^^ Use 2 (not 6) spaces for indenting an expression spanning multiple lines.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect { Foo.new }&.
+            to change { Bar.count }&.
+            from(1)&.to(2)
+        RUBY
+      end
+
+      it 'registers an offense and corrects proc call without a selector' do
+        expect_offense(<<~RUBY)
+          a
+           &.(args)
+           ^^^ Use 2 (not 1) spaces for indenting an expression spanning multiple lines.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a
+            &.(args)
+        RUBY
+      end
+
+      it 'registers an offense and corrects one space indentation of 2nd line' do
+        expect_offense(<<~RUBY)
+          a
+           &.b
+           ^^^ Use 2 (not 1) spaces for indenting an expression spanning multiple lines.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a
+            &.b
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyle is aligned' do
@@ -252,6 +359,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           authorize scope.includes(:user)
                          .where(name: 'Bob')
                          .order(:name)
+        RUBY
+      end
+
+      it 'accepts methods being aligned with safe navigation method call that is an argument' do
+        expect_no_offenses(<<~RUBY)
+          do_something obj.foo(key: value)
+                          &.bar(arg)
         RUBY
       end
 


### PR DESCRIPTION
Fixes #12199.

This PR fixes false negatives for `Layout/MultilineMethodCallIndentation` when using safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
