### PR TITLE
[Fix #12469] Make `Style/UnpackFirst` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_unpack_first_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_unpack_first_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12469](https://github.com/rubocop/rubocop/issues/12469): Make `Style/UnpackFirst` aware of safe navigation operator. ([@koic][])

--- a/spec/rubocop/cop/style/unpack_first_spec.rb
+++ b/spec/rubocop/cop/style/unpack_first_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Style::UnpackFirst, :config do
       it 'when using `#unpack` with `#first`' do
         expect_offense(<<~RUBY)
           x.unpack('h*').first
-          ^^^^^^^^^^^^^^^^^^^^ Use `x.unpack1('h*')` instead of `x.unpack('h*').first`.
+            ^^^^^^^^^^^^^^^^^^ Use `unpack1('h*')` instead of `unpack('h*').first`.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -14,10 +14,32 @@ RSpec.describe RuboCop::Cop::Style::UnpackFirst, :config do
         RUBY
       end
 
+      it 'when using `&.unpack` with `.first`' do
+        expect_offense(<<~RUBY)
+          x&.unpack('h*').first
+             ^^^^^^^^^^^^^^^^^^ Use `unpack1('h*')` instead of `unpack('h*').first`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          x&.unpack1('h*')
+        RUBY
+      end
+
+      it 'when using `&.unpack` with `&.first`' do
+        expect_offense(<<~RUBY)
+          x&.unpack('h*')&.first
+             ^^^^^^^^^^^^^^^^^^^ Use `unpack1('h*')` instead of `unpack('h*')&.first`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          x&.unpack1('h*')
+        RUBY
+      end
+
       it 'when using `#unpack` with square brackets' do
         expect_offense(<<~RUBY)
           ''.unpack(y)[0]
-          ^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y)[0]`.
+             ^^^^^^^^^^^^ Use `unpack1(y)` instead of `unpack(y)[0]`.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -28,7 +50,7 @@ RSpec.describe RuboCop::Cop::Style::UnpackFirst, :config do
       it 'when using `#unpack` with dot and square brackets' do
         expect_offense(<<~RUBY)
           ''.unpack(y).[](0)
-          ^^^^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y).[](0)`.
+             ^^^^^^^^^^^^^^^ Use `unpack1(y)` instead of `unpack(y).[](0)`.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -39,7 +61,7 @@ RSpec.describe RuboCop::Cop::Style::UnpackFirst, :config do
       it 'when using `#unpack` with `#slice`' do
         expect_offense(<<~RUBY)
           ''.unpack(y).slice(0)
-          ^^^^^^^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y).slice(0)`.
+             ^^^^^^^^^^^^^^^^^^ Use `unpack1(y)` instead of `unpack(y).slice(0)`.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -47,10 +69,32 @@ RSpec.describe RuboCop::Cop::Style::UnpackFirst, :config do
         RUBY
       end
 
+      it 'when using `&.unpack` with `.slice`' do
+        expect_offense(<<~RUBY)
+          ''&.unpack(y).slice(0)
+              ^^^^^^^^^^^^^^^^^^ Use `unpack1(y)` instead of `unpack(y).slice(0)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          ''&.unpack1(y)
+        RUBY
+      end
+
+      it 'when using `&.unpack` with `&.slice`' do
+        expect_offense(<<~RUBY)
+          ''&.unpack(y)&.slice(0)
+              ^^^^^^^^^^^^^^^^^^^ Use `unpack1(y)` instead of `unpack(y)&.slice(0)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          ''&.unpack1(y)
+        RUBY
+      end
+
       it 'when using `#unpack` with `#at`' do
         expect_offense(<<~RUBY)
           ''.unpack(y).at(0)
-          ^^^^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y).at(0)`.
+             ^^^^^^^^^^^^^^^ Use `unpack1(y)` instead of `unpack(y).at(0)`.
         RUBY
 
         expect_correction(<<~RUBY)


### PR DESCRIPTION
Fixes #12469.

This PR makes `Style/UnpackFirst` aware of safe navigation operator and tweaks offense message.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
