### PR TITLE
[Fix #12446] Make `Style/HashExcept` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_hash_except_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_hash_except_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12446](https://github.com/rubocop/rubocop/issues/12446): Make `Style/HashExcept` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/hash_except.rb
+++ b/lib/rubocop/cop/style/hash_except.rb
@@ -43,7 +43,7 @@ module RuboCop
         # @!method bad_method_with_poro?(node)
         def_node_matcher :bad_method_with_poro?, <<~PATTERN
           (block
-            (send _ _)
+            (call _ _)
             (args
               $(arg _)
               (arg _))
@@ -86,6 +86,7 @@ module RuboCop
             corrector.replace(range, preferred_method)
           end
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/style/hash_except_spec.rb
+++ b/spec/rubocop/cop/style/hash_except_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
       RUBY
     end
 
+    it 'registers and corrects an offense when using safe navigation `reject` call and comparing with `lvar == :sym`' do
+      expect_offense(<<~RUBY)
+        {foo: 1, bar: 2, baz: 3}&.reject { |k, v| k == :bar }
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `except(:bar)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        {foo: 1, bar: 2, baz: 3}&.except(:bar)
+      RUBY
+    end
+
     it 'registers and corrects an offense when using `reject` and comparing with `:sym == lvar`' do
       expect_offense(<<~RUBY)
         {foo: 1, bar: 2, baz: 3}.reject { |k, v| :bar == k }


### PR DESCRIPTION
Fixes #12446.

This PR makes `Style/HashExcept` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
