### PR TITLE
[Fix #12683] Fix an incorrect autocorrect for `Style/MapCompactWithConditionalBlock`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_map_compact_with_conditional_block.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_map_compact_with_conditional_block.md
@@ -1,0 +1,1 @@
+* [#12683](https://github.com/rubocop/rubocop/issues/12683): Fix an incorrect autocorrect for `Style/MapCompactWithConditionalBlock` when using guard clause with `next` implicitly nil. ([@koic][])

--- a/lib/rubocop/cop/style/map_compact_with_conditional_block.rb
+++ b/lib/rubocop/cop/style/map_compact_with_conditional_block.rb
@@ -116,10 +116,10 @@ module RuboCop
         def truthy_branch_for_guard?(node)
           if_node = node.left_sibling
 
-          if if_node.if? || if_node.ternary?
-            if_node.else_branch.nil?
-          elsif if_node.unless?
-            if_node.if_branch.nil?
+          if if_node.if?
+            if_node.if_branch.arguments.any?
+          else
+            if_node.if_branch.arguments.none?
           end
         end
 

--- a/spec/rubocop/cop/style/map_compact_with_conditional_block_spec.rb
+++ b/spec/rubocop/cop/style/map_compact_with_conditional_block_spec.rb
@@ -158,10 +158,10 @@ RSpec.describe RuboCop::Cop::Style::MapCompactWithConditionalBlock, :config do
       RUBY
     end
 
-    it 'registers an offense and corrects to `select` with guard clause of `if`' do
+    it 'registers an offense and corrects to `reject` with guard clause of `if`' do
       expect_offense(<<~RUBY)
         foo.map do |item|
-            ^^^^^^^^^^^^^ Replace `map { ... }.compact` with `select`.
+            ^^^^^^^^^^^^^ Replace `map { ... }.compact` with `reject`.
           next if item.bar?
 
           item
@@ -169,14 +169,14 @@ RSpec.describe RuboCop::Cop::Style::MapCompactWithConditionalBlock, :config do
       RUBY
 
       expect_correction <<~RUBY
-        foo.select { |item| item.bar? }
+        foo.reject { |item| item.bar? }
       RUBY
     end
 
-    it 'registers an offense and corrects to `reject` with guard clause of `unless`' do
+    it 'registers an offense and corrects to `select` with guard clause of `unless`' do
       expect_offense(<<~RUBY)
         foo.map do |item|
-            ^^^^^^^^^^^^^ Replace `map { ... }.compact` with `reject`.
+            ^^^^^^^^^^^^^ Replace `map { ... }.compact` with `select`.
           next unless item.bar?
 
           item
@@ -184,7 +184,7 @@ RSpec.describe RuboCop::Cop::Style::MapCompactWithConditionalBlock, :config do
       RUBY
 
       expect_correction <<~RUBY
-        foo.reject { |item| item.bar? }
+        foo.select { |item| item.bar? }
       RUBY
     end
 


### PR DESCRIPTION
Fixes #12683

This PR fixes an incorrect autocorrect for `Style/MapCompactWithConditionalBlock` when using guard clause with `next` implicitly nil. It also fixes the incorrect test code.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
