### PR TITLE
RuboCop::Server::Cache: explicitly require 'fileutils'

### DIFF
--- a/changelog/fix_inconsistent_cache_key_caused_by_fileutils_require.md
+++ b/changelog/fix_inconsistent_cache_key_caused_by_fileutils_require.md
@@ -1,0 +1,1 @@
+* [#12076](https://github.com/rubocop/rubocop/issues/12076): Fixed an issue where the top-level cache folder was named differently during two consecutive rubocop runs. ([@K-S-A][])

--- a/lib/rubocop/server/cache.rb
+++ b/lib/rubocop/server/cache.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'fileutils'
 require 'pathname'
 require_relative '../cache_config'
 require_relative '../config_finder'


### PR DESCRIPTION
This PR fixes #12076.

The reproduction script: https://gist.github.com/K-S-A/1d79105baaa88adde1b6e5f6b05d641a

Please, suggest on how to proceed with the "tests" checklist item.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
