### PR TITLE
Make `Lint/RedundantSafeNavigation` aware of constant receiver

### DIFF
--- a/changelog/new_make_lint_redundant_safe_navigation_aware_of_const_receiver.md
+++ b/changelog/new_make_lint_redundant_safe_navigation_aware_of_const_receiver.md
@@ -1,0 +1,1 @@
+* [#12299](https://github.com/rubocop/rubocop/issues/12299): Make `Lint/RedundantSafeNavigation` aware of constant receiver. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_safe_navigation.rb
+++ b/lib/rubocop/cop/lint/redundant_safe_navigation.rb
@@ -4,8 +4,12 @@ module RuboCop
   module Cop
     module Lint
       # Checks for redundant safe navigation calls.
-      # `instance_of?`, `kind_of?`, `is_a?`, `eql?`, `respond_to?`, and `equal?` methods
-      # are checked by default. These are customizable with `AllowedMethods` option.
+      # Use cases where a constant is `nil` are rare and an offense is detected
+      # when the receiver is a constant.
+      #
+      # For all receivers, the `instance_of?`, `kind_of?`, `is_a?`, `eql?`, `respond_to?`,
+      # and `equal?` methods are checked by default.
+      # These are customizable with `AllowedMethods` option.
       #
       # The `AllowedMethods` option specifies nil-safe methods,
       # in other words, it is a method that is allowed to skip safe navigation.
@@ -22,6 +26,9 @@ module RuboCop
       #
       # @example
       #   # bad
+      #   Const&.do_something
+      #
+      #   # bad
       #   do_something if attrs&.respond_to?(:[])
       #
       #   # good
@@ -31,6 +38,9 @@ module RuboCop
       #   while node&.is_a?(BeginNode)
       #     node = node.parent
       #   end
+      #
+      #   # good
+      #   Const.do_something
       #
       #   # good
       #   while node.is_a?(BeginNode)
@@ -63,8 +73,10 @@ module RuboCop
         PATTERN
 
         def on_csend(node)
-          return unless check?(node) && allowed_method?(node.method_name)
-          return if respond_to_nil_specific_method?(node)
+          unless node.receiver.const_type?
+            return unless check?(node) && allowed_method?(node.method_name)
+            return if respond_to_nil_specific_method?(node)
+          end
 
           range = range_between(node.loc.dot.begin_pos, node.source_range.end_pos)
           add_offense(range) { |corrector| corrector.replace(node.loc.dot, '.') }

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -3,6 +3,17 @@
 RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
   let(:cop_config) { { 'AllowedMethods' => %w[respond_to?] } }
 
+  it 'registers an offense and corrects when `&.` is used for const receiver' do
+    expect_offense(<<~RUBY)
+      Foo&.do_something
+         ^^^^^^^^^^^^^^ Redundant safe navigation detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Foo.do_something
+    RUBY
+  end
+
   it 'registers an offense and corrects when `&.` is used inside `if` condition' do
     expect_offense(<<~RUBY)
       if foo&.respond_to?(:bar)


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-rails/issues/1104.

This is an issue with RuboCop Rails, but it can likely be addressed as a generic issue.

So, this PR makes `Lint/RedundantSafeNavigation` aware of constant receiver. Because use cases where a constant is `nil` are rare and an offense is detected when the receiver is a constant. And this cop is already marked as unsafe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
