### PR TITLE
[Fix #12259] Fix an error for `Lint/MixedCaseRange`

### DIFF
--- a/changelog/fix_an_error_for_lint_mixed_case_range.md
+++ b/changelog/fix_an_error_for_lint_mixed_case_range.md
@@ -1,0 +1,1 @@
+* [#12259](https://github.com/rubocop/rubocop/issues/12259): Fix an error for `Lint/MixedCaseRange` when using nested character class in regexp. ([@koic][])

--- a/lib/rubocop/cop/lint/mixed_case_range.rb
+++ b/lib/rubocop/cop/lint/mixed_case_range.rb
@@ -95,7 +95,7 @@ module RuboCop
 
         def skip_range?(range_start, range_end)
           [range_start, range_end].any? do |bound|
-            bound.type == :escape
+            bound.type != :literal
           end
         end
 

--- a/spec/rubocop/cop/lint/mixed_case_range_spec.rb
+++ b/spec/rubocop/cop/lint/mixed_case_range_spec.rb
@@ -221,4 +221,10 @@ RSpec.describe RuboCop::Cop::Lint::MixedCaseRange, :config do
       foo = /[A\-z]/
     RUBY
   end
+
+  it 'does not register an offense with nested character class' do
+    expect_no_offenses(<<~RUBY)
+      foo = /[a-[bc]]/
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #12259.

This PR fixes an error for `Lint/MixedCaseRange` when using nested character class in regexp.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
