### PR TITLE
[Fix #12322] Fix an error for `Style/CombinableLoops`

### DIFF
--- a/changelog/fix_error_for_style_combinable_loops.md
+++ b/changelog/fix_error_for_style_combinable_loops.md
@@ -1,0 +1,1 @@
+* [#12322](https://github.com/rubocop/rubocop/issues/12322): Fix an error for `Style/CombinableLoops` when looping over the same data for the third consecutive time or more. ([@koic][])

--- a/lib/rubocop/cop/style/combinable_loops.rb
+++ b/lib/rubocop/cop/style/combinable_loops.rb
@@ -59,8 +59,6 @@ module RuboCop
       class CombinableLoops < Base
         extend AutoCorrector
 
-        include RangeHelp
-
         MSG = 'Combine this loop with the previous loop.'
 
         def on_block(node)
@@ -105,11 +103,8 @@ module RuboCop
         end
 
         def combine_with_left_sibling(corrector, node)
-          corrector.replace(
-            node.left_sibling.body,
-            "#{node.left_sibling.body.source}\n#{node.body.source}"
-          )
-          corrector.remove(range_with_surrounding_space(range: node.source_range, side: :left))
+          corrector.remove(node.left_sibling.body.source_range.end.join(node.left_sibling.loc.end))
+          corrector.remove(node.source_range.begin.join(node.body.source_range.begin))
         end
       end
     end

--- a/spec/rubocop/cop/style/combinable_loops_spec.rb
+++ b/spec/rubocop/cop/style/combinable_loops_spec.rb
@@ -29,6 +29,22 @@ RSpec.describe RuboCop::Cop::Style::CombinableLoops, :config do
       RUBY
     end
 
+    it 'registers an offense when looping over the same data for the third consecutive time' do
+      expect_offense(<<~RUBY)
+        items.each { |item| foo(item) }
+        items.each { |item| bar(item) }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Combine this loop with the previous loop.
+        items.each { |item| baz(item) }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Combine this loop with the previous loop.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        items.each { |item| foo(item)
+        bar(item)
+        baz(item) }
+      RUBY
+    end
+
     context 'Ruby 2.7' do
       it 'registers an offense when looping over the same data as previous loop in numblocks' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #12322.

This PR fixes an error for `Style/CombinableLoops` when looping over the same data for the third consecutive time or more.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
