### PR TITLE
[Fix #12296] Support `Redundant*Names` options for `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/change_support_redundant_options_for_style_arguments_forwarding.md
+++ b/changelog/change_support_redundant_options_for_style_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#12296](https://github.com/rubocop/rubocop/issues/12296): Support `RedundantRestArgumentNames`, `RedundantKeywordRestArgumentNames`, and `RedundantBlockArgumentNames` options for `Style/ArgumentsForwarding`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3089,7 +3089,19 @@ Style/ArgumentsForwarding:
   Enabled: pending
   AllowOnlyRestArgument: true
   UseAnonymousForwarding: true
+  RedundantRestArgumentNames:
+    - args
+    - arguments
+  RedundantKeywordRestArgumentNames:
+    - kwargs
+    - options
+    - opts
+  RedundantBlockArgumentNames:
+    - blk
+    - block
+    - proc
   VersionAdded: '1.1'
+  VersionChanged: '<<next>>'
 
 Style/ArrayCoercion:
   Description: >-


### PR DESCRIPTION
Fixes #12296.

This PR supports `RedundantRestArgumentNames`, `RedundantKeywordRestArgumentNames`, and `RedundantBlockArgumentNames` options for `Style/ArgumentsForwarding`.

Meaningless names that are commonly used can be anonymized by default as part of the new `Redundant*Names` defaults. e.g., `*args`, `**options`, `&block`, and some argument names.

Names not on this list are likely to be meaningful and are allowed by default.

This approach is designed to only detect generally meaningless names without the need for users to edit the configuration for each meaningful name, with the expectation that the default settings will work well for most cases.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
