### PR TITLE
Fix a false positive for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positive_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_positive_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#12607](https://github.com/rubocop/rubocop/pull/12607): Fix a false positive for `Style/RedundantParentheses` when regexp literal attempts to match against a parenthesized condition. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -53,7 +53,7 @@ module RuboCop
         def ignore_syntax?(node)
           return false unless (parent = node.parent)
 
-          parent.while_post_type? || parent.until_post_type? ||
+          parent.while_post_type? || parent.until_post_type? || parent.match_with_lvasgn_type? ||
             like_method_argument_parentheses?(parent)
         end
 

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -574,6 +574,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     expect_no_offenses('a...(b || c)')
   end
 
+  it 'accepts regexp literal attempts to match against a parenthesized condition' do
+    expect_no_offenses('/regexp/ =~ (b || c)')
+  end
+
+  it 'accepts variable attempts to match against a parenthesized condition' do
+    expect_no_offenses('regexp =~ (b || c)')
+  end
+
   it 'registers parentheses around `||` logical operator keywords in method definition' do
     expect_offense(<<~RUBY)
       def foo


### PR DESCRIPTION
This PR fixes a false positive for `Style/RedundantParentheses` when regexp literal attempts to match against a parenthesized condition.

The presence or absence of parentheses here changes the meaning of the syntax, so the parentheses are not redundant:

```console
$ ruby-parse -e '/regexp/ =~ (foo || bar)'
(match-with-lvasgn
  (regexp
    (str "regexp")
    (regopt))
  (begin
    (or
      (send nil :foo)
      (send nil :bar))))

$ ruby-parse -e '/regexp/ =~ foo || bar'
(or
  (match-with-lvasgn
    (regexp
      (str "regexp")
      (regopt))
    (send nil :foo))
  (send nil :bar))
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
