### PR TITLE
[feedback requested] Detect void value expressions

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2668,6 +2668,11 @@ Lint/Void:
 
 #################### Metrics ###############################
 
+Lint/VoidValueExpression:
+  Description: 'TODO: Write a description of the cop.'
+  Enabled: true
+  VersionAdded: '<<next>>'
+
 Metrics/AbcSize:
   Description: >-
                  A calculated magnitude based on number of assignments,

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -437,6 +437,7 @@ require_relative 'rubocop/cop/lint/useless_ruby2_keywords'
 require_relative 'rubocop/cop/lint/useless_setter_call'
 require_relative 'rubocop/cop/lint/useless_times'
 require_relative 'rubocop/cop/lint/void'
+require_relative 'rubocop/cop/lint/void_value_expression'
 
 require_relative 'rubocop/cop/metrics/utils/iterating_block'
 require_relative 'rubocop/cop/metrics/cyclomatic_complexity'

--- a/lib/rubocop/cop/lint/void_value_expression.rb
+++ b/lib/rubocop/cop/lint/void_value_expression.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      SKIPPABLE_STATEMENTS = %i[kwbegin if while begin rescue ensure resbody].freeze
+      LIMIT_STATEMENTS = %i[def defs block case when case_match in_pattern].freeze
+      CONTROL_STATEMENTS = %i[or and].freeze
+
+      class VoidValueExpression < Base
+        def on_return(return_node)
+          relevant_ancestry = filter_relevant_ancestry(return_node)
+          parent_node = relevant_ancestry.first
+
+          return unless parent_node
+          return unless parent_node.value_used? || %i[lvasgn send].include?(parent_node.type)
+          return if in_control_statement_but_not_first?(return_node, parent_node)
+
+          add_offense(return_node.loc.keyword, message: 'This return introduces a void value.')
+        end
+
+        private
+
+        def in_control_statement_but_not_first?(node, parent)
+          CONTROL_STATEMENTS.include?(parent.type) && parent.children.first != node
+        end
+
+        def filter_relevant_ancestry(node)
+          node
+            .ancestors
+            .take_while { |n| !LIMIT_STATEMENTS.include?(n.type) }
+            .reject { |n| SKIPPABLE_STATEMENTS.include?(n.type) }
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/lint/void_value_expression_spec.rb
+++ b/spec/rubocop/cop/lint/void_value_expression_spec.rb
@@ -1,0 +1,492 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Lint::VoidValueExpression, :config do
+  it 'registers an offense when a return appears first in a control statement ("and")' do
+    expect_offense(<<~RUBY)
+      def void_first_in_and
+        return a and b
+        ^^^^^^ This return introduces a void value.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a return appears first in a control statement ("or")' do
+    expect_offense(<<~RUBY)
+      def void_first_in_or
+        return a and b
+        ^^^^^^ This return introduces a void value.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when a return appears last in a control statement ("and")' do
+    expect_no_offenses(<<~RUBY)
+      def void_comes_last_in_and
+        circuit_breaker and return
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when a return appears last in a control statement ("or")' do
+    expect_no_offenses(<<~RUBY)
+      def void_comes_last_in_or
+        check_condition or return
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when a return appears in the middle of a longer control statement ("and")' do
+    expect_no_offenses(<<~RUBY)
+      def void_comes_in_long_control_statement_and
+        1 and return and 2
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when a return appears in the middle of a longer control statement ("or")' do
+    expect_no_offenses(<<~RUBY)
+      def void_comes_in_long_control_statement_or
+        1 or return or 2
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a return appears as rvalue of an assignment' do
+    expect_offense(<<~RUBY)
+      def void_assignment
+        a = return 1
+            ^^^^^^ This return introduces a void value.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a return appears as rvalue of an op-assignment' do
+    expect_offense(<<~RUBY)
+      def opassign_with_return
+        n += return n + 1
+             ^^^^^^ This return introduces a void value.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a return appears in an assignment within a loop' do
+    expect_offense(<<~RUBY)
+      def void_assignment_within_while
+        while running?
+          a = return 1
+              ^^^^^^ This return introduces a void value.
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when a return appears at the top level of a method' do
+    expect_no_offenses(<<~RUBY)
+      def perfectly_normal_method
+        return 1
+      end
+    RUBY
+  end
+
+  context 'begin block' do
+    it 'registers an offense when a return introduces a void value' do
+      expect_offense(<<~RUBY)
+        def void_assignment_within_begin
+          a ||=
+            begin
+              return 1 if foo
+              ^^^^^^ This return introduces a void value.
+              blah
+            end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a return does not introduce a void value' do
+      expect_no_offenses(<<~RUBY)
+        def perfectly_normal_method
+          begin
+            return 1
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a return appears in a rescue block without introducing a void value' do
+      expect_no_offenses(<<~RUBY)
+        def perfectly_normal_method
+          begin
+            do_something
+          rescue
+            return 1
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when a void assignment takes place in a rescue block' do
+      expect_offense(<<~RUBY)
+        def void_assignment_in_rescue
+          begin
+            do_something
+          rescue
+            a = return 1
+                ^^^^^^ This return introduces a void value.
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when a rescue block returns but a value was expected' do
+      expect_offense(<<~RUBY)
+        def rescue_assigns_a_void
+          a =
+            begin
+              do_something
+            rescue
+              return 1
+              ^^^^^^ This return introduces a void value.
+            end
+        end
+      RUBY
+    end
+  end
+
+  context 'block' do
+    it 'does not register an offense when a return does not introduce a void value' do
+      expect_no_offenses(<<~RUBY)
+        def return_within_block
+          items.each do |item|
+            return item
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the block returns but the method also returns a value' do
+      expect_no_offenses(<<~RUBY)
+        def return_within_block_and_query_method
+          a = list.fetch(1) { return }
+        end
+      RUBY
+    end
+
+    it 'registers an offense when a return introduces a void value into an assignment' do
+      expect_offense(<<~RUBY)
+        with_block {
+          a = return 1
+              ^^^^^^ This return introduces a void value.
+        }
+      RUBY
+    end
+
+    it 'registers an offense when a return introduces a void value into an expression' do
+      expect_offense(<<~RUBY)
+        def bad_return_in_block
+          items.each do |item|
+            return do_something(item) and 1
+            ^^^^^^ This return introduces a void value.
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a return appears in a ensure block without introducing a void value' do
+      expect_no_offenses(<<~RUBY)
+        def perfectly_normal_method
+          begin
+            do_something
+          ensure
+            return 1
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when a void assignment takes place in a ensure block' do
+      expect_offense(<<~RUBY)
+        def void_assignment_in_ensure
+          begin
+            do_something
+          ensure
+            a = return 1
+                ^^^^^^ This return introduces a void value.
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when a ensure block returns but a value was expected' do
+      expect_offense(<<~RUBY)
+        def ensure_assigns_a_void
+          a =
+            begin
+              do_something
+            ensure
+              return 1
+              ^^^^^^ This return introduces a void value.
+            end
+        end
+      RUBY
+    end
+  end
+
+  context 'conditional' do
+    it 'does not register an offense when a return appears in a conditional branch' do
+      expect_no_offenses(<<~RUBY)
+        def conditional_guard
+          return if foo
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a return appears in a rescue-able conditional branch' do
+      expect_no_offenses(<<~RUBY)
+        def conditional_guard_with_rescue
+          return if foo
+        rescue SomeException
+          handle_issue
+        end
+      RUBY
+    end
+
+    it 'registers an offense when a return introduces a void value into an expression' do
+      expect_offense(<<~RUBY)
+        def conditional_expression
+          1 +
+            if foo
+              2
+            else
+              return 1
+              ^^^^^^ This return introduces a void value.
+            end
+          end
+      RUBY
+    end
+
+    it 'registers an offense when a return introduces a void value into an assignment' do
+      expect_offense(<<~RUBY)
+        def conditional_assignment
+          bar =
+            if foo
+              2
+            else
+              return 1
+              ^^^^^^ This return introduces a void value.
+            end
+          end
+      RUBY
+    end
+  end
+
+  context 'case/when statement' do
+    it 'does not register an offense when a return appears in a when branch' do
+      expect_no_offenses(<<~RUBY)
+        def case_when_return
+          case foo
+          when 1
+            return
+          else
+            return
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a return appears in a rescue-able when statement' do
+      expect_no_offenses(<<~RUBY)
+        def case_with_rescue
+          case foo
+          when 1
+            return
+          else
+            return
+          end
+        rescue SomeException
+          handle_issue
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a return introduces a void value into an expression' do
+      expect_no_offenses(<<~RUBY)
+        def case_expression
+          1 +
+            case foo
+            when 1
+              return 1
+            else
+              return 2
+            end
+          end
+      RUBY
+    end
+
+    it 'does not register an offense when a return introduces a void value into an assignment' do
+      expect_no_offenses(<<~RUBY)
+        def case_assignment
+          bar =
+            case foo
+            when 1
+              return 1
+            else
+              return 2
+            end
+          end
+      RUBY
+    end
+  end
+
+  context 'case/in statement' do
+    it 'does not register an offense when a return appears in a in branch' do
+      expect_no_offenses(<<~RUBY)
+        def case_when_return
+          case foo
+          in 1
+            return
+          else
+            return
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a return appears in a rescue-able when statement' do
+      expect_no_offenses(<<~RUBY)
+        def case_with_rescue
+          case foo
+          in 1
+            return
+          else
+            return
+          end
+        rescue SomeException
+          handle_issue
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a return introduces a void value into an expression' do
+      expect_no_offenses(<<~RUBY)
+        def case_expression
+          1 +
+            case foo
+            in 1
+              return 1
+            else
+              return 2
+            end
+          end
+      RUBY
+    end
+
+    it 'does not register an offense when a return introduces a void value into an assignment' do
+      expect_no_offenses(<<~RUBY)
+        def case_assignment
+          bar =
+            case foo
+            in 1
+              return 1
+            else
+              return 2
+            end
+          end
+      RUBY
+    end
+  end
+
+  context 'method definition' do
+    it 'does not register an offense when a method definition is part of an expression' do
+      expect_no_offenses(<<~RUBY)
+        private def secret
+          return 123
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a method definition is part of an assignment' do
+      expect_no_offenses(<<~RUBY)
+        method_name = def secret
+          return 123
+        end
+      RUBY
+    end
+  end
+
+  context 'singleton method definition' do
+    it 'does not register an offense when a singleton method definition is part of an expression' do
+      expect_no_offenses(<<~RUBY)
+        private def foo.secret
+          return 123
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a singleton method definition is part of an assignment' do
+      expect_no_offenses(<<~RUBY)
+        method_name = def foo.secret
+          return 123
+        end
+      RUBY
+    end
+  end
+
+  # Not detected by MRI. Detected by JRuby
+  it 'registers an offense when a return introduces a void conditional within a begin block' do
+    expect_offense(<<~RUBY)
+      def void_assignment_with_if_plus_code
+        a =
+          begin
+            if true
+              return 1
+              ^^^^^^ This return introduces a void value.
+            end
+          end
+      end
+    RUBY
+  end
+
+  # Not detected by MRI or JRuby
+  it 'registers an offense when a return introduces a void conditional within a begin block and there is still code after that' do
+    expect_offense(<<~RUBY)
+      def void_assignment_with_if_plus_code
+        a =
+          begin
+            if true
+              return 1
+              ^^^^^^ This return introduces a void value.
+            end
+
+            puts "AFTER"
+          end
+      end
+    RUBY
+  end
+
+  # Not detected by MRI or JRuby
+  it 'registers an offense when there is still code after a bad return within a begin block' do
+    expect_offense(<<~RUBY)
+      def void_assignment_with_if_plus_code
+        a =
+          begin
+            return 1
+            ^^^^^^ This return introduces a void value.
+
+            puts "AFTER"
+          end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when a return appears in a metaprogrammed method' do
+    expect_no_offenses(<<~RUBY)
+      def metaprogrammed_module
+        my_module = Module.new {
+          define_method method_name do
+            return 1
+          end
+        }
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
This is a WIP 🚧  hoping to get some feedback before I commit more effort. I know it doesn't have documentation, changelog, etc. I hope this is fine for the moment 🙏 

Some interesting questions here would be:
- Is there a reason why Rubocop doesn't have a cop for this?
- Is there a desire to have a cop for this?
- Any tips on how to handle this?

### Detail

Recently I came across a new (to me) error in Ruby code similar to the following:

```ruby
def void_assignment
  a = return 1
end
```

This code would fail with the following syntax error:
```
run.rb: run.rb:2: void value expression (SyntaxError)
```

So that's ok, I can understand it. Also it is an interesting one: despite being a syntax error, it's not flagged by Rubocop or ruby-parse. I'm assuming the interpreter catches it after building the AST, as opposed to during the parsing process itself? Whichever way it is, the tools I use (including Rubocop) don't flag it so I don't get to know it's happening until I run the code.

I suspect this is well known scenario and there's a good reason why Rubocop is not catching it. Is this correct?

Just in case, it piqued my curiosity and I had a go at it :-) This PR is a first version of what a cop for this might look like, if there's desire for one. I'm sure I'm missing something. For one, I know that `next` and `break` can also cause a void value expression, so that'd be something to add. And of course documentation.

I have also noticed that `case` statements appear immune to it, so I'm not raising offences on them. However I wonder if that's something that should be an option to the rule.

Additionally, I have noticed that different MRI and JRuby treat this differently, which makes sense. There are edge cases (noted in the spec) where JRuby is better at catching these cases. Also there are questions of what to do in cases that look wrong, but the interpreters I have tried don't complain (see also marked in the spec).

## Checklist

Not fully checked as this is a WIP asking for feedback:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
