### PR TITLE
[Fix #12537] Fix false positives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_redundant_parentheses.md
+++ b/changelog/fix_false_positives_for_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#12537](https://github.com/rubocop/rubocop/issues/12537): Fix false positives for `Style/RedundantParentheses` when `AllowInMultilineConditions: true` of `Style/ParenthesesAroundCondition`. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -150,6 +150,7 @@ module RuboCop
           return if begin_node.chained?
 
           if node.and_type? || node.or_type?
+            return if node.multiline? && allow_in_multiline_conditions?
             return if ALLOWED_NODE_TYPES.include?(begin_node.parent&.type)
             return if begin_node.parent&.if_type? && begin_node.parent&.ternary?
 
@@ -164,6 +165,13 @@ module RuboCop
 
         # @!method interpolation?(node)
         def_node_matcher :interpolation?, '[^begin ^^dstr]'
+
+        def allow_in_multiline_conditions?
+          parentheses_around_condition_config = config.for_cop('Style/ParenthesesAroundCondition')
+          return false unless parentheses_around_condition_config['Enabled']
+
+          !!parentheses_around_condition_config['AllowInMultilineConditions']
+        end
 
         def check_send(begin_node, node)
           return check_unary(begin_node, node) if node.unary_operation?

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -206,6 +206,27 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'does not correct `AllowInMultilineConditions: true` of `Style/ParenthesesAroundCondition` with `Style/RedundantParentheses`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/ParenthesesAroundCondition:
+        AllowInMultilineConditions: true
+    YAML
+    source = <<~RUBY
+      if (foo &&
+          bar)
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run(['--autocorrect', '--only',
+                    'Style/ParenthesesAroundCondition,' \
+                    'Style/RedundantParentheses'])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      if (foo &&
+          bar)
+      end
+    RUBY
+  end
+
   it 'corrects `EnforcedShorthandSyntax: always` of `Style/HashSyntax` with `Style/RedundantParentheses` when using Ruby 3.1' do
     create_file('.rubocop.yml', <<~YAML)
       AllCops:

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -850,4 +850,109 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     it_behaves_like 'allowed parentheses', '1..2', 'a range literal'
     it_behaves_like 'allowed parentheses', '1', 'an int literal'
   end
+
+  context 'when `AllowInMultilineConditions: true` of `Style/ParenthesesAroundCondition`' do
+    let(:other_cops) do
+      {
+        'Style/ParenthesesAroundCondition' => {
+          'Enabled' => enabled, 'AllowInMultilineConditions' => true
+        }
+      }
+    end
+
+    context 'when `Style/ParenthesesAroundCondition` is enabled' do
+      let(:enabled) { true }
+
+      context 'when single line conditions' do
+        it_behaves_like 'redundant', '(x && y)', 'x && y', 'a logical expression'
+        it_behaves_like 'redundant', '(x || y)', 'x || y', 'a logical expression'
+        it_behaves_like 'redundant', '(x and y)', 'x and y', 'a logical expression'
+        it_behaves_like 'redundant', '(x or y)', 'x or y', 'a logical expression'
+      end
+
+      context 'when multiline conditions' do
+        it_behaves_like 'plausible', <<~RUBY
+          (x &&
+           y)
+        RUBY
+        it_behaves_like 'plausible', <<~RUBY
+          (x ||
+           y)
+        RUBY
+        it_behaves_like 'plausible', <<~RUBY
+          (x and
+           y)
+        RUBY
+        it_behaves_like 'plausible', <<~RUBY
+          (x or
+           y)
+        RUBY
+      end
+    end
+
+    context 'when `Style/ParenthesesAroundCondition` is disabled' do
+      let(:enabled) { false }
+
+      context 'when single line conditions' do
+        it_behaves_like 'redundant', '(x && y)', 'x && y', 'a logical expression'
+        it_behaves_like 'redundant', '(x || y)', 'x || y', 'a logical expression'
+        it_behaves_like 'redundant', '(x and y)', 'x and y', 'a logical expression'
+        it_behaves_like 'redundant', '(x or y)', 'x or y', 'a logical expression'
+      end
+
+      context 'when multiline conditions' do
+        it 'registers an offense when using `&&`' do
+          expect_offense(<<~RUBY)
+            (x &&
+            ^^^^^ Don't use parentheses around a logical expression.
+             y)
+          RUBY
+
+          expect_correction(<<~RUBY)
+            x &&
+             y
+          RUBY
+        end
+
+        it 'registers an offense when using `||`' do
+          expect_offense(<<~RUBY)
+            (x ||
+            ^^^^^ Don't use parentheses around a logical expression.
+             y)
+          RUBY
+
+          expect_correction(<<~RUBY)
+            x ||
+             y
+          RUBY
+        end
+
+        it 'registers an offense when using `and`' do
+          expect_offense(<<~RUBY)
+            (x and
+            ^^^^^^ Don't use parentheses around a logical expression.
+             y)
+          RUBY
+
+          expect_correction(<<~RUBY)
+            x and
+             y
+          RUBY
+        end
+
+        it 'registers an offense when using `or`' do
+          expect_offense(<<~RUBY)
+            (x or
+            ^^^^^ Don't use parentheses around a logical expression.
+             y)
+          RUBY
+
+          expect_correction(<<~RUBY)
+            x or
+             y
+          RUBY
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #12537.

This PR fixes false positives for `Style/RedundantParentheses` when `AllowInMultilineConditions: true` of `Style/ParenthesesAroundCondition`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
