### PR TITLE
Fix backslashes in Naming/VariableNumber example docs not showing in online docs

### DIFF
--- a/lib/rubocop/cop/naming/variable_name.rb
+++ b/lib/rubocop/cop/naming/variable_name.rb
@@ -24,7 +24,7 @@ module RuboCop
       #   # good (with EnforcedStyle: snake_case)
       #   fooBar = 1
       #
-      # @example AllowedPatterns: ['_v\d+\z']
+      # @example AllowedPatterns: ['_v\\d+\\z']
       #   # good (with EnforcedStyle: camelCase)
       #   :release_v1
       #


### PR DESCRIPTION
The file on rubydoc.info prints `AllowedPatterns: [‘_vd+z’]` but it should be `AllowedPatterns: [‘_v\d+\z’]`
<img width="255" alt="image" src="https://github.com/rubocop/rubocop/assets/1429026/f70c086e-ed32-4232-9358-dbed732abcae">
