### PR TITLE
Check gemspec `required_ruby_version` before `.ruby-version` and other sources

### DIFF
--- a/changelog/change_source_order_for_target_ruby.md
+++ b/changelog/change_source_order_for_target_ruby.md
@@ -1,0 +1,1 @@
+* [#12645](https://github.com/rubocop/rubocop/pull/12645): Change source order for target ruby to check gemspec after RuboCop configuration. ([@jenshenny][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -610,7 +610,7 @@ AllCops:
 
 Otherwise, RuboCop will then check your project for a series of files where
 the version may be specified already. The files that will be looked for are
-`.ruby-version`, `.tool-versions`, `Gemfile.lock`, and `*.gemspec`.
+`*.gemspec`, `.ruby-version`, `.tool-versions`, and `Gemfile.lock`.
 If Gemspec file has an array for `required_ruby_version`, the lowest version will be used.
 If none of the files are found a default version value will be used.
 

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -33,6 +33,203 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
   end
 
   context 'when TargetRubyVersion is not set' do
+    context 'when gemspec file is present' do
+      let(:base_path) { configuration.base_dir_for_path_parameters }
+      let(:gemspec_file_path) { File.join(base_path, 'example.gemspec') }
+
+      context 'when file contains `required_ruby_version` as a string' do
+        it 'sets target_ruby from inclusive range' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = '>= 2.7.2'
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq 2.7
+        end
+
+        it 'sets target_ruby from exclusive range' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = '> 2.7.8'
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq 2.7
+        end
+
+        it 'sets target_ruby from approximate version' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = '~> 2.7.0'
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq 2.7
+        end
+      end
+
+      context 'when file contains `required_ruby_version` as a requirement' do
+        it 'sets target_ruby from required_ruby_version from inclusive requirement range' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = Gem::Requirement.new('>= 2.3.1')
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq default_version
+        end
+
+        it 'sets first known ruby version that satisfies requirement' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = Gem::Requirement.new('< 3.0.0')
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq default_version
+        end
+
+        it 'sets first known ruby version that satisfies range requirement' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = Gem::Requirement.new('>= 2.3.1', '< 3.0.0')
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq default_version
+        end
+
+        it 'sets first known ruby version that satisfies range requirement in array notation' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = Gem::Requirement.new(['>= 2.3.1', '< 3.0.0'])
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq default_version
+        end
+
+        it 'sets first known ruby version that satisfies range requirement with frozen strings' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = Gem::Requirement.new('>= 2.3.1'.freeze, '< 3.0.0'.freeze)
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq default_version
+        end
+
+        it 'sets first known ruby version that satisfies range requirement in array notation with frozen strings' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = Gem::Requirement.new(['>= 2.3.1'.freeze, '< 3.0.0'.freeze])
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq default_version
+        end
+      end
+
+      context 'when file contains `required_ruby_version` as an array' do
+        it 'sets target_ruby to the minimal version satisfying the requirements' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = ['<=3.0.4', '>=2.7.5']
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq 2.7
+        end
+
+        it 'sets target_ruby from required_ruby_version with many requirements' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = ['<=3.1.0', '>2.6.8', '~>2.7.1']
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq 2.7
+        end
+      end
+
+      context 'when required_ruby_version sets the target ruby' do
+        before do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = '>= 2.7.2'
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+          create_file(gemspec_file_path, content)
+        end
+
+        it 'does not check the other sources' do
+          expect(described_class::RubyVersionFile).not_to receive(:new)
+          expect(described_class::ToolVersionsFile).not_to receive(:new)
+          expect(described_class::BundlerLockFile).not_to receive(:new)
+          expect(described_class::Default).not_to receive(:new)
+          target_ruby.version
+        end
+      end
+
+      context 'when file does not contain `required_ruby_version`' do
+        before do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.platform = Gem::Platform::RUBY
+              s.licenses = ['MIT']
+              s.summary = 'test tool.'
+            end
+          HEREDOC
+          create_file(gemspec_file_path, content)
+        end
+
+        it 'checks the rest of the sources' do
+          expect(described_class::RubyVersionFile).to receive(:new).and_call_original
+          expect(described_class::ToolVersionsFile).to receive(:new).and_call_original
+          expect(described_class::BundlerLockFile).to receive(:new).and_call_original
+          expect(described_class::Default).to receive(:new).and_call_original
+          target_ruby.version
+        end
+      end
+    end
+
     context 'when .ruby-version is present' do
       before do
         dir = configuration.base_dir_for_path_parameters
@@ -293,185 +490,6 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
       context 'when bundler lock files are not present' do
         it 'uses the default target ruby version' do
           expect(target_ruby.version).to eq default_version
-        end
-      end
-
-      context 'gemspec file' do
-        context 'when file contains `required_ruby_version` as a string' do
-          let(:base_path) { configuration.base_dir_for_path_parameters }
-          let(:gemspec_file_path) { File.join(base_path, 'example.gemspec') }
-
-          it 'sets target_ruby from inclusive range' do
-            content = <<~HEREDOC
-              Gem::Specification.new do |s|
-                s.name = 'test'
-                s.required_ruby_version = '>= 2.7.2'
-                s.licenses = ['MIT']
-              end
-            HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 2.7
-          end
-
-          it 'sets target_ruby from exclusive range' do
-            content = <<~HEREDOC
-              Gem::Specification.new do |s|
-                s.name = 'test'
-                s.required_ruby_version = '> 2.7.8'
-                s.licenses = ['MIT']
-              end
-            HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 2.7
-          end
-
-          it 'sets target_ruby from approximate version' do
-            content = <<~HEREDOC
-              Gem::Specification.new do |s|
-                s.name = 'test'
-                s.required_ruby_version = '~> 2.7.0'
-                s.licenses = ['MIT']
-              end
-            HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 2.7
-          end
-        end
-
-        context 'when file contains `required_ruby_version` as a requirement' do
-          let(:base_path) { configuration.base_dir_for_path_parameters }
-          let(:gemspec_file_path) { File.join(base_path, 'example.gemspec') }
-
-          it 'sets target_ruby from required_ruby_version from inclusive requirement range' do
-            content = <<~HEREDOC
-              Gem::Specification.new do |s|
-                s.name = 'test'
-                s.required_ruby_version = Gem::Requirement.new('>= 2.3.1')
-                s.licenses = ['MIT']
-              end
-            HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq default_version
-          end
-
-          it 'sets first known ruby version that satisfies requirement' do
-            content = <<~HEREDOC
-              Gem::Specification.new do |s|
-                s.name = 'test'
-                s.required_ruby_version = Gem::Requirement.new('< 3.0.0')
-                s.licenses = ['MIT']
-              end
-            HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq default_version
-          end
-
-          it 'sets first known ruby version that satisfies range requirement' do
-            content = <<~HEREDOC
-              Gem::Specification.new do |s|
-                s.name = 'test'
-                s.required_ruby_version = Gem::Requirement.new('>= 2.3.1', '< 3.0.0')
-                s.licenses = ['MIT']
-              end
-            HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq default_version
-          end
-
-          it 'sets first known ruby version that satisfies range requirement in array notation' do
-            content = <<~HEREDOC
-              Gem::Specification.new do |s|
-                s.name = 'test'
-                s.required_ruby_version = Gem::Requirement.new(['>= 2.3.1', '< 3.0.0'])
-                s.licenses = ['MIT']
-              end
-            HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq default_version
-          end
-
-          it 'sets first known ruby version that satisfies range requirement with frozen strings' do
-            content = <<~HEREDOC
-              Gem::Specification.new do |s|
-                s.name = 'test'
-                s.required_ruby_version = Gem::Requirement.new('>= 2.3.1'.freeze, '< 3.0.0'.freeze)
-                s.licenses = ['MIT']
-              end
-            HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq default_version
-          end
-
-          it 'sets first known ruby version that satisfies range requirement in array notation with frozen strings' do
-            content = <<~HEREDOC
-              Gem::Specification.new do |s|
-                s.name = 'test'
-                s.required_ruby_version = Gem::Requirement.new(['>= 2.3.1'.freeze, '< 3.0.0'.freeze])
-                s.licenses = ['MIT']
-              end
-            HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq default_version
-          end
-        end
-
-        context 'when file contains `required_ruby_version` as an array' do
-          let(:base_path) { configuration.base_dir_for_path_parameters }
-          let(:gemspec_file_path) { File.join(base_path, 'example.gemspec') }
-
-          it 'sets target_ruby to the minimal version satisfying the requirements' do
-            content = <<~HEREDOC
-              Gem::Specification.new do |s|
-                s.name = 'test'
-                s.required_ruby_version = ['<=3.0.4', '>=2.7.5']
-                s.licenses = ['MIT']
-              end
-            HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 2.7
-          end
-
-          it 'sets target_ruby from required_ruby_version with many requirements' do
-            content = <<~HEREDOC
-              Gem::Specification.new do |s|
-                s.name = 'test'
-                s.required_ruby_version = ['<=3.1.0', '>2.6.8', '~>2.7.1']
-                s.licenses = ['MIT']
-              end
-            HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 2.7
-          end
-        end
-
-        context 'when file does not contain `required_ruby_version`' do
-          let(:base_path) { configuration.base_dir_for_path_parameters }
-          let(:gemspec_file_path) { File.join(base_path, 'example.gemspec') }
-
-          it 'sets default target_ruby' do
-            content = <<~HEREDOC
-              Gem::Specification.new do |s|
-                s.name = 'test'
-                s.platform = Gem::Platform::RUBY
-                s.licenses = ['MIT']
-                s.summary = 'test tool.'
-              end
-            HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq default_version
-          end
         end
       end
     end


### PR DESCRIPTION
Currently, if I have a gem that has both a `.ruby-version` file and a `required_ruby_version` in the gemspec, Rubocop would default to the ruby version in the `.ruby-version` file.

However, it would be more correct to take the ruby version in the gemspec as the `TargetRubyVersion` [should be the oldest version of Ruby which your project supports with](https://docs.rubocop.org/rubocop/configuration.html#setting-the-target-ruby-version). `required_ruby_version` would specify any minimum Ruby version. The `.ruby-version` and other sources would get the development version in the project and might not be the oldest supported version. 

### Changes
Moved the GemspecFile source to be under the rubocop config.


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
