### PR TITLE
Fix an error for `Layout/RedundantLineBreak`

### DIFF
--- a/changelog/fix_error_for_layout_redundant_line_break.md
+++ b/changelog/fix_error_for_layout_redundant_line_break.md
@@ -1,0 +1,1 @@
+* [#12656](https://github.com/rubocop/rubocop/pull/12656): Fix an error for `Layout/RedundantLineBreak` when using index access call chained on multiline hash literal. ([@koic][])

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -89,7 +89,9 @@ module RuboCop
         end
 
         def index_access_call_chained?(node)
-          node.send_type? && node.method?(:[]) && node.children.first.method?(:[])
+          return false unless node.send_type? && node.method?(:[])
+
+          node.children.first.send_type? && node.children.first.method?(:[])
         end
 
         def configured_to_not_be_inspected?(node)

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -159,6 +159,19 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
         RUBY
       end
 
+      it 'registers an offense for index access call chained on multiline hash literal' do
+        expect_offense(<<~RUBY)
+          {
+          ^ Redundant line break detected.
+            key: value
+          }[key]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          { key: value }[key]
+        RUBY
+      end
+
       context 'with LineLength Max 100' do
         let(:max_line_length) { 100 }
 


### PR DESCRIPTION
This PR fixes the following error for `Layout/RedundantLineBreak` when using index access call chained on multiline hash literal:

```console
$ cat example.rb
{
  key: value
}[key]

$ bundle exec rubocop --only Layout/RedundantLineBreak -a -d
(snip)

An error occurred while Layout/RedundantLineBreak cop was inspecting /tmp/example.rb:1:0.
undefined method `method?' for an instance of RuboCop::AST::HashNode
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/layout/redundant_line_break.rb:92:in `index_access_call_chained?'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
