### PR TITLE
[Fix #12307] Fix an infinite loop error for `Layout/EndAlignment`

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_layout_end_alignment.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_end_alignment.md
@@ -1,0 +1,1 @@
+* [#12307](https://github.com/rubocop/rubocop/issues/12307): Fix an infinite loop error for `Layout/EndAlignment` when `EnforcedStyleAlignWith: variable` and using a conditional statement in a method argument on the same line and `end` with method call is not aligned. ([@koic][])

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -163,7 +163,13 @@ module RuboCop
           when :keyword
             node
           when :variable
-            alignment_node_for_variable_style(node)
+            align_to = alignment_node_for_variable_style(node)
+
+            while (parent = align_to.parent) && parent.send_type? && same_line?(align_to, parent)
+              align_to = parent
+            end
+
+            align_to
           else
             start_line_range(node)
           end

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -438,6 +438,21 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       RUBY
     end
 
+    it 'registers an offense when using a conditional statement in a method argument on the same line and `end` with method call is not aligned' do
+      expect_offense(<<~RUBY)
+        do_something case condition
+                     when expr
+                     end.method_call
+                     ^^^ `end` at 3, 13 is not aligned with `do_something case` at 1, 0.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something case condition
+                     when expr
+        end.method_call
+      RUBY
+    end
+
     it 'register an offense when using a pattern matching in a method argument and `end` is not aligned', :ruby27 do
       expect_offense(<<~RUBY)
         format(


### PR DESCRIPTION
Fixes #12307.

This PR fixes an infinite loop error for `Layout/EndAlignment` when `EnforcedStyleAlignWith: variable` and using a conditional statement in a method argument on the same line and `end` with method call is not aligned.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
