### PR TITLE
Fix BufPreWrite pattern in nvim-lspconfig rubocop formatting example

### DIFF
--- a/docs/modules/ROOT/pages/usage/lsp.adoc
+++ b/docs/modules/ROOT/pages/usage/lsp.adoc
@@ -111,7 +111,7 @@ Below is an example of additional setting for autocorrecting on save:
 
 ```lua
 vim.api.nvim_create_autocmd("BufWritePre", {
-  pattern = "ruby",
+  pattern = "*.rb",
   callback = function()
     vim.lsp.buf.format()
   end,


### PR DESCRIPTION
The pattern for `Buf*` commands in neovim looks to be a file names pattern, not file types. When set to `ruby`, automatic formatting doesn't work. It starts working only when I set it to `*.rb`.

Reference:
https://neovim.io/doc/user/api.html#:~:text=%22BufWinEnter%22%7D%2C%20%7B-,pattern%20%3D%20%7B%22*.c%22%2C%20%22*.h%22%7D,-%2C%0A%20%20callback%20%3D%20function

