### PR TITLE
Fix an infinite loop for `Layout/MultilineMethodCallIndentation`

### DIFF
--- a/changelog/fix_an_infinite_loop_for_layout_multiline_method_call_indentation.md
+++ b/changelog/fix_an_infinite_loop_for_layout_multiline_method_call_indentation.md
@@ -1,0 +1,1 @@
+* [#12261](https://github.com/rubocop/rubocop/issues/12261): Fix an infinite loop for `Layout/MultilineMethodCallIndentation` when multiline method chain with a block argument and method chain. ([@ydah][])

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -227,7 +227,11 @@ module RuboCop
           return unless (block_node = node.each_descendant(:block, :numblock).first)
           return unless block_node.multiline? && block_node.parent.call_type?
 
-          block_node.parent
+          if node.receiver.call_type?
+            node.receiver
+          else
+            block_node.parent
+          end
         end
 
         def first_call_has_a_dot(node)

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -99,6 +99,16 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
       RUBY
     end
 
+    it 'accepts aligned methods when multiline method chain with a block argument and method chain' do
+      expect_no_offenses(<<~RUBY)
+        a(b)
+          .c(
+            d do
+            end.f
+          )
+      RUBY
+    end
+
     it "doesn't crash on unaligned multiline lambdas" do
       expect_no_offenses(<<~RUBY)
         MyClass.(my_args)
@@ -333,6 +343,16 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
         expect_correction(<<~RUBY)
           a
             &.b
+        RUBY
+      end
+
+      it 'accepts aligned methods when multiline method chain with a block argument and method chain' do
+        expect_no_offenses(<<~RUBY)
+          a&.(b)
+            .c(
+              d do
+              end.f
+            )
         RUBY
       end
     end


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop/issues/12261

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
