### PR TITLE
Add support for `InternalAffairs/ExampleDescription` when using "registers no offense"

### DIFF
--- a/lib/rubocop/cop/internal_affairs/example_description.rb
+++ b/lib/rubocop/cop/internal_affairs/example_description.rb
@@ -45,6 +45,7 @@ module RuboCop
         EXPECT_OFFENSE_DESCRIPTION_MAPPING = {
           /\A(does not|doesn't) (register|find|flag|report)/ => 'registers',
           /\A(does not|doesn't) add (a|an|any )?offense/ => 'registers an offense',
+          /\Aregisters no offense/ => 'registers an offense',
           /\Aaccepts\b/ => 'registers'
         }.freeze
 

--- a/spec/rubocop/cop/internal_affairs/example_description_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/example_description_spec.rb
@@ -17,6 +17,21 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
       RUBY
     end
 
+    it 'registers an offense when given an improper description for `registers no offense`' do
+      expect_offense(<<~RUBY)
+        it 'registers no offense' do
+           ^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_offense`.
+          expect_offense('code')
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        it 'registers an offense' do
+          expect_offense('code')
+        end
+      RUBY
+    end
+
     it 'registers an offense when given an improper description with single option' do
       expect_offense(<<~RUBY)
         it 'does not register an offense', :ruby30 do

--- a/spec/rubocop/cop/style/require_order_spec.rb
+++ b/spec/rubocop/cop/style/require_order_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe RuboCop::Cop::Style::RequireOrder, :config do
   end
 
   context 'when conditional with multiple unsorted `require` is used between `require`' do
-    it 'registers no offense' do
+    it 'registers an offense' do
       expect_offense(<<~RUBY)
         require 'd'
         if foo


### PR DESCRIPTION
Follow up: https://github.com/rubocop/rubocop/pull/12777

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
