### PR TITLE
[Fix #12265] Fix an error for `Layout/MultilineMethodCallIndentation`

### DIFF
--- a/changelog/fix_an_error_for_layout_multiline_method_call_indentation.md
+++ b/changelog/fix_an_error_for_layout_multiline_method_call_indentation.md
@@ -1,0 +1,1 @@
+* [#12265](https://github.com/rubocop/rubocop/issues/12265): Fix an error for `Layout/MultilineMethodCallIndentation` when usingarithmetic operation with block inside a grouped expression. ([@koic][])

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -182,7 +182,7 @@ module RuboCop
           return unless rhs.source.start_with?('.', '&.')
 
           node = semantic_alignment_node(node)
-          return unless node&.loc&.selector
+          return unless node&.loc&.selector && node.loc.dot
 
           node.loc.dot.join(node.loc.selector)
         end

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -73,6 +73,16 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
       RUBY
     end
 
+    it 'accepts arithmetic operation with block inside a grouped expression' do
+      expect_no_offenses(<<~RUBY)
+        (
+          a * b do
+          end
+        )
+          .c
+      RUBY
+    end
+
     it 'accepts an expression where the first method spans multiple lines' do
       expect_no_offenses(<<~RUBY)
         subject.each do |item|


### PR DESCRIPTION
Fixes #12265.

This PR fixes an error for `Layout/MultilineMethodCallIndentation` when usingarithmetic operation with block inside a grouped expression.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
