### PR TITLE
[Fix #12271] Fix a false positive for `Lint/RedundantSafeNavigation`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_redundant_safe_navigation.md
+++ b/changelog/fix_a_false_positive_for_lint_redundant_safe_navigation.md
@@ -1,0 +1,1 @@
+* [#12271](https://github.com/rubocop/rubocop/issues/12271): Fix a false positive for `Lint/RedundantSafeNavigation` when using snake case constant receiver. ([@koic][])

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -3,14 +3,27 @@
 RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
   let(:cop_config) { { 'AllowedMethods' => %w[respond_to?] } }
 
-  it 'registers an offense and corrects when `&.` is used for const receiver' do
+  it 'registers an offense and corrects when `&.` is used for camel case const receiver' do
     expect_offense(<<~RUBY)
-      Foo&.do_something
-         ^^^^^^^^^^^^^^ Redundant safe navigation detected.
+      Const&.do_something
+           ^^^^^^^^^^^^^^ Redundant safe navigation detected.
+      ConstName&.do_something
+               ^^^^^^^^^^^^^^ Redundant safe navigation detected.
+      Const_name&.do_something # It is treated as camel case, similar to the `Naming/ConstantName` cop.
+                ^^^^^^^^^^^^^^ Redundant safe navigation detected.
     RUBY
 
     expect_correction(<<~RUBY)
-      Foo.do_something
+      Const.do_something
+      ConstName.do_something
+      Const_name.do_something # It is treated as camel case, similar to the `Naming/ConstantName` cop.
+    RUBY
+  end
+
+  it 'does not register an offense and corrects when `&.` is used for snake case const receiver' do
+    expect_no_offenses(<<~RUBY)
+      CONST&.do_something
+      CONST_NAME&.do_something
     RUBY
   end
 


### PR DESCRIPTION
Fixes #12271.

This PR fixes a false positive for `Lint/RedundantSafeNavigation` when using snake case constant receiver.

Camel case is used for naming classes and modules, while snake case is used for all other constants. This naming conforms with `Naming/ConstantName` cop.

Since constants that turn into classes or modules are normally not `nil`, they will continue to be detected.
However, this PR will update to allow safe navigation for constants in snake case.

This change resolves both issue https://github.com/rubocop/rubocop-rails/issues/1104 and #12271.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
