### PR TITLE
Support autocorrect for `InternalAffairs/ExampleDescription`

### DIFF
--- a/spec/rubocop/cop/internal_affairs/example_description_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/example_description_spec.rb
@@ -9,12 +9,24 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
           expect_offense('code')
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        it 'registers an offense' do
+          expect_offense('code')
+        end
+      RUBY
     end
 
     it 'registers an offense when given an improper description for `accepts`' do
       expect_offense(<<~RUBY)
         it 'accepts the case' do
            ^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_offense`.
+          expect_offense('code')
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        it 'registers the case' do
           expect_offense('code')
         end
       RUBY
@@ -38,10 +50,31 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
   end
 
   context 'with `expect_no_offenses`' do
-    it 'registers an offense when given an improper description' do
+    it 'registers an offense when given an improper description for `registers`' do
       expect_offense(<<~RUBY)
         it 'registers an offense' do
            ^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_no_offenses`.
+          expect_no_offenses('code')
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        it 'does not register an offense' do
+          expect_no_offenses('code')
+        end
+      RUBY
+    end
+
+    it 'registers an offense when given an improper description for `handles`' do
+      expect_offense(<<~RUBY)
+        it 'handles the case' do
+           ^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_no_offenses`.
+          expect_no_offenses('code')
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        it 'does not register the case' do
           expect_no_offenses('code')
         end
       RUBY


### PR DESCRIPTION
This PR supports autocorrect for `InternalAffairs/ExampleDescription`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
