### PR TITLE
Fix a false positive for `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_arguments_forwarding.md
+++ b/changelog/fix_a_false_positive_for_style_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#12720](https://github.com/rubocop/rubocop/issues/12720): Fix a false positive for `Style/ArgumentsForwarding` when using block arg forwarding to within block with Ruby 3.3.0. ([@koic][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -188,9 +188,12 @@ module RuboCop
 
           send_classifications.each do |send_node, _c, forward_rest, forward_kwrest, forward_block_arg| # rubocop:disable Layout/LineLength
             if !forward_rest && !forward_kwrest
-              register_forward_block_arg_offense(!forward_rest, node.arguments, block_arg)
-              register_forward_block_arg_offense(!forward_rest, send_node, forward_block_arg)
-
+              # Prevents `anonymous block parameter is also used within block (SyntaxError)` occurs
+              # in Ruby 3.3.0.
+              if outside_block?(forward_block_arg)
+                register_forward_block_arg_offense(!forward_rest, node.arguments, block_arg)
+                register_forward_block_arg_offense(!forward_rest, send_node, forward_block_arg)
+              end
               registered_block_arg_offense = true
               break
             else
@@ -222,6 +225,8 @@ module RuboCop
               register_forward_kwargs_offense(!forward_rest, send_node, forward_kwrest)
             end
 
+            # Prevents `anonymous block parameter is also used within block (SyntaxError)` occurs
+            # in Ruby 3.3.0.
             if outside_block?(forward_block_arg)
               register_forward_block_arg_offense(!forward_rest, def_node.arguments, block_arg)
               register_forward_block_arg_offense(!forward_rest, send_node, forward_block_arg)

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -836,21 +836,12 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'registers an offense when using block arg forwarding with positional arguments forwarding to within block' do
-      expect_offense(<<~RUBY)
+    # `anonymous block parameter is also used within block (SyntaxError)` occurs in Ruby 3.3.0:
+    it 'does not register an offense when using block arg forwarding with positional arguments forwarding to within block' do
+      expect_no_offenses(<<~RUBY)
         def baz(qux, quuz, &block)
-                           ^^^^^^ Use anonymous block arguments forwarding (`&`).
           with_block do
             bar(qux, quuz, &block)
-                           ^^^^^^ Use anonymous block arguments forwarding (`&`).
-          end
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        def baz(qux, quuz, &)
-          with_block do
-            bar(qux, quuz, &)
           end
         end
       RUBY


### PR DESCRIPTION
This PR fixes a false positive for `Style/ArgumentsForwarding` when using block arg forwarding to within block with Ruby 3.3.0.

The following `anonymous block parameter is also used within block (SyntaxError)` occurs in Ruby 3.3.0:

```console
$ cat example.rb
def baz(qux, quuz, &)
  with_block do
    bar(qux, quuz, &)
  end
end

$ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
example.rb: example.rb:3: anonymous block parameter is also used within block (SyntaxError)
```

This fix is based on the following comment:
https://github.com/rubocop/rubocop/issues/12571#issuecomment-1882650330

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
