### PR TITLE
[Fix #12600] Support Prism as a Ruby parser

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -76,6 +76,22 @@ jobs:
       - name: internal_investigation
         run: bundle exec rake internal_investigation
 
+  prism:
+    runs-on: ubuntu-latest
+    name: Prism
+    steps:
+      - uses: actions/checkout@v4
+      - name: set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          # Specify the minimum Ruby version 2.7 required for Prism to run.
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: spec
+        env:
+          PARSER_ENGINE: parser_prism
+        run: bundle exec rake prism_spec
+
   rspec4:
     runs-on: ubuntu-latest
     name: RSpec 4

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ InternalAffairs/NodeDestructuring:
 # Offense count: 55
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 191
+  Max: 192
 
 # Offense count: 235
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'asciidoctor'
 gem 'bump', require: false
 gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'memory_profiler', platform: :mri
+gem 'prism', '>= 0.24.0'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.20.0'

--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,10 @@ Dir['tasks/**/*.rake'].each { |t| load t }
 desc 'Run RuboCop over itself'
 RuboCop::RakeTask.new(:internal_investigation)
 
-task default: %i[documentation_syntax_check spec ascii_spec internal_investigation]
+# The `ascii_spec` task has not been failing for a while, so it will not be run by default.
+# However, `ascii_spec` task will continue to be checked in CI. If there are any failures
+# originating from `ascii_spec` in CI, please run `bundle exec ascii_spec` to investigate.
+task default: %i[documentation_syntax_check spec prism_spec internal_investigation]
 
 require 'yard'
 YARD::Rake::YardocTask.new

--- a/changelog/new_support_prism.md
+++ b/changelog/new_support_prism.md
@@ -1,0 +1,1 @@
+* [#12600](https://github.com/rubocop/rubocop/issues/12600): Support Prism as a Ruby parser (experimental). ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -144,6 +144,12 @@ AllCops:
   # Ruby version is still unresolved, RuboCop will use the oldest officially
   # supported Ruby version (currently Ruby 2.7).
   TargetRubyVersion: ~
+  # You can specify the parser engine. There are two options available:
+  # - `parser_whitequark` ... https://github.com/whitequark/parser
+  # - `parser_prism` ... https://github.com/ruby/prism (`Prism::Translation::Parser`)
+  # By default, `parser` is used. For the `TargetRubyVersion` value, `parser` can be specified for versions `2.0` and above.
+  # `parser_prism` can be specified for versions `3.3` and above. `parser_prism` is faster but still considered experimental.
+  ParserEngine: parser_whitequark
   # Determines if a notification for extension libraries should be shown when
   # rubocop is run. Keys are the name of the extension, and values are an array
   # of gems in the Gemfile that the extension is suggested for, if not already

--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -38,7 +38,9 @@ The following table is the runtime support matrix.
 | 3.4 (experimental) | -
 |===
 
-RuboCop targets Ruby 2.0+ code analysis since RuboCop 1.30. It restored code analysis support that had been removed earlier by mistake, together with dropping runtime support for unsupported Ruby versions.
+RuboCop targets Ruby 2.0+ code analysis with Parser gem as a parser since RuboCop 1.30. It restored code analysis support that had been removed earlier by mistake, together with dropping runtime support for unsupported Ruby versions.
+
+Starting from RuboCop 1.62, support for Prism's `Prism::Translation::parser` will enable analysis of Ruby 3.3+. For more details, please refer to the xref:configuration.adoc#setting-the-parser-engine[setting `ParserEngine`].
 
 NOTE: The compatibility xref:configuration.adoc#setting-the-target-ruby-version[setting `TargetRubyVersion`] is about code analysis (what RuboCop can analyze), not runtime (is RuboCop capable of running on some Ruby or not).
 

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -645,11 +645,57 @@ AllCops:
   TargetRubyVersion: 2.5
 ----
 
+NOTE: When `ParserEngine: parser_prism` is specified, the values that can be assigned to `TargetRubyVersion` must be `3.3` or higher.
+
 Otherwise, RuboCop will then check your project for a series of files where
 the version may be specified already. The files that will be looked for are
 `*.gemspec`, `.ruby-version`, `.tool-versions`, and `Gemfile.lock`.
 If Gemspec file has an array for `required_ruby_version`, the lowest version will be used.
 If none of the files are found a default version value will be used.
+
+== Setting the parser engine
+
+NOTE: The parser engine configuration was introduced in RuboCop 1.62. This experimental feature has been under consideration for a while.
+
+RuboCop allows switching the backend parser by specifying either `parser_whitequark` or `parser_prism` for the `ParserEngine`.
+
+Here are the parsers used as backends for each value:
+
+- `ParserEngine: parser_whitequark` ... https://github.com/whitequark/parser
+- `ParserEngine: parser_prism` ... https://github.com/ruby/prism (`Prism::Translation::Parser`)
+
+By default, `parser_whitequark` is implicitly used.
+
+`parser_whitequark` can analyze source code from Ruby 2.0 and above:
+
+[source,yaml]
+----
+AllCops:
+  ParserEngine: parser_whitequark
+----
+
+`parser_prism` can analyze source code from Ruby 3.3 and above:
+
+[source,yaml]
+----
+AllCops:
+  ParserEngine: parser_prism
+  TargetRubyVersion: 3.3
+----
+
+`parser_prism` tends to perform analysis faster than `parser_whitequark`.
+
+CAUTION: Since the use of Prism is experimental, it is not included in RuboCop's runtime dependencies.
+If running through Bundler, please first add `gem 'prism'` to your Gemfile:
+
+[source,ruby]
+----
+gem 'prism'
+----
+
+There are some incompatibilities with `parser_whitequark`, making it still considered experimental.
+For known issues, please refer to the Prism issues:
+https://github.com/ruby/prism/issues?q=is%3Aissue+is%3Aopen+label%3Arubocop
 
 == Automatically Generated Configuration
 

--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -372,6 +372,26 @@ This works because the correcting a file is implemented by repeating investigati
 
 Note that `expect_correction` in `Cop` specs only asserts the result after one pass.
 
+=== Run tests
+
+RuboCop supports two parser engines: the Parser gem and Prism. By default, tests are executed with the Parser:
+
+```console
+$ bundle exec rake spec
+```
+
+To run all tests with the experimental support for Prism, use `bundle exec prism_spec`, and to execute tests for individual files,
+specify the environment variable `PARSER_ENGINE=parser_prism`.
+
+e.g., `PARSER_ENGINE=parser_prism spec/rubocop/cop/style/hash_syntax_spec.rb`
+
+`bundle exec rake` runs tests for both Parser gem and Prism parsers.
+
+But `ascii_spec` rake task does not run by default. Because `ascii_spec` task has not been failing for a while.
+However, `ascii_spec` task will continue to be checked in CI.
+
+In CI, all tests required for merging are executed. Please investigate if anything fails.
+
 === Configuration
 
 Each cop can hold a configuration and you can refer to `cop_config` in the

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -62,7 +62,7 @@ module RuboCop
 
     def_delegators :@hash, :[], :[]=, :delete, :dig, :each, :key?, :keys, :each_key,
                    :fetch, :map, :merge, :replace, :to_h, :to_hash, :transform_values
-    def_delegators :@validator, :validate, :target_ruby_version
+    def_delegators :@validator, :validate, :target_ruby_version, :parser_engine
 
     def to_s
       @to_s ||= @hash.to_s

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -63,6 +63,10 @@ module RuboCop
       target_ruby.version
     end
 
+    def parser_engine
+      for_all_cops.fetch('ParserEngine', :parser_whitequark).to_sym
+    end
+
     def validate_section_presence(name)
       return unless @config.key?(name) && @config[name].nil?
 

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -232,6 +232,10 @@ module RuboCop
         @config.target_ruby_version
       end
 
+      def parser_engine
+        @config.parser_engine
+      end
+
       def target_rails_version
         @config.target_rails_version
       end
@@ -254,7 +258,7 @@ module RuboCop
 
       # There should be very limited reasons for a Cop to do it's own parsing
       def parse(source, path = nil)
-        ProcessedSource.new(source, target_ruby_version, path)
+        ProcessedSource.new(source, target_ruby_version, path, parser_engine: parser_engine)
       end
 
       # @api private

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -6,7 +6,11 @@ require 'tempfile'
 module CopHelper
   extend RSpec::SharedContext
 
-  let(:ruby_version) { RuboCop::TargetRuby::DEFAULT_VERSION }
+  let(:ruby_version) do
+    # The minimum version Prism can parse is 3.3.
+    ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : RuboCop::TargetRuby::DEFAULT_VERSION
+  end
+  let(:parser_engine) { ENV.fetch('PARSER_ENGINE', :parser_whitequark).to_sym }
   let(:rails_version) { false }
 
   def inspect_source(source, file = nil)
@@ -28,7 +32,9 @@ module CopHelper
       file = file.path
     end
 
-    processed_source = RuboCop::ProcessedSource.new(source, ruby_version, file)
+    processed_source = RuboCop::ProcessedSource.new(
+      source, ruby_version, file, parser_engine: parser_engine
+    )
     processed_source.config = configuration
     processed_source.registry = registry
     processed_source

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -139,47 +139,58 @@ RSpec.shared_context 'lsp' do
 end
 
 RSpec.shared_context 'ruby 2.0' do
-  let(:ruby_version) { 2.0 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.0 }
 end
 
 RSpec.shared_context 'ruby 2.1' do
-  let(:ruby_version) { 2.1 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.1 }
 end
 
 RSpec.shared_context 'ruby 2.2' do
-  let(:ruby_version) { 2.2 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.2 }
 end
 
 RSpec.shared_context 'ruby 2.3' do
-  let(:ruby_version) { 2.3 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.3 }
 end
 
 RSpec.shared_context 'ruby 2.4' do
-  let(:ruby_version) { 2.4 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.4 }
 end
 
 RSpec.shared_context 'ruby 2.5' do
-  let(:ruby_version) { 2.5 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.5 }
 end
 
 RSpec.shared_context 'ruby 2.6' do
-  let(:ruby_version) { 2.6 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.6 }
 end
 
 RSpec.shared_context 'ruby 2.7' do
-  let(:ruby_version) { 2.7 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.7 }
 end
 
 RSpec.shared_context 'ruby 3.0' do
-  let(:ruby_version) { 3.0 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 3.0 }
 end
 
 RSpec.shared_context 'ruby 3.1' do
-  let(:ruby_version) { 3.1 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 3.1 }
 end
 
 RSpec.shared_context 'ruby 3.2' do
-  let(:ruby_version) { 3.2 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 3.2 }
 end
 
 RSpec.shared_context 'ruby 3.3' do

--- a/lib/rubocop/rspec/support.rb
+++ b/lib/rubocop/rspec/support.rb
@@ -27,4 +27,5 @@ RSpec.configure do |config|
   config.include_context 'ruby 3.1', :ruby31
   config.include_context 'ruby 3.2', :ruby32
   config.include_context 'ruby 3.3', :ruby33
+  config.include_context 'ruby 3.4', :ruby34
 end

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -467,15 +467,21 @@ module RuboCop
       end
     end
 
+    # rubocop:disable Metrics/MethodLength
     def get_processed_source(file)
       config = @config_store.for_file(file)
       ruby_version = config.target_ruby_version
+      parser_engine = config.parser_engine
 
       processed_source = if @options[:stdin]
-                           ProcessedSource.new(@options[:stdin], ruby_version, file)
+                           ProcessedSource.new(
+                             @options[:stdin], ruby_version, file, parser_engine: parser_engine
+                           )
                          else
                            begin
-                             ProcessedSource.from_file(file, ruby_version)
+                             ProcessedSource.from_file(
+                               file, ruby_version, parser_engine: parser_engine
+                             )
                            rescue Errno::ENOENT
                              raise RuboCop::Error, "No such file or directory: #{file}"
                            end
@@ -484,6 +490,7 @@ module RuboCop
       processed_source.registry = mobilized_cop_classes(config)
       processed_source
     end
+    # rubocop:enable Metrics/MethodLength
 
     # A Cop::Team instance is stateful and may change when inspecting.
     # The "standby" team for a given config is an initialized but

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -5,7 +5,7 @@ module RuboCop
   module Version
     STRING = '1.61.0'
 
-    MSG = '%<version>s (using Parser %<parser_version>s, ' \
+    MSG = '%<version>s (using %<parser_version>s, ' \
           'rubocop-ast %<rubocop_ast_version>s, ' \
           'running on %<ruby_engine>s %<ruby_version>s)%<server_mode>s [%<ruby_platform>s]'
 
@@ -20,7 +20,7 @@ module RuboCop
     # @api private
     def self.version(debug: false, env: nil)
       if debug
-        verbose_version = format(MSG, version: STRING, parser_version: Parser::VERSION,
+        verbose_version = format(MSG, version: STRING, parser_version: parser_version,
                                       rubocop_ast_version: RuboCop::AST::Version::STRING,
                                       ruby_engine: RUBY_ENGINE, ruby_version: RUBY_VERSION,
                                       server_mode: server_mode,
@@ -36,6 +36,21 @@ module RuboCop
         VERSIONS
       else
         STRING
+      end
+    end
+
+    # @api private
+    def self.parser_version
+      config_path = ConfigFinder.find_config_path(Dir.pwd)
+      yaml = YAML.safe_load(
+        File.read(config_path), permitted_classes: [Regexp, Symbol], aliases: true
+      )
+
+      if yaml.dig('AllCops', 'ParserEngine') == 'parser_prism'
+        require 'prism'
+        "Prism #{Prism::VERSION}"
+      else
+        "Parser #{Parser::VERSION}"
       end
     end
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
   s.add_runtime_dependency('rexml', '>= 3.2.5', '< 4.0')
-  s.add_runtime_dependency('rubocop-ast', '>= 1.31.0', '< 2.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 1.31.1', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 2.4.0', '< 3.0')
 end

--- a/spec/rubocop/cop/alignment_corrector_spec.rb
+++ b/spec/rubocop/cop/alignment_corrector_spec.rb
@@ -69,7 +69,8 @@ RSpec.describe RuboCop::Cop::AlignmentCorrector, :config do
         it_behaves_like 'heredoc indenter', '<<DOC', 20
       end
 
-      context 'with heredoc in backticks (<<``)' do
+      # FIXME: https://github.com/ruby/prism/issues/2498
+      context 'with heredoc in backticks (<<``)', broken_on: :prism do
         it_behaves_like 'heredoc indenter', '<<`DOC`', 20
       end
     end

--- a/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
+++ b/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
@@ -2,13 +2,13 @@
 
 RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
   # rubocop:disable RSpec/RepeatedExampleGroupDescription
-  context 'target ruby version > 2.7', :ruby27 do
+  context 'target ruby version > 3.4', :ruby34 do
     # rubocop:enable RSpec/RepeatedExampleGroupDescription
     it 'registers an offense when `required_ruby_version` is specified with >= and is lower than `TargetRubyVersion`' do
       expect_offense(<<~RUBY, '/path/to/foo.gemspec')
         Gem::Specification.new do |spec|
-          spec.required_ruby_version = '>= 2.6.0'
-                                       ^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
+          spec.required_ruby_version = '>= 3.3.0'
+                                       ^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (3.4, which may be specified in .rubocop.yml) should be equal.
         end
       RUBY
     end
@@ -16,8 +16,8 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
     it 'registers an offense when `required_ruby_version` is specified with ~> and is lower than `TargetRubyVersion`' do
       expect_offense(<<~RUBY, '/path/to/foo.gemspec')
         Gem::Specification.new do |spec|
-          spec.required_ruby_version = '~> 2.6.0'
-                                       ^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
+          spec.required_ruby_version = '~> 3.3.0'
+                                       ^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (3.4, which may be specified in .rubocop.yml) should be equal.
         end
       RUBY
     end
@@ -25,8 +25,8 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
     it 'registers an offense when `required_ruby_version` is specified in array and is lower than `TargetRubyVersion`' do
       expect_offense(<<~RUBY, '/path/to/foo.gemspec')
         Gem::Specification.new do |spec|
-          spec.required_ruby_version = ['>= 2.6.0', '< 3.0.0']
-                                       ^^^^^^^^^^^^^^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
+          spec.required_ruby_version = ['>= 3.3.0', '< 4.0.0']
+                                       ^^^^^^^^^^^^^^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (3.4, which may be specified in .rubocop.yml) should be equal.
         end
       RUBY
     end
@@ -34,8 +34,8 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
     it 'recognizes Gem::Requirement and registers offense' do
       expect_offense(<<~RUBY, '/path/to/foo.gemspec')
         Gem::Specification.new do |spec|
-          spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
-                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
+          spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
+                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (3.4, which may be specified in .rubocop.yml) should be equal.
         end
       RUBY
     end
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
       expect_offense(<<~RUBY)
         Gem::Specification.new do |spec|
           spec.required_ruby_version = Gem::Requirement.new('< 3.4')
-                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
+                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (3.4, which may be specified in .rubocop.yml) should be equal.
         end
       RUBY
     end
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
     it 'recognizes a Gem::Requirement with multiple requirements and does not register an offense' do
       expect_no_offenses(<<~RUBY)
         Gem::Specification.new do |spec|
-          spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0", "<= 2.8")
+          spec.required_ruby_version = Gem::Requirement.new(">= 3.4.0", "<= 3.8")
         end
       RUBY
     end
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
          'is assigned as a variable (string literal)' do
         expect_no_offenses(<<~RUBY)
           Gem::Specification.new do |spec|
-            version = '>= 2.6.0'
+            version = '>= 3.3.0'
             spec.required_ruby_version = version
           end
         RUBY
@@ -72,8 +72,8 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
          'is assigned as a variable (an array of string literal)' do
         expect_no_offenses(<<~RUBY)
           Gem::Specification.new do |spec|
-            lowest_version = '>= 2.6.0'
-            highest_version = '< 2.8.0'
+            lowest_version = '>= 3.3.0'
+            highest_version = '< 3.8.0'
             spec.required_ruby_version = [lowest_version, highest_version]
           end
         RUBY
@@ -81,12 +81,12 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
     end
   end
 
-  context 'target ruby version > 2.6', :ruby26 do
+  context 'target ruby version > 3.3', :ruby33 do
     it 'registers an offense when `required_ruby_version` is specified with >= and is higher than `TargetRubyVersion`' do
       expect_offense(<<~RUBY, '/path/to/bar.gemspec')
         Gem::Specification.new do |spec|
-          spec.required_ruby_version = '>= 2.7.0'
-                                       ^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (2.6, which may be specified in .rubocop.yml) should be equal.
+          spec.required_ruby_version = '>= 3.4.0'
+                                       ^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (3.3, which may be specified in .rubocop.yml) should be equal.
         end
       RUBY
     end
@@ -94,20 +94,20 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
     it 'registers an offense when `required_ruby_version` is specified with ~> and is higher than `TargetRubyVersion`' do
       expect_offense(<<~RUBY, '/path/to/bar.gemspec')
         Gem::Specification.new do |spec|
-          spec.required_ruby_version = '~> 2.7.0'
-                                       ^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (2.6, which may be specified in .rubocop.yml) should be equal.
+          spec.required_ruby_version = '~> 3.4.0'
+                                       ^^^^^^^^^^ `required_ruby_version` and `TargetRubyVersion` (3.3, which may be specified in .rubocop.yml) should be equal.
         end
       RUBY
     end
   end
 
   # rubocop:disable RSpec/RepeatedExampleGroupDescription
-  context 'target ruby version > 2.7', :ruby27 do
+  context 'target ruby version > 3.4', :ruby34 do
     # rubocop:enable RSpec/RepeatedExampleGroupDescription
     it 'does not register an offense when `required_ruby_version` is specified with >= and equals `TargetRubyVersion`' do
       expect_no_offenses(<<~RUBY)
         Gem::Specification.new do |spec|
-          spec.required_ruby_version = '>= 2.7.0'
+          spec.required_ruby_version = '>= 3.4.0'
         end
       RUBY
     end
@@ -115,7 +115,7 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
     it 'does not register an offense when `required_ruby_version` is specified with ~> and equals `TargetRubyVersion`' do
       expect_no_offenses(<<~RUBY)
         Gem::Specification.new do |spec|
-          spec.required_ruby_version = '~> 2.7.0'
+          spec.required_ruby_version = '~> 3.4.0'
         end
       RUBY
     end
@@ -124,7 +124,7 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
        'equals `TargetRubyVersion`' do
       expect_no_offenses(<<~RUBY)
         Gem::Specification.new do |spec|
-          spec.required_ruby_version = '>= 2.7'
+          spec.required_ruby_version = '>= 3.4'
         end
       RUBY
     end
@@ -133,7 +133,7 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
        'equals `TargetRubyVersion`' do
       expect_no_offenses(<<~RUBY)
         Gem::Specification.new do |spec|
-          spec.required_ruby_version = '~> 2.7'
+          spec.required_ruby_version = '~> 3.4'
         end
       RUBY
     end
@@ -142,7 +142,7 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
        '`required_ruby_version` equals `TargetRubyVersion`' do
       expect_no_offenses(<<~RUBY)
         Gem::Specification.new do |spec|
-          spec.required_ruby_version = ['>= 2.7.0', '< 3.1.0']
+          spec.required_ruby_version = ['>= 3.4.0', '< 4.1.0']
         end
       RUBY
     end
@@ -151,8 +151,8 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
        'than `TargetRubyVersion`' do
       expect_offense(<<~RUBY, 'bar.gemspec')
         Gem::Specification.new do |spec|
-          spec.required_ruby_version = '>= 2'
-                                       ^^^^^^ `required_ruby_version` and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
+          spec.required_ruby_version = '>= 3'
+                                       ^^^^^^ `required_ruby_version` and `TargetRubyVersion` (3.4, which may be specified in .rubocop.yml) should be equal.
         end
       RUBY
     end
@@ -161,36 +161,36 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
        'than `TargetRubyVersion`' do
       expect_offense(<<~RUBY, 'bar.gemspec')
         Gem::Specification.new do |spec|
-          spec.required_ruby_version = '~> 2'
-                                       ^^^^^^ `required_ruby_version` and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
+          spec.required_ruby_version = '~> 3'
+                                       ^^^^^^ `required_ruby_version` and `TargetRubyVersion` (3.4, which may be specified in .rubocop.yml) should be equal.
         end
       RUBY
     end
-  end
 
-  it 'registers an offense when `required_ruby_version` is not specified' do
-    expect_offense(<<~RUBY, '/path/to/foo.gemspec')
-      Gem::Specification.new do |spec|
-      ^{} `required_ruby_version` should be specified.
-      end
-    RUBY
-  end
+    it 'registers an offense when `required_ruby_version` is not specified' do
+      expect_offense(<<~RUBY, '/path/to/foo.gemspec')
+        Gem::Specification.new do |spec|
+        ^{} `required_ruby_version` should be specified.
+        end
+      RUBY
+    end
 
-  it 'registers an offense when `required_ruby_version` is blank' do
-    expect_offense(<<~RUBY, 'bar.gemspec')
-      Gem::Specification.new do |spec|
-        spec.required_ruby_version = ''
-                                     ^^ `required_ruby_version` and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
-      end
-    RUBY
-  end
+    it 'registers an offense when `required_ruby_version` is blank' do
+      expect_offense(<<~RUBY, 'bar.gemspec')
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = ''
+                                       ^^ `required_ruby_version` and `TargetRubyVersion` (3.4, which may be specified in .rubocop.yml) should be equal.
+        end
+      RUBY
+    end
 
-  it 'registers an offense when `required_ruby_version` is an empty array' do
-    expect_offense(<<~RUBY, 'bar.gemspec')
-      Gem::Specification.new do |spec|
-        spec.required_ruby_version = []
-                                     ^^ `required_ruby_version` and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
-      end
-    RUBY
+    it 'registers an offense when `required_ruby_version` is an empty array' do
+      expect_offense(<<~RUBY, 'bar.gemspec')
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = []
+                                       ^^ `required_ruby_version` and `TargetRubyVersion` (3.4, which may be specified in .rubocop.yml) should be equal.
+        end
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/internal_affairs/location_line_equality_comparison_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/location_line_equality_comparison_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::InternalAffairs::LocationLineEqualityComparison, :config do
+# FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+# the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+# rubocop:disable Layout/LineLength
+RSpec.describe RuboCop::Cop::InternalAffairs::LocationLineEqualityComparison, :config, broken_on: :prism do
+  # rubocop:enable Layout/LineLength
   it 'registers and corrects an offense when comparing `#loc.line` with LHS and RHS' do
     expect_offense(<<~RUBY)
       node.loc.line == node.parent.loc.line

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -362,7 +362,8 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects when xstr heredoc constant is defined after public method' do
+  # FIXME: https://github.com/ruby/prism/issues/2498
+  it 'registers an offense and corrects when xstr heredoc constant is defined after public method', broken_on: :prism do
     expect_offense(<<~RUBY)
       class Foo
         def do_something

--- a/spec/rubocop/cop/layout/empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLines, :config do
     RUBY
   end
 
-  it 'does not register an offense for empty lines in a string' do
+  # FIXME: https://github.com/ruby/prism/issues/2512
+  it 'does not register an offense for empty lines in a string', broken_on: :prism do
     expect_no_offenses(<<~RUBY)
       result = "test
 
@@ -40,7 +41,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLines, :config do
     RUBY
   end
 
-  it 'does not register an offense for heredocs with empty lines inside' do
+  # FIXME: https://github.com/ruby/prism/issues/2512
+  it 'does not register an offense for heredocs with empty lines inside', broken_on: :prism do
     expect_no_offenses(<<~RUBY)
       str = <<-TEXT
       line 1

--- a/spec/rubocop/cop/layout/end_of_line_spec.rb
+++ b/spec/rubocop/cop/layout/end_of_line_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
       expect_no_offenses('x=0')
     end
 
-    it 'does not register offenses after __END__' do
+    it 'does not register offenses after __END__', broken_on: :prism do
       expect_no_offenses(<<~RUBY)
         x=0\r
         __END__

--- a/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
   let(:other_cops) { { 'Layout/LineLength' => { 'Max' => 5, 'AllowHeredoc' => allow_heredoc } } }
 
   shared_examples 'all heredoc type' do |quote|
-    context "quoted by #{quote}" do
+    # FIXME: https://github.com/ruby/prism/issues/2498
+    # Once the above will be resolved, the `options` can be removed.
+    options = quote == '`' ? { broken_on: :prism } : {}
+    context "quoted by #{quote}", options do
       it 'does not register an offense when not indented but with whitespace, with `-`' do
         expect_no_offenses(<<-RUBY)
           def foo
@@ -255,7 +258,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
     [nil, "'", '"', '`'].each { |quote| include_examples 'all heredoc type', quote }
   end
 
-  context 'when Ruby <= 2.2', :ruby22 do
+  context 'when Ruby <= 2.2', :ruby22, unsupported_on: :prism do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
         <<-RUBY2

--- a/spec/rubocop/cop/layout/indentation_style_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_style_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe RuboCop::Cop::Layout::IndentationStyle, :config do
       RUBY
     end
 
-    it 'registers offenses before __END__ but not after' do
+    # FIXME: https://github.com/ruby/prism/issues/2510
+    it 'registers offenses before __END__ but not after', broken_on: :prism do
       expect_offense(<<~RUBY)
         \tx = 0
         ^ Tab detected in indentation.
@@ -137,7 +138,8 @@ RSpec.describe RuboCop::Cop::Layout::IndentationStyle, :config do
       RUBY
     end
 
-    it 'registers offenses before __END__ but not after' do
+    # FIXME: https://github.com/ruby/prism/issues/2510
+    it 'registers offenses before __END__ but not after', broken_on: :prism do
       expect_offense(<<~RUBY)
           x = 0
         ^^ Space detected in indentation.

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
     RUBY
   end
 
-  it 'registers an offense for long line before __END__ but not after' do
+  # FIXME: https://github.com/ruby/prism/issues/2510
+  it 'registers an offense for long line before __END__ but not after', broken_on: :prism do
     maximum_string = '#' * 80
     expect_offense(<<~RUBY, maximum_string: maximum_string)
       #{maximum_string}#{'#' * 70}

--- a/spec/rubocop/cop/layout/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_keyword_spec.rb
@@ -127,7 +127,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   it_behaves_like 'missing after', 'until', '1 until""', '1 until ""'
   it_behaves_like 'missing before', 'when', 'case ""when a; end', 'case "" when a; end'
   it_behaves_like 'missing after', 'when', 'case a when""; end', 'case a when ""; end'
-  context '>= Ruby 2.7', :ruby27 do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+  # FIXME: https://github.com/ruby/prism/pull/2525
+  context '>= Ruby 2.7', :ruby27, broken_on: :prism do
     # TODO: `case ""in a; end` is syntax error in Ruby 3.0.1.
     #       This syntax is confirmed: https://bugs.ruby-lang.org/issues/17925
     #       The answer will determine whether to enable or discard the test in the future.

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -162,7 +162,9 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
     RUBY
   end
 
-  it 'accepts vertical alignment with operator' do
+  # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+  # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+  it 'accepts vertical alignment with operator', broken_on: :prism do
     expect_no_offenses(<<~RUBY)
       down? && !migrated.include?(migration.version.to_i)
       up?   &&  migrated.include?(migration.version.to_i)

--- a/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
+# FIXME: https://github.com/ruby/prism/issues/2467
+RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config, broken_on: :prism do
   let(:cop_config) { { 'EnforcedStyle' => 'space' } }
 
   context 'with space inside empty braces not allowed' do

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
     RUBY
   end
 
-  it 'registers offenses before __END__ but not after' do
+  # FIXME: https://github.com/ruby/prism/issues/2510
+  it 'registers offenses before __END__ but not after', broken_on: :prism do
     expect_offense(<<~RUBY)
       x = 0\t
            ^ Trailing whitespace detected.

--- a/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Lint::AmbiguousOperator, :config do
+# FIXME: https://github.com/ruby/prism/issues/2513 and https://github.com/ruby/prism/issues/2514
+RSpec.describe RuboCop::Cop::Lint::AmbiguousOperator, :config, broken_on: :prism do
   context 'with `+` unary operator in the first argument' do
     context 'without parentheses' do
       context 'without whitespaces on the right of the operator' do

--- a/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral, :config do
+# FIXME: https://github.com/ruby/prism/issues/2513
+RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral, :config, broken_on: :prism do
   shared_examples 'with a regexp literal in the first argument' do
     context 'without parentheses' do
       it 'registers an offense and corrects when single argument' do
@@ -179,7 +180,7 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral, :config do
     end
   end
 
-  context 'Ruby <= 2.7', :ruby27 do
+  context 'Ruby <= 2.7', :ruby27, unsupported_on: :prism do
     include_examples 'with a regexp literal in the first argument'
   end
 

--- a/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
+++ b/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Run test with Ruby 2.6 because this cop cannot handle invalid syntax in Ruby 2.7+.
-RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference, :config, :ruby26 do
+RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference, :config, :ruby26, unsupported_on: :prism do # rubocop:disable Layout/LineLength
   describe 'circular argument references in ordinal arguments' do
     context 'when the method contains a circular argument reference' do
       it 'registers an offense' do

--- a/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
@@ -62,7 +62,9 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedClassMethods, :config do
   end
 
   context 'prefer `block_given?` over `iterator?`' do
-    it 'registers an offense and corrects iterator?' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers an offense and corrects iterator?', broken_on: :prism do
       expect_offense(<<~RUBY)
         iterator?
         ^^^^^^^^^ `iterator?` is deprecated in favor of `block_given?`.
@@ -73,7 +75,9 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedClassMethods, :config do
       RUBY
     end
 
-    it 'does not register an offense for block_given?' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'does not register an offense for block_given?', broken_on: :prism do
       expect_no_offenses('block_given?')
     end
 

--- a/spec/rubocop/cop/lint/deprecated_constants_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_constants_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedConstants, :config do
     RUBY
   end
 
-  context 'Ruby <= 2.5', :ruby25 do
+  context 'Ruby <= 2.5', :ruby25, unsupported_on: :prism do
     it 'does not register an offense when using `Net::HTTPServerException`' do
       expect_no_offenses(<<~RUBY)
         Net::HTTPServerException
@@ -74,7 +74,7 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedConstants, :config do
     end
   end
 
-  context 'Ruby <= 2.7', :ruby27 do
+  context 'Ruby <= 2.7', :ruby27, unsupported_on: :prism do
     it 'does not register an offense when using `Random::DEFAULT`' do
       expect_no_offenses(<<~RUBY)
         Random::DEFAULT

--- a/spec/rubocop/cop/lint/erb_new_arguments_spec.rb
+++ b/spec/rubocop/cop/lint/erb_new_arguments_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::ErbNewArguments, :config do
-  context '<= Ruby 2.5', :ruby25 do
+  context '<= Ruby 2.5', :ruby25, unsupported_on: :prism do
     it 'does not register an offense when using `ERB.new` with non-keyword arguments' do
       expect_no_offenses(<<~RUBY)
         ERB.new(str, nil, '-', '@output_buffer')

--- a/spec/rubocop/cop/lint/non_deterministic_require_order_spec.rb
+++ b/spec/rubocop/cop/lint/non_deterministic_require_order_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::Lint::NonDeterministicRequireOrder, :config do
       end
     end
 
-    context 'when Ruby 2.7 or lower', :ruby27 do
+    context 'when Ruby 2.7 or lower', :ruby27, unsupported_on: :prism do
       context 'with unsorted index' do
         it 'registers an offense and autocorrects to add .sort when the block has `require`' do
           expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/lint/numbered_parameter_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/numbered_parameter_assignment_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Lint::NumberedParameterAssignment, :config do
   # NOTE: Assigning to numbered parameter (from `_1` to `_9`) cause an error in Ruby 3.0.
-  context 'when Ruby 2.7 or lower', :ruby27 do
+  context 'when Ruby 2.7 or lower', :ruby27, unsupported_on: :prism do
     (1..9).to_a.each do |number|
       it "registers an offense when using `_#{number}` numbered parameter" do
         expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -12,8 +12,9 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects for predicate method call with space ' \
-     'before the parenthesis' do
+  # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+  # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+  it 'registers an offense and corrects for predicate method call with space before the parenthesis', broken_on: :prism do
     expect_offense(<<~RUBY)
       is? (x)
          ^ `(x)` interpreted as grouped expression.

--- a/spec/rubocop/cop/lint/redundant_dir_glob_sort_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_dir_glob_sort_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantDirGlobSort, :config do
     end
   end
 
-  context 'when Ruby 2.7 or lower', :ruby27 do
+  context 'when Ruby 2.7 or lower', :ruby27, unsupported_on: :prism do
     it 'does not register an offense and correction when using `Dir.glob.sort`' do
       expect_no_offenses(<<~RUBY)
         Dir.glob(Rails.root.join('test', '*.rb')).sort.each(&method(:require))

--- a/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
     RUBY
   end
 
-  context 'target ruby version <= 2.0', :ruby20 do
+  context 'target ruby version <= 2.0', :ruby20, unsupported_on: :prism do
     it 'does not register an offense when using requiring `thread`' do
       expect_no_offenses(<<~RUBY)
         require 'thread'
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
     end
   end
 
-  context 'target ruby version <= 2.1', :ruby21 do
+  context 'target ruby version <= 2.1', :ruby21, unsupported_on: :prism do
     it 'does not register an offense when using requiring `rational`, `complex`' do
       expect_no_offenses(<<~RUBY)
         require 'rational'
@@ -96,7 +96,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
     end
   end
 
-  context 'target ruby version <= 2.4', :ruby24 do
+  context 'target ruby version <= 2.4', :ruby24, unsupported_on: :prism do
     it 'does not register an offense when using requiring `pp`' do
       expect_no_offenses(<<~RUBY)
         require 'pp'
@@ -186,7 +186,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
     end
   end
 
-  context 'target ruby version <= 2.6', :ruby26 do
+  context 'target ruby version <= 2.6', :ruby26, unsupported_on: :prism do
     it 'does not register an offense when using requiring `ruby2_keywords`' do
       expect_no_offenses(<<~RUBY)
         require 'ruby2_keywords'
@@ -218,7 +218,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
     end
   end
 
-  context 'target ruby version < 3.1', :ruby30 do
+  context 'target ruby version < 3.1', :ruby30, unsupported_on: :prism do
     it 'does not register an offense and corrects when using requiring `fiber`' do
       expect_no_offenses(<<~RUBY)
         require 'fiber'

--- a/spec/rubocop/cop/lint/refinement_import_methods_spec.rb
+++ b/spec/rubocop/cop/lint/refinement_import_methods_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::Lint::RefinementImportMethods, :config do
     end
   end
 
-  context 'Ruby <= 3.0', :ruby30 do
+  context 'Ruby <= 3.0', :ruby30, unsupported_on: :prism do
     it 'does not register an offense when using `include` in `refine` block' do
       expect_no_offenses(<<~RUBY)
         refine Foo do

--- a/spec/rubocop/cop/lint/require_parentheses_spec.rb
+++ b/spec/rubocop/cop/lint/require_parentheses_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe RuboCop::Cop::Lint::RequireParentheses, :config do
     RUBY
   end
 
-  it 'registers an offense for missing parentheses around expression with || operator' do
+  # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+  # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+  it 'registers an offense for missing parentheses around expression with || operator', broken_on: :prism do
     expect_offense(<<~RUBY)
       day_is? 'tuesday' || true
       ^^^^^^^^^^^^^^^^^^^^^^^^^ Use parentheses in the method call to avoid confusion about precedence.

--- a/spec/rubocop/cop/lint/syntax_spec.rb
+++ b/spec/rubocop/cop/lint/syntax_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe RuboCop::Cop::Lint::Syntax, :config do
   describe '.offenses_from_processed_source' do
     let(:commissioner) { RuboCop::Cop::Commissioner.new([cop]) }
     let(:offenses) { commissioner.investigate(processed_source).offenses }
+    let(:ruby_version) { 3.3 } # The minimum version Prism can parse is 3.3.
+    let(:syntax_error_message) do
+      parser_engine == :parser_whitequark ? 'unexpected token $end' : 'expected a matching `)`'
+    end
 
     context 'with a diagnostic error' do
       let(:source) { '(' }
@@ -11,8 +15,8 @@ RSpec.describe RuboCop::Cop::Lint::Syntax, :config do
       it 'returns an offense' do
         expect(offenses.size).to eq(1)
         message = <<~MESSAGE.chomp
-          unexpected token $end
-          (Using Ruby 2.7 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
+          #{syntax_error_message}
+          (Using Ruby 3.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
         MESSAGE
         offense = offenses.first
         expect(offense.message).to eq(message)
@@ -25,8 +29,8 @@ RSpec.describe RuboCop::Cop::Lint::Syntax, :config do
         it 'returns an offense with cop name' do
           expect(offenses.size).to eq(1)
           message = <<~MESSAGE.chomp
-            Lint/Syntax: unexpected token $end
-            (Using Ruby 2.7 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
+            Lint/Syntax: #{syntax_error_message}
+            (Using Ruby 3.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
           MESSAGE
           offense = offenses.first
           expect(offense.message).to eq(message)
@@ -42,8 +46,8 @@ RSpec.describe RuboCop::Cop::Lint::Syntax, :config do
         it 'returns an offense' do
           expect(offenses.size).to eq(1)
           message = <<~MESSAGE.chomp
-            unexpected token $end
-            (Using Ruby 2.7 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
+            #{syntax_error_message}
+            (Using Ruby 3.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
           MESSAGE
           offense = offenses.first
           expect(offense.message).to eq(message)
@@ -53,7 +57,7 @@ RSpec.describe RuboCop::Cop::Lint::Syntax, :config do
 
       context 'with `--lsp` option', :lsp do
         it 'does not include a configuration information in the offense message' do
-          expect(offenses.first.message).to eq('unexpected token $end')
+          expect(offenses.first.message).to eq(syntax_error_message)
         end
       end
     end

--- a/spec/rubocop/cop/lint/unified_integer_spec.rb
+++ b/spec/rubocop/cop/lint/unified_integer_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Lint::UnifiedInteger, :config do
   shared_examples 'registers an offense' do |klass|
-    context 'target ruby version < 2.4', :ruby23 do
+    context 'target ruby version < 2.4', :ruby23, unsupported_on: :prism do
       context "when #{klass}" do
         context 'without any decorations' do
           it 'registers an offense and autocorrects' do

--- a/spec/rubocop/cop/lint/useless_else_without_rescue_spec.rb
+++ b/spec/rubocop/cop/lint/useless_else_without_rescue_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::UselessElseWithoutRescue, :config do
-  context 'with `else` without `rescue`', :ruby25 do
+  context 'with `else` without `rescue`', :ruby25, unsupported_on: :prism do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         begin

--- a/spec/rubocop/cop/naming/block_forwarding_spec.rb
+++ b/spec/rubocop/cop/naming/block_forwarding_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe RuboCop::Cop::Naming::BlockForwarding, :config do
       end
     end
 
-    context 'Ruby < 3.0', :ruby30 do
+    context 'Ruby < 3.0', :ruby30, unsupported_on: :prism do
       it 'does not register an offense when not using anonymous block forwarding' do
         expect_no_offenses(<<~RUBY)
           def foo(&block)

--- a/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
+++ b/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
@@ -124,7 +124,8 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
         end
       end
 
-      context 'when using back tick delimiters' do
+      # FIXME: https://github.com/ruby/prism/issues/2498
+      context 'when using back tick delimiters', broken_on: :prism do
         it 'registers an offense and corrects with a lowercase delimiter' do
           expect_offense(<<~RUBY)
             <<-`sql`
@@ -174,7 +175,9 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
         end
       end
 
-      context 'when using blank heredoc delimiters' do
+      # FIXME: `<<''` is a syntax error. This test was added because Parser gem can parse it,
+      # but this will be removed after https://github.com/whitequark/parser/issues/996 is resolved.
+      context 'when using blank heredoc delimiters', unsupported_on: :prism do
         it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)
             <<''

--- a/spec/rubocop/cop/naming/heredoc_delimiter_naming_spec.rb
+++ b/spec/rubocop/cop/naming/heredoc_delimiter_naming_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterNaming, :config do
       end
     end
 
-    context 'when using back tick delimiters' do
+    # FIXME: https://github.com/ruby/prism/issues/2498
+    context 'when using back tick delimiters', broken_on: :prism do
       it 'registers an offense with a non-meaningful delimiter' do
         expect_offense(<<~RUBY)
           <<-`END`
@@ -91,7 +92,9 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterNaming, :config do
       end
     end
 
-    context 'when using blank heredoc delimiters' do
+    # FIXME: `<<~''` is a syntax error in Ruby. This test was added because Parser gem can parse it,
+    # but this will be removed after https://github.com/whitequark/parser/issues/996 is resolved.
+    context 'when using blank heredoc delimiters', unsupported_on: :prism do
       it 'registers an offense with a non-meaningful delimiter' do
         expect_offense(<<~RUBY)
           <<~''

--- a/spec/rubocop/cop/naming/variable_number_spec.rb
+++ b/spec/rubocop/cop/naming/variable_number_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
 
   shared_examples 'accepts' do |style, variable|
     # `_1 = 1` is a deprecated valid syntax in Ruby 2.7, but an invalid syntax in Ruby 3.0+.
-    it "accepts #{variable} in #{style}", :ruby27 do
+    it "accepts #{variable} in #{style}", :ruby27, unsupported_on: :prism do
       expect_no_offenses("#{variable} = 1")
     end
   end

--- a/spec/rubocop/cop/security/yaml_load_spec.rb
+++ b/spec/rubocop/cop/security/yaml_load_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::Security::YAMLLoad, :config do
     expect_no_offenses('Module::YAML.load("foo")')
   end
 
-  context 'Ruby <= 3.0', :ruby30 do
+  context 'Ruby <= 3.0', :ruby30, unsupported_on: :prism do
     it 'registers an offense and corrects load with a literal string' do
       expect_offense(<<~RUBY)
         YAML.load("--- !ruby/object:Foo {}")

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
   let(:redundant_keyword_rest_argument_names) { %w[kwargs options opts] }
   let(:redundant_block_argument_names) { %w[blk block proc] }
 
-  context 'TargetRubyVersion <= 2.6', :ruby26 do
+  context 'TargetRubyVersion <= 2.6', :ruby26, unsupported_on: :prism do
     it 'does not register an offense when using restarg with block arg' do
       expect_no_offenses(<<~RUBY)
         def foo(*args, &block)
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
   end
 
   context 'TargetRubyVersion >= 2.7', :ruby27 do
-    it 'registers an offense when using restarg and block arg' do
+    it 'registers an offense when using restarg and block arg', unsupported_on: :prism do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
                 ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
@@ -92,7 +92,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'registers an offense when passing restarg and block arg in defs' do
+    it 'registers an offense when passing restarg and block arg in defs', unsupported_on: :prism do
       expect_offense(<<~RUBY)
         def self.foo(*args, &block)
                      ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
@@ -108,7 +108,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'registers an offense when the parentheses of arguments are omitted' do
+    it 'registers an offense when the parentheses of arguments are omitted', unsupported_on: :prism do
       expect_offense(<<~RUBY)
         def foo *args, &block
                 ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
@@ -127,7 +127,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'registers an offense when forwarding to a method in block' do
+    it 'registers an offense when forwarding to a method in block', unsupported_on: :prism do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
                 ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
@@ -147,7 +147,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'registers an offense when delegating' do
+    it 'registers an offense when delegating', unsupported_on: :prism do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
                 ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
@@ -157,7 +157,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'registers an offense when using restarg and block arg for `.()` call' do
+    it 'registers an offense when using restarg and block arg for `.()` call', unsupported_on: :prism do
       expect_offense(<<~RUBY)
         def foo(*args, &block)
                 ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
@@ -173,7 +173,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when using block arg', :ruby30 do
+    it 'does not register an offense when using block arg', :ruby30, unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(&block)
           bar(&block)
@@ -208,7 +208,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     context 'when `RedundantBlockArgumentNames: [meaningless_block_name]`' do
       let(:redundant_block_argument_names) { ['meaningless_block_name'] }
 
-      it 'registers an offense when using restarg and block arg' do
+      it 'registers an offense when using restarg and block arg', unsupported_on: :prism do
         expect_offense(<<~RUBY)
           def foo(*args, &meaningless_block_name)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
@@ -224,7 +224,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
         RUBY
       end
 
-      it 'does not register an offense when using restarg and unconfigured block arg' do
+      it 'does not register an offense when using restarg and unconfigured block arg', unsupported_on: :prism do
         expect_no_offenses(<<~RUBY)
           def foo(*args, &block)
             bar(*args, &block)
@@ -275,7 +275,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when different arguments are used' do
+    it 'does not register an offense when different arguments are used', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(*args, &block)
           bar(*args)
@@ -291,7 +291,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when different splat argument names are used' do
+    it 'does not register an offense when different splat argument names are used', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(*args, &block)
           bar(*arguments, &block)
@@ -299,7 +299,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when different kwrest argument names are used' do
+    it 'does not register an offense when different kwrest argument names are used', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(**kwargs, &block)
           bar(**kwarguments, &block)
@@ -307,7 +307,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when the restarg is overwritten' do
+    it 'does not register an offense when the restarg is overwritten', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(*args, **kwargs, &block)
           args = new_args
@@ -316,7 +316,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when the kwarg is overwritten' do
+    it 'does not register an offense when the kwarg is overwritten', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(*args, **kwargs, &block)
           kwargs = new_kwargs
@@ -325,7 +325,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when the block arg is overwritten' do
+    it 'does not register an offense when the block arg is overwritten', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(*args, **kwargs, &block)
           block = new_block
@@ -334,7 +334,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when using the restarg outside forwarding method arguments' do
+    it 'does not register an offense when using the restarg outside forwarding method arguments', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(*args, **kwargs, &block)
           args.do_something
@@ -343,7 +343,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when assigning the restarg outside forwarding method arguments' do
+    it 'does not register an offense when assigning the restarg outside forwarding method arguments', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(*args, &block)
           var = args
@@ -352,7 +352,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when referencing the restarg outside forwarding method arguments' do
+    it 'does not register an offense when referencing the restarg outside forwarding method arguments', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(*args, &block)
           args
@@ -361,7 +361,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when not always passing the block as well as restarg' do
+    it 'does not register an offense when not always passing the block as well as restarg', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(*args, &block)
           bar(*args, &block)
@@ -370,7 +370,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when not always passing the block as well as kwrestarg' do
+    it 'does not register an offense when not always passing the block as well as kwrestarg', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(**kwargs, &block)
           bar(**kwargs, &block)
@@ -379,7 +379,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when not always forwarding all' do
+    it 'does not register an offense when not always forwarding all', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(*args, **kwargs, &block)
           bar(*args, **kwargs, &block)
@@ -389,7 +389,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when always forwarding the block but not other args' do
+    it 'does not register an offense when always forwarding the block but not other args', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(*args, &block)
           bar(*args, &block)
@@ -405,7 +405,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense with arg destructuring' do
+    it 'does not register an offense with arg destructuring', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo((bar, baz), **kwargs)
           forwarded(bar, baz, **kwargs)
@@ -413,7 +413,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense with an additional kwarg' do
+    it 'does not register an offense with an additional kwarg', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(first:, **kwargs, &block)
           forwarded(**kwargs, &block)
@@ -424,7 +424,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     context 'AllowOnlyRestArgument: true' do
       let(:cop_config) { { 'AllowOnlyRestArgument' => true } }
 
-      it 'does not register an offense when using only rest arg' do
+      it 'does not register an offense when using only rest arg', unsupported_on: :prism do
         expect_no_offenses(<<~RUBY)
           def foo(*args)
             bar(*args)
@@ -432,7 +432,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
         RUBY
       end
 
-      it 'does not register an offense when using only kwrest arg' do
+      it 'does not register an offense when using only kwrest arg', unsupported_on: :prism do
         expect_no_offenses(<<~RUBY)
           def foo(**kwargs)
             bar(**kwargs)
@@ -476,7 +476,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     context 'AllowOnlyRestArgument: false' do
       let(:cop_config) { { 'AllowOnlyRestArgument' => false } }
 
-      it 'registers an offense when using only rest arg' do
+      it 'registers an offense when using only rest arg', unsupported_on: :prism do
         expect_offense(<<~RUBY)
           def foo(*args)
                   ^^^^^ Use shorthand syntax `...` for arguments forwarding.
@@ -492,7 +492,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
         RUBY
       end
 
-      it 'registers an offense when using only kwrest arg' do
+      it 'registers an offense when using only kwrest arg', unsupported_on: :prism do
         expect_offense(<<~RUBY)
           def foo(**kwargs)
                   ^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
@@ -508,7 +508,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
         RUBY
       end
 
-      it 'does not register an offense with default positional arguments' do
+      it 'does not register an offense with default positional arguments', unsupported_on: :prism do
         expect_no_offenses(<<~RUBY)
           def foo(arg=1, *args)
             bar(*args)
@@ -516,7 +516,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
         RUBY
       end
 
-      it 'does not register an offense with default keyword arguments' do
+      it 'does not register an offense with default keyword arguments', unsupported_on: :prism do
         expect_no_offenses(<<~RUBY)
           def foo(*args, arg: 1)
             bar(*args)
@@ -589,7 +589,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       end
     end
 
-    it 'does not register an offense for restarg when passing block to separate call' do
+    it 'does not register an offense for restarg when passing block to separate call', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(*args, &block)
           bar(*args).baz(&block)
@@ -597,7 +597,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense for restarg and kwrestarg when passing block to separate call' do
+    it 'does not register an offense for restarg and kwrestarg when passing block to separate call', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(*args, **kwargs, &block)
           bar(*args, **kwargs).baz(&block)
@@ -605,7 +605,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense for restarg/kwrestarg/block passed to separate methods' do
+    it 'does not register an offense for restarg/kwrestarg/block passed to separate methods', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(*args, **kwargs, &block)
           bar(first(*args), second(**kwargs), third(&block))
@@ -613,7 +613,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense if an additional positional parameter is present' do
+    it 'does not register an offense if an additional positional parameter is present', unsupported_on: :prism do
       # Technically, forward-all supports leading additional arguments in Ruby >= 2.7.3, but for
       # simplicity we do not correct for any Ruby < 3.0
       # https://github.com/rubocop/rubocop/issues/12087#issuecomment-1662972732
@@ -652,7 +652,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense if kwargs are forwarded with a positional parameter' do
+    it 'does not register an offense if kwargs are forwarded with a positional parameter', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(m, **kwargs, &block)
           bar(m, **kwargs, &block)
@@ -660,7 +660,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense if args are forwarded with a positional parameter last' do
+    it 'does not register an offense if args are forwarded with a positional parameter last', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(m, *args, &block)
           bar(*args, m, &block)
@@ -668,7 +668,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense if args/kwargs are forwarded with a positional parameter' do
+    it 'does not register an offense if args/kwargs are forwarded with a positional parameter', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(m, *args, **kwargs, &block)
           bar(m, *args, **kwargs, &block)
@@ -692,7 +692,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when forwarding args/kwargs with an additional arg' do
+    it 'does not register an offense when forwarding args/kwargs with an additional arg', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def self.get(*args, **kwargs, &block)
           CanvasHttp.request(Net::HTTP::Get, *args, **kwargs, &block)
@@ -716,7 +716,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense when forwarding args with an additional arg' do
+    it 'does not register an offense when forwarding args with an additional arg', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def post(*args, &block)
           future_on(executor, *args, &block)
@@ -751,7 +751,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
   end
 
   context 'TargetRubyVersion >= 3.0', :ruby30 do
-    it 'does not register an offense if args are forwarded with a positional parameter last' do
+    it 'does not register an offense if args are forwarded with a positional parameter last', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(m, *args, &block)
           bar(*args, m, &block)
@@ -759,7 +759,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense with an additional required kwarg that is not forwarded' do
+    it 'does not register an offense with an additional required kwarg that is not forwarded', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(first:, **kwargs, &block)
           forwarded(**kwargs, &block)
@@ -767,7 +767,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense with an additional required kwarg that is forwarded' do
+    it 'does not register an offense with an additional required kwarg that is forwarded', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(first:, **kwargs, &block)
           forwarded(first: first, **kwargs, &block)
@@ -775,7 +775,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense with an additional optional kwarg that is not forwarded' do
+    it 'does not register an offense with an additional optional kwarg that is not forwarded', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(first: nil, **kwargs, &block)
           forwarded(**kwargs, &block)
@@ -783,7 +783,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense with an additional optional kwarg that is forwarded' do
+    it 'does not register an offense with an additional optional kwarg that is forwarded', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(first: nil, **kwargs, &block)
           forwarded(first: first, **kwargs, &block)
@@ -791,7 +791,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense if args/kwargs are forwarded with a positional parameter last' do
+    it 'does not register an offense if args/kwargs are forwarded with a positional parameter last', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(m, *args, **kwargs, &block)
           bar(*args, m, **kwargs, &block)
@@ -840,7 +840,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense if args/kwargs are forwarded with additional pre-kwarg' do
+    it 'does not register an offense if args/kwargs are forwarded with additional pre-kwarg', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(m, *args, **kwargs, &block)
           bar(m, *args, extra: :kwarg, **kwargs, &block)
@@ -848,7 +848,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'does not register an offense if args/kwargs are forwarded with additional post-kwarg' do
+    it 'does not register an offense if args/kwargs are forwarded with additional post-kwarg', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(m, *args, **kwargs, &block)
           bar(m, *args, **kwargs, extra: :kwarg, &block)
@@ -856,7 +856,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'registers an offense when forwarding args after dropping an additional arg' do
+    it 'registers an offense when forwarding args after dropping an additional arg', unsupported_on: :prism do
       expect_offense(<<~RUBY)
         def foo(x, *args, &block)
                    ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
@@ -872,7 +872,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'registers an offense when forwarding args with a leading default arg' do
+    it 'registers an offense when forwarding args with a leading default arg', unsupported_on: :prism do
       expect_offense(<<~RUBY)
         def foo(x, y = 42, *args, &block)
                            ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
@@ -888,7 +888,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'registers an offense when forwarding args with an additional arg' do
+    it 'registers an offense when forwarding args with an additional arg', unsupported_on: :prism do
       expect_offense(<<~RUBY)
         def post(*args, &block)
                  ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
@@ -920,7 +920,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'registers an offense when forwarding kwargs/block arg' do
+    it 'registers an offense when forwarding kwargs/block arg', unsupported_on: :prism do
       expect_offense(<<~RUBY)
         def foo(**kwargs, &block)
                 ^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
@@ -936,7 +936,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'registers an offense when forwarding kwargs/block arg and an additional arg' do
+    it 'registers an offense when forwarding kwargs/block arg and an additional arg', unsupported_on: :prism do
       expect_offense(<<~RUBY)
         def foo(x, **kwargs, &block)
                    ^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
@@ -955,7 +955,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     context 'AllowOnlyRestArgument: false' do
       let(:cop_config) { { 'AllowOnlyRestArgument' => false } }
 
-      it 'registers an offense when using only rest arg' do
+      it 'registers an offense when using only rest arg', unsupported_on: :prism do
         expect_offense(<<~RUBY)
           def foo(*args)
                   ^^^^^ Use shorthand syntax `...` for arguments forwarding.
@@ -989,7 +989,7 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
     end
   end
 
-  context 'TargetRubyVersion 3.1', :ruby31 do
+  context 'TargetRubyVersion 3.1', :ruby31, unsupported_on: :prism do
     it 'registers an offense when using restarg and anonymous block arg' do
       expect_offense(<<~RUBY)
         def foo(*args, &)

--- a/spec/rubocop/cop/style/array_intersect_spec.rb
+++ b/spec/rubocop/cop/style/array_intersect_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
-  context 'when TargetRubyVersion <= 3.0', :ruby30 do
+  context 'when TargetRubyVersion <= 3.0', :ruby30, unsupported_on: :prism do
     it 'does not register an offense when using `(array1 & array2).any?`' do
       expect_no_offenses(<<~RUBY)
         (array1 & array2).any?

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -163,11 +163,15 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       expect_no_offenses('return if any? { |x| x }')
     end
 
-    it 'accepts a single line block with {} if used in a logical or' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'accepts a single line block with {} if used in a logical or', broken_on: :prism do
       expect_no_offenses('any? { |c| c } || foo')
     end
 
-    it 'accepts a single line block with {} if used in a logical and' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'accepts a single line block with {} if used in a logical and', broken_on: :prism do
       expect_no_offenses('any? { |c| c } && foo')
     end
 

--- a/spec/rubocop/cop/style/collection_compact_spec.rb
+++ b/spec/rubocop/cop/style/collection_compact_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
     end
   end
 
-  context 'Ruby <= 3.0', :ruby30 do
+  context 'Ruby <= 3.0', :ruby30, unsupported_on: :prism do
     it 'does not register an offense and corrects when using `to_enum.reject` on array to reject nils' do
       expect_no_offenses(<<~RUBY)
         array.to_enum.reject { |e| e.nil? }
@@ -276,7 +276,7 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
     end
   end
 
-  context 'when Ruby <= 2.3', :ruby23 do
+  context 'when Ruby <= 2.3', :ruby23, unsupported_on: :prism do
     it 'does not register an offense when using `reject` on hash to reject nils' do
       expect_no_offenses(<<~RUBY)
         hash.reject { |k, v| v.nil? }

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -76,7 +76,8 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
   describe 'heredoc commands' do
     let(:cop_config) { { 'EnforcedStyle' => 'backticks' } }
 
-    it 'is ignored' do
+    # FIXME: https://github.com/ruby/prism/issues/2498
+    it 'is ignored', broken_on: :prism do
       expect_no_offenses(<<~RUBY)
         <<`COMMAND`
           ls

--- a/spec/rubocop/cop/style/comparable_clamp_spec.rb
+++ b/spec/rubocop/cop/style/comparable_clamp_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe RuboCop::Cop::Style::ComparableClamp, :config do
     end
   end
 
-  context 'target ruby version <= 2.3', :ruby23 do
+  context 'target ruby version <= 2.3', :ruby23, unsupported_on: :prism do
     it 'does not register an offense when using `[[x, low].max, high].min`' do
       expect_no_offenses(<<~RUBY)
         [[x, low].max, high].min

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -2,7 +2,9 @@
 
 RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
   shared_examples 'all variable types' do |variable|
-    it 'registers an offense assigning any variable type to ternary' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers an offense assigning any variable type to ternary', broken_on: :prism do
       expect_offense(<<~RUBY, variable: variable)
         %{variable} = foo? ? 1 : 2
         ^{variable}^^^^^^^^^^^^^^^ Assign variables inside of conditionals
@@ -165,7 +167,9 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
   end
 
   shared_examples 'all assignment types' do |assignment|
-    it 'registers an offense for any assignment to ternary' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers an offense for any assignment to ternary', broken_on: :prism do
       expect_offense(<<~RUBY, assignment: assignment)
         bar %{assignment} (foo? ? 1 : 2)
         ^^^^^{assignment}^^^^^^^^^^^^^^^ Assign variables inside of conditionals
@@ -698,7 +702,9 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
       RUBY
     end
 
-    it 'corrects assignment to a ternary operator' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'corrects assignment to a ternary operator', broken_on: :prism do
       expect_offense(<<~RUBY)
         bar = foo? ? 1 : 2
         ^^^^^^^^^^^^^^^^^^ Assign variables inside of conditionals
@@ -790,7 +796,9 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
       expect_no_offenses('bar << foo? ? 1 : 2')
     end
 
-    it 'registers an offense for assignment using a method that ends with an equal sign' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers an offense for assignment using a method that ends with an equal sign', broken_on: :prism do
       expect_offense(<<~RUBY)
         self.attributes = foo? ? 1 : 2
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Assign variables inside of conditionals

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -132,7 +132,9 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
     expect_no_offenses('bar = foo? ? "a" : "b"')
   end
 
-  it 'registers an offense for assignment in ternary operation using strings' do
+  # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+  # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+  it 'registers an offense for assignment in ternary operation using strings', broken_on: :prism do
     expect_offense(<<~RUBY)
       foo? ? bar = "a" : bar = "b"
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
@@ -189,7 +191,9 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
   end
 
   shared_examples 'comparison methods' do |method|
-    it 'registers an offense for comparison methods in ternary operations' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers an offense for comparison methods in ternary operations', broken_on: :prism do
       source = "foo? ? bar #{method} 1 : bar #{method} 2"
       expect_offense(<<~RUBY, source: source)
         %{source}
@@ -562,7 +566,9 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
   end
 
   shared_examples 'all variable types' do |variable, add_parens: false|
-    it 'registers an offense assigning any variable type in ternary' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers an offense assigning any variable type in ternary', broken_on: :prism do
       source = "foo? ? #{variable} = 1 : #{variable} = 2"
       expect_offense(<<~RUBY, source: source)
         %{source}
@@ -661,7 +667,9 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
 
     variable_types.each do |type, name|
       context "for a #{type} lval" do
-        it "registers an offense for assignment using #{assignment} in ternary" do
+        # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+        # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+        it "registers an offense for assignment using #{assignment} in ternary", broken_on: :prism do
           source = "foo? ? #{name} #{assignment} 1 : #{name} #{assignment} 2"
           expect_offense(<<~RUBY, source: source)
             %{source}
@@ -1230,7 +1238,9 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
   end
 
   describe 'autocorrect' do
-    it 'corrects =~ in ternary operations' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'corrects =~ in ternary operations', broken_on: :prism do
       expect_offense(<<~RUBY)
         foo? ? bar =~ /a/ : bar =~ /b/
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
@@ -2238,7 +2248,9 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
                           })
     end
 
-    it 'allows assignment in ternary operation' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'allows assignment in ternary operation', broken_on: :prism do
       expect_no_offenses('foo? ? bar = "a" : bar = "b"')
     end
   end

--- a/spec/rubocop/cop/style/data_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/data_inheritance_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe RuboCop::Cop::Style::DataInheritance, :config do
     end
   end
 
-  context 'Ruby <= 3.1', :ruby31 do
+  context 'Ruby <= 3.1', :ruby31, unsupported_on: :prism do
     it 'accepts extending instance of `Data.define`' do
       expect_no_offenses(<<~RUBY)
         class Person < Data.define(:first_name, :last_name)

--- a/spec/rubocop/cop/style/dir_empty_spec.rb
+++ b/spec/rubocop/cop/style/dir_empty_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe RuboCop::Cop::Style::DirEmpty, :config do
     end
   end
 
-  context 'target ruby version < 2.4', :ruby23 do
+  context 'target ruby version < 2.4', :ruby23, unsupported_on: :prism do
     it 'does not register an offense for `Dir.entries.size == 2`' do
       expect_no_offenses('Dir.entries("path/to/dir").size == 2')
     end

--- a/spec/rubocop/cop/style/file_empty_spec.rb
+++ b/spec/rubocop/cop/style/file_empty_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe RuboCop::Cop::Style::FileEmpty, :config do
     end
   end
 
-  context 'target ruby version < 2.4', :ruby23 do
+  context 'target ruby version < 2.4', :ruby23, unsupported_on: :prism do
     it 'does not register an offense for `File.zero?`' do
       expect_no_offenses("File.zero?('path/to/file')")
     end

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -1043,7 +1043,7 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     end
   end
 
-  context 'target_ruby_version < 2.3', :ruby22 do
+  context 'target_ruby_version < 2.3', :ruby22, unsupported_on: :prism do
     it 'accepts freezing a string' do
       expect_no_offenses('"x".freeze')
     end

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -460,7 +460,8 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
     RUBY
   end
 
-  it 'registers an offense when using xstr heredoc as an argument of raise in `else` branch' do
+  # FIXME: https://github.com/ruby/prism/issues/2498
+  it 'registers an offense when using xstr heredoc as an argument of raise in `else` branch', broken_on: :prism do
     expect_offense(<<~RUBY)
       def func
         unless condition

--- a/spec/rubocop/cop/style/hash_except_spec.rb
+++ b/spec/rubocop/cop/style/hash_except_spec.rb
@@ -684,7 +684,7 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
     end
   end
 
-  context 'Ruby 2.7 or lower', :ruby27 do
+  context 'Ruby 2.7 or lower', :ruby27, unsupported_on: :prism do
     it 'does not register an offense when using `reject` and comparing with `lvar == :key`' do
       expect_no_offenses(<<~RUBY)
         {foo: 1, bar: 2, baz: 3}.reject { |k, v| k == :bar }

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         expect_no_offenses('{}')
       end
 
-      context 'ruby < 2.2', :ruby21 do
+      context 'ruby < 2.2', :ruby21, unsupported_on: :prism do
         it 'accepts hash rockets when symbol keys have string in them' do
           expect_no_offenses('x = { :"string" => 0 }')
         end
@@ -478,7 +478,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
-      context 'ruby < 2.2', :ruby21 do
+      context 'ruby < 2.2', :ruby21, unsupported_on: :prism do
         it 'accepts hash rockets when keys have whitespaces in them' do
           expect_no_offenses('x = { :"t o" => 0, :b => 1 }')
         end
@@ -658,7 +658,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
-      context 'ruby < 2.2', :ruby21 do
+      context 'ruby < 2.2', :ruby21, unsupported_on: :prism do
         it 'accepts hash rockets when keys have whitespaces in them' do
           expect_no_offenses('x = { :"t o" => 0, :b => 1 }')
         end
@@ -1496,7 +1496,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       end
     end
 
-    context 'Ruby <= 3.0', :ruby30 do
+    context 'Ruby <= 3.0', :ruby30, unsupported_on: :prism do
       it 'does not register an offense when hash key and hash value are the same' do
         expect_no_offenses(<<~RUBY)
           {foo: foo, bar: bar}
@@ -1667,7 +1667,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       end
     end
 
-    context 'Ruby <= 3.0', :ruby30 do
+    context 'Ruby <= 3.0', :ruby30, unsupported_on: :prism do
       it 'does not register an offense when all hash key and hash values are the same' do
         expect_no_offenses(<<~RUBY)
           {foo: foo, bar: bar}

--- a/spec/rubocop/cop/style/hash_transform_keys_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_keys_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
     end
   end
 
-  context 'below Ruby 2.5', :ruby24 do
+  context 'below Ruby 2.5', :ruby24, unsupported_on: :prism do
     it 'does not flag even if transform_keys could be used' do
       expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[foo(k)] = v}')
     end
@@ -311,7 +311,7 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
     end
   end
 
-  context 'below Ruby 2.6', :ruby25 do
+  context 'below Ruby 2.6', :ruby25, unsupported_on: :prism do
     it 'does not flag _.to_h{...}' do
       expect_no_offenses(<<~RUBY)
         x.to_h {|k, v| [k.to_sym, v]}

--- a/spec/rubocop/cop/style/hash_transform_values_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_values_spec.rb
@@ -297,13 +297,13 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
     end
   end
 
-  context 'below Ruby 2.4', :ruby23 do
+  context 'below Ruby 2.4', :ruby23, unsupported_on: :prism do
     it 'does not flag even if transform_values could be used' do
       expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[k] = foo(v)}')
     end
   end
 
-  context 'below Ruby 2.6', :ruby25 do
+  context 'below Ruby 2.6', :ruby25, unsupported_on: :prism do
     it 'does not flag _.to_h{...}' do
       expect_no_offenses(<<~RUBY)
         x.to_h {|k, v| [k, foo(v)]}

--- a/spec/rubocop/cop/style/if_with_boolean_literal_branches_spec.rb
+++ b/spec/rubocop/cop/style/if_with_boolean_literal_branches_spec.rb
@@ -381,7 +381,9 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
   end
 
   context 'when complex condition' do
-    it 'registers and corrects an offense when using `if foo? && bar && baz?` with boolean literal branches' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers and corrects an offense when using `if foo? && bar && baz?` with boolean literal branches', broken_on: :prism do
       expect_offense(<<~RUBY)
         if foo? && bar && baz?
         ^^ Remove redundant `if` with boolean literal branches.
@@ -406,7 +408,9 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
       RUBY
     end
 
-    it 'registers and corrects an offense when using `if foo? || bar && baz?` with boolean literal branches' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers and corrects an offense when using `if foo? || bar && baz?` with boolean literal branches', broken_on: :prism do
       expect_offense(<<~RUBY)
         if foo? || bar && baz?
         ^^ Remove redundant `if` with boolean literal branches.
@@ -421,7 +425,9 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
       RUBY
     end
 
-    it 'registers and corrects an offense when using `if foo? || (bar && baz)?` with boolean literal branches' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers and corrects an offense when using `if foo? || (bar && baz)?` with boolean literal branches', broken_on: :prism do
       expect_offense(<<~RUBY)
         if foo? || (bar && baz?)
         ^^ Remove redundant `if` with boolean literal branches.
@@ -483,7 +489,9 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
   end
 
   context 'when condition is a logical operator and all operands are predicate methods' do
-    it 'registers and corrects an offense when using `if foo? && bar?` with boolean literal branches' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers and corrects an offense when using `if foo? && bar?` with boolean literal branches', broken_on: :prism do
       expect_offense(<<~RUBY)
         if foo? && bar?
         ^^ Remove redundant `if` with boolean literal branches.
@@ -513,7 +521,9 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
       RUBY
     end
 
-    it 'registers and corrects an offense when using `unless foo? || bar?` with boolean literal branches' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers and corrects an offense when using `unless foo? || bar?` with boolean literal branches', broken_on: :prism do
       expect_offense(<<~RUBY)
         unless foo? || bar?
         ^^^^^^ Remove redundant `unless` with boolean literal branches.
@@ -543,7 +553,9 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
       RUBY
     end
 
-    it 'registers and corrects an offense when using `if foo? && bar? && baz?` with boolean literal branches' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers and corrects an offense when using `if foo? && bar? && baz?` with boolean literal branches', broken_on: :prism do
       expect_offense(<<~RUBY)
         if foo? && bar? && baz?
         ^^ Remove redundant `if` with boolean literal branches.
@@ -558,7 +570,9 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
       RUBY
     end
 
-    it 'registers and corrects an offense when using `if foo? && bar? || baz?` with boolean literal branches' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers and corrects an offense when using `if foo? && bar? || baz?` with boolean literal branches', broken_on: :prism do
       expect_offense(<<~RUBY)
         if foo? && bar? || baz?
         ^^ Remove redundant `if` with boolean literal branches.

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -50,7 +50,9 @@ RSpec.describe RuboCop::Cop::Style::MultilineTernaryOperator, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects when nesting multiline ternary operators' do
+  # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+  # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+  it 'registers an offense and corrects when nesting multiline ternary operators', broken_on: :prism do
     expect_offense(<<~RUBY)
       cond_a? ? foo :
       ^^^^^^^^^^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.

--- a/spec/rubocop/cop/style/multiline_when_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_when_then_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MultilineWhenThen, :config do
-  it 'registers an offense for empty when statement with then' do
+  # FIXME: https://github.com/ruby/prism/issues/2508
+  it 'registers an offense for empty when statement with then', broken_on: :prism do
     expect_offense(<<~RUBY)
       case foo
       when bar then
@@ -133,7 +134,8 @@ RSpec.describe RuboCop::Cop::Style::MultilineWhenThen, :config do
     RUBY
   end
 
-  it 'registers an offense when one line for multiple candidate values of `when`' do
+  # FIXME: https://github.com/ruby/prism/issues/2508
+  it 'registers an offense when one line for multiple candidate values of `when`', broken_on: :prism do
     expect_offense(<<~RUBY)
       case foo
       when bar, baz then

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
       end
     end
 
-    context 'Ruby 2.7 or lower', :ruby27 do
+    context 'Ruby 2.7 or lower', :ruby27, unsupported_on: :prism do
       context 'when the frozen string literal comment is missing' do
         it_behaves_like 'mutable objects', '"#{a}"'
       end
@@ -348,7 +348,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
       end
     end
 
-    context 'Ruby 2.7 or lower', :ruby27 do
+    context 'Ruby 2.7 or lower', :ruby27, unsupported_on: :prism do
       context 'when assigning a regexp' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/nested_file_dirname_spec.rb
+++ b/spec/rubocop/cop/style/nested_file_dirname_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::Style::NestedFileDirname, :config do
     end
   end
 
-  context 'Ruby <= 3.0', :ruby30 do
+  context 'Ruby <= 3.0', :ruby30, unsupported_on: :prism do
     it 'does not register an offense when using `File.dirname(path)` nested two times' do
       expect_no_offenses(<<~RUBY)
         File.dirname(File.dirname(path))

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -116,7 +116,8 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
     RUBY
   end
 
-  it 'autocorrects numbers with spaces between leading minus and numbers' do
+  # FIXME: https://github.com/ruby/prism/issues/2501
+  it 'autocorrects numbers with spaces between leading minus and numbers', broken_on: :prism do
     expect_offense(<<~RUBY)
       a = -
           ^ Use underscores(_) as thousands separator and separate every 3 digits with them.

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
         end
       end
 
-      context 'when target ruby version is 2.2 or lower', :ruby22 do
+      context 'when target ruby version is 2.2 or lower', :ruby22, unsupported_on: :prism do
         it 'does not register an offense' do
           expect_no_offenses('number > 0')
         end
@@ -193,7 +193,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
         end
       end
 
-      context 'when target ruby version is 2.2 or lower', :ruby22 do
+      context 'when target ruby version is 2.2 or lower', :ruby22, unsupported_on: :prism do
         it 'does not register an offense' do
           expect_no_offenses('number < 0')
         end
@@ -328,7 +328,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
             end
           end
 
-          context 'when target ruby version is 2.2 or lower', :ruby22 do
+          context 'when target ruby version is 2.2 or lower', :ruby22, unsupported_on: :prism do
             it 'does not register an offense' do
               expect_no_offenses('exclude { number > 0 }')
             end
@@ -349,7 +349,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
             end
           end
 
-          context 'when target ruby version is 2.2 or lower', :ruby22 do
+          context 'when target ruby version is 2.2 or lower', :ruby22, unsupported_on: :prism do
             it 'does not register an offense' do
               expect_no_offenses('exclude { number > 0 }')
             end

--- a/spec/rubocop/cop/style/object_then_spec.rb
+++ b/spec/rubocop/cop/style/object_then_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::Style::ObjectThen, :config do
   context 'EnforcedStyle: then' do
     let(:cop_config) { { 'EnforcedStyle' => 'then' } }
 
-    context 'Ruby 2.5', :ruby25 do
+    context 'Ruby 2.5', :ruby25, unsupported_on: :prism do
       it 'accepts yield_self with block' do
         expect_no_offenses(<<~RUBY)
           obj.yield_self { |e| e.test }

--- a/spec/rubocop/cop/style/quoted_symbols_spec.rb
+++ b/spec/rubocop/cop/style/quoted_symbols_spec.rb
@@ -63,7 +63,8 @@ RSpec.describe RuboCop::Cop::Style::QuotedSymbols, :config do
       RUBY
     end
 
-    it 'accepts double quotes with line breaks' do
+    # FIXME: https://github.com/ruby/prism/issues/2506
+    it 'accepts double quotes with line breaks', broken_on: :prism do
       expect_no_offenses(<<~RUBY)
         :"a
           bc"
@@ -216,14 +217,16 @@ RSpec.describe RuboCop::Cop::Style::QuotedSymbols, :config do
       RUBY
     end
 
-    it 'accepts single quotes with line breaks' do
+    # FIXME: https://github.com/ruby/prism/issues/2506
+    it 'accepts single quotes with line breaks', broken_on: :prism do
       expect_no_offenses(<<~RUBY)
         :'a
           bc'
       RUBY
     end
 
-    it 'accepts double quotes with line breaks' do
+    # FIXME: https://github.com/ruby/prism/issues/2506
+    it 'accepts double quotes with line breaks', broken_on: :prism do
       expect_no_offenses(<<~RUBY)
         :'a
           bc'

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     RUBY
   end
 
-  context '< Ruby 2.5', :ruby24 do
+  context '< Ruby 2.5', :ruby24, unsupported_on: :prism do
     it 'accepts a do-end block with a begin-end' do
       expect_no_offenses(<<~RUBY)
         do_something do

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze, :config do
       end
     end
 
-    context 'Ruby 2.7 or lower', :ruby27 do
+    context 'Ruby 2.7 or lower', :ruby27, unsupported_on: :prism do
       context 'when the frozen string literal comment is missing' do
         it_behaves_like 'mutable objects', '"#{a}"'
       end
@@ -122,7 +122,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze, :config do
         it_behaves_like 'immutable objects', '(1...5)'
       end
 
-      context 'Ruby 2.7 or lower', :ruby27 do
+      context 'Ruby 2.7 or lower', :ruby27, unsupported_on: :prism do
         it_behaves_like 'mutable objects', '/./'
         it_behaves_like 'mutable objects', '(1..5)'
         it_behaves_like 'mutable objects', '(1...5)'

--- a/spec/rubocop/cop/style/redundant_heredoc_delimiter_quotes_spec.rb
+++ b/spec/rubocop/cop/style/redundant_heredoc_delimiter_quotes_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe RuboCop::Cop::Style::RedundantHeredocDelimiterQuotes, :config do
     RUBY
   end
 
-  it 'does not register an offense when using the redundant heredoc delimiter backquotes' do
+  # FIXME: https://github.com/ruby/prism/issues/2498
+  it 'does not register an offense when using the redundant heredoc delimiter backquotes', broken_on: :prism do
     expect_no_offenses(<<~RUBY)
       do_something(<<~`EOS`)
         command
@@ -162,7 +163,9 @@ RSpec.describe RuboCop::Cop::Style::RedundantHeredocDelimiterQuotes, :config do
     RUBY
   end
 
-  it 'does not register an offense when using the blank heredoc delimiter' do
+  # FIXME: `<<''` is a syntax error in Ruby. This test was added because Parser gem can parse it,
+  # but this will be removed after https://github.com/whitequark/parser/issues/996 is resolved.
+  it 'does not register an offense when using the blank heredoc delimiter', unsupported_on: :prism do
     expect_no_offenses(<<~RUBY)
       <<''
     RUBY

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -905,7 +905,8 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
 
   context 'pin operator', :ruby31 do
     shared_examples 'redundant parentheses' do |variable, description|
-      it "registers an offense and corrects #{description}" do
+      # FIXME: https://github.com/ruby/prism/issues/2499
+      it "registers an offense and corrects #{description}", broken_on: :prism do
         expect_offense(<<~RUBY, variable: variable)
           var = 0
           foo in { bar: ^(%{variable}) }

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -18,14 +18,15 @@ RSpec.describe RuboCop::Cop::Style::RescueModifier, :config do
     RUBY
   end
 
-  it 'registers an offense for modifier rescue around parallel assignment', :ruby26 do
+  it 'registers an offense for modifier rescue around parallel assignment', :ruby26, unsupported_on: :prism do
     expect_offense(<<~RUBY)
       a, b = 1, 2 rescue nil
       ^^^^^^^^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
     RUBY
   end
 
-  it 'registers an offense for modifier rescue around parallel assignment', :ruby27 do
+  # FIXME: https://github.com/ruby/prism/issues/2500
+  it 'registers an offense for modifier rescue around parallel assignment', :ruby27, broken_on: :prism do
     expect_offense(<<~RUBY)
       a, b = 1, 2 rescue nil
              ^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -1191,7 +1191,7 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
     end
   end
 
-  context 'when Ruby <= 2.2', :ruby22 do
+  context 'when Ruby <= 2.2', :ruby22, unsupported_on: :prism do
     it 'does not register an offense when a method call that nil responds to safe guarded by an object check' do
       expect_no_offenses('foo.bar if foo')
     end

--- a/spec/rubocop/cop/style/select_by_regexp_spec.rb
+++ b/spec/rubocop/cop/style/select_by_regexp_spec.rb
@@ -482,7 +482,7 @@ RSpec.describe RuboCop::Cop::Style::SelectByRegexp, :config do
     include_examples('regexp mismatch', 'find_all', 'grep_v')
   end
 
-  context 'when Ruby <= 2.2', :ruby22 do
+  context 'when Ruby <= 2.2', :ruby22, unsupported_on: :prism do
     include_examples('regexp match', 'select', 'grep')
     include_examples('regexp match', 'find_all', 'grep')
     include_examples('regexp mismatch', 'reject', 'grep')

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
       it_behaves_like 'convert to endless method'
     end
 
-    context 'prior to ruby 3.0', :ruby27 do
+    context 'prior to ruby 3.0', :ruby27, unsupported_on: :prism do
       let(:endless_method_config) { { 'EnforcedStyle' => 'allow_always' } }
 
       it 'corrects to a multiline method' do

--- a/spec/rubocop/cop/style/slicing_with_range_spec.rb
+++ b/spec/rubocop/cop/style/slicing_with_range_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::SlicingWithRange, :config do
-  context '<= Ruby 2.5', :ruby25 do
+  context '<= Ruby 2.5', :ruby25, unsupported_on: :prism do
     it 'reports no offense for array slicing end with `-1`' do
       expect_no_offenses(<<~RUBY)
         ary[1..-1]

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -338,7 +338,8 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
         }
       end
 
-      it 'registers an offense for strings with line breaks in them' do
+      # FIXME: https://github.com/ruby/prism/issues/2515
+      it 'registers an offense for strings with line breaks in them', broken_on: :prism do
         expect_offense(<<~RUBY)
           "--
           ^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
     # $ ruby-parse --27 -e 'foo in bar'
     # (match-pattern (send nil :foo) (match-var :bar))
     #
-    context 'with one line pattern matching', :ruby27 do
+    context 'with one line pattern matching', :ruby27, unsupported_on: :prism do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)
           (foo in bar) ? a : b
@@ -414,7 +414,8 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
     # $ ruby-parse --30 -e 'foo in bar'
     # (match-pattern-p (send nil :foo) (match-var :bar))
     #
-    context 'with one line pattern matching', :ruby30 do
+    # FIXME: https://github.com/ruby/prism/pull/2525
+    context 'with one line pattern matching', :ruby30, broken_on: :prism do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)
           (foo in bar) ? a : b

--- a/spec/rubocop/cop/style/yaml_file_read_spec.rb
+++ b/spec/rubocop/cop/style/yaml_file_read_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe RuboCop::Cop::Style::YAMLFileRead, :config do
     end
   end
 
-  context 'when Ruby <= 2.7', :ruby27 do
+  context 'when Ruby <= 2.7', :ruby27, unsupported_on: :prism do
     it 'registers an offense when using `YAML.load` with `File.read` argument' do
       expect_offense(<<~RUBY)
         YAML.load(File.read(path))

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -109,7 +109,9 @@ RSpec.describe RuboCop::Cop::Style::YodaCondition, :config do
       RUBY
     end
 
-    it 'registers an offense for boolean literal on left' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers an offense for boolean literal on left', broken_on: :prism do
       expect_offense(<<~RUBY)
         false == active?
         ^^^^^^^^^^^^^^^^ Reverse the order of the operands `false == active?`.
@@ -350,7 +352,9 @@ RSpec.describe RuboCop::Cop::Style::YodaCondition, :config do
       RUBY
     end
 
-    it 'registers an offense for boolean literal on right' do
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers an offense for boolean literal on right', broken_on: :prism do
       expect_offense(<<~RUBY)
         active? == false
         ^^^^^^^^^^^^^^^^ Reverse the order of the operands `active? == false`.

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -90,7 +90,9 @@ RSpec.describe RuboCop::Cop::Team do
 
     let(:file_path) { 'example.rb' }
     let(:source) do
-      source = RuboCop::ProcessedSource.from_file(file_path, ruby_version)
+      source = RuboCop::ProcessedSource.from_file(
+        file_path, ruby_version, parser_engine: parser_engine
+      )
       source.config = config
       source.registry = RuboCop::Cop::Registry.new(cop_classes.cops)
       source
@@ -109,7 +111,8 @@ RSpec.describe RuboCop::Cop::Team do
 
       let(:cop_names) { offenses.map(&:cop_name) }
 
-      it 'returns Parser warning offenses' do
+      # FIXME: https://github.com/ruby/prism/issues/2513
+      it 'returns Parser warning offenses', broken_on: :prism do
         expect(cop_names.include?('Lint/AmbiguousOperator')).to be(true)
       end
 
@@ -118,7 +121,8 @@ RSpec.describe RuboCop::Cop::Team do
       end
 
       context 'when a cop has no interest in the file' do
-        it 'returns all offenses except the ones of the cop' do
+        # FIXME: https://github.com/ruby/prism/issues/2513
+        it 'returns all offenses except the ones of the cop', broken_on: :prism do
           allow_any_instance_of(RuboCop::Cop::Layout::LineLength)
             .to receive(:excluded_file?).and_return(true)
 

--- a/spec/rubocop/cop/variable_force/assignment_spec.rb
+++ b/spec/rubocop/cop/variable_force/assignment_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::VariableForce::Assignment do
   include RuboCop::AST::Sexp
 
-  let(:ast) { RuboCop::ProcessedSource.new(source, ruby_version).ast }
+  let(:ast) { RuboCop::ProcessedSource.new(source, ruby_version, parser_engine: parser_engine).ast }
 
   let(:source) do
     <<~RUBY

--- a/spec/rubocop/cop/variable_force/scope_spec.rb
+++ b/spec/rubocop/cop/variable_force/scope_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::VariableForce::Scope do
 
   subject(:scope) { described_class.new(scope_node) }
 
-  let(:ast) { RuboCop::ProcessedSource.new(source, ruby_version).ast }
+  let(:ast) { RuboCop::ProcessedSource.new(source, ruby_version, parser_engine: parser_engine).ast }
 
   let(:scope_node) { ast.each_node(scope_node_type).first }
 

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -136,12 +136,13 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
         described_class.ruby_extractors.shift
       end
 
+      # rubocop:disable Layout/LineLength
       let(:custom_ruby_extractor) do
         lambda do |_processed_source|
           [
             {
               offset: 1,
-              processed_source: RuboCop::ProcessedSource.new(<<~RUBY, 3.1, 'dummy.rb')
+              processed_source: RuboCop::ProcessedSource.new(<<~RUBY, 3.3, 'dummy.rb', parser_engine: parser_engine)
                 # frozen_string_literal: true
 
                 def valid_code; end
@@ -149,11 +150,12 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
             },
             {
               offset: 2,
-              processed_source: RuboCop::ProcessedSource.new(source, 3.1, 'dummy.rb')
+              processed_source: RuboCop::ProcessedSource.new(source, 3.3, 'dummy.rb', parser_engine: parser_engine)
             }
           ]
         end
       end
+      # rubocop:enable Layout/LineLength
 
       let(:source) do
         <<~RUBY

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,6 +59,10 @@ RSpec.configure do |config|
   end
 
   config.filter_run_excluding broken_on: :jruby if ENV.fetch('GITHUB_JOB', nil) == 'jruby'
+  config.filter_run_excluding broken_on: :prism if ENV['PARSER_ENGINE'] == 'parser_prism'
+
+  # Prism supports Ruby 3.3+ parsing.
+  config.filter_run_excluding unsupported_on: :prism if ENV['PARSER_ENGINE'] == 'parser_prism'
 end
 
 module ::RSpec

--- a/tasks/spec_runner.rake
+++ b/tasks/spec_runner.rake
@@ -168,3 +168,8 @@ desc 'Run RSpec code examples with ASCII encoding'
 task :ascii_spec do
   RuboCop::SpecRunner.new(external_encoding: 'ASCII').run_specs
 end
+
+desc 'Run RSpec code examples with Prism'
+task :prism_spec do
+  sh('PARSER_ENGINE=parser_prism bundle exec rake spec')
+end


### PR DESCRIPTION
Resolves #12600.

This is the initial basic implementation to support multiple parser engines. It is still in an experimental phase. There are still incompatibilities with Prism compared to the Parser gem, but as the RuboCop core, it is possible to begin providing support for Prism independently within the RuboCop core.

> [!IMPORTANT]
> To work this feature, the following patch for RuboCop AST needs to be released:
> https://github.com/rubocop/rubocop-ast/pull/277

## Setting the parser engine

RuboCop allows switching the backend parser by specifying either `parser_whitequark` or `parser_prism` for the `ParserEngine`.

Here are the parsers used as backends for each value:

- `ParserEngine: parser_whitequark` ... https://github.com/whitequark/parser
- `ParserEngine: parser_prism` ... https://github.com/ruby/prism (`Prism::Translation::Parser`)

By default, `parser_whitequark` is implicitly used.

`parser_whitequark` can analyze source code from Ruby 2.0 and above:

```yaml
AllCops:
  ParserEngine: parser_whitequark
```

`parser_prism` can analyze source code from Ruby 3.3 and above:

```yaml
AllCops:
  ParserEngine: parser_prism
  TargetRubyVersion: 3.3
```

`parser_prism` tends to perform analysis faster than `parser_whitequark`.

> [!CAUTION]
> Since the use of Prism is experimental, it is not included in RuboCop's runtime dependencies.
> If running through Bundler, please first add `gem 'prism'` to your Gemfile:
>
> ```ruby
> gem 'prism'
> ```

There are some incompatibilities with `parser_whitequark`, making it still considered experimental. For known issues, please refer to the Prism issues: https://github.com/ruby/prism/issues?q=is%3Aissue+is%3Aopen+label%3Arubocop

## Incompatibility

At the time of opening this PR, the following cops have incompatibility with Prism:

- `Gemspec/RequiredRubyVersion`
- `InternalAffairs/LocationLineEqualityComparison`
- `Layout/ClassStructure`
- `Layout/EmptyLines`
- `Layout/EndOfLine`
- `Layout/HeredocIndentation`
- `Layout/IndentationStyle`
- `Layout/LineLength`
- `Layout/SpaceAroundKeyword`
- `Layout/SpaceAroundOperators`
- `Layout/SpaceInsideHashLiteralBraces`
- `Layout/TrailingWhitespace`
- `Lint/AmbiguousOperator`
- `Lint/AmbiguousRegexpLiteral`
- `Lint/CircularArgumentReference`
- `Lint/DeprecatedClassMethods`
- `Lint/DeprecatedConstants`
- `Lint/ErbNewArguments`
- `Lint/NonDeterministicRequireOrder`
- `Lint/NumberedParameterAssignment`
- `Lint/ParenthesesAsGroupedExpression`
- `Lint/RedundantDirGlobSort`
- `Lint/RedundantRequireStatement`
- `Lint/RefinementImportMethods`
- `Lint/RequireParentheses`
- `Lint/Syntax`
- `Lint/UnifiedInteger`
- `Lint/UselessElseWithoutRescue`
- `Naming/BlockForwarding`
- `Naming/HeredocDelimiterCase`
- `Naming/HeredocDelimiterNaming`
- `Naming/VariableNumber`
- `Security/YamlLoad`
- `Style/ArgumentsForwarding`
- `Style/ArrayIntersect`
- `Style/BlockDelimiters`
- `Style/CollectionCompact`
- `Style/CommandLiteral`
- `Style/ComparableClamp`
- `Style/ConditionalAssignmentAssignInCondition`
- `Style/ConditionalAssignmentAssignToCondition`
- `Style/DataInheritance`
- `Style/DirEmpty`
- `Style/FileEmpty`
- `Style/FrozenStringLiteralComment`
- `Style/GuardClause`
- `Style/HashExcept`
- `Style/HashSyntax`
- `Style/HashTransformKeys`
- `Style/HashTransformValues`
- `Style/IfWithBooleanLiteralBranches`
- `Style/MultilineTernaryOperator`
- `Style/MultilineWhenThen`
- `Style/MutableConstant`
- `Style/NestedFileDirname`
- `Style/NumericLiterals`
- `Style/NumericPredicate`
- `Style/ObjectThen`
- `Style/QuotedSymbols`
- `Style/RedundantBegin`
- `Style/RedundantFreeze`
- `Style/RedundantHeredocDelimiterQuotes`
- `Style/RedundantParentheses`
- `Style/RescueModifier`
- `Style/SafeNavigation`
- `Style/SelectByRegexp`
- `Style/SingleLineMethods`
- `Style/SlicingWithRange`
- `Style/StringLiterals`
- `Style/TernaryParentheses`
- `Style/YamlFileRead`
- `Style/YodaCondition`

Some cop incompatibilities have been resolved in the Prism development line.

For known issues, please refer to the Prism issues: https://github.com/ruby/prism/issues?q=is%3Aissue+is%3Aopen+label%3Arubocop

### `Lint/Syntax` cop

The messages generated by Lint/Syntax depend on the parser engine used.

Parser gem:

```console
$ ruby -rparser/ruby33 -ve 'p Parser::Ruby33.parse("(")'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
(string):1:2: error: unexpected token $end
```

Displays `unexpected token $end`.

Prism:

```console
$ ruby -rprism -rprism/translation/parser33 -ve 'p Prism::Translation::Parser33.parse("(")'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
(string):1:2: error: expected a matching `)`
```

Displays `expected a matching )`.

There are differences in the messages between Parser gem and Prism, but since Prism can provide clearer messages in some cases, this incompatibility is accepted. In other words, the messages may vary depending on the parser engine.

## Test

To run tests with Prism, the command `bundle exec rake prism_spec` is provided. This task is also executed in GitHub Actions.

To run tests with Prism specifying files, set the environment variable `PARSER_ENGINE=parser_prism`:

```console
$ PARSER_ENGINE=parser_prism path/to/test_spec.rb
```

In the context of testing with Prism, two options for test cases are provided: `broken_on: :prism` and `unsupported_on: :prism`.
Both options are utilized to skip tests specifically for Prism.

### `broken_on: :prism`

Test cases failing due to Prism incompatibilities are marked with `broken_on: :prism`. This indicates an expectation for the issue to be resolved within Prism.

### `unsupported_on: :prism`

Prism is designed to parse Ruby versions 3.3+, which means that features unique to Ruby versions 2.0 through 3.2 are not supported.
Test cases falling into this category are marked with `unsupported_on: :prism`. This marker is used for cases that are testable with the Parser gem but not with Prism.

> [!NOTE]
> With `bundle exec rake`, `prism_spec` will be run instead of `ascii_spec`. The `ascii_spec` task has not been failing for a while, so it will not be run by default. However, `ascii_spec` task will continue to be checked in CI. If there are any failures originating from `ascii_spec` in CI, please run `bundle exec ascii_spec` to investigate.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
