### PR TITLE
[Fix #12337] Support `EnforcedStyleForRationalLiterals` for `Layout/SpaceAroundOperators`

### DIFF
--- a/changelog/change_support_a_new_enforced_style_for_layout_space_around_operators.md
+++ b/changelog/change_support_a_new_enforced_style_for_layout_space_around_operators.md
@@ -1,0 +1,1 @@
+* [#12337](https://github.com/rubocop/rubocop/issues/12337): Supports `EnforcedStyleForRationalLiterals` option for `Layout/SpaceAroundOperators`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1351,6 +1351,10 @@ Layout/SpaceAroundOperators:
   SupportedStylesForExponentOperator:
     - space
     - no_space
+  EnforcedStyleForRationalLiterals: no_space
+  SupportedStylesForRationalLiterals:
+    - space
+    - no_space
 
 Layout/SpaceBeforeBlockBraces:
   Description: >-

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -320,8 +320,9 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             .to eq(['# Offense count: 1',
                     '# This cop supports safe autocorrection (--autocorrect).',
                     '# Configuration parameters: AllowForAlignment, ' \
-                    'EnforcedStyleForExponentOperator.',
+                    'EnforcedStyleForExponentOperator, EnforcedStyleForRationalLiterals.',
                     '# SupportedStylesForExponentOperator: space, no_space',
+                    '# SupportedStylesForRationalLiterals: space, no_space',
                     'Layout/SpaceAroundOperators:',
                     '  Exclude:',
                     "    - 'example1.rb'",
@@ -862,8 +863,9 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '# Offense count: 1',
          '# This cop supports safe autocorrection (--autocorrect).',
          '# Configuration parameters: AllowForAlignment, ' \
-         'EnforcedStyleForExponentOperator.',
+         'EnforcedStyleForExponentOperator, EnforcedStyleForRationalLiterals.',
          '# SupportedStylesForExponentOperator: space, no_space',
+         '# SupportedStylesForRationalLiterals: space, no_space',
          'Layout/SpaceAroundOperators:',
          '  Exclude:',
          "    - 'example1.rb'",
@@ -964,8 +966,9 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '# Offense count: 1',
          '# This cop supports safe autocorrection (--autocorrect).',
          '# Configuration parameters: AllowForAlignment, ' \
-         'EnforcedStyleForExponentOperator.',
+         'EnforcedStyleForExponentOperator, EnforcedStyleForRationalLiterals.',
          '# SupportedStylesForExponentOperator: space, no_space',
+         '# SupportedStylesForRationalLiterals: space, no_space',
          'Layout/SpaceAroundOperators:',
          '  Exclude:',
          "    - 'example1.rb'",
@@ -1260,8 +1263,9 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '',
          '# This cop supports safe autocorrection (--autocorrect).',
          '# Configuration parameters: AllowForAlignment, ' \
-         'EnforcedStyleForExponentOperator.',
+         'EnforcedStyleForExponentOperator, EnforcedStyleForRationalLiterals.',
          '# SupportedStylesForExponentOperator: space, no_space',
+         '# SupportedStylesForRationalLiterals: space, no_space',
          'Layout/SpaceAroundOperators:',
          '  Exclude:',
          "    - 'example1.rb'",


### PR DESCRIPTION
Fixes #12337.

This PR supports `EnforcedStyleForRationalLiterals` option for `Layout/SpaceAroundOperators`. Like `SupportedStylesForExponentOperator` option, the default follows the style guide with `no_space`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
