### PR TITLE
[Fix #12486] Make `Style/RedundantArgument` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_redundant_argument_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_redundant_argument_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12486](https://github.com/rubocop/rubocop/issues/12486): Make `Style/RedundantArgument` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_argument.rb
+++ b/lib/rubocop/cop/style/redundant_argument.rb
@@ -73,6 +73,7 @@ module RuboCop
             corrector.remove(offense_range)
           end
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/style/redundant_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_argument_spec.rb
@@ -39,6 +39,29 @@ RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when safe navigation method called on variable' do
+    expect_offense(<<~'RUBY')
+      foo&.join('')
+               ^^^^ Argument '' is redundant because it is implied by default.
+      foo&.sum(0)
+              ^^^ Argument 0 is redundant because it is implied by default.
+      foo&.split(' ')
+                ^^^^^ Argument ' ' is redundant because it is implied by default.
+      foo&.chomp("\n")
+                ^^^^^^ Argument "\n" is redundant because it is implied by default.
+      foo&.chomp!("\n")
+                 ^^^^^^ Argument "\n" is redundant because it is implied by default.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.join
+      foo&.sum
+      foo&.split
+      foo&.chomp
+      foo&.chomp!
+    RUBY
+  end
+
   it 'registers an offense and corrects when method called without parenthesis on variable' do
     expect_offense(<<~RUBY)
       foo.join ''


### PR DESCRIPTION
Fixes #12486.

This PR makes `Style/RedundantArgument` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
