### PR TITLE
Fix an error for `Style/HashEachMethods` when a block with both parameters has no body

### DIFF
--- a/changelog/fix_an_error_for_style_hash_each_methods.md
+++ b/changelog/fix_an_error_for_style_hash_each_methods.md
@@ -1,0 +1,1 @@
+* [#12636](https://github.com/rubocop/rubocop/pull/12636): Fix an error for `Style/HashEachMethods` when a block with both parameters has no body. ([@earlopain][])

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -71,6 +71,8 @@ module RuboCop
 
         # rubocop:disable Metrics/AbcSize
         def check_unused_block_args(node, key, value)
+          return if node.body.nil?
+
           value_unused = unused_block_arg_exist?(node, value)
           key_unused = unused_block_arg_exist?(node, key)
           return if value_unused && key_unused

--- a/spec/rubocop/cop/style/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/style/hash_each_methods_spec.rb
@@ -109,6 +109,10 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         expect_no_offenses('foo.each { |k, v| do_something }')
       end
 
+      it 'does not register an offense when the body of `Enumerable#each` is empty' do
+        expect_no_offenses('foo.each { |k, v| }')
+      end
+
       it 'registers an offense when the rest value block argument of `Enumerable#each` method is unused' do
         expect_offense(<<~RUBY)
           foo.each { |k, *v| do_something(*v) }


### PR DESCRIPTION
Depends on #12635.

`Lint/EmptyBlock` takes care of this case:

```
test.rb:1:1: W: Lint/EmptyBlock: Empty block detected.
foo.each { |k, v| }
```

I have based this on #12635 because without this the cop would produce the following offense for the added testcase:
```rb
foo.each { |k, v| }
# => autocorrect
foo.each_key { |k| }
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
