### PR TITLE
Handle trailing line continuation in Layout/LineContinuationLeadingSpace

### DIFF
--- a/changelog/fix_handle_trailing_line_continuation_in_layout_line_continuation_leading_space.md
+++ b/changelog/fix_handle_trailing_line_continuation_in_layout_line_continuation_leading_space.md
@@ -1,0 +1,1 @@
+* [#12581](https://github.com/rubocop/rubocop/pull/12581): Handle trailing line continuation in `Layout/LineContinuationLeadingSpace`. ([@eugeneius][])

--- a/lib/rubocop/cop/layout/line_continuation_leading_space.rb
+++ b/lib/rubocop/cop/layout/line_continuation_leading_space.rb
@@ -107,7 +107,7 @@ module RuboCop
           return false unless line.end_with?("\\\n")
 
           # Ensure backslash isn't part of a token spanning to the next line.
-          node.children.none? { |c| c.first_line == line_num && c.multiline? }
+          node.children.none? { |c| (c.first_line...c.last_line).cover?(line_num) && c.multiline? }
         end
 
         def autocorrect(corrector, offense_range, insert_pos, spaces)

--- a/spec/rubocop/cop/layout/line_continuation_leading_space_spec.rb
+++ b/spec/rubocop/cop/layout/line_continuation_leading_space_spec.rb
@@ -113,6 +113,29 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
       RUBY
     end
 
+    it 'registers no offense when multiline string ends with a line continuation' do
+      expect_no_offenses(<<~'RUBY')
+        "" "foo
+        bar\
+        "
+      RUBY
+    end
+
+    it 'registers an offense when multiline string ends on 1st line' do
+      expect_offense(<<~'RUBY')
+        "foo
+        bar" \
+        " baz"
+         ^ Move leading spaces to the end of previous line.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "foo
+        bar " \
+        "baz"
+      RUBY
+    end
+
     describe 'interpolated strings' do
       it 'registers no offense on interpolated string alone' do
         expect_no_offenses(<<~'RUBY')


### PR DESCRIPTION
Previously this would crash with:

    NoMethodError: undefined method `length' for nil:NilClass

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/