### PR TITLE
[Fix #12146] Fix a false positive for `Lint/FloatComparison`

### DIFF
--- a/changelog/fix_a_false_positive_for_float_comparision_with_zero_nonzero.md
+++ b/changelog/fix_a_false_positive_for_float_comparision_with_zero_nonzero.md
@@ -1,0 +1,1 @@
+* [#12146](https://github.com/rubocop/rubocop/issues/12146): Fix a false positive for `Lint/FloatComparison` when comparing against zero. ([@earlopain][])

--- a/lib/rubocop/cop/lint/float_comparison.rb
+++ b/lib/rubocop/cop/lint/float_comparison.rb
@@ -18,6 +18,10 @@ module RuboCop
       #   # good - using BigDecimal
       #   x.to_d == 0.1.to_d
       #
+      #  # good - comparing against zero
+      #   x == 0.0
+      #   x != 0.0
+      #
       #   # good
       #   (x - 0.1).abs < Float::EPSILON
       #
@@ -39,6 +43,8 @@ module RuboCop
 
         def on_send(node)
           lhs, _method, rhs = *node
+          return if literal_zero?(lhs) || literal_zero?(rhs)
+
           add_offense(node) if float?(lhs) || float?(rhs)
         end
 
@@ -57,6 +63,10 @@ module RuboCop
           else
             false
           end
+        end
+
+        def literal_zero?(node)
+          node&.numeric_type? && node.value.zero?
         end
 
         # rubocop:disable Metrics/PerceivedComplexity

--- a/spec/rubocop/cop/lint/float_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/float_comparison_spec.rb
@@ -67,4 +67,16 @@ RSpec.describe RuboCop::Cop::Lint::FloatComparison, :config do
       (x - 0.1) < epsilon
     RUBY
   end
+
+  it 'does not register an offense when comparing against zero' do
+    expect_no_offenses(<<~RUBY)
+      x == 0.0
+      x.to_f == 0
+      x.to_f.abs == 0.0
+      x != 0.0
+      x.to_f != 0
+      x.to_f.zero?
+      x.to_f.nonzero?
+    RUBY
+  end
 end


### PR DESCRIPTION
Allow comparing against 0. See https://github.com/rubocop/rubocop/pull/12387#issuecomment-1818508562

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
