### PR TITLE
[Fix #12494] Make `Layout/SingleLineBlockChain` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_single_line_block_chain_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_single_line_block_chain_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12494](https://github.com/rubocop/rubocop/issues/12494): Make `Layout/SingleLineBlockChain` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/layout/single_line_block_chain.rb
+++ b/lib/rubocop/cop/layout/single_line_block_chain.rb
@@ -33,6 +33,7 @@ module RuboCop
           range = offending_range(node)
           add_offense(range) { |corrector| corrector.insert_before(range, "\n") } if range
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/layout/single_line_block_chain_spec.rb
+++ b/spec/rubocop/cop/layout/single_line_block_chain_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe RuboCop::Cop::Layout::SingleLineBlockChain, :config do
     RUBY
   end
 
+  it 'registers an offense for safe navigation method call chained on the same line as a block' do
+    expect_offense(<<~RUBY)
+      example.select { |item| item.cond? }&.join('-')
+                                          ^^^^^^ Put method call on a separate line if chained to a single line block.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      example.select { |item| item.cond? }
+      &.join('-')
+    RUBY
+  end
+
   it 'registers an offense for no selector method call chained on the same line as a block' do
     expect_offense(<<~RUBY)
       example.select { |item| item.cond? }.(42)


### PR DESCRIPTION
Fixes #12494.

This PR makes `Layout/SingleLineBlockChain` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
