### PR TITLE
build(deps): avoid loading json 2.7.0

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.add_runtime_dependency('json', '~> 2.3')
+  s.add_runtime_dependency('json', '~> 2.3', '!= 2.7.0')
   s.add_runtime_dependency('language_server-protocol', '>= 3.17.0')
   s.add_runtime_dependency('parallel', '~> 1.10')
   s.add_runtime_dependency('parser', '>= 3.2.2.4')


### PR DESCRIPTION
Avoid loading release 2.7.0 of the `json` gem as it contains a backward-compatibility issue.

(Basically, on 2.7.0 you can't do `JSON.dump(a:1, b:2, c:3)` but you need to do `JSON.dump({ a:1, b:2, c:3 })`

Refrences:
- Issue => https://github.com/flori/json/issues/553
- PR => https://github.com/flori/json/pull/554 and https://github.com/flori/json/pull/556

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
