### PR TITLE
Fix an error for `Style/Alias` when calling `alias_method` with fewer than 2 arguments.

### DIFF
--- a/changelog/fix_an_error_for_style_alias.md
+++ b/changelog/fix_an_error_for_style_alias.md
@@ -1,0 +1,1 @@
+* [#12782](https://github.com/rubocop/rubocop/pull/12782): Fix an error for `Style/Alias` with `EnforcedStyle: prefer_alias` when calling `alias_method` with fewer than 2 arguments. ([@earlopain][])

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -41,6 +41,7 @@ module RuboCop
         def on_send(node)
           return unless node.command?(:alias_method)
           return unless style == :prefer_alias && alias_keyword_possible?(node)
+          return unless node.arguments.count == 2
 
           msg = format(MSG_ALIAS_METHOD, current: lexical_scope_type(node))
           add_offense(node.loc.selector, message: msg) do |corrector|

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe RuboCop::Cop::Style::Alias, :config do
         end
       RUBY
     end
+
+    it 'register an offense for alias_method when calling with no arguments' do
+      expect_no_offenses('alias_method')
+    end
+
+    it 'registers no offense for alias_method when calling with one argument' do
+      expect_no_offenses('alias_method :foo')
+    end
   end
 
   context 'when EnforcedStyle is prefer_alias' do
@@ -207,6 +215,14 @@ RSpec.describe RuboCop::Cop::Style::Alias, :config do
           end
         end
       RUBY
+    end
+
+    it 'registers no offense for alias_method when calling with no arguments' do
+      expect_no_offenses('alias_method')
+    end
+
+    it 'registers no offense for alias_method when calling with one argument' do
+      expect_no_offenses('alias_method :foo')
     end
   end
 end


### PR DESCRIPTION
This happens in every context. Classes, Modules, etc. I don't believe it necessary to add one for each. I've also added tests for the other EnforcedStyle but it doesn't raise currently.

I've added no tests for `alias` calls with fewer arguments call since that is just a syntax error.



-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
