### PR TITLE
[Fix #12413] Make `Style/InverseMethods` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_inverse_methods_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_inverse_methods_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12413](https://github.com/rubocop/rubocop/issues/12413): Make `Style/InverseMethods` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -60,17 +60,17 @@ module RuboCop
         # @!method inverse_candidate?(node)
         def_node_matcher :inverse_candidate?, <<~PATTERN
           {
-            (send $(send $(...) $_ $...) :!)
-            (send ({block numblock} $(send $(...) $_) $...) :!)
-            (send (begin $(send $(...) $_ $...)) :!)
+            (send $(call $(...) $_ $...) :!)
+            (send ({block numblock} $(call $(...) $_) $...) :!)
+            (send (begin $(call $(...) $_ $...)) :!)
           }
         PATTERN
 
         # @!method inverse_block?(node)
         def_node_matcher :inverse_block?, <<~PATTERN
-          ({block numblock} $(send (...) $_) ... { $(send ... :!)
+          ({block numblock} $(call (...) $_) ... { $(call ... :!)
                                                    $(send (...) {:!= :!~} ...)
-                                                   (begin ... $(send ... :!))
+                                                   (begin ... $(call ... :!))
                                                    (begin ... $(send (...) {:!= :!~} ...))
                                                  })
         PATTERN
@@ -87,6 +87,7 @@ module RuboCop
             end
           end
         end
+        alias on_csend on_send
 
         def on_block(node)
           inverse_block?(node) do |_method_call, method, block|

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods, :config do
     RUBY
   end
 
+  it 'registers an offense for safe navigation calling !.none? with a symbol proc' do
+    expect_offense(<<~RUBY)
+      !foo&.none?(&:even?)
+      ^^^^^^^^^^^^^^^^^^^^ Use `any?` instead of inverting `none?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.any?(&:even?)
+    RUBY
+  end
+
   it 'registers an offense for calling !.none? with a block' do
     expect_offense(<<~RUBY)
       !foo.none? { |f| f.even? }
@@ -41,6 +52,17 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods, :config do
 
     expect_correction(<<~RUBY)
       foo.any? { |f| f.even? }
+    RUBY
+  end
+
+  it 'registers an offense for safe navigation calling !.none? with a block' do
+    expect_offense(<<~RUBY)
+      !foo&.none? { |f| f.even? }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `any?` instead of inverting `none?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.any? { |f| f.even? }
     RUBY
   end
 
@@ -65,6 +87,17 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods, :config do
 
     expect_correction(<<~RUBY)
       foo.none? &:working?
+    RUBY
+  end
+
+  it 'registers an offense for safe navigation calling !.any? inside parens' do
+    expect_offense(<<~RUBY)
+      !(foo&.any? &:working?)
+      ^^^^^^^^^^^^^^^^^^^^^^^ Use `none?` instead of inverting `any?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.none? &:working?
     RUBY
   end
 
@@ -232,6 +265,17 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods, :config do
         RUBY
       end
 
+      it "registers an offense for foo&.#{method} { |e| !e }" do
+        expect_offense(<<~RUBY, method: method)
+          foo&.%{method} { |e| !e }
+          ^^^^^^{method}^^^^^^^^^^^ Use `#{inverse}` instead of inverting `#{method}`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo&.#{inverse} { |e| e }
+        RUBY
+      end
+
       it 'registers an offense for a multiline method call where the last method is inverted' do
         expect_offense(<<~RUBY, method: method)
           foo.%{method} do |e|
@@ -245,6 +289,23 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods, :config do
           foo.#{inverse} do |e|
             something
             e.bar
+          end
+        RUBY
+      end
+
+      it 'registers an offense for a multiline safe navigation method call where the last method is inverted' do
+        expect_offense(<<~RUBY, method: method)
+          foo&.%{method} do |e|
+          ^^^^^^{method}^^^^^^^ Use `#{inverse}` instead of inverting `#{method}`.
+            something
+            e&.bar&.!
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo&.#{inverse} do |e|
+            something
+            e&.bar
           end
         RUBY
       end
@@ -309,6 +370,17 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods, :config do
 
         expect_correction(<<~RUBY)
           foo.#{inverse} { |e| e.bar? }
+        RUBY
+      end
+
+      it 'corrects an inverted safe navigation method call when using `BasicObject#!`' do
+        expect_offense(<<~RUBY, method: method)
+          foo&.%{method} { |e| e&.bar?&.! }
+          ^^^^^^{method}^^^^^^^^^^^^^^^^^^^ Use `#{inverse}` instead of inverting `#{method}`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo&.#{inverse} { |e| e&.bar? }
         RUBY
       end
 


### PR DESCRIPTION
Fixes #12413.

This PR makes `Style/InverseMethods` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
