### PR TITLE
Handle implicit receivers in `Style/InvertibleUnlessCondition`

### DIFF
--- a/changelog/fix_handle_implicit_receivers_in.md
+++ b/changelog/fix_handle_implicit_receivers_in.md
@@ -1,0 +1,1 @@
+* [#12711](https://github.com/rubocop/rubocop/pull/12711): Handle implicit receivers in `Style/InvertibleUnlessCondition`. ([@sambostock][])

--- a/lib/rubocop/cop/style/invertible_unless_condition.rb
+++ b/lib/rubocop/cop/style/invertible_unless_condition.rb
@@ -99,23 +99,23 @@ module RuboCop
           end
         end
 
-        def preferred_send_condition(node)
-          receiver_source = node.receiver.source
+        def preferred_send_condition(node) # rubocop:disable Metrics/CyclomaticComplexity
+          receiver_source = node.receiver&.source
           return receiver_source if node.method?(:!)
 
+          receive = receiver_source ? "#{receiver_source}." : '' # receiver may be implicit (self)
+
           inverse_method_name = inverse_methods[node.method_name]
-          return "#{receiver_source}.#{inverse_method_name}" unless node.arguments?
+          return "#{receive}#{inverse_method_name}" unless node.arguments?
 
           argument_list = node.arguments.map(&:source).join(', ')
           if node.operator_method?
             return "#{receiver_source} #{inverse_method_name} #{argument_list}"
           end
 
-          if node.parenthesized?
-            return "#{receiver_source}.#{inverse_method_name}(#{argument_list})"
-          end
+          return "#{receive}#{inverse_method_name}(#{argument_list})" if node.parenthesized?
 
-          "#{receiver_source}.#{inverse_method_name} #{argument_list}"
+          "#{receive}#{inverse_method_name} #{argument_list}"
         end
 
         def preferred_logical_condition(node)

--- a/spec/rubocop/cop/style/invertible_unless_condition_spec.rb
+++ b/spec/rubocop/cop/style/invertible_unless_condition_spec.rb
@@ -91,6 +91,39 @@ RSpec.describe RuboCop::Cop::Style::InvertibleUnlessCondition, :config do
     end
   end
 
+  it 'registers an offense and corrects methods without arguments called with implicit receivers' do
+    expect_offense(<<~RUBY)
+      foo unless odd?
+      ^^^^^^^^^^^^^^^ Prefer `if even?` over `unless odd?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo if even?
+    RUBY
+  end
+
+  it 'registers an offense and corrects parenthesized methods with arguments called with implicit receivers' do
+    expect_offense(<<~RUBY)
+      foo unless include?(value)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `if exclude?(value)` over `unless include?(value)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo if exclude?(value)
+    RUBY
+  end
+
+  it 'registers an offense and corrects unparenthesized methods with arguments called with implicit receivers' do
+    expect_offense(<<~RUBY)
+      foo unless include? value
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `if exclude? value` over `unless include? value`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo if exclude? value
+    RUBY
+  end
+
   it 'does not register an offense when using explicit begin condition' do
     expect_no_offenses(<<~RUBY)
       foo unless begin x != y end


### PR DESCRIPTION
Previously, we would attempt to call `node.receiver.source`, but `node.receiver` could be `nil`.

```
An error occurred while Style/InvertibleUnlessCondition cop was inspecting /path/to/file.rb:123:4.
undefined method `source' for nil
```

This teaches the cop to handle implicit receivers.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
