### PR TITLE
Update the Compatibility Policy

### DIFF
--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -13,8 +13,9 @@ NOTE: RuboCop might be working with other Ruby implementations as well, but it's
 
 == Support Matrix
 
-RuboCop generally aims to follow MRI's own support policy - meaning RuboCop would support all officially supported MRI releases.footnote:[Typically the last 3 releases.] To give people extra time for a smooth transition, we've customarily provided support for about one year after EOL of MRI version.
-This means that if Ruby 2.7 reaches its EOL in Spring 2023, it would be supported by RuboCop (at least) until Spring 2024.footnote:[At the core team's discretion this policy might be waived aside for MRI releases causing significant maintenance overhead.]
+RuboCop generally aims to follow MRI's own support policy - meaning RuboCop would support all officially supported MRI releases.footnote:[Typically the last 3 releases.] To give people extra time for a smooth transition, we've customarily provided support for about one year after EOL of MRI version. footnote:[At the core team's discretion this policy might be waived aside for MRI releases causing significant maintenance overhead.]
+
+NOTE: There are major version incompatibilities between Ruby 2.7 and Ruby 3.0, and the latest stable version of Ruby on Rails, 7.1, still supports Ruby 2.7. Therefore, it might be early for RuboCop to drop support for Ruby 2.7 at this stage. As long as Rails 7.1 is in the "Bug Fix" phase of the https://guides.rubyonrails.org/maintenance_policy.html[Maintenance Policy for Ruby on Rails], RuboCop will continue supporting Ruby 2.7.
 
 The following table is the runtime support matrix.
 


### PR DESCRIPTION
This PR proposes to update the Compatibility Policy.

There are major version incompatibilities between Ruby 2.7 and Ruby 3.0. And the latest stable version of Ruby on Rails, 7.1, still supports Ruby 2.7. So, dropping support for Ruby 2.7 from RuboCop might be premature for the market at this stage.

At least for the duration that Rails 7.1 is classified as being in the "Bug Fix" phase under the [Maintenance Policy for Ruby on Rails] (https://guides.rubyonrails.org/maintenance_policy.html), RuboCop will continue to support Ruby 2.7.

In reality, RuboCop is mostly used for code analysis with the same version of the Ruby runtime. I think that ensuring such users can smoothly upgrade their RuboCop version justifies maintaining support for older Ruby version 2.7 for an extended period.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
