### PR TITLE
[Fix #12738] Fix an error for `Style/Encoding`

### DIFF
--- a/changelog/fix_an_error_for_style_encoding.md
+++ b/changelog/fix_an_error_for_style_encoding.md
@@ -1,0 +1,1 @@
+* [#12738](https://github.com/rubocop/rubocop/issues/12738): Fix an error for `Style/Encoding` when magic encoding with mixed case present. ([@koic][])

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -268,7 +268,7 @@ module RuboCop
 
       # Rewrite the comment without a given token type
       def without(type)
-        if @comment.match?(/\A#\s*#{self.class::KEYWORDS[type.to_sym]}/)
+        if @comment.match?(/\A#\s*#{self.class::KEYWORDS[type.to_sym]}/io)
           ''
         else
           @comment

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe RuboCop::Cop::Style::Encoding, :config do
     RUBY
   end
 
+  it 'registers an offense when magic encoding with mixed case present' do
+    expect_offense(<<~RUBY)
+      # Encoding: UTF-8
+      ^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
+    RUBY
+
+    expect_correction('')
+  end
+
   it 'registers an offense when encoding present on 2nd line after shebang' do
     expect_offense(<<~RUBY)
       #!/usr/bin/env ruby


### PR DESCRIPTION
Fixees #12738.

This PR fixes an error for `Style/Encoding` when magic encoding with mixed case present.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
