### PR TITLE
[Fix #12558] Fix an incorrect autocorrect for `Style/MapToHash`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_map_to_hash.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_map_to_hash.md
@@ -1,0 +1,1 @@
+* [#12558](https://github.com/rubocop/rubocop/issues/12558): Fix an incorrect autocorrect for `Style/MapToHash` when using `map.to_h` without receiver. ([@koic][])

--- a/spec/rubocop/cop/style/map_to_hash_spec.rb
+++ b/spec/rubocop/cop/style/map_to_hash_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe RuboCop::Cop::Style::MapToHash, :config do
         end
       end
 
+      context "for `#{method}.to_h` without receiver" do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            #{method} { |x| [x, x * 2] }.to_h
+            ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            to_h { |x| [x, x * 2] }
+          RUBY
+        end
+      end
+
       context "for `#{method}&.to_h` with block arity 1" do
         it 'registers an offense and corrects' do
           expect_offense(<<~RUBY, method: method)
@@ -46,11 +59,11 @@ RSpec.describe RuboCop::Cop::Style::MapToHash, :config do
         it 'registers an offense and corrects' do
           expect_offense(<<~RUBY, method: method)
             foo&.#{method} { |x| [x, x * 2] }.to_h
-                 ^{method} Pass a block to `to_h` instead of calling `#{method}&.to_h`.
+                 ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
           RUBY
 
           expect_correction(<<~RUBY)
-            foo.to_h { |x| [x, x * 2] }
+            foo&.to_h { |x| [x, x * 2] }
           RUBY
         end
       end


### PR DESCRIPTION
Fixes #12558.

This PR fixes an incorrect autocorrect for `Style/MapToHash` when using `map.to_h` without receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
