### PR TITLE
Update Helix LSP config based on v23.10 changes

### DIFF
--- a/docs/modules/ROOT/pages/usage/lsp.adoc
+++ b/docs/modules/ROOT/pages/usage/lsp.adoc
@@ -124,6 +124,23 @@ https://github.com/helix-editor/helix[Helix] is a post-modern modal text editor 
 
 Add the following to your Helix language configuration file (e.g. `~/.config/helix/languages.toml`):
 
+Helix 23.10 or later:
+
+```toml
+[language-server.rubocop]
+command = "bundle"
+args = ["exec", "rubocop", "--lsp"]
+
+[[language]]
+name = "ruby"
+auto-format = true
+language-servers = [
+  { name = "rubocop" }
+]
+```
+
+Before Helix 23.10 or earlier:
+
 ```toml
 [[language]]
 name = "ruby"


### PR DESCRIPTION
The [newly released Helix 23.10](https://helix-editor.com/news/release-23-10-highlights/) changed the language config structure with the introduction of multiple language server support.

This change updates the example to reflect the current configuration instructions based on the docs: https://docs.helix-editor.com/languages.html#language-server-configuration