### PR TITLE
[Fix #12478] Make `Style/EachForSimpleLoop` cops aware of safe navigation operator

### DIFF
--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -52,7 +52,7 @@ module RuboCop
         # @!method each_range(node)
         def_node_matcher :each_range, <<~PATTERN
           (block
-            (send
+            (call
               (begin
                 (${irange erange}
                   (int $_) (int $_)))
@@ -64,7 +64,7 @@ module RuboCop
         # @!method each_range_with_zero_origin?(node)
         def_node_matcher :each_range_with_zero_origin?, <<~PATTERN
           (block
-            (send
+            (call
               (begin
                 ({irange erange}
                   (int 0) (int _)))
@@ -76,7 +76,7 @@ module RuboCop
         # @!method each_range_without_block_argument?(node)
         def_node_matcher :each_range_without_block_argument?, <<~PATTERN
           (block
-            (send
+            (call
               (begin
                 ({irange erange}
                   (int _) (int _)))

--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -37,6 +37,36 @@ RSpec.describe RuboCop::Cop::Style::EachForSimpleLoop, :config do
     end
   end
 
+  context 'when using safe navigation operator' do
+    context 'with inline block with parameters' do
+      it 'autocorrects an offense' do
+        expect_offense(<<~RUBY)
+          (0...10)&.each { |n| }
+          ^^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          10.times { |n| }
+        RUBY
+      end
+    end
+
+    context 'with multiline block with parameters' do
+      it 'autocorrects an offense' do
+        expect_offense(<<~RUBY)
+          (0...10)&.each do |n|
+          ^^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          10.times do |n|
+          end
+        RUBY
+      end
+    end
+  end
+
   it 'does not register offense for character range' do
     expect_no_offenses("('a'..'b').each {}")
   end
@@ -77,6 +107,21 @@ RSpec.describe RuboCop::Cop::Style::EachForSimpleLoop, :config do
         5.times do
         end
       RUBY
+    end
+
+    context 'when using safe navigation operator' do
+      it 'autocorrects the range not starting with zero' do
+        expect_offense(<<~RUBY)
+          (3..7)&.each do
+          ^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          5.times do
+          end
+        RUBY
+      end
     end
 
     it 'does not register offense for range not starting with zero and using param' do


### PR DESCRIPTION
Fixes #12478.

This PR makes `Style/EachForSimpleLoop` cops aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
