### PR TITLE
Fix false negatives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_negatives_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_negatives_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#12247](https://github.com/rubocop/rubocop/pull/12247): Fix false negatives for `Style/RedundantParentheses` when using logical or comparison expressions with redundant parentheses. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -160,6 +160,19 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   it_behaves_like 'redundant', '({0 => :a}[0])', '{0 => :a}[0]', 'a method call'
   it_behaves_like 'redundant', '(x; y)', 'x; y', 'a method call'
 
+  it_behaves_like 'redundant', '(x && y)', 'x && y', 'a logical expression'
+  it_behaves_like 'redundant', '(x || y)', 'x || y', 'a logical expression'
+  it_behaves_like 'redundant', '(x and y)', 'x and y', 'a logical expression'
+  it_behaves_like 'redundant', '(x or y)', 'x or y', 'a logical expression'
+
+  it_behaves_like 'redundant', '(x == y)', 'x == y', 'a comparison expression'
+  it_behaves_like 'redundant', '(x === y)', 'x === y', 'a comparison expression'
+  it_behaves_like 'redundant', '(x != y)', 'x != y', 'a comparison expression'
+  it_behaves_like 'redundant', '(x > y)', 'x > y', 'a comparison expression'
+  it_behaves_like 'redundant', '(x >= y)', 'x >= y', 'a comparison expression'
+  it_behaves_like 'redundant', '(x < y)', 'x < y', 'a comparison expression'
+  it_behaves_like 'redundant', '(x <= y)', 'x <= y', 'a comparison expression'
+
   it_behaves_like 'redundant', '(!x)', '!x', 'a unary operation'
   it_behaves_like 'redundant', '(~x)', '~x', 'a unary operation'
   it_behaves_like 'redundant', '(-x)', '-x', 'a unary operation'
@@ -480,8 +493,25 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     expect_no_offenses('(a...b)')
   end
 
-  it 'accepts parentheses around operator keywords' do
+  it 'accepts parentheses around logical operator keywords' do
     expect_no_offenses('(1 and 2) and (3 or 4)')
+  end
+
+  it 'accepts parentheses around comparison operator keywords' do
+    # Parentheses are redundant, but respect user's intentions for readability.
+    expect_no_offenses('x && (y == z)')
+  end
+
+  it 'accepts parentheses around a method call with parenthesized logical expression receiver' do
+    expect_no_offenses('(x || y).z')
+  end
+
+  it 'accepts parentheses around a method call with parenthesized comparison expression receiver' do
+    expect_no_offenses('(x == y).zero?')
+  end
+
+  it 'accepts parentheses around single argument separated by semicolon' do
+    expect_no_offenses('x((prepare; perform))')
   end
 
   it 'registers an offense when there is space around the parentheses' do


### PR DESCRIPTION
This PR fix false negatives for `Style/RedundantParentheses` when using logical or comparison expressions with redundant parentheses.

e.g. `assert(('rubocop-minitest' == actual))`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
