### PR TITLE
[Fix #12556] Fix false positives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_positives_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#12556](https://github.com/rubocop/rubocop/issues/12556): Fix false positives for `Style/RedundantParentheses` when parentheses are used around a semantic operator in expressions within assignments. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -150,6 +150,7 @@ module RuboCop
           return if begin_node.chained?
 
           if node.and_type? || node.or_type?
+            return if node.semantic_operator? && begin_node.parent
             return if node.multiline? && allow_in_multiline_conditions?
             return if ALLOWED_NODE_TYPES.include?(begin_node.parent&.type)
             return if begin_node.parent&.if_type? && begin_node.parent&.ternary?

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -508,6 +508,36 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'registers an offense when the use of parentheses around `&&` expressions in assignment' do
+    expect_offense(<<~RUBY)
+      var = (foo && bar)
+            ^^^^^^^^^^^^ Don't use parentheses around a logical expression.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      var = foo && bar
+    RUBY
+  end
+
+  it 'registers an offense when the use of parentheses around `||` expressions in assignment' do
+    expect_offense(<<~RUBY)
+      var = (foo || bar)
+            ^^^^^^^^^^^^ Don't use parentheses around a logical expression.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      var = foo || bar
+    RUBY
+  end
+
+  it 'accepts the use of parentheses around `or` expressions in assignment' do
+    expect_no_offenses('var = (foo or bar)')
+  end
+
+  it 'accepts the use of parentheses around `and` expressions in assignment' do
+    expect_no_offenses('var = (foo and bar)')
+  end
+
   it 'accepts parentheses around a method call with unparenthesized arguments' do
     expect_no_offenses('(a 1, 2) && (1 + 1)')
   end


### PR DESCRIPTION
Fixes #12556.

This PR fixes false positives for `Style/RedundantParentheses` when parentheses are used around a semantic operator in expressions within assignments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
