### PR TITLE
[Fix #12490] Make `Lint/NumberConversion` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_lint_number_conversion_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_lint_number_conversion_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12490](https://github.com/rubocop/rubocop/issues/12490): Make `Lint/NumberConversion` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -91,19 +91,24 @@ module RuboCop
 
         # @!method to_method(node)
         def_node_matcher :to_method, <<~PATTERN
-          (send $_ ${#{METHODS}})
+          (call $_ ${#{METHODS}})
         PATTERN
 
         # @!method to_method_symbol(node)
         def_node_matcher :to_method_symbol, <<~PATTERN
-          {(send _ $_ ${(sym ${#{METHODS}})} ...)
-           (send _ $_ ${(block_pass (sym ${#{METHODS}}))} ...)}
+          (call _ $_ ${
+            {
+              (sym ${#{METHODS}})
+              (block_pass (sym ${#{METHODS}}))
+            }
+          } ...)
         PATTERN
 
         def on_send(node)
           handle_conversion_method(node)
           handle_as_symbol(node)
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/lint/number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/number_conversion_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
       RUBY
     end
 
+    it 'when using `&.to_i`' do
+      expect_offense(<<~RUBY)
+        "10"&.to_i
+        ^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using `"10".to_i`, use stricter `Integer("10", 10)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Integer("10", 10)
+      RUBY
+    end
+
     it 'when using `#to_f`' do
       expect_offense(<<~RUBY)
         "10.2".to_f
@@ -169,6 +180,17 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
       RUBY
     end
 
+    it 'registers offense and autocorrects when using safe navigation operator' do
+      expect_offense(<<~RUBY)
+        "1,2,3,foo,5,6,7,8".split(',')&.map(&:to_i)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using `&:to_i`, use stricter `{ |i| Integer(i, 10) }`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        "1,2,3,foo,5,6,7,8".split(',')&.map { |i| Integer(i, 10) }
+      RUBY
+    end
+
     it 'registers offense and autocorrects without parentheses' do
       expect_offense(<<~RUBY)
         "1,2,3,foo,5,6,7,8".split(',').map &:to_i
@@ -188,6 +210,17 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
 
       expect_correction(<<~RUBY)
         "foo".try { |i| Float(i) }
+      RUBY
+    end
+
+    it 'registers offense with `&.try`' do
+      expect_offense(<<~RUBY)
+        "foo"&.try(:to_f)
+        ^^^^^^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using `:to_f`, use stricter `{ |i| Float(i) }`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        "foo"&.try { |i| Float(i) }
       RUBY
     end
 


### PR DESCRIPTION
Fixes #12490.

This PR makes `Lint/NumberConversion` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
