### PR TITLE
[Fix #12244] Fix a false negative for `Lint/Debugger`

### DIFF
--- a/changelog/fix_a_false_negative_for_lint_debugger.md
+++ b/changelog/fix_a_false_negative_for_lint_debugger.md
@@ -1,0 +1,1 @@
+* [#12244](https://github.com/rubocop/rubocop/issues/12244): Fix a false negative for `Lint/Debugger` when using debugger method inside block. ([@koic][])

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -95,8 +95,11 @@ module RuboCop
         def assumed_usage_context?(node)
           # Basically, debugger methods are not used as a method argument without arguments.
           return false unless node.arguments.empty? && node.each_ancestor(:send, :csend).any?
+          return true if assumed_argument?(node)
 
-          node.each_ancestor.none?(&:lambda_or_proc?)
+          node.each_ancestor.none? do |ancestor|
+            ancestor.block_type? || ancestor.numblock_type? || ancestor.lambda_or_proc?
+          end
         end
 
         def chained_method_name(send_node)
@@ -108,6 +111,12 @@ module RuboCop
             receiver = receiver.receiver
           end
           chained_method_name
+        end
+
+        def assumed_argument?(node)
+          parent = node.parent
+
+          parent.call_type? || parent.literal? || parent.pair_type?
         end
       end
     end

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -23,6 +23,23 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
       RUBY
     end
 
+    it 'registers an offense for a `custom_debugger` call when used in block' do
+      expect_offense(<<~RUBY)
+        x.y = do_something { custom_debugger }
+                             ^^^^^^^^^^^^^^^ Remove debugger entry point `custom_debugger`.
+      RUBY
+    end
+
+    it 'registers an offense for a `custom_debugger` call when used in numbered block' do
+      expect_offense(<<~RUBY)
+        x.y = do_something do
+          z(_1)
+          custom_debugger
+          ^^^^^^^^^^^^^^^ Remove debugger entry point `custom_debugger`.
+        end
+      RUBY
+    end
+
     it 'registers an offense for a `custom_debugger` call when used in lambda literal' do
       expect_offense(<<~RUBY)
         x.y = -> { custom_debugger }
@@ -170,6 +187,14 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
         let(:p) { foo }
 
         it { expect(do_something(k: p)).to eq bar }
+      RUBY
+    end
+
+    it 'does not register an offense when `p` is a array argument of method call' do
+      expect_no_offenses(<<~RUBY)
+        let(:p) { foo }
+
+        it { expect(do_something([k, p])).to eq bar }
       RUBY
     end
   end


### PR DESCRIPTION
Fixes #12244.

This PR fixes a false negative for `Lint/Debugger` when using debugger method inside block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
