### PR TITLE
Fix false negative for `Style/RedundantAssignment`

### DIFF
--- a/changelog/fix_false_negative_for_style_redundant_assignment.md
+++ b/changelog/fix_false_negative_for_style_redundant_assignment.md
@@ -1,0 +1,1 @@
+* [#12707](https://github.com/rubocop/rubocop/pull/12707): Fix false negative for `Style/RedundantAssignment` when using pattern matching. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_assignment.rb
+++ b/lib/rubocop/cop/style/redundant_assignment.rb
@@ -54,12 +54,14 @@ module RuboCop
 
         private
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def check_branch(node)
           return unless node
 
           case node.type
-          when :case   then check_case_node(node)
-          when :if     then check_if_node(node)
+          when :case       then check_case_node(node)
+          when :case_match then check_case_match_node(node)
+          when :if         then check_if_node(node)
           when :rescue, :resbody
             check_rescue_node(node)
           when :ensure then check_ensure_node(node)
@@ -67,9 +69,15 @@ module RuboCop
             check_begin_node(node)
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def check_case_node(node)
           node.when_branches.each { |when_node| check_branch(when_node.body) }
+          check_branch(node.else_branch)
+        end
+
+        def check_case_match_node(node)
+          node.in_pattern_branches.each { |in_pattern_node| check_branch(in_pattern_node.body) }
           check_branch(node.else_branch)
         end
 

--- a/spec/rubocop/cop/style/redundant_assignment_spec.rb
+++ b/spec/rubocop/cop/style/redundant_assignment_spec.rb
@@ -180,6 +180,59 @@ RSpec.describe RuboCop::Cop::Style::RedundantAssignment, :config do
     RUBY
   end
 
+  context 'when inside an `in` branch' do
+    it 'registers an offense and autocorrects' do
+      expect_offense(<<~RUBY)
+        def func
+          some_preceding_statements
+          case x
+          in y
+            res = 1
+            ^^^^^^^ Redundant assignment before returning detected.
+            res
+          in z
+            2
+          in q
+          else
+            res = 3
+            ^^^^^^^ Redundant assignment before returning detected.
+            res
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def func
+          some_preceding_statements
+          case x
+          in y
+            1
+           #{trailing_whitespace}
+          in z
+            2
+          in q
+          else
+            3
+           #{trailing_whitespace}
+          end
+        end
+      RUBY
+    end
+  end
+
+  it 'accepts empty `in` nodes' do
+    expect_no_offenses(<<~RUBY)
+      def func
+        case x
+        in y then 1
+        in z # do nothing
+        else
+          3
+        end
+      end
+    RUBY
+  end
+
   it 'accepts empty method body' do
     expect_no_offenses(<<~RUBY)
       def func


### PR DESCRIPTION
This PR fixes false negative for `Style/RedundantAssignment` when using pattern matching.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
