### PR TITLE
[Fix #12237] Fix an error for `Style/NestedTernaryOperator`

### DIFF
--- a/changelog/fix_an_error_for_style_nested_ternary_operator.md
+++ b/changelog/fix_an_error_for_style_nested_ternary_operator.md
@@ -1,0 +1,1 @@
+* [#12237](https://github.com/rubocop/rubocop/issues/12237): Fix an error for `Style/NestedTernaryOperator` when a ternary operator has a nested ternary operator within an `if`. ([@koic][])

--- a/lib/rubocop/cop/style/nested_ternary_operator.rb
+++ b/lib/rubocop/cop/style/nested_ternary_operator.rb
@@ -27,23 +27,15 @@ module RuboCop
 
           node.each_descendant(:if).select(&:ternary?).each do |nested_ternary|
             add_offense(nested_ternary) do |corrector|
-              if_node = if_node(nested_ternary)
-              next if part_of_ignored_node?(if_node)
+              next if part_of_ignored_node?(node)
 
-              autocorrect(corrector, if_node)
-              ignore_node(if_node)
+              autocorrect(corrector, node)
+              ignore_node(node)
             end
           end
         end
 
         private
-
-        def if_node(node)
-          node = node.parent
-          return node if node.if_type?
-
-          if_node(node)
-        end
 
         def autocorrect(corrector, if_node)
           replace_loc_and_whitespace(corrector, if_node.loc.question, "\n")

--- a/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
@@ -47,6 +47,29 @@ RSpec.describe RuboCop::Cop::Style::NestedTernaryOperator, :config do
     RUBY
   end
 
+  it 'registers an offense when a ternary operator has a nested ternary operator within an `if`' do
+    expect_offense(<<~RUBY)
+      a ? (
+        if b
+          c ? 1 : 2
+          ^^^^^^^^^ Ternary operators must not be nested. Prefer `if` or `else` constructs instead.
+        end
+      ) : 3
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if a
+
+        if b
+          c ? 1 : 2
+        end
+
+      else
+      3
+      end
+    RUBY
+  end
+
   it 'accepts a non-nested ternary operator within an if' do
     expect_no_offenses(<<~RUBY)
       a = if x


### PR DESCRIPTION
Fixes #12237.

This PR fixes an error for `Style/NestedTernaryOperator` when a ternary operator has a nested ternary operator within an `if`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
