### PR TITLE
Add Errno::EROFS exception handling for read-only file systems

### DIFF
--- a/changelog/fix_errno_erofs.md
+++ b/changelog/fix_errno_erofs.md
@@ -1,0 +1,1 @@
+* [#12625](https://github.com/rubocop/rubocop/pull/12625): Fix an error when server cache dir has read-only file system. ([@Strzesia][])

--- a/lib/rubocop/server/cache.rb
+++ b/lib/rubocop/server/cache.rb
@@ -117,7 +117,7 @@ module RuboCop
 
         def pid_running?
           Process.kill(0, pid_path.read.to_i) == 1
-        rescue Errno::ESRCH, Errno::ENOENT, Errno::EACCES
+        rescue Errno::ESRCH, Errno::ENOENT, Errno::EACCES, Errno::EROFS
           false
         end
 

--- a/spec/rubocop/server/cache_spec.rb
+++ b/spec/rubocop/server/cache_spec.rb
@@ -292,6 +292,15 @@ RSpec.describe RuboCop::Server::Cache do
         end
         expect(described_class.pid_running?).to be(false)
       end
+
+      it 'works properly when the file system is read-only' do
+        expect(described_class).to receive(:pid_path).and_wrap_original do |method|
+          result = method.call
+          allow(result).to receive(:read).and_raise(Errno::EROFS)
+          result
+        end
+        expect(described_class.pid_running?).to be(false)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR addresses an issue encountered when running RuboCop in a Docker container configured with `read_only: true` in the `docker-compose` file.

Changes in this PR include:

- Added `Errno::EROFS` to the rescue clause in `lib/rubocop/server/cache.rb` to handle `Read-only file system` errors. This change allows the application to gracefully handle situations where the filesystem is read-only, such as in certain Docker configurations.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
