### PR TITLE
[Fix #12274] Fix a false positive for `Lint/Void`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_void.md
+++ b/changelog/fix_a_false_positive_for_lint_void.md
@@ -1,0 +1,1 @@
+* [#12274](https://github.com/rubocop/rubocop/issues/12274): Fix a false positive for `Lint/Void` when `each`'s receiver is an object of `Enumerator` to which `filter` has been applied. ([@koic][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -57,6 +57,7 @@ module RuboCop
 
         OP_MSG = 'Operator `%<op>s` used in void context.'
         VAR_MSG = 'Variable `%<var>s` used in void context.'
+        CONST_MSG = 'Constant `%<var>s` used in void context.'
         LIT_MSG = 'Literal `%<lit>s` used in void context.'
         SELF_MSG = '`self` used in void context.'
         EXPRESSION_MSG = '`%<expression>s` used in void context.'
@@ -127,15 +128,18 @@ module RuboCop
         def check_var(node)
           return unless node.variable? || node.const_type?
 
-          if node.const_type? && node.special_keyword?
-            add_offense(node, message: format(VAR_MSG, var: node.source)) do |corrector|
-              autocorrect_void_expression(corrector, node)
-            end
+          if node.const_type?
+            template = node.special_keyword? ? VAR_MSG : CONST_MSG
+
+            offense_range = node
+            message = format(template, var: node.source)
           else
-            add_offense(node.loc.name,
-                        message: format(VAR_MSG, var: node.loc.name.source)) do |corrector|
-              autocorrect_void_expression(corrector, node)
-            end
+            offense_range = node.loc.name
+            message = format(VAR_MSG, var: node.loc.name.source)
+          end
+
+          add_offense(offense_range, message: message) do |corrector|
+            autocorrect_void_expression(corrector, node)
           end
         end
 

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -451,6 +451,16 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     RUBY
   end
 
+  it 'does not register `#each` block with conditional expression' do
+    expect_no_offenses(<<~RUBY)
+      enumerator_as_filter.each do |item|
+        # The `filter` method is used to filter for matches with `42`.
+        # In this case, it's not void.
+        item == 42
+      end
+    RUBY
+  end
+
   context 'Ruby 2.7', :ruby27 do
     it 'registers two offenses for void literals in `#tap` method' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     end
   end
 
-  %w[var @var @@var VAR $var].each do |var|
+  %w[var @var @@var $var].each do |var|
     it "registers an offense for void var #{var} if not on last line" do
       expect_offense(<<~RUBY, var: var)
         %{var} = 5
@@ -99,6 +99,20 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         top
       RUBY
     end
+  end
+
+  it 'registers an offense for void constant `CONST` if not on last line' do
+    expect_offense(<<~RUBY)
+      CONST = 5
+      CONST
+      ^^^^^ Constant `CONST` used in void context.
+      top
+    RUBY
+
+    expect_correction(<<~RUBY)
+      CONST = 5
+      top
+    RUBY
   end
 
   %w(1 2.0 :test /test/ [1] {}).each do |lit|
@@ -428,6 +442,20 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         ^^ Literal `42` used in void context.
         42
         ^^ Literal `42` used in void context.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array.each do |_item|
+      end
+    RUBY
+  end
+
+  it 'registers an offenses for void constant in a `#each` method' do
+    expect_offense(<<~RUBY)
+      array.each do |_item|
+        CONST
+        ^^^^^ Constant `CONST` used in void context.
       end
     RUBY
 


### PR DESCRIPTION
Fixes #12274.

This PR fixes a false positive for `Lint/Void` when `each`'s receiver is an object of `Enumerator` to which `filter` has been applied.

`each` blocks are allowed to prevent false positives. The expression inside the following block is not void:

```ruby
enumerator = [1, 2, 3].filter
enumerator.each { |item| item >= 2 } #=> [2, 3]
```

This might introduce false negatives, but higher severity Lint cop should aim for as safe detections as possible, I think.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
