### PR TITLE
[Fix #12542] Fix false positive for `Lint/MixedRegexpCaptureTypes`

### DIFF
--- a/changelog/fix_false_positive_for_lint_mixed_regexp_capture_types.md
+++ b/changelog/fix_false_positive_for_lint_mixed_regexp_capture_types.md
@@ -1,0 +1,1 @@
+* [#12542](https://github.com/rubocop/rubocop/issues/12542): Fix false positive for `Lint/MixedRegexpCaptureTypes` when using look-ahead matcher. ([@marocchino][])

--- a/lib/rubocop/ext/regexp_node.rb
+++ b/lib/rubocop/ext/regexp_node.rb
@@ -54,16 +54,21 @@ module RuboCop
         return enum_for(__method__, named: named) unless block_given?
 
         parsed_tree&.traverse do |event, exp, _index|
-          yield(exp) if event == :enter &&
-                        named == exp.respond_to?(:name) &&
-                        exp.respond_to?(:capturing?) &&
-                        exp.capturing?
+          yield(exp) if named_capturing?(exp, event, named)
         end
 
         self
       end
 
       private
+
+      def named_capturing?(exp, event, named)
+        event == :enter &&
+          named == exp.respond_to?(:name) &&
+          !exp.text.start_with?('(?<=') &&
+          exp.respond_to?(:capturing?) &&
+          exp.capturing?
+      end
 
       def with_interpolations_blanked
         # Ignore the trailing regopt node

--- a/spec/rubocop/cop/lint/mixed_regexp_capture_types_spec.rb
+++ b/spec/rubocop/cop/lint/mixed_regexp_capture_types_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe RuboCop::Cop::Lint::MixedRegexpCaptureTypes, :config do
     RUBY
   end
 
+  it 'does not register offense to a regexp with look behind' do
+    expect_no_offenses(<<~RUBY)
+      /(?<=>)(<br>)(?=><)/
+    RUBY
+  end
+
   it 'does not register offense to a regexp with numbered capture only' do
     expect_no_offenses(<<~RUBY)
       /(foo)(bar)/


### PR DESCRIPTION
Fix false positive for `Lint/MixedRegexpCaptureTypes` when > is included in the look-ahead matcher rubocop recognizes the matcher as a named matcher.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
