### PR TITLE
Revert "Make `Style/SingleArgumentDig` aware of safe navigation operator"

### DIFF
--- a/changelog/fix_make_style_single_argument_dig_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_single_argument_dig_aware_of_safe_navigation_operator.md
@@ -1,1 +1,0 @@
-* [#12460](https://github.com/rubocop/rubocop/issues/12460): Make `Style/SingleArgumentDig` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/single_argument_dig.rb
+++ b/lib/rubocop/cop/style/single_argument_dig.rb
@@ -3,8 +3,11 @@
 module RuboCop
   module Cop
     module Style
-      # Sometimes using dig method ends up with just a single
-      # argument. In such cases, dig should be replaced with [].
+      # Sometimes using `dig` method ends up with just a single
+      # argument. In such cases, dig should be replaced with `[]`.
+      #
+      # Since replacing `hash&.dig(:key)` with `hash[:key]` could potentially lead to error,
+      # calls to the `dig` method using safe navigation will be ignored.
       #
       # @safety
       #   This cop is unsafe because it cannot be guaranteed that the receiver
@@ -37,7 +40,7 @@ module RuboCop
 
         # @!method single_argument_dig?(node)
         def_node_matcher :single_argument_dig?, <<~PATTERN
-          (call _ :dig $!splat)
+          (send _ :dig $!splat)
         PATTERN
 
         def on_send(node)
@@ -60,7 +63,6 @@ module RuboCop
 
           ignore_node(node)
         end
-        alias on_csend on_send
       end
     end
   end

--- a/spec/rubocop/cop/style/single_argument_dig_spec.rb
+++ b/spec/rubocop/cop/style/single_argument_dig_spec.rb
@@ -14,14 +14,9 @@ RSpec.describe RuboCop::Cop::Style::SingleArgumentDig, :config do
         RUBY
       end
 
-      it 'registers an offense and corrects unsuitable use of dig with safe navigation operator' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense and corrects unsuitable use of dig with safe navigation operator' do
+        expect_no_offenses(<<~RUBY)
           { key: 'value' }&.dig(:key)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `{ key: 'value' }[:key]` instead of `{ key: 'value' }&.dig(:key)`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          { key: 'value' }[:key]
         RUBY
       end
     end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/12463#pullrequestreview-1771198386

This PR reverts #12463.

As for the scope of this cop's role, it is reasonable to ignore cases where safe navigation is used. This PR will update the documentation and tests to indicate that this behavior is expected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
