### PR TITLE
[Fix #12687] Fix a false positive for `Lint/Void`

### DIFF
--- a/changelog/fix_false_positive_for_lint_void.md
+++ b/changelog/fix_false_positive_for_lint_void.md
@@ -1,0 +1,1 @@
+* [#12687](https://github.com/rubocop/rubocop/issues/12687): Fix a false positive for `Lint/Void` when `each` block with conditional expressions that has multiple statements. ([@koic][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -100,7 +100,12 @@ module RuboCop
           expressions = *node
           expressions.pop unless in_void_context?(node)
           expressions.each do |expr|
-            check_void_op(expr)
+            check_void_op(expr) do
+              block_node = node.each_ancestor(:block).first
+
+              block_node&.method?(:each)
+            end
+
             check_expression(expr)
           end
         end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -614,6 +614,18 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     RUBY
   end
 
+  it 'does not register `#each` block with conditional expressions that has multiple statements' do
+    expect_no_offenses(<<~RUBY)
+      enumerator_as_filter.each do |item|
+        puts item
+
+        # The `filter` method is used to filter for matches with `42`.
+        # In this case, it's not void.
+        item == 42
+      end
+    RUBY
+  end
+
   context 'Ruby 2.7', :ruby27 do
     it 'registers two offenses for void literals in `#tap` method' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #12687.

This PR fixes a false positive for `Lint/Void` when `each` block with conditional expressions that has multiple statements.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
