### PR TITLE
Require Parser 3.3.0.2 or higher

### DIFF
--- a/changelog/change_require_parser_3_3_0_0.md
+++ b/changelog/change_require_parser_3_3_0_0.md
@@ -1,0 +1,1 @@
+* [#12593](https://github.com/rubocop/rubocop/pull/12593): Require Parser 3.3.0.2 or higher. ([@koic][])

--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -33,7 +33,7 @@ The following table is the runtime support matrix.
 | 3.0 | -
 | 3.1 | -
 | 3.2 | -
-| 3.3 (experimental) | -
+| 3.3 | -
 |===
 
 RuboCop targets Ruby 2.0+ code analysis since RuboCop 1.30. It restored code analysis support that had been removed earlier by mistake, together with dropping runtime support for unsupported Ruby versions.

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('json', '~> 2.3')
   s.add_runtime_dependency('language_server-protocol', '>= 3.17.0')
   s.add_runtime_dependency('parallel', '~> 1.10')
-  s.add_runtime_dependency('parser', '>= 3.2.2.4')
+  s.add_runtime_dependency('parser', '>= 3.3.0.2')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
   s.add_runtime_dependency('rexml', '>= 3.2.5', '< 4.0')


### PR DESCRIPTION
Ruby 3.3 and Parser 3.3.0.2 have been released.

- https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released
- https://rubygems.org/gems/parser/versions/3.3.0.2

This PR requires Parser 3.3.0.2 or higher and removes "experimental" label from support matrix.

The Parser gem specifies version 3.3.0.2+, not 3.3.0.0, as it applies the following patch:
https://github.com/whitequark/parser/pull/987

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
