### PR TITLE
Workaround for an error when parsing heredoc with non-word delimiters

### DIFF
--- a/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
+++ b/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
@@ -166,6 +166,10 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
 
       context 'when using non-word delimiters' do
         it 'does not register an offense' do
+          # FIXME: Pending until the following error in Parser 3.3.0.1 is resolved.
+          # https://github.com/whitequark/parser/pull/987
+          pending 'Prevents an error when using heredoc with non-word delimiters.'
+
           expect_no_offenses(<<~RUBY)
             <<-'+'
               foo

--- a/spec/rubocop/cop/naming/heredoc_delimiter_naming_spec.rb
+++ b/spec/rubocop/cop/naming/heredoc_delimiter_naming_spec.rb
@@ -82,6 +82,10 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterNaming, :config do
 
     context 'when using non-word delimiters' do
       it 'registers an offense' do
+        # FIXME: Pending until the following error in Parser 3.3.0.1 is resolved.
+        # https://github.com/whitequark/parser/pull/987
+        pending 'Prevents an error when using heredoc with non-word delimiters.'
+
         expect_offense(<<~RUBY)
           <<-'+'
             foo


### PR DESCRIPTION
Pending two specs until the following error in Parser 3.3.0.1 is resolved. https://github.com/whitequark/parser/pull/987

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
