### PR TITLE
[Fix #12231] Fix a false negative for `Metrics/ModuleLength`

### DIFF
--- a/changelog/fix_a_false_negative_for_metrics_module_length.md
+++ b/changelog/fix_a_false_negative_for_metrics_module_length.md
@@ -1,0 +1,1 @@
+* [#12231](https://github.com/rubocop/rubocop/issues/12231): Fix a false negative for `Metrics/ModuleLength` when defining a singleton class in a module. ([@koic][])

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -10,7 +10,7 @@ module RuboCop
           include Util
 
           FOLDABLE_TYPES = %i[array hash heredoc send csend].freeze
-          CLASSLIKE_TYPES = %i[class module sclass].freeze
+          CLASSLIKE_TYPES = %i[class module].freeze
           private_constant :FOLDABLE_TYPES, :CLASSLIKE_TYPES
 
           def initialize(node, processed_source, count_comments: false, foldable_types: [])
@@ -145,7 +145,7 @@ module RuboCop
 
           def extract_body(node)
             case node.type
-            when :class, :module, :block, :numblock, :def, :defs
+            when :class, :module, :sclass, :block, :numblock, :def, :defs
               node.body
             when :casgn
               _scope, _name, value = *node

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -160,6 +160,43 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
       RUBY
     end
 
+    it 'rejects a module with more than 5 lines including its singleton class' do
+      expect_offense(<<~RUBY)
+        module Test
+        ^^^^^^^^^^^ Module has too many lines. [8/5]
+          class << self
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+            a = 6
+          end
+        end
+      RUBY
+    end
+
+    it 'rejects a module with more than 5 lines that belong to the module directly and including its singleton class' do
+      expect_offense(<<~RUBY)
+        module NamespaceModule
+        ^^^^^^^^^^^^^^^^^^^^^^ Module has too many lines. [13/5]
+          class << self
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+
     it 'rejects a module with 6 lines that belong to the module directly' do
       expect_offense(<<~RUBY)
         module NamespaceModule


### PR DESCRIPTION
Fixes #12231.

This PR fixes a false negative for `Metrics/ModuleLength` when defining a singleton class in a module.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
