### PR TITLE
[Fix #12377] Fix false positives for `Lint/Void`

### DIFF
--- a/changelog/fix_false_positives_for_lint_void.md
+++ b/changelog/fix_false_positives_for_lint_void.md
@@ -1,0 +1,1 @@
+* [#12377](https://github.com/rubocop/rubocop/issues/12377): Fix false positives for `Lint/Void` when a collection literal that includes non-literal elements in a method definition. ([@koic][])

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -387,6 +387,131 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     end
   end
 
+  it 'does not register an offense for an array literal that includes non-literal elements in a method definition' do
+    expect_no_offenses(<<~RUBY)
+      def something
+        [foo, bar]
+        baz
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a nested array literal that includes non-literal elements in a method definition' do
+    expect_no_offenses(<<~RUBY)
+      def something
+        [1, 2, [foo, bar]]
+        baz
+      end
+    RUBY
+  end
+
+  it 'registers an offense for an array literal composed entirely of literals in a method definition' do
+    expect_offense(<<~RUBY)
+      def something
+        [1, 2]
+        ^^^^^^ Literal `[1, 2]` used in void context.
+        baz
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a nested array literal composed entirely of literals in a method definition' do
+    expect_offense(<<~RUBY)
+      def something
+        [1, 2, [3]]
+        ^^^^^^^^^^^ Literal `[1, 2, [3]]` used in void context.
+        baz
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a hash literal that includes non-literal value elements in a method definition' do
+    expect_no_offenses(<<~RUBY)
+      def something
+        {k1: foo, k2: bar}
+        baz
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a nested hash literal that includes non-literal value elements in a method definition' do
+    expect_no_offenses(<<~RUBY)
+      def something
+        {k0: {k1: foo, k2: bar}}
+        baz
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a hash literal that includes non-literal key elements in a method definition' do
+    expect_no_offenses(<<~RUBY)
+      def something
+        {foo => 1, bar => 2}
+        baz
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a nested hash literal that includes non-literal key elements in a method definition' do
+    expect_no_offenses(<<~RUBY)
+      def something
+        {foo: 1, bar: {baz => 2}}
+        baz
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a hash literal composed entirely of literals in a method definition' do
+    expect_offense(<<~RUBY)
+      def something
+        {k1: 1, k2: 2}
+        ^^^^^^^^^^^^^^ Literal `{k1: 1, k2: 2}` used in void context.
+        baz
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def something
+        baz
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a nested hash literal composed entirely of literals in a method definition' do
+    expect_offense(<<~RUBY)
+      def something
+        {x: {k1: 1, k2: 2}}
+        ^^^^^^^^^^^^^^^^^^^ Literal `{x: {k1: 1, k2: 2}}` used in void context.
+        baz
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def something
+        baz
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a hash literal that includes array literal key within non-literal elements in a method definition' do
+    expect_no_offenses(<<~RUBY)
+      def something
+        {[foo, bar] => :foo}
+        baz
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a hash literal that includes array literal key within literal elements in a method definition' do
+    expect_offense(<<~RUBY)
+      def something
+        {[1, 2] => :foo}
+        ^^^^^^^^^^^^^^^^ Literal `{[1, 2] => :foo}` used in void context.
+        baz
+      end
+    RUBY
+  end
+
   it 'registers an offense for void literal in a method definition' do
     expect_offense(<<~RUBY)
       def something


### PR DESCRIPTION
Fixes #12377.

This PR fixes false positives for `Lint/Void` when a collection literal that includes non-literal elements in a method definition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
