### PR TITLE
[Fix #12695] Handle Include from inherited file in parent directory

### DIFF
--- a/changelog/fix_config_include_bug.md
+++ b/changelog/fix_config_include_bug.md
@@ -1,0 +1,1 @@
+* [#12695](https://github.com/rubocop/rubocop/issues/12695): Fix bug in `Include` from inherited file in a parent directory. ([@jonas054][])

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -44,7 +44,7 @@ module RuboCop
       end
     end
 
-    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def match_path?(pattern, path)
       case pattern
       when String
@@ -52,6 +52,10 @@ module RuboCop
           if pattern == path
             true
           elsif glob?(pattern)
+            # File name matching doesn't really work with relative patterns the start with "..". We
+            # get around that problem by converting the pattern to an absolute path.
+            pattern = File.expand_path(pattern) if pattern.start_with?('..')
+
             File.fnmatch?(pattern, path, File::FNM_PATHNAME | File::FNM_EXTGLOB)
           end
 
@@ -66,7 +70,7 @@ module RuboCop
         end
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     # Returns true for an absolute Unix or Windows path.
     def absolute?(path)


### PR DESCRIPTION
When we inherit configuration from a file in a parent or ancestor directory, and that file is called `.rubocop.yml`, the paths in its Include parameters are interpreted as being relative to the file, or rather its directory. This is specific for file names starting with `.rubocop`. The problem is that file name matching that we do when searching for target files to inspect doesn't work for patterns that start with `..`. Solve the problem by matching absolute paths in these corner cases.