### PR TITLE
[Fix #12460] Make `Style/SingleArgumentDig` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_single_argument_dig_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_single_argument_dig_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12460](https://github.com/rubocop/rubocop/issues/12460): Make `Style/SingleArgumentDig` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/single_argument_dig.rb
+++ b/lib/rubocop/cop/style/single_argument_dig.rb
@@ -37,7 +37,7 @@ module RuboCop
 
         # @!method single_argument_dig?(node)
         def_node_matcher :single_argument_dig?, <<~PATTERN
-          (send _ :dig $!splat)
+          (call _ :dig $!splat)
         PATTERN
 
         def on_send(node)
@@ -60,6 +60,7 @@ module RuboCop
 
           ignore_node(node)
         end
+        alias on_csend on_send
       end
     end
   end

--- a/spec/rubocop/cop/style/single_argument_dig_spec.rb
+++ b/spec/rubocop/cop/style/single_argument_dig_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe RuboCop::Cop::Style::SingleArgumentDig, :config do
           { key: 'value' }[:key]
         RUBY
       end
+
+      it 'registers an offense and corrects unsuitable use of dig with safe navigation operator' do
+        expect_offense(<<~RUBY)
+          { key: 'value' }&.dig(:key)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `{ key: 'value' }[:key]` instead of `{ key: 'value' }&.dig(:key)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          { key: 'value' }[:key]
+        RUBY
+      end
     end
 
     context 'with multiple arguments' do


### PR DESCRIPTION
Fixes #12460.

This PR makes `Style/SingleArgumentDig` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
