### PR TITLE
Fix an error for `Lint/UselessTimes` when no block is present

### DIFF
--- a/changelog/fix_an_error_for_lint_useless_times.md
+++ b/changelog/fix_an_error_for_lint_useless_times.md
@@ -1,0 +1,1 @@
+* [#12775](https://github.com/rubocop/rubocop/pull/12775): Fix an error for `Lint/UselessTimes` when no block is present. ([@earlopain][])

--- a/lib/rubocop/cop/lint/useless_times.rb
+++ b/lib/rubocop/cop/lint/useless_times.rb
@@ -64,7 +64,7 @@ module RuboCop
             remove_node(corrector, node)
           elsif !proc_name.empty?
             autocorrect_block_pass(corrector, node, proc_name)
-          else
+          elsif node.block_type?
             autocorrect_block(corrector, node)
           end
         end

--- a/spec/rubocop/cop/lint/useless_times_spec.rb
+++ b/spec/rubocop/cop/lint/useless_times_spec.rb
@@ -292,6 +292,15 @@ RSpec.describe RuboCop::Cop::Lint::UselessTimes, :config do
 
         expect_no_corrections
       end
+
+      it 'registers no offense for 1.times without block' do
+        expect_offense(<<~RUBY)
+          1.times
+          ^^^^^^^ Useless call to `1.times` detected.
+        RUBY
+
+        expect_no_corrections
+      end
     end
   end
 end


### PR DESCRIPTION
Another thing that's more common with an LSP.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
