### PR TITLE
[Fix #12667] Avoid loading excluded configuration

### DIFF
--- a/changelog/fix_loading_of_excluded_config.md
+++ b/changelog/fix_loading_of_excluded_config.md
@@ -1,0 +1,1 @@
+* [#12667](https://github.com/rubocop/rubocop/issues/12667): Don't load excluded configuration. ([@jonas054][])

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module RuboCop
-  # This class finds target files to inspect by scanning the directory tree
-  # and picking ruby files.
+  # This class finds target files to inspect by scanning the directory tree and picking ruby files.
   # @api private
   class TargetFinder
     HIDDEN_PATH_SUBSTRING = "#{File::SEPARATOR}."
@@ -12,25 +11,8 @@ module RuboCop
       @options = options
     end
 
-    def force_exclusion?
-      @options[:force_exclusion]
-    end
-
-    def ignore_parent_exclusion?
-      @options[:ignore_parent_exclusion]
-    end
-
-    def debug?
-      @options[:debug]
-    end
-
-    def fail_fast?
-      @options[:fail_fast]
-    end
-
-    # Generate a list of target files by expanding globbing patterns
-    # (if any). If args is empty, recursively find all Ruby source
-    # files under the current directory
+    # Generate a list of target files by expanding globbing patterns (if any). If args is empty,
+    # recursively find all Ruby source files under the current directory
     # @return [Array] array of file paths
     def find(args, mode)
       return target_files_in_dir if args.empty?
@@ -48,12 +30,11 @@ module RuboCop
       files.map { |f| File.expand_path(f) }.uniq
     end
 
-    # Finds all Ruby source files under the current or other supplied
-    # directory. A Ruby source file is defined as a file with the `.rb`
-    # extension or a file with no extension that has a ruby shebang line
-    # as its first line.
-    # It is possible to specify includes and excludes using the config file,
-    # so you can include other Ruby files like Rakefiles and gemspecs.
+    # Finds all Ruby source files under the current or other supplied directory. A Ruby source file
+    # is defined as a file with the `.rb` extension or a file with no extension that has a ruby
+    # shebang line as its first line.
+    # It is possible to specify includes and excludes using the config file, so you can include
+    # other Ruby files like Rakefiles and gemspecs.
     # @param base_dir Root directory under which to search for
     #   ruby source files
     # @return [Array] Array of filenames
@@ -70,20 +51,10 @@ module RuboCop
       target_files.sort_by!(&order)
     end
 
-    def to_inspect?(file, hidden_files, base_dir_config)
-      return false if base_dir_config.file_to_exclude?(file)
-      return true if !hidden_files.bsearch do |hidden_file|
-        file <=> hidden_file
-      end && ruby_file?(file)
-
-      base_dir_config.file_to_include?(file)
-    end
-
-    # Search for files recursively starting at the given base directory using
-    # the given flags that determine how the match is made. Excluded files will
-    # be removed later by the caller, but as an optimization find_files removes
-    # the top level directories that are excluded in configuration in the
-    # normal way (dir/**/*).
+    # Search for files recursively starting at the given base directory using the given flags that
+    # determine how the match is made. Excluded files will be removed later by the caller, but as an
+    # optimization find_files removes the top level directories that are excluded in configuration
+    # in the normal way (dir/**/*).
     def find_files(base_dir, flags)
       # get all wanted directories first to improve speed of finding all files
       exclude_pattern = combined_exclude_glob_patterns(base_dir)
@@ -95,6 +66,17 @@ module RuboCop
       patterns = [File.join(base_dir, '**/*')] if patterns.empty?
 
       Dir.glob(patterns, flags).select { |path| FileTest.file?(path) }
+    end
+
+    private
+
+    def to_inspect?(file, hidden_files, base_dir_config)
+      return false if base_dir_config.file_to_exclude?(file)
+      return true if !hidden_files.bsearch do |hidden_file|
+        file <=> hidden_file
+      end && ruby_file?(file)
+
+      base_dir_config.file_to_include?(file)
     end
 
     def wanted_dir_patterns(base_dir, exclude_pattern, flags)
@@ -128,6 +110,50 @@ module RuboCop
       "#{base_dir}/{#{patterns.join(',')}}"
     end
 
+    def ruby_filenames
+      @ruby_filenames ||= begin
+        file_patterns = all_cops_include.reject { |pattern| pattern.start_with?('**/*.') }
+        file_patterns.map { |pattern| pattern.sub('**/', '') }
+      end
+    end
+
+    def all_cops_include
+      @all_cops_include ||= @config_store.for_pwd.for_all_cops['Include'].map(&:to_s)
+    end
+
+    def process_explicit_path(path, mode)
+      files = path.include?('*') ? Dir[path] : [path]
+
+      if mode == :only_recognized_file_types || force_exclusion?
+        files.select! { |file| included_file?(file) }
+      end
+
+      force_exclusion? ? without_excluded(files) : files
+    end
+
+    def without_excluded(files)
+      files.reject do |file|
+        # When --ignore-parent-exclusion is given, we must look at the configuration associated with
+        # the file, but in the default case when --ignore-parent-exclusion is not given, can safely
+        # look only at the configuration for the current directory, since it's only the Exclude
+        # parameters we're going to check.
+        config = @config_store.for(ignore_parent_exclusion? ? file : '.')
+        config.file_to_exclude?(file)
+      end
+    end
+
+    def included_file?(file)
+      ruby_file?(file) || configured_include?(file)
+    end
+
+    def ruby_file?(file)
+      stdin? || ruby_extension?(file) || ruby_filename?(file) || ruby_executable?(file)
+    end
+
+    def stdin?
+      @options.key?(:stdin)
+    end
+
     def ruby_extension?(file)
       ruby_extensions.include?(File.extname(file))
     end
@@ -143,15 +169,8 @@ module RuboCop
       ruby_filenames.include?(File.basename(file))
     end
 
-    def ruby_filenames
-      @ruby_filenames ||= begin
-        file_patterns = all_cops_include.reject { |pattern| pattern.start_with?('**/*.') }
-        file_patterns.map { |pattern| pattern.sub('**/', '') }
-      end
-    end
-
-    def all_cops_include
-      @all_cops_include ||= @config_store.for_pwd.for_all_cops['Include'].map(&:to_s)
+    def configured_include?(file)
+      @config_store.for_pwd.file_to_include?(file)
     end
 
     def ruby_executable?(file)
@@ -169,43 +188,6 @@ module RuboCop
       @config_store.for(file).for_all_cops['RubyInterpreters']
     end
 
-    def stdin?
-      @options.key?(:stdin)
-    end
-
-    def ruby_file?(file)
-      stdin? || ruby_extension?(file) || ruby_filename?(file) || ruby_executable?(file)
-    end
-
-    def configured_include?(file)
-      @config_store.for_pwd.file_to_include?(file)
-    end
-
-    def included_file?(file)
-      ruby_file?(file) || configured_include?(file)
-    end
-
-    def process_explicit_path(path, mode) # rubocop:disable Metrics/CyclomaticComplexity
-      files = path.include?('*') ? Dir[path] : [path]
-
-      if mode == :only_recognized_file_types || force_exclusion?
-        files.select! { |file| included_file?(file) }
-      end
-
-      return files unless force_exclusion?
-
-      files.reject do |file|
-        # When --ignore-parent-exclusion is given, we must look at the configuration associated with
-        # the file, but in the default case when --ignore-parent-exclusion is not given, can safely
-        # look only at the configuration for the current directory, since it's only the Exclude
-        # parameters we're going to check.
-        config = @config_store.for(ignore_parent_exclusion? ? file : '.')
-        config.file_to_exclude?(file)
-      end
-    end
-
-    private
-
     def order
       if fail_fast?
         # Most recently modified file first.
@@ -213,6 +195,22 @@ module RuboCop
       else
         :itself
       end
+    end
+
+    def force_exclusion?
+      @options[:force_exclusion]
+    end
+
+    def ignore_parent_exclusion?
+      @options[:ignore_parent_exclusion]
+    end
+
+    def debug?
+      @options[:debug]
+    end
+
+    def fail_fast?
+      @options[:fail_fast]
     end
   end
 end


### PR DESCRIPTION
This change fixes an error that can occur when file names are given explicitly on the command line together with `--force-exclusion`.

In order to check if the given files are to be excluded, we must load configuration. The problem is that `.rubocop.yml` files in directories with excluded files (e.g. a `vendor` directory) might contain directives that will cause RuboCop to crash, such as `require` with an extension that's not available.

What saves us in this situation is that we don't need to load configuration for the file as such. We can load configuration for the current directory instead. The reason is that `Exclude` parameters on the top level are not shadowed by `Exclude` in other `.rubocop.yml` files in subdirectories, as documented here:

https://docs.rubocop.org/rubocop/1.60/configuration.html#include-and-exclude-are-relative-to-their-directory

The `--ignore-parent-exclusion` flag, if given, changes the situation and we must load the most adjacent `.rubocop.yml` file.