### PR TITLE
[Fix #12409] Fix an incorrect autocorrect for `Lint/SafeNavigationChain`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_lint_safe_navigation_chain.md
+++ b/changelog/fix_incorrect_autocorrect_for_lint_safe_navigation_chain.md
@@ -1,0 +1,1 @@
+* [#12409](https://github.com/rubocop/rubocop/issues/12409): Fix an incorrect autocorrect for `Lint/SafeNavigationChain` when ordinary method chain exists after safe navigation leading dot method call. ([@koic][])

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -45,10 +45,9 @@ module RuboCop
           bad_method?(node) do |safe_nav, method|
             return if nil_methods.include?(method) || PLUS_MINUS_METHODS.include?(node.method_name)
 
-            location =
-              Parser::Source::Range.new(node.source_range.source_buffer,
-                                        safe_nav.source_range.end_pos,
-                                        node.source_range.end_pos)
+            begin_range = node.loc.dot || safe_nav.source_range.end
+            location = begin_range.join(node.source_range.end)
+
             add_offense(location) do |corrector|
               autocorrect(corrector, offense_range: location, send_node: node)
             end

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -72,6 +72,21 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
       RUBY
     end
 
+    it 'registers an offense for ordinary method chain exists after safe navigation leading dot method call' do
+      expect_offense(<<~RUBY)
+        x&.foo
+         &.bar
+         .baz
+         ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.foo
+         &.bar
+         &.baz
+      RUBY
+    end
+
     it 'registers an offense for ordinary method chain exists after ' \
        'safe navigation method call with an argument' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #12409.

This PR fixes an incorrect autocorrect for `Lint/SafeNavigationChain` when ordinary method chain exists after safe navigation leading dot method call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
