### PR TITLE
Fix false negatives for `Style/RedundantReturn`

### DIFF
--- a/changelog/fix_false_negative_for_style_redundant_return.md
+++ b/changelog/fix_false_negative_for_style_redundant_return.md
@@ -1,0 +1,1 @@
+* [#12674](https://github.com/rubocop/rubocop/pull/12674): Fix false negatives for `Style/RedundantReturn` when using pattern matching. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -113,6 +113,7 @@ module RuboCop
           case node.type
           when :return then check_return_node(node)
           when :case   then check_case_node(node)
+          when :case_match then check_case_match_node(node)
           when :if     then check_if_node(node)
           when :rescue then check_rescue_node(node)
           when :resbody then check_resbody_node(node)
@@ -137,6 +138,11 @@ module RuboCop
 
         def check_case_node(node)
           node.when_branches.each { |when_node| check_branch(when_node.body) }
+          check_branch(node.else_branch)
+        end
+
+        def check_case_match_node(node)
+          node.in_pattern_branches.each { |in_pattern_node| check_branch(in_pattern_node.body) }
           check_branch(node.else_branch)
         end
 

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -601,4 +601,52 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
       RUBY
     end
   end
+
+  context 'when return is inside a in-branch' do
+    it 'registers an offense and autocorrects' do
+      expect_offense(<<~RUBY)
+        def func
+          some_preceding_statements
+          case x
+          in y then return 1
+                    ^^^^^^ Redundant `return` detected.
+          in z then return 2
+                    ^^^^^^ Redundant `return` detected.
+          in q
+          else
+            return 3
+            ^^^^^^ Redundant `return` detected.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def func
+          some_preceding_statements
+          case x
+          in y then 1
+          in z then 2
+          in q
+          else
+            3
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when case match nodes are empty' do
+    it 'accepts empty in nodes' do
+      expect_no_offenses(<<~RUBY)
+        def func
+          case x
+          in y then 1
+          in z # do nothing
+          else
+            3
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes false negatives for `Style/RedundantReturn` when using pattern matching.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
