### PR TITLE
[Fix #12703] Fix an error for `Lint/MixedCaseRange` with invalid byte sequence in UTF-8

### DIFF
--- a/changelog/fix_error_for_lint_mixed_case_range.md
+++ b/changelog/fix_error_for_lint_mixed_case_range.md
@@ -1,0 +1,1 @@
+* [#12703](https://github.com/rubocop/rubocop/issues/12703): Fix an error for `Lint/MixedCaseRange` with invalid byte sequence in UTF-8. ([@earlopain][])

--- a/lib/rubocop/cop/utils/regexp_ranges.rb
+++ b/lib/rubocop/cop/utils/regexp_ranges.rb
@@ -88,7 +88,7 @@ module RuboCop
         end
 
         def escaped_octal?(expr)
-          expr.text =~ /^\\[0-7]$/
+          expr.text.valid_encoding? && expr.text =~ /^\\[0-7]$/
         end
 
         def octal_digit?(char)

--- a/spec/rubocop/cop/lint/mixed_case_range_spec.rb
+++ b/spec/rubocop/cop/lint/mixed_case_range_spec.rb
@@ -227,4 +227,10 @@ RSpec.describe RuboCop::Cop::Lint::MixedCaseRange, :config do
       foo = /[a-[bc]]/
     RUBY
   end
+
+  it 'does not register an offense with invalid byte sequence in UTF-8' do
+    expect_no_offenses(<<~'RUBY')
+      foo = /[\–]/
+    RUBY
+  end
 end


### PR DESCRIPTION
Closes #12703

While this fixes the above issues, there is still a problem with this cop. If a regex contains this escape _and_ also contains an offense, it will still error. I have openend #12750 for this. Fixing this as well turned out to be too complicated for me.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
