### PR TITLE
Fix a false positive for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_parentheses.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#12505](https://github.com/rubocop/rubocop/pull/12505): Fix a false positive for `Style/RedundantParentheses` when using parenthesized `lambda` or `proc` with `do`...`end` block. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -144,7 +144,9 @@ module RuboCop
           return 'a literal' if disallowed_literal?(begin_node, node)
           return 'a variable' if node.variable?
           return 'a constant' if node.const_type?
-          return 'an expression' if node.lambda_or_proc?
+          if node.lambda_or_proc? && (node.braces? || node.send_node.lambda_literal?)
+            return 'an expression'
+          end
           return 'an interpolated expression' if interpolation?(begin_node)
 
           return if begin_node.chained?

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -405,6 +405,37 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'registers an offense for parens around `->` with `do`...`end` block' do
+    expect_offense(<<~RUBY)
+      scope :my_scope, (-> do
+                       ^^^^^^ Don't use parentheses around an expression.
+        where(column: :value)
+      end)
+    RUBY
+
+    expect_correction(<<~RUBY)
+      scope :my_scope, -> do
+        where(column: :value)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for parens around `lambda` with `do`...`end` block' do
+    expect_no_offenses(<<~RUBY)
+      scope :my_scope, (lambda do
+        where(column: :value)
+      end)
+    RUBY
+  end
+
+  it 'does not register an offense for parens around `proc` with `do`...`end` block' do
+    expect_no_offenses(<<~RUBY)
+      scope :my_scope, (proc do
+        where(column: :value)
+      end)
+    RUBY
+  end
+
   it_behaves_like 'plausible', '(-2)**2'
   it_behaves_like 'plausible', '(-2.1)**2'
 


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/12381#issuecomment-1837926968.

This PR fixes a false positive for `Style/RedundantParentheses` when using parenthesized `lambda` or `proc` with `do`...`end` block.

`do`...`end` and `{`...`}` have different precedence, so with `do`...`end`, parentheses are needed to correct the order of association. However, with `->`, there is no need to worry about precedence, so the parentheses can be removed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
