### PR TITLE
Add `--editor-mode` CLI option

### DIFF
--- a/changelog/new_add_editor_mode_option.md
+++ b/changelog/new_add_editor_mode_option.md
@@ -1,0 +1,1 @@
+* [#12682](https://github.com/rubocop/rubocop/issues/12682): Add `--editor-mode` CLI option. ([@koic][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -587,7 +587,7 @@ Style/PerlBackrefs:
 ==== `contextual`
 
 This setting enables autocorrection when launched from the `rubocop` command, but it is not available through LSP.
-e.g., `rubocop --lsp` or a program where `RuboCop::LSP.enable` has been applied.
+e.g., `rubocop --lsp`, `rubocop --editor-mode`, or a program where `RuboCop::LSP.enable` has been applied.
 
 Inspections via the command line are treated as code that has been finalized.
 

--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -267,6 +267,9 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | `-s/--stdin`
 | Pipe source from STDIN. This is useful for editor integration. Takes one argument, a path, relative to the root of the project. RuboCop will use this path to determine which cops are enabled (via eg. Include/Exclude), and so that certain cops like Naming/FileName can be checked.
 
+| `--editor-mode`
+| Optimize real-time feedback in editors, adjusting behaviors for editing experience. Editors that run RuboCop directly (e.g., by shelling out) encounter the same issues as with `--lsp`. This option is designed for such editors.
+
 | `-S/--display-style-guide`
 | Display style guide URLs in offense messages.
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -12,7 +12,7 @@ module RuboCop
     STATUS_INTERRUPTED = Signal.list['INT'] + 128
     DEFAULT_PARALLEL_OPTIONS = %i[
       color config debug display_style_guide display_time display_only_fail_level_offenses
-      display_only_failed except extra_details fail_level fix_layout format
+      display_only_failed editor_mode except extra_details fail_level fix_layout format
       ignore_disable_comments lint only only_guide_cops require safe
       autocorrect safe_autocorrect autocorrect_all
     ].freeze
@@ -151,6 +151,7 @@ module RuboCop
 
     def act_on_options
       set_options_to_config_loader
+      handle_editor_mode
 
       @config_store.options_config = @options[:config] if @options[:config]
       @config_store.force_default_config! if @options[:force_default_config]
@@ -172,6 +173,10 @@ module RuboCop
       ConfigLoader.enable_pending_cops = @options[:enable_pending_cops]
       ConfigLoader.ignore_parent_exclusion = @options[:ignore_parent_exclusion]
       ConfigLoader.ignore_unrecognized_cops = @options[:ignore_unrecognized_cops]
+    end
+
+    def handle_editor_mode
+      RuboCop::LSP.enable if @options[:editor_mode]
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -95,6 +95,7 @@ module RuboCop
         option(opts, '--ignore-unrecognized-cops')
         option(opts, '--force-default-config')
         option(opts, '-s', '--stdin FILE')
+        option(opts, '--editor-mode')
         option(opts, '-P', '--[no-]parallel')
         option(opts, '--raise-cop-error')
         add_severity_option(opts)
@@ -369,6 +370,7 @@ module RuboCop
       validate_display_only_failed
       validate_display_only_failed_and_display_only_correctable
       validate_display_only_correctable_and_autocorrect
+      validate_lsp_and_editor_mode
       disable_parallel_when_invalid_option_combo
 
       return if incompatible_options.size <= 1
@@ -414,6 +416,13 @@ module RuboCop
 
       raise OptionArgumentError,
             format('--display-only-failed cannot be used together with other display options.')
+    end
+
+    def validate_lsp_and_editor_mode
+      return if !@options.key?(:lsp) || !@options.key?(:editor_mode)
+
+      raise OptionArgumentError,
+            format('Do not specify `--editor-mode` as it is redundant in `--lsp`.')
     end
 
     def validate_autocorrect
@@ -609,6 +618,8 @@ module RuboCop
                                          'parallel. Default is true.'],
       stdin:                            ['Pipe source from STDIN, using FILE in offense',
                                          'reports. This is useful for editor integration.'],
+      editor_mode:                      ['Optimize real-time feedback in editors,',
+                                         'adjusting behaviors for editing experience.'],
       init:                             'Generate a .rubocop.yml file in the current directory.',
       server:                           ['If a server process has not been started yet, start',
                                          'the server process and execute inspection with server.',

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -68,6 +68,8 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                files are present in the directory tree.
               -s, --stdin FILE                 Pipe source from STDIN, using FILE in offense
                                                reports. This is useful for editor integration.
+                  --editor-mode                Optimize real-time feedback in editors,
+                                               adjusting behaviors for editing experience.
               -P, --[no-]parallel              Use available CPUs to execute inspection in
                                                parallel. Default is true.
                   --raise-cop-error            Raise cop-related errors with cause and location.
@@ -260,6 +262,13 @@ RSpec.describe RuboCop::Options, :isolated_environment do
         msg = 'Incompatible cli options: [:verbose_version, :show_cops]'
         expect { options.parse %w[-V --show-cops] }
           .to raise_error(RuboCop::OptionArgumentError, msg)
+      end
+
+      it 'rejects using `--lsp` with `--editor-mode`' do
+        msg = 'Do not specify `--editor-mode` as it is redundant in `--lsp`.'
+        expect do
+          options.parse %w[--lsp --editor-mode]
+        end.to raise_error(RuboCop::OptionArgumentError, msg)
       end
 
       it 'mentions all incompatible options when more than two are used' do


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/12657#issuecomment-1937084864.

This PR adds `--editor-mode` CLI option, which optimize real-time feedback in editors, adjusting behaviors for editing experience.

Editors that run RuboCop directly (e.g., by shelling out) encounter the same issues as with `--lsp`. This option is designed for such editors.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
