### PR TITLE
[Fix #12456] Make `Style/RedundantSortBy` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_redundant_sort_by_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_redundant_sort_by_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12456](https://github.com/rubocop/rubocop/issues/12456): Make `Style/RedundantSortBy` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_sort_by.rb
+++ b/lib/rubocop/cop/style/redundant_sort_by.rb
@@ -46,12 +46,12 @@ module RuboCop
 
         # @!method redundant_sort_by_block(node)
         def_node_matcher :redundant_sort_by_block, <<~PATTERN
-          (block $(send _ :sort_by) (args (arg $_x)) (lvar _x))
+          (block $(call _ :sort_by) (args (arg $_x)) (lvar _x))
         PATTERN
 
         # @!method redundant_sort_by_numblock(node)
         def_node_matcher :redundant_sort_by_numblock, <<~PATTERN
-          (numblock $(send _ :sort_by) 1 (lvar :_1))
+          (numblock $(call _ :sort_by) 1 (lvar :_1))
         PATTERN
 
         def sort_by_range(send, node)

--- a/spec/rubocop/cop/style/redundant_sort_by_spec.rb
+++ b/spec/rubocop/cop/style/redundant_sort_by_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantSortBy, :config do
     RUBY
   end
 
+  it 'autocorrects array&.sort_by { |x| x }' do
+    expect_offense(<<~RUBY)
+      array&.sort_by { |x| x }
+             ^^^^^^^^^^^^^^^^^ Use `sort` instead of `sort_by { |x| x }`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array&.sort
+    RUBY
+  end
+
   context 'Ruby 2.7', :ruby27 do
     it 'autocorrects array.sort_by { |x| x }' do
       expect_offense(<<~RUBY)
@@ -21,6 +32,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantSortBy, :config do
 
       expect_correction(<<~RUBY)
         array.sort
+      RUBY
+    end
+
+    it 'autocorrects array&.sort_by { |x| x }' do
+      expect_offense(<<~RUBY)
+        array&.sort_by { _1 }
+               ^^^^^^^^^^^^^^ Use `sort` instead of `sort_by { _1 }`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array&.sort
       RUBY
     end
   end


### PR DESCRIPTION
Fixes #12456.

This PR makes `Style/RedundantSortBy` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
