### PR TITLE
Fix a false positive for `Style/HashEachMethods` when both arguments are unused

### DIFF
--- a/changelog/fix_a_false_positive_for_style_hash_each_methods.md
+++ b/changelog/fix_a_false_positive_for_style_hash_each_methods.md
@@ -1,0 +1,1 @@
+* [#12635](https://github.com/rubocop/rubocop/pull/12635): Fix a false positive for `Style/HashEachMethods` when both arguments are unused. ([@earlopain][])

--- a/spec/rubocop/cop/style/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/style/hash_each_methods_spec.rb
@@ -105,6 +105,10 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         expect_no_offenses('foo.each { |*k, v| do_something(*k, v) }')
       end
 
+      it 'does not register an offense when both arguments of `Enumerable#each` are unused' do
+        expect_no_offenses('foo.each { |k, v| do_something }')
+      end
+
       it 'registers an offense when the rest value block argument of `Enumerable#each` method is unused' do
         expect_offense(<<~RUBY)
           foo.each { |k, *v| do_something(*v) }


### PR DESCRIPTION
```rb
foo.each { |k, v| do_something }
# => autocorrect
foo.each_key { |k| do_something }
```

`Lint/UnusedBlockArgument` should instead say something about this:

```
test.rb:1:13: W: [Correctable] Lint/UnusedBlockArgument: Unused block argument - k. You can omit all the arguments if you don't care about them.
foo.each { |k, v| do_something }
            ^
test.rb:1:16: W: [Correctable] Lint/UnusedBlockArgument: Unused block argument - v. You can omit all the arguments if you don't care about them.
foo.each { |k, v| do_something }
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
