### PR TITLE
Fix false positives for `Lint/LiteralAssignmentInCondition`

### DIFF
--- a/changelog/fix_false_positives_for_lint_literal_assignment_in_condition.md
+++ b/changelog/fix_false_positives_for_lint_literal_assignment_in_condition.md
@@ -1,0 +1,1 @@
+* [#12539](https://github.com/rubocop/rubocop/pull/12539): Fix false positives for `Lint/LiteralAssignmentInCondition` when a collection literal contains non-literal elements. ([@koic][])

--- a/spec/rubocop/cop/lint/literal_assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_assignment_in_condition_spec.rb
@@ -31,10 +31,55 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAssignmentInCondition, :config do
     RUBY
   end
 
-  it 'registers an offense when assigning array literal to local variable in `if` condition' do
+  it 'registers an offense when assigning empty array literal to local variable in `if` condition' do
     expect_offense(<<~RUBY)
       if test = []
               ^^^^ Don't use literal assignment `= []` in conditional, should be `==` or non-literal operand.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when assigning array literal with only literal elements to local variable in `if` condition' do
+    expect_offense(<<~RUBY)
+      if test = [1, 2, 3]
+              ^^^^^^^^^^^ Don't use literal assignment `= [1, 2, 3]` in conditional, should be `==` or non-literal operand.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when assigning array literal with non-literal elements to local variable in `if` condition' do
+    expect_no_offenses(<<~RUBY)
+      if test = [42, x, y]
+      end
+    RUBY
+  end
+
+  it 'registers an offense when assigning empty hash literal to local variable in `if` condition' do
+    expect_offense(<<~RUBY)
+      if test = {}
+              ^^^^ Don't use literal assignment `= {}` in conditional, should be `==` or non-literal operand.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when assigning hash literal with only literal elements to local variable in `if` condition' do
+    expect_offense(<<~RUBY)
+      if test = {x: :y}
+              ^^^^^^^^^ Don't use literal assignment `= {x: :y}` in conditional, should be `==` or non-literal operand.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when assigning hash literal with non-literal key to local variable in `if` condition' do
+    expect_no_offenses(<<~RUBY)
+      if test = {x => :y}
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when assigning hash literal with non-literal value to local variable in `if` condition' do
+    expect_no_offenses(<<~RUBY)
+      if test = {x: y}
       end
     RUBY
   end


### PR DESCRIPTION
This PR fixes the following false positive for `Lint/LiteralAssignmentInCondition` when a collection lireal contains non-literal elements:

```console
$ echo 'x = 1; if test = [42, x]; end' | be rubocop --stdin test.rb --only Lint/LiteralAssignmentInCondition
Inspecting 1 file
W

Offenses:

test.rb:1:16: W: Lint/LiteralAssignmentInCondition: Don't use literal assignment = [42, x] in conditional,
should be == or non-literal operand.
x = 1; if test = [42, x]; end
               ^^^^^^^^^

1 file inspected, 1 offense detected
```

In cases where non-literal elements are included in the collection, no warning will be displayed.

```console
$ ruby -we 'x = 1; if test = [42, x]; end'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
