### PR TITLE
[Fix #12310] Drop `base64` gem from runtime dependency

### DIFF
--- a/changelog/fix_drop_base64_gem_from_runtime_dependency.md
+++ b/changelog/fix_drop_base64_gem_from_runtime_dependency.md
@@ -1,0 +1,1 @@
+* [#12310](https://github.com/rubocop/rubocop/issues/12310): Drop `base64` gem from runtime dependency. ([@koic][])

--- a/lib/rubocop/formatter/html_formatter.rb
+++ b/lib/rubocop/formatter/html_formatter.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'base64'
 require 'cgi'
 require 'erb'
 require 'ostruct'
@@ -124,7 +123,10 @@ module RuboCop
 
         def base64_encoded_logo_image
           image = File.read(LOGO_IMAGE_PATH, binmode: true)
-          Base64.encode64(image)
+
+          # `Base64.encode64` compatible:
+          # https://github.com/ruby/base64/blob/v0.1.1/lib/base64.rb#L27-L40
+          [image].pack('m')
         end
       end
     end

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.add_runtime_dependency('base64', '~> 0.1.1')
   s.add_runtime_dependency('json', '~> 2.3')
   s.add_runtime_dependency('language_server-protocol', '>= 3.17.0')
   s.add_runtime_dependency('parallel', '~> 1.10')


### PR DESCRIPTION
Fixes #12310.

This PR drops `base64` gem from runtime dependency.

RuboCop only uses `Base64.encode64` from the `base64` gem. Therefore, there's no need to depend on the entire `base64` gem. The implementation of `Base64.encode64` is quite simple: https://github.com/ruby/base64/blob/v0.1.1/lib/base64.rb#L27-L40

This change is a better approach that has also been adopted by https://github.com/rack/rack/pull/2110.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
