### PR TITLE
CircleCI against Ruby 3.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,29 @@ jobs:
     steps:
       *rubocop_steps
 
+  # Ruby 3.3
+  ruby-3.3-spec:
+    docker:
+      - image: cimg/ruby:3.3
+    environment:
+      <<: *common_env
+    steps:
+      *spec_steps
+  ruby-3.3-ascii_spec:
+    docker:
+      - image: cimg/ruby:3.3
+    environment:
+      <<: *common_env
+    steps:
+      *ascii_spec_steps
+  ruby-3.3-rubocop:
+    docker:
+      - image: cimg/ruby:3.3
+    environment:
+      <<: *common_env
+    steps:
+      *rubocop_steps
+
   # ruby-head (nightly snapshot build)
   ruby-head-spec:
     docker:
@@ -159,7 +182,7 @@ jobs:
   cc-setup:
     docker:
       # Specify the latest version to prevent "cimg/ruby:latest not found: manifest unknown: manifest unknown" error.
-      - image: cimg/ruby:3.2
+      - image: cimg/ruby:3.3
     environment:
       <<: *common_env
     steps:
@@ -178,7 +201,7 @@ jobs:
   cc-upload-coverage:
     docker:
       # Specify the latest version to prevent "cimg/ruby:latest not found: manifest unknown: manifest unknown" error.
-      - image: cimg/ruby:3.2
+      - image: cimg/ruby:3.3
         environment:
           CC_TEST_REPORTER_ID: a11b66bfbb1acdf220d5cb317b2e945a986fd85adebe29a76d411ad6d74ec31f
     environment:
@@ -189,14 +212,14 @@ jobs:
       - run:
           name: Upload coverage results to Code Climate
           command: |
-            ./tmp/cc-test-reporter sum-coverage tmp/codeclimate.*.json --parts 4 --output tmp/codeclimate.total.json
+            ./tmp/cc-test-reporter sum-coverage tmp/codeclimate.*.json --parts 5 --output tmp/codeclimate.total.json
             ./tmp/cc-test-reporter upload-coverage --input tmp/codeclimate.total.json
 
   # Miscellaneous tasks
   documentation-checks:
     docker:
       # Specify the latest version to prevent "cimg/ruby:latest not found: manifest unknown: manifest unknown" error.
-      - image: cimg/ruby:3.2
+      - image: cimg/ruby:3.3
     environment:
       <<: *common_env
     steps:
@@ -232,6 +255,11 @@ workflows:
             - cc-setup
       - ruby-3.2-ascii_spec
       - ruby-3.2-rubocop
+      - ruby-3.3-spec:
+          requires:
+            - cc-setup
+      - ruby-3.3-ascii_spec
+      - ruby-3.3-rubocop
       - ruby-head-spec:
           requires:
             - cc-setup
@@ -244,3 +272,4 @@ workflows:
             - ruby-3.0-spec
             - ruby-3.1-spec
             - ruby-3.2-spec
+            - ruby-3.3-spec


### PR DESCRIPTION
Ruby 3.3.0 has been released and this Ruby version is available on `cimg/ruby:3.3` image.

- https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
- https://circleci.com/developer/en/images/image/cimg/ruby

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
