### PR TITLE
[Fix #12574] Handle unrecognized style better in --auto-gen-config

### DIFF
--- a/changelog/fix_bug_for_unrecognized_style.md
+++ b/changelog/fix_bug_for_unrecognized_style.md
@@ -1,0 +1,1 @@
+* [#12574](https://github.com/rubocop/rubocop/issues/12574): Fix bug for unrecognized style in --auto-gen-config. ([@jonas054][])

--- a/lib/rubocop/cop/mixin/configurable_formatting.rb
+++ b/lib/rubocop/cop/mixin/configurable_formatting.rb
@@ -18,6 +18,7 @@ module RuboCop
         alternative_styles.each do |alternative|
           return unexpected_style_detected(alternative) if valid_name?(node, name, alternative)
         end
+        unrecognized_style_detected
       end
 
       def valid_name?(node, name, given_style = style)

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -1546,6 +1546,30 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
       end
     end
 
+    context 'when there is code conforming to chosen enforced style and code not conforming to any supported style' do
+      it 'generates an Exclude list' do
+        create_file('.rubocop.yml', <<~YAML)
+          AllCops:
+            DisabledByDefault: true
+
+          Naming/MethodName:
+            Enabled: true
+        YAML
+
+        create_file('bad.rb', ['def Bad', 'end'])
+        create_file('good.rb', ['def good', 'end'])
+
+        expect(cli.run(['--auto-gen-config'])).to eq(0)
+        expect(File.readlines('.rubocop_todo.yml')[10..].join)
+          .to eq(<<~YAML)
+            # SupportedStyles: snake_case, camelCase
+            Naming/MethodName:
+              Exclude:
+                - 'bad.rb'
+          YAML
+      end
+    end
+
     it 'can be called when there are no files to inspection' do
       expect(cli.run(['--auto-gen-config'])).to eq(0)
     end


### PR DESCRIPTION
When there are supported styles in the cop configuration, auto-generated configuration should get an `EnforcedStyle` entry if the inspected code base conforms, not to the currently select style, but to one of the other styles, and follows that style in all places.

If the code base contains code the conforms to different styles, we should get an `Exclude` entry instead. The same goes for code that doesn't conform to any of the cop's supported styles. This last case is where we had a bug. We didn't mark the style as unrecognized, which is why we got an `EnforcedStyle` instead of an `Exclude`.