### PR TITLE
Fix an error for `Lint/RedundantWithIndex` when there is no receiver

### DIFF
--- a/changelog/fix_an_error_for_lint_redundant_with_index.md
+++ b/changelog/fix_an_error_for_lint_redundant_with_index.md
@@ -1,0 +1,1 @@
+* [#12770](https://github.com/rubocop/rubocop/pull/12770): Fix an error for `Lint/RedundantWithIndex` when the method has no receiver. ([@earlopain][])

--- a/lib/rubocop/cop/lint/redundant_with_index.rb
+++ b/lib/rubocop/cop/lint/redundant_with_index.rb
@@ -34,6 +34,7 @@ module RuboCop
         MSG_WITH_INDEX = 'Remove redundant `with_index`.'
 
         def on_block(node)
+          return unless node.receiver
           return unless (send = redundant_with_index?(node))
 
           range = with_index_range(send)

--- a/spec/rubocop/cop/lint/redundant_with_index_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_with_index_spec.rb
@@ -100,5 +100,13 @@ RSpec.describe RuboCop::Cop::Lint::RedundantWithIndex, :config do
     it 'accepts an index is used as a numblock argument' do
       expect_no_offenses('ary.each_with_index { _1; _2 }')
     end
+
+    it 'accepts with_index without receiver with a block' do
+      expect_no_offenses('with_index { |v| v }')
+    end
+
+    it 'accepts with_index without receiver with a numblock' do
+      expect_no_offenses('with_index { _1 }')
+    end
   end
 end


### PR DESCRIPTION
Did not validate that there even is a receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
