### PR TITLE
[Fix #12488] Make `Lint/HashCompareByIdentity` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_lint_hash_compare_by_identity_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_lint_hash_compare_by_identity_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12488](https://github.com/rubocop/rubocop/issues/12488): Make `Lint/HashCompareByIdentity` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/lint/hash_compare_by_identity.rb
+++ b/lib/rubocop/cop/lint/hash_compare_by_identity.rb
@@ -35,12 +35,13 @@ module RuboCop
 
         # @!method id_as_hash_key?(node)
         def_node_matcher :id_as_hash_key?, <<~PATTERN
-          (send _ {:key? :has_key? :fetch :[] :[]=} (send _ :object_id) ...)
+          (call _ {:key? :has_key? :fetch :[] :[]=} (send _ :object_id) ...)
         PATTERN
 
         def on_send(node)
           add_offense(node) if id_as_hash_key?(node)
         end
+        alias on_csend on_send
       end
     end
   end

--- a/spec/rubocop/cop/lint/hash_compare_by_identity_spec.rb
+++ b/spec/rubocop/cop/lint/hash_compare_by_identity_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe RuboCop::Cop::Lint::HashCompareByIdentity, :config do
     RUBY
   end
 
+  it 'registers an offense when using hash method with `object_id` as a key with safe navigation' do
+    expect_offense(<<~RUBY)
+      hash&.key?(object_id)
+      ^^^^^^^^^^^^^^^^^^^^^ Use `Hash#compare_by_identity` instead of using `object_id` for keys.
+    RUBY
+  end
+
   it 'does not register an offense for hash methods without `object_id` as key' do
     expect_no_offenses(<<~RUBY)
       hash.key?(foo)


### PR DESCRIPTION
Fixes #12488.

This PR makes `Lint/HashCompareByIdentity` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
