### PR TITLE
[Fix #12435] Fix a false positive for `Lint/SelfAssignment`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_self_assignment.md
+++ b/changelog/fix_a_false_positive_for_lint_self_assignment.md
@@ -1,0 +1,1 @@
+* [#12435](https://github.com/rubocop/rubocop/issues/12435): Fix a false positive for `Lint/SelfAssignment` when using attribute assignment with method call with arguments. ([@koic][])

--- a/lib/rubocop/cop/lint/self_assignment.rb
+++ b/lib/rubocop/cop/lint/self_assignment.rb
@@ -102,6 +102,7 @@ module RuboCop
 
         def handle_attribute_assignment(node)
           first_argument = node.first_argument
+          return unless first_argument.respond_to?(:arguments) && first_argument.arguments.empty?
 
           if first_argument.call_type? &&
              node.receiver == first_argument.receiver &&

--- a/spec/rubocop/cop/lint/self_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/self_assignment_spec.rb
@@ -162,6 +162,18 @@ RSpec.describe RuboCop::Cop::Lint::SelfAssignment, :config do
     RUBY
   end
 
+  it 'does not register an offense when using attribute assignment with method call with arguments' do
+    expect_no_offenses(<<~RUBY)
+      foo.bar = foo.bar(arg)
+    RUBY
+  end
+
+  it 'does not register an offense when using attribute assignment with literals' do
+    expect_no_offenses(<<~RUBY)
+      foo.bar = true
+    RUBY
+  end
+
   it 'registers an offense when using []= self-assignment with same string literals' do
     expect_offense(<<~RUBY)
       foo["bar"] = foo["bar"]


### PR DESCRIPTION
Fixes #12435.

This PR fixes a false positive for `Lint/SelfAssignment` when using attribute assignment with method call with arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
