### PR TITLE
Fix invalid autocorrect in Layout/SpaceInsideHashLiteralBraces

### DIFF
--- a/changelog/fix_invalid_autocorrect_in_layout_space_inside_hash_literal_braces.md
+++ b/changelog/fix_invalid_autocorrect_in_layout_space_inside_hash_literal_braces.md
@@ -1,0 +1,1 @@
+* [#12736](https://github.com/rubocop/rubocop/issues/12736): Fix invalid autocorrect in `Layout/SpaceInsideHashLiteralBraces`. ([@bquorning][])

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -116,7 +116,7 @@ module RuboCop
 
         def incorrect_style_detected(token1, token2,
                                      expect_space, is_empty_braces)
-          brace = (token1.text == '{' ? token1 : token2).pos
+          brace = (token1.left_brace? ? token1 : token2).pos
           range = expect_space ? brace : space_range(brace)
           detected_style = expect_space ? 'no_space' : 'space'
 

--- a/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
@@ -101,6 +101,18 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config, brok
     RUBY
   end
 
+  it 'handles "{" as final hash value' do
+    expect_offense(<<~RUBY)
+      h = {a: '{'}
+                 ^ Space inside } missing.
+          ^ Space inside { missing.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      h = { a: '{' }
+    RUBY
+  end
+
   context 'when EnforcedStyle is no_space' do
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 
@@ -124,6 +136,18 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config, brok
 
       expect_correction(<<~RUBY)
         h = {a: 1}
+      RUBY
+    end
+
+    it 'handles "{" as final hash value' do
+      expect_offense(<<~RUBY)
+        h = { a: '{' }
+                    ^ Space inside } detected.
+             ^ Space inside { detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        h = {a: '{'}
       RUBY
     end
 

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -48,9 +48,7 @@ RSpec.describe RuboCop::Cop::Registry do
 
     it 'disallows it if done too late' do
       expect(registry.cops.include?(cop_class)).to be(true)
-      # rubocop:disable RSpec/RepeatedSubjectCall
       expect { registry.dismiss(cop_class) }.to raise_error(RuntimeError)
-      # rubocop:enable RSpec/RepeatedSubjectCall
     end
 
     it 'allows re-listing' do


### PR DESCRIPTION
Fix an invalid autocorrect in `Layout/SpaceInsideHashLiteralBraces` when the last hash element’s value is the text '{'.

Fixes #12736

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
