### PR TITLE
[Fix #12372] Fix a false negative for `Lint/Debugger`

### DIFF
--- a/changelog/fix_a_false_negative_for_lint_debugger.md
+++ b/changelog/fix_a_false_negative_for_lint_debugger.md
@@ -1,0 +1,1 @@
+* [#12372](https://github.com/rubocop/rubocop/issues/12372): Fix a false negative for `Lint/Debugger` when used within method arguments a `begin`...`end` block. ([@koic][])

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -66,6 +66,7 @@ module RuboCop
       #   end
       class Debugger < Base
         MSG = 'Remove debugger entry point `%<source>s`.'
+        BLOCK_TYPES = %i[block numblock kwbegin].freeze
 
         def on_send(node)
           return if !debugger_method?(node) || assumed_usage_context?(node)
@@ -98,7 +99,7 @@ module RuboCop
           return true if assumed_argument?(node)
 
           node.each_ancestor.none? do |ancestor|
-            ancestor.block_type? || ancestor.numblock_type? || ancestor.lambda_or_proc?
+            BLOCK_TYPES.include?(ancestor.type) || ancestor.lambda_or_proc?
           end
         end
 

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -68,6 +68,17 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
       RUBY
     end
 
+    it 'registers an offense for a `custom_debugger` call when used within method arguments a `begin`...`end` block' do
+      expect_offense(<<~RUBY)
+        do_something(
+          begin
+            custom_debugger
+            ^^^^^^^^^^^^^^^ Remove debugger entry point `custom_debugger`.
+          end
+        )
+      RUBY
+    end
+
     context 'nested custom configurations' do
       let(:cop_config) { { 'DebuggerMethods' => { 'Custom' => %w[custom_debugger] } } }
 


### PR DESCRIPTION
Fixes #12372.

This PR fixes a false negative for `Lint/Debugger` when used within method arguments a `begin`...`end` block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
