### PR TITLE
[Fix #12649] Fix false positives for `Style/InverseMethods`

### DIFF
--- a/changelog/fix_false_positives_for_style_inverse_methods.md
+++ b/changelog/fix_false_positives_for_style_inverse_methods.md
@@ -1,0 +1,1 @@
+* [#12649](https://github.com/rubocop/rubocop/issues/12649): Fix false positives for `Style/InverseMethods` when using relational comparison operator with safe navigation. ([@koic][])

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -76,9 +76,9 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          inverse_candidate?(node) do |_method_call, lhs, method, rhs|
+          inverse_candidate?(node) do |method_call, lhs, method, rhs|
             return unless inverse_methods.key?(method)
-            return if negated?(node)
+            return if negated?(node) || relational_comparison_with_safe_navigation?(method_call)
             return if part_of_ignored_node?(node)
             return if possible_class_hierarchy_check?(lhs, rhs, method)
 
@@ -153,6 +153,10 @@ module RuboCop
 
         def negated?(node)
           node.parent.respond_to?(:method?) && node.parent.method?(:!)
+        end
+
+        def relational_comparison_with_safe_navigation?(node)
+          node.csend_type? && CLASS_COMPARISON_METHODS.include?(node.method_name)
         end
 
         def not_to_receiver(node, method_call)

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -209,6 +209,30 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods, :config do
     end
   end
 
+  it 'allows comparing for relational comparison operator (`<`) with safe navigation operator' do
+    expect_no_offenses(<<~RUBY)
+      !nullable&.<(0)
+    RUBY
+  end
+
+  it 'allows comparing for relational comparison operator (`<=`) with safe navigation operator' do
+    expect_no_offenses(<<~RUBY)
+      !nullable&.<=(0)
+    RUBY
+  end
+
+  it 'allows comparing for relational comparison operator (`>`) with safe navigation operator' do
+    expect_no_offenses(<<~RUBY)
+      !nullable&.>(0)
+    RUBY
+  end
+
+  it 'allows comparing for relational comparison operator (`>=`) with safe navigation operator' do
+    expect_no_offenses(<<~RUBY)
+      !nullable&.>=(0)
+    RUBY
+  end
+
   it 'allows comparing camel case constants on the right' do
     expect_no_offenses(<<~RUBY)
       klass = self.class


### PR DESCRIPTION
Fixes #12649.

This PR fixes false positives for `Style/InverseMethods` when using relational comparison operator with safe navigation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
