### PR TITLE
[Fix #12249] Fix a false positive `Style/IdenticalConditionalBranches`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_identical_conditional_branches.md
+++ b/changelog/fix_a_false_positive_for_style_identical_conditional_branches.md
@@ -1,0 +1,1 @@
+* [#12249](https://github.com/rubocop/rubocop/issues/12249): Fix a false positive `Style/IdenticalConditionalBranches` when `if`..`else` with identical leading lines and assign to condition value. ([@koic][])

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -72,6 +72,103 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
     end
   end
 
+  context 'on if..else with identical leading lines and assign to condition value of method call receiver' do
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        if x.condition
+          x = do_something
+          foo
+        else
+          x = do_something
+          bar
+        end
+      RUBY
+    end
+  end
+
+  context 'on if..else with identical leading lines and assign to condition value of safe navigation call receiver' do
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        if x&.condition
+          x = do_something
+          foo
+        else
+          x = do_something
+          bar
+        end
+      RUBY
+    end
+  end
+
+  context 'on if..else with identical leading lines and assign to condition value of method call' do
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        if x
+          x = do_something
+          foo
+        else
+          x = do_something
+          bar
+        end
+      RUBY
+    end
+  end
+
+  context 'on if..else with identical leading lines and assign to condition local variable' do
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        x = 42
+
+        if x
+          x = do_something
+          foo
+        else
+          x = do_something
+          bar
+        end
+      RUBY
+    end
+  end
+
+  context 'on if..else with identical leading lines and assign to condition instance variable' do
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        if @x
+          @x = do_something
+          foo
+        else
+          @x = do_something
+          bar
+        end
+      RUBY
+    end
+  end
+
+  context 'on if..else with identical trailing lines and assign to condition value' do
+    it 'registers and corrects an offense' do
+      expect_offense(<<~RUBY)
+        if x.condition
+          foo
+          x = do_something
+          ^^^^^^^^^^^^^^^^ Move `x = do_something` out of the conditional.
+        else
+          bar
+          x = do_something
+          ^^^^^^^^^^^^^^^^ Move `x = do_something` out of the conditional.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if x.condition
+          foo
+        else
+          bar
+        end
+        x = do_something
+      RUBY
+    end
+  end
+
   context 'on if..else with identical leading lines, single child branch and last node of the parent' do
     it "doesn't register an offense" do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #12249.

This PR fixes a false positive `Style/IdenticalConditionalBranches` when `if`..`else` with identical leading lines and assign to condition value.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
