### PR TITLE
Fix `Style/RedundantDoubleSplatHashBraces` to handle nested hashes

### DIFF
--- a/changelog/fix_redundant_double_splat_hash_braces_nested_hashes.md
+++ b/changelog/fix_redundant_double_splat_hash_braces_nested_hashes.md
@@ -1,0 +1,1 @@
+* [#12264](https://github.com/rubocop/rubocop/pull/12264): Fix `Style/RedundantDoubleSplatHashBraces` to handle nested hashes. ([@fatkodima][])

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -25,8 +25,10 @@ module RuboCop
         MSG = 'Remove the redundant double splat and braces, use keyword arguments directly.'
         MERGE_METHODS = %i[merge merge!].freeze
 
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable Metrics
         def on_hash(node)
+          node = outermost_hash(node)
+
           return if !node.braces? || node.pairs.empty? || node.pairs.any?(&:hash_rocket?)
           return unless (parent = node.parent)
           return unless (kwsplat = node.each_ancestor(:kwsplat).first)
@@ -36,9 +38,16 @@ module RuboCop
             autocorrect(corrector, node, kwsplat)
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:enable Metrics
 
         private
+
+        def outermost_hash(node)
+          while (parent = node.parent)&.pair_type?
+            node = parent.parent
+          end
+          node
+        end
 
         def autocorrect(corrector, node, kwsplat)
           corrector.remove(kwsplat.loc.operator)

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -162,6 +162,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
     RUBY
   end
 
+  it 'does not register an offense when using method call that is not `merge` for double splat hash braces arguments and nested hashes' do
+    expect_no_offenses(<<~RUBY)
+      do_something(**options.reverse_merge(foo: { bar: baz }))
+    RUBY
+  end
+
   it 'does not register an offense when using hash braces arguments' do
     expect_no_offenses(<<~RUBY)
       do_something({foo: bar, baz: qux})


### PR DESCRIPTION
While tried to run on a `rails/rails` `Style/RedundantDoubleSplatHashBraces` cop, I got a false positive for https://github.com/rails/rails/blob/3064a255c53e04a2f4885aa5d5134786ac3904e9/actionpack/test/dispatch/ssl_test.rb#L13.