### PR TITLE
Mark `Lint/RedundantRequireStatement` as unsafe autocorrect

### DIFF
--- a/changelog/change_mark_lint_redundant_require_statement_as_unsafe_autocorrect.md
+++ b/changelog/change_mark_lint_redundant_require_statement_as_unsafe_autocorrect.md
@@ -1,0 +1,1 @@
+* [#12250](https://github.com/rubocop/rubocop/pull/12250): Mark `Lint/RedundantRequireStatement` as unsafe autocorrect. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2170,7 +2170,9 @@ Lint/RedundantRegexpQuantifiers:
 Lint/RedundantRequireStatement:
   Description: 'Checks for unnecessary `require` statement.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.76'
+  VersionChanged: '<<next>>'
 
 Lint/RedundantSafeNavigation:
   Description: 'Checks for redundant safe navigation calls.'

--- a/lib/rubocop/cop/lint/redundant_require_statement.rb
+++ b/lib/rubocop/cop/lint/redundant_require_statement.rb
@@ -24,6 +24,10 @@ module RuboCop
       #
       # This cop target those features.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because if `require 'pp'` is removed from one file,
+      #   `NameError` can be encountered when another file uses `PP.pp`.
+      #
       # @example
       #   # bad
       #   require 'unloaded_feature'


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/11931#issuecomment-1603717583.

This PR marks `Lint/RedundantRequireStatement` as unsafe autocorrect because if `require 'pp'` is removed from one file, `NameError` can be encountered when another file uses `PP.pp`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
