### PR TITLE
[Fix #12404] Fix a false positive for `Layout/RescueEnsureAlignment`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_rescue_ensure_alignment.md
+++ b/changelog/fix_a_false_positive_for_layout_rescue_ensure_alignment.md
@@ -1,0 +1,1 @@
+* [#12404](https://github.com/rubocop/rubocop/issues/12404): Fix a false positive for `Layout/RescueEnsureAlignment` when aligned `rescue` in `do`-`end` numbered block in a method. ([@koic][])

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -29,7 +29,7 @@ module RuboCop
         MSG = '`%<kw_loc>s` at %<kw_loc_line>d, %<kw_loc_column>d is not ' \
               'aligned with `%<beginning>s` at ' \
               '%<begin_loc_line>d, %<begin_loc_column>d.'
-        ANCESTOR_TYPES = %i[kwbegin def defs class module block].freeze
+        ANCESTOR_TYPES = %i[kwbegin def defs class module block numblock].freeze
         ANCESTOR_TYPES_WITH_ACCESS_MODIFIERS = %i[def defs].freeze
         ALTERNATIVE_ACCESS_MODIFIERS = %i[public_class_method private_class_method].freeze
 
@@ -95,7 +95,7 @@ module RuboCop
         def alignment_source(node, starting_loc)
           ending_loc =
             case node.type
-            when :block, :kwbegin
+            when :block, :numblock, :kwbegin
               node.loc.begin
             when :def, :defs, :class, :module,
                  :lvasgn, :ivasgn, :cvasgn, :gvasgn, :casgn

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -603,6 +603,45 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
     end
   end
 
+  context 'Ruby 2.7', :ruby27 do
+    it 'accepts aligned rescue in do-end numbered block in a method' do
+      expect_no_offenses(<<~RUBY)
+        def foo
+          [1, 2, 3].each do
+            _1.to_s
+          rescue StandardError => _exception
+            next
+          end
+        end
+      RUBY
+    end
+
+    context 'rescue with do-end numbered block' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          def foo
+            [1, 2, 3].each do
+              _1.to_s
+          rescue StandardError => _exception
+          ^^^^^^ `rescue` at 4, 0 is not aligned with `[1, 2, 3].each do` at 2, 2.
+              next
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo
+            [1, 2, 3].each do
+              _1.to_s
+            rescue StandardError => _exception
+              next
+            end
+          end
+        RUBY
+      end
+    end
+  end
+
   context 'rescue in do-end block assigned to local variable' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #12404.

This PR fixes a false positive for `Layout/RescueEnsureAlignment` when aligned `rescue` in `do`-`end` numbered block in a method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
