### PR TITLE
[Fix #12394] Fix false negatives for `Style/RedundantReturn`

### DIFF
--- a/changelog/fix_false_negatives_for_style_redundant_return.md
+++ b/changelog/fix_false_negatives_for_style_redundant_return.md
@@ -1,0 +1,1 @@
+* [#12394](https://github.com/rubocop/rubocop/issues/12394): Fix false negatives for `Style/RedundantReturn` when `lambda`, `->`, or `proc` ending with `return`. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -58,7 +58,7 @@ module RuboCop
 
         MSG = 'Redundant `return` detected.'
         MULTI_RETURN_MSG = 'To return multiple values, use an array.'
-        RESTRICT_ON_SEND = %i[define_method define_singleton_method].freeze
+        RESTRICT_ON_SEND = %i[define_method define_singleton_method lambda proc].freeze
 
         def on_send(node)
           return unless (parent = node.parent) && parent.block_type?

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -118,6 +118,57 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
     RUBY
   end
 
+  it 'reports an offense for lambda ending with return' do
+    expect_offense(<<~RUBY)
+      lambda do
+        some_preceding_statements
+        return something
+        ^^^^^^ Redundant `return` detected.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      lambda do
+        some_preceding_statements
+        something
+      end
+    RUBY
+  end
+
+  it 'reports an offense for -> ending with return' do
+    expect_offense(<<~RUBY)
+      -> do
+        some_preceding_statements
+        return something
+        ^^^^^^ Redundant `return` detected.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      -> do
+        some_preceding_statements
+        something
+      end
+    RUBY
+  end
+
+  it 'reports an offense for proc ending with return' do
+    expect_offense(<<~RUBY)
+      proc do
+        some_preceding_statements
+        return something
+        ^^^^^^ Redundant `return` detected.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      proc do
+        some_preceding_statements
+        something
+      end
+    RUBY
+  end
+
   it 'reports an offense for def ending with return with splat argument' do
     expect_offense(<<~RUBY)
       def func


### PR DESCRIPTION
Fixes #12394.

This PR fixes false negatives for `Style/RedundantReturn` when `lambda`, `->`, or `proc` ending with `return`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
