### PR TITLE
Fix an error for `Style/RedundantDoubleSplatHashBraces`

### DIFF
--- a/changelog/fix_an_error_for_style_redundant_double_splat_hash_braces.md
+++ b/changelog/fix_an_error_for_style_redundant_double_splat_hash_braces.md
@@ -1,0 +1,1 @@
+* [#12326](https://github.com/rubocop/rubocop/pull/12326): Fix an error for `Style/RedundantDoubleSplatHashBraces` when method call for parenthesized no hash double double splat. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -25,20 +25,20 @@ module RuboCop
         MSG = 'Remove the redundant double splat and braces, use keyword arguments directly.'
         MERGE_METHODS = %i[merge merge!].freeze
 
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_hash(node)
           return if node.pairs.empty? || node.pairs.any?(&:hash_rocket?)
           return unless (parent = node.parent)
           return unless parent.call_type? || parent.kwsplat_type?
           return unless mergeable?(parent)
           return unless (kwsplat = node.each_ancestor(:kwsplat).first)
-          return if allowed_double_splat_receiver?(kwsplat)
+          return if !node.braces? || allowed_double_splat_receiver?(kwsplat)
 
           add_offense(kwsplat) do |corrector|
             autocorrect(corrector, node, kwsplat)
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         private
 

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -165,6 +165,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
     RUBY
   end
 
+  it 'does not register an offense when method call for parenthesized no hash double double splat' do
+    expect_no_offenses(<<~RUBY)
+      do_something(**(options.merge(foo: bar)))
+    RUBY
+  end
+
   it 'does not register an offense when using empty double splat hash braces arguments' do
     expect_no_offenses(<<~RUBY)
       do_something(**{})


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/12275#issuecomment-1786554892.

This PR fixes an error for `Style/RedundantDoubleSplatHashBraces` when method call for parenthesized no hash double double splat.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
