### PR TITLE
Include expanded EnforcedStyle options when --no-auto-gen-enforced-style is given

### DIFF
--- a/changelog/change_reject_additional_enforced_style_options.md
+++ b/changelog/change_reject_additional_enforced_style_options.md
@@ -1,0 +1,1 @@
+* [#12388](https://github.com/rubocop/rubocop/pull/12388): Reject additional 'expanded' `EnforcedStyle` options when `--no-auto-gen-enforced-style` is given. ([@kpost][])

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -192,8 +192,8 @@ module RuboCop
         # 'Enabled' option will be put into file only if exclude
         # limit is exceeded.
         rejected_keys = ['Enabled']
-        rejected_keys << 'EnforcedStyle' unless auto_gen_enforced_style?
-        cfg.reject { |key| rejected_keys.include?(key) }
+        rejected_keys << /^EnforcedStyle\w*/ unless auto_gen_enforced_style?
+        cfg.reject { |key| include_or_match?(rejected_keys, key) }
       end
 
       def output_offending_files(output_buffer, cfg, cop_name)
@@ -261,6 +261,12 @@ module RuboCop
 
       def no_exclude_limit?
         @options[:no_exclude_limit] == false
+      end
+
+      # Returns true if the given arr include the given elm or if any of the
+      # given arr is a regexp that matches the given elm.
+      def include_or_match?(arr, elm)
+        arr.include?(elm) || arr.any? { |x| x.is_a?(Regexp) && x.match?(elm) }
       end
     end
   end

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -192,7 +192,7 @@ module RuboCop
         # 'Enabled' option will be put into file only if exclude
         # limit is exceeded.
         rejected_keys = ['Enabled']
-        rejected_keys << /^EnforcedStyle\w*/ unless auto_gen_enforced_style?
+        rejected_keys << /\AEnforcedStyle\w*/ unless auto_gen_enforced_style?
         cfg.reject { |key| include_or_match?(rejected_keys, key) }
       end
 

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -1522,6 +1522,21 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                 - 'example1.rb'
           YAML
       end
+
+      it 'generates Exclude for expanded EnforcedStyle if it solves all offenses' do
+        create_file('example1.rb', ['# frozen_string_literal: true', '', 'h{}'])
+
+        expect(cli.run(['--auto-gen-config', '--no-auto-gen-enforced-style'])).to eq(0)
+        expect(File.readlines('.rubocop_todo.yml')[10..].join)
+          .to eq(<<~YAML)
+            # Configuration parameters: EnforcedStyle.
+            # SupportedStyles: space, no_space
+            # SupportedStylesForEmptyBraces: space, no_space
+            Layout/SpaceBeforeBlockBraces:
+              Exclude:
+                - 'example1.rb'
+          YAML
+      end
     end
 
     context 'when hash value omission enabled', :ruby31 do


### PR DESCRIPTION
It seems to me that when the `--no-auto-gen-enforced-style` is given, not only `EnforcedStyle` should be rejected, but also all 'expanded' `EnforcedStyle` options as well, like for example `EnforcedStyleForEmptyBraces`. In order to achieve this I used a Regex when checking which keys should be rejected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
