### PR TITLE
Fix an error for `Gemspec/RequiredRubyVersion` when the file is empty

### DIFF
--- a/changelog/fix_an_error_for_gemspec_required_ruby_version.md
+++ b/changelog/fix_an_error_for_gemspec_required_ruby_version.md
@@ -1,0 +1,1 @@
+* [#12752](https://github.com/rubocop/rubocop/pull/12752): Fix an error for `Gemspec/RequiredRubyVersion` when the file is empty. ([@earlopain][])

--- a/lib/rubocop/cop/gemspec/required_ruby_version.rb
+++ b/lib/rubocop/cop/gemspec/required_ruby_version.rb
@@ -76,7 +76,9 @@ module RuboCop
         PATTERN
 
         def on_new_investigation
-          add_global_offense(MISSING_MSG) unless required_ruby_version?(processed_source.ast)
+          return if processed_source.ast && required_ruby_version?(processed_source.ast)
+
+          add_global_offense(MISSING_MSG)
         end
 
         def on_send(node)

--- a/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
+++ b/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
@@ -193,4 +193,10 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
       RUBY
     end
   end
+
+  it 'registers an offense when the file is empty' do
+    expect_offense(<<~RUBY, 'bar.gemspec')
+      ^{} `required_ruby_version` should be specified.
+    RUBY
+  end
 end


### PR DESCRIPTION
This happens if you have `ruby-lsp` enabled and create a new gemspec file.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
