### PR TITLE
Fix a false negative for `Style/Semicolon`

### DIFF
--- a/changelog/fix_a_false_negative_for_style_semicolon.md
+++ b/changelog/fix_a_false_negative_for_style_semicolon.md
@@ -1,0 +1,1 @@
+* [#12378](https://github.com/rubocop/rubocop/pull/12378): Fix a false negative for `Style/Semicolon` when a semicolon at the beginning of a lambda block. ([@koic][])

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -80,6 +80,7 @@ module RuboCop
           processed_source.tokens.group_by(&:line)
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def semicolon_position(tokens)
           if tokens.last.semicolon?
             -1
@@ -90,10 +91,13 @@ module RuboCop
           elsif exist_semicolon_after_left_curly_brace?(tokens) ||
                 exist_semicolon_after_left_string_interpolation_brace?(tokens)
             2
+          elsif exist_semicolon_after_left_lambda_curly_brace?(tokens)
+            3
           elsif exist_semicolon_before_right_string_interpolation_brace?(tokens)
             -4
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def exist_semicolon_before_right_curly_brace?(tokens)
           tokens[-2]&.right_curly_brace? && tokens[-3]&.semicolon?
@@ -101,6 +105,10 @@ module RuboCop
 
         def exist_semicolon_after_left_curly_brace?(tokens)
           tokens[1]&.left_curly_brace? && tokens[2]&.semicolon?
+        end
+
+        def exist_semicolon_after_left_lambda_curly_brace?(tokens)
+          tokens[2]&.type == :tLAMBEG && tokens[3]&.semicolon?
         end
 
         def exist_semicolon_before_right_string_interpolation_brace?(tokens)

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -119,6 +119,17 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
     RUBY
   end
 
+  it 'registers an offense for a semicolon at the beginning of a lambda block' do
+    expect_offense(<<~RUBY)
+      foo -> {; bar }
+              ^ Do not use semicolons to terminate expressions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo -> { bar }
+    RUBY
+  end
+
   it 'registers an offense for a semicolon at the end of a block' do
     expect_offense(<<~RUBY)
       foo { bar; }


### PR DESCRIPTION
This PR fixes a false negative for `Style/Semicolon` when a semicolon at the beginning of a lambda block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
