### PR TITLE
[Fix #12457] Make `Style/Sample` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_sample_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_sample_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12457](https://github.com/rubocop/rubocop/issues/12457): Make `Style/Sample` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/sample.rb
+++ b/lib/rubocop/cop/style/sample.rb
@@ -35,7 +35,7 @@ module RuboCop
 
         # @!method sample_candidate?(node)
         def_node_matcher :sample_candidate?, <<~PATTERN
-          (send $(send _ :shuffle $...) ${:#{RESTRICT_ON_SEND.join(' :')}} $...)
+          (call $(call _ :shuffle $...) ${:#{RESTRICT_ON_SEND.join(' :')}} $...)
         PATTERN
 
         def on_send(node)
@@ -52,6 +52,7 @@ module RuboCop
             end
           end
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/style/sample_spec.rb
+++ b/spec/rubocop/cop/style/sample_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Style::Sample, :config do
         [1, 2, 3].#{right}
       RUBY
     end
+
+    it "registers an offense for safe navigation #{wrong} call" do
+      expect_offense(<<~RUBY, wrong: wrong)
+        [1, 2, 3]&.%{wrong}
+                   ^{wrong} Use `#{right}` instead of `#{wrong}`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3]&.#{right}
+      RUBY
+    end
   end
 
   shared_examples 'accepts' do |acceptable|
@@ -22,6 +33,8 @@ RSpec.describe RuboCop::Cop::Style::Sample, :config do
 
   it_behaves_like('offense', 'shuffle.first', 'sample')
   it_behaves_like('offense', 'shuffle.last', 'sample')
+  it_behaves_like('offense', 'shuffle&.first', 'sample')
+  it_behaves_like('offense', 'shuffle&.last', 'sample')
   it_behaves_like('offense', 'shuffle[0]', 'sample')
   it_behaves_like('offense', 'shuffle[-1]', 'sample')
   context 'Ruby >= 2.7', :ruby27 do


### PR DESCRIPTION
Fixes #12457.

This PR makes `Style/Sample` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
