### PR TITLE
Fix a false positive for `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/fix_false_positive_for_style_arguments_forwarding.md
+++ b/changelog/fix_false_positive_for_style_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#12628](https://github.com/rubocop/rubocop/pull/12628): Fix a false positive for `Style/ArgumentsForwarding` when using block arg forwarding with positional arguments forwarding to within block. ([@koic][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -178,7 +178,7 @@ module RuboCop
           registered_block_arg_offense = false
 
           send_classifications.each do |send_node, _c, forward_rest, forward_kwrest, forward_block_arg| # rubocop:disable Layout/LineLength
-            if !forward_rest && !forward_kwrest && outside_block?(forward_block_arg)
+            if !forward_rest && !forward_kwrest
               register_forward_block_arg_offense(!forward_rest, node.arguments, block_arg)
               register_forward_block_arg_offense(!forward_rest, send_node, forward_block_arg)
 

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -836,6 +836,26 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
+    it 'registers an offense when using block arg forwarding with positional arguments forwarding to within block' do
+      expect_offense(<<~RUBY)
+        def baz(qux, quuz, &block)
+                           ^^^^^^ Use anonymous block arguments forwarding (`&`).
+          with_block do
+            bar(qux, quuz, &block)
+                           ^^^^^^ Use anonymous block arguments forwarding (`&`).
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def baz(qux, quuz, &)
+          with_block do
+            bar(qux, quuz, &)
+          end
+        end
+      RUBY
+    end
+
     it 'registers an offense when using block arg forwarding with no forwarding arguments' do
       expect_offense(<<~RUBY)
         def before_transition(options = {}, &block)


### PR DESCRIPTION
Resolves https://github.com/rubocop/rubocop/issues/12618#issuecomment-1896303457.

This PR fixes a false positive for `Style/ArgumentsForwarding` when using block arg forwarding with positional arguments forwarding to within block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
