### PR TITLE
Document `Style/SymbolProc` protected method incompatibility

### DIFF
--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -37,6 +37,42 @@ module RuboCop
       #   # ArgumentError: wrong number of arguments (given 1, expected 0)
       #   ----
       #
+      #   It is also unsafe because `Symbol#to_proc` does not work with
+      #   `protected` methods which would otherwise be accessible.
+      #
+      #   For example:
+      #
+      #   [source,ruby]
+      #   ----
+      #   class Box
+      #     def initialize
+      #       @secret = rand
+      #     end
+      #
+      #     def normal_matches?(*others)
+      #       others.map { |other| other.secret }.any?(secret)
+      #     end
+      #
+      #     def symbol_to_proc_matches?(*others)
+      #       others.map(&:secret).any?(secret)
+      #     end
+      #
+      #     protected
+      #
+      #     attr_reader :secret
+      #   end
+      #
+      #   boxes = [Box.new, Box.new]
+      #   Box.new.normal_matches?(*boxes)
+      #   # => false
+      #   boxes.first.normal_matches?(*boxes)
+      #   # => true
+      #   Box.new.symbol_to_proc_matches?(*boxes)
+      #   # => NoMethodError: protected method `secret' called for #<Box...>
+      #   boxes.first.symbol_to_proc_matches?(*boxes)
+      #   # => NoMethodError: protected method `secret' called for #<Box...>
+      #   ----
+      #
       # @example
       #   # bad
       #   something.map { |s| s.upcase }


### PR DESCRIPTION
This documents the false positive for `Style/SymbolProc` when used with a `protected` method. `public` and `private` method behaviour matches, but `protected` methods which work in the normal block style break when using `Symbol#to_proc`.

The motivation for this is that it's not something that comes up very often (`protected` is not as common as `public` or `private`, and even less so used in iteration/blocks), so reviewers will often need to ask why a `rubocop:disable Style/SymbolProc` comment is being added. Documenting this makes it easier to discover the reason.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* ~Added tests.~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
