### PR TITLE
[Fix #12373] Fix a false negative for Lint/SymbolConversion

### DIFF
--- a/changelog/fix_false_negative_for_lint_symbol_conversion.md
+++ b/changelog/fix_false_negative_for_lint_symbol_conversion.md
@@ -1,0 +1,1 @@
+* [#12373](https://github.com/rubocop/rubocop/issues/12373): Fix a false negative for `Lint/SymbolConversion` when using string interpolation. ([@earlopain][])

--- a/lib/rubocop/cop/gemspec/deprecated_attribute_assignment.rb
+++ b/lib/rubocop/cop/gemspec/deprecated_attribute_assignment.rb
@@ -65,7 +65,7 @@ module RuboCop
             lhs, _op, _rhs = *node
             [lhs, attribute]
           else
-            [node, "#{attribute}=".to_sym]
+            [node, :"#{attribute}="]
           end
         end
 

--- a/lib/rubocop/cop/lint/symbol_conversion.rb
+++ b/lib/rubocop/cop/lint/symbol_conversion.rb
@@ -19,6 +19,7 @@ module RuboCop
       #   'underscored_string'.to_sym
       #   :'underscored_symbol'
       #   'hyphenated-string'.to_sym
+      #   "string_#{interpolation}".to_sym
       #
       #   # good
       #   :string
@@ -26,6 +27,7 @@ module RuboCop
       #   :underscored_string
       #   :underscored_symbol
       #   :'hyphenated-string'
+      #   :"string_#{interpolation}"
       #
       # @example EnforcedStyle: strict (default)
       #
@@ -75,9 +77,12 @@ module RuboCop
 
         def on_send(node)
           return unless node.receiver
-          return unless node.receiver.str_type? || node.receiver.sym_type?
 
-          register_offense(node, correction: node.receiver.value.to_sym.inspect)
+          if node.receiver.str_type? || node.receiver.sym_type?
+            register_offense(node, correction: node.receiver.value.to_sym.inspect)
+          elsif node.receiver.dstr_type?
+            register_offense(node, correction: ":\"#{node.receiver.value.to_sym}\"")
+          end
         end
 
         def on_sym(node)

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -256,7 +256,7 @@ module RuboCop
 
         def any_method_definition?(child)
           cop_config.fetch('MethodCreatingMethods', []).any? do |m|
-            matcher_name = "#{m}_method?".to_sym
+            matcher_name = :"#{m}_method?"
             unless respond_to?(matcher_name)
               self.class.def_node_matcher matcher_name, <<~PATTERN
                 {def (send nil? :#{m} ...)}
@@ -279,7 +279,7 @@ module RuboCop
 
         def any_context_creating_methods?(child)
           cop_config.fetch('ContextCreatingMethods', []).any? do |m|
-            matcher_name = "#{m}_block?".to_sym
+            matcher_name = :"#{m}_block?"
             unless respond_to?(matcher_name)
               self.class.def_node_matcher matcher_name, <<~PATTERN
                 ({block numblock} (send {nil? const} {:#{m}} ...) ...)


### PR DESCRIPTION
Issue #12373: This PR fixes a false negative for `Lint/SymbolConversion` when using string interpolation

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ x Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
