### PR TITLE
[Fix #12614] Fix false positiveis for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_positives_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#12614](https://github.com/rubocop/rubocop/issues/12614): Fix false positiveis for `Style/RedundantParentheses` when parentheses in control flow keyword with multiline style argument. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -54,7 +54,7 @@ module RuboCop
           return false unless (parent = node.parent)
 
           parent.while_post_type? || parent.until_post_type? || parent.match_with_lvasgn_type? ||
-            like_method_argument_parentheses?(parent)
+            like_method_argument_parentheses?(parent) || multiline_control_flow_statements?(node)
         end
 
         def allowed_expression?(node)
@@ -102,6 +102,13 @@ module RuboCop
 
           node.arguments.one? && !node.parenthesized? &&
             !node.arithmetic_operation? && node.first_argument.begin_type?
+        end
+
+        def multiline_control_flow_statements?(node)
+          return false unless (parent = node.parent)
+          return false if parent.single_line?
+
+          parent.return_type? || parent.next_type? || parent.break_type?
         end
 
         def empty_parentheses?(node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -793,6 +793,63 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'accepts parentheses in `return` with multiline style argument' do
+    expect_no_offenses(<<~RUBY)
+      return (
+        42
+      )
+    RUBY
+  end
+
+  it 'registers an offense when parentheses in `return` with single style argument' do
+    expect_offense(<<~RUBY)
+      return (42)
+             ^^^^ Don't use parentheses around a literal.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      return 42
+    RUBY
+  end
+
+  it 'accepts parentheses in `next` with multiline style argument' do
+    expect_no_offenses(<<~RUBY)
+      next (
+        42
+      )
+    RUBY
+  end
+
+  it 'registers an offense when parentheses in `next` with single style argument' do
+    expect_offense(<<~RUBY)
+      next (42)
+           ^^^^ Don't use parentheses around a literal.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      next 42
+    RUBY
+  end
+
+  it 'accepts parentheses in `break` with multiline style argument' do
+    expect_no_offenses(<<~RUBY)
+      break (
+        42
+      )
+    RUBY
+  end
+
+  it 'registers an offense when parentheses in `break` with single style argument' do
+    expect_offense(<<~RUBY)
+      break (42)
+            ^^^^ Don't use parentheses around a literal.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      break 42
+    RUBY
+  end
+
   it 'registers an offense and corrects when method arguments are unnecessarily parenthesized' do
     expect_offense(<<~RUBY)
       foo(


### PR DESCRIPTION
Fixes #12614.

This PR fixes false positiveis for `Style/RedundantParentheses` when parentheses in control flow keyword with multiline style argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
