### PR TITLE
[Fix #12328] Make `Style/AutoResourceCleanup` aware of `Tempfile.open`

### DIFF
--- a/changelog/change_change_make_style_auto_resource_cleanup_aware_of_tempfile_open.md
+++ b/changelog/change_change_make_style_auto_resource_cleanup_aware_of_tempfile_open.md
@@ -1,0 +1,1 @@
+* [#12328](https://github.com/rubocop/rubocop/issues/12328): Make `Style/AutoResourceCleanup` aware of `Tempfile.open`. ([@koic][])

--- a/spec/rubocop/cop/style/auto_resource_cleanup_spec.rb
+++ b/spec/rubocop/cop/style/auto_resource_cleanup_spec.rb
@@ -8,6 +8,27 @@ RSpec.describe RuboCop::Cop::Style::AutoResourceCleanup, :config do
     RUBY
   end
 
+  it 'registers an offense for Tempfile.open without block' do
+    expect_offense(<<~RUBY)
+      Tempfile.open("filename")
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Use the block version of `Tempfile.open`.
+    RUBY
+  end
+
+  it 'registers an offense for ::File.open without block' do
+    expect_offense(<<~RUBY)
+      ::File.open("filename")
+      ^^^^^^^^^^^^^^^^^^^^^^^ Use the block version of `::File.open`.
+    RUBY
+  end
+
+  it 'registers an offense for ::Tempfile.open without block' do
+    expect_offense(<<~RUBY)
+      ::Tempfile.open("filename")
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the block version of `::Tempfile.open`.
+    RUBY
+  end
+
   it 'does not register an offense for File.open with block' do
     expect_no_offenses('File.open("file") { |f| something }')
   end


### PR DESCRIPTION
Fixes #12328.

This PR makes `Style/AutoResourceCleanup` aware of `Tempfile.open`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
