### PR TITLE
Fix false positives for `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/fix_false_positives_for_style_arguments_forwarding.md
+++ b/changelog/fix_false_positives_for_style_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#12578](https://github.com/rubocop/rubocop/pull/12578): Fix false positives for `Style/ArgumentsForwarding` when rest arguments forwarding to a method in block. ([@koic][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -186,12 +186,12 @@ module RuboCop
           rest_arg, kwrest_arg, _block_arg = *forwardable_args
 
           send_classifications.each do |send_node, _c, forward_rest, forward_kwrest|
-            if forward_rest
+            if outside_block?(forward_rest)
               register_forward_args_offense(def_node.arguments, rest_arg)
               register_forward_args_offense(send_node, forward_rest)
             end
 
-            if forward_kwrest
+            if outside_block?(forward_kwrest)
               register_forward_kwargs_offense(!forward_rest, def_node.arguments, kwrest_arg)
               register_forward_kwargs_offense(!forward_rest, send_node, forward_kwrest)
             end
@@ -248,6 +248,12 @@ module RuboCop
           end << keyword
 
           redundant_arg_names.include?(arg.source) ? arg : nil
+        end
+
+        def outside_block?(node)
+          return false unless node
+
+          node.each_ancestor(:block, :numblock).none?
         end
 
         def register_forward_args_offense(def_arguments_or_send, rest_arg_or_splat)

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -1548,21 +1548,53 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'registers an offense when forwarding to a method in block' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense when rest arguments forwarding to a method in block' do
+      expect_no_offenses(<<~RUBY)
         def foo(*args, &block)
-                ^^^^^ Use anonymous positional arguments forwarding (`*`).
           do_something do
             bar(*args, &block)
-                ^^^^^ Use anonymous positional arguments forwarding (`*`).
           end
         end
       RUBY
+    end
 
-      expect_correction(<<~RUBY)
-        def foo(*, &block)
+    it 'does not register an offense when rest arguments forwarding to a method in numbered block' do
+      expect_no_offenses(<<~RUBY)
+        def foo(*args, &block)
           do_something do
-            bar(*, &block)
+            bar(*args, &block)
+            baz(_1)
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when keyword rest arguments forwarding to a method in block' do
+      expect_no_offenses(<<~RUBY)
+        def foo(**kwargs, &block)
+          do_something do
+            bar(**kwargs, &block)
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when keyword rest arguments forwarding to a method in numbered block' do
+      expect_no_offenses(<<~RUBY)
+        def foo(**kwargs, &block)
+          do_something do
+            bar(**kwargs, &block)
+            baz(_1)
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when rest arguments and keyword rest arguments forwarding to a method in block' do
+      expect_no_offenses(<<~RUBY)
+        def foo(*args, **kwargs)
+          block_method do
+            bar(*args, **kwargs)
           end
         end
       RUBY


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/12571#issuecomment-1870575888.

This PR fixes false positives for `Style/ArgumentsForwarding` when rest arguments forwarding to a method in block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
