### PR TITLE
Support `AutoCorrect: contextual` option for LSP

### DIFF
--- a/changelog/new_extend_autocorrect_option_for_lsp.md
+++ b/changelog/new_extend_autocorrect_option_for_lsp.md
@@ -1,0 +1,1 @@
+* [#12657](https://github.com/rubocop/rubocop/pull/12657): Support `AutoCorrect: contextual` option for LSP. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -556,7 +556,9 @@ Layout/ElseAlignment:
 Layout/EmptyComment:
   Description: 'Checks empty comment.'
   Enabled: true
+  AutoCorrect: contextual
   VersionAdded: '0.53'
+  VersionChanged: '<<next>>'
   AllowBorderComment: true
   AllowMarginComment: true
 
@@ -1825,16 +1827,18 @@ Lint/EmptyClass:
 Lint/EmptyConditionalBody:
   Description: 'Checks for the presence of `if`, `elsif` and `unless` branches without a body.'
   Enabled: true
+  AutoCorrect: contextual
   SafeAutoCorrect: false
   AllowComments: true
   VersionAdded: '0.89'
-  VersionChanged: '1.34'
+  VersionChanged: '<<next>>'
 
 Lint/EmptyEnsure:
   Description: 'Checks for empty ensure block.'
   Enabled: true
+  AutoCorrect: contextual
   VersionAdded: '0.10'
-  VersionChanged: '0.48'
+  VersionChanged: '<<next>>'
 
 Lint/EmptyExpression:
   Description: 'Checks for empty expressions.'
@@ -1856,8 +1860,9 @@ Lint/EmptyInPattern:
 Lint/EmptyInterpolation:
   Description: 'Checks for empty string interpolation.'
   Enabled: true
+  AutoCorrect: contextual
   VersionAdded: '0.20'
-  VersionChanged: '0.45'
+  VersionChanged: '<<next>>'
 
 Lint/EmptyWhen:
   Description: 'Checks for `when` branches with empty bodies.'
@@ -2395,7 +2400,9 @@ Lint/TopLevelReturnWithArgument:
 Lint/TrailingCommaInAttributeDeclaration:
   Description: 'Checks for trailing commas in attribute declarations.'
   Enabled: true
+  AutoCorrect: contextual
   VersionAdded: '0.90'
+  VersionChanged: '<<next>>'
 
 Lint/TripleQuotes:
   Description: 'Checks for useless triple quote constructs.'
@@ -2455,8 +2462,9 @@ Lint/UnusedBlockArgument:
   Description: 'Checks for unused block arguments.'
   StyleGuide: '#underscore-unused-vars'
   Enabled: true
+  AutoCorrect: contextual
   VersionAdded: '0.21'
-  VersionChanged: '0.22'
+  VersionChanged: '<<next>>'
   IgnoreEmptyBlocks: true
   AllowUnusedKeywordArguments: false
 
@@ -2464,8 +2472,9 @@ Lint/UnusedMethodArgument:
   Description: 'Checks for unused method arguments.'
   StyleGuide: '#underscore-unused-vars'
   Enabled: true
+  AutoCorrect: contextual
   VersionAdded: '0.21'
-  VersionChanged: '0.81'
+  VersionChanged: '<<next>>'
   AllowUnusedKeywordArguments: false
   IgnoreEmptyMethods: true
   IgnoreNotImplementedMethods: true
@@ -2489,8 +2498,9 @@ Lint/UriRegexp:
 Lint/UselessAccessModifier:
   Description: 'Checks for useless access modifiers.'
   Enabled: true
+  AutoCorrect: contextual
   VersionAdded: '0.20'
-  VersionChanged: '0.83'
+  VersionChanged: '<<next>>'
   ContextCreatingMethods: []
   MethodCreatingMethods: []
 
@@ -2498,8 +2508,9 @@ Lint/UselessAssignment:
   Description: 'Checks for useless assignment to a local variable.'
   StyleGuide: '#underscore-unused-vars'
   Enabled: true
+  AutoCorrect: contextual
   VersionAdded: '0.11'
-  VersionChanged: '1.51'
+  VersionChanged: '<<next>>'
   SafeAutoCorrect: false
 
 Lint/UselessElseWithoutRescue:
@@ -2511,8 +2522,9 @@ Lint/UselessElseWithoutRescue:
 Lint/UselessMethodDefinition:
   Description: 'Checks for useless method definitions.'
   Enabled: true
+  AutoCorrect: contextual
   VersionAdded: '0.90'
-  VersionChanged: '0.91'
+  VersionChanged: '<<next>>'
   Safe: false
 
 Lint/UselessRescue:
@@ -2535,13 +2547,17 @@ Lint/UselessSetterCall:
 Lint/UselessTimes:
   Description: 'Checks for useless `Integer#times` calls.'
   Enabled: true
-  VersionAdded: '0.91'
   Safe: false
+  AutoCorrect: contextual
+  VersionAdded: '0.91'
+  VersionChanged: '<<next>>'
 
 Lint/Void:
   Description: 'Possible use of operator/literal/variable in void context.'
   Enabled: true
+  AutoCorrect: contextual
   VersionAdded: '0.9'
+  VersionChanged: '<<next>>'
   CheckForMethodsWithNoSideEffects: false
 
 #################### Metrics ###############################
@@ -3701,8 +3717,9 @@ Style/EmptyCaseCondition:
 Style/EmptyElse:
   Description: 'Avoid empty else-clauses.'
   Enabled: true
+  AutoCorrect: contextual
   VersionAdded: '0.28'
-  VersionChanged: '0.32'
+  VersionChanged: '<<next>>'
   EnforcedStyle: both
   # empty - warn only on empty `else`
   # nil - warn on `else` with nil in it
@@ -3716,7 +3733,9 @@ Style/EmptyElse:
 Style/EmptyHeredoc:
   Description: 'Checks for using empty heredoc to reduce redundancy.'
   Enabled: pending
+  AutoCorrect: contextual
   VersionAdded: '1.32'
+  VersionChanged: '<<next>>'
 
 Style/EmptyLambdaParameter:
   Description: 'Omit parens for empty lambda parameters.'
@@ -3734,7 +3753,9 @@ Style/EmptyMethod:
   Description: 'Checks the formatting of empty method definitions.'
   StyleGuide: '#no-single-line-methods'
   Enabled: true
+  AutoCorrect: contextual
   VersionAdded: '0.46'
+  VersionChanged: '<<next>>'
   EnforcedStyle: compact
   SupportedStyles:
     - compact
@@ -4978,10 +4999,11 @@ Style/RedundantHeredocDelimiterQuotes:
 Style/RedundantInitialize:
   Description: 'Checks for redundant `initialize` methods.'
   Enabled: pending
+  AutoCorrect: contextual
   Safe: false
   AllowComments: true
   VersionAdded: '1.27'
-  VersionChanged: '1.28'
+  VersionChanged: '<<next>>'
 
 Style/RedundantInterpolation:
   Description: 'Checks for strings that are just an interpolated expression.'

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -567,13 +567,46 @@ These details will only be seen when RuboCop is run with the `--extra-details` f
 
 === AutoCorrect
 
-Cops that support the `--autocorrect` option can have that support
-disabled. For example:
+Cops that support the `--autocorrect` option offer flexible settings for autocorrection.
+These settings can be specified in the configuration file as follows:
+
+- `always`
+- `contextual`
+- `disabled`
+
+==== `always (Default)`
+
+This setting enables autocorrection always by default. For backward compatibility, `true` is treated the same as `always`.
 
 [source,yaml]
 ----
 Style/PerlBackrefs:
-  AutoCorrect: false
+  AutoCorrect: always # or true
+----
+
+==== `contextual`
+
+This setting enables autocorrection when launched from the `rubocop` command, but it is not available through LSP.
+e.g., `rubocop --lsp` or a program where `RuboCop::LSP.enable` has been applied.
+
+Inspections via the command line are treated as code that has been finalized.
+
+[source,yaml]
+----
+Style/PerlBackrefs:
+  AutoCorrect: contextual
+----
+
+This setting prevents autocorrection during editing in the editor.
+
+==== `disabled`
+
+This setting disables autocorrection. For backward compatibility, `false` is treated the same as `disabled`.
+
+[source,yaml]
+----
+Style/PerlBackrefs:
+  AutoCorrect: disabled # or false
 ----
 
 == Common configuration parameters

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -32,7 +32,12 @@ module RuboCop
         # allow turning off autocorrect on a cop by cop basis
         return true unless cop_config
 
-        return false if cop_config['AutoCorrect'] == false
+        # `false` is the same as `disabled` for backward compatibility.
+        return false if ['disabled', false].include?(cop_config['AutoCorrect'])
+
+        # When LSP is enabled, it is considered as editing source code,
+        # and autocorrection with `AutoCorrect: contextual` will not be performed.
+        return false if contextual_autocorrect? && LSP.enabled?
 
         # :safe_autocorrect is a derived option based on several command-line
         # arguments - see RuboCop::Options#add_autocorrection_options

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -305,6 +305,17 @@ module RuboCop
         @current_original = original
       end
 
+      # @api private
+      def always_autocorrect?
+        # `true` is the same as `'always'` for backward compatibility.
+        ['always', true].include?(cop_config.fetch('AutoCorrect', 'always'))
+      end
+
+      # @api private
+      def contextual_autocorrect?
+        cop_config.fetch('AutoCorrect', 'always') == 'contextual'
+      end
+
       def inspect # :nodoc:
         "#<#{self.class.name}:#{object_id} @config=#{@config} @options=#{@options}>"
       end
@@ -389,7 +400,7 @@ module RuboCop
       def use_corrector(range, corrector)
         if autocorrect?
           attempt_correction(range, corrector)
-        elsif corrector && cop_config.fetch('AutoCorrect', true)
+        elsif corrector && (always_autocorrect? || (contextual_autocorrect? && !LSP.enabled?))
           :uncorrected
         else
           :unsupported

--- a/lib/rubocop/cops_documentation_generator.rb
+++ b/lib/rubocop/cops_documentation_generator.rb
@@ -97,7 +97,9 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
       'Version Changed'
     ]
     autocorrect = if cop.support_autocorrect?
-                    "Yes#{' (Unsafe)' unless cop.new(config).safe_autocorrect?}"
+                    context = cop.new.always_autocorrect? ? 'Always' : 'Command-line only'
+
+                    "#{context}#{' (Unsafe)' unless cop.new(config).safe_autocorrect?}"
                   else
                     'No'
                   end

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -100,10 +100,10 @@ RSpec.shared_context 'config' do # rubocop:disable Metrics/BlockLength
   let(:cur_cop_config) do
     RuboCop::ConfigLoader
       .default_configuration.for_cop(cop_class)
-      .merge({
-               'Enabled' => true, # in case it is 'pending'
-               'AutoCorrect' => true # in case defaults set it to false
-             })
+      .merge(
+        'Enabled' => true, # in case it is 'pending'
+        'AutoCorrect' => 'always' # in case defaults set it to 'disabled' or false
+      )
       .merge(cop_config)
   end
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1077,7 +1077,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     create_file('example.rb', source)
     create_file('.rubocop.yml', <<~YAML)
       Layout/DefEndAlignment:
-        AutoCorrect: true
+        AutoCorrect: always
     YAML
     expect(cli.run(['--autocorrect-all'])).to eq(0)
     corrected = <<~RUBY
@@ -1869,7 +1869,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       AllCops:
         TargetRubyVersion: 2.7
       Style/Semicolon:
-        AutoCorrect: false
+        AutoCorrect: disabled
     YAML
     create_file('example.rb', src)
     exit_status = cli.run(
@@ -1942,7 +1942,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     create_file('example.rb', 'puts "Hello", 123456')
     create_file('.rubocop.yml', <<~YAML)
       Style/StringLiterals:
-        AutoCorrect: false
+        AutoCorrect: disabled
     YAML
     expect(cli.run(%w[--autocorrect-all])).to eq(1)
     expect($stderr.string).to eq('')
@@ -2852,7 +2852,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     create_file('.rubocop.yml', <<~YAML)
       Layout/BeginEndAlignment:
         EnforcedStyleAlignWith: start_of_line
-        AutoCorrect: true
+        AutoCorrect: always
 
       Layout/CaseIndentation:
         EnforcedStyle: end

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -2006,11 +2006,11 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       end
     end
 
-    context 'when setting `AutoCorrect: false` for `Style/StringLiterals`' do
+    context 'when setting `AutoCorrect: disabled` for `Style/StringLiterals`' do
       before do
         create_file('.rubocop.yml', <<~YAML)
           Style/StringLiterals:
-            AutoCorrect: false
+            AutoCorrect: disabled
         YAML
       end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1820,6 +1820,29 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
   end
 
   describe 'configuration of `AutoCorrect`' do
+    context 'when setting `AutoCorrect: disabled` for `Style/StringLiterals`' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          Style/StringLiterals:
+            AutoCorrect: disabled
+        YAML
+      end
+
+      it 'does not suggest `1 offense autocorrectable` for `Style/StringLiterals`' do
+        create_file('example.rb', <<~RUBY)
+          # frozen_string_literal: true
+
+          a = "Hello"
+        RUBY
+
+        expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
+        expect($stdout.string.lines.to_a.last).to eq(
+          "1 file inspected, 2 offenses detected, 1 offense autocorrectable\n"
+        )
+      end
+    end
+
+    # For backward compatibility, `false` is treated the same as `'disabled'`.
     context 'when setting `AutoCorrect: false` for `Style/StringLiterals`' do
       before do
         create_file('.rubocop.yml', <<~YAML)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1709,6 +1709,24 @@ RSpec.describe RuboCop::ConfigLoader do
       end
     end
 
+    context 'does not set `always`, `contextual`, `disabled`, or boolean to `AutoCorrect`' do
+      before do
+        create_file(configuration_path, <<~YAML)
+          Layout/EmptyComment:
+            AutoCorrect: unknown
+        YAML
+      end
+
+      it 'gets a warning message' do
+        expect do
+          load_file
+        end.to raise_error(
+          RuboCop::ValidationError,
+          /supposed to be `always`, `contextual`, `disabled`, or a boolean and unknown is not/
+        )
+      end
+    end
+
     context 'does not set `pending`, `disable`, or `enable` to `NewCops`' do
       before do
         create_file(configuration_path, <<~YAML)

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -195,6 +195,51 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
     end
   end
 
+  describe 'format by default (safe autocorrect) with an `AutoCorrect: contextual` cop' do
+    let(:empty_comment) { "##{eol}" }
+
+    let(:requests) do
+      [
+        {
+          jsonrpc: '2.0',
+          method: 'textDocument/didOpen',
+          params: {
+            textDocument: {
+              languageId: 'ruby',
+              text: empty_comment,
+              uri: 'file:///path/to/file.rb',
+              version: 0
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          method: 'textDocument/didChange',
+          params: {
+            contentChanges: [{ text: empty_comment }],
+            textDocument: {
+              uri: 'file:///path/to/file.rb',
+              version: 10
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          id: 20,
+          method: 'textDocument/formatting',
+          params: {
+            options: { insertSpaces: true, tabSize: 2 },
+            textDocument: { uri: 'file:///path/to/file.rb' }
+          }
+        }
+      ]
+    end
+
+    it 'handles requests, but does not autocorrect with `Layout/EmptyComment` as an `AutoCorrect: contextual` cop' do
+      expect(stderr).to eq('')
+      format_result = messages.last
+      expect(format_result).to eq(jsonrpc: '2.0', id: 20, result: [])
+    end
+  end
+
   describe 'format with `safeAutocorrect: true`' do
     let(:requests) do
       [


### PR DESCRIPTION
## Summary

This PR introduces `AutoCorrect: contextual` option that prevents autocorrection during typing in LSP.

This option extends the existing `AutoCorrect` parameter.

- Before: `AutoCorrect: true` or `AutoCorrect: false`
- After: `AutoCorrect: always`, `AutoCorrect: disabled`, or `AutoCorrect: contextual`

Note, `AutoCorrect: always` maintains compatibility with `AutoCorrect: true`,
and `AutoCorrect: disabled` maintains compatibility with `AutoCorrect: false`.

## Details

For example, `Style/EmptyMethod` should not autocorrect to one-liner while in the process of writing the body of the method.
This isn't an issue with autocorrection itself, but rather due to differing requirements in contexts such as editing (LSP) and command line (e.g., CI).

So, `AutoCorrect: contextual` is set for some cops like this. There may be other cases, but for the obvious following cops. The classification is as follows:

### Cops that might remove code being edited

- `Layout/EmptyComment` cop
- `Lint/EmptyConditionalBody` cop
- `Lint/EmptyEnsure` cop
- `Lint/EmptyInterpolation` cop
- `Lint/TrailingCommaInAttributeDeclaration` cop
- `Lint/UselessAccessModifier` cop
- `Lint/UselessAssignment` cop
- `Lint/UselessMethodDefinition` cop
- `Lint/UselessTimes` cop
- `Lint/Void` cop
- `Style/EmptyElse` cop
- `Style/RedundantInitialize` cop

### Cops that might adjust code being edited

- `Lint/UnusedBlockArgument` cop
- `Lint/UnusedMethodArgument` cop
- `Style/EmptyHeredoc` cop
- `Style/EmptyMethod` cop

As a result, it allows for a distinction in the use of autocorrection between the LSP and command-line contexts.

## Other Information

Here is why the parameter name was chosen as `contextual`.

In this PR, autocorrection from LSP is always not applied in the case of `contextual`. However, even when `contextual` is set, I was considering a possibility for autocorrection to be forcibly applied from LSP under certain conditions.

Therefore, the initial thought was to name it `contextual`, but it might have been too abstract in context, so it was changed to `contextual`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
