### PR TITLE
Follow a Ruby 3.3 warning for `Security/Open `

### DIFF
--- a/changelog/change_follow_ruby33_warning_for_security_open.md
+++ b/changelog/change_follow_ruby33_warning_for_security_open.md
@@ -1,0 +1,1 @@
+* [#12572](https://github.com/rubocop/rubocop/pull/12572): Follow a Ruby 3.3 warning for `Security/Open` when `open` with a literal string starting with a pipe. ([@koic][])

--- a/lib/rubocop/cop/security/open.rb
+++ b/lib/rubocop/cop/security/open.rb
@@ -23,6 +23,7 @@ module RuboCop
       #   # bad
       #   open(something)
       #   open("| #{something}")
+      #   open("| foo")
       #   URI.open(something)
       #
       #   # good
@@ -32,7 +33,6 @@ module RuboCop
       #
       #   # good (literal strings)
       #   open("foo.text")
-      #   open("| foo")
       #   URI.open("http://example.com")
       class Open < Base
         MSG = 'The use of `%<receiver>sopen` is a serious security risk.'
@@ -40,7 +40,7 @@ module RuboCop
 
         # @!method open?(node)
         def_node_matcher :open?, <<~PATTERN
-          (send ${nil? (const {nil? cbase} :URI)} :open $!str ...)
+          (send ${nil? (const {nil? cbase} :URI)} :open $_ ...)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/security/open_spec.rb
+++ b/spec/rubocop/cop/security/open_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe RuboCop::Cop::Security::Open, :config do
     RUBY
   end
 
+  it 'registers an offense for open with a literal string starting with a pipe' do
+    expect_offense(<<~RUBY)
+      open('| foo')
+      ^^^^ The use of `Kernel#open` is a serious security risk.
+    RUBY
+  end
+
   it 'registers an offense for open with a block' do
     expect_offense(<<~'RUBY')
       open("#{foo}.txt") do |f|
@@ -87,9 +94,5 @@ RSpec.describe RuboCop::Cop::Security::Open, :config do
 
   it 'accepts open with a string that interpolates a literal' do
     expect_no_offenses('open "foo#{2}.txt"')
-  end
-
-  it 'accepts open with a literal string starting with a pipe' do
-    expect_no_offenses('open "| foo"')
   end
 end


### PR DESCRIPTION
This PR follows the following Ruby 3.3 warning for `Security/Open` when `open` with a literal string starting with a pipe:

```console
$ ruby -we "open('| ls')"
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
-e:1: warning: Calling Kernel#open with a leading '|' is deprecated
and will be removed in Ruby 4.0; use IO.popen instead
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
