### PR TITLE
[Fix #12257] Make `Style/RedundantDoubleSplatHashBraces` aware of `merge`

### DIFF
--- a/changelog/new_make_style_redundant_double_splat_hash_braces_aware_of_merge.md
+++ b/changelog/new_make_style_redundant_double_splat_hash_braces_aware_of_merge.md
@@ -1,0 +1,1 @@
+* [#12257](https://github.com/rubocop/rubocop/issues/12257): Make `Style/RedundantDoubleSplatHashBraces` aware of `merge` methods. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -13,24 +13,49 @@ module RuboCop
       #   # good
       #   do_something(foo: bar, baz: qux)
       #
+      #   # bad
+      #   do_something(**{foo: bar, baz: qux}.merge(options))
+      #
+      #   # good
+      #   do_something(foo: bar, baz: qux, **options)
+      #
       class RedundantDoubleSplatHashBraces < Base
         extend AutoCorrector
 
         MSG = 'Remove the redundant double splat and braces, use keyword arguments directly.'
+        MERGE_METHODS = %i[merge merge!].freeze
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def on_hash(node)
           return if node.pairs.empty? || node.pairs.any?(&:hash_rocket?)
           return unless (parent = node.parent)
-          return unless parent.kwsplat_type?
+          return unless (kwsplat = node.each_ancestor(:kwsplat).first)
+          return if parent.call_type? && !merge_method?(parent)
 
-          add_offense(parent) do |corrector|
-            corrector.remove(parent.loc.operator)
-            corrector.remove(opening_brace(node))
-            corrector.remove(closing_brace(node))
+          add_offense(kwsplat) do |corrector|
+            autocorrect(corrector, node, kwsplat)
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         private
+
+        def autocorrect(corrector, node, kwsplat)
+          corrector.remove(kwsplat.loc.operator)
+          corrector.remove(opening_brace(node))
+          corrector.remove(closing_brace(node))
+
+          merge_methods = select_merge_method_nodes(kwsplat)
+          return if merge_methods.empty?
+
+          autocorrect_merge_methods(corrector, merge_methods, kwsplat)
+        end
+
+        def select_merge_method_nodes(kwsplat)
+          extract_send_methods(kwsplat).select do |node|
+            merge_method?(node)
+          end
+        end
 
         def opening_brace(node)
           node.loc.begin.join(node.children.first.source_range.begin)
@@ -38,6 +63,44 @@ module RuboCop
 
         def closing_brace(node)
           node.children.last.source_range.end.join(node.loc.end)
+        end
+
+        def autocorrect_merge_methods(corrector, merge_methods, kwsplat)
+          range = range_of_merge_methods(merge_methods)
+
+          new_kwsplat_arguments = extract_send_methods(kwsplat).map do |descendant|
+            convert_to_new_arguments(descendant)
+          end
+          new_source = new_kwsplat_arguments.compact.reverse.unshift('').join(', ')
+
+          corrector.replace(range, new_source)
+        end
+
+        def range_of_merge_methods(merge_methods)
+          begin_merge_method = merge_methods.last
+          end_merge_method = merge_methods.first
+
+          begin_merge_method.loc.dot.begin.join(end_merge_method.source_range.end)
+        end
+
+        def extract_send_methods(kwsplat)
+          @extract_send_methods ||= kwsplat.each_descendant(:send, :csend)
+        end
+
+        def convert_to_new_arguments(node)
+          return unless merge_method?(node)
+
+          node.arguments.map do |arg|
+            if arg.hash_type?
+              arg.source
+            else
+              "**#{arg.source}"
+            end
+          end
+        end
+
+        def merge_method?(node)
+          MERGE_METHODS.include?(node.method_name)
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -35,6 +35,83 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
     RUBY
   end
 
+  it 'registers an offense when using double splat hash braces with `merge` method call' do
+    expect_offense(<<~RUBY)
+      do_something(**{foo: bar, baz: qux}.merge(options))
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something(foo: bar, baz: qux, **options)
+    RUBY
+  end
+
+  it 'registers an offense when using double splat hash braces with `merge!` method call' do
+    expect_offense(<<~RUBY)
+      do_something(**{foo: bar, baz: qux}.merge!(options))
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something(foo: bar, baz: qux, **options)
+    RUBY
+  end
+
+  it 'registers an offense when using double splat hash braces with `merge` pair arguments method call' do
+    expect_offense(<<~RUBY)
+      do_something(**{foo: bar, baz: qux}.merge(x: y))
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something(foo: bar, baz: qux, x: y)
+    RUBY
+  end
+
+  it 'registers an offense when using double splat hash braces with `merge` safe navigation method call' do
+    expect_offense(<<~RUBY)
+      do_something(**{foo: bar, baz: qux}&.merge(options))
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something(foo: bar, baz: qux, **options)
+    RUBY
+  end
+
+  it 'registers an offense when using double splat hash braces with `merge` multiple arguments method call' do
+    expect_offense(<<~RUBY)
+      do_something(**{foo: bar, baz: qux}.merge(options1, options2))
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something(foo: bar, baz: qux, **options1, **options2)
+    RUBY
+  end
+
+  it 'registers an offense when using double splat hash braces with `merge` method chain' do
+    expect_offense(<<~RUBY)
+      do_something(**{foo: bar, baz: qux}.merge(options1, options2).merge(options3))
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something(foo: bar, baz: qux, **options1, **options2, **options3)
+    RUBY
+  end
+
+  it 'registers an offense when using double splat hash braces with complex `merge` method chain' do
+    expect_offense(<<~RUBY)
+      do_something(**{foo: bar, baz: qux}.merge(options1, options2)&.merge!(options3))
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something(foo: bar, baz: qux, **options1, **options2, **options3)
+    RUBY
+  end
+
   it 'does not register an offense when using keyword arguments' do
     expect_no_offenses(<<~RUBY)
       do_something(foo: bar, baz: qux)
@@ -59,9 +136,9 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
     RUBY
   end
 
-  it 'does not register an offense when using method call for double splat hash braces arguments' do
+  it 'does not register an offense when using method call that is not `merge` for double splat hash braces arguments' do
     expect_no_offenses(<<~RUBY)
-      do_something(**{foo: bar}.merge(options))
+      do_something(**{foo: bar}.invert)
     RUBY
   end
 


### PR DESCRIPTION
Resolves #12257.

This PR makes `Style/RedundantDoubleSplatHashBraces` aware of `merge` methods. Instead of introducing a new cop, this `Style/RedundantDoubleSplatHashBraces` cop can be extended.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
