### PR TITLE
Fix handling of textDocument/diagnostic

### DIFF
--- a/changelog/fix_handling_of_text_document_diagnostic.md
+++ b/changelog/fix_handling_of_text_document_diagnostic.md
@@ -1,0 +1,1 @@
+* [#12664](https://github.com/rubocop/rubocop/pull/12664): Fix handling of `textDocument/diagnostic`. ([@muxcmux][])

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -73,9 +73,7 @@ module RuboCop
       end
 
       handle 'textDocument/diagnostic' do |request|
-        doc = request[:params][:textDocument]
-        result = diagnostic(doc[:uri], doc[:text])
-        @server.write(result)
+        # no-op, diagnostics are handled in textDocument/didChange
       end
 
       handle 'textDocument/didChange' do |request|

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -103,10 +103,7 @@ RSpec.describe RuboCop::Lsp::Server, :isolated_environment do
         method: 'textDocument/diagnostic',
         params: {
           textDocument: {
-            languageId: 'ruby',
-            text: "def hi#{eol}  [1, 2,#{eol}   3  ]#{eol}end#{eol}",
-            uri: 'file:///path/to/file.rb',
-            version: 0
+            uri: 'file:///path/to/file.rb'
           }
         }
       ]
@@ -114,32 +111,7 @@ RSpec.describe RuboCop::Lsp::Server, :isolated_environment do
 
     it 'handles requests' do
       expect(stderr).to eq('')
-      expect(messages.count).to eq(1)
-      expect(messages.first).to eq(
-        jsonrpc: '2.0',
-        method: 'textDocument/publishDiagnostics',
-        params: {
-          diagnostics: [
-            {
-              code: 'Style/FrozenStringLiteralComment',
-              message: 'Missing frozen string literal comment.',
-              range: {
-                start: { character: 0, line: 0 }, end: { character: 0, line: 0 }
-              },
-              severity: 3,
-              source: 'rubocop'
-            }, {
-              code: 'Layout/SpaceInsideArrayLiteralBrackets',
-              message: 'Do not use space inside array brackets.',
-              range: {
-                start: { character: 4, line: 2 }, end: { character: 5, line: 2 }
-              },
-              severity: 3,
-              source: 'rubocop'
-            }
-          ], uri: 'file:///path/to/file.rb'
-        }
-      )
+      expect(messages.count).to eq(0)
     end
   end
 


### PR DESCRIPTION
The `textDocument` parameter for the `textDocument/diagnostic` request is of type `TextDocumentIdentifier`, which has a single property `uri` of type `DocumentUri`.

Ref: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_diagnostic

According to the spec the `DocumentUri` type does not hold the contents of the document, which the handler currently relies on in order to publish diagnostics to the client.

This breaks the LSP mode in Neovim 0.10, which now supports pull diagnostics, and possibly other editors too. The same problem exists in `standardrb` (https://github.com/standardrb/standard/issues/575)

I have made the `textDocument/diagnostic` hander a no-op, since diagnostics are already being pushed to clients on `textDocument/didChange`.

~~Let me know if you want to merge this in, and I'll add a changelog entry 👍~~

- [x] Add changelog entry