### PR TITLE
Publish `RuboCop::LSP.enable` to enable LSP mode

### DIFF
--- a/changelog/new_publish_lsp_enable_api.md
+++ b/changelog/new_publish_lsp_enable_api.md
@@ -1,0 +1,1 @@
+* [#12679](https://github.com/rubocop/rubocop/pull/12679): Publish `RuboCop::LSP.enable` API to enable LSP mode. ([@koic][])

--- a/docs/modules/ROOT/pages/usage/lsp.adoc
+++ b/docs/modules/ROOT/pages/usage/lsp.adoc
@@ -259,3 +259,12 @@ user             17414   0.0  0.2  5557716 144376   ??  Ss    4:48PM   0:02.13 /
 ```
 
 NOTE: `rubocop --lsp` is for starting LSP client, so users don't manually execute it.
+
+== Language Server Development
+
+RuboCop provides APIs for developers of original language server or tools analogous to LSP, using RuboCop as the backend, instead of the RuboCop's built-in LSP.
+
+- `RuboCop::LSP.enable` enables LSP mode, customizing for LSP-specific features such as autocorrection and short offense message.
+- `RuboCop::LSP.disable` disables LSP mode, which can be particularly useful for testing.
+
+When implementing custom cops, `RuboCop::LSP.enabled?` can be used to achieve behavior that considers these states.

--- a/lib/rubocop/cli/command/lsp.rb
+++ b/lib/rubocop/cli/command/lsp.rb
@@ -7,11 +7,11 @@ module RuboCop
     module Command
       # Start Language Server Protocol of RuboCop.
       # @api private
-      class Lsp < Base
+      class LSP < Base
         self.command_name = :lsp
 
         def run
-          RuboCop::Lsp::Server.new(@config_store).start
+          RuboCop::LSP::Server.new(@config_store).start
         end
       end
     end

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -84,24 +84,6 @@ module RuboCop
         false
       end
 
-      ### LSP
-
-      # This experimental feature has been under consideration for a while.
-      # @api private
-      def self.lsp_mode?
-        !!@lsp_mode
-      end
-
-      # This experimental feature has been under consideration for a while.
-      def self.enable_lsp_mode
-        @lsp_mode = true
-      end
-
-      # This experimental feature has been under consideration for a while.
-      def self.disable_lsp_mode
-        @lsp_mode = false
-      end
-
       ### Naming
 
       def self.badge

--- a/lib/rubocop/cop/lint/syntax.rb
+++ b/lib/rubocop/cop/lint/syntax.rb
@@ -17,7 +17,7 @@ module RuboCop
         private
 
         def add_offense_from_diagnostic(diagnostic, ruby_version)
-          message = if Base.lsp_mode?
+          message = if LSP.enabled?
                       diagnostic.message
                     else
                       "#{diagnostic.message}\n(Using Ruby #{ruby_version} parser; " \

--- a/lib/rubocop/lsp.rb
+++ b/lib/rubocop/lsp.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # The RuboCop's built-in LSP module.
+  module LSP
+    module_function
+
+    # Returns true when LSP is enabled, false when disabled.
+    #
+    # @return [Boolean]
+    def enabled?
+      @enabled ||= false
+    end
+
+    # Enable LSP.
+    #
+    # @return [void]
+    def enable
+      @enabled = true
+    end
+
+    # Disable LSP.
+    #
+    # @return [void]
+    def disable
+      @enabled = false
+    end
+  end
+end

--- a/lib/rubocop/lsp/logger.rb
+++ b/lib/rubocop/lsp/logger.rb
@@ -10,7 +10,7 @@
 # https://github.com/standardrb/standard/blob/main/LICENSE.txt
 #
 module RuboCop
-  module Lsp
+  module LSP
     # Log for Language Server Protocol of RuboCop.
     # @api private
     class Logger

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -12,7 +12,7 @@ require_relative 'severity'
 # https://github.com/standardrb/standard/blob/main/LICENSE.txt
 #
 module RuboCop
-  module Lsp
+  module LSP
     # Routes for Language Server Protocol of RuboCop.
     # @api private
     class Routes

--- a/lib/rubocop/lsp/runtime.rb
+++ b/lib/rubocop/lsp/runtime.rb
@@ -10,7 +10,7 @@
 # https://github.com/standardrb/standard/blob/main/LICENSE.txt
 #
 module RuboCop
-  module Lsp
+  module LSP
     # Runtime for Language Server Protocol of RuboCop.
     # @api private
     class Runtime

--- a/lib/rubocop/lsp/server.rb
+++ b/lib/rubocop/lsp/server.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'language_server-protocol'
+require_relative '../lsp'
 require_relative 'logger'
 require_relative 'routes'
 require_relative 'runtime'
@@ -15,16 +16,16 @@ require_relative 'runtime'
 # https://github.com/standardrb/standard/blob/main/LICENSE.txt
 #
 module RuboCop
-  module Lsp
+  module LSP
     # Language Server Protocol of RuboCop.
     # @api private
     class Server
       def initialize(config_store)
-        RuboCop::Cop::Base.enable_lsp_mode
+        RuboCop::LSP.enable
 
         @reader = LanguageServer::Protocol::Transport::Io::Reader.new($stdin)
         @writer = LanguageServer::Protocol::Transport::Io::Writer.new($stdout)
-        @runtime = RuboCop::Lsp::Runtime.new(config_store)
+        @runtime = RuboCop::LSP::Runtime.new(config_store)
         @routes = Routes.new(self)
       end
 

--- a/lib/rubocop/lsp/severity.rb
+++ b/lib/rubocop/lsp/severity.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module RuboCop
-  module Lsp
+  module LSP
     # Severity for Language Server Protocol of RuboCop.
     # @api private
     class Severity

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -128,13 +128,13 @@ RSpec.shared_context 'mock console output' do
   end
 end
 
-RSpec.shared_context 'lsp mode' do
+RSpec.shared_context 'lsp' do
   before do
-    RuboCop::Cop::Base.enable_lsp_mode
+    RuboCop::LSP.enable
   end
 
   after do
-    RuboCop::Cop::Base.disable_lsp_mode
+    RuboCop::LSP.disable
   end
 end
 

--- a/lib/rubocop/rspec/support.rb
+++ b/lib/rubocop/rspec/support.rb
@@ -13,7 +13,7 @@ RSpec.configure do |config|
   config.include HostEnvironmentSimulatorHelper
   config.include_context 'config', :config
   config.include_context 'isolated environment', :isolated_environment
-  config.include_context 'lsp mode', :lsp_mode
+  config.include_context 'lsp', :lsp
   config.include_context 'maintain registry', :restore_registry
   config.include_context 'ruby 2.0', :ruby20
   config.include_context 'ruby 2.1', :ruby21

--- a/spec/rubocop/cop/lint/syntax_spec.rb
+++ b/spec/rubocop/cop/lint/syntax_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Cop::Lint::Syntax, :config do
         end
       end
 
-      context 'with `--lsp` option', :lsp_mode do
+      context 'with `--lsp` option', :lsp do
         it 'does not include a configuration information in the offense message' do
           expect(offenses.first.message).to eq('unexpected token $end')
         end

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Lsp::Server, :isolated_environment do
-  include LspHelper
+RSpec.describe RuboCop::LSP::Server, :isolated_environment do
+  include LSPHelper
 
   subject(:result) { run_server_on_requests(*requests) }
 
   after do
-    RuboCop::Cop::Base.disable_lsp_mode
+    RuboCop::LSP.disable
   end
 
   let(:messages) { result[0] }
@@ -1240,7 +1240,7 @@ RSpec.describe RuboCop::Lsp::Server, :isolated_environment do
 
   context 'when an internal error occurs' do
     before do
-      allow_any_instance_of(RuboCop::Lsp::Routes).to receive(:for).with('initialize').and_raise # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(RuboCop::LSP::Routes).to receive(:for).with('initialize').and_raise # rubocop:disable RSpec/AnyInstance
     end
 
     let(:requests) do

--- a/spec/rubocop/lsp/severity_spec.rb
+++ b/spec/rubocop/lsp/severity_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Lsp::Severity do
+RSpec.describe RuboCop::LSP::Severity do
   describe '.find_by' do
     subject(:lsp_severity) { described_class.find_by(rubocop_severity) }
 

--- a/spec/rubocop/lsp_spec.rb
+++ b/spec/rubocop/lsp_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::LSP, :lsp do
+  describe '.enabled?' do
+    context 'when `RuboCop::LSP.enable` is called' do
+      before { described_class.enable }
+
+      it 'returns true' do
+        expect(described_class.enabled?).to be(true)
+      end
+    end
+
+    context 'when `RuboCop::LSP.disable` is called' do
+      before { described_class.disable }
+
+      it 'returns false' do
+        expect(described_class.enabled?).to be(false)
+      end
+    end
+  end
+end

--- a/spec/support/lsp_helper.rb
+++ b/spec/support/lsp_helper.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-module LspHelper
+module LSPHelper
   def run_server_on_requests(*requests)
     stdin = StringIO.new(requests.map { |request| to_jsonrpc(request) }.join)
 
     RuboCop::Server::Helper.redirect(stdin: stdin) do
       config_store = RuboCop::ConfigStore.new
 
-      RuboCop::Lsp::Server.new(config_store).start
+      RuboCop::LSP::Server.new(config_store).start
     end
 
     messages = parse_jsonrpc_messages($stdout)


### PR DESCRIPTION
`RuboCop::Cop::Base.enable_lsp_mode` will be renamed to `RuboCop::LSP.enable`.

Before:

```ruby
RuboCop::Cop::Base.enable_lsp_mode
```

After:

```ruby
RuboCop::LSP.enable
```

This is because whether or not it is LSP should not be set per cop but should be a state controlled for the entire RuboCop process.

Since `RuboCop::Cop::Base.enable_lsp_mode` was an experimental private API, it will be renamed without a deprecation warning.

Along with this, the module name has been changed from `RuboCop::Lsp` to `RuboCop::LSP`. This change is made to align with Ruby's standard API, like `RubyVM::YJIT.enable`, making it `RuboCop::LSP.enable` instead. `RuboCop::Lsp.enable` does not look as pretty name.

With the renaming to `RuboCop::LSP.enable`, the usage of this API will be documented. This allows libraries like Ruby LSP and Solargraph, which use internal modules other than RuboCop's built-in `RuboCop::LSP::Server#start`, to easily utilize the features in #12586 and #12657.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
