### PR TITLE
Fix a false positive for `Style/NilComparison` without receiver and `EnforcedStyle: comparison`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_nil_comparison.md
+++ b/changelog/fix_a_false_positive_for_style_nil_comparison.md
@@ -1,0 +1,1 @@
+* [#12768](https://github.com/rubocop/rubocop/pull/12768): Fix a false positive for `Style/NilComparison` without receiver and `EnforcedStyle: comparison`. ([@earlopain][])

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -44,6 +44,8 @@ module RuboCop
         def_node_matcher :nil_check?, '(send _ :nil?)'
 
         def on_send(node)
+          return unless node.receiver
+
           style_check?(node) do
             add_offense(node.loc.selector) do |corrector|
               new_code = if prefer_comparison?

--- a/spec/rubocop/cop/style/nil_comparison_spec.rb
+++ b/spec/rubocop/cop/style/nil_comparison_spec.rb
@@ -62,5 +62,11 @@ RSpec.describe RuboCop::Cop::Style::NilComparison, :config do
         !(x == nil)
       RUBY
     end
+
+    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
+    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
+    it 'registers no offense when there is no receiver', broken_on: :prism do
+      expect_no_offenses('nil?')
+    end
   end
 end


### PR DESCRIPTION
This would previously show an offense and get into an infinite loop during correction.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
