### PR TITLE
Lint/LiteralInInterpolation: Accept an empty string literal interpolated in %W[]/%I[]

### DIFF
--- a/changelog/fix_accept_empty_string_literal_interpolated_in_words_literal.md
+++ b/changelog/fix_accept_empty_string_literal_interpolated_in_words_literal.md
@@ -1,0 +1,1 @@
+* [#12253](https://github.com/rubocop/rubocop/pull/12253): Fix `Lint/LiteralInInterpolation` to accept an empty string literal interpolated in words literal. ([@knu][])

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -34,7 +34,7 @@ module RuboCop
           # interpolation should not be removed if the expanded value
           # contains a space character.
           expanded_value = autocorrected_value(final_node)
-          return if in_array_percent_literal?(begin_node) && /\s/.match?(expanded_value)
+          return if in_array_percent_literal?(begin_node) && /\s|\A\z/.match?(expanded_value)
 
           add_offense(final_node) do |corrector|
             return if final_node.dstr_type? # nested, fixed in next iteration

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -206,6 +206,12 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation, :config do
       RUBY
     end
 
+    it "accepts interpolation of an empty string literal in #{prefix}[]" do
+      expect_no_offenses(<<~RUBY)
+        #{prefix}[\#{""} is significant]
+      RUBY
+    end
+
     it "accepts interpolation of a symbol literal with space in #{prefix}[]" do
       expect_no_offenses(<<~RUBY)
         #{prefix}[\#{:"this interpolation"} is significant]


### PR DESCRIPTION
An empty string in those words literals is significant and should not be expanded.

e.g.

```ruby
system(*%W[git commit -m #{""} file])
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
