### PR TITLE
Teach `Lint/AssignmentInCondition` about `case`

### DIFF
--- a/changelog/change_teach_lint_assignment_in_condition_about_case.md
+++ b/changelog/change_teach_lint_assignment_in_condition_about_case.md
@@ -1,0 +1,1 @@
+* [#12546](https://github.com/rubocop/rubocop/pull/12546): Teach `Lint/AssignmentInCondition` about `case`. ([@sambostock][])

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -68,6 +68,7 @@ module RuboCop
         end
         alias on_while on_if
         alias on_until on_if
+        alias on_case on_if
 
         private
 

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -42,6 +42,21 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     RUBY
   end
 
+  it 'registers an offense for lvar assignment in case condition' do
+    expect_offense(<<~RUBY)
+      case test = 10
+                ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
+      when nil
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case (test = 10)
+      when nil
+      end
+    RUBY
+  end
+
   it 'registers an offense for ivar assignment in condition' do
     expect_offense(<<~RUBY)
       if @test = 10


### PR DESCRIPTION
This teaches `Lint/AssignmentInCondition` about `case`, to match the behavior with other conditionals.

```diff
 case test = 10
+          ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
 when nil
 end
```

```ruby
case (test = 10)
when nil
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
