### PR TITLE
[Fix #12617] Make `Style/CollectionCompact` aware of `grep_v` with nil

### DIFF
--- a/changelog/change_make_style_collection_compact_aware_of_grep_v_with_nil.md
+++ b/changelog/change_make_style_collection_compact_aware_of_grep_v_with_nil.md
@@ -1,0 +1,1 @@
+* [#12617](https://github.com/rubocop/rubocop/issues/12617): Make `Style/CollectionCompact` aware of `grep_v` with nil. ([@koic][])

--- a/spec/rubocop/cop/style/collection_compact_spec.rb
+++ b/spec/rubocop/cop/style/collection_compact_spec.rb
@@ -146,6 +146,45 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `grep_v(nil)`' do
+    expect_offense(<<~RUBY)
+      array.grep_v(nil)
+            ^^^^^^^^^^^ Use `compact` instead of `grep_v(nil)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array.compact
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `grep_v(NilClass)`' do
+    expect_offense(<<~RUBY)
+      array.grep_v(NilClass)
+            ^^^^^^^^^^^^^^^^ Use `compact` instead of `grep_v(NilClass)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array.compact
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `grep_v(::NilClass)`' do
+    expect_offense(<<~RUBY)
+      array.grep_v(::NilClass)
+            ^^^^^^^^^^^^^^^^^^ Use `compact` instead of `grep_v(::NilClass)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array.compact
+    RUBY
+  end
+
+  it 'does not register an offense and corrects when using `grep_v(pattern)`' do
+    expect_no_offenses(<<~RUBY)
+      array.grep_v(pattern)
+    RUBY
+  end
+
   it 'does not register an offense when using `reject` to not to rejecting nils' do
     expect_no_offenses(<<~RUBY)
       array.reject { |e| e.odd? }


### PR DESCRIPTION
Resolves #12617.

This PR makes `Style/CollectionCompact` aware of `grep_v` with nil.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
