### PR TITLE
[Fix #12208] Fix an incorrect autocorrect for the `--disable-uncorrectable` option

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_disable_uncorrectable_option.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_disable_uncorrectable_option.md
@@ -1,0 +1,1 @@
+* [#12208](https://github.com/rubocop/rubocop/issues/12208): Fix an incorrect autocorrect for the `--disable-uncorrectable` command line option when registering an offense is outside a percent array. ([@koic][])

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -82,7 +82,9 @@ module RuboCop
           node.array_type? && node.percent_literal?
         end
 
-        percent_array.map(&:source_range).find { |range| range.overlaps?(offense_range) }
+        percent_array.map(&:source_range).find do |range|
+          offense_range.begin_pos > range.begin_pos && range.overlaps?(offense_range)
+        end
       end
 
       def range_of_first_line(range)


### PR DESCRIPTION
Fixes #12208.

This PR fixes an incorrect autocorrect for the `--disable-uncorrectable` command line option when registering an offense is outside a percent array.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
