### PR TITLE
Tweak autocorrection for `Style/RedundantBegin`

### DIFF
--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -114,7 +114,7 @@ module RuboCop
             if node.parent&.assignment?
               replace_begin_with_statement(corrector, offense_range, node)
             else
-              corrector.remove(offense_range)
+              remove_begin(corrector, offense_range, node)
             end
 
             if use_modifier_form_after_multiline_begin_block?(node)
@@ -134,6 +134,14 @@ module RuboCop
           corrector.remove(range_between(offense_range.end_pos, first_child.source_range.end_pos))
 
           restore_removed_comments(corrector, offense_range, node, first_child)
+        end
+
+        def remove_begin(corrector, offense_range, node)
+          if node.parent.respond_to?(:endless?) && node.parent.endless?
+            offense_range = range_with_surrounding_space(offense_range, newlines: true)
+          end
+
+          corrector.remove(offense_range)
         end
 
         # Restore comments that occur between "begin" and "first_child".

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -579,7 +579,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
         end
       RUBY
 
-      expect_correction("def foo = \n  bar\n\n")
+      expect_correction("def foo =  bar\n\n")
     end
 
     it 'accepts when `begin` block has multiple statements' do


### PR DESCRIPTION
This PR tweaks autocorrection for `Style/RedundantBegin` when using endless method definition with redundant `begin`.

```ruby
def foo = begin
  bar
end
```

## Before

```console
% bundle exec rubocop --only Style/RedundantBegin -a
(snip)

example.rb:1:11: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
def foo = begin
          ^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

```ruby
def foo =
  bar
```

## After

```ruby
def foo =  bar
```

This would be more closer to a one-liner endless idiom.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
