### PR TITLE
add base support for minitest focus keyword

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -54,6 +54,8 @@ require_relative 'rubocop/cop/generator/configuration_injector'
 require_relative 'rubocop/cop/generator/require_file_injector'
 require_relative 'rubocop/magic_comment'
 
+require_relative 'rubocop/cop/minitest/focus'
+
 require_relative 'rubocop/cop/variable_force'
 require_relative 'rubocop/cop/variable_force/branch'
 require_relative 'rubocop/cop/variable_force/branchable'

--- a/lib/rubocop/cop/minitest/focus.rb
+++ b/lib/rubocop/cop/minitest/focus.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RuboCop::Cop::Minitest
+  class NoFocus < RuboCop::Cop::Cop
+    MSG = 'Remove `focus` from tests.'
+
+    def_node_matcher :focused?, <<-MATCHER
+      (send nil? :focus)
+    MATCHER
+
+    def on_send(node)
+      return unless focused?(node)
+
+      add_offense node
+    end
+  end
+end


### PR DESCRIPTION
Fix for this issue, based on its comment: https://github.com/rubocop/rubocop/issues/3773#issuecomment-420662102

Provides a rule for the `Minitest` keyword "`focus`", which causes the suite to only run that test.  This often creates false-success messages for PR CI. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
