### PR TITLE
[Fix #12746] Fix a false positive for `Lint/ToEnumArguments`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_to_enum_arguments.md
+++ b/changelog/fix_a_false_positive_for_lint_to_enum_arguments.md
@@ -1,0 +1,1 @@
+* [#12746](https://github.com/rubocop/rubocop/pull/12746): Fix a false positive for `Lint/ToEnumArguments` when enumerator is created for another method in no arguments method definition. ([@koic][])

--- a/lib/rubocop/cop/lint/to_enum_arguments.rb
+++ b/lib/rubocop/cop/lint/to_enum_arguments.rb
@@ -51,8 +51,13 @@ module RuboCop
           enum_conversion_call?(node) do |method_node, arguments|
             next if method_node.call_type? &&
                     !method_node.method?(:__method__) && !method_node.method?(:__callee__)
-            next if method_name?(method_node, def_node.method_name) &&
-                    arguments_match?(arguments, def_node)
+
+            valid = if method_name?(method_node, def_node.method_name)
+                      arguments_match?(arguments, def_node)
+                    else
+                      def_node.arguments.empty?
+                    end
+            return if valid
 
             add_offense(node)
           end

--- a/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
+++ b/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
@@ -113,6 +113,14 @@ RSpec.describe RuboCop::Cop::Lint::ToEnumArguments, :config do
     RUBY
   end
 
+  it 'does not register an offense when enumerator is created for another method in no arguments method definition' do
+    expect_no_offenses(<<~RUBY)
+      def m
+        return to_enum(:not_m) unless block_given?
+      end
+    RUBY
+  end
+
   it 'registers an offense when enumerator is created for `__method__` with missing arguments' do
     expect_offense(<<~RUBY)
       def m(x)


### PR DESCRIPTION
Fixes #12746.

This PR fixes a false positive for `Lint/ToEnumArguments` when enumerator is created for another method in no arguments method definition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
