### PR TITLE
Add `Bundler.with_unbundled_env` to `RSpec.shared_context 'isolated environment'`

### DIFF
--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2073,7 +2073,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
           'string'
         RUBY
+
         create_empty_file('Gemfile')
+        create_empty_file('Gemfile.lock')
       end
 
       after do

--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -7,11 +7,6 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
 
   include_context 'cli spec behavior'
 
-  before do
-    # Makes sure the project dir of rubocop server is the isolated_environment
-    create_empty_file('Gemfile')
-  end
-
   after do
     `ruby -I . "#{rubocop}" --stop-server`
   end
@@ -56,12 +51,15 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
           '--stdin', 'example.rb',
           stdin_data: 'puts 0'
         )
+
         expect(status.success?).to be true
+
         expect(stdout).to eq(<<~RUBY)
           # frozen_string_literal: true
 
           puts 0
         RUBY
+
         expect(stderr)
           .to include('[Corrected] Style/FrozenStringLiteralComment')
           .and include('[Corrected] Layout/EmptyLineAfterMagicComment')
@@ -79,6 +77,7 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
             'ruby', '-I', '.',
             rubocop, '--server', '--format=json', '--stdin', 'example.rb', stdin_data: 'puts 0'
           )
+
           expect(stdout).not_to start_with 'RuboCop server starting on '
         end
       end


### PR DESCRIPTION
It's more correct. And without it there are errors, like about `yard` gem:

```
> bundle exec rspec

...
/home/alex/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundler/definition.rb:570:in `materialize': Could not find yard-0.9.34 in locally installed gems (Bundler::GemNotFound)
	from /home/alex/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundler/definition.rb:203:in `specs'
	from /home/alex/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundler/definition.rb:270:in `specs_for'
...
```

There are some incompatibilities, but they can be resolved.

---

Basically, I couldn't run specs from "the cold start".

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
