### PR TITLE
[Fix #12627] Fix a false positive for `Layout/RedundantLineBreak`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_redundant_line_break.md
+++ b/changelog/fix_a_false_positive_for_layout_redundant_line_break.md
@@ -1,0 +1,1 @@
+* [#12627](https://github.com/rubocop/rubocop/issues/12627): Fix a false positive for `Layout/RedundantLineBreak` when using index access call chained on multiple lines with backslash. ([@koic][])

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -85,7 +85,11 @@ module RuboCop
 
         def offense?(node)
           node.multiline? && !too_long?(node) && suitable_as_single_line?(node) &&
-            !configured_to_not_be_inspected?(node)
+            !index_access_call_chained?(node) && !configured_to_not_be_inspected?(node)
+        end
+
+        def index_access_call_chained?(node)
+          node.send_type? && node.method?(:[]) && node.children.first.method?(:[])
         end
 
         def configured_to_not_be_inspected?(node)

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -152,6 +152,13 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
         RUBY
       end
 
+      it 'does not register an offense for index access call chained on multiple lines with backslash' do
+        expect_no_offenses(<<~RUBY)
+          hash[:foo] \\
+            [:bar]
+        RUBY
+      end
+
       context 'with LineLength Max 100' do
         let(:max_line_length) { 100 }
 


### PR DESCRIPTION
Fix #12627.

This PR fixes a false positive for `Layout/RedundantLineBreak` when using index access call chained on multiple lines with backslash.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
