### PR TITLE
Fix detecting `encoding` magic comment inside other comments

### DIFF
--- a/changelog/fix_detecting_encoding_magic_comment_inside_other_comments.md
+++ b/changelog/fix_detecting_encoding_magic_comment_inside_other_comments.md
@@ -1,0 +1,1 @@
+* [#12213](https://github.com/rubocop/rubocop/issues/12213): Fix detecting `encoding` magic comment inside other comments. ([@fatkodima][])

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -261,7 +261,7 @@ module RuboCop
     class SimpleComment < MagicComment
       # Match `encoding` or `coding`
       def encoding
-        extract(/\A\s*\#.*\b#{KEYWORDS[:encoding]}: (#{TOKEN})/io)
+        extract(/\A\s*\#\s*#{KEYWORDS[:encoding]}: (#{TOKEN})/io)
       end
 
       # Rewrite the comment without a given token type

--- a/spec/rubocop/cop/lint/ordered_magic_comments_spec.rb
+++ b/spec/rubocop/cop/lint/ordered_magic_comments_spec.rb
@@ -96,4 +96,14 @@ RSpec.describe RuboCop::Cop::Lint::OrderedMagicComments, :config do
       puts x
     RUBY
   end
+
+  it 'does not register an offense when using `encoding` magic comment inside other comment' do
+    expect_no_offenses(<<~RUBY)
+      # frozen_string_literal: true
+      # Example:
+      #
+      #   re = eval("# encoding: ascii/")
+      #   re.encoding
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #12213.

Original regexp erroneously matched additional characters, while it should accept only spaces after the `#`.