### PR TITLE
[Fix #12524] Fix a false positive for `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_method_call_with_args_parentheses.md
+++ b/changelog/fix_a_false_positive_for_style_method_call_with_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#12524](https://github.com/rubocop/rubocop/issues/12524): Fix a false positive for `Style/MethodCallWithArgsParentheses` when `EnforcedStyle: omit_parentheses` and parens in `when` clause is used to pass an argument. ([@koic][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -86,6 +86,7 @@ module RuboCop
 
           def legitimate_call_with_parentheses?(node) # rubocop:disable Metrics/PerceivedComplexity
             call_in_literals?(node) ||
+              node.parent&.when_type? ||
               call_with_ambiguous_arguments?(node) ||
               call_in_logical_operators?(node) ||
               call_in_optional_arguments?(node) ||

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -904,6 +904,14 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    it 'accepts parens in `when` clause is used to pass an argument' do
+      expect_no_offenses(<<-RUBY)
+        case condition
+          when do_something(arg)
+        end
+      RUBY
+    end
+
     it 'autocorrects single-line calls' do
       expect_offense(<<~RUBY)
         top.test(1, 2, foo: bar(3))


### PR DESCRIPTION
Fixes #12524.

This PR fixes a false positive for `Style/MethodCallWithArgsParentheses` when `EnforcedStyle: omit_parentheses` and parens in `when` clause is used to pass an argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
