### PR TITLE
[Fix #12529] Fix false positives for `Style/ParenthesesAroundCondition`

### DIFF
--- a/changelog/fix_false_positives_for_style_parentheses_around_condition.md
+++ b/changelog/fix_false_positives_for_style_parentheses_around_condition.md
@@ -1,0 +1,1 @@
+* [#12529](https://github.com/rubocop/rubocop/issues/12529): Fix false positives for `Style/ParenthesesAroundCondition`. ([@koic][])

--- a/lib/rubocop/cop/style/parentheses_around_condition.rb
+++ b/lib/rubocop/cop/style/parentheses_around_condition.rb
@@ -81,6 +81,7 @@ module RuboCop
           cond = node.condition
 
           control_op_condition(cond) do |first_child, rest_children|
+            return if require_parentheses?(node, first_child)
             return if semicolon_separated_expressions?(first_child, rest_children)
             return if modifier_op?(first_child)
             return if parens_allowed?(cond)
@@ -90,6 +91,13 @@ module RuboCop
               ParenthesesCorrector.correct(corrector, cond)
             end
           end
+        end
+
+        def require_parentheses?(node, condition_body)
+          return false if !node.while_type? && !node.until_type?
+          return false if !condition_body.block_type? && !condition_body.numblock_type?
+
+          condition_body.send_node.block_literal? && condition_body.keywords?
         end
 
         def semicolon_separated_expressions?(first_exp, rest_exps)

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -102,6 +102,100 @@ RSpec.describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
     RUBY
   end
 
+  it 'does not register an offense when using a method call with `do`...`end` block as a condition in `while` loop' do
+    expect_no_offenses(<<~RUBY)
+      while (foo do
+            end)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using a method call with `do`...`end` block as a condition in `until` loop' do
+    expect_no_offenses(<<~RUBY)
+      until (foo do
+            end)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using a method call with `do`...`end` numbered block as a condition in `while` loop' do
+    expect_no_offenses(<<~RUBY)
+      while (foo do
+              _1
+            end)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using a method call with `do`...`end` numbered block as a condition in `until` loop' do
+    expect_no_offenses(<<~RUBY)
+      until (foo do
+              _1
+            end)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using method call with `{`...`}` block as a `while` condition' do
+    expect_offense(<<~RUBY)
+      while (foo {
+            ^^^^^^ Don't use parentheses around the condition of a `while`.
+            })
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      while foo {
+            }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using method call with `{`...`}` block as a `until` condition' do
+    expect_offense(<<~RUBY)
+      until (foo {
+            ^^^^^^ Don't use parentheses around the condition of an `until`.
+            })
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      until foo {
+            }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using method call with `do`...`end` block as a `if` condition' do
+    expect_offense(<<~RUBY)
+      if (foo do
+         ^^^^^^^ Don't use parentheses around the condition of an `if`.
+         end)
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo do
+         end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using method call with `{`...`}` block as a `if` condition' do
+    expect_offense(<<~RUBY)
+      if (foo {
+         ^^^^^^ Don't use parentheses around the condition of an `if`.
+         })
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo {
+         }
+      end
+    RUBY
+  end
+
   it 'does not register an offense when parentheses in multiple expressions separated by semicolon' do
     expect_no_offenses(<<~RUBY)
       if (foo; bar)


### PR DESCRIPTION
Fixes #12529.

This PR fixes false positives for `Style/ParenthesesAroundCondition` when using a method call with `do`...`end` block as a condition in a loop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
