### PR TITLE
[Fix #12444] Fix false positive for `Style/HashEachMethods`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_hash_each_methods.md
+++ b/changelog/fix_a_false_positive_for_style_hash_each_methods.md
@@ -1,0 +1,1 @@
+* [#12444](https://github.com/rubocop/rubocop/issues/12444): Fix false positive for `Style/HashEachMethods` when receiver literal is not a hash literal. ([@koic][])

--- a/spec/rubocop/cop/style/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/style/hash_each_methods_spec.rb
@@ -144,6 +144,23 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects when `{hash: :literal}.keys.each`' do
+        expect_offense(<<~RUBY)
+          {hash: :literal}.keys.each { |k| p k }
+                           ^^^^^^^^^ Use `each_key` instead of `keys.each`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {hash: :literal}.each_key { |k| p k }
+        RUBY
+      end
+
+      it 'does not register an offense when `[[1, 2, 3], [4 ,5, 6]].each`' do
+        expect_no_offenses(<<~RUBY)
+          [[1, 2, 3], [4, 5, 6]].each { |a, _| p a }
+        RUBY
+      end
+
       it 'does not register an offense for foo#each_key' do
         expect_no_offenses('foo.each_key { |k| p k }')
       end


### PR DESCRIPTION
Fixes #12444.

This PR fixes false positive for `Style/HashEachMethods` when receiver literal is not a hash literal.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
