### PR TITLE
[Fix #12484] Make `Style/Next` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_next_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_next_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12484](https://github.com/rubocop/rubocop/issues/12484): Make `Style/Next` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -66,7 +66,7 @@ module RuboCop
         end
 
         def on_block(node)
-          return unless node.send_node.send_type? && node.send_node.enumerator_method?
+          return unless node.send_node.call_type? && node.send_node.enumerator_method?
 
           check(node)
         end

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -62,6 +62,24 @@ RSpec.describe RuboCop::Cop::Style::Next, :config do
       RUBY
     end
 
+    it "registers an offense for #{condition} inside of safe navigation `each` call" do
+      expect_offense(<<~RUBY, condition: condition)
+        []&.each do |o|
+          %{condition} o == 1
+          ^{condition}^^^^^^^ Use `next` to skip iteration.
+            puts o
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        []&.each do |o|
+          next #{opposite} o == 1
+          puts o
+        end
+      RUBY
+    end
+
     it "registers an offense for #{condition} inside of each_with_object" do
       expect_offense(<<~RUBY, condition: condition)
         [].each_with_object({}) do |o, a|


### PR DESCRIPTION
Fixes #12484.

This PR makes `Style/Next` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
