### PR TITLE
[Fix #12549] Fix a false positive for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_line_continuation.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_line_continuation.md
@@ -1,0 +1,1 @@
+* [#12549](https://github.com/rubocop/rubocop/issues/12549): Fix a false positive for `Style/RedundantLineContinuation` when line continuations for multiline leading dot method chain with a blank line. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -94,7 +94,8 @@ module RuboCop
           !ends_with_backslash_without_comment?(range.source_line) ||
             string_concatenation?(range.source_line) ||
             start_with_arithmetic_operator?(processed_source[range.line]) ||
-            inside_string_literal_or_method_with_argument?(range)
+            inside_string_literal_or_method_with_argument?(range) ||
+            leading_dot_method_chain_with_blank_line?(range)
         end
 
         def ends_with_backslash_without_comment?(source_line)
@@ -111,6 +112,12 @@ module RuboCop
 
             inside_string_literal?(range, token) || method_with_argument?(token, next_token)
           end
+        end
+
+        def leading_dot_method_chain_with_blank_line?(range)
+          return false unless range.source_line.strip.start_with?('.', '&.')
+
+          processed_source[range.line].strip.empty?
         end
 
         def redundant_line_continuation?(range)

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -114,6 +114,80 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'does not register an offense when required line continuations for multiline leading dot method chain with an empty line' do
+    expect_no_offenses(<<~'RUBY')
+      obj
+       .foo(42) \
+
+       .bar
+    RUBY
+  end
+
+  it 'does not register an offense when required line continuations for multiline leading dot safe navigation method chain with an empty line' do
+    expect_no_offenses(<<~'RUBY')
+      obj
+       &.foo(42) \
+
+       .bar
+    RUBY
+  end
+
+  it 'does not register an offense when required line continuations for multiline leading dot method chain with a blank line' do
+    expect_no_offenses(<<~RUBY)
+      obj
+       .foo(42) \\
+      #{' '}
+       .bar
+    RUBY
+  end
+
+  it 'registers an offense when redundant line continuations for multiline leading dot method chain without an empty line' do
+    expect_offense(<<~'RUBY')
+      obj
+       .foo(42) \
+                ^ Redundant line continuation.
+       .bar
+    RUBY
+
+    expect_correction(<<~RUBY)
+      obj
+       .foo(42)#{' '}
+       .bar
+    RUBY
+  end
+
+  it 'registers an offense when redundant line continuations for multiline trailing dot method chain with an empty line' do
+    expect_offense(<<~'RUBY')
+      obj.
+       foo(42). \
+                ^ Redundant line continuation.
+
+       bar
+    RUBY
+
+    expect_correction(<<~RUBY)
+      obj.
+       foo(42).#{' '}
+
+       bar
+    RUBY
+  end
+
+  it 'registers an offense when redundant line continuations for multiline trailing dot method chain without an empty line' do
+    expect_offense(<<~'RUBY')
+      obj.
+       foo(42). \
+                ^ Redundant line continuation.
+       bar
+    RUBY
+
+    expect_correction(<<~RUBY)
+      obj.
+       foo(42).#{' '}
+       bar
+    RUBY
+  end
+
   it 'registers an offense when redundant line continuations for array' do
     expect_offense(<<~'RUBY')
       [foo, \


### PR DESCRIPTION
Fixes #12549.

This PR fixes a false positive for `Style/RedundantLineContinuation` when line continuations for multiline leading dot method chain with a blank line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
