### PR TITLE
Fix false positive for `Lint/LiteralAssignmentInCondition`

### DIFF
--- a/changelog/fix_false_positive_for_lint_literal_assignment_in_condition.md
+++ b/changelog/fix_false_positive_for_lint_literal_assignment_in_condition.md
@@ -1,0 +1,1 @@
+* [#12432](https://github.com/rubocop/rubocop/pull/12432): Fix a false positive for `Lint/LiteralAssignmentInCondition` when using parallel assignment with splat operator in block of guard condition. ([@koic][])

--- a/spec/rubocop/cop/lint/literal_assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_assignment_in_condition_spec.rb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::LiteralAssignmentInCondition, :config do
-  it 'registers an offense when assigning literal to local variable in `if` condition' do
+  it 'registers an offense when assigning integer literal to local variable in `if` condition' do
     expect_offense(<<~RUBY)
       if test = 42
               ^^^^ Don't use literal assignment `= 42` in conditional, should be `==` or non-literal operand.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when assigning array literal to local variable in `if` condition' do
+    expect_offense(<<~RUBY)
+      if test = []
+              ^^^^ Don't use literal assignment `= []` in conditional, should be `==` or non-literal operand.
       end
     RUBY
   end
@@ -149,6 +157,14 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAssignmentInCondition, :config do
   it 'does not blow up when empty `unless` condition' do
     expect_no_offenses(<<~RUBY)
       unless ()
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using parallel assignment with splat operator in the block of guard condition' do
+    expect_no_offenses(<<~RUBY)
+      return if do_something do |z|
+        x, y = *z
       end
     RUBY
   end


### PR DESCRIPTION
This PR fixes the following false positive for `Lint/LiteralAssignmentInCondition` when using parallel assignment with splat operator:

```ruby
return if do_something do |z|
  x, y = *z
end
```

```console
$ bundle exec rubocop example.rb --only Lint/LiteralAssignmentInCondition
Inspecting 1 file
W

Offenses:

example.rb:2:8: W: Lint/LiteralAssignmentInCondition: Don't use literal assignment = *z
in conditional, should be == or non-literal operand.
  x, y = *z
       ^^^^

1 file inspected, 1 offense detected
```

This is a false positive because `ruby -w` doesn't warn.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
