### PR TITLE
[Fix #12492] Make `Lint/RedundantWithObject` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_lint_redundant_with_object_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_lint_redundant_with_object_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12492](https://github.com/rubocop/rubocop/issues/12492): Make `Lint/RedundantWithObject` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_with_object.rb
+++ b/lib/rubocop/cop/lint/redundant_with_object.rb
@@ -56,9 +56,9 @@ module RuboCop
         def_node_matcher :redundant_with_object?, <<~PATTERN
           {
             (block
-              $(send _ {:each_with_object :with_object} _) (args (arg _)) ...)
+              $(call _ {:each_with_object :with_object} _) (args (arg _)) ...)
             (numblock
-              $(send _ {:each_with_object :with_object} _) 1 ...)
+              $(call _ {:each_with_object :with_object} _) 1 ...)
           }
         PATTERN
 

--- a/spec/rubocop/cop/lint/redundant_with_object_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_with_object_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Lint::RedundantWithObject, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `ary&.each_with_object { |v| v }`' do
+    expect_offense(<<~RUBY)
+      ary&.each_with_object([]) { |v| v }
+           ^^^^^^^^^^^^^^^^^^^^ Use `each` instead of `each_with_object`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ary&.each { |v| v }
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `ary.each.with_object([]) { |v| v }`' do
     expect_offense(<<~RUBY)
       ary.each.with_object([]) { |v| v }
@@ -77,6 +88,17 @@ RSpec.describe RuboCop::Cop::Lint::RedundantWithObject, :config do
 
       expect_correction(<<~RUBY)
         ary.each { _1 }
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using `ary&.each_with_object { _1 }`' do
+      expect_offense(<<~RUBY)
+        ary&.each_with_object([]) { _1 }
+             ^^^^^^^^^^^^^^^^^^^^ Use `each` instead of `each_with_object`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ary&.each { _1 }
       RUBY
     end
 


### PR DESCRIPTION
Fixes #12492.

This PR makes `Lint/RedundantWithObject` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
