### PR TITLE
[Fix #12476] Make `Style/ConcatArrayLiterals` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_date_time_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_date_time_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12476](https://github.com/rubocop/rubocop/issues/12476): Make `Style/DateTime` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/date_time.rb
+++ b/lib/rubocop/cop/style/date_time.rb
@@ -49,12 +49,12 @@ module RuboCop
       class DateTime < Base
         extend AutoCorrector
 
-        CLASS_MSG = 'Prefer Time over DateTime.'
-        COERCION_MSG = 'Do not use #to_datetime.'
+        CLASS_MSG = 'Prefer `Time` over `DateTime`.'
+        COERCION_MSG = 'Do not use `#to_datetime`.'
 
         # @!method date_time?(node)
         def_node_matcher :date_time?, <<~PATTERN
-          (send (const {nil? (cbase)} :DateTime) ...)
+          (call (const {nil? (cbase)} :DateTime) ...)
         PATTERN
 
         # @!method historic_date?(node)
@@ -64,7 +64,7 @@ module RuboCop
 
         # @!method to_datetime?(node)
         def_node_matcher :to_datetime?, <<~PATTERN
-          (send _ :to_datetime)
+          (call _ :to_datetime)
         PATTERN
 
         def on_send(node)
@@ -75,6 +75,7 @@ module RuboCop
 
           add_offense(node, message: message) { |corrector| autocorrect(corrector, node) }
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/style/date_time_spec.rb
+++ b/spec/rubocop/cop/style/date_time_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Style::DateTime, :config do
   it 'registers an offense when using DateTime for current time' do
     expect_offense(<<~RUBY)
       DateTime.now
-      ^^^^^^^^^^^^ Prefer Time over DateTime.
+      ^^^^^^^^^^^^ Prefer `Time` over `DateTime`.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -14,10 +14,21 @@ RSpec.describe RuboCop::Cop::Style::DateTime, :config do
     RUBY
   end
 
+  it 'registers an offense when using DateTime for current time with safe navigation operator' do
+    expect_offense(<<~RUBY)
+      DateTime&.now
+      ^^^^^^^^^^^^^ Prefer `Time` over `DateTime`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Time&.now
+    RUBY
+  end
+
   it 'registers an offense when using ::DateTime for current time' do
     expect_offense(<<~RUBY)
       ::DateTime.now
-      ^^^^^^^^^^^^^^ Prefer Time over DateTime.
+      ^^^^^^^^^^^^^^ Prefer `Time` over `DateTime`.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -28,7 +39,7 @@ RSpec.describe RuboCop::Cop::Style::DateTime, :config do
   it 'registers an offense when using DateTime for modern date' do
     expect_offense(<<~RUBY)
       DateTime.iso8601('2016-06-29')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer Time over DateTime.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Time` over `DateTime`.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -62,7 +73,14 @@ RSpec.describe RuboCop::Cop::Style::DateTime, :config do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         thing.to_datetime
-        ^^^^^^^^^^^^^^^^^ Do not use #to_datetime.
+        ^^^^^^^^^^^^^^^^^ Do not use `#to_datetime`.
+      RUBY
+    end
+
+    it 'registers an offense when using safe navigation operator' do
+      expect_offense(<<~RUBY)
+        thing&.to_datetime
+        ^^^^^^^^^^^^^^^^^^ Do not use `#to_datetime`.
       RUBY
     end
   end


### PR DESCRIPTION
Fixes #12476.

This PR make `Style/ConcatArrayLiterals` aware of safe navigation operator and tweaks this cop's offense message.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
