### PR TITLE
[Fix #12213] Fix a false positive for `Lint/OrderedMagicComments`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_ordered_magic_comments.md
+++ b/changelog/fix_a_false_positive_for_lint_ordered_magic_comments.md
@@ -1,0 +1,1 @@
+* [#12213](https://github.com/rubocop/rubocop/issues/12213): Fix a false positive for `Lint/OrderedMagicComments` when comment text `# encoding: ISO-8859-1` is embedded within example code as source code comment. ([@koic][])

--- a/spec/rubocop/cop/lint/ordered_magic_comments_spec.rb
+++ b/spec/rubocop/cop/lint/ordered_magic_comments_spec.rb
@@ -96,4 +96,13 @@ RSpec.describe RuboCop::Cop::Lint::OrderedMagicComments, :config do
       puts x
     RUBY
   end
+
+  it 'does not register an offense when comment text `# encoding: ISO-8859-1` is embedded within ' \
+     'example code as source code comment' do
+    expect_no_offenses(<<~RUBY)
+      # frozen_string_literal: true
+
+      # eval('# encoding: ISO-8859-1')
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #12213.

This PR fixes a false positive for `Lint/OrderedMagicComments` when comment text `# encoding: ISO-8859-1` is embedded within example code as source code comment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
