### PR TITLE
Fix an infinite loop for `Style/RaiseArgs` with `EnforcedStyle: compact` when passing more than 2 arguments to `raise`

### DIFF
--- a/changelog/fix_infinite_loop_for_style_raise_args.md
+++ b/changelog/fix_infinite_loop_for_style_raise_args.md
@@ -1,0 +1,1 @@
+* [#12774](https://github.com/rubocop/rubocop/pull/12774): Fix an infinite loop for `Style/RaiseArgs` with `EnforcedStyle: compact` when passing more than 2 arguments to `raise`. ([@earlopain][])

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -80,7 +80,7 @@ module RuboCop
 
         def correction_exploded_to_compact(node)
           exception_node, *message_nodes = *node.arguments
-          return node.source if message_nodes.size > 1
+          return if message_nodes.size > 1
 
           argument = message_nodes.first.source
           exception_class = exception_node.receiver&.source || exception_node.source

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -169,12 +169,13 @@ module RuboCop
 
         return if @last_corrector.empty?
 
-        # In order to print a nice diff, e.g. what source got corrected to,
-        # we need to run the actual corrections
-
+        # This is just here for a pretty diff if the source actually got changed
         new_source = @last_corrector.rewrite
-
         expect(new_source).to eq(@processed_source.buffer.source)
+
+        # There is an infinite loop if a corrector is present that did not make
+        # any changes. It will cause the same offense/correction on the next loop.
+        raise RuboCop::Runner::InfiniteCorrectionLoop.new(@processed_source.path, [@offenses])
       end
 
       def expect_no_offenses(source, file = nil)


### PR DESCRIPTION
The following test causes the loop: https://github.com/rubocop/rubocop/blob/5ee786dcadfa3c91096d9e81dcd16e4776ca6186/spec/rubocop/cop/style/raise_args_spec.rb#L130-L140

This changes `expect_no_corrections`  to always raise if there are correctors. In this case the corrector replaced nothing, resulting in the same cop being invocted again for the same reason.

Undoing the cop change while keeping the assertion change will produce a failure. The source assertion is left in because it produces nice diffs if there are actually changes.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
