### PR TITLE
Use 'registers no offense' instead of 'register no offense'

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,6 +123,9 @@ Naming/InclusiveLanguage:
     'does not registers':
       Suggestions:
         - does not register
+    'register no offense':
+      Suggestions:
+        - registers no offense
   Exclude:
     - lib/rubocop/cop/naming/inclusive_language.rb
     - lib/rubocop/cop/mixin/auto_corrector.rb

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -1319,11 +1319,11 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
     end
   end
 
-  it 'register no offense for superclass call without args' do
+  it 'registers no offense for superclass call without args' do
     expect_no_offenses('super')
   end
 
-  it 'register no offense for yield without args' do
+  it 'registers no offense for yield without args' do
     expect_no_offenses('yield')
   end
 

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -150,15 +150,15 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'register no offense for superclass call without args' do
+    it 'registers no offense for superclass call without args' do
       expect_no_offenses('super')
     end
 
-    it 'register no offense for yield without args' do
+    it 'registers no offense for yield without args' do
       expect_no_offenses('yield')
     end
 
-    it 'register no offense for superclass call with parens' do
+    it 'registers no offense for superclass call with parens' do
       expect_no_offenses('super(a)')
     end
 


### PR DESCRIPTION
This PR use 'registers no offense' instead of 'register no offense'

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
