### PR TITLE
[Fix #12480] Make `Style/ExactRegexpMatch` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_regexp_match_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_regexp_match_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12480](https://github.com/rubocop/rubocop/issues/12480): Make `Style/ExactRegexpMatch` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/exact_regexp_match.rb
+++ b/lib/rubocop/cop/style/exact_regexp_match.rb
@@ -30,7 +30,7 @@ module RuboCop
 
         # @!method exact_regexp_match(node)
         def_node_matcher :exact_regexp_match, <<~PATTERN
-          (send
+          (call
             _ {:=~ :=== :!~ :match :match?}
             (regexp
               (str $_)
@@ -49,6 +49,7 @@ module RuboCop
             corrector.replace(node, prefer)
           end
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/style/exact_regexp_match_spec.rb
+++ b/spec/rubocop/cop/style/exact_regexp_match_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe RuboCop::Cop::Style::ExactRegexpMatch, :config do
     RUBY
   end
 
+  it 'registers an offense when using `string&.match(/\Astring\z/)`' do
+    expect_offense(<<~'RUBY')
+      string&.match(/\Astring\z/)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `string == 'string'`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      string == 'string'
+    RUBY
+  end
+
   it 'registers an offense when using `string.match?(/\Astring\z/)`' do
     expect_offense(<<~'RUBY')
       string.match?(/\Astring\z/)


### PR DESCRIPTION
Fixes #12480.

This PR makes `Style/ExactRegexpMatch` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
