### PR TITLE
LSP mode configurable from external source

### DIFF
--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -84,6 +84,24 @@ module RuboCop
         false
       end
 
+      ### LSP
+
+      # This experimental feature has been under consideration for a while.
+      # @api private
+      def self.lsp_mode?
+        !!@lsp_mode
+      end
+
+      # This experimental feature has been under consideration for a while.
+      def self.enable_lsp_mode
+        @lsp_mode = true
+      end
+
+      # This experimental feature has been under consideration for a while.
+      def self.disable_lsp_mode
+        @lsp_mode = false
+      end
+
       ### Naming
 
       def self.badge
@@ -480,12 +498,6 @@ module RuboCop
           range.begin_pos + @current_offset,
           range.end_pos + @current_offset
         )
-      end
-
-      # This experimental feature has been under consideration for a while.
-      # @api private
-      def lsp_mode?
-        ARGV.include?('--lsp')
       end
     end
   end

--- a/lib/rubocop/cop/lint/syntax.rb
+++ b/lib/rubocop/cop/lint/syntax.rb
@@ -17,7 +17,7 @@ module RuboCop
         private
 
         def add_offense_from_diagnostic(diagnostic, ruby_version)
-          message = if lsp_mode?
+          message = if Base.lsp_mode?
                       diagnostic.message
                     else
                       "#{diagnostic.message}\n(Using Ruby #{ruby_version} parser; " \

--- a/lib/rubocop/lsp/server.rb
+++ b/lib/rubocop/lsp/server.rb
@@ -20,6 +20,8 @@ module RuboCop
     # @api private
     class Server
       def initialize(config_store)
+        RuboCop::Cop::Base.enable_lsp_mode
+
         @reader = LanguageServer::Protocol::Transport::Io::Reader.new($stdin)
         @writer = LanguageServer::Protocol::Transport::Io::Writer.new($stdout)
         @runtime = RuboCop::Lsp::Runtime.new(config_store)

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -130,7 +130,11 @@ end
 
 RSpec.shared_context 'lsp mode' do
   before do
-    allow(cop).to receive(:lsp_mode?).and_return(true)
+    RuboCop::Cop::Base.enable_lsp_mode
+  end
+
+  after do
+    RuboCop::Cop::Base.disable_lsp_mode
   end
 end
 

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe RuboCop::Lsp::Server, :isolated_environment do
 
   subject(:result) { run_server_on_requests(*requests) }
 
+  after do
+    RuboCop::Cop::Base.disable_lsp_mode
+  end
+
   let(:messages) { result[0] }
   let(:stderr) { result[1].string }
 


### PR DESCRIPTION
The original LSP mode determination relied on the `--lsp` command-line argument, making it hard to set the mode from 3rd party LSP(-like) tools. This PR refines the API to resolve this issue. Additionally, as a side effect, it improves the mocking part of spec.

However, the APIs are still experimental and not yet mature.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
