### PR TITLE
[Fix #12445] Make `Style/CollectionCompact` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_collection_compact_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_collection_compact_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12445](https://github.com/rubocop/rubocop/issues/12445): Make `Style/CollectionCompact` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/collection_compact.rb
+++ b/lib/rubocop/cop/style/collection_compact.rb
@@ -53,7 +53,7 @@ module RuboCop
 
         # @!method reject_method_with_block_pass?(node)
         def_node_matcher :reject_method_with_block_pass?, <<~PATTERN
-          (send !nil? {:reject :delete_if :reject!}
+          (call !nil? {:reject :delete_if :reject!}
             (block_pass
               (sym :nil?)))
         PATTERN
@@ -61,21 +61,21 @@ module RuboCop
         # @!method reject_method?(node)
         def_node_matcher :reject_method?, <<~PATTERN
           (block
-            (send
+            (call
               !nil? {:reject :delete_if :reject!})
             $(args ...)
-            (send
+            (call
               $(lvar _) :nil?))
         PATTERN
 
         # @!method select_method?(node)
         def_node_matcher :select_method?, <<~PATTERN
           (block
-            (send
+            (call
               !nil? {:select :select!})
             $(args ...)
-            (send
-              (send
+            (call
+              (call
                 $(lvar _) :nil?) :!))
         PATTERN
 
@@ -91,6 +91,7 @@ module RuboCop
 
           add_offense(range, message: message) { |corrector| corrector.replace(range, good) }
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/style/collection_compact_spec.rb
+++ b/spec/rubocop/cop/style/collection_compact_spec.rb
@@ -18,6 +18,23 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
     RUBY
   end
 
+  it 'registers an offense and corrects when using safe navigation `reject` call on array to reject nils' do
+    expect_offense(<<~RUBY)
+      array&.reject { |e| e&.nil? }
+             ^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `reject { |e| e&.nil? }`.
+      array&.delete_if { |e| e&.nil? }
+             ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `delete_if { |e| e&.nil? }`.
+      array&.reject! { |e| e&.nil? }
+             ^^^^^^^^^^^^^^^^^^^^^^^ Use `compact!` instead of `reject! { |e| e&.nil? }`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array&.compact
+      array&.compact
+      array&.compact!
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `reject` with block pass arg on array to reject nils' do
     expect_offense(<<~RUBY)
       array.reject(&:nil?)
@@ -32,6 +49,23 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
       array.compact
       array.compact
       array.compact!
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using safe navigation `reject` call with block pass arg on array to reject nils' do
+    expect_offense(<<~RUBY)
+      array&.reject(&:nil?)
+             ^^^^^^^^^^^^^^ Use `compact` instead of `reject(&:nil?)`.
+      array&.delete_if(&:nil?)
+             ^^^^^^^^^^^^^^^^^ Use `compact` instead of `delete_if(&:nil?)`.
+      array&.reject!(&:nil?)
+             ^^^^^^^^^^^^^^^ Use `compact!` instead of `reject!(&:nil?)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array&.compact
+      array&.compact
+      array&.compact!
     RUBY
   end
 
@@ -77,6 +111,20 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
     expect_correction(<<~RUBY)
       array.compact
       hash.compact!
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using safe navigation `select/select!` call to reject nils' do
+    expect_offense(<<~RUBY)
+      array&.select { |e| e&.nil?&.! }
+             ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `select { |e| e&.nil?&.! }`.
+      hash&.select! { |k, v| v&.nil?&.! }
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact!` instead of `select! { |k, v| v&.nil?&.! }`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array&.compact
+      hash&.compact!
     RUBY
   end
 


### PR DESCRIPTION
Fixes #12445.

This PR makes `Style/CollectionCompact` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
