### PR TITLE
Update `crack` to v0.4.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,9 +25,7 @@ group :test do
   # FIXME: This `base64` dependency can be removed when https://github.com/bblimke/webmock/pull/1041
   # is merged and released. It's a workaround until then.
   gem 'base64'
-  # FIXME: This `bigdecimal` dependency can be removed when https://github.com/jnunemaker/crack/pull/75
-  # is merged and released. It's a workaround until then.
-  gem 'bigdecimal', platform: %i[mri windows]
+  gem 'crack', '>= 0.4.6' # Needed for webmock on Ruby 3.3
   gem 'webmock', require: false
 end
 


### PR DESCRIPTION
https://github.com/jnunemaker/crack/pull/75 was merged so this should allow the `bigdecimal` dependency to be removed.