### PR TITLE
[Fix #12691] Fix an error for `Style/MultilineTernaryOperator`

### DIFF
--- a/changelog/fix_error_for_style_multiline_ternary_operator.md
+++ b/changelog/fix_error_for_style_multiline_ternary_operator.md
@@ -1,0 +1,1 @@
+* [#12691](https://github.com/rubocop/rubocop/issues/12691): Fix an error for `Style/MultilineTernaryOperator` when nesting multiline ternary operators. ([@koic][])

--- a/lib/rubocop/cop/style/multiline_ternary_operator.rb
+++ b/lib/rubocop/cop/style/multiline_ternary_operator.rb
@@ -47,7 +47,11 @@ module RuboCop
           message = enforce_single_line_ternary_operator?(node) ? MSG_SINGLE_LINE : MSG_IF
 
           add_offense(node, message: message) do |corrector|
+            next if part_of_ignored_node?(node)
+
             autocorrect(corrector, node)
+
+            ignore_node(node)
           end
         end
 

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -50,6 +50,28 @@ RSpec.describe RuboCop::Cop::Style::MultilineTernaryOperator, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when nesting multiline ternary operators' do
+    expect_offense(<<~RUBY)
+      cond_a? ? foo :
+      ^^^^^^^^^^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
+        cond_b? ? bar :
+        ^^^^^^^^^^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
+          cond_c? ? baz : qux
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if cond_a?
+        foo
+      else
+        if cond_b?
+        bar
+      else
+        cond_c? ? baz : qux
+      end
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects when everything is on a separate line' do
     expect_offense(<<~RUBY)
       a = cond ?


### PR DESCRIPTION
Fixes #12691.

This PR fixes an error for `Style/MultilineTernaryOperator` when nesting multiline ternary operators.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
