### PR TITLE
Fix numblock regressions in `omit_parentheses` Style/MethodCallWithArgsParentheses`

### DIFF
--- a/changelog/fix_numblock_regressions_in_omit_parentheses.md
+++ b/changelog/fix_numblock_regressions_in_omit_parentheses.md
@@ -1,0 +1,1 @@
+* [#12648](https://github.com/rubocop/rubocop/pull/12648): Fix numblock regressions in `omit_parentheses` `Style/MethodCallWithArgsParentheses`. ([@gsamokovarov][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -132,7 +132,7 @@ module RuboCop
               call_in_match_pattern?(node) ||
               hash_literal_in_arguments?(node) ||
               node.descendants.any? do |n|
-                n.forwarded_args_type? || n.block_type? ||
+                n.forwarded_args_type? || n.block_type? || n.numblock_type? ||
                   ambiguous_literal?(n) || logical_operator?(n)
               end
           end

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -771,6 +771,18 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('foo(1) { 2 }')
     end
 
+    it 'accepts parens around argument values with blocks' do
+      expect_no_offenses(<<~RUBY)
+        Foo::Bar.find(pending.things.map { |t| t['code'] }.first)
+      RUBY
+    end
+
+    it 'accepts parens around argument values with numblocks', :ruby27 do
+      expect_no_offenses(<<~RUBY)
+        Foo::Bar.find(pending.things.map { _1['code'] })
+      RUBY
+    end
+
     it 'accepts parens in array literal calls with blocks' do
       expect_no_offenses(<<~RUBY)
         [
@@ -1016,6 +1028,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
 
       it 'accepts no parens in the last call if previous calls with parens' do
         expect_no_offenses('foo().bar(3).wait 4')
+      end
+
+      it 'accept parens when previously chained sends have numblocks', :ruby27 do
+        expect_no_offenses(<<~RUBY)
+          [a, b].map { _1.call 'something' }.uniq.join(' - ')
+        RUBY
       end
 
       it 'accepts parens in the last call if any previous calls with parentheses' do


### PR DESCRIPTION
My [last change](https://github.com/rubocop/rubocop/pull/12610) was trying to fix an edge case where RuboCop wanted us to remove parentheses in the following example, but removing the parens was resulting in a `SyntaxError`:

```ruby
AnyCable.middleware.use(
  Class.new(AnyCable::Middleware) do
           ^^^^^^^^^^^^^^^^^^^^^^ Omit parentheses for method calls with arguments.
    pass
  end
)
```

As it often happens, though, I broke a few other cases where we now want to remove parens, while the removal can result in ambiguous code:

**Case 1**

```ruby
Foo::Bar.find(pending.things.map { _1['code'] })
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Omit parentheses for method calls with arguments.
```

While we can remove the parentheses in *Case 1*, the author has to be well aware of the difference between the do/end and braced blocks method bounding semantics. Allowing the author to put the parens can remove this ambiguity and we used to allow it.

**Case 2**

```ruby
[a, b].map { _1.call 'something' }.uniq.join(' - ')
                                            ^^^^^^^ Omit parentheses for method calls with arguments.
```

If we set `AllowParenthesesInChaining: true`, we should allow parentheses in chained calls. However, this is broken in current RuboCop.

Both of the issues were caused by a 'refactoring' that replaced a braced block check that handled `numblock`s with a more general `block` check while forgetting about `numblock`s.