### PR TITLE
[Fix #12301] Make `Style/RedundantFilterChain` aware of safe navigation

### DIFF
--- a/changelog/fix_make_style_redundant_filter_chain_aware_of_safe_navigation.md
+++ b/changelog/fix_make_style_redundant_filter_chain_aware_of_safe_navigation.md
@@ -1,0 +1,1 @@
+* [#12301](https://github.com/rubocop/rubocop/issues/12301): Make `Style/RedundantFilterChain` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_filter_chain.rb
+++ b/lib/rubocop/cop/style/redundant_filter_chain.rb
@@ -60,10 +60,10 @@ module RuboCop
 
         # @!method select_predicate?(node)
         def_node_matcher :select_predicate?, <<~PATTERN
-          (send
+          (call
             {
-              (block $(send _ {:select :filter :find_all}) ...)
-              $(send _ {:select :filter :find_all} block_pass_type?)
+              (block $(call _ {:select :filter :find_all}) ...)
+              $(call _ {:select :filter :find_all} block_pass_type?)
             }
             ${:#{RESTRICT_ON_SEND.join(' :')}})
         PATTERN
@@ -87,6 +87,7 @@ module RuboCop
             register_offense(select_node, node)
           end
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/style/redundant_filter_chain_spec.rb
+++ b/spec/rubocop/cop/style/redundant_filter_chain_spec.rb
@@ -75,6 +75,52 @@ RSpec.describe RuboCop::Cop::Style::RedundantFilterChain, :config do
         arr.#{method}(&:odd?).any? { |x| x > 10 }
       RUBY
     end
+
+    context 'when using safe navigation operator' do
+      it "registers an offense when using `##{method}` followed by `#any?`" do
+        expect_offense(<<~RUBY, method: method)
+          arr&.%{method} { |x| x > 1 }&.any?
+               ^{method}^^^^^^^^^^^^^^^^^^^^ Use `any?` instead of `#{method}.any?`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          arr&.any? { |x| x > 1 }
+        RUBY
+      end
+
+      it "registers an offense when using `##{method}` followed by `#empty?`" do
+        expect_offense(<<~RUBY, method: method)
+          arr&.%{method} { |x| x > 1 }&.empty?
+               ^{method}^^^^^^^^^^^^^^^^^^^^^^ Use `none?` instead of `#{method}.empty?`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          arr&.none? { |x| x > 1 }
+        RUBY
+      end
+
+      it "registers an offense when using `##{method}` followed by `#none?`" do
+        expect_offense(<<~RUBY, method: method)
+          arr&.%{method} { |x| x > 1 }&.none?
+               ^{method}^^^^^^^^^^^^^^^^^^^^^ Use `none?` instead of `#{method}.none?`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          arr&.none? { |x| x > 1 }
+        RUBY
+      end
+
+      it "registers an offense when using `##{method}` with block-pass followed by `#none?`" do
+        expect_offense(<<~RUBY, method: method)
+          arr&.%{method}(&:odd?)&.none?
+               ^{method}^^^^^^^^^^^^^^^ Use `none?` instead of `#{method}.none?`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          arr&.none?(&:odd?)
+        RUBY
+      end
+    end
   end
 
   it 'does not register an offense when using `#any?`' do


### PR DESCRIPTION
Fixes #12301.

This PR makes `Style/RedundantFilterChain` aware of safe navigation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
