### PR TITLE
[Fix #12312] Fix an incorrect autocorrect for `Style/HashSyntax`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_style_hash_syntax.md
+++ b/changelog/fix_an_incorrect_autocorrect_style_hash_syntax.md
@@ -1,0 +1,1 @@
+* [#12312](https://github.com/rubocop/rubocop/issues/12312): Fix an incorrect autocorrect for `Style/HashSyntax` when braced hash key and value are the same and it is used in `if`...`else`. ([@koic][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -48,18 +48,21 @@ module RuboCop
 
       def register_offense(node, message, replacement) # rubocop:disable Metrics/AbcSize
         add_offense(node.value, message: message) do |corrector|
-          if (def_node = def_node_that_require_parentheses(node))
-            last_argument = def_node.last_argument
-            if last_argument.nil? || !last_argument.hash_type?
-              next corrector.replace(node, replacement)
-            end
-
-            white_spaces = range_between(def_node.selector.end_pos,
-                                         def_node.first_argument.source_range.begin_pos)
-            corrector.replace(white_spaces, '(')
-            corrector.insert_after(last_argument, ')') if node == last_argument.pairs.last
-          end
           corrector.replace(node, replacement)
+
+          next unless (def_node = def_node_that_require_parentheses(node))
+
+          last_argument = def_node.last_argument
+          if last_argument.nil? || !last_argument.hash_type?
+            next corrector.replace(node, replacement)
+          end
+
+          white_spaces = range_between(def_node.selector.end_pos,
+                                       def_node.first_argument.source_range.begin_pos)
+          next if node.parent.braces?
+
+          corrector.replace(white_spaces, '(')
+          corrector.insert_after(last_argument, ')') if node == last_argument.pairs.last
         end
       end
 

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -938,6 +938,25 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'registers and corrects an offense when braced hash key and value are the same and it is used in `if`...`else`' do
+        expect_offense(<<~RUBY)
+          if condition
+            template % {value: value}
+                               ^^^^^ Omit the hash value.
+          else
+            do_something
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if condition
+            template % {value:}
+          else
+            do_something
+          end
+        RUBY
+      end
+
       it 'registers and corrects an offense when hash key and hash value are the same and it in the method body' do
         expect_offense(<<~RUBY)
           def do_something


### PR DESCRIPTION
Fixes #12312.

This PR fixes an incorrect autocorrect for `Style/HashSyntax` when braced hash key and value are the same and it is used in `if`...`else`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
