### PR TITLE
Fix an error for `Layout/MultilineMethodCallIndentation` with safe navigation and assignment method

### DIFF
--- a/changelog/fix_and_error_for_layout_multiline_method_call_indentation.md
+++ b/changelog/fix_and_error_for_layout_multiline_method_call_indentation.md
@@ -1,0 +1,1 @@
+* [#12765](https://github.com/rubocop/rubocop/pull/12765): Fix an error for `Layout/MultilineMethodCallIndentation` with safe navigation and assignment method. ([@earlopain][])

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -189,7 +189,7 @@ module RuboCop
         case node.type
         when :casgn   then _scope, _lhs, rhs = *node
         when :op_asgn then _lhs, _op, rhs = *node
-        when :send    then rhs = node.last_argument
+        when :send, :csend then rhs = node.last_argument
         else               _lhs, rhs = *node
         end
         rhs

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -355,6 +355,19 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
             )
         RUBY
       end
+
+      it "doesn't crash on multiline method calls with safe navigation and assignment" do
+        expect_offense(<<~RUBY)
+          MyClass.
+          foo&.bar = 'baz'
+          ^^^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          MyClass.
+            foo&.bar = 'baz'
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
It wasn't checking for csend, resulting in `:method_name=.begin_pos` later down.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
