### PR TITLE
Fix an error for `Style/RedundantLineContinuation` when using `Prism::Translation::Parser`

### DIFF
--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -114,6 +114,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'registers an offense when line continuations with `if`' do
+    expect_offense(<<~'RUBY')
+      if foo \
+             ^ Redundant line continuation.
+      then bar
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo#{' '}
+      then bar
+      end
+    RUBY
+  end
+
   it 'does not register an offense when required line continuations for multiline leading dot method chain with an empty line' do
     expect_no_offenses(<<~'RUBY')
       obj
@@ -284,10 +299,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'does not register an offense when using line concatenation and calling a method without parentheses in multiple expression block' do
+    expect_no_offenses(<<~'RUBY')
+      foo do
+        bar \
+          key: value
+
+        baz
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using line concatenation for assigning a return value and without argument parentheses of method call' do
     expect_no_offenses(<<~'RUBY')
       foo = do_something \
         argument
+    RUBY
+  end
+
+  it 'does not register an offense when using line concatenation for assigning a return value and without hash argument parentheses of method call' do
+    expect_no_offenses(<<~'RUBY')
+      foo.bar = do_something \
+        key: value
     RUBY
   end
 
@@ -441,6 +474,24 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     expect_no_offenses(<<~'RUBY')
       foo \
         || bar
+    RUBY
+  end
+
+  it 'does not register an offense when line continuations with `&&` in method definition' do
+    expect_no_offenses(<<~'RUBY')
+      def do_something
+        foo \
+          && bar
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when line continuations with `||` in method definition' do
+    expect_no_offenses(<<~'RUBY')
+      def do_something
+        foo \
+          || bar
+      end
     RUBY
   end
 


### PR DESCRIPTION
This PR fixes the following error `Style/RedundantLineContinuation` when using `Prism::Translation::Parser` as a parser:

```console
$ bundle exec ruby -rprism/translation/parser/rubocop $(bundle exec which rubocop)
(snip)

An error occurred while Style/RedundantLineContinuation cop was inspecting
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb.
undefined method `complete?' for an instance of AST::Node
/Users/koic/src/github.com/rubocop/rubocop-ast/lib/rubocop/ast/node.rb:104:in `block in initialize'
```

This is a similar error to #12677.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
