### PR TITLE
[Fix #12714] Fix an error for `Gemspec/RequiredRubyVersion`

### DIFF
--- a/changelog/fix_an_error_for_gemspec_required_ruby_version.md
+++ b/changelog/fix_an_error_for_gemspec_required_ruby_version.md
@@ -1,0 +1,1 @@
+* [#12714](https://github.com/rubocop/rubocop/issues/12714): Fix an error for `Gemspec/RequiredRubyVersion` when `required_ruby_version` is specified with `Gem::Requirement.new` and is higher than `TargetRubyVersion`. ([@koic][])

--- a/lib/rubocop/cop/gemspec/required_ruby_version.rb
+++ b/lib/rubocop/cop/gemspec/required_ruby_version.rb
@@ -110,6 +110,8 @@ module RuboCop
             end
           end
 
+          return unless required_ruby_version
+
           required_ruby_version.str_content.scan(/\d/).first(2).join('.')
         end
 

--- a/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
+++ b/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
       RUBY
     end
 
+    it 'registers an offense when `required_ruby_version` is specified with `Gem::Requirement.new` and is higher than `TargetRubyVersion`' do
+      expect_offense(<<~RUBY)
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = Gem::Requirement.new('< 3.4')
+                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
+        end
+      RUBY
+    end
+
     it 'recognizes a Gem::Requirement with multiple requirements and does not register an offense' do
       expect_no_offenses(<<~RUBY)
         Gem::Specification.new do |spec|


### PR DESCRIPTION
Fixes #12714.

This PR fixes an error for `Gemspec/RequiredRubyVersion` when `required_ruby_version` is specified with `Gem::Requirement.new` and is higher than `TargetRubyVersion`.

When specifying only an upper version limit, an offense is registered because lower Ruby version that matches `TargetRubyVersion` is unknown.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
