### PR TITLE
 Fix false negative in `Style/ArgumentsForwarding` when a block is forwarded but other args aren't

### DIFF
--- a/changelog/fix_fix_false_negative_in_style_arguments_forwarding.md
+++ b/changelog/fix_fix_false_negative_in_style_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#12541](https://github.com/rubocop/rubocop/pull/12541): Fix false negative in `Style/ArgumentsForwarding` when a block is forwarded but other args aren't. ([@dvandersluis][])

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -240,12 +240,12 @@ module RuboCop
         self
       end
 
-      def select(&block)
-        cops.select(&block)
+      def select(...)
+        cops.select(...)
       end
 
-      def each(&block)
-        cops.each(&block)
+      def each(...)
+        cops.each(...)
       end
 
       # @param [String] cop_name

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -340,7 +340,7 @@ module RuboCop
           end
 
           def classification
-            return nil unless forwarded_rest_arg || forwarded_kwrest_arg
+            return nil unless forwarded_rest_arg || forwarded_kwrest_arg || forwarded_block_arg
 
             if can_forward_all?
               :all
@@ -424,8 +424,15 @@ module RuboCop
           def no_additional_args?
             forwardable_count = [@rest_arg, @kwrest_arg, @block_arg].compact.size
 
+            return false if missing_rest_arg_or_kwrest_arg?
+
             @def_node.arguments.size == forwardable_count &&
               @send_node.arguments.size == forwardable_count
+          end
+
+          def missing_rest_arg_or_kwrest_arg?
+            (@rest_arg_name && !forwarded_rest_arg) ||
+              (@kwrest_arg_name && !forwarded_kwrest_arg)
           end
         end
       end

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -142,8 +142,8 @@ module RuboCop
             @assignments = assignments
           end
 
-          def tsort_each_node(&block)
-            @assignments.each(&block)
+          def tsort_each_node(...)
+            @assignments.each(...)
           end
 
           def tsort_each_child(assignment)

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -219,8 +219,24 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
 
     it 'does not register an offense when different argument names are used' do
       expect_no_offenses(<<~RUBY)
+        def foo(arg)
+          bar(argument)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when different splat argument names are used' do
+      expect_no_offenses(<<~RUBY)
         def foo(*args, &block)
           bar(*arguments, &block)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when different kwrest argument names are used' do
+      expect_no_offenses(<<~RUBY)
+        def foo(**kwargs, &block)
+          bar(**kwarguments, &block)
         end
       RUBY
     end
@@ -303,6 +319,15 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
           bar(*args, **kwargs, &block)
           bar(*args, &block)
           bar(**kwargs, &block)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when always forwarding the block but not other args' do
+      expect_no_offenses(<<~RUBY)
+        def foo(*args, &block)
+          bar(*args, &block)
+          bar(&block)
         end
       RUBY
     end
@@ -1195,6 +1220,15 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
+    it 'does not register an offense when always forwarding the block but not other args' do
+      expect_no_offenses(<<~RUBY)
+        def foo(*, &block)
+          bar(*, &block)
+          bar(&block)
+        end
+      RUBY
+    end
+
     it 'registers an offense when args are forwarded at several call sites' do
       expect_offense(<<~RUBY)
         def foo(bar, *args)
@@ -1592,8 +1626,24 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
 
     it 'does not register an offense when different argument names are used' do
       expect_no_offenses(<<~RUBY)
+        def foo(arg)
+          bar(argument)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when different splat argument names are used' do
+      expect_no_offenses(<<~RUBY)
         def foo(*args, &block)
           bar(*arguments, &block)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when different kwrest argument names are used' do
+      expect_no_offenses(<<~RUBY)
+        def foo(**kwargs, &block)
+          bar(**kwarguments, &block)
         end
       RUBY
     end


### PR DESCRIPTION
The following code gets registered as a false negative by `Style/ArgumentsForwarding`

```ruby
def foo(*args, &block)
  bar(*args, &block)
  baz(&block)
end
```

Which results in the following invalid autocorrection (`&block` is now longer defined):
```ruby
def foo(...)
  bar(...)
  baz(&block)
end
```

This change fixes that case by considering block arguments when determining if forwarding is possible. 

This had two side effects:
1. The test for different argument names failed due to the block parameter now being considered when determining if there is an offense. To fix this, we now check that the rest and kwrest arguments have the same name.
2. This revealed a few offenses in rubocop code where only a block argument should have been replaced with forwarding.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
