### PR TITLE
[Fix #12632] Fix an infinite loop error for `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/fix_infinite_loop_error_for_style_argument_forwarding.md
+++ b/changelog/fix_infinite_loop_error_for_style_argument_forwarding.md
@@ -1,0 +1,1 @@
+* [#12632](https://github.com/rubocop/rubocop/issues/12632): Fix an infinite loop error when `EnforcedStyle: explicit` of `Naming/BlockForwarding` with `Style/ArgumentsForwarding`. ([@koic][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -104,7 +104,7 @@ module RuboCop
       #   end
       #
       # @example RedundantBlockArgumentNames: ['blk', 'block', 'proc'] (default)
-      #   # bad
+      #   # bad - But it is good with `EnforcedStyle: explicit` set for `Naming/BlockForwarding`.
       #   def foo(&block)
       #     bar(&block)
       #   end
@@ -291,7 +291,7 @@ module RuboCop
         end
 
         def register_forward_block_arg_offense(add_parens, def_arguments_or_send, block_arg)
-          return if target_ruby_version <= 3.0 || block_arg.source == '&'
+          return if target_ruby_version <= 3.0 || block_arg.source == '&' || explicit_block_name?
 
           add_offense(block_arg, message: BLOCK_MSG) do |corrector|
             add_parens_if_missing(def_arguments_or_send, corrector) if add_parens
@@ -468,6 +468,13 @@ module RuboCop
             (@rest_arg_name && !forwarded_rest_arg) ||
               (@kwrest_arg_name && !forwarded_kwrest_arg)
           end
+        end
+
+        def explicit_block_name?
+          block_forwarding_config = config.for_cop('Naming/BlockForwarding')
+          return false unless block_forwarding_config['Enabled']
+
+          block_forwarding_config['EnforcedStyle'] == 'explicit'
         end
       end
     end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -593,6 +593,30 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `EnforcedStyle: explicit` of `Naming/BlockForwarding` with `Style/ArgumentsForwarding`' do
+    create_file('.rubocop.yml', <<~YAML)
+      AllCops:
+        TargetRubyVersion: 3.1
+      Naming/BlockForwarding:
+        EnforcedStyle: explicit
+    YAML
+    source = <<~RUBY
+      def some_method(&block)
+        render &block
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--autocorrect',
+                     '--only', 'Naming/BlockForwarding,Style/ArgumentsForwarding'
+                   ])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      def some_method(&block)
+        render &block
+      end
+    RUBY
+  end
+
   describe 'trailing comma cops' do
     let(:source) do
       <<~RUBY


### PR DESCRIPTION
Fixes #12632.

This PR fixes an infinite loop error when `EnforcedStyle: explicit` of `Naming/BlockForwarding` with `Style/ArgumentsForwarding`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
