### PR TITLE
[Fix #12690] Fix an error for `Style/CaseLikeIf`

### DIFF
--- a/changelog/fix_an_error_for_style_case_like_if.md
+++ b/changelog/fix_an_error_for_style_case_like_if.md
@@ -1,0 +1,1 @@
+* [#12690](https://github.com/rubocop/rubocop/issues/12690): Fix an error for `Style/CaseLikeIf` when using `==` with literal and using ternary operator. ([@koic][])

--- a/lib/rubocop/cop/style/case_like_if.rb
+++ b/lib/rubocop/cop/style/case_like_if.rb
@@ -230,7 +230,7 @@ module RuboCop
 
         def branch_conditions(node)
           conditions = []
-          while node&.if_type?
+          while node&.if_type? && !node.ternary?
             conditions << node.condition
             node = node.else_branch
           end

--- a/spec/rubocop/cop/style/case_like_if_spec.rb
+++ b/spec/rubocop/cop/style/case_like_if_spec.rb
@@ -59,6 +59,26 @@ RSpec.describe RuboCop::Cop::Style::CaseLikeIf, :config do
     RUBY
   end
 
+  it 'registers an offense when using `==` with literal and using ternary operator' do
+    expect_offense(<<~RUBY)
+      if foo == 1
+      ^^^^^^^^^^^ Convert `if-elsif` to `case-when`.
+      elsif foo == 2
+      else
+        foo == 3 ? bar : baz
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case foo
+      when 1
+      when 2
+      else
+        foo == 3 ? bar : baz
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using `==` with method call with arguments' do
     expect_no_offenses(<<~RUBY)
       if x == foo(1)


### PR DESCRIPTION
Fixes #12690.

This PR fixes an error for `Style/CaseLikeIf` when using `==` with literal and using ternary operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
