### PR TITLE
Improve invertible unless message

### DIFF
--- a/lib/rubocop/cop/style/invertible_unless_condition.rb
+++ b/lib/rubocop/cop/style/invertible_unless_condition.rb
@@ -51,7 +51,7 @@ module RuboCop
       class InvertibleUnlessCondition < Base
         extend AutoCorrector
 
-        MSG = 'Favor `if` with inverted condition over `unless`.'
+        MSG = 'Prefer `%<prefer>s` over `%<current>s`.'
 
         def on_if(node)
           return unless node.unless?
@@ -59,7 +59,10 @@ module RuboCop
           condition = node.condition
           return unless invertible?(condition)
 
-          add_offense(node) do |corrector|
+          message = format(MSG, prefer: "#{node.inverse_keyword} #{preferred_condition(condition)}",
+                                current: "#{node.keyword} #{condition.source}")
+
+          add_offense(node, message: message) do |corrector|
             corrector.replace(node.loc.keyword, node.inverse_keyword)
             autocorrect(corrector, condition)
           end
@@ -86,6 +89,40 @@ module RuboCop
           argument = node.first_argument
           node.method?(:<) &&
             (argument.const_type? && argument.short_name.to_s.upcase != argument.short_name.to_s)
+        end
+
+        def preferred_condition(node)
+          case node.type
+          when :begin    then "(#{preferred_condition(node.children.first)})"
+          when :send     then preferred_send_condition(node)
+          when :or, :and then preferred_logical_condition(node)
+          end
+        end
+
+        def preferred_send_condition(node)
+          receiver_source = node.receiver.source
+          return receiver_source if node.method?(:!)
+
+          inverse_method_name = inverse_methods[node.method_name]
+          return "#{receiver_source}.#{inverse_method_name}" unless node.arguments?
+
+          argument_list = node.arguments.map(&:source).join(', ')
+          if node.operator_method?
+            return "#{receiver_source} #{inverse_method_name} #{argument_list}"
+          end
+
+          if node.parenthesized?
+            return "#{receiver_source}.#{inverse_method_name}(#{argument_list})"
+          end
+
+          "#{receiver_source}.#{inverse_method_name} #{argument_list}"
+        end
+
+        def preferred_logical_condition(node)
+          preferred_lhs = preferred_condition(node.lhs)
+          preferred_rhs = preferred_condition(node.rhs)
+
+          "#{preferred_lhs} #{node.inverse_operator} #{preferred_rhs}"
         end
 
         def autocorrect(corrector, node)


### PR DESCRIPTION
The existing message is ambiguous about how to invert the condition, leading many to assume the cop is suggesting replacing code like

```ruby
unless number.odd?
^^^^^^^^^^^^^^^^^^ Favor `if` with inverted condition over `unless`.
```

with

```ruby
if !number.odd?
```

which would conflict with `Style/NegatedIf`.

This updates the message to clearly describe the change being recommended:

```ruby
unless number.odd?
^^^^^^^^^^^^^^^^^^ Prefer `if number.even?` over `unless number.odd?`.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
