### PR TITLE
Make `Style/MapToHash` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_map_to_hash_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_map_to_hash_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12408](https://github.com/rubocop/rubocop/pull/12408): Make `Style/MapToHash` aware of safe navigation operator. ([@koic][])

--- a/spec/rubocop/cop/style/map_to_hash_spec.rb
+++ b/spec/rubocop/cop/style/map_to_hash_spec.rb
@@ -29,6 +29,32 @@ RSpec.describe RuboCop::Cop::Style::MapToHash, :config do
         end
       end
 
+      context "for `#{method}&.to_h` with block arity 1" do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            foo&.#{method} { |x| [x, x * 2] }&.to_h
+                 ^{method} Pass a block to `to_h` instead of calling `#{method}&.to_h`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo&.to_h { |x| [x, x * 2] }
+          RUBY
+        end
+      end
+
+      context "for `#{method}&.to_h` with block arity 2" do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            foo&.#{method} { |x, y| [x.to_s, y.to_i] }&.to_h
+                 ^{method} Pass a block to `to_h` instead of calling `#{method}&.to_h`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo&.to_h { |x, y| [x.to_s, y.to_i] }
+          RUBY
+        end
+      end
+
       context 'when using numbered parameters', :ruby27 do
         context "for `#{method}.to_h` with block arity 1" do
           it 'registers an offense and corrects' do
@@ -66,6 +92,19 @@ RSpec.describe RuboCop::Cop::Style::MapToHash, :config do
 
           expect_correction(<<~RUBY)
             foo.to_h(&:do_something)
+          RUBY
+        end
+      end
+
+      context "for `#{method}&.to_h` with symbol proc" do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            foo&.#{method}(&:do_something)&.to_h
+                 ^{method} Pass a block to `to_h` instead of calling `#{method}&.to_h`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo&.to_h(&:do_something)
           RUBY
         end
       end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/12407#issuecomment-1825353313.

This PR makes `Style/MapToHash` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
