### PR TITLE
[Fix #12455] Make `Style/RedundantSort` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_redundant_sort_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_redundant_sort_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12455](https://github.com/rubocop/rubocop/issues/12455): Make `Style/RedundantSortBy` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_sort.rb
+++ b/lib/rubocop/cop/style/redundant_sort.rb
@@ -87,15 +87,15 @@ module RuboCop
         # @!method redundant_sort?(node)
         def_node_matcher :redundant_sort?, <<~MATCHER
           {
-            (send $(send _ $:sort) ${:last :first})
-            (send $(send _ $:sort) ${:[] :at :slice} {(int 0) (int -1)})
+            (call $(call _ $:sort) ${:last :first})
+            (call $(call _ $:sort) ${:[] :at :slice} {(int 0) (int -1)})
 
-            (send $(send _ $:sort_by _) ${:last :first})
+            (call $(call _ $:sort_by _) ${:last :first})
             (send $(send _ $:sort_by _) ${:[] :at :slice} {(int 0) (int -1)})
 
-            (send ({block numblock} $(send _ ${:sort_by :sort}) ...) ${:last :first})
-            (send
-              ({block numblock} $(send _ ${:sort_by :sort}) ...)
+            (call ({block numblock} $(call _ ${:sort_by :sort}) ...) ${:last :first})
+            (call
+              ({block numblock} $(call _ ${:sort_by :sort}) ...)
               ${:[] :at :slice} {(int 0) (int -1)}
             )
           }
@@ -108,6 +108,7 @@ module RuboCop
 
           register_offense(ancestor, sort_node, sorter, accessor)
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/style/redundant_sort_spec.rb
+++ b/spec/rubocop/cop/style/redundant_sort_spec.rb
@@ -12,6 +12,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort, :config do
     RUBY
   end
 
+  it 'registers an offense when `first` is called with safe navigation `sort`' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3]&.sort.first
+                 ^^^^^^^^^^ Use `min` instead of `sort...first`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3]&.min
+    RUBY
+  end
+
+  it 'registers an offense when `first` is safe navigation called with safe navigation `sort`' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3]&.sort&.first
+                 ^^^^^^^^^^^ Use `min` instead of `sort...first`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3]&.min
+    RUBY
+  end
+
   it 'registers an offense when last is called with sort' do
     expect_offense(<<~RUBY)
       [1, 2].sort.last
@@ -20,6 +42,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort, :config do
 
     expect_correction(<<~RUBY)
       [1, 2].max
+    RUBY
+  end
+
+  it 'registers an offense when `last` is called with safe navigation `sort`' do
+    expect_offense(<<~RUBY)
+      [1, 2]&.sort.last
+              ^^^^^^^^^ Use `max` instead of `sort...last`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2]&.max
+    RUBY
+  end
+
+  it 'registers an offense when `last` is safe navigation called with safe navigation `sort`' do
+    expect_offense(<<~RUBY)
+      [1, 2]&.sort&.last
+              ^^^^^^^^^^ Use `max` instead of `sort...last`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2]&.max
     RUBY
   end
 
@@ -34,6 +78,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort, :config do
     RUBY
   end
 
+  it 'registers an offense when `last` is called on safe navigation `sort` with comparator' do
+    expect_offense(<<~RUBY)
+      foo&.sort { |a, b| b <=> a }.last
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `max` instead of `sort...last`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.max { |a, b| b <=> a }
+    RUBY
+  end
+
+  it 'registers an offense when `last` is safe navigation called on safe navigation `sort` with comparator' do
+    expect_offense(<<~RUBY)
+      foo&.sort { |a, b| b <=> a }&.last
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `max` instead of `sort...last`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.max { |a, b| b <=> a }
+    RUBY
+  end
+
   it 'registers an offense when first is called on sort_by' do
     expect_offense(<<~RUBY)
       [1, 2, 3].sort_by { |x| x.length }.first
@@ -42,6 +108,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort, :config do
 
     expect_correction(<<~RUBY)
       [1, 2, 3].min_by { |x| x.length }
+    RUBY
+  end
+
+  it 'registers an offense when `first` is called on safe navigation `sort_by`' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3]&.sort_by { |x| x.length }.first
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `min_by` instead of `sort_by...first`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3]&.min_by { |x| x.length }
+    RUBY
+  end
+
+  it 'registers an offense when `first` is safe navigation called on safe navigation `sort_by`' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3]&.sort_by { |x| x.length }&.first
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `min_by` instead of `sort_by...first`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3]&.min_by { |x| x.length }
     RUBY
   end
 
@@ -161,6 +249,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort, :config do
 
     expect_correction(<<~RUBY)
       [1, 2].max
+    RUBY
+  end
+
+  it 'registers an offense when `at(-1)` is with safe navigation `sort`' do
+    expect_offense(<<~RUBY)
+      [1, 2]&.sort.at(-1)
+              ^^^^^^^^^^^ Use `max` instead of `sort...at(-1)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2]&.max
+    RUBY
+  end
+
+  it 'registers an offense when `at(-1)` is safe navigation called with safe navigation `sort`' do
+    expect_offense(<<~RUBY)
+      [1, 2]&.sort&.at(-1)
+              ^^^^^^^^^^^^ Use `max` instead of `sort...at(-1)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2]&.max
     RUBY
   end
 
@@ -369,6 +479,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort, :config do
 
         expect_correction(<<~RUBY)
           [1, 2, 3].min_by { _1.foo }
+        RUBY
+      end
+
+      it 'registers an offense and corrects when `at(0)` is called on safe navigation `sort_by`' do
+        expect_offense(<<~RUBY)
+          [1, 2, 3]&.sort_by { _1.foo }.at(0)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^ Use `min_by` instead of `sort_by...at(0)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [1, 2, 3]&.min_by { _1.foo }
+        RUBY
+      end
+
+      it 'registers an offense and corrects when `at(0)` is safe navigation called on safe navigation `sort_by`' do
+        expect_offense(<<~RUBY)
+          [1, 2, 3]&.sort_by { _1.foo }&.at(0)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `min_by` instead of `sort_by...at(0)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [1, 2, 3]&.min_by { _1.foo }
         RUBY
       end
     end


### PR DESCRIPTION
Fixes #12455.

This PR makes `Style/RedundantSort` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
