### PR TITLE
Make error message clearer when the namespace is incorrect

### DIFF
--- a/changelog/change_error_message_on_incorrect_namespace.md
+++ b/changelog/change_error_message_on_incorrect_namespace.md
@@ -1,0 +1,1 @@
+* [#12641](https://github.com/rubocop/rubocop/pull/12641): Make error message clearer when the namespace is incorrect. ([@maruth-stripe][])

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -300,7 +300,7 @@ module RuboCop
         unless given_badge.match?(real_badge)
           path = PathUtil.smart_path(source_path)
           warn "#{path}: #{given_badge} has the wrong namespace - " \
-               "should be #{real_badge.department}"
+               "replace it with #{given_badge.with_department(real_badge.department)}"
         end
 
         real_badge.to_s

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -469,7 +469,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
       expect($stderr.string)
         .to eq(['example.rb: Style/LineLength has the wrong ' \
-                'namespace - should be Layout',
+                'namespace - replace it with Layout/LineLength',
                 ''].join("\n"))
       # 2 real cops were disabled, and 1 that was incorrect
       # 2 real cops was enabled, but only 1 had been disabled correctly

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -854,7 +854,7 @@ RSpec.describe RuboCop::ConfigLoader do
             .to output(
               a_string_including(
                 '.rubocop.yml: Custom/Loop has the ' \
-                "wrong namespace - should be Lint\n"
+                "wrong namespace - replace it with Lint/Loop\n"
               )
             ).to_stderr
         end

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::Registry do
 
     it 'emits a warning when namespace is incorrect' do
       warning = '/app/.rubocop.yml: Style/MethodLength has the wrong ' \
-                "namespace - should be Metrics\n"
+                "namespace - replace it with Metrics/MethodLength\n"
       qualified = nil
 
       expect do


### PR DESCRIPTION
Updates the error message when the namespace is incorrect to specify the exact action the developer must take to fix the error. 

The error message as it exists today does not immediately signal an action to fix it to developers unfamiliar with Rubocop terminology.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [X] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
