### PR TITLE
[Fix #12693] Fix an incorrect autocorrect for `Style/ObjectThen`

### DIFF
--- a/changelog/fix_an_incorrect_for_style_object_then.md
+++ b/changelog/fix_an_incorrect_for_style_object_then.md
@@ -1,0 +1,1 @@
+* [#12693](https://github.com/rubocop/rubocop/issues/12693): Fix an incorrect autocorrect for `Style/ObjectThen` when using `yield_self` without receiver. ([@koic][])

--- a/lib/rubocop/cop/style/object_then.rb
+++ b/lib/rubocop/cop/style/object_then.rb
@@ -46,15 +46,17 @@ module RuboCop
         private
 
         def check_method_node(node)
-          return unless preferred_method(node)
+          return unless preferred_method?(node)
 
           message = message(node)
           add_offense(node.loc.selector, message: message) do |corrector|
-            corrector.replace(node.loc.selector, style.to_s)
+            prefer = style == :then && node.receiver.nil? ? 'self.then' : style
+
+            corrector.replace(node.loc.selector, prefer)
           end
         end
 
-        def preferred_method(node)
+        def preferred_method?(node)
           case style
           when :then
             node.method?(:yield_self)

--- a/spec/rubocop/cop/style/object_then_spec.rb
+++ b/spec/rubocop/cop/style/object_then_spec.rb
@@ -36,6 +36,17 @@ RSpec.describe RuboCop::Cop::Style::ObjectThen, :config do
           obj.then { _1.test }
         RUBY
       end
+
+      it 'registers an offense for `yield_self` without receiver' do
+        expect_offense(<<~RUBY)
+          yield_self { |obj| obj.test }
+          ^^^^^^^^^^ Prefer `then` over `yield_self`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          self.then { |obj| obj.test }
+        RUBY
+      end
     end
 
     it 'registers an offense for yield_self with proc param' do


### PR DESCRIPTION
Fixes #12693.

This PR fixes an incorrect autocorrect for `Style/ObjectThen` when using `yield_self` without receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
