### PR TITLE
[Fix #12548] Fix an infinite loop error for `Layout/FirstArgumentIndentation`

### DIFF
--- a/changelog/fix_an_error_for_layout_first_array_element_indentation.md
+++ b/changelog/fix_an_error_for_layout_first_array_element_indentation.md
@@ -1,0 +1,1 @@
+* [#12548](https://github.com/rubocop/rubocop/issues/12548): Fix an infinite loop error for `Layout/FirstArgumentIndentation` when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArrayAlignment`. ([@koic][])

--- a/lib/rubocop/cop/layout/first_array_element_indentation.rb
+++ b/lib/rubocop/cop/layout/first_array_element_indentation.rb
@@ -5,7 +5,10 @@ module RuboCop
     module Layout
       # Checks the indentation of the first element in an array literal
       # where the opening bracket and the first element are on separate lines.
-      # The other elements' indentations are handled by the ArrayAlignment cop.
+      # The other elements' indentations are handled by `Layout/ArrayAlignment` cop.
+      #
+      # This cop will respect `Layout/ArrayAlignment` and will not work when
+      # `EnforcedStyle: with_fixed_indentation` is specified for `Layout/ArrayAlignment`.
       #
       # By default, array literals that are arguments in a method call with
       # parentheses, and where the opening square bracket of the array is on the
@@ -93,6 +96,8 @@ module RuboCop
         end
 
         def on_send(node)
+          return if style != :consistent && enforce_first_argument_with_fixed_indentation?
+
           each_argument_node(node, :array) do |array_node, left_parenthesis|
             check(array_node, left_parenthesis)
           end
@@ -173,6 +178,16 @@ module RuboCop
             'Indent the right bracket the same as the start of the line ' \
             'where the left bracket is.'
           end
+        end
+
+        def enforce_first_argument_with_fixed_indentation?
+          return false unless array_alignment_config['Enabled']
+
+          array_alignment_config['EnforcedStyle'] == 'with_fixed_indentation'
+        end
+
+        def array_alignment_config
+          config.for_cop('Layout/ArrayAlignment')
         end
       end
     end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2396,6 +2396,34 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArrayAlignment` and ' \
+     '`Layout/FirstArrayElementIndentation`' do
+    create_file('example.rb', <<~RUBY)
+      puts([
+        'foo',
+        'bar'
+      ])
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/ArrayAlignment:
+        EnforcedStyle: with_fixed_indentation
+    YAML
+
+    expect(
+      cli.run(
+        ['--autocorrect', '--only', 'Layout/ArrayAlignment,Layout/FirstArrayElementIndentation']
+      )
+    ).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      puts([
+        'foo',
+        'bar'
+      ])
+    RUBY
+  end
+
   it 'does not crash Lint/SafeNavigationWithEmpty and offenses and accepts Style/SafeNavigation ' \
      'when checking `foo&.empty?` in a conditional' do
     create_file('example.rb', <<~RUBY)


### PR DESCRIPTION
Fixes #12548.

This PR fixes an infinite loop error for `Layout/FirstArgumentIndentation` when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArrayAlignment`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
