### PR TITLE
[Fix #12479] Make `Style/EachWithObject` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_each_with_object_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_each_with_object_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12479](https://github.com/rubocop/rubocop/issues/12479): Make `Style/EachWithObject` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/each_with_object.rb
+++ b/lib/rubocop/cop/style/each_with_object.rb
@@ -58,12 +58,12 @@ module RuboCop
 
         # @!method each_with_object_block_candidate?(node)
         def_node_matcher :each_with_object_block_candidate?, <<~PATTERN
-          (block $(send _ {:inject :reduce} _) $_ $_)
+          (block $(call _ {:inject :reduce} _) $_ $_)
         PATTERN
 
         # @!method each_with_object_numblock_candidate?(node)
         def_node_matcher :each_with_object_numblock_candidate?, <<~PATTERN
-          (numblock $(send _ {:inject :reduce} _) 2 $_)
+          (numblock $(call _ {:inject :reduce} _) 2 $_)
         PATTERN
 
         def autocorrect_block(corrector, node, return_value)

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe RuboCop::Cop::Style::EachWithObject, :config do
     RUBY
   end
 
+  it 'finds inject is safe navigation called with passed in and returned hash' do
+    expect_offense(<<~RUBY)
+      []&.inject({}) { |a, e| a }
+          ^^^^^^ Use `each_with_object` instead of `inject`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      []&.each_with_object({}) { |e, a|  }
+    RUBY
+  end
+
   context 'Ruby 2.7', :ruby27 do
     it 'finds inject and reduce with passed in and returned hash and numblock' do
       expect_offense(<<~RUBY)
@@ -36,6 +47,23 @@ RSpec.describe RuboCop::Cop::Style::EachWithObject, :config do
 
       expect_correction(<<~RUBY)
         [].each_with_object({}) do
+          _2[_1] = 1
+          _2
+        end
+      RUBY
+    end
+
+    it 'finds `reduce` is called with passed in and returned hash and numblock' do
+      expect_offense(<<~RUBY)
+        []&.reduce({}) do
+            ^^^^^^ Use `each_with_object` instead of `reduce`.
+          _1[_2] = 1
+          _1
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        []&.each_with_object({}) do
           _2[_1] = 1
           _2
         end


### PR DESCRIPTION
Fixes #12479.

This PR makes `Style/EachWithObject` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
