### PR TITLE
Make `InternalAffairs/MethodNameEqual` aware of `!=`

### DIFF
--- a/lib/rubocop/cop/internal_affairs/method_name_equal.rb
+++ b/lib/rubocop/cop/internal_affairs/method_name_equal.rb
@@ -12,37 +12,36 @@ module RuboCop
       #   # good
       #   node.method?(:do_something)
       #
+      #   # bad
+      #   node.method_name != :do_something
+      #
+      #   # good
+      #   !node.method?(:do_something)
+      #
       class MethodNameEqual < Base
-        include RangeHelp
         extend AutoCorrector
 
-        MSG = 'Use `method?(%<method_name>s)` instead of `method_name == %<method_name>s`.'
-        RESTRICT_ON_SEND = %i[==].freeze
+        MSG = 'Use `%<prefer>s` instead.'
+        RESTRICT_ON_SEND = %i[== !=].freeze
 
-        # @!method method_name?(node)
-        def_node_matcher :method_name?, <<~PATTERN
+        # @!method method_name(node)
+        def_node_matcher :method_name, <<~PATTERN
           (send
-            $(send
-              (...) :method_name) :==
-            $...)
+            (send
+              (...) :method_name) {:== :!=}
+            $_)
         PATTERN
 
         def on_send(node)
-          method_name?(node) do |method_name_node, method_name_arg|
-            message = format(MSG, method_name: method_name_arg.first.source)
+          method_name(node) do |method_name_arg|
+            bang = node.method?(:!=) ? '!' : ''
+            prefer = "#{bang}#{node.receiver.receiver.source}.method?(#{method_name_arg.source})"
+            message = format(MSG, prefer: prefer)
 
-            range = range(method_name_node, node)
-
-            add_offense(range, message: message) do |corrector|
-              corrector.replace(range, "method?(#{method_name_arg.first.source})")
+            add_offense(node, message: message) do |corrector|
+              corrector.replace(node, prefer)
             end
           end
-        end
-
-        private
-
-        def range(method_name_node, node)
-          range_between(method_name_node.loc.selector.begin_pos, node.source_range.end_pos)
         end
       end
     end

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -253,7 +253,7 @@ module RuboCop
           # Assume that if a method definition is inside any block call which
           # we can't identify, it could be a DSL
           node.each_ancestor(:block).any? do |ancestor|
-            ancestor.method_name != :class_eval && !ancestor.class_constructor?
+            !ancestor.method?(:class_eval) && !ancestor.class_constructor?
           end
         end
 

--- a/lib/rubocop/cop/style/auto_resource_cleanup.rb
+++ b/lib/rubocop/cop/style/auto_resource_cleanup.rb
@@ -25,7 +25,7 @@ module RuboCop
 
         def on_send(node)
           TARGET_METHODS.each do |target_class, target_method|
-            next if node.method_name != target_method
+            next unless node.method?(target_method)
 
             target_receiver = s(:const, nil, target_class)
             next if node.receiver != target_receiver

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -534,7 +534,7 @@ module RuboCop
           end
 
           def element_assignment?(node)
-            node.send_type? && node.method_name != :[]=
+            node.send_type? && !node.method?(:[]=)
           end
 
           def extract_branches(node)

--- a/spec/rubocop/cop/internal_affairs/method_name_equal_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/method_name_equal_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::MethodNameEqual, :config do
   it 'registers an offense when using `#method == :do_something`' do
     expect_offense(<<~RUBY)
       node.method_name == :do_something
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `method?(:do_something)` instead of `method_name == :do_something`.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.method?(:do_something)` instead.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -12,10 +12,21 @@ RSpec.describe RuboCop::Cop::InternalAffairs::MethodNameEqual, :config do
     RUBY
   end
 
+  it 'registers an offense when using `#method != :do_something`' do
+    expect_offense(<<~RUBY)
+      node.method_name != :do_something
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!node.method?(:do_something)` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !node.method?(:do_something)
+    RUBY
+  end
+
   it 'registers an offense when using `#method == other_node.do_something`' do
     expect_offense(<<~RUBY)
       node.method_name == other_node.do_something
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `method?(other_node.do_something)` instead of `method_name == other_node.do_something`.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.method?(other_node.do_something)` instead.
     RUBY
 
     expect_correction(<<~RUBY)


### PR DESCRIPTION
This PR makes `InternalAffairs/MethodNameEqual` aware of `node.method_name != method_name` and suppresses the following new offenses:

```console
$ bundle exec rubocop -a
(snip)

Offenses:

lib/rubocop/cop/lint/duplicate_methods.rb:256:13: C: [Corrected] InternalAffairs/MethodNameEqual:
Use !ancestor.method?(:class_eval) instead.
            ancestor.method_name != :class_eval && !ancestor.class_constructor?
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/style/auto_resource_cleanup.rb:28:13: C: [Corrected] Style/NegatedIf:
Favor unless over if for negative conditions.
            next if !node.method?(target_method)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/style/auto_resource_cleanup.rb:28:21: C: [Corrected] InternalAffairs/MethodNameEqual:
Use !node.method?(target_method) instead.
            next if node.method_name != target_method
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/style/conditional_assignment.rb:537:32: C: [Corrected] InternalAffairs/MethodNameEqual:
Use !node.method?(:[]=) instead.
            node.send_type? && node.method_name != :[]=
                               ^^^^^^^^^^^^^^^^^^^^^^^^

1517 files inspected, 4 offenses detected, 4 offenses corrected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
