### PR TITLE
Fix an incorrect autocorrect for `Style/MapToHash` with `Layout/SingleLineBlockChain`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_layout_single_line_block_chain_with_style_map_to_hash.md
+++ b/changelog/fix_incorrect_autocorrect_for_layout_single_line_block_chain_with_style_map_to_hash.md
@@ -1,0 +1,1 @@
+* [#12407](https://github.com/rubocop/rubocop/pull/12407): Fix an incorrect autocorrect for `Style/MapToHash` with `Layout/SingleLineBlockChain`. ([@koic][])

--- a/lib/rubocop/cop/layout/single_line_block_chain.rb
+++ b/lib/rubocop/cop/layout/single_line_block_chain.rb
@@ -25,6 +25,10 @@ module RuboCop
 
         MSG = 'Put method call on a separate line if chained to a single line block.'
 
+        def self.autocorrect_incompatible_with
+          [Style::MapToHash]
+        end
+
         def on_send(node)
           range = offending_range(node)
           add_offense(range) { |corrector| corrector.insert_before(range, "\n") } if range

--- a/lib/rubocop/cop/style/map_to_hash.rb
+++ b/lib/rubocop/cop/style/map_to_hash.rb
@@ -45,6 +45,10 @@ module RuboCop
           }
         PATTERN
 
+        def self.autocorrect_incompatible_with
+          [Layout::SingleLineBlockChain]
+        end
+
         def on_send(node)
           return unless (to_h_node, map_node = map_to_h?(node))
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2706,6 +2706,21 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Style/MapToHash` and `Layout/SingleLineBlockChain` offenses' do
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~RUBY)
+      obj.map { |i| foo(i) }.to_h
+         .bar
+    RUBY
+
+    expect(cli.run(['-A', '--only', 'Style/MapToHash,Layout/SingleLineBlockChain'])).to eq(0)
+
+    expect(source_file.read).to eq(<<~RUBY)
+      obj.to_h { |i| foo(i) }
+         .bar
+    RUBY
+  end
+
   it 'does not crash when using `Layout/CaseIndentation` and `Layout/ElseAlignment`' do
     source_file = Pathname('example.rb')
     create_file(source_file, <<~RUBY)


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Style/MapToHash` with `Layout/SingleLineBlockChain`, which makes the following syntax error occur:

```console
$ cat example.rb
obj.map { |i| foo(i) }.to_h
   .bar

$ bundle exec rubocop -A example.rb --only Style/MapToHash,Layout/SingleLineBlockChain
Inspecting 1 file
F

Offenses:

example.rb:1:5: C: [Corrected] Style/MapToHash: Pass a block to to_h instead of calling map.to_h.
obj.map { |i| foo(i) }.to_h
    ^^^
example.rb:1:23: C: [Corrected] Layout/SingleLineBlockChain: Put method call on a separate line if chained to a single line block.
obj.map { |i| foo(i) }.to_h
                      ^^^^^
example.rb:3:4: F: Lint/Syntax: unexpected token tDOT
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
   .bar
   ^

1 file inspected, 3 offenses detected, 2 offenses corrected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
