### PR TITLE
[Fix #12298] Fix a false positive for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_parentheses.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#12298](https://github.com/rubocop/rubocop/issues/12298): Fix a false positive for `Style/RedundantParentheses` when using a parenthesized hash literal as the first argument in a method call without parentheses. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -548,6 +548,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   context 'when the first argument in a method call begins with a hash literal' do
     it 'accepts parentheses if the argument list is not parenthesized' do
       expect_no_offenses('x ({ y: 1 }), z')
+      expect_no_offenses('x ({ y: 1 }).merge({ y: 2 }), z')
       expect_no_offenses('x ({ y: 1 }.merge({ y: 2 })), z')
       expect_no_offenses('x ({ y: 1 }.merge({ y: 2 }).merge({ y: 3 })), z')
     end


### PR DESCRIPTION
Fixes #12298.

This PR fixes a false positive for `Style/RedundantParentheses` when using a parenthesized hash literal as the first argument in a method call without parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
