### PR TITLE
Fix false positives for `Style/RedundantDoubleSplatHashBraces`

### DIFF
--- a/changelog/fix_false_positive_for_style_redundant_double_splat_hash_braces.md
+++ b/changelog/fix_false_positive_for_style_redundant_double_splat_hash_braces.md
@@ -1,0 +1,1 @@
+* [#12263](https://github.com/rubocop/rubocop/issues/12263): Fix false positives for `Style/RedundantDoubleSplatHashBraces` when method call for no hash braced double splat receiver. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -138,6 +138,18 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
     RUBY
   end
 
+  it 'does not register an offense when method call for no hash braced double splat receiver' do
+    expect_no_offenses(<<~RUBY)
+      do_something(**options.merge({foo: bar}))
+    RUBY
+  end
+
+  it 'does not register an offense when safe navigation method call for no hash braced double splat receiver' do
+    expect_no_offenses(<<~RUBY)
+      do_something(**options&.merge({foo: bar}))
+    RUBY
+  end
+
   it 'does not register an offense when using empty double splat hash braces arguments' do
     expect_no_offenses(<<~RUBY)
       do_something(**{})


### PR DESCRIPTION
Fixes #12263.

This PR fixes false positives for `Style/RedundantDoubleSplatHashBraces` when method call for no hash braced double splat receiver.

The code shown in #12263 is incompatible as shown below and is a false positive:

```ruby
def x(opts) = puts(opts)

h = {foo: :bar}

x(**h.merge(k: :h)) #=> {:foo=>:bar, :k=>:h}
x(k: :v, **h)       #=> {:k=>:v, :foo=>:bar}
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
