### PR TITLE
Fix false positives for `Style/HashEachMethods`

### DIFF
--- a/changelog/fix_false_positives_for_style_hash_each_methods_when_array_converter.md
+++ b/changelog/fix_false_positives_for_style_hash_each_methods_when_array_converter.md
@@ -1,0 +1,1 @@
+* [#12642](https://github.com/rubocop/rubocop/pull/12642): Fix false positives for `Style/HashEachMethods` when using array converter method. ([@koic][])

--- a/spec/rubocop/cop/style/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/style/hash_each_methods_spec.rb
@@ -179,6 +179,54 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         RUBY
       end
 
+      it 'does not register an offense when the key block argument of `Enumerable#each` method is unused after `assoc`' do
+        expect_no_offenses(<<~RUBY)
+          foo.assoc(key).each { |unused_key, v| do_something(v) }
+        RUBY
+      end
+
+      it 'does not register an offense when the key block argument of `Enumerable#each` method is unused after `flatten`' do
+        expect_no_offenses(<<~RUBY)
+          foo.flatten.each { |unused_key, v| do_something(v) }
+        RUBY
+      end
+
+      it 'does not register an offense when the key block argument of `Enumerable#each` method is unused after `rassoc`' do
+        expect_no_offenses(<<~RUBY)
+          foo.rassoc(value).each { |unused_key, v| do_something(v) }
+        RUBY
+      end
+
+      it 'does not register an offense when the key block argument of `Enumerable#each` method is unused after `sort`' do
+        expect_no_offenses(<<~RUBY)
+          foo.sort.each { |unused_key, v| do_something(v) }
+        RUBY
+      end
+
+      it 'does not register an offense when the key block argument of `Enumerable#each` method is unused after `sort_by`' do
+        expect_no_offenses(<<~RUBY)
+          foo.sort_by { |k, v| v }.each { |unused_key, v| do_something(v) }
+        RUBY
+      end
+
+      it 'does not register an offense when the key block argument of `Enumerable#each` method is unused after `sort_by` with numblock' do
+        expect_no_offenses(<<~RUBY)
+          foo.sort_by { _2 }.each { |unused_key, v| do_something(v) }
+        RUBY
+      end
+
+      it 'does not register an offense when the key block argument of `Enumerable#each` method is unused after `to_a`' do
+        expect_no_offenses(<<~RUBY)
+          foo.to_a.each { |unused_key, v| do_something(v) }
+        RUBY
+      end
+
+      it 'does not register an offense when the key block argument of `Enumerable#each` method is unused after `to_a` with safe navigation' do
+        expect_no_offenses(<<~RUBY)
+          foo&.to_a.each { |unused_key, v| do_something(v) }
+        RUBY
+      end
+
       it 'registers an offense when the destructed key block argument of `Enumerable#each` method is unused' do
         expect_offense(<<~RUBY)
           foo.each { |(_, unused_key), v| do_something(v) }


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/12534#issuecomment-1871676010.

This PR fixes false positives for `Style/HashEachMethods` when using array converter method.

Hash object converted to an Array cannot process `Hash#each_key` and `Hash#each_value`. Therefore, if methods that convert to an Array are used before `each`, they should be ignored.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
