### PR TITLE
Make an options_spec as pending when using Ruby 3.4.0dev

### DIFF
--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
 
       it 'shows help text' do
+        # FIXME: Update to behavior in accordance with the inquiry results of
+        #        https://bugs.ruby-lang.org/issues/20252
+        skip 'Adjust to the behavior expected of optparse in Ruby 3.4.' if RUBY_VERSION >= '3.4'
+
         begin
           options.parse(['--help'])
         rescue SystemExit # rubocop:disable Lint/SuppressedException


### PR DESCRIPTION
This PR makes the following options_spec as pending when using Ruby 3.4.0dev.

```console
$ ruby -v
ruby 3.4.0dev (2024-02-09T12:28:26Z master 08b77dd682) [x86_64-darwin23]
$ bundle exec rspec './spec/rubocop/options_spec.rb[1:1:1:2]'
(snip)

1 example, 1 failure

Failed examples:

rspec ./spec/rubocop/options_spec.rb:29 # RuboCop::Options option -h/--help shows help text
```

https://github.com/rubocop/rubocop/actions/runs/7845618444/job/21410458812?pr=12657

The pending spec should be update to behavior in accordance with the inquiry results of https://bugs.ruby-lang.org/issues/20252.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
