### PR TITLE
Skip `LineLength` phase on `--auto-gen-only-exclude`

### DIFF
--- a/changelog/change_skip_line_length_phase_on_auto_gen_only_exclude.md
+++ b/changelog/change_skip_line_length_phase_on_auto_gen_only_exclude.md
@@ -1,0 +1,1 @@
+* [#12730](https://github.com/rubocop/rubocop/pull/12730): Skip `LineLength` phase on `--auto-gen-only-exclude`. ([@sambostock][])

--- a/lib/rubocop/cli/command/auto_generate_config.rb
+++ b/lib/rubocop/cli/command/auto_generate_config.rb
@@ -17,7 +17,10 @@ module RuboCop
 
         PHASE_1_OVERRIDDEN = '(skipped because the default Layout/LineLength:Max is overridden)'
         PHASE_1_DISABLED = '(skipped because Layout/LineLength is disabled)'
-        PHASE_1_SKIPPED = '(skipped because a list of cops is passed to the `--only` flag)'
+        PHASE_1_SKIPPED_ONLY_COPS =
+          '(skipped because a list of cops is passed to the `--only` flag)'
+        PHASE_1_SKIPPED_ONLY_EXCLUDE =
+          '(skipped because only excludes will be generated due to `--auto-gen-only-exclude` flag)'
 
         def run
           add_formatter
@@ -29,12 +32,14 @@ module RuboCop
         private
 
         def maybe_run_line_length_cop
-          if !line_length_enabled?(@config_store.for_pwd)
+          if only_exclude?
+            skip_line_length_cop(PHASE_1_SKIPPED_ONLY_EXCLUDE)
+          elsif !line_length_enabled?(@config_store.for_pwd)
             skip_line_length_cop(PHASE_1_DISABLED)
           elsif !same_max_line_length?(@config_store.for_pwd, ConfigLoader.default_configuration)
             skip_line_length_cop(PHASE_1_OVERRIDDEN)
           elsif options_has_only_flag?
-            skip_line_length_cop(PHASE_1_SKIPPED)
+            skip_line_length_cop(PHASE_1_SKIPPED_ONLY_COPS)
           else
             run_line_length_cop
           end
@@ -63,6 +68,10 @@ module RuboCop
 
         def options_has_only_flag?
           @options[:only]
+        end
+
+        def only_exclude?
+          @options[:auto_gen_only_exclude]
         end
 
         # Do an initial run with only Layout/LineLength so that cops that

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -1309,8 +1309,13 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
       # absolute Exclude paths will point into this example's work directory.
       RuboCop::ConfigLoader.default_configuration = nil
 
+      $stdout = StringIO.new
       expect(cli.run(['--auto-gen-config', '--auto-gen-only-exclude',
                       '--exclude-limit', '1'])).to eq(0)
+      expect($stdout.string.include?(<<~STRING)).to be(true)
+        Phase 1 of 2: run Layout/LineLength cop (skipped because only excludes will be generated due to `--auto-gen-only-exclude` flag)
+        Phase 2 of 2: run all cops
+      STRING
       actual = File.read('.rubocop_todo.yml').split($RS)
 
       # With --exclude-limit 1 we get MinDigits generated for NumericLiterals
@@ -1319,6 +1324,9 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
       # the same cop in a single file. Exclude properties are generated for
       # them.
       expect(actual.grep(/^[^#]/).join($RS)).to eq(<<~YAML.chomp)
+        Layout/LineLength:
+          Exclude:
+            - 'example1.rb'
         Lint/UnusedMethodArgument:
           Exclude:
             - 'example2.rb'
@@ -1329,9 +1337,6 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           Enabled: false
         Style/NumericLiterals:
           MinDigits: 7
-        Layout/LineLength:
-          Exclude:
-            - 'example1.rb'
       YAML
     end
 


### PR DESCRIPTION
Phase 1 of config auto-generation runs the `Layout/LineLength` cop on all files to discover the `Max` line length, so it can be used by cops which depend on it.

The `--auto-gen-only-exclude` config skips generating any `Max` configs, meaning phase 1 is redundant, as we won't generate the `Max` for use by phase 2.

Therefore, we can skip phase 1 entirely. Even though we're only running `Layout/LineLength`, parsing the entire codebase twice can get quite time consuming on large repositories.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
