### PR TITLE
[Fix #12210] Mark `Style/RedundantFilterChain` as unsafe autocorrect

### DIFF
--- a/changelog/change_mark_style_redundant_filter_chain_as_unsafe_autocorrect.md
+++ b/changelog/change_mark_style_redundant_filter_chain_as_unsafe_autocorrect.md
@@ -1,0 +1,1 @@
+* [#12210](https://github.com/rubocop/rubocop/issues/12210): Mark `Style/RedundantFilterChain` as unsafe autocorrect. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4920,7 +4920,9 @@ Style/RedundantFilterChain:
                   Identifies usages of `any?`, `empty?`, `none?` or `one?` predicate methods chained to
                   `select`/`filter`/`find_all` and change them to use predicate method instead.
   Enabled: pending
+  SafeAutoCorrect: false
   VersionAdded: '1.52'
+  VersionChanged: '<<next>>'
 
 Style/RedundantFreeze:
   Description: "Checks usages of Object#freeze on immutable objects."

--- a/lib/rubocop/cop/style/redundant_filter_chain.rb
+++ b/lib/rubocop/cop/style/redundant_filter_chain.rb
@@ -6,6 +6,12 @@ module RuboCop
       # Identifies usages of `any?`, `empty?` or `none?` predicate methods
       # chained to `select`/`filter`/`find_all` and change them to use predicate method instead.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because `array.select.any?` evaluates all elements
+      #   through the `select` method, while `array.any?` uses short-circuit evaluation.
+      #   In other words, `array.select.any?` guarantees the evaluation of every element,
+      #   but `array.any?` does not necessarily evaluate all of them.
+      #
       # @example
       #   # bad
       #   arr.select { |x| x > 1 }.any?


### PR DESCRIPTION
Fixes #12210.

This PR marks `Style/RedundantFilterChain` as unsafe autocorrect.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
