### PR TITLE
Fix an incorrect autocorrect for `Style/MapToHash`

### DIFF
--- a/lib/rubocop/cop/style/map_to_hash.rb
+++ b/lib/rubocop/cop/style/map_to_hash.rb
@@ -64,12 +64,17 @@ module RuboCop
 
         private
 
+        # rubocop:disable Metrics/AbcSize
         def autocorrect(corrector, to_h, map)
           removal_range = range_between(to_h.loc.dot.begin_pos, to_h.loc.selector.end_pos)
 
           corrector.remove(range_with_surrounding_space(removal_range, side: :left))
+          if (map_dot = map.loc.dot)
+            corrector.replace(map_dot, to_h.loc.dot.source)
+          end
           corrector.replace(map.loc.selector, 'to_h')
         end
+        # rubocop:enable Metrics/AbcSize
       end
     end
   end

--- a/spec/rubocop/cop/style/map_to_hash_spec.rb
+++ b/spec/rubocop/cop/style/map_to_hash_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe RuboCop::Cop::Style::MapToHash, :config do
           RUBY
 
           expect_correction(<<~RUBY)
-            foo&.to_h { |x| [x, x * 2] }
+            foo.to_h { |x| [x, x * 2] }
           RUBY
         end
       end


### PR DESCRIPTION
Follow https://github.com/rubocop/rubocop/pull/12560#discussion_r1432423841

This PR fixes an incorrect autocorrect for `Style/MapToHash` using safe navigation operator.

NOTE: This is a partial unreleased regression of #12560. So, it has not been added to the changelog.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
