### PR TITLE
[Fix #12275] Fix a false positive for `Style/RedundantDoubleSplatHashBraces`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_double_splat_hash_brace.md
+++ b/changelog/fix_false_positives_for_style_redundant_double_splat_hash_brace.md
@@ -1,0 +1,1 @@
+* [#12275](https://github.com/rubocop/rubocop/issues/12275): Fix a false positive for `Style/RedundantDoubleSplatHashBraces` when using double splat within block argument containing a hash literal in an array literal. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -42,9 +42,11 @@ module RuboCop
         private
 
         def allowed_double_splat_receiver?(kwsplat)
-          return false unless kwsplat.children.first.call_type?
+          first_child = kwsplat.children.first
+          return true if first_child.block_type? || first_child.numblock_type?
+          return false unless first_child.call_type?
 
-          root_receiver = root_receiver(kwsplat.children.first)
+          root_receiver = root_receiver(first_child)
 
           !root_receiver&.hash_type?
         end

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -126,6 +126,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
     RUBY
   end
 
+  it 'registers an offense when using double splat hash braces inside block' do
+    expect_offense(<<~RUBY)
+      block do
+        do_something(**{foo: bar, baz: qux})
+                     ^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      block do
+        do_something(foo: bar, baz: qux)
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using keyword arguments' do
     expect_no_offenses(<<~RUBY)
       do_something(foo: bar, baz: qux)
@@ -189,6 +204,24 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
   it 'does not register an offense when using hash literal' do
     expect_no_offenses(<<~RUBY)
       { a: a }
+    RUBY
+  end
+
+  it 'does not register an offense when using double splat within block argument containing a hash literal in an array literal' do
+    expect_no_offenses(<<~RUBY)
+      do_something(**x.do_something { [foo: bar] })
+    RUBY
+  end
+
+  it 'does not register an offense when using double splat within block argument containing a nested hash literal' do
+    expect_no_offenses(<<~RUBY)
+      do_something(**x.do_something { {foo: {bar: baz}} })
+    RUBY
+  end
+
+  it 'does not register an offense when using double splat within numbered block argument containing a nested hash literal' do
+    expect_no_offenses(<<~RUBY)
+      do_something(**x.do_something { {foo: {bar: _1}} })
     RUBY
   end
 end


### PR DESCRIPTION
Fixes #12275.

This PR fixes a false positive for `Style/RedundantDoubleSplatHashBraces` when using double splat within block argument containing a hash literal in an array literal.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
