### PR TITLE
Revert "Add default tags to issue templates"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,6 @@
 ---
 name: Bug Report
 about: Report an issue with RuboCop you've discovered.
-labels: bug
 ---
 
 *Be clear, concise and precise in your description of the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,6 @@
 ---
 name: Feature Request
 about: Suggest new RuboCop features or improvements to existing features.
-labels: enhancement
 ---
 
 ## Is your feature request related to a problem? Please describe.


### PR DESCRIPTION
Reverts #12644.

It's been a few days since the introduction, but there are false reports of the "bug" label being applied to items that are not confirmed as bugs or are not bugs. The default "bug" label is confusing for unconfirmed feedback. Despite considering user likelihood to change labels, submissions are often made with the default.

For feature request, sometimes labels other than "enhancement", like "feature" or others, are more appropriate.

Labeling can suit mechanical operations (e.g., bot), but may not fit uncertain feedback needing review, as seen in this repository.

To avoid misleading labels on unresolved issues, the default labels will be removed from the issue template for maintenance reasons.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
