### PR TITLE
Call .value to get gemspec required_ruby_version only if str_type?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.20.0'
 gem 'rubocop-rake', '~> 0.6.0'
-gem 'rubocop-rspec', '~> 2.27.0'
+gem 'rubocop-rspec', '~> 2.27.1'
 # Workaround for cc-test-reporter with SimpleCov 0.18.
 # Stop upgrading SimpleCov until the following issue will be resolved.
 # https://github.com/codeclimate/test-reporter/issues/418

--- a/changelog/fix_call_value_to_get_gemspec_required_ruby_version.md
+++ b/changelog/fix_call_value_to_get_gemspec_required_ruby_version.md
@@ -1,0 +1,1 @@
+* [#12732](https://github.com/rubocop/rubocop/pull/12732): Fix error determining target Ruby when gemspec `required_ruby_version` is read from another file. ([@davidrunger][])

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -109,7 +109,7 @@ module RuboCop
           version_from_array(right_hand_side)
         elsif gem_requirement_versions
           gem_requirement_versions.map(&:value)
-        else
+        elsif right_hand_side.str_type?
           right_hand_side.value
         end
       end

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -42,39 +42,39 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           content = <<~HEREDOC
             Gem::Specification.new do |s|
               s.name = 'test'
-              s.required_ruby_version = '>= 2.7.2'
+              s.required_ruby_version = '>= 3.2.2'
               s.licenses = ['MIT']
             end
           HEREDOC
 
           create_file(gemspec_file_path, content)
-          expect(target_ruby.version).to eq 2.7
+          expect(target_ruby.version).to eq 3.2
         end
 
         it 'sets target_ruby from exclusive range' do
           content = <<~HEREDOC
             Gem::Specification.new do |s|
               s.name = 'test'
-              s.required_ruby_version = '> 2.7.8'
+              s.required_ruby_version = '> 3.2.2'
               s.licenses = ['MIT']
             end
           HEREDOC
 
           create_file(gemspec_file_path, content)
-          expect(target_ruby.version).to eq 2.7
+          expect(target_ruby.version).to eq 3.2
         end
 
         it 'sets target_ruby from approximate version' do
           content = <<~HEREDOC
             Gem::Specification.new do |s|
               s.name = 'test'
-              s.required_ruby_version = '~> 2.7.0'
+              s.required_ruby_version = '~> 3.2.0'
               s.licenses = ['MIT']
             end
           HEREDOC
 
           create_file(gemspec_file_path, content)
-          expect(target_ruby.version).to eq 2.7
+          expect(target_ruby.version).to eq 3.2
         end
       end
 
@@ -163,26 +163,41 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           content = <<~HEREDOC
             Gem::Specification.new do |s|
               s.name = 'test'
-              s.required_ruby_version = ['<=3.0.4', '>=2.7.5']
+              s.required_ruby_version = ['<=3.3.0', '>=3.1.3']
               s.licenses = ['MIT']
             end
           HEREDOC
 
           create_file(gemspec_file_path, content)
-          expect(target_ruby.version).to eq 2.7
+          expect(target_ruby.version).to eq 3.1
         end
 
         it 'sets target_ruby from required_ruby_version with many requirements' do
           content = <<~HEREDOC
             Gem::Specification.new do |s|
               s.name = 'test'
-              s.required_ruby_version = ['<=3.1.0', '>2.6.8', '~>2.7.1']
+              s.required_ruby_version = ['<=3.3.0', '>3.1.1', '~>3.2.1']
               s.licenses = ['MIT']
             end
           HEREDOC
 
           create_file(gemspec_file_path, content)
-          expect(target_ruby.version).to eq 2.7
+          expect(target_ruby.version).to eq 3.2
+        end
+      end
+
+      context 'when file reads the required_ruby_version from another file' do
+        it 'uses the default target ruby version' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = Gem::Requirement.new(">= \#{File.read('.ruby-version').rstrip}")
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq default_version
         end
       end
 


### PR DESCRIPTION
fixes #12744

This change avoids an exception (NoMethodError: undefined method \`value' for an instance of RuboCop::AST::SendNode) that currently occurs in `rubocop` version 1.61.0 when the project has a gemspec file and that gemspec specifies a `required_ruby_version` by reading from another file (such as `.ruby-version`).

**Example of an affected gemspec file:**

```rb
Gem::Specification.new do |spec|
  # ...
  spec.required_ruby_version = Gem::Requirement.new(">= #{File.read('.ruby-version').rstrip}")
  # ...
end
```

This bug began occurring in several of my projects as a result of #12645 (d1746bedd) ("Check gemspec `required_ruby_version` before `.ruby-version` and other sources"). My projects have both a `.ruby-version` file and also a gemspec that (as in the example above) sets the `required_ruby_version` by reading from that `.ruby-version` file. Prior to #12645, the latent bug that this change fixes was not occurring for me, because the GemspecFile TargetRuby finder was never running, because the RubyVersionFile TargetRuby finder had higher precedence (and a target Ruby version was found using this finder), and so the GemspecFile TargetRubyVersion finder was never invoked.

With #12645, because the GemspecFile finder now runs before the RubyVersionFile finder, this exception has started occurring in these projects, when I try to run rubocop 1.61.0.

This change fixes/avoids this exception by checking that the `right_hand_side` is a `str_type?` before attempting to call `right_hand_side.value`. In a setup like mentioned in my projects above, `right_hand_side` will be a `RuboCop::AST::SendNode` and `str_type?` will be `false`, so we avoid the NoMethodError exception that otherwise will occur if we attempt to call `.value` on that node.

With this change, for projects with such a gemspec file that reads from a `.ruby-version` file, the GemspecFile finder will now return `nil` for the target Ruby version (rather than raising an unhandled exception), and so we will continue through the other TargetRuby finder classes, until the RubyVersionFile finder returns a Ruby version based on the one specified in the `.ruby-version` file.

I also updated several of the specs in the `target_ruby_spec.rb` file. The motivation for these spec changes is that several of the specs were at risk of "falsely passing", because they had spec setups that intended for `2.7` to be returned as the target Ruby version, but Ruby 2.7 is also currently the `RuboCop::TargetRuby::DEFAULT_VERSION`. So, in working on the bug that is the focus of this change, although one of my initial attempts to fix the bug actually broke some relevant functionality, all of the specs nevertheless still passed, because they expected a target Ruby version of 2.7 to be returned, and it _was_ still being returned, even after I had broken some of the functionality, simply because Ruby 2.7 is also the default. By setting up the specs to expect a target Ruby version other than the default (Ruby 2.7), the specs will now fail, if/when the relevant functionality under test is broken.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
