### PR TITLE
[Fix #12198] Fix an error for flip-flop with beginless or endless ranges

### DIFF
--- a/changelog/fix_an_error_for_flip_flop_with_beginless_or_endless_ranges.md
+++ b/changelog/fix_an_error_for_flip_flop_with_beginless_or_endless_ranges.md
@@ -1,0 +1,1 @@
+* [#12198](https://github.com/rubocop/rubocop/issues/12198): Fix an error for flip-flop with beginless or endless ranges. ([@koic][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('json', '~> 2.3')
   s.add_runtime_dependency('language_server-protocol', '>= 3.17.0')
   s.add_runtime_dependency('parallel', '~> 1.10')
-  s.add_runtime_dependency('parser', '>= 3.2.2.3')
+  s.add_runtime_dependency('parser', '>= 3.2.2.4')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
   s.add_runtime_dependency('rexml', '>= 3.2.5', '< 4.0')


### PR DESCRIPTION
Fixes #12198.

Parser 3.2.2.4 includes https://github.com/whitequark/parser/pull/946.

This PR requires Parser 3.2.2.4+ to fix an error for flip-flop with beginless or endless ranges.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
