### PR TITLE
Fix an error for `Style/For` with `EnforcedStyle: for` when no receiver

### DIFF
--- a/changelog/fix_an_error_for_style_for.md
+++ b/changelog/fix_an_error_for_style_for.md
@@ -1,0 +1,1 @@
+* [#12773](https://github.com/rubocop/rubocop/pull/12773): Fix an error for `Style/For` with `EnforcedStyle: for` when no receiver. ([@earlopain][])

--- a/lib/rubocop/cop/style/for.rb
+++ b/lib/rubocop/cop/style/for.rb
@@ -66,6 +66,8 @@ module RuboCop
           return unless suspect_enumerable?(node)
 
           if style == :for
+            return unless node.receiver
+
             add_offense(node, message: PREFER_FOR) do |corrector|
               EachToForCorrector.new(node).call(corrector)
               opposite_style_detected

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -488,6 +488,14 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
       RUBY
     end
 
+    it 'registers no offense when there is no receiver' do
+      expect_no_offenses(<<~RUBY)
+        each do |n|
+          puts n
+        end
+      RUBY
+    end
+
     it 'registers multiple offenses' do
       expect_offense(<<~RUBY)
         for n in [1, 2, 3] do


### PR DESCRIPTION
There is no autocorrect I can see that makes sense in this case.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
