### PR TITLE
[Fix #12473] Make `Style/ClassCheck` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_class_check_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_class_check_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12473](https://github.com/rubocop/rubocop/issues/12473): Make `Style/ClassCheck` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/class_check.rb
+++ b/lib/rubocop/cop/style/class_check.rb
@@ -40,6 +40,7 @@ module RuboCop
             corrector.replace(node.loc.selector, replacement)
           end
         end
+        alias on_csend on_send
 
         def message(node)
           if node.method?(:is_a?)

--- a/spec/rubocop/cop/style/class_check_spec.rb
+++ b/spec/rubocop/cop/style/class_check_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::ClassCheck, :config do
-  context 'when enforced style is is_a?' do
+  context 'when enforced style is `is_a?`' do
     let(:cop_config) { { 'EnforcedStyle' => 'is_a?' } }
 
-    it 'registers an offense for kind_of? and corrects to is_a?' do
+    it 'registers an offense for `kind_of?` and corrects to `is_a?`' do
       expect_offense(<<~RUBY)
         x.kind_of? y
           ^^^^^^^^ Prefer `Object#is_a?` over `Object#kind_of?`.
@@ -14,12 +14,23 @@ RSpec.describe RuboCop::Cop::Style::ClassCheck, :config do
         x.is_a? y
       RUBY
     end
+
+    it 'registers an offense for `kind_of?` is safe navigation called and corrects to `is_a?`' do
+      expect_offense(<<~RUBY)
+        x&.kind_of? y
+           ^^^^^^^^ Prefer `Object#is_a?` over `Object#kind_of?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.is_a? y
+      RUBY
+    end
   end
 
   context 'when enforced style is kind_of?' do
     let(:cop_config) { { 'EnforcedStyle' => 'kind_of?' } }
 
-    it 'registers an offense for is_a? and corrects to kind_of?' do
+    it 'registers an offense for `is_a?` and corrects to `kind_of?`' do
       expect_offense(<<~RUBY)
         x.is_a? y
           ^^^^^ Prefer `Object#kind_of?` over `Object#is_a?`.
@@ -27,6 +38,17 @@ RSpec.describe RuboCop::Cop::Style::ClassCheck, :config do
 
       expect_correction(<<~RUBY)
         x.kind_of? y
+      RUBY
+    end
+
+    it 'registers an offense for `is_a?` is safe navigation called and corrects to `kind_of?`' do
+      expect_offense(<<~RUBY)
+        x&.is_a? y
+           ^^^^^ Prefer `Object#kind_of?` over `Object#is_a?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.kind_of? y
       RUBY
     end
   end


### PR DESCRIPTION
Fixes #12473.

This PR makes `Style/ClassCheck` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
