### PR TITLE
Allow autocorrect with display-only-fail-level-offenses

### DIFF
--- a/changelog/change_allow_autocorrect_with.md
+++ b/changelog/change_allow_autocorrect_with.md
@@ -1,0 +1,1 @@
+* [#12535](https://github.com/rubocop/rubocop/pull/12535): Allow --autocorrect with --display-only-fail-level-offenses. ([@naveg][])

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -364,10 +364,6 @@ module RuboCop
         raise OptionArgumentError, '-C/--cache argument must be true or false'
       end
 
-      if display_only_fail_level_offenses_with_autocorrect?
-        raise OptionArgumentError, '--autocorrect cannot be used with ' \
-                                   '--display-only-fail-level-offenses.'
-      end
       validate_auto_gen_config
       validate_autocorrect
       validate_display_only_failed
@@ -458,10 +454,6 @@ module RuboCop
     def only_includes_redundant_disable?
       @options.key?(:only) &&
         (@options[:only] & %w[Lint/RedundantCopDisableDirective RedundantCopDisableDirective]).any?
-    end
-
-    def display_only_fail_level_offenses_with_autocorrect?
-      @options.key?(:display_only_fail_level_offenses) && @options.key?(:autocorrect)
     end
 
     def except_syntax?

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -356,10 +356,10 @@ RSpec.describe RuboCop::Options, :isolated_environment do
     end
 
     describe '--display-only-fail-level-offenses' do
-      it 'fails if given with an autocorrect argument' do
-        %w[--fix-layout -x --autocorrect -a --autocorrect-all -A].each do |o|
-          expect { options.parse ['--display-only-correctable', o] }
-            .to raise_error(RuboCop::OptionArgumentError)
+      %w[--fix-layout -x --autocorrect -a --autocorrect-all -A].each do |o|
+        it 'fails if given with an autocorrect argument' do
+          expect { options.parse ['--display-only-fail-level-offenses', o] }
+            .not_to raise_error(RuboCop::OptionArgumentError)
         end
       end
     end


### PR DESCRIPTION
The `--display-only-fail-level-offenses` option uses
`considered_failure?` to determine what to print. The same method is
used to determine the exit code of `rubocop`, so the two options should
be entirely safe to use together.

This change is useful when using rubocop as part of a pre-commit hook.
When the hook fails becuase rubocop exited with a non-zero status, we
can use `--display-only-fail-level-offenses` to avoid having the output
cluttered up with non-blocking offenses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
