### PR TITLE
Fix an infinite loop for `Style/MultilineMethodSignature` when line break after def

### DIFF
--- a/changelog/fix_infinite_loop_for_style_multiline_method_signature.md
+++ b/changelog/fix_infinite_loop_for_style_multiline_method_signature.md
@@ -1,0 +1,1 @@
+* [#12763](https://github.com/rubocop/rubocop/pull/12763): Fix an infinite loop for `Style/MultilineMethodSignature` when there is a newline directly after the def keyword. ([@earlopain][])

--- a/lib/rubocop/cop/style/multiline_method_signature.rb
+++ b/lib/rubocop/cop/style/multiline_method_signature.rb
@@ -38,6 +38,7 @@ module RuboCop
 
         private
 
+        # rubocop:disable Metrics/AbcSize
         def autocorrect(corrector, node, begin_of_arguments)
           arguments = node.arguments
           joined_arguments = arguments.map(&:source).join(', ')
@@ -49,9 +50,17 @@ module RuboCop
             corrector.remove(range_by_whole_lines(arguments.loc.end, include_final_newline: true))
           end
 
-          corrector.remove(arguments_range(node))
+          arguments_range = arguments_range(node)
+          # If the method name isn't on the same line as def, move it directly after def
+          if arguments_range.first_line != opening_line(node)
+            corrector.remove(node.loc.name)
+            corrector.insert_after(node.loc.keyword, " #{node.loc.name.source}")
+          end
+
+          corrector.remove(arguments_range)
           corrector.insert_after(begin_of_arguments, joined_arguments)
         end
+        # rubocop:enable Metrics/AbcSize
 
         def last_line_source_of_arguments(arguments)
           processed_source[arguments.last_line - 1].strip

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -126,7 +126,7 @@ module RuboCop
         @offenses
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
       def expect_correction(correction, loop: true, source: nil)
         if source
           expected_annotations = parse_annotations(source, raise_error: false)
@@ -148,7 +148,6 @@ module RuboCop
 
           break corrected_source unless loop
           break corrected_source if @last_corrector.empty?
-          break corrected_source if corrected_source == @processed_source.buffer.source
 
           if iteration > RuboCop::Runner::MAX_ITERATIONS
             raise RuboCop::Runner::InfiniteCorrectionLoop.new(@processed_source.path, [@offenses])
@@ -163,7 +162,7 @@ module RuboCop
 
         expect(new_source).to eq(correction)
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
 
       def expect_no_corrections
         raise '`expect_no_corrections` must follow `expect_offense`' unless @processed_source

--- a/spec/rubocop/cop/style/multiline_method_signature_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_signature_spec.rb
@@ -47,8 +47,29 @@ RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
         RUBY
 
         expect_correction(<<~RUBY)
+          def foo
+          (bar)
+          end
+        RUBY
+      end
+
+      it 'registers an offense and corrects when closing paren is on the following line' \
+         'and multiple line breaks after `def` keyword' do
+        expect_offense(<<~RUBY)
           def
-          foo(bar)
+          ^^^ Avoid multi-line method signatures.
+
+
+          foo(bar
+              )
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo
+
+
+          (bar)
           end
         RUBY
       end


### PR DESCRIPTION
This undoes a part of #8090, specifically at https://github.com/rubocop/rubocop/pull/8090/commits/448eb9662d2e5067b65c1e8de9b4dd8019cc9e0c. There don't seem to be any consequences of doing so except for uncovering this bug.

A test case for this issue has already been added in #11768 but after the result has been reached there are still correctors that result in an infinite loop. In practice some other cop comes in first and makes this situation unlikely to actually encounter, unless it is disabled of course.

While I was working on #12753 I got into a similar situation, where my assertions where passing but actually running it on the codebase resulted in an infinite loop. 

This PR fixes the ininite loop and makes these situations impossible by only considering a correction done if there are no correctors left.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
