### PR TITLE
[Fix #12221] Fix a false positive for `Layout/EmptyLineAfterGuardClause`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_empty_line_after_guard_clause.md
+++ b/changelog/fix_a_false_positive_for_layout_empty_line_after_guard_clause.md
@@ -1,0 +1,1 @@
+* [#12221](https://github.com/rubocop/rubocop/issues/12221): Fix a false positive for `Layout/EmptyLineAfterGuardClause` when using `return` before guard condition with heredoc. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
@@ -164,6 +164,8 @@ module RuboCop
 
           if node.if_branch.and_type?
             node.if_branch.children.first
+          elsif use_heredoc_in_condition?(node.condition)
+            node.condition
           else
             node.if_branch.children.last
           end
@@ -178,6 +180,12 @@ module RuboCop
 
         def heredoc?(node)
           node.respond_to?(:heredoc?) && node.heredoc?
+        end
+
+        def use_heredoc_in_condition?(condition)
+          condition.descendants.any? do |descendant|
+            descendant.respond_to?(:heredoc?) && descendant.heredoc?
+          end
         end
 
         def offense_location(node)

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -482,6 +482,30 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
+  it 'does not register an offense and corrects when using `return` before guard condition with heredoc' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        return true if <<~TEXT.length > bar
+          hi
+        TEXT
+
+        false
+      end
+    RUBY
+  end
+
+  it 'does not register an offense and corrects when using `raise` before guard condition with heredoc' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        raise if <<~TEXT.length > bar
+          hi
+        TEXT
+
+        baz
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects a guard clause that is a ternary operator' do
     expect_offense(<<~RUBY)
       def foo


### PR DESCRIPTION
Fixes #12221.

This PR fixes a false positive for `Layout/EmptyLineAfterGuardClause` when using `return` before guard condition with heredoc.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
