### PR TITLE
[Fix #12740] Tweak annotation pattern for `expect_offense`

### DIFF
--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -212,7 +212,7 @@ module RuboCop
 
       # Parsed representation of code annotated with the `^^^ Message` style
       class AnnotatedSource
-        ANNOTATION_PATTERN = /\A\s*(\^+|\^{}) /.freeze
+        ANNOTATION_PATTERN = /\A\s*(\^+|\^{}) ?/.freeze
         ABBREV = "[...]\n"
 
         # @param annotated_source [String] string passed to the matchers


### PR DESCRIPTION
Fixes #12740.

This PR tweaks annotation pattern for `expect_offense`.

When there is no space between `^` annotation and message, as follows:

```ruby
expect_offense(<<~RUBY)
  #!/usr/bin/env ruby
  # encoding: utf-8
  ^^^^^^^^^^^^^^^^^Unnecessary utf-8 encoding comment.
  def foo() end
RUBY
```

## Before

Despite being correct with `expect_offense`, it suggests using `expect_no_offenses`:

```console
$ bundle exec rspec spec/rubocop/cop/style/encoding_spec.rb
(snip)

Failures:

  1) RuboCop::Cop::Style::Encoding registers an offense when encoding present on 2nd line after shebang
     Failure/Error: raise 'Use `expect_no_offenses` to assert that no offenses are found'

     RuntimeError:
       Use `expect_no_offenses` to assert that no offenses are found
     # ./lib/rubocop/rspec/expect_offense.rb:196:in `parse_annotations'
     # ./lib/rubocop/rspec/expect_offense.rb:115:in `expect_offense'
     # ./spec/rubocop/cop/style/encoding_spec.rb:37:in `block (2 levels) in <top (required)>'
```

## After

It suggests that the usage of annotation is incorrect:

```console
$ bundle exec rspec spec/rubocop/cop/style/encoding_spec.rb
(snip)

Failures:

  1) RuboCop::Cop::Style::Encoding registers an offense when encoding present on 2nd line after shebang
     Failure/Error: expect(actual_annotations).to eq(expected_annotations), ''

       Diff:
       @@ -1,5 +1,5 @@
        #!/usr/bin/env ruby
        # encoding: utf-8
       -^^^^^^^^^^^^^^^^^Unnecessary utf-8 encoding comment.
       +^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
        def foo() end

     # ./lib/rubocop/rspec/expect_offense.rb:123:in `expect_offense'
     # ./spec/rubocop/cop/style/encoding_spec.rb:37:in `block (2 levels) in <top (required)>'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
