### PR TITLE
[Fix #12717] Re-use definition of directive comments from CommentedKeyword

### DIFF
--- a/changelog/fix_commented_keyword.md
+++ b/changelog/fix_commented_keyword.md
@@ -1,0 +1,1 @@
+* [#12717](https://github.com/rubocop/rubocop/issues/12717): Fix regexp for inline disable comments in `Style/CommentedKeyword`. ([@jonas054][])

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../directive_comment'
+
 module RuboCop
   module Cop
     module Style
@@ -49,8 +51,9 @@ module RuboCop
         KEYWORDS = %w[begin class def end module].freeze
         KEYWORD_REGEXES = KEYWORDS.map { |w| /^\s*#{w}\s/ }.freeze
 
-        ALLOWED_COMMENTS = %w[:nodoc: :yields: rubocop:disable rubocop:todo].freeze
-        ALLOWED_COMMENT_REGEXES = ALLOWED_COMMENTS.map { |c| /#\s*#{c}/ }.freeze
+        ALLOWED_COMMENTS = %w[:nodoc: :yields:].freeze
+        ALLOWED_COMMENT_REGEXES = (ALLOWED_COMMENTS.map { |c| /#\s*#{c}/ } +
+                                   [DirectiveComment::DIRECTIVE_COMMENT_REGEXP]).freeze
 
         REGEXP = /(?<keyword>\S+).*#/.freeze
 

--- a/spec/rubocop/cop/style/commented_keyword_spec.rb
+++ b/spec/rubocop/cop/style/commented_keyword_spec.rb
@@ -181,12 +181,22 @@ RSpec.describe RuboCop::Cop::Style::CommentedKeyword, :config do
       end
     RUBY
     expect_no_offenses(<<~RUBY)
-      def x # rubocop:disable Metrics/MethodLength
+      def x # rubocop:disable  Metrics/MethodLength
         y
       end
     RUBY
     expect_no_offenses(<<~RUBY)
-      def x # rubocop:todo Metrics/MethodLength
+      def x # rubocop: disable Metrics/MethodLength
+        y
+      end
+    RUBY
+    expect_no_offenses(<<~RUBY)
+      def x # rubocop :todo Metrics/MethodLength
+        y
+      end
+    RUBY
+    expect_no_offenses(<<~RUBY)
+      def x # rubocop:  todo Metrics/MethodLength
         y
       end
     RUBY


### PR DESCRIPTION
To make sure we don't have a different, more strict definition of what constitutes a `rubocop:disable` or `rubocop:todo` comment in the cop compared to elsewhere in the code, use the definition implemented in `DirectiveComment`.

We also get the `rubocop:enable` comments included in this definition, but it's not a problem if we allow those comments in the cop, as they don't make any sense as end-of-line comments and are unlikely to occur.