### PR TITLE
[Fix #12758] Fix false positives for `Layout/RedundantLineBreak`

### DIFF
--- a/changelog/fix_false_positive_for_layout_redundant_line_break.md
+++ b/changelog/fix_false_positive_for_layout_redundant_line_break.md
@@ -1,0 +1,1 @@
+* [#12758](https://github.com/rubocop/rubocop/issues/12758): Fix false positives for `Layout/RedundantLineBreak` when using `&&` or `||` after a backslash newline. ([@koic][])

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -84,8 +84,14 @@ module RuboCop
         end
 
         def offense?(node)
-          node.multiline? && !too_long?(node) && suitable_as_single_line?(node) &&
-            !index_access_call_chained?(node) && !configured_to_not_be_inspected?(node)
+          return false if !node.multiline? || too_long?(node) || !suitable_as_single_line?(node)
+          return require_backslash?(node) if node.and_type? || node.or_type?
+
+          !index_access_call_chained?(node) && !configured_to_not_be_inspected?(node)
+        end
+
+        def require_backslash?(node)
+          processed_source.lines[node.loc.operator.line - 1].end_with?('\\')
         end
 
         def index_access_call_chained?(node)

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -172,6 +172,44 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
         RUBY
       end
 
+      it 'registers an offense when using `&&` before a backslash newline' do
+        expect_offense(<<~RUBY)
+          foo && \\
+          ^^^^^^^^ Redundant line break detected.
+            bar
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo && bar
+        RUBY
+      end
+
+      it 'does not register an offense when using `&&` after a backslash newline' do
+        expect_no_offenses(<<~RUBY)
+          foo \\
+            && bar
+        RUBY
+      end
+
+      it 'registers an offense when using `||` before a backslash newline' do
+        expect_offense(<<~RUBY)
+          foo || \\
+          ^^^^^^^^ Redundant line break detected.
+            bar
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo || bar
+        RUBY
+      end
+
+      it 'does not register an offense when using `||` after a backslash newline' do
+        expect_no_offenses(<<~RUBY)
+          foo \\
+            || bar
+        RUBY
+      end
+
       context 'with LineLength Max 100' do
         let(:max_line_length) { 100 }
 


### PR DESCRIPTION
Fixes #12758.

This PR fixes false positives for `Layout/RedundantLineBreak` when using `&&` or `||` after a backslash newline.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
