### PR TITLE
Enhance `Style/FormatString`'s autocorrection

### DIFF
--- a/changelog/change_enhance_style_format_string_autocorrection.md
+++ b/changelog/change_enhance_style_format_string_autocorrection.md
@@ -1,0 +1,1 @@
+* [#12234](https://github.com/rubocop/rubocop/pull/12234): Enhance `Style/FormatString`'s autocorrection when using known conversion methods whose return value is not an array. ([@koic][])

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -37,6 +37,85 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
       RUBY
     end
 
+    context 'when using a known autocorrectable method that does not convert to an array' do
+      it 'registers an offense for `to_s`' do
+        expect_offense(<<~RUBY)
+          puts "%s" % a.to_s
+                    ^ Favor `sprintf` over `String#%`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts sprintf("%s", a.to_s)
+        RUBY
+      end
+
+      it 'registers an offense for `to_h`' do
+        expect_offense(<<~RUBY)
+          puts "%s" % a.to_h
+                    ^ Favor `sprintf` over `String#%`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts sprintf("%s", a.to_h)
+        RUBY
+      end
+
+      it 'registers an offense for `to_i`' do
+        expect_offense(<<~RUBY)
+          puts "%s" % a.to_i
+                    ^ Favor `sprintf` over `String#%`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts sprintf("%s", a.to_i)
+        RUBY
+      end
+
+      it 'registers an offense for `to_f`' do
+        expect_offense(<<~RUBY)
+          puts "%s" % a.to_f
+                    ^ Favor `sprintf` over `String#%`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts sprintf("%s", a.to_f)
+        RUBY
+      end
+
+      it 'registers an offense for `to_r`' do
+        expect_offense(<<~RUBY)
+          puts "%s" % a.to_r
+                    ^ Favor `sprintf` over `String#%`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts sprintf("%s", a.to_r)
+        RUBY
+      end
+
+      it 'registers an offense for `to_d`' do
+        expect_offense(<<~RUBY)
+          puts "%s" % a.to_d
+                    ^ Favor `sprintf` over `String#%`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts sprintf("%s", a.to_d)
+        RUBY
+      end
+
+      it 'registers an offense for `to_sym`' do
+        expect_offense(<<~RUBY)
+          puts "%s" % a.to_sym
+                    ^ Favor `sprintf` over `String#%`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts sprintf("%s", a.to_sym)
+        RUBY
+      end
+    end
+
     it 'registers an offense for variable argument but does not autocorrect' do
       expect_offense(<<~RUBY)
         puts "%f" % a
@@ -132,6 +211,85 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
       expect_correction(<<~RUBY)
         puts format(x, a: 10, b: 11)
       RUBY
+    end
+
+    context 'when using a known conversion method that does not convert to an array' do
+      it 'registers an offense for `to_s`' do
+        expect_offense(<<~RUBY)
+          puts "%s" % a.to_s
+                    ^ Favor `format` over `String#%`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts format("%s", a.to_s)
+        RUBY
+      end
+
+      it 'registers an offense for `to_h`' do
+        expect_offense(<<~RUBY)
+          puts "%s" % a.to_h
+                    ^ Favor `format` over `String#%`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts format("%s", a.to_h)
+        RUBY
+      end
+
+      it 'registers an offense for `to_i`' do
+        expect_offense(<<~RUBY)
+          puts "%s" % a.to_i
+                    ^ Favor `format` over `String#%`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts format("%s", a.to_i)
+        RUBY
+      end
+
+      it 'registers an offense for `to_f`' do
+        expect_offense(<<~RUBY)
+          puts "%s" % a.to_f
+                    ^ Favor `format` over `String#%`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts format("%s", a.to_f)
+        RUBY
+      end
+
+      it 'registers an offense for `to_r`' do
+        expect_offense(<<~RUBY)
+          puts "%s" % a.to_r
+                    ^ Favor `format` over `String#%`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts format("%s", a.to_r)
+        RUBY
+      end
+
+      it 'registers an offense for `to_d`' do
+        expect_offense(<<~RUBY)
+          puts "%s" % a.to_d
+                    ^ Favor `format` over `String#%`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts format("%s", a.to_d)
+        RUBY
+      end
+
+      it 'registers an offense for `to_sym`' do
+        expect_offense(<<~RUBY)
+          puts "%s" % a.to_sym
+                    ^ Favor `format` over `String#%`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts format("%s", a.to_sym)
+        RUBY
+      end
     end
 
     it 'registers an offense for variable argument but does not autocorrect' do


### PR DESCRIPTION
This PR enhances `Style/FormatString`'s autocorrection when using known conversion methods whose return value is not an array.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
