### PR TITLE
Only parse target Ruby from gemspec if array elements are strings

### DIFF
--- a/changelog/fix_only_parse_target_ruby_from_gemspec_if_array.md
+++ b/changelog/fix_only_parse_target_ruby_from_gemspec_if_array.md
@@ -1,0 +1,1 @@
+* [#12756](https://github.com/rubocop/rubocop/pull/12756): Only parse target Ruby from gemspec if array elements are strings. ([@davidrunger][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -647,11 +647,33 @@ AllCops:
 
 NOTE: When `ParserEngine: parser_prism` is specified, the values that can be assigned to `TargetRubyVersion` must be `3.3` or higher.
 
-Otherwise, RuboCop will then check your project for a series of files where
-the version may be specified already. The files that will be looked for are
+If a `TargetRubyVersion` is not specified in your config, then RuboCop will
+check your project for a series of other files where the Ruby version may be
+specified already. The files that will be checked are (in this order):
 `*.gemspec`, `.ruby-version`, `.tool-versions`, and `Gemfile.lock`.
-If Gemspec file has an array for `required_ruby_version`, the lowest version will be used.
-If none of the files are found a default version value will be used.
+
+If a target Ruby version cannot be found via any of the above sources, then a
+default target Ruby version will be used.
+
+=== Finding target Ruby in a `*.gemspec` file
+
+In order for RuboCop to parse a `*.gemspec` file's `required_ruby_version`, the
+Ruby version must be specified using one of these syntaxes:
+
+1. a string range, e.g. `'~> 3.2.0'` or `'>= 3.2.2'`
+2. an array of strings, e.g. `['>= 3.0.0', '< 3.4.0']`
+3. a `Gem::Requirement`, e.g. `Gem::Requirement.new('>= 3.1.2')`
+
+If a `*.gemspec` file specifies a range of supported Ruby versions via any of
+these means, then the greater of the following Ruby versions will be used:
+
+- the lowest Ruby version that is compatible with your specified range
+- the lowest version of Ruby that is still supported by your version of RuboCop
+
+If a `*.gemspec` file defines its `required_ruby_version` dynamically (e.g. by
+reading from a `.ruby-version` file, via an environment variable, referencing a
+constant or local variable, etc), then RuboCop will _not_ detect that Ruby
+version, and will instead try to find a target Ruby version elsewhere.
 
 == Setting the parser engine
 

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -105,7 +105,7 @@ module RuboCop
       def version_from_right_hand_side(right_hand_side)
         gem_requirement_versions = gem_requirement_versions(right_hand_side)
 
-        if right_hand_side.array_type?
+        if right_hand_side.array_type? && right_hand_side.children.all?(&:str_type?)
           version_from_array(right_hand_side)
         elsif gem_requirement_versions
           gem_requirement_versions.map(&:value)

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -188,10 +188,25 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
 
       context 'when file reads the required_ruby_version from another file' do
         it 'uses the default target ruby version' do
-          content = <<~HEREDOC
+          content = <<~'HEREDOC'
             Gem::Specification.new do |s|
               s.name = 'test'
-              s.required_ruby_version = Gem::Requirement.new(">= \#{File.read('.ruby-version').rstrip}")
+              s.required_ruby_version = Gem::Requirement.new(">= #{File.read('.ruby-version').rstrip}")
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq default_version
+        end
+      end
+
+      context 'when file reads the required_ruby_version from another file in an array' do
+        it 'uses the default target ruby version' do
+          content = <<~'HEREDOC'
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = [">= #{File.read('.ruby-version').rstrip}"]
               s.licenses = ['MIT']
             end
           HEREDOC


### PR DESCRIPTION
This fixes an issue mentioned in [this comment](https://github.com/rubocop/rubocop/issues/12579#issuecomment-1974916930) on issue #12579. (I believe that the main/original issue mentioned in issue #12579 has essentially already been fixed by #12732.)

This change is a related/similar followup to #12732 (50263938f). That PR avoided an exception that was occurring in the
`RuboCop::TargetRuby::GemspecFile` target Ruby finder when a project's gemspec determines the value of `required_ruby_version` in some dynamic way (such as by reading from a `.ruby-version` file).

However, #12732 did not handle a case where the dynamic value for the gemspec's `required_ruby_version` is wrapped within an array, and, in such a case, currently, an exception like the following will occur:

```
Gem::Requirement::BadRequirementError:
  Illformed requirement [">= \#{File.read('.ruby-version').rstrip}"]
  ./lib/rubocop/target_ruby.rb:123:in `new'
  ./lib/rubocop/target_ruby.rb:123:in `find_default_minimal_known_ruby'
  ./lib/rubocop/target_ruby.rb:83:in `find_version'
  ./lib/rubocop/target_ruby.rb:29:in `initialize'
  ./lib/rubocop/target_ruby.rb:259:in `new'
```

(As with the scenario that _was_ fixed by #12732, I believe that this is essentially a "latent" issue that is now occurring in more projects than previously, due to #12645 having increased the precedence of the `GemspecFile` target Ruby finder in the `RuboCop::TargetRuby::SOURCES` list.)

This change avoids this exception by only attempting to parse a target Ruby version from an array value for a gemspec's `required_ruby_version` if every value in the array is a string. When the values within the `required_ruby_version` array are _not_ all strings, now, rather than raising an unhandled exception, the `GemspecFile` finder will return `nil` for the target Ruby version, and so we will continue on to the other TargetRuby finder classes, in order to find a target Ruby version.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/