### PR TITLE
[Docs] Update the doc for `Style/ReturnNil`

### DIFF
--- a/lib/rubocop/cop/style/return_nil.rb
+++ b/lib/rubocop/cop/style/return_nil.rb
@@ -3,9 +3,13 @@
 module RuboCop
   module Cop
     module Style
-      # Enforces consistency between 'return nil' and 'return'.
+      # Enforces consistency between `return nil` and `return`.
       #
-      # Supported styles are: return, return_nil.
+      # This cop is disabled by default. Because there seems to be a perceived semantic difference
+      # between `return` and `return nil`. The former can be seen as just halting evaluation,
+      # while the latter might be used when the return value is of specific concern.
+      #
+      # Supported styles are `return` and `return_nil`.
       #
       # @example EnforcedStyle: return (default)
       #   # bad


### PR DESCRIPTION
This PR updates the doc for `Style/ReturnNil` based on the following comments about why `Style/ReturnNil` cop is disabled by default.
https://github.com/rubocop/rubocop/pull/4638#issuecomment-325219286

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
