### PR TITLE
[Fix #12237] Fix `Style/NestedTernaryOperator` autocorrection to support conditionals between nested ternaries

### DIFF
--- a/changelog/fix_style_nested_ternary_operator_should_allow.md
+++ b/changelog/fix_style_nested_ternary_operator_should_allow.md
@@ -1,0 +1,1 @@
+* [#12237](https://github.com/rubocop/rubocop/issues/12237): Fix `Style/NestedTernaryOperator` autocorrection to support conditionals between nested ternaries. ([@stevegeek][])

--- a/lib/rubocop/cop/style/nested_ternary_operator.rb
+++ b/lib/rubocop/cop/style/nested_ternary_operator.rb
@@ -40,7 +40,7 @@ module RuboCop
 
         def if_node(node)
           node = node.parent
-          return node if node.if_type?
+          return node if node.if_type? && node.ternary?
 
           if_node(node)
         end

--- a/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
@@ -76,4 +76,23 @@ RSpec.describe RuboCop::Cop::Style::NestedTernaryOperator, :config do
       end
     RUBY
   end
+
+  it 'can handle nested ternaries mixed with conditionals' do
+    expect_offense(<<~RUBY)
+      a ? (if b
+        c ? 1 : 2
+        ^^^^^^^^^ Ternary operators must not be nested. Prefer `if` or `else` constructs instead.
+      end) : 3
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if a
+      if b
+        c ? 1 : 2
+      end
+      else
+      3
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This fixes issue #12237 to ensure that when autocorrecting the cop looks for parent ternaries, and not just any `if` node.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
