### PR TITLE
[Fix #12454] Make `Style/RedundantFetchBlock` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_redundant_fetch_block_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_redundant_fetch_block_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12454](https://github.com/rubocop/rubocop/issues/12454): Make `Style/RedundantFetchBlock` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_fetch_block.rb
+++ b/lib/rubocop/cop/style/redundant_fetch_block.rb
@@ -47,7 +47,7 @@ module RuboCop
         # @!method redundant_fetch_block_candidate?(node)
         def_node_matcher :redundant_fetch_block_candidate?, <<~PATTERN
           (block
-            $(send _ :fetch _)
+            $(call _ :fetch _)
             (args)
             ${nil? #basic_literal? #const_type?})
         PATTERN
@@ -61,10 +61,10 @@ module RuboCop
             bad = build_bad_method(send, body)
 
             add_offense(range, message: format(MSG, good: good, bad: bad)) do |corrector|
-              receiver, _, key = send.children
+              _, _, key = send.children
               default_value = body ? body.source : 'nil'
 
-              corrector.replace(node, "#{receiver.source}.fetch(#{key.source}, #{default_value})")
+              corrector.replace(range, "fetch(#{key.source}, #{default_value})")
             end
           end
         end

--- a/spec/rubocop/cop/style/redundant_fetch_block_spec.rb
+++ b/spec/rubocop/cop/style/redundant_fetch_block_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantFetchBlock, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when using `&.fetch` with Integer in the block' do
+      expect_offense(<<~RUBY)
+        hash&.fetch(:key) { 5 }
+              ^^^^^^^^^^^^^^^^^ Use `fetch(:key, 5)` instead of `fetch(:key) { 5 }`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        hash&.fetch(:key, 5)
+      RUBY
+    end
+
     it 'registers an offense and corrects when using `#fetch` with Float in the block' do
       expect_offense(<<~RUBY)
         hash.fetch(:key) { 2.5 }


### PR DESCRIPTION
Fixes #12454.

This PR makes `Style/RedundantFetchBlock` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
