### PR TITLE
Make `Style/MethodCallWithoutArgsParentheses` allow parenthesized `it`

### DIFF
--- a/changelog/change_make_style_method_call_without_args_parentheses_respect_ruby33_warn.md
+++ b/changelog/change_make_style_method_call_without_args_parentheses_respect_ruby33_warn.md
@@ -1,0 +1,1 @@
+* [#12522](https://github.com/rubocop/rubocop/pull/12522): Make `Style/MethodCallWithoutArgsParentheses` allow the parenthesized `it` method in a block. ([@koic][])

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -29,6 +29,51 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
     expect_no_offenses('not(something)')
   end
 
+  it 'does not register an offense when using `it()` in the single line block' do
+    # `Lint/ItWithoutArgumentsInBlock` respects for this syntax.
+    expect_no_offenses(<<~RUBY)
+      0.times { it() }
+    RUBY
+  end
+
+  it 'does not register an offense when using `it()` in the multiline block' do
+    # `Lint/ItWithoutArgumentsInBlock` respects for this syntax.
+    expect_no_offenses(<<~RUBY)
+      0.times do
+        it()
+        it = 1
+        it
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `it` without arguments in `def` body' do
+    expect_offense(<<~RUBY)
+      def foo
+        it()
+          ^^ Do not use parentheses for method calls with no arguments.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `it` without arguments in the block with empty block parameter' do
+    expect_offense(<<~RUBY)
+      0.times { ||
+        it()
+          ^^ Do not use parentheses for method calls with no arguments.
+      }
+    RUBY
+  end
+
+  it 'registers an offense when using `it` without arguments in the block with useless block parameter' do
+    expect_offense(<<~RUBY)
+      0.times { |_n|
+        it()
+          ^^ Do not use parentheses for method calls with no arguments.
+      }
+    RUBY
+  end
+
   context 'when AllowedMethods is enabled' do
     let(:cop_config) { { 'AllowedMethods' => %w[s] } }
 


### PR DESCRIPTION
This PR makes `Style/MethodCallWithoutArgsParentheses` allow the parenthesized `it` method in a block.

It respects following Ruby 3.3's warning:

```console
$ ruby -e '0.times { begin; it; end }'
-e:1: warning: `it` calls without arguments will refer to the first block param in Ruby 3.4; use it() or self.it
```

Related PR ... https://github.com/rubocop/rubocop/pull/12518

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
