### PR TITLE
[Fix #11652] Generate inherit_from correctly also with ERB

### DIFF
--- a/changelog/fix_auto_gen_config_with_erb.md
+++ b/changelog/fix_auto_gen_config_with_erb.md
@@ -1,0 +1,1 @@
+* [#11652](https://github.com/rubocop/rubocop/issues/11652): Make `--auto-gen-config` generate `inherit_from` correctly inside ERB `if`. ([@jonas054][])


### PR DESCRIPTION
The problem with the existing algorithm, for generating the `inherit_from` line in `--auto-gen-config` runs, was that we started by removing the `inherit_from` (if present) and then inserted it later.

The things we must deal with in the algorithm are
* there could be a pre-existing `inherit_from` in `.rubocop.yml`, or not
* there could be a YAML doc start `---`, or not
* there could be inheritance from one or multiple files

A more robust approach to the removing, generating, and re-inserting is to assume that any pre-existing `inherit_from` directive is already in the right place. By replacing it with a placeholder and later replacing the placeholder with the new inheritance directive, we will get it right without much effort.