### PR TITLE
[Fix #12279] Fix false positives for `Lint/EmptyConditionalBody`

### DIFF
--- a/changelog/fix_false_positives_for_lint_empty_conditional_body.md
+++ b/changelog/fix_false_positives_for_lint_empty_conditional_body.md
@@ -1,0 +1,1 @@
+* [#12279](https://github.com/rubocop/rubocop/issues/12279): Fix false positives for `Lint/EmptyConditionalBody` when missing 2nd `if` body with a comment. ([@koic][])

--- a/lib/rubocop/cop/mixin/comments_help.rb
+++ b/lib/rubocop/cop/mixin/comments_help.rb
@@ -62,25 +62,29 @@ module RuboCop
       # Returns the end line of a node, which might be a comment and not part of the AST
       # End line is considered either the line at which another node starts, or
       # the line at which the parent node ends.
-      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Lint/DuplicateBranch
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       def find_end_line(node)
-        if node.if_type? && node.else?
-          node.loc.else.line
-        elsif node.if_type? && node.ternary?
-          node.else_branch.loc.line
-        elsif node.if_type? && node.elsif?
-          node.each_ancestor(:if).find(&:if?).loc.end.line
+        if node.if_type?
+          if node.else?
+            node.loc.else.line
+          elsif node.ternary?
+            node.else_branch.loc.line
+          elsif node.elsif?
+            node.each_ancestor(:if).find(&:if?).loc.end.line
+          end
         elsif node.block_type? || node.numblock_type?
           node.loc.end.line
         elsif (next_sibling = node.right_sibling) && next_sibling.is_a?(AST::Node)
           next_sibling.loc.line
         elsif (parent = node.parent)
-          parent.loc.respond_to?(:end) && parent.loc.end ? parent.loc.end.line : parent.loc.line
-        else
-          node.loc.end.line
-        end
+          if parent.loc.respond_to?(:end) && parent.loc.end
+            parent.loc.end.line
+          else
+            parent.loc.line
+          end
+        end || node.loc.end.line
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Lint/DuplicateBranch
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     end
   end
 end

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -75,6 +75,17 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     RUBY
   end
 
+  it 'does not register an offense for missing 2nd `if` body with a comment' do
+    expect_no_offenses(<<~RUBY)
+      if condition1
+        do_something1
+      end
+      if condition2
+        # noop
+      end
+    RUBY
+  end
+
   it 'does not register an offense for missing 2nd `elsif` body with a comment' do
     expect_no_offenses(<<~RUBY)
       if condition1
@@ -347,10 +358,10 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     it 'registers an offense for multi-line value omission in `unless`' do
       expect_offense(<<~RUBY)
         var =
+          # This is the value of `other:`, like so: `other: condition || other_condition`
           unless object.action value:, other:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid `unless` branches without a body.
-            condition || other_condition # This is the value of `other:`, like so:
-                                         # `other: condition || other_condition`
+            condition || other_condition
           end
       RUBY
     end


### PR DESCRIPTION
Fixes #12279.

This PR fixes false positives for `Lint/EmptyConditionalBody` when missing 2nd `if` body with a comment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
