### PR TITLE
Fix an error for `Style/ClassVars` when calling `class_variable_set` without arguments

### DIFF
--- a/changelog/fix_an_error_for_style_class_vars.md
+++ b/changelog/fix_an_error_for_style_class_vars.md
@@ -1,0 +1,1 @@
+* [#12772](https://github.com/rubocop/rubocop/pull/12772): Fix an error for `Style/ClassVars` when calling `class_variable_set` without arguments. ([@earlopain][])

--- a/lib/rubocop/cop/style/class_vars.rb
+++ b/lib/rubocop/cop/style/class_vars.rb
@@ -54,9 +54,9 @@ module RuboCop
         end
 
         def on_send(node)
-          add_offense(
-            node.first_argument, message: format(MSG, class_var: node.first_argument.source)
-          )
+          return unless (first_argument = node.first_argument)
+
+          add_offense(first_argument, message: format(MSG, class_var: first_argument.source))
         end
       end
     end

--- a/spec/rubocop/cop/style/class_vars_spec.rb
+++ b/spec/rubocop/cop/style/class_vars_spec.rb
@@ -28,4 +28,8 @@ RSpec.describe RuboCop::Cop::Style::ClassVars, :config do
   it 'does not register an offense for class variable usage' do
     expect_no_offenses('@@test.test(20)')
   end
+
+  it 'registers no offense for class variable set without arguments' do
+    expect_no_offenses('class_variable_set')
+  end
 end


### PR DESCRIPTION
LSP stuff, happens when you type and excessively save.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
