### PR TITLE
Don't assume first and last comments are aligned

### DIFF
--- a/changelog/fix_false_negative_for_layout_extra_spacing.md
+++ b/changelog/fix_false_negative_for_layout_extra_spacing.md
@@ -1,0 +1,1 @@
+* [#12366](https://github.com/rubocop/rubocop/pull/12366): Fix a false negative for `Layout/ExtraSpacing` when a file has exactly two comments. ([@eugeneius][])

--- a/lib/rubocop/cop/layout/extra_spacing.rb
+++ b/lib/rubocop/cop/layout/extra_spacing.rb
@@ -49,19 +49,13 @@ module RuboCop
 
         private
 
-        def aligned_locations(locs) # rubocop:disable Metrics/AbcSize
+        def aligned_locations(locs)
           return [] if locs.empty?
 
-          aligned = Set[locs.first.line, locs.last.line]
-          locs.each_cons(3) do |before, loc, after|
-            col = loc.column
-            aligned << loc.line if col == before.column || col == after.column
+          aligned = Set.new
+          locs.each_cons(2) do |loc1, loc2|
+            aligned << loc1.line << loc2.line if loc1.column == loc2.column
           end
-
-          # if locs.size > 2 and the size of variable `aligned`
-          # has not increased from its initial value, there are not aligned lines.
-          return [] if locs.size > 2 && aligned.size == 2
-
           aligned
         end
 

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -604,6 +604,33 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
   end
 
+  context 'when exactly two comments have extra spaces' do
+    context 'and they are aligned' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          one  # comment one
+          two  # comment two
+        RUBY
+      end
+    end
+
+    context 'and they are not aligned' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          one  # comment one
+             ^ Unnecessary spacing detected.
+          two   # comment two
+             ^^ Unnecessary spacing detected.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          one # comment one
+          two # comment two
+        RUBY
+      end
+    end
+  end
+
   context 'when multiple comments have extra spaces' do
     it 'registers offenses for all comments' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Currently we use `each_cons(3)` to find comments that align with their neighbours, but this means the first and last comments aren't checked. We treat them as always aligned, but this leads to false negatives.

We can instead use `each_cons(2)` to look at each pair of comments and add both if they're aligned. This does mean that sometimes lines are added twice, but this is fine since `Set#<<` is idempotent.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/