### PR TITLE
Fix an error for `Style/ExactRegexpMatch` when calling `match` without a receiver

### DIFF
--- a/changelog/fix_an_error_for_style_exact_regexp_match.md
+++ b/changelog/fix_an_error_for_style_exact_regexp_match.md
@@ -1,0 +1,1 @@
+* [#12781](https://github.com/rubocop/rubocop/pull/12781): Fix an error for `Style/ExactRegexpMatch` when calling `match` without a receiver. ([@earlopain][])

--- a/lib/rubocop/cop/style/exact_regexp_match.rb
+++ b/lib/rubocop/cop/style/exact_regexp_match.rb
@@ -38,12 +38,13 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return unless (receiver = node.receiver)
           return unless (regexp = exact_regexp_match(node))
 
           parsed_regexp = Regexp::Parser.parse(regexp)
           return unless exact_match_pattern?(parsed_regexp)
 
-          prefer = "#{node.receiver.source} #{new_method(node)} '#{parsed_regexp[1].text}'"
+          prefer = "#{receiver.source} #{new_method(node)} '#{parsed_regexp[1].text}'"
 
           add_offense(node, message: format(MSG, prefer: prefer)) do |corrector|
             corrector.replace(node, prefer)

--- a/spec/rubocop/cop/style/exact_regexp_match_spec.rb
+++ b/spec/rubocop/cop/style/exact_regexp_match_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe RuboCop::Cop::Style::ExactRegexpMatch, :config do
     RUBY
   end
 
+  it 'does not register an offense when using match without receiver' do
+    expect_no_offenses('match(/\\Astring\\z/)')
+  end
+
   it 'registers an offense when using `string.match?(/\Astring\z/)`' do
     expect_offense(<<~'RUBY')
       string.match?(/\Astring\z/)


### PR DESCRIPTION
`match(/\Astring\z/)` for example raises.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
