### PR TITLE
Fix a wrong offense message for `InternalAffairs/NodeMatcherDirective`

### DIFF
--- a/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
+++ b/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
@@ -116,8 +116,7 @@ module RuboCop
           # The method directive being prefixed by 'self.' is always an offense.
           # The matched method_name does not contain the receiver but the
           # def_node_match method name may so it must be removed.
-          actual_name_without_receiver = actual_name.delete_prefix('self.')
-          if directive[:method_name] != actual_name_without_receiver || directive[:receiver]
+          if directive[:method_name] != remove_receiver(actual_name) || directive[:receiver]
             :wrong_name
           end
         end
@@ -157,7 +156,8 @@ module RuboCop
                            else
                              directive[:method_name]
                            end
-            format(MSG_WRONG_NAME, expected: actual_name, actual: current_name)
+            # The correct name will never include a receiver, remove it
+            format(MSG_WRONG_NAME, expected: remove_receiver(actual_name), actual: current_name)
           when :wrong_scope
             MSG_WRONG_SCOPE_SELF
           when :no_scope
@@ -167,6 +167,10 @@ module RuboCop
           end
         end
         # rubocop:enable Metrics/MethodLength
+
+        def remove_receiver(current)
+          current.delete_prefix('self.')
+        end
 
         def insert_method_directive(corrector, node, actual_name)
           # If the pattern matcher uses arguments (`%1`, `%2`, etc.), include them in the directive
@@ -216,7 +220,7 @@ module RuboCop
         end
 
         def correct_method_directive(corrector, directive, actual_name)
-          correct = "@!method #{actual_name.delete_prefix('self.')}"
+          correct = "@!method #{remove_receiver(actual_name)}"
           current_name = (directive[:receiver] || '') + directive[:method_name]
           regexp = /@!method\s+#{Regexp.escape(current_name)}/
 

--- a/spec/rubocop/cop/internal_affairs/node_matcher_directive_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/node_matcher_directive_spec.rb
@@ -393,6 +393,25 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeMatcherDirective, :config do
           PATTERN
         RUBY
       end
+
+      it 'gives the correct message for "self." prefix on @!method when @!scope is correctly "class"' do
+        expect_offense(<<~RUBY, method: method)
+          # @!method self.foo?(node)
+          # @!scope class
+          #{method} 'self.foo?', <<~PATTERN
+          ^{method}^^^^^^^^^^^^^^^^^^^^^^^^ `@!method` YARD directive has invalid method name, use `foo?` instead of `self.foo?`.
+            (str)
+          PATTERN
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # @!method foo?(node)
+          # @!scope class
+          #{method} 'self.foo?', <<~PATTERN
+            (str)
+          PATTERN
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
See https://github.com/rubocop/rubocop/pull/12753#issuecomment-1987246707

cc @bquorning, thanks for trying it out early.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
