### PR TITLE
[Fix #12638] Fix an `Errno::ENOENT` error when using server mode

### DIFF
--- a/changelog/fix_an_error_when_using_sever_mode.md
+++ b/changelog/fix_an_error_when_using_sever_mode.md
@@ -1,0 +1,1 @@
+* [#12638](https://github.com/rubocop/rubocop/issues/12638): Fix an `Errno::ENOENT` error when using server mode. ([@koic][])

--- a/lib/rubocop/server/client_command/exec.rb
+++ b/lib/rubocop/server/client_command/exec.rb
@@ -17,7 +17,6 @@ module RuboCop
       class Exec < Base
         def run
           ensure_server!
-          Cache.status_path.delete if Cache.status_path.file?
           read_stdin = ARGV.include?('-s') || ARGV.include?('--stdin')
           send_request(
             command: 'exec',

--- a/lib/rubocop/server/server_command/exec.rb
+++ b/lib/rubocop/server/server_command/exec.rb
@@ -16,7 +16,6 @@ module RuboCop
       # @api private
       class Exec < Base
         def run
-          Cache.status_path.delete if Cache.status_path.file?
           # RuboCop output is colorized by default where there is a TTY.
           # We must pass the --color option to preserve this behavior.
           @args.unshift('--color') unless %w[--color --no-color].any? { |f| @args.include?(f) }


### PR DESCRIPTION
Fixes #12638.

There is a possibility of a race condition occurring with the status file when using server mode. The status file is updated to a new status by `Cache.write_status_file` (`Pathname#write`), so there is no need to clear it by deleting the file.

Due to the difficulty in reproducing this race conditions, test code for this have not been added.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
