### PR TITLE
Fix an incorrect autocorrect for `Style/RedundantDoubleSplatHashBraces`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_redundant_double_splat_hash_braces.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_redundant_double_splat_hash_braces.md
@@ -1,0 +1,1 @@
+* [#12262](https://github.com/rubocop/rubocop/pull/12262): Fix an incorrect autocorrect for `Style/RedundantDoubleSplatHashBraces` when using double splat hash braces with `merge` method call twice. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -84,7 +84,7 @@ module RuboCop
         end
 
         def extract_send_methods(kwsplat)
-          @extract_send_methods ||= kwsplat.each_descendant(:send, :csend)
+          kwsplat.each_descendant(:send, :csend)
         end
 
         def convert_to_new_arguments(node)

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -79,6 +79,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
     RUBY
   end
 
+  it 'registers an offense when using double splat hash braces with `merge` method call twice' do
+    expect_offense(<<~RUBY)
+      do_something(**{ foo: bar }.merge(options))
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+      do_something(**{ baz: qux }.merge(options))
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something(foo: bar, **options)
+      do_something(baz: qux, **options)
+    RUBY
+  end
+
   it 'registers an offense when using double splat hash braces with `merge` multiple arguments method call' do
     expect_offense(<<~RUBY)
       do_something(**{foo: bar, baz: qux}.merge(options1, options2))


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for `Style/RedundantDoubleSplatHashBraces` when using double splat hash braces with `merge` method call twice.

```console
$ bundle exec rspec  spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb:82
Run options: include {:locations=>{"./spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb"=>[82]}}
(snip)

  Failures:

    1) RuboCop::Cop::Style::RedundantDoubleSplatHashBraces registers an offense
    when using double splat hash braces with `merge` method call twice
    Failure/Error: expect(new_source).to eq(correction)

      expected: "do_something(foo: bar, **options)\ndo_something(baz: qux, **options)\n"
           got: "do_something(foo: bar, **options)\ndo_something(baz: qux.merge(options))\n"

      (compared using ==)

      Diff:
      @@ -1,3 +1,3 @@
       do_something(foo: bar, **options)
      -do_something(baz: qux, **options)
      +do_something(baz: qux.merge(options))

# ./lib/rubocop/rspec/expect_offense.rb:164:in `expect_correction'
# ./spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb:90:in `block (2 levels) in <top (required)>'

Finished in 0.15475 seconds (files took 1.24 seconds to load)
1 example, 1 failure
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
