### PR TITLE
[Fix #12495] Make `Layout/RedundantLineBreak` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_redundant_line_break_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_redundant_line_break_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12495](https://github.com/rubocop/rubocop/issues/12495): Make `Layout/RedundantLineBreak` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -62,6 +62,7 @@ module RuboCop
 
           register_offense(node)
         end
+        alias on_csend on_send
 
         private
 
@@ -135,7 +136,7 @@ module RuboCop
             .gsub(/" *\\\n\s*'/, %q(" + ')) # Double quote, backslash, and then single quote
             .gsub(/' *\\\n\s*"/, %q(' + ")) # Single quote, backslash, and then double quote
             .gsub(/(["']) *\\\n\s*\1/, '')  # Double or single quote, backslash, then same quote
-            .gsub(/\n\s*(?=\.\w)/, '')      # Extra space within method chaining
+            .gsub(/\n\s*(?=(&)?\.\w)/, '')  # Extra space within method chaining which includes `&.`
             .gsub(/\s*\\?\n\s*/, ' ')       # Any other line break, with or without backslash
         end
 

--- a/lib/rubocop/cop/naming/constant_name.rb
+++ b/lib/rubocop/cop/naming/constant_name.rb
@@ -61,8 +61,7 @@ module RuboCop
         end
 
         def allowed_method_call_on_rhs?(node)
-          node&.send_type? &&
-            (node.receiver.nil? || !literal_receiver?(node))
+          node&.send_type? && (node.receiver.nil? || !literal_receiver?(node))
         end
 
         # @!method literal_receiver?(node)

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -28,6 +28,32 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
           ^^^^^^^^^^^^^^^^^^^^^^^^ Redundant line break detected.
            .join + []
         RUBY
+
+        expect_correction(<<~RUBY)
+          e.select { |i| i.cond? }.join
+          a = e.select { |i| i.cond? }.join
+          e.select { |i| i.cond? }.join + []
+        RUBY
+      end
+
+      it 'reports an offense for a safe navigation method call chained onto a single line block' do
+        expect_offense(<<~RUBY)
+          e&.select { |i| i.cond? }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant line break detected.
+            &.join
+          a = e&.select { |i| i.cond? }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant line break detected.
+            &.join
+          e&.select { |i| i.cond? }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant line break detected.
+            &.join + []
+        RUBY
+
+        expect_correction(<<~RUBY)
+          e&.select { |i| i.cond? }&.join
+          a = e&.select { |i| i.cond? }&.join
+          e&.select { |i| i.cond? }&.join + []
+        RUBY
       end
     end
 


### PR DESCRIPTION
Fixes #12495.

This PR makes `Layout/RedundantLineBreak` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
