### PR TITLE
[Fix #11033] Change warning message for `Lint/Syntax` when using LSP

### DIFF
--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -481,6 +481,12 @@ module RuboCop
           range.end_pos + @current_offset
         )
       end
+
+      # This experimental feature has been under consideration for a while.
+      # @api private
+      def lsp_mode?
+        ARGV.include?('--lsp')
+      end
     end
   end
 end

--- a/lib/rubocop/cop/lint/syntax.rb
+++ b/lib/rubocop/cop/lint/syntax.rb
@@ -17,9 +17,12 @@ module RuboCop
         private
 
         def add_offense_from_diagnostic(diagnostic, ruby_version)
-          message =
-            "#{diagnostic.message}\n(Using Ruby #{ruby_version} parser; " \
-            'configure using `TargetRubyVersion` parameter, under `AllCops`)'
+          message = if lsp_mode?
+                      diagnostic.message
+                    else
+                      "#{diagnostic.message}\n(Using Ruby #{ruby_version} parser; " \
+                        'configure using `TargetRubyVersion` parameter, under `AllCops`)'
+                    end
           add_offense(diagnostic.location, message: message, severity: diagnostic.level)
         end
 

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -128,6 +128,12 @@ RSpec.shared_context 'mock console output' do
   end
 end
 
+RSpec.shared_context 'lsp mode' do
+  before do
+    allow(cop).to receive(:lsp_mode?).and_return(true)
+  end
+end
+
 RSpec.shared_context 'ruby 2.0' do
   let(:ruby_version) { 2.0 }
 end

--- a/lib/rubocop/rspec/support.rb
+++ b/lib/rubocop/rspec/support.rb
@@ -13,6 +13,7 @@ RSpec.configure do |config|
   config.include HostEnvironmentSimulatorHelper
   config.include_context 'config', :config
   config.include_context 'isolated environment', :isolated_environment
+  config.include_context 'lsp mode', :lsp_mode
   config.include_context 'maintain registry', :restore_registry
   config.include_context 'ruby 2.0', :ruby20
   config.include_context 'ruby 2.1', :ruby21

--- a/spec/rubocop/cop/lint/syntax_spec.rb
+++ b/spec/rubocop/cop/lint/syntax_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe RuboCop::Cop::Lint::Syntax, :config do
           expect(offense.severity).to eq(:fatal)
         end
       end
+
+      context 'with `--lsp` option', :lsp_mode do
+        it 'does not include a configuration information in the offense message' do
+          expect(offenses.first.message).to eq('unexpected token $end')
+        end
+      end
     end
 
     context 'with a parser error' do


### PR DESCRIPTION
Fixes #11033.

## Summary

This PR changes warning message for `Lint/Syntax` between LSP and the command line.

The redundancy of the offense message probably depends on the context. The context in which the issue has been reported is LSP.

In LSP, source code being typed may still be evaluated as invalid syntax. On the other hand, when executed via the `rubocop` command line, the input is usually complete and evaluated as valid syntax in most cases. This means that suggesting a possible misconfiguration in .rubocop.yml would be sufficient only when using the command line.

So, this is because the difference in evaluation timing of source code. Therefore, it is implemented as a distinction based on the execution context, rather than as a configuration option.

## Additional Information

To resolve this, it seems reasonable to switch the context of the message between LSP and the `rubocop` command line.

As for implementation, while the issue in Solargraph won't be directly resolved, considering a switch to RuboCop's built-in LSP could be an option.

This PR adds the `RuboCop::Base#lsp_mode?` method, which is intended to be used for the LSP mode expansion I'm currently considering. The LSP still can be carved, and I think there is potential to make RuboCop's LSP more user-friendly and improve it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
