### PR TITLE
[Fix #12646] Handle opposite styles for Layout/SpaceBeforeBlockBraces

### DIFF
--- a/changelog/fix_auto_gen_config_SpaceBeforeBlockBraces.md
+++ b/changelog/fix_auto_gen_config_SpaceBeforeBlockBraces.md
@@ -1,0 +1,1 @@
+* [#12646](https://github.com/rubocop/rubocop/issues/12646): Fix `--auto-gen-config` bug for `Layout/SpaceBeforeBlockBraces`. ([@jonas054][])

--- a/lib/rubocop/cop/layout/space_before_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_before_block_braces.rb
@@ -80,10 +80,18 @@ module RuboCop
 
         private
 
+        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         def check_empty(left_brace, space_plus_brace, used_style)
-          return if style_for_empty_braces == used_style
-
-          config_to_allow_offenses['EnforcedStyleForEmptyBraces'] = used_style.to_s
+          if style_for_empty_braces == used_style
+            if config_to_allow_offenses['EnforcedStyleForEmptyBraces'] &&
+               config_to_allow_offenses['EnforcedStyleForEmptyBraces'].to_sym != used_style
+              config_to_allow_offenses.clear
+              config_to_allow_offenses['Enabled'] = false
+            end
+            return
+          elsif !config_to_allow_offenses.key?('Enabled')
+            config_to_allow_offenses['EnforcedStyleForEmptyBraces'] = used_style.to_s
+          end
 
           if style_for_empty_braces == :space
             add_offense(left_brace, message: MISSING_MSG) do |corrector|
@@ -96,6 +104,7 @@ module RuboCop
             end
           end
         end
+        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
         def check_non_empty(left_brace, space_plus_brace, used_style)
           case used_style

--- a/lib/rubocop/cop/layout/space_before_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_before_block_braces.rb
@@ -80,31 +80,31 @@ module RuboCop
 
         private
 
-        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         def check_empty(left_brace, space_plus_brace, used_style)
           if style_for_empty_braces == used_style
-            if config_to_allow_offenses['EnforcedStyleForEmptyBraces'] &&
-               config_to_allow_offenses['EnforcedStyleForEmptyBraces'].to_sym != used_style
-              config_to_allow_offenses.clear
-              config_to_allow_offenses['Enabled'] = false
-            end
+            handle_different_styles_for_empty_braces(used_style)
             return
           elsif !config_to_allow_offenses.key?('Enabled')
             config_to_allow_offenses['EnforcedStyleForEmptyBraces'] = used_style.to_s
           end
 
           if style_for_empty_braces == :space
-            add_offense(left_brace, message: MISSING_MSG) do |corrector|
-              autocorrect(corrector, left_brace)
-            end
+            range = left_brace
+            msg = MISSING_MSG
           else
-            space = range_between(space_plus_brace.begin_pos, left_brace.begin_pos)
-            add_offense(space, message: DETECTED_MSG) do |corrector|
-              autocorrect(corrector, space)
-            end
+            range = range_between(space_plus_brace.begin_pos, left_brace.begin_pos)
+            msg = DETECTED_MSG
+          end
+          add_offense(range, message: msg) { |corrector| autocorrect(corrector, range) }
+        end
+
+        def handle_different_styles_for_empty_braces(used_style)
+          if config_to_allow_offenses['EnforcedStyleForEmptyBraces'] &&
+             config_to_allow_offenses['EnforcedStyleForEmptyBraces'].to_sym != used_style
+            config_to_allow_offenses.clear
+            config_to_allow_offenses['Enabled'] = false
           end
         end
-        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
         def check_non_empty(left_brace, space_plus_brace, used_style)
           case used_style

--- a/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
             ^ Space missing to the left of {.
       RUBY
 
+      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'no_space')
       expect_correction(<<~RUBY)
         each { puts }
       RUBY
@@ -26,6 +27,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
         each { puts }
       RUBY
 
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       expect_correction(<<~RUBY)
         each { puts }
         each { puts }
@@ -56,6 +58,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
           each { _1 }
         RUBY
 
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
         expect_correction(<<~RUBY)
           each { _1 }
           each { _1 }
@@ -89,6 +92,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
             ^ Space detected to the left of {.
       RUBY
 
+      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'space')
       expect_correction(<<~RUBY)
         each{ puts }
       RUBY
@@ -101,6 +105,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
             ^ Space detected to the left of {.
       RUBY
 
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       expect_correction(<<~RUBY)
         each{ puts }
         each{ puts }
@@ -119,6 +124,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
               ^ Space detected to the left of {.
         RUBY
 
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
         expect_correction(<<~RUBY)
           each{ _1 }
           each{ _1 }
@@ -164,6 +170,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
           ^ Space detected to the left of {.
       RUBY
 
+      expect(cop.config_to_allow_offenses).to eq('EnforcedStyleForEmptyBraces' => 'space')
       expect_correction(<<~RUBY)
         ->{}
       RUBY
@@ -188,6 +195,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
           ^ Space missing to the left of {.
       RUBY
 
+      expect(cop.config_to_allow_offenses).to eq('EnforcedStyleForEmptyBraces' => 'no_space')
       expect_correction(<<~RUBY)
         -> {}
       RUBY


### PR DESCRIPTION
The `Layout/SpaceBeforeBlockBraces` cop has two separate style parameters, `EnforcedStyle` and `EnforcedStyleForEmptyBraces`. The logic for generating `Enabled: false` when opposite styles are detected during `--auto-gen-config` was implemented for `EnforcedStyle`, but it was missing for `EnforcedStyleForEmptyBraces`.