### PR TITLE
[Fix #12540] Fix false positives for `Style/HashEachMethods`

### DIFF
--- a/changelog/fix_false_positives_for_style_hash_each_methods.md
+++ b/changelog/fix_false_positives_for_style_hash_each_methods.md
@@ -1,0 +1,1 @@
+* [#12540](https://github.com/rubocop/rubocop/issues/12540): Fix false positives for `Style/HashEachMethods` when rest block argument of `Enumerable#each` method is used. ([@koic][])

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -111,11 +111,11 @@ module RuboCop
           lvar_sources = node.body.each_descendant(:lvar).map(&:source)
 
           if block_arg.mlhs_type?
-            block_arg.each_descendant(:arg).all? do |block_arg|
-              lvar_sources.none?(block_arg.source)
+            block_arg.each_descendant(:arg, :restarg).all? do |block_arg|
+              lvar_sources.none?(block_arg.source.delete_prefix('*'))
             end
           else
-            lvar_sources.none?(block_arg.source)
+            lvar_sources.none?(block_arg.source.delete_prefix('*'))
           end
         end
 

--- a/spec/rubocop/cop/style/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/style/hash_each_methods_spec.rb
@@ -81,12 +81,50 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         expect_no_offenses('foo.each { |(_, k), v| do_something(k, v) }')
       end
 
+      it 'does not register an offense when the destructed rest value block arguments of `Enumerable#each` method are used' do
+        expect_no_offenses('foo.each { |k, (_, *v)| do_something(k, *v) }')
+      end
+
+      it 'does not register an offense when the destructed rest key block arguments of `Enumerable#each` method are used' do
+        expect_no_offenses('foo.each { |(_, *k), v| do_something(*k, v) }')
+      end
+
       it 'does not register an offense when the single block argument of `Enumerable#each` method is used' do
         expect_no_offenses('foo.each { |e| do_something(e) }')
       end
 
       it 'does not register an offense when the parenthesized key and value block arguments of `Enumerable#each` method are unused' do
         expect_no_offenses('foo.each { |(k, v)| do_something(e) }')
+      end
+
+      it 'does not register an offense when the rest value block argument of `Enumerable#each` method is used' do
+        expect_no_offenses('foo.each { |k, *v| do_something(k, *v) }')
+      end
+
+      it 'does not register an offense when the rest key block argument of `Enumerable#each` method is used' do
+        expect_no_offenses('foo.each { |*k, v| do_something(*k, v) }')
+      end
+
+      it 'registers an offense when the rest value block argument of `Enumerable#each` method is unused' do
+        expect_offense(<<~RUBY)
+          foo.each { |k, *v| do_something(*v) }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `each_value` instead of `each` and remove the unused `k` block argument.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo.each_value { |*v| do_something(*v) }
+        RUBY
+      end
+
+      it 'registers an offense when the rest key block argument of `Enumerable#each` method is unused' do
+        expect_offense(<<~RUBY)
+          foo.each { |*k, v| do_something(*k) }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `each_key` instead of `each` and remove the unused `v` block argument.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo.each_key { |*k| do_something(*k) }
+        RUBY
       end
 
       it 'registers an offense when the value block argument of `Enumerable#each` method is unused' do


### PR DESCRIPTION
Fixes #12540.

This PR fixes false positives for `Style/HashEachMethods` when rest block argument of `Enumerable#each` method is used.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
