### PR TITLE
Fix false negatives for `Style/MultilineBlockChain`

### DIFF
--- a/changelog/fix_false_negatives_for_style_multiline_block_chain.md
+++ b/changelog/fix_false_negatives_for_style_multiline_block_chain.md
@@ -1,0 +1,1 @@
+* [#12228](https://github.com/rubocop/rubocop/pull/12228): Fix false negatives for `Style/MultilineBlockChain` when using multiline block chain with safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/multiline_block_chain.rb
+++ b/lib/rubocop/cop/style/multiline_block_chain.rb
@@ -28,7 +28,7 @@ module RuboCop
         MSG = 'Avoid multi-line chains of blocks.'
 
         def on_block(node)
-          node.send_node.each_node(:send) do |send_node|
+          node.send_node.each_node(:send, :csend) do |send_node|
             receiver = send_node.receiver
 
             next unless (receiver&.block_type? || receiver&.numblock_type?) && receiver&.multiline?

--- a/spec/rubocop/cop/style/multiline_block_chain_spec.rb
+++ b/spec/rubocop/cop/style/multiline_block_chain_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe RuboCop::Cop::Style::MultilineBlockChain, :config do
       RUBY
     end
 
+    it 'registers an offense for a simple case with safe navigation operator' do
+      expect_offense(<<~RUBY)
+        a do
+          b
+        end&.c do
+        ^^^^^^ Avoid multi-line chains of blocks.
+          d
+        end
+      RUBY
+    end
+
     it 'registers an offense for a slightly more complicated case' do
       expect_offense(<<~RUBY)
         a do


### PR DESCRIPTION
This PR fixes false negatives for `Style/MultilineBlockChain` when using multiline block chain with safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
