### PR TITLE
[Fix #12374] Fix a false positive for `Layout/SpaceBeforeSemicolon`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_space_before_semicolon.md
+++ b/changelog/fix_a_false_positive_for_layout_space_before_semicolon.md
@@ -1,0 +1,1 @@
+* [#12374](https://github.com/rubocop/rubocop/issues/12374): Fix a false positive for `Layout/SpaceBeforeSemicolon` when a space between an opening lambda brace and a semicolon. ([@koic][])

--- a/lib/rubocop/cop/mixin/space_before_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_before_punctuation.rb
@@ -36,7 +36,7 @@ module RuboCop
       end
 
       def space_required_after?(token)
-        token.left_curly_brace? && space_required_after_lcurly?
+        (token.left_curly_brace? || token.type == :tLAMBEG) && space_required_after_lcurly?
       end
 
       def space_required_after_lcurly?

--- a/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeSemicolon, :config do
       it 'accepts a space between an opening brace and a semicolon' do
         expect_no_offenses('test { ; }')
       end
+
+      it 'accepts a space between an opening lambda brace and a semicolon' do
+        expect_no_offenses('-> { ; }')
+      end
     end
 
     context 'when EnforcedStyle for SpaceInsideBlockBraces is no_space' do


### PR DESCRIPTION
Fixes #12374.

This PR fixes a false positive for `Layout/SpaceBeforeSemicolon` when a space between an opening lambda brace and a semicolon.

NOTE: When `Token#left_curly_brace?` supports `:tLAMBEG`, the condition `token.type == :tLAMBEG` can be removed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
