### PR TITLE
Tweak the changelog URL on RubyGems.org

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     'homepage_uri' => 'https://rubocop.org/',
-    'changelog_uri' => 'https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md',
+    'changelog_uri' => "https://github.com/rubocop/rubocop/releases/tag/v#{RuboCop::Version.version}",
     'source_code_uri' => 'https://github.com/rubocop/rubocop/',
     'documentation_uri' => "https://docs.rubocop.org/rubocop/#{RuboCop::Version.document_version}/",
     'bug_tracker_uri' => 'https://github.com/rubocop/rubocop/issues',


### PR DESCRIPTION
This PR tweaks changelog URL on RubyGems.org.
https://rubygems.org/gems/rubocop

The CHANGELOG.md is extensive, so the link of the changelog on RubyGems.org will be updated to point to the GitHub release page, focusing on the release version. e.g., https://github.com/rubocop/rubocop/releases/tag/v1.59.0

The idea is the same as in https://github.com/rubocop/rubocop/pull/8775.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
