### PR TITLE
Correction: Style/ArrayFirstLast documentation typo

### DIFF
--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -579,7 +579,7 @@ Array(paths).each { |path| do_something(path) }
 |===
 
 Identifies usages of `arr[0]` and `arr[-1]` and suggests to change
-them to use `arr.first` and `arr.instead`.
+them to use `arr.first` and `arr.last` instead.
 
 The cop is disabled by default due to safety concerns.
 

--- a/lib/rubocop/cop/style/array_first_last.rb
+++ b/lib/rubocop/cop/style/array_first_last.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Style
       # Identifies usages of `arr[0]` and `arr[-1]` and suggests to change
-      # them to use `arr.first` and `arr.instead`.
+      # them to use `arr.first` and `arr.last` instead.
       #
       # The cop is disabled by default due to safety concerns.
       #


### PR DESCRIPTION
Small correction of the documentation for `Style/ArrayFirstLast`, where a word is missing.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] ~Added tests.~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
