### PR TITLE
Make `Style/SelfAssignment` aware of some operators

### DIFF
--- a/changelog/change_make_style_self_assignment_aware_of_some_operators.md
+++ b/changelog/change_make_style_self_assignment_aware_of_some_operators.md
@@ -1,0 +1,1 @@
+* [#12421](https://github.com/rubocop/rubocop/pull/12421): Make `Style/SelfAssignment` aware of `%`, `^`, `<<`, and `>>` operators. ([@koic][])

--- a/lib/rubocop/cop/style/self_assignment.rb
+++ b/lib/rubocop/cop/style/self_assignment.rb
@@ -16,7 +16,7 @@ module RuboCop
         extend AutoCorrector
 
         MSG = 'Use self-assignment shorthand `%<method>s=`.'
-        OPS = %i[+ - * ** / | &].freeze
+        OPS = %i[+ - * ** / % ^ << >> | &].freeze
 
         def self.autocorrect_incompatible_with
           [Layout::SpaceAroundOperators]

--- a/spec/rubocop/cop/style/self_assignment_spec.rb
+++ b/spec/rubocop/cop/style/self_assignment_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::SelfAssignment, :config do
-  %i[+ - * ** / | & || &&].product(['x', '@x', '@@x']).each do |op, var|
+  %i[+ - * ** / % ^ << >> | & || &&].product(['x', '@x', '@@x']).each do |op, var|
     it "registers an offense for non-shorthand assignment #{op} and #{var}" do
       expect_offense(<<~RUBY, op: op, var: var)
         %{var} = %{var} %{op} y


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/issues/12410#issuecomment-1825941817.

This PR makes `Style/SelfAssignment` aware of `%`, `^`, `<<`, and `>>` operators.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
