### PR TITLE
[Fix #12436] Fix false positives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_positives_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#12436](https://github.com/rubocop/rubocop/issues/12436): Fix false positives for `Style/RedundantParentheses` when a part of range is a parenthesized condition. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -22,9 +22,6 @@ module RuboCop
         # @!method square_brackets?(node)
         def_node_matcher :square_brackets?, '(send {(send _recv _msg) str array hash} :[] ...)'
 
-        # @!method range_end?(node)
-        def_node_matcher :range_end?, '^^{irange erange}'
-
         # @!method method_node_and_args(node)
         def_node_matcher :method_node_and_args, '$(call _recv _msg $...)'
 
@@ -64,7 +61,8 @@ module RuboCop
           allowed_ancestor?(node) ||
             allowed_method_call?(node) ||
             allowed_multiple_expression?(node) ||
-            allowed_ternary?(node)
+            allowed_ternary?(node) ||
+            node.parent&.range_type?
         end
 
         def allowed_ancestor?(node)
@@ -229,7 +227,6 @@ module RuboCop
         def method_call_with_redundant_parentheses?(node)
           return false unless node.call_type?
           return false if node.prefix_not?
-          return false if range_end?(node)
 
           send_node, args = method_node_and_args(node)
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2015,6 +2015,18 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Lint/AmbiguousRange` and offenses and accepts Style/RedundantParentheses' do
+    create_file('example.rb', <<~RUBY)
+      x...(y || z)
+    RUBY
+    expect(
+      cli.run(['--autocorrect-all', '--only', 'Lint/AmbiguousRange,Style/RedundantParentheses'])
+    ).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      x...(y || z)
+    RUBY
+  end
+
   it 'corrects Lint/ParenthesesAsGroupedExpression and offenses and ' \
      'accepts Style/RedundantParentheses' do
     create_file('example.rb', <<~RUBY)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -497,6 +497,22 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     expect_no_offenses('(a...b)')
   end
 
+  it 'accepts an irange starting is a parenthesized condition' do
+    expect_no_offenses('(a || b)..c')
+  end
+
+  it 'accepts an erange starting is a parenthesized condition' do
+    expect_no_offenses('(a || b)...c')
+  end
+
+  it 'accepts an irange ending is a parenthesized condition' do
+    expect_no_offenses('a..(b || c)')
+  end
+
+  it 'accepts an erange ending is a parenthesized condition' do
+    expect_no_offenses('a...(b || c)')
+  end
+
   it 'registers parentheses around `||` logical operator keywords in method definition' do
     expect_offense(<<~RUBY)
       def foo


### PR DESCRIPTION
Fixes #12436.

This PR fixes false positives for `Style/RedundantParentheses` when a part of range is a parenthesized condition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
