### PR TITLE
[Fix #12569] Fix an error for `Style/IdenticalConditionalBranches`

### DIFF
--- a/changelog/fix_an_error_for_style_identical_conditional_branches.md
+++ b/changelog/fix_an_error_for_style_identical_conditional_branches.md
@@ -1,0 +1,1 @@
+* [#12569](https://github.com/rubocop/rubocop/issues/12569): Fix an error for `Style/IdenticalConditionalBranches` when using `if`...`else` with identical leading lines that assign to `self.foo`. ([@koic][])

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -158,7 +158,10 @@ module RuboCop
           if head.assignment?
             # The `send` node is used instead of the `indexasgn` node, so `name` cannot be used.
             # https://github.com/rubocop/rubocop-ast/blob/v1.29.0/lib/rubocop/ast/node/indexasgn_node.rb
-            assigned_value = head.send_type? ? head.receiver.source : head.name.to_s
+            #
+            # FIXME: It would be better to update `RuboCop::AST::OpAsgnNode` or its subclasses to
+            # handle `self.foo ||= value` as a solution, instead of using `head.node_parts[0].to_s`.
+            assigned_value = head.send_type? ? head.receiver.source : head.node_parts[0].to_s
 
             return if condition_variable == assigned_value
           end

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -111,6 +111,31 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
     end
   end
 
+  context 'on if...else with identical leading lines and assign to `self.foo`' do
+    it 'registers and corrects an offense' do
+      expect_offense(<<~RUBY)
+        if something
+          self.foo ||= default
+          ^^^^^^^^^^^^^^^^^^^^ Move `self.foo ||= default` out of the conditional.
+          do_x
+        else
+          self.foo ||= default
+          ^^^^^^^^^^^^^^^^^^^^ Move `self.foo ||= default` out of the conditional.
+          do_y
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        self.foo ||= default
+        if something
+          do_x
+        else
+          do_y
+        end
+      RUBY
+    end
+  end
+
   context 'on if..else with identical leading lines and assign to condition value of method call receiver' do
     it "doesn't register an offense" do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #12569.

This PR fixes an error for `Style/IdenticalConditionalBranches` when using `if`...`else` with identical leading lines that assign to `self.foo`.

NOTE: It would be better to update `RuboCop::AST::OpAsgnNode` to handle `self.foo ||= value` to solve the issue in future.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
