### PR TITLE
Fix a build error on windows mingw matrix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :test do
   gem 'base64'
   # FIXME: This `bigdecimal` dependency can be removed when https://github.com/jnunemaker/crack/pull/75
   # is merged and released. It's a workaround until then.
-  gem 'bigdecimal', platform: :mri
+  gem 'bigdecimal', platform: %i[mri windows]
   gem 'webmock', require: false
 end
 


### PR DESCRIPTION
This PR fixes the following build error on windows mingw matrix:

```console
D:/a/rubocop/rubocop/vendor/bundle/ruby/3.4.0+0/gems/crack-0.4.5/lib/crack/xml.rb:9:
warning: bigdecimal was loaded from the standard library, but is not part of the default gems since Ruby 3.4.0.
Add bigdecimal to your Gemfile or gemspec.

An error occurred while loading spec_helper. - Did you mean?
                    rspec ./spec/spec_helper.rb

Failure/Error: require 'webmock/rspec'

LoadError:
  cannot load such file -- bigdecimal
# ./vendor/bundle/ruby/3.4.0+0/gems/crack-0.4.5/lib/crack/xml.rb:9:in `<top (required)>'
```

https://github.com/rubocop/rubocop/actions/runs/7567518866/job/20606843322?pr=12633

This occurred due to BigDecimal has been extracted as a bundled gem: ruby/ruby#9573

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
