### PR TITLE
Fix an incorrect autocorrect for `Style/RedundantConditional` when unless/else with boolean results

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_conditional.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_conditional.md
@@ -1,0 +1,1 @@
+* [#12202](https://github.com/rubocop/rubocop/pull/12202): Fix an incorrect autocorrect for `Style/RedundantConditional` when unless/else with boolean results. ([@ydah][])

--- a/lib/rubocop/cop/style/redundant_conditional.rb
+++ b/lib/rubocop/cop/style/redundant_conditional.rb
@@ -70,17 +70,9 @@ module RuboCop
 
         def replacement_condition(node)
           condition = node.condition.source
-          expression = invert_expression?(node) ? "!(#{condition})" : condition
+          expression = redundant_condition_inverted?(node) ? "!(#{condition})" : condition
 
           node.elsif? ? indented_else_node(expression, node) : expression
-        end
-
-        def invert_expression?(node)
-          (
-            (node.if? || node.elsif? || node.ternary?) && redundant_condition_inverted?(node)
-          ) || (
-            node.unless? && redundant_condition?(node)
-          )
         end
 
         def indented_else_node(expression, node)

--- a/spec/rubocop/cop/style/redundant_conditional_spec.rb
+++ b/spec/rubocop/cop/style/redundant_conditional_spec.rb
@@ -57,6 +57,36 @@ RSpec.describe RuboCop::Cop::Style::RedundantConditional, :config do
     RUBY
   end
 
+  it 'registers an offense for unless/else with boolean results' do
+    expect_offense(<<~RUBY)
+      unless x == y
+      ^^^^^^^^^^^^^ This conditional expression can just be replaced by `!(x == y)`.
+        true
+      else
+        false
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !(x == y)
+    RUBY
+  end
+
+  it 'registers an offense for unless/else with negated boolean results' do
+    expect_offense(<<~RUBY)
+      unless x == y
+      ^^^^^^^^^^^^^ This conditional expression can just be replaced by `x == y`.
+        false
+      else
+        true
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x == y
+    RUBY
+  end
+
   it 'registers an offense for if/elsif/else with boolean results' do
     expect_offense(<<~RUBY)
       if cond


### PR DESCRIPTION
This PR fix an incorrect autocorrect for `Style/RedundantConditional` when unless/else with boolean results.

The following code:
```ruby
unless x == y
  true
else
  false
end
```

Expected autocorrection
```ruby
!(x == y)
```

Actual autocorrection
```ruby
x == y
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
