### PR TITLE
Fix an error for `Style/RedundantEach` when using `reverse_each.each` without a block

### DIFF
--- a/changelog/fix_an_error_for_style_redundant_each.md
+++ b/changelog/fix_an_error_for_style_redundant_each.md
@@ -1,0 +1,1 @@
+* [#12780](https://github.com/rubocop/rubocop/issues/12780): Fix an error for `Style/RedundantEach` when using `reverse_each.each` without a block. ([@earlopain][])

--- a/lib/rubocop/cop/style/redundant_each.rb
+++ b/lib/rubocop/cop/style/redundant_each.rb
@@ -86,7 +86,7 @@ module RuboCop
         def range(node)
           return node.selector unless node.method?(:each)
 
-          if node.parent.call_type?
+          if node.parent&.call_type?
             node.selector.join(node.parent.loc.dot)
           else
             node.loc.dot.join(node.selector)

--- a/spec/rubocop/cop/style/redundant_each_spec.rb
+++ b/spec/rubocop/cop/style/redundant_each_spec.rb
@@ -115,6 +115,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantEach, :config do
     RUBY
   end
 
+  it 'registers an offense when using `reverse_each.each` without a block' do
+    expect_offense(<<~RUBY)
+      context.reverse_each.each
+                          ^^^^^ Remove redundant `each`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      context.reverse_each
+    RUBY
+  end
+
   it 'registers an offense when using `reverse_each&.each`' do
     expect_offense(<<~RUBY)
       context.reverse_each&.each { |i| do_something(i) }


### PR DESCRIPTION
See added test

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
