### PR TITLE
[Fix #12461] Make `Style/StringChars` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_string_chars_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_string_chars_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12461](https://github.com/rubocop/rubocop/issues/12461): Make `Style/StringChars` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/string_chars.rb
+++ b/lib/rubocop/cop/style/string_chars.rb
@@ -35,6 +35,7 @@ module RuboCop
             corrector.replace(range, 'chars')
           end
         end
+        alias on_csend on_send
       end
     end
   end

--- a/spec/rubocop/cop/style/string_chars_spec.rb
+++ b/spec/rubocop/cop/style/string_chars_spec.rb
@@ -45,6 +45,17 @@ RSpec.describe RuboCop::Cop::Style::StringChars, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when using safe navigation `split(//)` call' do
+    expect_offense(<<~RUBY)
+      string&.split(//)
+              ^^^^^^^^^ Use `chars` instead of `split(//)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      string&.chars
+    RUBY
+  end
+
   it 'does not register an offense when using `chars`' do
     expect_no_offenses(<<~RUBY)
       string.chars


### PR DESCRIPTION
Fixes #12461.

This PR makes `Style/StringChars` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
