### PR TITLE
[Fix #12458] Make `Style/SelectByRegexp` cops aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_style_select_by_regexp_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_style_select_by_regexp_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12458](https://github.com/rubocop/rubocop/issues/12458): Make `Style/SelectByRegexp` cops aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/select_by_regexp.rb
+++ b/lib/rubocop/cop/style/select_by_regexp.rb
@@ -55,8 +55,8 @@ module RuboCop
         # @!method regexp_match?(node)
         def_node_matcher :regexp_match?, <<~PATTERN
           {
-            (block send (args (arg $_)) ${(send _ %REGEXP_METHODS _) match-with-lvasgn})
-            (numblock send $1 ${(send _ %REGEXP_METHODS _) match-with-lvasgn})
+            (block call (args (arg $_)) ${(send _ %REGEXP_METHODS _) match-with-lvasgn})
+            (numblock call $1 ${(send _ %REGEXP_METHODS _) match-with-lvasgn})
           }
         PATTERN
 
@@ -64,9 +64,9 @@ module RuboCop
         # @!method creates_hash?(node)
         def_node_matcher :creates_hash?, <<~PATTERN
           {
-            (send (const _ :Hash) {:new :[]} ...)
-            (block (send (const _ :Hash) :new ...) ...)
-            (send _ { :to_h :to_hash } ...)
+            (call (const _ :Hash) {:new :[]} ...)
+            (block (call (const _ :Hash) :new ...) ...)
+            (call _ { :to_h :to_hash } ...)
           }
         PATTERN
 
@@ -100,6 +100,7 @@ module RuboCop
           register_offense(node, block_node, regexp, replacement)
         end
         # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        alias on_csend on_send
 
         private
 


### PR DESCRIPTION
Fixes #12458.

This PR makes `Style/SelectByRegexp` cops aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
