### PR TITLE
Fix an incorrect autocorrect for `Lint/SafeNavigationChain`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_safe_navigation_chain.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_safe_navigation_chain.md
@@ -1,0 +1,1 @@
+* [#12203](https://github.com/rubocop/rubocop/pull/12203): Fix an incorrect autocorrect for `Lint/SafeNavigationChain` when using safe navigation with comparison operator as an expression of logical operator or comparison operator's operand. ([@koic][])

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -82,15 +82,22 @@ module RuboCop
         def autocorrect(corrector, offense_range:, send_node:)
           corrector.replace(
             offense_range,
-            add_safe_navigation_operator(
-              offense_range: offense_range,
-              send_node: send_node
-            )
+            add_safe_navigation_operator(offense_range: offense_range, send_node: send_node)
           )
+
+          corrector.wrap(send_node, '(', ')') if require_parentheses?(send_node)
         end
 
         def brackets?(send_node)
           send_node.method?(:[]) || send_node.method?(:[]=)
+        end
+
+        def require_parentheses?(send_node)
+          return false unless send_node.comparison_method?
+          return false unless (node = send_node.parent)
+
+          (node.respond_to?(:logical_operator?) && node.logical_operator?) ||
+            (node.respond_to?(:comparison_method?) && node.comparison_method?)
         end
       end
     end

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -156,6 +156,72 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
       RUBY
     end
 
+    it 'registers an offense for safe navigation with a method call as an expression of `&&` operand' do
+      expect_offense(<<~RUBY)
+        do_something && x&.foo.bar
+                              ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something && x&.foo&.bar
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with `>=` operator as an expression of `&&` operand' do
+      expect_offense(<<~RUBY)
+        do_something && x&.foo >= bar
+                              ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something && (x&.foo&. >= bar)
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with `>=` operator as an expression of `||` operand' do
+      expect_offense(<<~RUBY)
+        do_something || x&.foo >= bar
+                              ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something || (x&.foo&. >= bar)
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with `>=` operator as an expression of `and` operand' do
+      expect_offense(<<~RUBY)
+        do_something and x&.foo >= bar
+                               ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something and x&.foo&. >= bar
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with `>=` operator as an expression of `or` operand' do
+      expect_offense(<<~RUBY)
+        do_something or x&.foo >= bar
+                              ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something or x&.foo&. >= bar
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with `>=` operator as an expression of comparison method operand' do
+      expect_offense(<<~RUBY)
+        do_something == x&.foo >= bar
+                              ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something == (x&.foo&. >= bar)
+      RUBY
+    end
+
     it 'registers an offense for safe navigation with + operator' do
       expect_offense(<<~RUBY)
         x&.foo + bar


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Lint/SafeNavigationChain` when using safe navigation with comparison operator as an expression of logical operator or comparison operator's operand:

## Before

The autocorrected code is a syntax error:

```console
$ echo 'do_something && x&.foo >= bar' | be rubocop --stdin example.rb -a
Inspecting 1 file
F

Offenses:

example.rb:1:2: C: [Corrected] Layout/InitialIndentation: Indentation of first line in file detected.
do_something && x&.foo >= bar
^^^^^^^^^^^^
example.rb:1:24: W: [Corrected] Lint/SafeNavigationChain: Do not chain ordinary method call after safe navigation operator.
do_something && x&.foo >= bar
                      ^^^^^^^
example.rb:1:29: F: Lint/Syntax: unexpected token tIDENTIFIER
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
do_something && x&.foo&. >= bar
                            ^^^

1 file inspected, 3 offenses detected, 2 offenses corrected
====================
do_something && x&.foo&. >= bar
```

```console
$ ruby -ce 'do_something && x&.foo&. >= bar'
-e:1: syntax error, unexpected local variable or method, expecting end-of-input
do_something && x&.foo&. >= bar
-e: compile error (SyntaxError)
```

## After

Adding the necessary parentheses will autocorrect the syntax to make it valid:

```console
$ echo 'do_something && x&.foo >= bar' | be rubocop --stdin example.rb -a
Inspecting 1 file
W

Offenses:

example.rb:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
do_something && (x&.foo&.>= bar)
^
example.rb:1:2: C: [Corrected] Layout/InitialIndentation: Indentation of first line in file detected.
do_something && x&.foo >= bar
^^^^^^^^^^^^
example.rb:1:24: W: [Corrected] Lint/SafeNavigationChain: Do not chain ordinary method call after safe navigation operator.
do_something && x&.foo >= bar
                      ^^^^^^^
example.rb:1:26: C: [Corrected] Layout/SpaceAroundMethodCallOperator: Avoid using spaces around a method call operator.
do_something && (x&.foo&. >= bar)
                         ^

1 file inspected, 4 offenses detected, 3 offenses corrected, 1 more offense can be corrected with `rubocop -A`
====================
do_something && (x&.foo&.>= bar)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
