### PR TITLE
Add tests for `expect_no_corrections` and `expect_correction` loop behaviour

### DIFF
--- a/spec/rubocop/rspec/expect_offense_spec.rb
+++ b/spec/rubocop/rspec/expect_offense_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::RSpec::ExpectOffense, :config do
+  context 'with a cop that loops during autocorrection' do
+    let(:cop_class) { RuboCop::Cop::Test::InfiniteLoopDuringAutocorrectCop }
+
+    it '`expect_no_corrections` raises' do
+      expect_offense(<<~RUBY)
+        class Test
+        ^^^^^^^^^^ Class must be a Module
+        end
+      RUBY
+
+      expect { expect_no_corrections }.to raise_error(RuboCop::Runner::InfiniteCorrectionLoop)
+    end
+  end
+
+  context 'with a cop that loops after autocorrecting something' do
+    let(:cop_class) { RuboCop::Cop::Test::InfiniteLoopDuringAutocorrectWithChangeCop }
+
+    it '`expect_correction` raises' do
+      expect_offense(<<~RUBY)
+        class Test
+        ^^^^^^^^^^ Class must be a Module
+        end
+      RUBY
+
+      expect do
+        expect_correction(<<~RUBY)
+          module Test
+          end
+        RUBY
+      end.to raise_error(RuboCop::Runner::InfiniteCorrectionLoop)
+    end
+  end
+end

--- a/spec/support/cops/infinite_loop_during_autocorrect.rb
+++ b/spec/support/cops/infinite_loop_during_autocorrect.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Test
+      class InfiniteLoopDuringAutocorrectCop < RuboCop::Cop::Base
+        extend AutoCorrector
+
+        def on_class(node)
+          add_offense(node, message: 'Class must be a Module') do |corrector|
+            # Replace the offense with itself, will be picked up again next loop
+            corrector.replace(node, node.source)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/cops/infinite_loop_during_autocorrect_with_change.rb
+++ b/spec/support/cops/infinite_loop_during_autocorrect_with_change.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Test
+      class InfiniteLoopDuringAutocorrectWithChangeCop < RuboCop::Cop::Base
+        extend AutoCorrector
+
+        def on_class(node)
+          add_offense(node, message: 'Class must be a Module') do |corrector|
+            corrector.replace(node.loc.keyword, 'module')
+          end
+        end
+
+        def on_module(node)
+          add_offense(node, message: 'Module must be a Class') do |corrector|
+            # Will register an offense during the next loop again
+            corrector.replace(node, node.source)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This relates to #12763 and #12774, where behaviour for these two methods was changed. Undoing changes from these PRs will make these new tests fail.

I thought it would be nice to explicitly test against since there shouldn't ever be code here where this behaviour is actually triggered. I haven't found a place where the expectations were already tested so I made a new file for that.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
