### PR TITLE
Add missing PR feedback changes from #12711

### DIFF
--- a/lib/rubocop/cop/style/invertible_unless_condition.rb
+++ b/lib/rubocop/cop/style/invertible_unless_condition.rb
@@ -32,12 +32,14 @@ module RuboCop
       #   foo unless x != y
       #   foo unless x >= 10
       #   foo unless x.even?
+      #   foo unless odd?
       #
       #   # good
       #   foo if bar
       #   foo if x == y
       #   foo if x < 10
       #   foo if x.odd?
+      #   foo if even?
       #
       #   # bad (complex condition)
       #   foo unless x != y || x.even?

--- a/lib/rubocop/cop/style/invertible_unless_condition.rb
+++ b/lib/rubocop/cop/style/invertible_unless_condition.rb
@@ -105,19 +105,22 @@ module RuboCop
           receiver_source = node.receiver&.source
           return receiver_source if node.method?(:!)
 
-          receive = receiver_source ? "#{receiver_source}." : '' # receiver may be implicit (self)
+          # receiver may be implicit (self)
+          dotted_receiver_source = receiver_source ? "#{receiver_source}." : ''
 
           inverse_method_name = inverse_methods[node.method_name]
-          return "#{receive}#{inverse_method_name}" unless node.arguments?
+          return "#{dotted_receiver_source}#{inverse_method_name}" unless node.arguments?
 
           argument_list = node.arguments.map(&:source).join(', ')
           if node.operator_method?
             return "#{receiver_source} #{inverse_method_name} #{argument_list}"
           end
 
-          return "#{receive}#{inverse_method_name}(#{argument_list})" if node.parenthesized?
+          if node.parenthesized?
+            return "#{dotted_receiver_source}#{inverse_method_name}(#{argument_list})"
+          end
 
-          "#{receive}#{inverse_method_name} #{argument_list}"
+          "#{dotted_receiver_source}#{inverse_method_name} #{argument_list}"
         end
 
         def preferred_logical_condition(node)


### PR DESCRIPTION
These changes were meant to appear in #12711 in response to feedback on the PR, but were accidentally not pushed.

cc. @bbatsov

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* ~Added tests.~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
