### PR TITLE
Use `ParserEngine` parameter to parse gemspec

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -62,7 +62,7 @@ module RuboCop
 
     def_delegators :@hash, :[], :[]=, :delete, :dig, :each, :key?, :keys, :each_key,
                    :fetch, :map, :merge, :replace, :to_h, :to_hash, :transform_values
-    def_delegators :@validator, :validate, :target_ruby_version, :parser_engine
+    def_delegators :@validator, :validate, :target_ruby_version
 
     def to_s
       @to_s ||= @hash.to_s
@@ -242,6 +242,10 @@ module RuboCop
         else
           Dir.pwd
         end
+    end
+
+    def parser_engine
+      @parser_engine ||= for_all_cops.fetch('ParserEngine', :parser_whitequark).to_sym
     end
 
     def target_rails_version

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -63,10 +63,6 @@ module RuboCop
       target_ruby.version
     end
 
-    def parser_engine
-      for_all_cops.fetch('ParserEngine', :parser_whitequark).to_sym
-    end
-
     def validate_section_presence(name)
       return unless @config.key?(name) && @config[name].nil?
 

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -96,7 +96,9 @@ module RuboCop
       end
 
       def version_from_gemspec_file(file)
-        processed_source = ProcessedSource.from_file(file, DEFAULT_VERSION)
+        processed_source = ProcessedSource.from_file(
+          file, DEFAULT_VERSION, parser_engine: @config.parser_engine
+        )
         required_ruby_version(processed_source.ast).first
       end
 


### PR DESCRIPTION
There was remaining code where `ParserEngine` parameter was not used by `ProcessedSource`, and Parser gem was always used. With this PR, switching between Parser and Prism will be implemented at all usage points of `RuboCop::ProcessedSource`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
