### PR TITLE
[Fix #12311] Fix false negatives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_negatives_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_negatives_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#12311](https://github.com/rubocop/rubocop/issues/12311): Fix false negatives for `Style/RedundantParentheses` when parentheses around logical operator keywords in method definition. ([@koic][])

--- a/lib/rubocop/cop/mixin/preceding_following_alignment.rb
+++ b/lib/rubocop/cop/mixin/preceding_following_alignment.rb
@@ -79,7 +79,7 @@ module RuboCop
       end
 
       def aligned_operator?(range, line)
-        (aligned_identical?(range, line) || aligned_assignment?(range, line))
+        aligned_identical?(range, line) || aligned_assignment?(range, line)
       end
 
       def aligned_words?(range, line)

--- a/lib/rubocop/cop/style/redundant_string_escape.rb
+++ b/lib/rubocop/cop/style/redundant_string_escape.rb
@@ -133,7 +133,7 @@ module RuboCop
         end
 
         def percent_array_literal?(node)
-          (percent_w_literal?(node) || percent_w_upper_literal?(node))
+          percent_w_literal?(node) || percent_w_upper_literal?(node)
         end
 
         def heredoc_with_disabled_interpolation?(node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -493,13 +493,85 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     expect_no_offenses('(a...b)')
   end
 
-  it 'accepts parentheses around logical operator keywords' do
+  it 'registers parentheses around `||` logical operator keywords in method definition' do
+    expect_offense(<<~RUBY)
+      def foo
+        (x || y)
+        ^^^^^^^^ Don't use parentheses around a logical expression.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        x || y
+      end
+    RUBY
+  end
+
+  it 'registers parentheses around `&&` logical operator keywords in method definition' do
+    expect_offense(<<~RUBY)
+      def foo
+        (x && y)
+        ^^^^^^^^ Don't use parentheses around a logical expression.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        x && y
+      end
+    RUBY
+  end
+
+  it 'accepts parentheses around arithmetic operator' do
+    expect_no_offenses('x - (y || z)')
+  end
+
+  it 'accepts parentheses around logical operator keywords (`and`, `and`, `or`)' do
     expect_no_offenses('(1 and 2) and (3 or 4)')
+  end
+
+  it 'accepts parentheses around logical operator keywords (`or`, `or`, `and`)' do
+    expect_no_offenses('(1 or 2) or (3 and 4)')
   end
 
   it 'accepts parentheses around comparison operator keywords' do
     # Parentheses are redundant, but respect user's intentions for readability.
     expect_no_offenses('x && (y == z)')
+  end
+
+  it 'accepts parentheses around logical operator in splat' do
+    # Parentheses are redundant, but respect user's intentions for readability.
+    expect_no_offenses('x = *(y || z)')
+  end
+
+  it 'accepts parentheses around logical operator in double splat' do
+    # Parentheses are redundant, but respect user's intentions for readability.
+    expect_no_offenses('x(**(y || z))')
+  end
+
+  it 'accepts parentheses around logical operator in ternary operator' do
+    # Parentheses are redundant, but respect user's intentions for readability.
+    expect_no_offenses('cond ? x : (y || z)')
+  end
+
+  it 'registers parentheses around logical operator in `if`...`else`' do
+    expect_offense(<<~RUBY)
+      if cond
+        x
+      else
+        (y || z)
+        ^^^^^^^^ Don't use parentheses around a logical expression.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if cond
+        x
+      else
+        y || z
+      end
+    RUBY
   end
 
   it 'accepts parentheses around a method call with parenthesized logical expression receiver' do


### PR DESCRIPTION
Fixes #12311.

This PR fixes false negatives for `Style/RedundantParentheses` when parentheses around logical operator keywords in method definition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
