### PR TITLE
[Fix #12424] Make `Style/HashEachMethods` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_hash_each_methods_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_hash_each_methods_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12424](https://github.com/rubocop/rubocop/issues/12424): Make `Style/HashEachMethods` aware of safe navigation operator. ([@koic][])

--- a/spec/rubocop/cop/style/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/style/hash_each_methods_spec.rb
@@ -14,6 +14,17 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         RUBY
       end
 
+      it 'registers offense, autocorrects `foo&.keys&.each` to `foo&.each_key`' do
+        expect_offense(<<~RUBY)
+          foo&.keys&.each { |k| p k }
+               ^^^^^^^^^^ Use `each_key` instead of `keys&.each`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo&.each_key { |k| p k }
+        RUBY
+      end
+
       it 'registers offense, autocorrects foo#values.each to foo#each_value' do
         expect_offense(<<~RUBY)
           foo.values.each { |v| p v }
@@ -22,6 +33,17 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
 
         expect_correction(<<~RUBY)
           foo.each_value { |v| p v }
+        RUBY
+      end
+
+      it 'registers offense, autocorrects `foo&.values&.each` to `foo&.each_value`' do
+        expect_offense(<<~RUBY)
+          foo&.values&.each { |v| p v }
+               ^^^^^^^^^^^^ Use `each_value` instead of `values&.each`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo&.each_value { |v| p v }
         RUBY
       end
 
@@ -67,6 +89,17 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
 
         expect_correction(<<~RUBY)
           foo.each_key { |k| do_something(k) }
+        RUBY
+      end
+
+      it 'registers an offense when the value block argument of `Enumerable#each` method with safe navigation call is unused' do
+        expect_offense(<<~RUBY)
+          foo&.each { |k, unused_value| do_something(k) }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `each_key` instead of `each` and remove the unused `unused_value` block argument.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo&.each_key { |k| do_something(k) }
         RUBY
       end
 
@@ -137,6 +170,17 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         RUBY
       end
 
+      it 'registers offense, autocorrects `{}&.keys&.each` to `{}&.each_key` with a symbol proc argument' do
+        expect_offense(<<~RUBY)
+          {}&.keys&.each(&:bar)
+              ^^^^^^^^^^ Use `each_key` instead of `keys&.each`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {}&.each_key(&:bar)
+        RUBY
+      end
+
       it 'registers offense, autocorrects {}#values.each to {}#each_value with a symbol proc argument' do
         expect_offense(<<~RUBY)
           {}.values.each(&:bar)
@@ -145,6 +189,17 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
 
         expect_correction(<<~RUBY)
           {}.each_value(&:bar)
+        RUBY
+      end
+
+      it 'registers offense, autocorrects `{}&.values.each` to `{}&.each_value` with a symbol proc argument' do
+        expect_offense(<<~RUBY)
+          {}&.values&.each(&:bar)
+              ^^^^^^^^^^^^ Use `each_value` instead of `values&.each`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {}&.each_value(&:bar)
         RUBY
       end
 


### PR DESCRIPTION
Fixes #12424.

This PR makes `Style/HashEachMethods` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
