### PR TITLE
Fixes bug in `Metrics/MethodLength` cop. The cop does not count block comments even though count comments setting is turned off.

### DIFF
--- a/changelog/fix_adds_count_comments_flag_and_cleanup.md
+++ b/changelog/fix_adds_count_comments_flag_and_cleanup.md
@@ -1,0 +1,1 @@
+* [#12658](https://github.com/rubocop/rubocop/pull/12658): Fixes bug in `Metrics/MethodLength` cop: the cop does not count block comments even though count comments setting is turned on. ([@KarlHeitmann][])

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -79,8 +79,8 @@ module RuboCop
                   body.source.lines
                 end
 
-              source = clean_block_comments(source, false) if true
-              source.count { |line| !irrelevant_line?(line) } # This filters out the comments
+              source = clean_block_comments(source, false) unless count_comments?
+              source.count { |line| !irrelevant_line?(line) }
             end
           end
 
@@ -112,10 +112,13 @@ module RuboCop
                                   line_numbers_of_inner_nodes(node, :module, :class)
 
             # OPTIMIZE: too much loops over the target_line_numbers array
-            clean_block_comments(
-              target_line_numbers.map { |line_number| @processed_source[line_number] }, false
-            )
-              .reduce(0) do |length, source_line|
+            if count_comments?
+              target_line_numbers.map { |line_number| @processed_source[line_number] }
+            else
+              clean_block_comments(
+                target_line_numbers.map { |line_number| @processed_source[line_number] }, false
+              )
+            end.reduce(0) do |length, source_line|
               next length if irrelevant_line?(source_line) # TARGET
 
               length + 1

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -79,7 +79,27 @@ module RuboCop
                   body.source.lines
                 end
 
-              source.count { |line| !irrelevant_line?(line) }
+              source = clean_block_comments(source, false) if true
+              source.count { |line| !irrelevant_line?(line) } # This filters out the comments
+            end
+          end
+
+          def clean_block_comments(lines, inside_block_comment)
+            return [] if lines.empty?
+
+            head = lines.shift
+            if inside_block_comment
+              if head[..3] == '=end'
+                return [] + clean_block_comments(lines, false)
+              else
+                return [] + clean_block_comments(lines, true)
+              end
+            else
+              if head[..5] == '=begin'
+                return [] + clean_block_comments(lines, true)
+              else
+                return [head] + clean_block_comments(lines, false)
+              end
             end
           end
 

--- a/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
@@ -336,6 +336,24 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::CodeLengthCalculator do
     end
 
     context 'when class' do
+      context 'when contains block comment' do
+        it 'calculates class length' do
+          source = parse_source(<<~RUBY)
+            class Test
+              a = 1
+            =begin
+                z = 9
+            =end
+              # a = 2
+              a = 3
+            end
+          RUBY
+
+          length = described_class.new(source.ast, source).calculate
+          expect(length).to eq(2)
+        end
+      end
+
       it 'calculates class length' do
         source = parse_source(<<~RUBY)
           class Test

--- a/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
@@ -19,6 +19,29 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::CodeLengthCalculator do
         expect(length).to eq(5)
       end
 
+      context 'block comments' do
+        it 'does not count block comments in the middle of a method definition' do
+          source = parse_source(<<~RUBY)
+            def testting
+              a = 1
+              # This is a comment
+            =begin
+            kkkkkk = 92
+            =end
+              # ANOTHER comment
+            =begin
+            a = 6
+            =end
+              b = 2
+            end
+          RUBY
+
+          # source is a ProcessedSource, and node is source.ast
+          length = described_class.new(source.ast, source).calculate
+          expect(length).to eq(2)
+        end
+      end
+
       it 'does not count blank lines' do
         source = parse_source(<<~RUBY)
           def test

--- a/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::CodeLengthCalculator do
             end
           RUBY
 
-          # source is a ProcessedSource, and node is source.ast
           length = described_class.new(source.ast, source).calculate
           expect(length).to eq(2)
         end


### PR DESCRIPTION
**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

The other day I was trying to reduce the number of lines in the methods of my project. I am not a big fan of block comments but I usually use them to toggle code snippets I want to test later on. I discovered my rubocop LSP instance was complaining that the method had a lot of lines, that was because I commented with `=begin ... =end` _a lot_ of lines.

The code changes on this PR attempts to fix the issue, so it will not count block comments. The main problem is this "bad API" [method](https://github.com/rubocop/rubocop/blob/b6ee1c20a553e13c404b0b48137a17120a64e176/lib/rubocop/cop/util.rb#L17) was used by [CodeLengthCalculator#irrelevant_line?](https://github.com/rubocop/rubocop/blob/b6ee1c20a553e13c404b0b48137a17120a64e176/lib/rubocop/cop/metrics/utils/code_length_calculator.rb#L160). So, block comments were not considered by the `CodeLengthCalculator` (because the regex in the "bad API" method does not catch multiline comments (ie, block comments)).

My first approach to solve the issue consisted in using [@processed_source](https://github.com/rubocop/rubocop/blob/b6ee1c20a553e13c404b0b48137a17120a64e176/lib/rubocop/cop/metrics/utils/code_length_calculator.rb#L18) to analyze its tokens array. But I found out that the tokens array value is set using [tokenise(create_parser(ruby_version))](https://github.com/rubocop/rubocop-ast/blob/fa414056753a0682aa4ce18270f1c9263e902e0f/lib/rubocop/ast/processed_source.rb#L210). `create_parser` must use a specific ruby version class depending on the ruby version used. After realizing that, I thought "Mmmhh... maybe this `create_parser` method is very expensive in terms of computation and maybe I should not use it..."

Then, I decided to follow a simpler approach: find all the places [irrelevant_line?](https://github.com/rubocop/rubocop/blob/b6ee1c20a553e13c404b0b48137a17120a64e176/lib/rubocop/cop/metrics/utils/code_length_calculator.rb#L159) method is called, and add a filter stage just before the method is called. The filter stage consists in calling a [recursive method](https://github.com/KarlHeitmann/rubocop/blob/2efb69bdf89914f018b86f5333cefc965509cef3/lib/rubocop/cop/metrics/utils/code_length_calculator.rb#L87) that will remove all lines between a `"=begin"` tag, and `"=end"` tag.

For example, by using this [CodeLengthCalculator#clean_block_comments](https://github.com/KarlHeitmann/rubocop/blob/2efb69bdf89914f018b86f5333cefc965509cef3/lib/rubocop/cop/metrics/utils/code_length_calculator.rb#L87) recursive method, you will transform this array:

```ruby
["a = 1\n", "  # This is a comment\n", "=begin\n", "kkkkkk = 92\n", "=end\n", "  # ANOTHER comment\n", "=begin\n", "a = 6\n", "=end\n", "  b = 2"]
```

and convert that array into this one:

```ruby
["a = 1\n", "  # This is a comment\n", "  # ANOTHER comment\n", "  b = 2"]
```

My solution seems to work, I can add more tests to it if you want more. But I'd love to make a more efficient solution to this bug. Any feedback is welcome.

### Notes on the checklist item:

- I don't know if is worth to squash at least the 2 first commits of this PR. If you'd like me to squash the first 2 or all the commits into one, just ping me here.
- I've introduced some alerts: `Metrics/PerceivedComplexity` and `Metrics/AbcSize`. I don't know how to solve these two issues.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
