### PR TITLE
Do not accept abbreviated options for cli

### DIFF
--- a/changelog/fix_do_not_accept_abbreviated_options_for_cli.md
+++ b/changelog/fix_do_not_accept_abbreviated_options_for_cli.md
@@ -1,0 +1,1 @@
+* [#12280](https://github.com/rubocop/rubocop/issues/12280): Do not accept abbreviated options for cli. ([@fatkodima][])

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -53,6 +53,7 @@ module RuboCop
     def define_options
       OptionParser.new do |opts|
         opts.banner = rainbow.wrap('Usage: rubocop [options] [file1, file2, ...]').bright
+        opts.require_exact = true
 
         add_check_options(opts)
         add_cache_options(opts)

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -2268,12 +2268,22 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
   end
 
   describe 'option is invalid' do
-    it 'suggests to use the --help flag' do
+    it 'suggests to use the --help flag when non existing option' do
       invalid_option = '--invalid-option'
 
       expect(cli.run([invalid_option])).to eq(2)
       expect($stderr.string).to eq(<<~RESULT)
         invalid option: #{invalid_option}
+        For usage information, use --help
+      RESULT
+    end
+
+    it 'suggests to use the --help flag when abbreviated option' do
+      abbreviated_option = '--disable-p' # `--disable-pending-cops`
+
+      expect(cli.run([abbreviated_option])).to eq(2)
+      expect($stderr.string).to eq(<<~RESULT)
+        invalid option: #{abbreviated_option}
         For usage information, use --help
       RESULT
     end


### PR DESCRIPTION
Fixes #12280.

Was also surprised that rubocop's cli accepts abbreviated options. I do not think this is a convenience, but more like a bug if you do not specify the correct option.