### PR TITLE
[Fix #12474] Make `Style/ConcatArrayLiterals` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_concat_array_literals_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_concat_array_literals_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12474](https://github.com/rubocop/rubocop/issues/12474): Make `Style/ConcatArrayLiterals` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/concat_array_literals.rb
+++ b/lib/rubocop/cop/style/concat_array_literals.rb
@@ -63,6 +63,7 @@ module RuboCop
           end
         end
         # rubocop:enable Metrics
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/style/concat_array_literals_spec.rb
+++ b/spec/rubocop/cop/style/concat_array_literals_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Style::ConcatArrayLiterals, :config do
     RUBY
   end
 
+  it 'registers an offense when using safe navigation `concat` with single element array literal argument' do
+    expect_offense(<<~RUBY)
+      arr&.concat([item])
+           ^^^^^^^^^^^^^^ Use `push(item)` instead of `concat([item])`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      arr&.push(item)
+    RUBY
+  end
+
   it 'registers an offense when using `concat` with multiple elements array literal argument' do
     expect_offense(<<~RUBY)
       arr.concat([foo, bar])


### PR DESCRIPTION
Fixes #12474.

This PR makes `Style/ConcatArrayLiterals` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
