### PR TITLE
[Fix #12226] Fix false positives for `Layout/MultilineMethodCallIndentation`

### DIFF
--- a/changelog/fix_false_positives_for_layout_multiline_method_call_indentation.md
+++ b/changelog/fix_false_positives_for_layout_multiline_method_call_indentation.md
@@ -1,0 +1,1 @@
+* [#12226](https://github.com/rubocop/rubocop/issues/12226): Fix false positives for `Layout/MultilineMethodCallIndentation` when aligning methods in multiline block chain. ([@koic][])

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -204,6 +204,10 @@ module RuboCop
           dot_right_above = get_dot_right_above(node)
           return dot_right_above if dot_right_above
 
+          if (multiline_block_chain_node = find_multiline_block_chain_node(node))
+            return multiline_block_chain_node
+          end
+
           node = first_call_has_a_dot(node)
           return if node.loc.dot.line != node.first_line
 
@@ -217,6 +221,13 @@ module RuboCop
 
             dot.line == node.loc.dot.line - 1 && dot.column == node.loc.dot.column
           end
+        end
+
+        def find_multiline_block_chain_node(node)
+          return unless (block_node = node.each_descendant(:block, :numblock).first)
+          return unless block_node.multiline? && block_node.parent.call_type?
+
+          block_node.parent
         end
 
         def first_call_has_a_dot(node)

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -693,6 +693,46 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects misaligned methods in multiline block chain' do
+      expect_offense(<<~RUBY)
+        do_something.foo do
+        end.bar
+                    .baz
+                    ^^^^ Align `.baz` with `.bar` on line 2.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something.foo do
+        end.bar
+           .baz
+      RUBY
+    end
+
+    it 'accepts aligned methods in multiline block chain' do
+      expect_no_offenses(<<~RUBY)
+        do_something.foo do
+        end.bar
+           .baz
+      RUBY
+    end
+
+    it 'accepts aligned methods in multiline numbered block chain' do
+      expect_no_offenses(<<~RUBY)
+        do_something.foo do
+          bar(_1)
+        end.baz
+           .qux
+      RUBY
+    end
+
+    it 'accepts aligned methods in multiline block chain with safe navigation operator' do
+      expect_no_offenses(<<~RUBY)
+        do_something.foo do
+        end&.bar
+           &.baz
+      RUBY
+    end
+
     it 'registers an offense and corrects misaligned methods in local variable assignment' do
       expect_offense(<<~RUBY)
         a = b.c.


### PR DESCRIPTION
Fixes #12226.

This PR fixes false positives for `Layout/MultilineMethodCallIndentation` when aligning methods in multiline block chain.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
