### PR TITLE
[Fix #12447] Make `Style/MapCompactWithConditionalBlock` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_map_compact_with_conditional_block_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_map_compact_with_conditional_block_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12447](https://github.com/rubocop/rubocop/issues/12447): Make `Style/MapCompactWithConditionalBlock` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/map_compact_with_conditional_block.rb
+++ b/lib/rubocop/cop/style/map_compact_with_conditional_block.rb
@@ -44,9 +44,9 @@ module RuboCop
 
         # @!method map_and_compact?(node)
         def_node_matcher :map_and_compact?, <<~RUBY
-          (send
+          (call
             (block
-              (send _ :map)
+              (call _ :map)
               (args
                 $(arg _))
               {
@@ -85,6 +85,7 @@ module RuboCop
             end
           end
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/style/map_compact_with_conditional_block_spec.rb
+++ b/spec/rubocop/cop/style/map_compact_with_conditional_block_spec.rb
@@ -19,6 +19,23 @@ RSpec.describe RuboCop::Cop::Style::MapCompactWithConditionalBlock, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects to safe navigation `select` call with `if` condition' do
+      expect_offense(<<~RUBY)
+        foo&.map do |item|
+             ^^^^^^^^^^^^^ Replace `map { ... }.compact` with `select`.
+          if item.bar?
+            item
+          else
+            next
+          end
+        end&.compact
+      RUBY
+
+      expect_correction <<~RUBY
+        foo&.select { |item| item.bar? }
+      RUBY
+    end
+
     it 'registers an offense and corrects to `select` with multi-line `if` condition' do
       expect_offense(<<~RUBY)
         foo.map do |item|


### PR DESCRIPTION
Fixes #12447.

This PR makes `Style/MapCompactWithConditionalBlock` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
