### PR TITLE
[Fix #12293] Fix a false positive for `Style/RedundantDoubleSplatHashBraces`

### DIFF
--- a/changelog/changelog/fix_a_false_positive_for_style_redundant_double_splat_hash_braces.md
+++ b/changelog/changelog/fix_a_false_positive_for_style_redundant_double_splat_hash_braces.md
@@ -1,0 +1,1 @@
+* [#12293](https://github.com/rubocop/rubocop/issues/12293): Fix a false positive for `Style/RedundantDoubleSplatHashBraces` when using double splat hash braces with `merge` and method chain. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -25,12 +25,12 @@ module RuboCop
         MSG = 'Remove the redundant double splat and braces, use keyword arguments directly.'
         MERGE_METHODS = %i[merge merge!].freeze
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_hash(node)
           return if node.pairs.empty? || node.pairs.any?(&:hash_rocket?)
           return unless (parent = node.parent)
           return unless parent.call_type? || parent.kwsplat_type?
-          return if parent.call_type? && !merge_method?(parent)
+          return unless mergeable?(parent)
           return unless (kwsplat = node.each_ancestor(:kwsplat).first)
           return if allowed_double_splat_receiver?(kwsplat)
 
@@ -38,7 +38,7 @@ module RuboCop
             autocorrect(corrector, node, kwsplat)
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         private
 
@@ -74,7 +74,7 @@ module RuboCop
 
         def select_merge_method_nodes(kwsplat)
           extract_send_methods(kwsplat).select do |node|
-            merge_method?(node)
+            mergeable?(node)
           end
         end
 
@@ -109,7 +109,7 @@ module RuboCop
         end
 
         def convert_to_new_arguments(node)
-          return unless merge_method?(node)
+          return unless mergeable?(node)
 
           node.arguments.map do |arg|
             if arg.hash_type?
@@ -120,8 +120,12 @@ module RuboCop
           end
         end
 
-        def merge_method?(node)
-          MERGE_METHODS.include?(node.method_name)
+        def mergeable?(node)
+          return true unless node.call_type?
+          return false unless MERGE_METHODS.include?(node.method_name)
+          return true unless (parent = node.parent)
+
+          mergeable?(parent)
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -189,6 +189,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
     RUBY
   end
 
+  it 'does not register an offense when using double splat hash braces with `merge` and method chain' do
+    expect_no_offenses(<<~RUBY)
+      do_something(**{foo: bar, baz: qux}.merge(options).compact_blank)
+    RUBY
+  end
+
   it 'does not register an offense when using hash braces arguments' do
     expect_no_offenses(<<~RUBY)
       do_something({foo: bar, baz: qux})


### PR DESCRIPTION
Fixes #12293.

This PR fixes a false positive for `Style/RedundantDoubleSplatHashBraces` when using double splat hash braces with `merge` and method chain.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
