### PR TITLE
[Fix #12663] Prevent `Lint/Syntax` being disabled by directive comments

### DIFF
--- a/changelog/fix_lint_syntax_being_disabled_by_directive_comments.md
+++ b/changelog/fix_lint_syntax_being_disabled_by_directive_comments.md
@@ -1,0 +1,1 @@
+* [#12663](https://github.com/rubocop/rubocop/issues/12663): Fix `Lint/Syntax` getting disabled by `rubocop:disable Lint/Syntax`. ([@earlopain][])

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -6,9 +6,11 @@ module RuboCop
   # cops it contains.
   class DirectiveComment
     # @api private
-    REDUNDANT_DIRECTIVE_COP_DEPARTMENT = 'Lint'
+    LINT_DEPARTMENT = 'Lint'
     # @api private
-    REDUNDANT_DIRECTIVE_COP = "#{REDUNDANT_DIRECTIVE_COP_DEPARTMENT}/RedundantCopDisableDirective"
+    LINT_REDUNDANT_DIRECTIVE_COP = "#{LINT_DEPARTMENT}/RedundantCopDisableDirective"
+    # @api private
+    LINT_SYNTAX_COP = "#{LINT_DEPARTMENT}/Syntax"
     # @api private
     COP_NAME_PATTERN = '([A-Z]\w+/)*(?:[A-Z]\w+)'
     # @api private
@@ -118,9 +120,10 @@ module RuboCop
     end
 
     def parsed_cop_names
-      splitted_cops_string.map do |name|
+      cops = splitted_cops_string.map do |name|
         department?(name) ? cop_names_for_department(name) : name
       end.flatten
+      cops - [LINT_SYNTAX_COP]
     end
 
     def department?(name)
@@ -128,17 +131,16 @@ module RuboCop
     end
 
     def all_cop_names
-      exclude_redundant_directive_cop(cop_registry.names)
+      exclude_lint_department_cops(cop_registry.names)
     end
 
     def cop_names_for_department(department)
       names = cop_registry.names_for_department(department)
-      has_redundant_directive_cop = department == REDUNDANT_DIRECTIVE_COP_DEPARTMENT
-      has_redundant_directive_cop ? exclude_redundant_directive_cop(names) : names
+      department == LINT_DEPARTMENT ? exclude_lint_department_cops(names) : names
     end
 
-    def exclude_redundant_directive_cop(cops)
-      cops - [REDUNDANT_DIRECTIVE_COP]
+    def exclude_lint_department_cops(cops)
+      cops - [LINT_REDUNDANT_DIRECTIVE_COP, LINT_SYNTAX_COP]
     end
   end
 end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -368,6 +368,42 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         $stdout.string.include?('F:  1:  7: Lint/Syntax: unexpected token tINTEGER')
       ).to be(true)
     end
+
+    it '`Lint/Syntax` must be enabled when disabled by directive comment' do
+      create_file('example.rb', <<~RUBY)
+        # rubocop:disable Lint/Syntax
+        1 /// 2
+      RUBY
+
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
+      expect(
+        $stdout.string.include?('F:  2:  7: Lint/Syntax: unexpected token tINTEGER')
+      ).to be(true)
+    end
+
+    it '`Lint/Syntax` must be enabled when disabled by directive department comment' do
+      create_file('example.rb', <<~RUBY)
+        # rubocop:disable Lint
+        1 /// 2
+      RUBY
+
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
+      expect(
+        $stdout.string.include?('F:  2:  7: Lint/Syntax: unexpected token tINTEGER')
+      ).to be(true)
+    end
+
+    it '`Lint/Syntax` must be enabled when disabled by directive all comment' do
+      create_file('example.rb', <<~RUBY)
+        # rubocop:disable all
+        1 /// 2
+      RUBY
+
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
+      expect(
+        $stdout.string.include?('F:  2:  7: Lint/Syntax: unexpected token tINTEGER')
+      ).to be(true)
+    end
   end
 
   describe 'rubocop:disable comment' do

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -140,13 +140,11 @@ RSpec.describe RuboCop::CommentConfig do
       expect(loop_disabled_lines.include?(20)).to be(false)
     end
 
-    it 'supports disabling all cops except Lint/RedundantCopDisableDirective with keyword all' do
+    it 'supports disabling all cops except Lint/RedundantCopDisableDirective and Lint/Syntax with keyword all' do
       expected_part = (7..8).to_a
 
-      cops = RuboCop::Cop::Registry.all.reject do |klass|
-        klass == RuboCop::Cop::Lint::RedundantCopDisableDirective
-      end
-
+      excluded = [RuboCop::Cop::Lint::RedundantCopDisableDirective, RuboCop::Cop::Lint::Syntax]
+      cops = RuboCop::Cop::Registry.all - excluded
       cops.each do |cop|
         disabled_lines = disabled_lines_of_cop(cop)
         expect(disabled_lines & expected_part).to eq(expected_part)


### PR DESCRIPTION
Fixes #12663

This would swallow the syntax error, making it look like the file is all good.
In reality all other cops are not being run, even if `Lint/Syntax` is "enabled" again later on.

This code for example would show as having no offenses.
```rb
# rubocop:disable Lint/Syntax
1 /// 2
# rubocop:enable Lint/Syntax

a = ""
b = ''
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
