### PR TITLE
Suppress a Ruby warning when using Ruby 3.3.0dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,9 @@ gem 'test-queue'
 gem 'yard', '~> 0.9'
 
 group :test do
+  # FIXME: This `base64` dependency can be removed when https://github.com/bblimke/webmock/pull/1041
+  # is merged and released. It's a workaround until then.
+  gem 'base64'
   # FIXME: This `bigdecimal` dependency can be removed when https://github.com/jnunemaker/crack/pull/75
   # is merged and released. It's a workaround until then.
   gem 'bigdecimal', platform: :mri


### PR DESCRIPTION
Follow up #12313.

`base64` is not needed at runtime, but it was required as a test dependency. So, this PR suppresses the following warning when using Ruby 3.3.0dev:

```consle
$ ruby -v
ruby 3.3.0dev (2023-10-23T08:04:27Z master e6fcf07a6f) [x86_64-darwin22]

$ cd path/to/rubocop
$ bundle exec rspec
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/webmock-3.19.1/lib/webmock/util/headers.rb:3:
warning: base64 which will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.
```

https://app.circleci.com/pipelines/github/rubocop/rubocop/10108/workflows/20097132-bbe3-4fa4-ad7e-de7c30c86e69/jobs/291956?invite=true#step-104-0_163

The `base64` dependency can be removed from Gemfile when https://github.com/bblimke/webmock/pull/1041 is merged and released. It's a workaround until then.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
