### PR TITLE
Avoid redundant `parse` for `Style/RedundantArgument`

### DIFF
--- a/lib/rubocop/cop/style/redundant_argument.rb
+++ b/lib/rubocop/cop/style/redundant_argument.rb
@@ -81,14 +81,14 @@ module RuboCop
           redundant_argument = redundant_arg_for_method(node.method_name.to_s)
           return false if redundant_argument.nil?
 
-          node.first_argument == redundant_argument
+          node.first_argument.source.sub(/\A'/, '"').sub(/'\z/, '"') == redundant_argument
         end
 
         def redundant_arg_for_method(method_name)
           arg = cop_config['Methods'].fetch(method_name) { return }
 
           @mem ||= {}
-          @mem[method_name] ||= parse(arg.inspect).ast
+          @mem[method_name] ||= arg.inspect
         end
 
         def argument_range(node)


### PR DESCRIPTION
This PR avoids redundant repetitive `parse` for `Style/RedundantArgument`.

Similar to #12677 and #12678, there is no need to parse code that has already been parsed once.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
