### PR TITLE
Fix `RedundantCurrentDirectoryInPath` cop exception in case of `require_relative` without any arguments

### DIFF
--- a/changelog/fix_error_for_redundant_current_directory_in_path.md
+++ b/changelog/fix_error_for_redundant_current_directory_in_path.md
@@ -1,0 +1,1 @@
+* [#12755](https://github.com/rubocop/rubocop/pull/12755): Fix an exception for `RedundantCurrentDirectoryInPath` in case of `require_relative` without arguments. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/redundant_current_directory_in_path.rb
+++ b/lib/rubocop/cop/style/redundant_current_directory_in_path.rb
@@ -22,10 +22,11 @@ module RuboCop
 
         def on_send(node)
           return unless node.method?(:require_relative)
-          return unless node.first_argument.str_content&.start_with?(CURRENT_DIRECTORY_PATH)
-          return unless (index = node.first_argument.source.index(CURRENT_DIRECTORY_PATH))
+          return unless (first_argument = node.first_argument)
+          return unless first_argument.str_content&.start_with?(CURRENT_DIRECTORY_PATH)
+          return unless (index = first_argument.source.index(CURRENT_DIRECTORY_PATH))
 
-          begin_pos = node.first_argument.source_range.begin.begin_pos + index
+          begin_pos = first_argument.source_range.begin.begin_pos + index
           range = range_between(begin_pos, begin_pos + 2)
 
           add_offense(range) do |corrector|

--- a/spec/rubocop/cop/style/redundant_current_directory_in_path_spec.rb
+++ b/spec/rubocop/cop/style/redundant_current_directory_in_path_spec.rb
@@ -63,4 +63,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantCurrentDirectoryInPath, :config do
       do_something
     RUBY
   end
+
+  it 'does not register an offense when a `require_relative` with no arguments is used' do
+    expect_no_offenses(<<~RUBY)
+      require_relative
+    RUBY
+  end
 end


### PR DESCRIPTION
Consider the following (completely valid) ruby program:

```ruby
# frozen_string_literal: true

require_relative
```

Checking it with rubocop produces the following exception:

```bash
bundle exec rubocop -d test.rb
...
undefined method `str_content' for nil:NilClass
/home/viralpraxis/.asdf/installs/ruby/3.2.3/lib/ruby/gems/3.2.0/gems/rubocop-1.61.0/lib/rubocop/cop/style/redundant_current_directory_in_path.rb:25:in `on_send'
...
```

To fix the issue we can simply enhance

`return unless node.first_argument.str_content&.start_with?(CURRENT_DIRECTORY_PATH)`

so that it returns if `node.first_argument` is `nil`

1.62.0 (using Parser 3.3.0.5, rubocop-ast 1.31.1, running on ruby 3.3.0) [x86_64-linux]
