### PR TITLE
[Fix #12603] Fix an infinite loop error for `Style/MultilineTernaryOperator`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_multiline_ternary_operator.md
+++ b/changelog/fix_a_false_positive_for_style_multiline_ternary_operator.md
@@ -1,0 +1,1 @@
+* [#12603](https://github.com/rubocop/rubocop/issues/12603): Fix an infinite loop error for `Style/MultilineTernaryOperator` when using a method call as a ternary operator condition with a line break between receiver and method. ([@koic][])

--- a/lib/rubocop/cop/style/multiline_ternary_operator.rb
+++ b/lib/rubocop/cop/style/multiline_ternary_operator.rb
@@ -54,12 +54,10 @@ module RuboCop
         private
 
         def offense?(node)
-          node.ternary? && node.multiline?
+          node.ternary? && node.multiline? && node.source != replacement(node)
         end
 
         def autocorrect(corrector, node)
-          return unless offense?(node)
-
           corrector.replace(node, replacement(node))
           return unless (parent = node.parent)
           return unless (comments_in_condition = comments_in_condition(node))

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2971,6 +2971,21 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'does not cause an infinite loop error for `Style/MultilineTernaryOperator`' do
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~RUBY)
+      do_something(arg
+                     .foo ? bar : baz)
+    RUBY
+
+    status = cli.run(%w[--autocorrect-all --only Style/MultilineTernaryOperator])
+    expect(status).to eq(0)
+    expect(source_file.read).to eq(<<~RUBY)
+      do_something(arg
+                     .foo ? bar : baz)
+    RUBY
+  end
+
   it 'respects `Lint/ConstantResolution` over `Style/RedundantConstantBase` when enabling`Lint/ConstantResolution`' do
     source_file = Pathname('example.rb')
     create_file(source_file, <<~RUBY)

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -124,6 +124,15 @@ RSpec.describe RuboCop::Cop::Style::MultilineTernaryOperator, :config do
     RUBY
   end
 
+  it 'does not register an offense when using a method call as a ternary operator condition with a line break ' \
+     'between receiver and method' do
+    # NOTE: Redundant line break is corrected by `Layout/RedundantLineBreak`.
+    expect_no_offenses(<<~RUBY)
+      do_something(arg
+                     .foo ? bar : baz)
+    RUBY
+  end
+
   it 'registers an offense and corrects when returning a multiline ternary operator expression with `return`' do
     expect_offense(<<~RUBY)
       return cond ?


### PR DESCRIPTION
Fixes #12603.

This PR fixes an infinite loop error for `Style/MultilineTernaryOperator` when using a method call as a ternary operator condition with a line break between receiver and method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
