### PR TITLE
[Fix #12601] Make `Style/EachForSimpleLoop` accept block with no parameters

### DIFF
--- a/changelog/fix_make_style_each_for_simple_loop_allows_block_with_no_params.md
+++ b/changelog/fix_make_style_each_for_simple_loop_allows_block_with_no_params.md
@@ -1,0 +1,1 @@
+* [#12601](https://github.com/rubocop/rubocop/issues/12601): Make `Style/EachForSimpleLoop` accept block with no parameters. ([@koic][])

--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -32,20 +32,20 @@ module RuboCop
 
           send_node = node.send_node
 
-          range = send_node.receiver.source_range.join(send_node.loc.selector)
-
-          add_offense(range) do |corrector|
+          add_offense(send_node) do |corrector|
             range_type, min, max = each_range(node)
 
             max += 1 if range_type == :irange
 
-            corrector.replace(node.send_node, "#{max - min}.times")
+            corrector.replace(send_node, "#{max - min}.times")
           end
         end
 
         private
 
         def offending?(node)
+          return false unless node.arguments.empty?
+
           each_range_with_zero_origin?(node) || each_range_without_block_argument?(node)
         end
 

--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -9,58 +9,98 @@ RSpec.describe RuboCop::Cop::Style::EachForSimpleLoop, :config do
     expect_no_offenses('(0..b).each {}')
   end
 
-  context 'with inline block with parameters' do
+  context 'with inline block with no parameters' do
     it 'autocorrects an offense' do
       expect_offense(<<~RUBY)
-        (0...10).each { |n| }
+        (0...10).each { do_something }
         ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
       RUBY
 
       expect_correction(<<~RUBY)
-        10.times { |n| }
+        10.times { do_something }
+      RUBY
+    end
+  end
+
+  context 'with inline block with parameters' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        (0...10).each { |n| do_something(n) }
+      RUBY
+    end
+  end
+
+  context 'with multiline block with no parameters' do
+    it 'autocorrects an offense' do
+      expect_offense(<<~RUBY)
+        (0...10).each do
+        ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
+          do_something
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        10.times do
+          do_something
+        end
       RUBY
     end
   end
 
   context 'with multiline block with parameters' do
-    it 'autocorrects an offense' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
         (0...10).each do |n|
-        ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        10.times do |n|
+          do_something(n)
         end
       RUBY
     end
   end
 
   context 'when using safe navigation operator' do
-    context 'with inline block with parameters' do
+    context 'with inline block with no parameters' do
       it 'autocorrects an offense' do
         expect_offense(<<~RUBY)
-          (0...10)&.each { |n| }
+          (0...10)&.each { do_something }
           ^^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
         RUBY
 
         expect_correction(<<~RUBY)
-          10.times { |n| }
+          10.times { do_something }
+        RUBY
+      end
+    end
+
+    context 'with inline block with parameters' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          (0...10)&.each { |n| do_something(n) }
+        RUBY
+      end
+    end
+
+    context 'with multiline block with no parameters' do
+      it 'autocorrects an offense' do
+        expect_offense(<<~RUBY)
+          (0...10)&.each do
+          ^^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
+            do_something
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          10.times do
+            do_something
+          end
         RUBY
       end
     end
 
     context 'with multiline block with parameters' do
-      it 'autocorrects an offense' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
           (0...10)&.each do |n|
-          ^^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          10.times do |n|
+            do_something(n)
           end
         RUBY
       end


### PR DESCRIPTION
Fixes #12601.

This PR makes `Style/EachForSimpleLoop` accept block with no parameters.

This is the behavior according to the documentation:

> This check only applies if the block takes no parameters.

https://docs.rubocop.org/rubocop/1.59/cops_style.html#styleeachforsimpleloop

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
