### PR TITLE
[Fix #12721] Add `DebuggerRequires` to `Lint/Debugger`

### DIFF
--- a/changelog/change_make_lint_debugger_aware_of_require.md
+++ b/changelog/change_make_lint_debugger_aware_of_require.md
@@ -1,0 +1,1 @@
+* [#12721](https://github.com/rubocop/rubocop/issues/12721): Make `Lint/Debugger` aware of `ruby/debug` requires. ([@earlopain][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1657,7 +1657,7 @@ Lint/Debugger:
   Description: 'Check for debugger calls.'
   Enabled: true
   VersionAdded: '0.14'
-  VersionChanged: '1.46'
+  VersionChanged: '<<next>>'
   DebuggerMethods:
     # Groups are available so that a specific group can be disabled in
     # a user's configuration, but are otherwise not significant.
@@ -1693,6 +1693,11 @@ Lint/Debugger:
       - jard
     WebConsole:
       - binding.console
+  DebuggerRequires:
+    debug.rb:
+      - debug/open
+      - debug/open_nonstop
+      - debug/start
 
 Lint/DeprecatedClassMethods:
   Description: 'Check for deprecated class method calls.'

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -29,6 +29,11 @@ module RuboCop
       #       MyDebugger.debug_this
       # ----
       #
+      # Some gems also ship files that will start a debugging session when required,
+      # for example `require 'debug/start'` from `ruby/debug`. These requires can
+      # be configured through `DebuggerRequires`. It has the same structure as
+      # `DebuggerMethods`, which you can read about above.
+      #
       # @example
       #
       #   # bad (ok during development)
@@ -64,14 +69,20 @@ module RuboCop
       #   def some_method
       #     my_debugger
       #   end
+      #
+      # @example DebuggerRequires: [my_debugger/start]
+      #
+      #   # bad (ok during development)
+      #
+      #   require 'my_debugger/start'
       class Debugger < Base
         MSG = 'Remove debugger entry point `%<source>s`.'
         BLOCK_TYPES = %i[block numblock kwbegin].freeze
 
         def on_send(node)
-          return if !debugger_method?(node) || assumed_usage_context?(node)
+          return if assumed_usage_context?(node)
 
-          add_offense(node)
+          add_offense(node) if debugger_method?(node) || debugger_require?(node)
         end
 
         private
@@ -87,10 +98,24 @@ module RuboCop
           end
         end
 
+        def debugger_requires
+          @debugger_requires ||= begin
+            config = cop_config.fetch('DebuggerRequires', [])
+            config.is_a?(Array) ? config : config.values.flatten
+          end
+        end
+
         def debugger_method?(send_node)
           return false if send_node.parent&.send_type? && send_node.parent.receiver == send_node
 
           debugger_methods.include?(chained_method_name(send_node))
+        end
+
+        def debugger_require?(send_node)
+          return false unless send_node.method?(:require) && send_node.arguments.one?
+          return false unless (argument = send_node.first_argument).str_type?
+
+          debugger_requires.include?(argument.value)
         end
 
         def assumed_usage_context?(node)


### PR DESCRIPTION
I debated adding requires like `debug` or `pry` but believe that would do more harm than good.
RuboCops own spec_helper requires pry. This seems to come from some sort of template.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
