### PR TITLE
[Fix #12668] Fix an incorrect autocorrect for `Lint/EmptyConditionalBody`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_empty_conditional_body.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_empty_conditional_body.md
@@ -1,0 +1,1 @@
+* [#12668](https://github.com/rubocop/rubocop/issues/12668): Fix an incorrect autocorrect for `Lint/EmptyConditionalBody` when missing `if` body with conditional `else` body. ([@koic][])

--- a/lib/rubocop/cop/lint/empty_conditional_body.rb
+++ b/lib/rubocop/cop/lint/empty_conditional_body.rb
@@ -104,7 +104,7 @@ module RuboCop
         def correct_other_branches(corrector, node)
           return unless require_other_branches_correction?(node)
 
-          if node.else_branch&.if_type?
+          if node.else_branch&.if_type? && !node.else_branch.modifier_form?
             # Replace an orphaned `elsif` with `if`
             corrector.replace(node.else_branch.loc.keyword, 'if')
           else

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -208,6 +208,38 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     RUBY
   end
 
+  it 'registers an offense for missing `if` body with conditional `else` body' do
+    expect_offense(<<~RUBY)
+      if condition
+      ^^^^^^^^^^^^ Avoid `if` branches without a body.
+      else
+        do_something if x
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      unless condition
+        do_something if x
+      end
+    RUBY
+  end
+
+  it 'registers an offense for missing `unless` body with conditional `else` body' do
+    expect_offense(<<~RUBY)
+      unless condition
+      ^^^^^^^^^^^^^^^^ Avoid `unless` branches without a body.
+      else
+        do_something if x
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if condition
+        do_something if x
+      end
+    RUBY
+  end
+
   it 'registers an offense for missing `unless` and `else` body' do
     expect_offense(<<~RUBY)
       unless condition


### PR DESCRIPTION
Fixes #12668.

This PR fixes an incorrect autocorrect for `Lint/EmptyConditionalBody` when missing `if` body with conditional `else` body.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
