### PR TITLE
[Fix #12489] Make `Lint/NextWithoutAccumulator` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_lint_next_without_accumulator_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_lint_next_without_accumulator_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12489](https://github.com/rubocop/rubocop/issues/12489): Make `Lint/NextWithoutAccumulator` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/lint/next_without_accumulator.rb
+++ b/lib/rubocop/cop/lint/next_without_accumulator.rb
@@ -34,35 +34,20 @@ module RuboCop
             add_offense(void_next) if void_next
           end
         end
-
-        def on_numblock(node)
-          on_numblock_body_of_reduce(node) do |body|
-            void_next = body.each_node(:next).find do |n|
-              n.children.empty? && parent_numblock_node(n) == node
-            end
-
-            add_offense(void_next) if void_next
-          end
-        end
+        alias on_numblock on_block
 
         private
 
         # @!method on_block_body_of_reduce(node)
         def_node_matcher :on_block_body_of_reduce, <<~PATTERN
-          (block (send _recv {:reduce :inject} !sym) _blockargs $(begin ...))
-        PATTERN
-
-        # @!method on_numblock_body_of_reduce(node)
-        def_node_matcher :on_numblock_body_of_reduce, <<~PATTERN
-          (numblock (send _recv {:reduce :inject} !sym) _argscount $(begin ...))
+          {
+            (block (call _recv {:reduce :inject} !sym) _blockargs $(begin ...))
+            (numblock (call _recv {:reduce :inject} !sym) _argscount $(begin ...))
+          }
         PATTERN
 
         def parent_block_node(node)
-          node.each_ancestor(:block).first
-        end
-
-        def parent_numblock_node(node)
-          node.each_ancestor(:numblock).first
+          node.each_ancestor(:block, :numblock).first
         end
       end
     end

--- a/spec/rubocop/cop/lint/next_without_accumulator_spec.rb
+++ b/spec/rubocop/cop/lint/next_without_accumulator_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe RuboCop::Cop::Lint::NextWithoutAccumulator, :config do
         RUBY
       end
 
+      it 'registers an offense for a bare `next` in the block of safe navigation method called' do
+        expect_offense(<<~RUBY)
+          (1..4)&.#{reduce_alias}(0) do |acc, i|
+            next if i.odd?
+            ^^^^ Use `next` with an accumulator argument in a `reduce`.
+            acc + i
+          end
+        RUBY
+      end
+
       it 'accepts next with a value' do
         expect_no_offenses(<<~RUBY)
           (1..4).#{reduce_alias}(0) do |acc, i|
@@ -38,6 +48,16 @@ RSpec.describe RuboCop::Cop::Lint::NextWithoutAccumulator, :config do
         it 'registers an offense for a bare next' do
           expect_offense(<<~RUBY)
             (1..4).#{reduce_alias}(0) do
+              next if _2.odd?
+              ^^^^ Use `next` with an accumulator argument in a `reduce`.
+              _1 + i
+            end
+          RUBY
+        end
+
+        it 'registers an offense for a bare `next` in the block of safe navigation method call' do
+          expect_offense(<<~RUBY)
+            (1..4)&.#{reduce_alias}(0) do
               next if _2.odd?
               ^^^^ Use `next` with an accumulator argument in a `reduce`.
               _1 + i


### PR DESCRIPTION
Fixes #12489.

This PR makes `Lint/NextWithoutAccumulator` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
