### PR TITLE
[Fix #12291] Fix a false positive for `Metrics/ClassLength`

### DIFF
--- a/changelog/fix_a_false_positive_for_metrics_class_length.md
+++ b/changelog/fix_a_false_positive_for_metrics_class_length.md
@@ -1,0 +1,1 @@
+* [#12291](https://github.com/rubocop/rubocop/issues/12291): Fix a false positive for `Metrics/ClassLength` when a class with a singleton class definition. ([@koic][])

--- a/lib/rubocop/cop/metrics/class_length.rb
+++ b/lib/rubocop/cop/metrics/class_length.rb
@@ -42,7 +42,12 @@ module RuboCop
         def on_class(node)
           check_code_length(node)
         end
-        alias on_sclass on_class
+
+        def on_sclass(node)
+          return if node.each_ancestor(:class).any?
+
+          on_class(node)
+        end
 
         def on_casgn(node)
           parent = node.parent

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -17,6 +17,22 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
     RUBY
   end
 
+  it 'registers an offense when a class with a singleton class definition has more than 5 lines' do
+    expect_offense(<<~RUBY)
+      class Test
+      ^^^^^^^^^^ Class has too many lines. [8/5]
+        class << self
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      end
+    RUBY
+  end
+
   it 'reports the correct beginning and end lines' do
     offenses = expect_offense(<<~RUBY)
       class Test


### PR DESCRIPTION
Fixes #12291.

This PR fixes a false positive for `Metrics/ClassLength` when a class with a singleton class definition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
