### PR TITLE
[Fix #12453] Make `Style/RedundantEach` aware of safe navigation operator

### DIFF
--- a/changelog/change_make_style_redundant_each_aware_of_safe_navigation_operator.md
+++ b/changelog/change_make_style_redundant_each_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#12453](https://github.com/rubocop/rubocop/issues/12453): Make `Style/RedundantEach` aware of safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_each.rb
+++ b/lib/rubocop/cop/style/redundant_each.rb
@@ -56,6 +56,7 @@ module RuboCop
             end
           end
         end
+        alias on_csend on_send
 
         private
 
@@ -64,7 +65,7 @@ module RuboCop
           return if node.last_argument&.block_pass_type?
 
           if node.method?(:each) && !node.parent&.block_type?
-            ancestor_node = node.each_ancestor(:send).detect do |ancestor|
+            ancestor_node = node.each_ancestor(:send, :csend).detect do |ancestor|
               ancestor.receiver == node &&
                 (RESTRICT_ON_SEND.include?(ancestor.method_name) || ancestor.method?(:reverse_each))
             end
@@ -83,10 +84,12 @@ module RuboCop
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def range(node)
-          if node.method?(:each)
-            node.loc.dot.join(node.loc.selector)
+          return node.selector unless node.method?(:each)
+
+          if node.parent.call_type?
+            node.selector.join(node.parent.loc.dot)
           else
-            node.loc.selector
+            node.loc.dot.join(node.selector)
           end
         end
 

--- a/spec/rubocop/cop/style/redundant_each_spec.rb
+++ b/spec/rubocop/cop/style/redundant_each_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantEach, :config do
   it 'registers an offense when using `each.each`' do
     expect_offense(<<~RUBY)
       array.each.each { |v| do_something(v) }
-           ^^^^^ Remove redundant `each`.
+            ^^^^^ Remove redundant `each`.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -12,10 +12,43 @@ RSpec.describe RuboCop::Cop::Style::RedundantEach, :config do
     RUBY
   end
 
+  it 'registers an offense when using `each&.each`' do
+    expect_offense(<<~RUBY)
+      array.each&.each { |v| do_something(v) }
+            ^^^^^^ Remove redundant `each`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array.each { |v| do_something(v) }
+    RUBY
+  end
+
+  it 'registers an offense when using `&.each.each`' do
+    expect_offense(<<~RUBY)
+      array&.each.each { |v| do_something(v) }
+             ^^^^^ Remove redundant `each`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array&.each { |v| do_something(v) }
+    RUBY
+  end
+
+  it 'registers an offense when using `&.each&.each`' do
+    expect_offense(<<~RUBY)
+      array&.each&.each { |v| do_something(v) }
+             ^^^^^^ Remove redundant `each`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array&.each { |v| do_something(v) }
+    RUBY
+  end
+
   it 'registers an offense when using `each.each(&:foo)`' do
     expect_offense(<<~RUBY)
       array.each.each(&:foo)
-           ^^^^^ Remove redundant `each`.
+            ^^^^^ Remove redundant `each`.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -26,7 +59,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantEach, :config do
   it 'registers an offense when using `each.each_with_index`' do
     expect_offense(<<~RUBY)
       array.each.each_with_index { |v| do_something(v) }
-           ^^^^^ Remove redundant `each`.
+            ^^^^^ Remove redundant `each`.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -37,7 +70,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantEach, :config do
   it 'registers an offense when using `each.each_with_object`' do
     expect_offense(<<~RUBY)
       array.each.each_with_object([]) { |v, o| do_something(v, o) }
-           ^^^^^ Remove redundant `each`.
+            ^^^^^ Remove redundant `each`.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -82,10 +115,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantEach, :config do
     RUBY
   end
 
+  it 'registers an offense when using `reverse_each&.each`' do
+    expect_offense(<<~RUBY)
+      context.reverse_each&.each { |i| do_something(i) }
+                          ^^^^^^ Remove redundant `each`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      context.reverse_each { |i| do_something(i) }
+    RUBY
+  end
+
   it 'registers an offense when using `each.reverse_each`' do
     expect_offense(<<~RUBY)
       context.each.reverse_each { |i| do_something(i) }
-             ^^^^^ Remove redundant `each`.
+              ^^^^^ Remove redundant `each`.
     RUBY
 
     expect_correction(<<~RUBY)


### PR DESCRIPTION
Fixes #12453.

This PR makes `Style/RedundantEach` aware of safe navigation operator.

And offense range has been tweaked to clarify whether the target for removal, associated with the detection of safe navigation, is `.` or `&.`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
