### PR TITLE
[Fix 12300] Fix an error for `Style/IdenticalConditionalBranches`

### DIFF
--- a/changelog/fix_error_for_style_identical_conditional_branches.md
+++ b/changelog/fix_error_for_style_identical_conditional_branches.md
@@ -1,0 +1,1 @@
+* [#12300](https://github.com/rubocop/rubocop/issues/12300): Fix an error for `Style/IdenticalConditionalBranches` when `if`...`else` with identical leading lines and using index assign. ([@koic][])

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -153,7 +153,15 @@ module RuboCop
           return unless duplicated_expressions?(node, heads)
 
           condition_variable = assignable_condition_value(node)
-          return if heads.first.assignment? && condition_variable == heads.first.name.to_s
+
+          head = heads.first
+          if head.assignment?
+            # The `send` node is used instead of the `indexasgn` node, so `name` cannot be used.
+            # https://github.com/rubocop/rubocop-ast/blob/v1.29.0/lib/rubocop/ast/node/indexasgn_node.rb
+            assigned_value = head.send_type? ? head.receiver.source : head.name.to_s
+
+            return if condition_variable == assigned_value
+          end
 
           check_expressions(node, heads, :before_condition)
         end

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -72,6 +72,45 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
     end
   end
 
+  context 'on if...else with identical leading lines and using index assign' do
+    it 'registers and corrects an offense' do
+      expect_offense(<<~RUBY)
+        if condition
+          h[:key] = foo
+          ^^^^^^^^^^^^^ Move `h[:key] = foo` out of the conditional.
+          bar
+        else
+          h[:key] = foo
+          ^^^^^^^^^^^^^ Move `h[:key] = foo` out of the conditional.
+          baz
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        h[:key] = foo
+        if condition
+          bar
+        else
+          baz
+        end
+      RUBY
+    end
+  end
+
+  context 'on if...else with identical leading lines and index assign to condition value' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        if h[:key]
+          h[:key] = foo
+          bar
+        else
+          h[:key] = foo
+          baz
+        end
+      RUBY
+    end
+  end
+
   context 'on if..else with identical leading lines and assign to condition value of method call receiver' do
     it "doesn't register an offense" do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #12300.

This PR fixes an error for `Style/IdenticalConditionalBranches` when `if`...`else` with identical leading lines and using index assign.

In RuboCop, the `send` node is used instead of the `indexasgn` node, so `name` cannot be used. https://github.com/rubocop/rubocop-ast/blob/v1.29.0/lib/rubocop/ast/node/indexasgn_node.rb

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
