### PR TITLE
Accept parentheses in argument calls with blocks

### DIFF
--- a/changelog/fix_accept_parentheses_in_argument_calls_with_blocks.md
+++ b/changelog/fix_accept_parentheses_in_argument_calls_with_blocks.md
@@ -1,0 +1,1 @@
+* [#12610](https://github.com/rubocop/rubocop/pull/12610): Accept parentheses in argument calls with blocks for `Style/MethodCallWithArgsParentheses` `omit_parentheses` style. ([@gsamokovarov][])

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -785,7 +785,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('foo(1) { 2 }')
     end
 
-    it 'accepts parens in array literal calls' do
+    it 'accepts parens in array literal calls with blocks' do
       expect_no_offenses(<<~RUBY)
         [
           foo.bar.quux(:args) do
@@ -1055,6 +1055,46 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         expect_no_offenses(<<~RUBY)
           test(
             foo: bar
+          )
+        RUBY
+      end
+
+      it 'accepts parens in argument calls with blocks' do
+        expect_no_offenses(<<~RUBY)
+          foo(
+            bar.new(quux) do
+              pass
+            end
+          )
+        RUBY
+      end
+
+      it 'accepts parens in argument csend with blocks' do
+        expect_no_offenses(<<~RUBY)
+          foo(
+            bar&.new(quux) do
+              pass
+            end
+          )
+        RUBY
+      end
+
+      it 'accepts parens in super argument call with blocks' do
+        expect_no_offenses(<<~RUBY)
+          super(
+            bar.new(quux) do
+              pass
+            end
+          )
+        RUBY
+      end
+
+      it 'accepts parens in yield argument call with blocks' do
+        expect_no_offenses(<<~RUBY)
+          yield(
+            bar.new(quux) do
+              pass
+            end
           )
         RUBY
       end


### PR DESCRIPTION
In `Style/MethodCallWithArgsParentheses` with `omit_parentheses` enforced style we need to allow parentheses in method calls with blocks, when their value is used as an arguments in method dispatch calls. We have syntax errors when we enforce their omissions:

```ruby
foo(
  Class.new(Base) do
    # valid Ruby
  end
)
```

Should be allowed as the example below is invalid Ruby:

```ruby
foo(
  Class.new Base do
    # invalid Ruby
  end
)
```