### PR TITLE
Support searching for `rubocop/config.yml` in compliance with dot-config

### DIFF
--- a/changelog/new_support_dot_config.md
+++ b/changelog/new_support_dot_config.md
@@ -1,1 +1,1 @@
-* [#12699](https://github.com/rubocop/rubocop/issues/12699): Support searching for `.rubocop.yml` in compliance with dot-config. ([@koic][])
+* [#12699](https://github.com/rubocop/rubocop/issues/12699): Support searching for `.rubocop.yml` and `rubocop/config.yml` in compliance with dot-config. ([@koic][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -34,7 +34,7 @@ and the user's global config locations. The user's global config locations consi
 dotfile or a config file inside the https://specifications.freedesktop.org/basedir-spec/latest/index.html[XDG Base Directory
 specification].
 
-* `.config/.rubocop.yml` of the project root
+* `.config/.rubocop.yml` or `.config/rubocop/config.yml` at the project root
 * `~/.rubocop.yml`
 * `$XDG_CONFIG_HOME/rubocop/config.yml` (expands to `~/.config/rubocop/config.yml`
 if `$XDG_CONFIG_HOME` is not set)
@@ -49,6 +49,7 @@ files:
 * `/path/to/project/lib/.rubocop.yml`
 * `/path/to/project/.rubocop.yml`
 * `/path/to/project/.config/.rubocop.yml`
+* `/path/to/project/.config/rubocop/config.yml`
 * `/.rubocop.yml`
 * `~/.rubocop.yml`
 * `~/.config/rubocop/config.yml`

--- a/lib/rubocop/config_finder.rb
+++ b/lib/rubocop/config_finder.rb
@@ -44,9 +44,11 @@ module RuboCop
       def find_project_root_dot_config
         return unless project_root
 
-        file = File.join(project_root, '.config', DOTFILE)
+        dotfile = File.join(project_root, '.config', DOTFILE)
+        return dotfile if File.exist?(dotfile)
 
-        file if File.exist?(file)
+        xdg_config = File.join(project_root, '.config', 'rubocop', XDG_CONFIG)
+        xdg_config if File.exist?(xdg_config)
       end
 
       def find_user_dotfile

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -29,26 +29,61 @@ RSpec.describe RuboCop::ConfigLoader do
 
       before { create_empty_file('dir/example.rb') }
 
-      context 'but a config file exists in .config directory of the project root' do
+      context 'but a config file exists in .config/.rubocop.yml of the project root' do
         before do
           create_empty_file('Gemfile')
           create_empty_file('.config/.rubocop.yml')
         end
 
-        it 'returns the path to the file in home directory' do
+        it 'returns the path to the file in .config directory' do
           expect(configuration_file_for).to end_with('.config/.rubocop.yml')
         end
       end
 
-      context 'but a config file exists in both .config of the project root and home directories' do
+      context 'but a config file exists in both .config/.rubocop.yml of the project root and home directory' do
         before do
           create_empty_file('Gemfile')
           create_empty_file('.config/.rubocop.yml')
           create_empty_file('~/.rubocop.yml')
         end
 
-        it 'returns the path to the file in home directory' do
+        it 'returns the path to the file in .config directory' do
           expect(configuration_file_for).to end_with('.config/.rubocop.yml')
+        end
+      end
+
+      context 'but a config file exists in .config/rubocop/config.yml of the project root' do
+        before do
+          create_empty_file('Gemfile')
+          create_empty_file('.config/rubocop/config.yml')
+        end
+
+        it 'returns the path to the file in .config/rubocop directory' do
+          expect(configuration_file_for).to end_with('.config/rubocop/config.yml')
+        end
+      end
+
+      context 'but a config file exists in both .config/.rubocop.yml and .config/rubocop/config.yml of the project root' do
+        before do
+          create_empty_file('Gemfile')
+          create_empty_file('.config/.rubocop.yml')
+          create_empty_file('.config/rubocop/config.yml')
+        end
+
+        it 'returns the path to the file in .config directory' do
+          expect(configuration_file_for).to end_with('.config/.rubocop.yml')
+        end
+      end
+
+      context 'but a config file exists in both .config//rubocop/config.yml of the project root and home directory' do
+        before do
+          create_empty_file('Gemfile')
+          create_empty_file('.config/rubocop/config.yml')
+          create_empty_file('~/.rubocop.yml')
+        end
+
+        it 'returns the path to the file in .config/rubocop directory' do
+          expect(configuration_file_for).to end_with('.config/rubocop/config.yml')
         end
       end
 


### PR DESCRIPTION
Follow https://github.com/rubocop/rubocop/pull/12700#issuecomment-1949764386

This PR supports searching for `rubocop/config.yml` in compliance with dot-config.

This PR adds `project_root/.config/rubocop/config.yml` to the list of paths to search, matching XDG path format of the already targeted `~/.config/rubocop/config.yml`.

However, support for `~/.config/rubocop.yml` is not included in this PR, as the outcome of inquiry https://github.com/dot-config/dot-config.github.io/issues/17 regarding it is still pending.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
