### PR TITLE
[Fix #12437] Fix an infinite loop error for `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/changelog/fix_an_error_for_style_method_call_with_args_parentheses.md
+++ b/changelog/fix_an_error_for_style_method_call_with_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#12437](https://github.com/rubocop/rubocop/issues/12437): Fix an infinite loop error for `EnforcedStyle: omit_parentheses` of `Style/MethodCallWithArgsParentheses` with `Style/SuperWithArgsParentheses`. ([@koic][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -218,15 +218,13 @@ module RuboCop
           send(style, node) # call require_parentheses or omit_parentheses
         end
         alias on_csend on_send
-        alias on_super on_send
         alias on_yield on_send
 
         private
 
         def args_begin(node)
           loc = node.loc
-          selector =
-            node.super_type? || node.yield_type? ? loc.keyword : loc.selector
+          selector = node.yield_type? ? loc.keyword : loc.selector
 
           resize_by = args_parenthesized?(node) ? 2 : 1
           selector.end.resize(resize_by)

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -457,6 +457,36 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `EnforcedStyle: omit_parentheses` of `Style/MethodCallWithArgsParentheses` with ' \
+     '`Style/SuperWithArgsParentheses`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/MethodCallWithArgsParentheses:
+        EnforcedStyle: omit_parentheses
+    YAML
+    create_file('example.rb', <<~RUBY)
+      class Derived < Base
+        def do_something(arg)
+         super(arg)
+        end
+      end
+    RUBY
+    expect(
+      cli.run(
+        [
+          '--autocorrect',
+          '--only', 'Style/MethodCallWithArgsParentheses,Style/SuperWithArgsParentheses'
+        ]
+      )
+    ).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      class Derived < Base
+        def do_something(arg)
+         super(arg)
+        end
+      end
+    RUBY
+  end
+
   it 'corrects `Style/IfUnlessModifier` with `Style/SoleNestedConditional`' do
     source = <<~RUBY
       def foo

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -142,17 +142,10 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'registers an offense for superclass call without parens' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense for superclass call without parens' do
+      expect_no_offenses(<<~RUBY)
         def foo
           super a
-          ^^^^^^^ Use parentheses for method calls with arguments.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        def foo
-          super(a)
         end
       RUBY
     end
@@ -526,17 +519,10 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'registers an offense for superclass call with parens' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense for superclass call with parens' do
+      expect_no_offenses(<<~RUBY)
         def foo
           super(a)
-               ^^^ Omit parentheses for method calls with arguments.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        def foo
-          super a
         end
       RUBY
     end


### PR DESCRIPTION
Fixes #12437.

This PR fixes an infinite loop error for `EnforcedStyle: omit_parentheses` of `Style/MethodCallWithArgsParentheses` with `Style/SuperWithArgsParentheses`.

In #12390, `super` has become a separate `Style/SuperWithArgsParentheses` cop. This PR prevents the infinite loop error by ensuring that `Style/MethodCallWithArgsParentheses` no longer detects `super`, following the separation of `super` into `Style/SuperWithArgsParentheses` cop.

This approach aligns with the perspective that methods and `super` have different considerations regarding parentheses usage, as mentioned in #12390.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
