### PR TITLE
Fix pr reference to the new `Lint/ItWithoutArgumentsInBlock` cop in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### New features
 
-* [#12516](https://github.com/rubocop/rubocop/pull/12516): Add new `Lint/ItWithoutArgumentsInBlock` cop. ([@koic][])
+* [#12518](https://github.com/rubocop/rubocop/pull/12518): Add new `Lint/ItWithoutArgumentsInBlock` cop. ([@koic][])
 
 ### Bug fixes
 


### PR DESCRIPTION
Reference to the new cop pr was incorrect #12516 is unrelated to the correct #12518