### PR TITLE
Fix an incorrect autocorrect for `Style/OperatorMethodCall`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_operator_method_call.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_operator_method_call.md
@@ -1,0 +1,1 @@
+* [#12206](https://github.com/rubocop/rubocop/pull/12206): Fix an incorrect autocorrect for `Style/OperatorMethodCall` when using `foo./bar`. ([@koic][])

--- a/lib/rubocop/cop/style/operator_method_call.rb
+++ b/lib/rubocop/cop/style/operator_method_call.rb
@@ -23,6 +23,7 @@ module RuboCop
         MSG = 'Redundant dot detected.'
         RESTRICT_ON_SEND = %i[| ^ & <=> == === =~ > >= < <= << >> + - * / % ** ~ ! != !~].freeze
 
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
         def on_send(node)
           return unless (dot = node.loc.dot)
           return if node.receiver.const_type? || !node.arguments.one?
@@ -33,8 +34,12 @@ module RuboCop
           add_offense(dot) do |corrector|
             wrap_in_parentheses_if_chained(corrector, node)
             corrector.replace(dot, ' ')
+
+            selector = node.loc.selector
+            corrector.insert_after(selector, ' ') if selector.end_pos == rhs.source_range.begin_pos
           end
         end
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
         private
 

--- a/spec/rubocop/cop/style/operator_method_call_spec.rb
+++ b/spec/rubocop/cop/style/operator_method_call_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe RuboCop::Cop::Style::OperatorMethodCall, :config do
       RUBY
     end
 
+    it "registers an offense when using `foo.#{operator_method}bar`" do
+      expect_offense(<<~RUBY, operator_method: operator_method)
+        foo.#{operator_method}bar
+           ^ Redundant dot detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo #{operator_method} bar
+      RUBY
+    end
+
     it "does not register an offense when using `foo #{operator_method} bar`" do
       expect_no_offenses(<<~RUBY)
         foo #{operator_method} bar


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Style/OperatorMethodCall` when using `foo./bar`:

```console
% echo 'arg./100.0' | bundle exec rubocop --stdin example.rb -a -d
(snip)

F

Offenses:

example.rb:1:4: C: [Corrected] Style/OperatorMethodCall: Redundant dot detected.
arg./100.0
   ^
example.rb:1:5: F: Lint/Syntax: ambiguous first argument; put parentheses or a space even after the operator
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
arg /100.0
    ^

1 file inspected, 2 offenses detected, 1 offense corrected
====================
arg /100.0
```

It solves the above `Lint/Syntax`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
