### PR TITLE
Mark `Style/RaiseArgs` as unsafe

### DIFF
--- a/changelog/change_mark_style_raise_args_as_unsafe.md
+++ b/changelog/change_mark_style_raise_args_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#12637](https://github.com/rubocop/rubocop/pull/12637): Mark `Style/RaiseArgs` as unsafe. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4835,8 +4835,9 @@ Style/RaiseArgs:
   Description: 'Checks the arguments passed to raise/fail.'
   StyleGuide: '#exception-class-messages'
   Enabled: true
+  Safe: false
   VersionAdded: '0.14'
-  VersionChanged: '1.2'
+  VersionChanged: '<<next>>'
   EnforcedStyle: exploded
   SupportedStyles:
     - compact # raise Exception.new(msg)

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -16,6 +16,9 @@ module RuboCop
       # The exploded style has an `AllowedCompactTypes` configuration
       # option that takes an Array of exception name Strings.
       #
+      # @safety
+      #   This cop is unsafe because `raise Foo` calls `Foo.exception`, not `Foo.new`.
+      #
       # @example EnforcedStyle: exploded (default)
       #   # bad
       #   raise StandardError.new('message')


### PR DESCRIPTION
`.exception` and `.new` behave roughly the same way, but I don't think they are guaranteed to always be so.

What do you think?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
