### PR TITLE
Resolve Fixme in Gemfile, remove bigdecimal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,9 +25,6 @@ group :test do
   # FIXME: This `base64` dependency can be removed when https://github.com/bblimke/webmock/pull/1041
   # is merged and released. It's a workaround until then.
   gem 'base64'
-  # FIXME: This `bigdecimal` dependency can be removed when https://github.com/jnunemaker/crack/pull/75
-  # is merged and released. It's a workaround until then.
-  gem 'bigdecimal', platform: %i[mri windows]
   gem 'webmock', require: false
 end
 


### PR DESCRIPTION
This is a follow up on https://github.com/rubocop/rubocop/pull/12153 . The mentioned PR was merged in to `crack` and released as v0.4.6

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
