### PR TITLE
Fix an error for `Style/HashSyntax` when using `Prism::Translation::Parser`

### DIFF
--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -195,6 +195,7 @@ module RuboCop
           acceptable_19_syntax_symbol?(pair.key.source)
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def acceptable_19_syntax_symbol?(sym_name)
           sym_name.delete_prefix!(':')
 
@@ -209,9 +210,12 @@ module RuboCop
           # Most hash keys can be matched against a simple regex.
           return true if /\A[_a-z]\w*[?!]?\z/i.match?(sym_name)
 
-          # For more complicated hash keys, let the parser validate the syntax.
-          parse("{ #{sym_name}: :foo }").valid_syntax?
+          return false if target_ruby_version <= 2.1
+
+          (sym_name.start_with?("'") && sym_name.end_with?("'")) ||
+            (sym_name.start_with?('"') && sym_name.end_with?('"'))
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def check(pairs, delim, msg)
           pairs.each do |pair|

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         end
       end
 
-      it 'registers an offense when symbol keys have strings in them' do
+      it 'registers an offense when symbol keys have strings in them', :ruby22 do
         expect_offense(<<~RUBY)
           x = { :"string" => 0 }
                 ^^^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.


### PR DESCRIPTION
This PR fixes the following error `Style/HashSyntax` when using `Prism::Translation::Parser` as a parser:

```console
$ bundle exec ruby -rprism/translation/parser/rubocop $(bundle exec which rubocop) \
  --only Style/HashSyntax -d lib/rubocop/cop/style/not.rb
(snip)

An error occurred while Style/HashSyntax cop was inspecting
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/not.rb:23:27.
undefined method `loc' for an instance of AST::Node
/Users/koic/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/parser-3.3.0.5/lib/parser/builders/default.rb:1875:
in `join_exprs'
```

Other ways to resolve this might exist, but using `RuboCop::Cop::Base#parser` is not necessary.

Currently, no repro tests have been added as it is sufficient to verify that it is not broken with the Parser gem. And, this is for refactoring aimed at integration with `Prism`, no changelog entry will be added.

cf. https://github.com/ruby/prism/blob/v0.21.0/docs/parser_translation.md#rubocop

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
