### PR TITLE
Enable auto parallel inspection when config file is specified

### DIFF
--- a/changelog/change_enable_auto_parallel_inspection_when_config_file.md
+++ b/changelog/change_enable_auto_parallel_inspection_when_config_file.md
@@ -1,0 +1,1 @@
+* [#12235](https://github.com/rubocop/rubocop/pull/12235): Enable auto parallel inspection when config file is specified. ([@aboutNisblee][])

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -11,7 +11,7 @@ module RuboCop
     STATUS_ERROR       = 2
     STATUS_INTERRUPTED = Signal.list['INT'] + 128
     DEFAULT_PARALLEL_OPTIONS = %i[
-      color debug display_style_guide display_time display_only_fail_level_offenses
+      color config debug display_style_guide display_time display_only_fail_level_offenses
       display_only_failed except extra_details fail_level fix_layout format
       ignore_disable_comments lint only only_guide_cops require safe
       autocorrect safe_autocorrect autocorrect_all

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -220,13 +220,26 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     #       In other words, even if no option is specified, it will be parallelized by default.
     describe 'when parallel static by default' do
       context 'when specifying `--debug` option only`' do
-        it 'fails with an error message' do
+        it 'uses parallel inspection' do
           create_file('example1.rb', <<~RUBY)
             # frozen_string_literal: true
 
             puts 'hello'
           RUBY
           expect(cli.run(['--debug'])).to eq(0)
+          expect($stdout.string.include?('Use parallel by default.')).to be(true)
+        end
+      end
+
+      context 'when specifying configuration file' do
+        it 'uses parallel inspection' do
+          create_file('example1.rb', <<~RUBY)
+            # frozen_string_literal: true
+
+            puts 'hello'
+          RUBY
+          create_empty_file('.rubocop.yml')
+          expect(cli.run(['--debug', '--config', '.rubocop.yml'])).to eq(0)
           expect($stdout.string.include?('Use parallel by default.')).to be(true)
         end
       end
@@ -249,7 +262,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
 
       context 'when setting `UseCache: true`' do
-        it 'fails with an error message' do
+        it 'uses parallel inspection' do
           create_file('example.rb', <<~RUBY)
             # frozen_string_literal: true
 
@@ -265,7 +278,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
 
       context 'when setting `UseCache: false`' do
-        it 'fails with an error message' do
+        it 'does not use parallel inspection' do
           create_file('example.rb', <<~RUBY)
             # frozen_string_literal: true
 


### PR DESCRIPTION
This change also allows automatic parallel inspection when a config file is explicitly specified.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
