### PR TITLE
[Fix #12236] Fix an error for `Lint/ShadowedArgument`

### DIFF
--- a/changelog/fix_an_error_for_lint_shadowed_argument.md
+++ b/changelog/fix_an_error_for_lint_shadowed_argument.md
@@ -1,0 +1,1 @@
+* [#12236](https://github.com/rubocop/rubocop/issues/12236): Fix an error for `Lint/ShadowedArgument` when self assigning to a block argument in `for`. ([@koic][])

--- a/lib/rubocop/cop/lint/shadowed_argument.rb
+++ b/lib/rubocop/cop/lint/shadowed_argument.rb
@@ -123,6 +123,7 @@ module RuboCop
 
             # Shorthand assignments always use their arguments
             next false if assignment_node.shorthand_asgn?
+            next false unless assignment_node.parent
 
             node_within_block_or_conditional =
               node_within_block_or_conditional?(assignment_node.parent, argument.scope.node)

--- a/spec/rubocop/cop/lint/shadowed_argument_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_argument_spec.rb
@@ -97,6 +97,16 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedArgument, :config do
         end
       end
 
+      context 'when self assigning to a block argument in `for`' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            for item in items
+              do_something { |arg| arg = arg }
+            end
+          RUBY
+        end
+      end
+
       context 'when binding is used' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #12236.

This PR fixes an error for `Lint/ShadowedArgument` when self assigning to a block argument in `for`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
