### PR TITLE
[Fix #12363] Fix incorrect rendering in `HTMLFormatter` formatter

### DIFF
--- a/changelog/fix_incorrect_rendering_in_formatter_html_formatter.md
+++ b/changelog/fix_incorrect_rendering_in_formatter_html_formatter.md
@@ -1,0 +1,1 @@
+* [#12363](https://github.com/rubocop/rubocop/issues/12363): Fix incorrect rendering of HTML character entities in `HTMLFormatter` formatter. ([@koic][])

--- a/lib/rubocop/formatter/html_formatter.rb
+++ b/lib/rubocop/formatter/html_formatter.rb
@@ -87,7 +87,7 @@ module RuboCop
         # rubocop:enable Lint/UselessMethodDefinition
 
         def decorated_message(offense)
-          offense.message.gsub(/`(.+?)`/) { "<code>#{Regexp.last_match(1)}</code>" }
+          offense.message.gsub(/`(.+?)`/) { "<code>#{escape(Regexp.last_match(1))}</code>" }
         end
 
         def highlighted_source_line(offense)

--- a/spec/fixtures/html_formatter/expected.html
+++ b/spec/fixtures/html_formatter/expected.html
@@ -367,7 +367,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
       <div class="infobox">
         <div class="total">
           3 files inspected,
-          22 offenses detected:
+          23 offenses detected:
         </div>
         <ul class="offenses-list">
           
@@ -388,7 +388,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
             
             <li>
               <a href="#offense_app/models/book.rb">
-                app/models/book.rb - 6 offenses
+                app/models/book.rb - 7 offenses
               </a>
             </li>
           
@@ -596,7 +596,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
       
       <div class="offense-box" id="offense_app/models/book.rb">
         <div class="box-title-placeholder"><h3>&nbsp;</h3></div>
-        <div class="box-title"><h3>app/models/book.rb - 6 offenses</h3></div>
+        <div class="box-title"><h3>app/models/book.rb - 7 offenses</h3></div>
         <div class="offense-reports">
           
           <div class="report">
@@ -647,6 +647,17 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
             <div class="meta">
               <span class="location">Line #4</span> –
               <span class="severity convention">convention:</span>
+              <span class="message">Style/RedundantRegexpArgument: Use string <code>&quot;&amp;amp;&amp;lt;&quot;</code> as argument instead of regexp <code>/&amp;amp;&amp;lt;/</code>.</span>
+            </div>
+            
+            <pre><code>    qux(quux.scan(<span class="highlight convention">/&amp;amp;&amp;lt;/</span>))</code></pre>
+            
+          </div>
+          
+          <div class="report">
+            <div class="meta">
+              <span class="location">Line #5</span> –
+              <span class="severity convention">convention:</span>
               <span class="message">Style/RescueModifier: Avoid using <code>rescue</code> in its modifier form.</span>
             </div>
             
@@ -656,7 +667,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
           
           <div class="report">
             <div class="meta">
-              <span class="location">Line #4</span> –
+              <span class="location">Line #5</span> –
               <span class="severity convention">convention:</span>
               <span class="message">Style/RegexpLiteral: Use <code>%r</code> around regular expression.</span>
             </div>

--- a/spec/fixtures/html_formatter/project/app/models/book.rb
+++ b/spec/fixtures/html_formatter/project/app/models/book.rb
@@ -1,6 +1,7 @@
 class Book < ActiveRecord::Base
   def someMethod
     foo = bar = baz
+    qux(quux.scan(/&amp;&lt;/))
     Regexp.new(/\A<p>(.*)<\/p>\Z/m).match(full_document)[1] rescue full_document
   end
 end

--- a/spec/rubocop/formatter/html_formatter_spec.rb
+++ b/spec/rubocop/formatter/html_formatter_spec.rb
@@ -10,10 +10,19 @@ RSpec.describe RuboCop::Formatter::HTMLFormatter, :isolated_environment do
     Dir.chdir(File.basename(project_path)) { example.run }
   end
 
-  # Run without Style/EndOfLine as it gives different results on
-  # different platforms.
-  # Metrics/AbcSize is very strict, exclude it too
-  let(:options) { %w[--except Layout/EndOfLine,Metrics/AbcSize --format html --out] }
+  let(:enabled_cops) do
+    [
+      'Layout/EmptyLinesAroundAccessModifier', 'Layout/IndentationConsistency',
+      'Layout/IndentationWidth', 'Layout/LineLength', 'Lint/UselessAssignment',
+      'Naming/MethodName', 'Style/Documentation', 'Style/EmptyMethod',
+      'Style/FrozenStringLiteralComment', 'Style/RedundantRegexpArgument', 'Style/RegexpLiteral',
+      'Style/RescueModifier', 'Style/SymbolArray'
+    ].join(',')
+  end
+
+  let(:options) do
+    ['--only', enabled_cops, '--format', 'html', '--out']
+  end
 
   let(:actual_html_path) do
     path = File.expand_path('result.html')


### PR DESCRIPTION
Fixes #12363.

This PR fixes incorrect rendering of HTML character entities in `HTMLFormatter` formatter.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
