### PR TITLE
[Fix #12468] Make `Style/Strip` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_strip_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_strip_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12468](https://github.com/rubocop/rubocop/issues/12468): Make `Style/Strip` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/strip.rb
+++ b/lib/rubocop/cop/style/strip.rb
@@ -22,20 +22,23 @@ module RuboCop
 
         # @!method lstrip_rstrip(node)
         def_node_matcher :lstrip_rstrip, <<~PATTERN
-          {(send $(send _ $:rstrip) $:lstrip)
-           (send $(send _ $:lstrip) $:rstrip)}
+          {
+            (call $(call _ :rstrip) :lstrip)
+            (call $(call _ :lstrip) :rstrip)
+          }
         PATTERN
 
         def on_send(node)
-          lstrip_rstrip(node) do |first_send, method_one, method_two|
+          lstrip_rstrip(node) do |first_send|
             range = range_between(first_send.loc.selector.begin_pos, node.source_range.end_pos)
-            message = format(MSG, methods: "#{method_one}.#{method_two}")
+            message = format(MSG, methods: range.source)
 
             add_offense(range, message: message) do |corrector|
               corrector.replace(range, 'strip')
             end
           end
         end
+        alias on_csend on_send
       end
     end
   end

--- a/spec/rubocop/cop/style/strip_spec.rb
+++ b/spec/rubocop/cop/style/strip_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::Strip, :config do
-  it 'registers an offense for str.lstrip.rstrip' do
+  it 'registers an offense for `str.lstrip.rstrip`' do
     expect_offense(<<~RUBY)
       str.lstrip.rstrip
           ^^^^^^^^^^^^^ Use `strip` instead of `lstrip.rstrip`.
@@ -12,7 +12,29 @@ RSpec.describe RuboCop::Cop::Style::Strip, :config do
     RUBY
   end
 
-  it 'registers an offense for str.rstrip.lstrip' do
+  it 'registers an offense for `str&.lstrip.rstrip`' do
+    expect_offense(<<~RUBY)
+      str&.lstrip.rstrip
+           ^^^^^^^^^^^^^ Use `strip` instead of `lstrip.rstrip`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      str&.strip
+    RUBY
+  end
+
+  it 'registers an offense for `str&.lstrip&.rstrip`' do
+    expect_offense(<<~RUBY)
+      str&.lstrip&.rstrip
+           ^^^^^^^^^^^^^^ Use `strip` instead of `lstrip&.rstrip`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      str&.strip
+    RUBY
+  end
+
+  it 'registers an offense for `str.rstrip.lstrip`' do
     expect_offense(<<~RUBY)
       str.rstrip.lstrip
           ^^^^^^^^^^^^^ Use `strip` instead of `rstrip.lstrip`.
@@ -20,6 +42,28 @@ RSpec.describe RuboCop::Cop::Style::Strip, :config do
 
     expect_correction(<<~RUBY)
       str.strip
+    RUBY
+  end
+
+  it 'registers an offense for `str&.rstrip.lstrip`' do
+    expect_offense(<<~RUBY)
+      str&.rstrip.lstrip
+           ^^^^^^^^^^^^^ Use `strip` instead of `rstrip.lstrip`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      str&.strip
+    RUBY
+  end
+
+  it 'registers an offense for `str&.rstrip&.lstrip`' do
+    expect_offense(<<~RUBY)
+      str&.rstrip&.lstrip
+           ^^^^^^^^^^^^^^ Use `strip` instead of `rstrip&.lstrip`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      str&.strip
     RUBY
   end
 end


### PR DESCRIPTION
Fixes #12468.

This PR makes `Style/Strip` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
