### PR TITLE
Handle case when `node.receiver` is `nil` in `Style/InvertibleUnlessCondition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#12661](https://github.com/rubocop/rubocop/pull/12661): Fix error when running `Style/InvertibleUnlessCondition` on node with no receiver. ([@shioyama][])
+
 ## 1.60.2 (2024-01-24)
 
 ### Bug fixes
@@ -7579,3 +7583,4 @@
 [@kpost]: https://github.com/kpost
 [@marocchino]: https://github.com/marocchino
 [@Strzesia]: https://github.com/Strzesia
+[@shioyama]: https://github.com/shioyama

--- a/spec/rubocop/cop/style/invertible_unless_condition_spec.rb
+++ b/spec/rubocop/cop/style/invertible_unless_condition_spec.rb
@@ -114,4 +114,14 @@ RSpec.describe RuboCop::Cop::Style::InvertibleUnlessCondition, :config do
       foo if !condition
     RUBY
   end
+
+  it 'registers correct offense when there is no receiver' do
+    expect_offense(<<~RUBY)
+      module Bar
+        unless include?(Kernel)
+        ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `if exclude?(Kernel)` over `unless include?(Kernel)`.
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
`Style/InvertibleUnlessCondition` changes in https://github.com/rubocop/rubocop/pull/12562 caused this cop to fail in the case where the node `receiver` is `nil`. See the failing test. I made a fix.

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
