### PR TITLE
[Fix #12710] Fix a false negative for `Layout/EmptyLineAfterMagicComment` when the file is comments only

### DIFF
--- a/changelog/fix_false_negative_for_layout_empty_line_after_magic_comment.md
+++ b/changelog/fix_false_negative_for_layout_empty_line_after_magic_comment.md
@@ -1,0 +1,1 @@
+* [#12710](https://github.com/rubocop/rubocop/issues/12710): Fix a false negative for `Layout/EmptyLineAfterMagicComment` when the file is comments only. ([@earlopain][])

--- a/lib/rubocop/cop/layout/empty_line_after_magic_comment.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_magic_comment.rb
@@ -27,9 +27,9 @@ module RuboCop
         MSG = 'Add an empty line after magic comments.'
 
         def on_new_investigation
-          return unless processed_source.ast &&
-                        (last_magic_comment = last_magic_comment(processed_source))
-          return if processed_source[last_magic_comment.loc.line].strip.empty?
+          return unless (last_magic_comment = last_magic_comment(processed_source))
+          return unless (next_line = processed_source[last_magic_comment.loc.line])
+          return if next_line.strip.empty?
 
           offending_range = offending_range(last_magic_comment)
 
@@ -46,17 +46,24 @@ module RuboCop
 
         # Find the last magic comment in the source file.
         #
-        # Take all comments that precede the first line of code, select the
+        # Take all comments that precede the first line of code (or just take
+        # them all in the case when there is no code), select the
         # magic comments, and return the last magic comment in the file.
         #
         # @return [Parser::Source::Comment] if magic comments exist before code
         # @return [nil] otherwise
         def last_magic_comment(source)
-          source
-            .comments
-            .take_while { |comment| comment.loc.line < source.ast.loc.line }
+          comments_before_code(source)
             .reverse
             .find { |comment| MagicComment.parse(comment.text).any? }
+        end
+
+        def comments_before_code(source)
+          if source.ast
+            source.comments.take_while { |comment| comment.loc.line < source.ast.loc.line }
+          else
+            source.comments
+          end
         end
       end
     end

--- a/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
@@ -118,6 +118,20 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
     RUBY
   end
 
+  it 'registers an offense when the file is comments only' do
+    expect_offense(<<~RUBY)
+      # frozen_string_literal: true
+      # Hello!
+      ^ Add an empty line after magic comments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # frozen_string_literal: true
+
+      # Hello!
+    RUBY
+  end
+
   it 'accepts code that separates the comment from the code with a newline' do
     expect_no_offenses(<<~RUBY)
       # frozen_string_literal: true


### PR DESCRIPTION
Fixes #12710

When there is no code, there are also no comments before code. In that case, just consider all comments in the file.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
