### PR TITLE
[Fix #12242] Support `AllowModifiersOnAttrs` option for `Style/AccessModifierDeclarations`

### DIFF
--- a/changelog/new_support_allow_modifiers_on_attrs_option_for_style_access_modifier_declarations.md
+++ b/changelog/new_support_allow_modifiers_on_attrs_option_for_style_access_modifier_declarations.md
@@ -1,0 +1,1 @@
+* [#12242](https://github.com/rubocop/rubocop/issues/12242): Support `AllowModifiersOnAttrs` option for `Style/AccessModifierDeclarations`. ([@krororo][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3090,6 +3090,7 @@ Style/AccessModifierDeclarations:
     - inline
     - group
   AllowModifiersOnSymbols: true
+  AllowModifiersOnAttrs: true
   SafeAutoCorrect: false
 
 Style/AccessorGrouping:


### PR DESCRIPTION
Fixes #12242

This PR supports `AllowModifiersOnAttrs` options for `Style/AccessModifierDeclarations`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
