### PR TITLE
Fix false negatives for `Lint/RedundantSafeNavigation`

### DIFF
--- a/changelog/fix_false_negatives_for_lint_redundant_safe_navigation.md
+++ b/changelog/fix_false_negatives_for_lint_redundant_safe_navigation.md
@@ -1,0 +1,1 @@
+* [#12673](https://github.com/rubocop/rubocop/pull/12673): Fix false negatives for `Lint/RedundantSafeNavigation` when using safe navigation operator for literal receiver. ([@koic][])

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -58,6 +58,56 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when `&.` is used for string literals' do
+    expect_offense(<<~RUBY)
+      '2012-03-02 16:05:37'&.to_time
+                           ^^^^^^^^^ Redundant safe navigation detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      '2012-03-02 16:05:37'.to_time
+    RUBY
+  end
+
+  it 'registers an offense and corrects when `&.` is used for integer literals' do
+    expect_offense(<<~RUBY)
+      42&.minutes
+        ^^^^^^^^^ Redundant safe navigation detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      42.minutes
+    RUBY
+  end
+
+  it 'registers an offense and corrects when `&.` is used for array literals' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3]&.join(', ')
+               ^^^^^^^^^^^^ Redundant safe navigation detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].join(', ')
+    RUBY
+  end
+
+  it 'registers an offense and corrects when `&.` is used for hash literals' do
+    expect_offense(<<~RUBY)
+      {k: :v}&.count
+             ^^^^^^^ Redundant safe navigation detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      {k: :v}.count
+    RUBY
+  end
+
+  it 'does not register an offense and corrects when `&.` is used for `nil` literal' do
+    expect_no_offenses(<<~RUBY)
+      nil&.to_i
+    RUBY
+  end
+
   %i[while until].each do |loop_type|
     it 'registers an offense and corrects when `&.` is used inside `#{loop_type}` condition' do
       expect_offense(<<~RUBY, loop_type: loop_type)


### PR DESCRIPTION
This is similar to detection #12246.

This PR fixes false negatives for `Lint/RedundantSafeNavigation` when using safe navigation operator for literal receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
