### PR TITLE
[Fix #12284] Fix false positives for `Style/SingleArgumentDig`

### DIFF
--- a/changelog/fix_false_positives_for_style_single_argument_dig.md
+++ b/changelog/fix_false_positives_for_style_single_argument_dig.md
@@ -1,0 +1,1 @@
+* [#12284](https://github.com/rubocop/rubocop/issues/12284): Fix false positives for `Style/SingleArgumentDig` when using some anonymous argument syntax. ([@koic][])

--- a/lib/rubocop/cop/style/single_argument_dig.rb
+++ b/lib/rubocop/cop/style/single_argument_dig.rb
@@ -33,6 +33,7 @@ module RuboCop
 
         MSG = 'Use `%<receiver>s[%<argument>s]` instead of `%<original>s`.'
         RESTRICT_ON_SEND = %i[dig].freeze
+        IGNORED_ARGUMENT_TYPES = %i[block_pass forwarded_restarg forwarded_args hash].freeze
 
         # @!method single_argument_dig?(node)
         def_node_matcher :single_argument_dig?, <<~PATTERN
@@ -44,7 +45,7 @@ module RuboCop
 
           expression = single_argument_dig?(node)
           return unless expression
-          return if expression.forwarded_args_type?
+          return if IGNORED_ARGUMENT_TYPES.include?(expression.type)
 
           receiver = node.receiver.source
           argument = expression.source

--- a/spec/rubocop/cop/style/single_argument_dig_spec.rb
+++ b/spec/rubocop/cop/style/single_argument_dig_spec.rb
@@ -44,6 +44,40 @@ RSpec.describe RuboCop::Cop::Style::SingleArgumentDig, :config do
     end
   end
 
+  context '>= Ruby 3.1', :ruby31 do
+    context 'when using dig with anonymous block argument forwarding' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def foo(&)
+            { key: 'value' }.dig(&)
+          end
+        RUBY
+      end
+    end
+  end
+
+  context '>= Ruby 3.2', :ruby32 do
+    context 'when using dig with anonymous rest argument forwarding' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def foo(*)
+            { key: 'value' }.dig(*)
+          end
+        RUBY
+      end
+    end
+
+    context 'when using dig with anonymous keyword argument forwarding' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def foo(**)
+            { key: 'value' }.dig(**)
+          end
+        RUBY
+      end
+    end
+  end
+
   describe 'dig over a variable as caller' do
     context 'with single argument' do
       it 'registers an offense and corrects unsuitable use of dig' do


### PR DESCRIPTION
Fixes #12284.

This PR fixes false positives for `Style/SingleArgumentDig` when using some anonymous argument syntax.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
