### PR TITLE
Fix an error for `Style/SingleLineDoEndBlock`

### DIFF
--- a/changelog/fix_an_error_for_style_single_line_do_end_block.md
+++ b/changelog/fix_an_error_for_style_single_line_do_end_block.md
@@ -1,0 +1,1 @@
+* [#12283](https://github.com/rubocop/rubocop/pull/12283): Fix an error for `Style/SingleLineDoEndBlock` when using single line `do`...`end` with no body. ([@koic][])

--- a/lib/rubocop/cop/style/single_line_do_end_block.rb
+++ b/lib/rubocop/cop/style/single_line_do_end_block.rb
@@ -30,6 +30,7 @@ module RuboCop
 
         MSG = 'Prefer multiline `do`...`end` block.'
 
+        # rubocop:disable Metrics/AbcSize
         def on_block(node)
           return if !node.single_line? || node.braces?
 
@@ -42,10 +43,11 @@ module RuboCop
               corrector.remove(node.loc.end)
               corrector.insert_after(node_body.loc.heredoc_end, "\nend")
             else
-              corrector.insert_after(node_body, "\n")
+              corrector.insert_before(node.loc.end, "\n")
             end
           end
         end
+        # rubocop:enable Metrics/AbcSize
         alias on_numblock on_block
 
         private

--- a/spec/rubocop/cop/style/single_line_do_end_block_spec.rb
+++ b/spec/rubocop/cop/style/single_line_do_end_block_spec.rb
@@ -9,8 +9,21 @@ RSpec.describe RuboCop::Cop::Style::SingleLineDoEndBlock, :config do
 
     expect_correction(<<~RUBY)
       foo do
-       bar
-       end
+       bar#{' '}
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using single line `do`...`end` with no body' do
+    expect_offense(<<~RUBY)
+      foo do end
+      ^^^^^^^^^^ Prefer multiline `do`...`end` block.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo do
+      #{' '}
+      end
     RUBY
   end
 
@@ -22,8 +35,8 @@ RSpec.describe RuboCop::Cop::Style::SingleLineDoEndBlock, :config do
 
     expect_correction(<<~RUBY)
       foo do |arg|
-       bar(arg)
-       end
+       bar(arg)#{' '}
+      end
     RUBY
   end
 
@@ -35,8 +48,8 @@ RSpec.describe RuboCop::Cop::Style::SingleLineDoEndBlock, :config do
 
     expect_correction(<<~RUBY)
       foo do
-       bar(_1)
-       end
+       bar(_1)#{' '}
+      end
     RUBY
   end
 
@@ -65,8 +78,8 @@ RSpec.describe RuboCop::Cop::Style::SingleLineDoEndBlock, :config do
 
     expect_correction(<<~RUBY)
       ->(arg) do
-       foo arg
-       end
+       foo arg#{' '}
+      end
     RUBY
   end
 
@@ -78,8 +91,8 @@ RSpec.describe RuboCop::Cop::Style::SingleLineDoEndBlock, :config do
 
     expect_correction(<<~RUBY)
       lambda do |arg|
-       foo(arg)
-       end
+       foo(arg)#{' '}
+      end
     RUBY
   end
 


### PR DESCRIPTION
This PR fixes the following error for `Style/SingleLineDoEndBlock` when using single line `do`...`end` with no body

```console
$ echo 'foo do end' | bunlde exec rubocop --stdin test.rb -d --only Style/SingleLineDoEndBlock
(snip)

An error occurred while Style/SingleLineDoEndBlock cop was inspecting
/Users/koic/src/github.com/rubocop/rubocop/test.rb:1:0.
Expected a Parser::Source::Range, Comment or RuboCop::AST::Node, got NilClass
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/corrector.rb:111:in `to_range'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/corrector.rb:120:in `check_range_validity'
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/parser-3.2.2.4/
lib/parser/source/tree_rewriter.rb:398:in `combine'
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/parser-3.2.2.4/
lib/parser/source/tree_rewriter.rb:207:in `wrap'
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/parser-3.2.2.4/
lib/parser/source/tree_rewriter.rb:243:in `insert_after'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/single_line_do_end_block.rb:45:in `block in on_block'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
