### PR TITLE
[Fix #12402] Fix false negatives for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_false_negatives_for_style_redundant_line_continuation.md
+++ b/changelog/fix_false_negatives_for_style_redundant_line_continuation.md
@@ -1,0 +1,1 @@
+* [#12402](https://github.com/rubocop/rubocop/issues/12402): Fix false negatives for `Style/RedundantLineContinuation` when redundant line continuations for a block are used, especially without parentheses around first argument. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -107,6 +107,8 @@ module RuboCop
 
         def inside_string_literal_or_method_with_argument?(range)
           processed_source.tokens.each_cons(2).any? do |token, next_token|
+            next if token.line == next_token.line
+
             inside_string_literal?(range, token) || method_with_argument?(token, next_token)
           end
         end

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -59,6 +59,25 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'registers an offense when redundant line continuations for a block are used, ' \
+     'especially without parentheses around first argument' do
+    expect_offense(<<~'RUBY')
+      let :foo do \
+                  ^ Redundant line continuation.
+        foo(bar, \
+                 ^ Redundant line continuation.
+            baz)
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      let :foo do#{' '}
+        foo(bar,#{' '}
+            baz)
+      end
+    RUBY
+  end
+
   it 'registers an offense when redundant line continuations for method chain' do
     expect_offense(<<~'RUBY')
       foo. \


### PR DESCRIPTION
Fixes #12402.

This PR fixes false negatives for `Style/RedundantLineContinuation` when redundant line continuations for a block are used, especially without parentheses around first argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
