### PR TITLE
[Fix #12761] Fix a false positive for `Style/HashEachMethods`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_hash_each_methods.md
+++ b/changelog/fix_a_false_positive_for_style_hash_each_methods.md
@@ -1,0 +1,1 @@
+* [#12761](https://github.com/rubocop/rubocop/issues/12761): Fix a false positive for `Style/HashEachMethods` when the key block argument of `Enumerable#each` method is unused after `chunk`. ([@koic][])

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -40,7 +40,7 @@ module RuboCop
 
         MSG = 'Use `%<prefer>s` instead of `%<current>s`.'
         UNUSED_BLOCK_ARG_MSG = "#{MSG.chop} and remove the unused `%<unused_code>s` block argument."
-        ARRAY_CONVERTER_METHODS = %i[assoc flatten rassoc sort sort_by to_a].freeze
+        ARRAY_CONVERTER_METHODS = %i[assoc chunk flatten rassoc sort sort_by to_a].freeze
 
         # @!method kv_each(node)
         def_node_matcher :kv_each, <<~PATTERN

--- a/spec/rubocop/cop/style/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/style/hash_each_methods_spec.rb
@@ -185,6 +185,12 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         RUBY
       end
 
+      it 'does not register an offense when the key block argument of `Enumerable#each` method is unused after `chunk`' do
+        expect_no_offenses(<<~RUBY)
+          foo.chunk { |i| i.do_something }.each { |unused_key, v| do_something(v) }
+        RUBY
+      end
+
       it 'does not register an offense when the key block argument of `Enumerable#each` method is unused after `flatten`' do
         expect_no_offenses(<<~RUBY)
           foo.flatten.each { |unused_key, v| do_something(v) }


### PR DESCRIPTION
Fixes #12761.

This PR fixes a false positive for `Style/HashEachMethods` when the key block argument of `Enumerable#each` method is unused after `chunk`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
