### PR TITLE
[Fix #12434] Fix a false positive for `Lint/LiteralAssignmentInCondition`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_literal_assignment_in_condition.md
+++ b/changelog/fix_a_false_positive_for_lint_literal_assignment_in_condition.md
@@ -1,0 +1,1 @@
+* [#12434](https://github.com/rubocop/rubocop/issues/12434): Fix a false positive for `Lint/LiteralAssignmentInCondition` when using interpolated string or xstring literals. ([@koic][])

--- a/lib/rubocop/cop/lint/literal_assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/literal_assignment_in_condition.rb
@@ -41,7 +41,7 @@ module RuboCop
             next unless asgn_node.loc.operator
 
             rhs = asgn_node.to_a.last
-            next if !literal?(rhs) || parallel_assignment_with_splat_operator?(rhs)
+            next if !forbidden_literal?(rhs) || parallel_assignment_with_splat_operator?(rhs)
 
             range = offense_range(asgn_node, rhs)
 
@@ -59,7 +59,9 @@ module RuboCop
           node.each_child_node { |child| traverse_node(child, &block) }
         end
 
-        def literal?(node)
+        def forbidden_literal?(node)
+          return false if node.dstr_type? || node.xstr_type?
+
           node.respond_to?(:literal?) && node.literal?
         end
 

--- a/spec/rubocop/cop/lint/literal_assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_assignment_in_condition_spec.rb
@@ -9,6 +9,28 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAssignmentInCondition, :config do
     RUBY
   end
 
+  it 'registers an offense when assigning string literal to local variable in `if` condition' do
+    expect_offense(<<~RUBY)
+      if test = 'foo'
+              ^^^^^^^ Don't use literal assignment `= 'foo'` in conditional, should be `==` or non-literal operand.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when assigning interpolated string literal to local variable in `if` condition' do
+    expect_no_offenses(<<~'RUBY')
+      if test = "#{foo}"
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when assigning xstring literal to local variable in `if` condition' do
+    expect_no_offenses(<<~RUBY)
+      if test = `echo 'hi'`
+      end
+    RUBY
+  end
+
   it 'registers an offense when assigning array literal to local variable in `if` condition' do
     expect_offense(<<~RUBY)
       if test = []


### PR DESCRIPTION
Fixes #12434.

This PR fixes a false positive for `Lint/LiteralAssignmentInCondition` when using interpolated string or xstring literals.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
