### PR TITLE
[Fix #12273] Make `OffenseCountFormatter` display autocorrection info

### DIFF
--- a/changelog/new_make_offense_count_formatter_display_autocorrection_info.md
+++ b/changelog/new_make_offense_count_formatter_display_autocorrection_info.md
@@ -1,0 +1,1 @@
+* [#12273](https://github.com/rubocop/rubocop/issues/12273): Make `OffenseCountFormatter` display autocorrection information. ([@koic][])

--- a/docs/modules/ROOT/pages/formatters.adoc
+++ b/docs/modules/ROOT/pages/formatters.adoc
@@ -305,17 +305,17 @@ cops and the number of offenses found for each by running:
 ----
 $ rubocop --format offenses
 
-36   Layout/LineLength
-18   Style/StringLiterals
+36   Layout/LineLength [Safe Correctable]
+18   Style/StringLiterals [Safe Correctable]
 13   Style/Documentation
-10   Style/ExpandPathArguments
-8    Style/EmptyMethod
-6    Layout/IndentationConsistency
+10   Style/ExpandPathArguments [Safe Correctable]
+8    Style/EmptyMethod [Safe Correctable]
+6    Layout/IndentationConsistency [Safe Correctable]
 4    Lint/SuppressedException
-3    Layout/EmptyLinesAroundAccessModifier
-2    Layout/ExtraSpacing
-1    Layout/AccessModifierIndentation
-1    Style/ClassAndModuleChildren
+3    Layout/EmptyLinesAroundAccessModifier [Safe Correctable]
+2    Layout/ExtraSpacing [Safe Correctable]
+1    Layout/AccessModifierIndentation [Safe Correctable]
+1    Style/ClassAndModuleChildren [Unsafe Correctable]
 --
 102  Total in 31 files
 ----

--- a/lib/rubocop/formatter/offense_count_formatter.rb
+++ b/lib/rubocop/formatter/offense_count_formatter.rb
@@ -61,8 +61,7 @@ module RuboCop
 
         column_width = total_count.to_s.length + 2
         per_cop_counts.each do |cop_name, count|
-          output.puts "#{count.to_s.ljust(column_width)}#{cop_name}" \
-                      "#{@style_guide_links[cop_name]}\n"
+          output.puts "#{count.to_s.ljust(column_width)}#{cop_information(cop_name)}"
         end
         output.puts '--'
         output.puts "#{total_count}  Total in #{offending_files_count} files"
@@ -77,6 +76,17 @@ module RuboCop
 
       def total_offense_count(offense_counts)
         offense_counts.values.sum
+      end
+
+      def cop_information(cop_name)
+        cop = RuboCop::Cop::Registry.global.find_by_cop_name(cop_name).new
+
+        if cop.correctable?
+          safety = cop.safe_autocorrect? ? 'Safe' : 'Unsafe'
+          correctable = Rainbow(" [#{safety} Correctable]").yellow
+        end
+
+        "#{cop_name}#{correctable}#{@style_guide_links[cop_name]}"
       end
     end
   end

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -1022,7 +1022,9 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
         $stdout = StringIO.new
         expect(cli.run(['--format', 'offenses'])).to eq(1)
-        expect($stdout.string.lines.grep(%r{/})).to eq(["1  Layout/TrailingWhitespace\n"])
+        expect($stdout.string.lines.grep(%r{/})).to eq(
+          ["1  Layout/TrailingWhitespace [Safe Correctable]\n"]
+        )
       end
 
       shared_examples 'leaves out Excludes' do |merge_style, config|

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1623,14 +1623,14 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
     expect($stdout.string).to eq(<<~RESULT)
 
-      4   Layout/TrailingWhitespace
-      3   Style/Semicolon
-      2   Layout/IndentationConsistency
-      2   Style/SingleLineMethods
-      1   Layout/DefEndAlignment
-      1   Layout/EmptyLineBetweenDefs
-      1   Style/DefWithParentheses
-      1   Style/TrailingBodyOnMethodDefinition
+      4   Layout/TrailingWhitespace [Safe Correctable]
+      3   Style/Semicolon [Safe Correctable]
+      2   Layout/IndentationConsistency [Safe Correctable]
+      2   Style/SingleLineMethods [Safe Correctable]
+      1   Layout/DefEndAlignment [Safe Correctable]
+      1   Layout/EmptyLineBetweenDefs [Safe Correctable]
+      1   Style/DefWithParentheses [Safe Correctable]
+      1   Style/TrailingBodyOnMethodDefinition [Safe Correctable]
       --
       15  Total in 1 files
 
@@ -1737,8 +1737,8 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     expect($stdout.string)
       .to eq(<<~RESULT)
 
-        4  Layout/SpaceAfterComma
-        2  Style/WordArray
+        4  Layout/SpaceAfterComma [Safe Correctable]
+        2  Style/WordArray [Safe Correctable]
         --
         6  Total in 1 files
 

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -780,12 +780,12 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         expect(cli.run(%w[-f offenses --only Layout example.rb])).to eq(1)
         expect($stdout.string).to eq(<<~RESULT)
 
-          1  Layout/CommentIndentation
-          1  Layout/IndentationStyle
-          1  Layout/IndentationWidth
-          1  Layout/LineLength
-          1  Layout/SpaceAroundOperators
-          1  Layout/TrailingWhitespace
+          1  Layout/CommentIndentation [Safe Correctable]
+          1  Layout/IndentationStyle [Safe Correctable]
+          1  Layout/IndentationWidth [Safe Correctable]
+          1  Layout/LineLength [Safe Correctable]
+          1  Layout/SpaceAroundOperators [Safe Correctable]
+          1  Layout/TrailingWhitespace [Safe Correctable]
           --
           6  Total in 1 files
 
@@ -804,13 +804,13 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         expect($stdout.string)
           .to eq(<<~RESULT)
 
-            1  Layout/CommentIndentation
-            1  Layout/IndentationStyle
-            1  Layout/IndentationWidth
-            1  Layout/LineLength
-            1  Layout/TrailingWhitespace
-            1  Style/FrozenStringLiteralComment
-            1  Style/NumericLiterals
+            1  Layout/CommentIndentation [Safe Correctable]
+            1  Layout/IndentationStyle [Safe Correctable]
+            1  Layout/IndentationWidth [Safe Correctable]
+            1  Layout/LineLength [Safe Correctable]
+            1  Layout/TrailingWhitespace [Safe Correctable]
+            1  Style/FrozenStringLiteralComment [Unsafe Correctable]
+            1  Style/NumericLiterals [Safe Correctable]
             --
             7  Total in 1 files
 
@@ -943,10 +943,10 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
           .to eq(<<~RESULT)
 
             1  Lint/MissingCopEnableDirective
-            1  Lint/RedundantCopDisableDirective
-            1  Migration/DepartmentName
-            1  Style/FrozenStringLiteralComment
-            1  Style/NumericPredicate
+            1  Lint/RedundantCopDisableDirective [Safe Correctable]
+            1  Migration/DepartmentName [Safe Correctable]
+            1  Style/FrozenStringLiteralComment [Unsafe Correctable]
+            1  Style/NumericPredicate [Unsafe Correctable]
             --
             5  Total in 1 files
 
@@ -963,15 +963,15 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         expect($stdout.string)
           .to eq(<<~RESULT)
 
-            1  Layout/IndentationStyle
-            1  Layout/IndentationWidth
-            1  Layout/SpaceAroundOperators
-            1  Layout/TrailingWhitespace
+            1  Layout/IndentationStyle [Safe Correctable]
+            1  Layout/IndentationWidth [Safe Correctable]
+            1  Layout/SpaceAroundOperators [Safe Correctable]
+            1  Layout/TrailingWhitespace [Safe Correctable]
             1  Lint/MissingCopEnableDirective
-            1  Lint/UselessAssignment
-            1  Migration/DepartmentName
-            1  Style/FrozenStringLiteralComment
-            1  Style/NumericPredicate
+            1  Lint/UselessAssignment [Unsafe Correctable]
+            1  Migration/DepartmentName [Safe Correctable]
+            1  Style/FrozenStringLiteralComment [Unsafe Correctable]
+            1  Style/NumericPredicate [Unsafe Correctable]
             --
             9  Total in 1 files
 
@@ -991,7 +991,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
         expect($stderr.string).to eq('')
         expect(without_option.split($RS) - with_option.split($RS))
-          .to eq(['1  Style/IfUnlessModifier', '7  Total in 1 files'])
+          .to eq(['1  Style/IfUnlessModifier [Safe Correctable]', '7  Total in 1 files'])
       end
     end
 
@@ -1013,10 +1013,10 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
           expect($stdout.string)
             .to eq(<<~RESULT)
 
-              1  Layout/IndentationWidth
-              1  Layout/TrailingWhitespace
-              1  Style/FrozenStringLiteralComment
-              1  Style/NumericLiterals
+              1  Layout/IndentationWidth [Safe Correctable]
+              1  Layout/TrailingWhitespace [Safe Correctable]
+              1  Style/FrozenStringLiteralComment [Unsafe Correctable]
+              1  Style/NumericLiterals [Safe Correctable]
               --
               4  Total in 1 files
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -436,7 +436,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(['--format', 'offenses', '-A', 'example.rb'])).to eq(0)
         expect($stdout.string).to eq(<<~RESULT)
 
-          1  Style/FrozenStringLiteralComment
+          1  Style/FrozenStringLiteralComment [Unsafe Correctable]
           --
           1  Total in 1 files
 
@@ -730,7 +730,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
             expect($stdout.string).to eq(<<~RESULT)
 
-              1  Style/AndOr
+              1  Style/AndOr [Unsafe Correctable]
               --
               1  Total in 1 files
 
@@ -746,8 +746,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
             expect($stdout.string).to eq(<<~RESULT)
 
-              3  Layout/LineLength
-              1  Style/AndOr
+              3  Layout/LineLength [Safe Correctable]
+              1  Style/AndOr [Unsafe Correctable]
               --
               4  Total in 1 files
 
@@ -767,7 +767,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
             expect($stdout.string).to eq(<<~RESULT)
 
-              3  Layout/LineLength
+              3  Layout/LineLength [Safe Correctable]
               --
               3  Total in 1 files
 
@@ -783,8 +783,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
             expect($stdout.string).to eq(<<~RESULT)
 
-              3  Layout/LineLength
-              1  Style/AndOr
+              3  Layout/LineLength [Safe Correctable]
+              1  Style/AndOr [Unsafe Correctable]
               --
               4  Total in 1 files
 
@@ -1078,7 +1078,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect($stdout.string)
         .to eq(<<~RESULT)
 
-          1  Layout/TrailingWhitespace
+          1  Layout/TrailingWhitespace [Safe Correctable]
           --
           1  Total in 1 files
 

--- a/spec/rubocop/formatter/offense_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/offense_count_formatter_spec.rb
@@ -38,16 +38,18 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
 
   describe '#report_summary' do
     context 'when an offense is detected' do
-      let(:cop_counts) { { 'OffendedCop' => 3 } }
+      let(:cop_counts) { { 'Style/FrozenStringLiteralComment' => 3 } }
 
       before { formatter.started(files) }
 
       it 'shows the cop and the offense count' do
         formatter.report_summary(cop_counts, 2)
-        expect(output.string.include?(<<~OUTPUT)).to be(true)
-          3  OffendedCop
+        expect(output.string).to eq(<<~OUTPUT)
+
+          3  Style/FrozenStringLiteralComment [Unsafe Correctable]
           --
           3  Total in 2 files
+
         OUTPUT
       end
     end
@@ -58,7 +60,7 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
       let(:files) { super().take(1) }
 
       let(:offenses) do
-        %w[CopB CopA CopC CopC].map do |cop|
+        %w[Style/AndOr Style/HashSyntax Naming/ConstantName Naming/ConstantName].map do |cop|
           instance_double(RuboCop::Cop::Offense, cop_name: cop)
         end
       end
@@ -78,9 +80,9 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
           formatter.finished(files)
           expect(output.string).to eq(<<~OUTPUT)
 
-            2  CopC
-            1  CopA
-            1  CopB
+            2  Naming/ConstantName
+            1  Style/AndOr [Unsafe Correctable]
+            1  Style/HashSyntax [Safe Correctable]
             --
             4  Total in 1 files
 
@@ -95,9 +97,9 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
           formatter.finished(files)
           expect(output.string).to eq(<<~OUTPUT)
 
-            2  CopC (https://rubystyle.guide#no-good-CopC)
-            1  CopA (https://rubystyle.guide#no-good-CopA)
-            1  CopB (https://rubystyle.guide#no-good-CopB)
+            2  Naming/ConstantName (https://rubystyle.guide#no-good-Naming/ConstantName)
+            1  Style/AndOr [Unsafe Correctable] (https://rubystyle.guide#no-good-Style/AndOr)
+            1  Style/HashSyntax [Safe Correctable] (https://rubystyle.guide#no-good-Style/HashSyntax)
             --
             4  Total in 1 files
 
@@ -108,7 +110,7 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
 
     context 'when output tty is true' do
       let(:offenses) do
-        %w[CopB CopA CopC CopC].map do |cop|
+        %w[Style/AndOr Style/HashSyntax Naming/ConstantName Naming/ConstantName].map do |cop|
           instance_double(RuboCop::Cop::Offense, cop_name: cop)
         end
       end

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -131,8 +131,8 @@ RSpec.describe RuboCop::RakeTask do
       expect($stdout.string).to eq(<<~RESULT)
         Running RuboCop...
 
-        1  Style/FrozenStringLiteralComment
-        1  Style/SpecialGlobalVars
+        1  Style/FrozenStringLiteralComment [Unsafe Correctable]
+        1  Style/SpecialGlobalVars [Unsafe Correctable]
         --
         2  Total in 1 files
 


### PR DESCRIPTION
Fixes #12273.

This PR makes `OffenseCountFormatter` display autocorrection information.

This solves the use case of checking and selectively applying cops that support autocorrection when there are some unresolved offenses.

Although it may be possible to provide an option, finding use cases for making them optional seems unlikely. Therefore, the new autocorrection information will always be displayed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
