### PR TITLE
[Fix #12442] Fix an incorrect autocorrect for `Style/CombinableLoops`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_combinable_loops.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_combinable_loops.md
@@ -1,0 +1,1 @@
+* [#12442](https://github.com/rubocop/rubocop/issues/12442): Fix an incorrect autocorrect for `Style/CombinableLoops` when looping over the same data as previous loop in `do`...`end` and `{`...`}` blocks. ([@koic][])

--- a/lib/rubocop/cop/style/combinable_loops.rb
+++ b/lib/rubocop/cop/style/combinable_loops.rb
@@ -105,6 +105,17 @@ module RuboCop
         def combine_with_left_sibling(corrector, node)
           corrector.remove(node.left_sibling.body.source_range.end.join(node.left_sibling.loc.end))
           corrector.remove(node.source_range.begin.join(node.body.source_range.begin))
+
+          correct_end_of_block(corrector, node)
+        end
+
+        def correct_end_of_block(corrector, node)
+          return unless node.left_sibling.respond_to?(:braces?)
+          return if node.right_sibling&.block_type? || node.right_sibling&.numblock_type?
+
+          end_of_block = node.left_sibling.braces? ? '}' : ' end'
+          corrector.remove(node.loc.end)
+          corrector.insert_before(node.source_range.end, end_of_block)
         end
       end
     end


### PR DESCRIPTION
Fixes #12442.

This PR fixes an incorrect autocorrect for `Style/CombinableLoops` when looping over the same data as previous loop in `do`...`end` and `{`...`}` blocks.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
