### PR TITLE
[Fix #12324] Fix an error for `Layout/RescueEnsureAlignment`

### DIFF
--- a/changelog/fix_error_for_layout_rescue_ensure_alignment.md
+++ b/changelog/fix_error_for_layout_rescue_ensure_alignment.md
@@ -1,0 +1,1 @@
+* [#12324](https://github.com/rubocop/rubocop/issues/12324): Fix an error for `Layout/RescueEnsureAlignment` when using `rescue` in `do`...`end` block assigned to object attribute. ([@koic][])

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -104,8 +104,8 @@ module RuboCop
               mlhs_node, = *node
               mlhs_node.source_range
             else
-              # It is a wrapper with access modifier.
-              node.child_nodes.first.loc.name
+              # It is a wrapper with receiver of object attribute or access modifier.
+              node.receiver&.source_range || node.child_nodes.first.loc.name
             end
 
           range_between(starting_loc.begin_pos, ending_loc.end_pos).source

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -688,6 +688,23 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
     end
   end
 
+  context 'rescue in do-end block assigned to object attribute' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        obj.attr = do_something do
+          rescue StandardError
+          ^^^^^^ `rescue` at 2, 2 is not aligned with `obj` at 1, 0.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        obj.attr = do_something do
+        rescue StandardError
+        end
+      RUBY
+    end
+  end
+
   context 'rescue in do-end block on multi-assignment' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #12324.

This PR fixes an error for `Layout/RescueEnsureAlignment` when using `rescue` in `do`...`end` block assigned to object attribute.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
