### PR TITLE
Attempt to fix offense.highlighted_area returning an incorrectly constructed range

### DIFF
--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -140,7 +140,8 @@ module RuboCop
       # @return [Parser::Source::Range]
       #   the range of the code that is highlighted
       def highlighted_area
-        Parser::Source::Range.new(source_line, column, column + column_length)
+        range = location.source_buffer.line_range(line)
+        range.with(begin_pos: column, end_pos: column + column_length)
       end
 
       # @api private


### PR DESCRIPTION
Attempt at #12527. This is not correct yet because tests are not passing.

To be honest, I'm not sure what's wrong here. Sometimes it starts one character to the left, adding 1 all the time is not the fix since it then starts one to the right in some cases. There's some offset fuckery going on that I'm not getting behind.

If someone can give insight into why that might be, that would be appreciated. I will add changleog/tests when I've got this figured out.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
