### PR TITLE
Add a project spec

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -305,6 +305,10 @@ RSpec.describe 'RuboCop Project', type: :feature do
 
       dir = File.expand_path('../changelog', __dir__)
 
+      it 'will not have a directory' do
+        expect(Dir["#{dir}/*"].none? { |path| File.directory?(path) }).to be(true)
+      end
+
       Dir["#{dir}/*.md"].each do |path|
         context "For #{path}" do
           let(:path) { path }


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/commit/d995cb4

This PR adds a project spec to prevent an unexpected changelog entry file path. For instance, if an unexpected file named `changelog/changelog/fix_foo.md` exists, it will fail as follows:

```console
$ bundle exec rspec spec/project_spec.rb:309
(snip)

  1) RuboCop Project Changelog future entries will not have a directory
     Failure/Error: expect(Dir[dir].all? { |path| File.file?(path) }).to be(true)

       expected true
            got false
     # ./spec/project_spec.rb:309:in `block (4 levels) in <top (required)>'

Finished in 0.02034 seconds (files took 1.71 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/project_spec.rb:308 # RuboCop Project Changelog future entries will not have a directory
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
