### PR TITLE
[Fix #12493] Make `Lint/UnmodifiedReduceAccumulator` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_lint_unmodified_reduce_accumulator_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_lint_unmodified_reduce_accumulator_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12493](https://github.com/rubocop/rubocop/issues/12493): Make `Lint/UnmodifiedReduceAccumulator` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/lint/unmodified_reduce_accumulator.rb
+++ b/lib/rubocop/cop/lint/unmodified_reduce_accumulator.rb
@@ -69,8 +69,8 @@ module RuboCop
         # @!method reduce_with_block?(node)
         def_node_matcher :reduce_with_block?, <<~PATTERN
           {
-            (block (send _recv {:reduce :inject} ...) args ...)
-            (numblock (send _recv {:reduce :inject} ...) ...)
+            (block (call _recv {:reduce :inject} ...) args ...)
+            (numblock (call _recv {:reduce :inject} ...) ...)
           }
         PATTERN
 

--- a/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
+++ b/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
@@ -45,6 +45,25 @@ RSpec.describe RuboCop::Cop::Lint::UnmodifiedReduceAccumulator, :config do
         end
       end
 
+      it 'registers an offense when returning the element in the block of safe navigation method call' do
+        aggregate_failures do
+          expect_offense(<<~RUBY)
+            (1..4)&.#{method}(0) do |acc, el|
+              el
+              ^^ Ensure the accumulator `acc` will be modified by `#{method}`.
+            end
+          RUBY
+
+          expect_offense(<<~RUBY)
+            values&.#{method}({}) do |acc, el|
+              acc[el] = true
+              el
+              ^^ Ensure the accumulator `acc` will be modified by `#{method}`.
+            end
+          RUBY
+        end
+      end
+
       it 'registers an offense when called with no argument' do
         expect_offense(<<~RUBY)
           (1..4).#{method} do |acc, el|
@@ -606,6 +625,13 @@ RSpec.describe RuboCop::Cop::Lint::UnmodifiedReduceAccumulator, :config do
           expect_offense(<<~RUBY, method: method)
             (1..4).#{method}(0) { _2 }
                    _{method}      ^^ Ensure the accumulator `_1` will be modified by `#{method}`.
+          RUBY
+        end
+
+        it 'registers an offense when returning the element in the block of safe navigation method call' do
+          expect_offense(<<~RUBY, method: method)
+            (1..4)&.#{method}(0) { _2 }
+                    _{method}      ^^ Ensure the accumulator `_1` will be modified by `#{method}`.
           RUBY
         end
 


### PR DESCRIPTION
Fixes #12493.

This PR makes `Lint/UnmodifiedReduceAccumulator` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
