### PR TITLE
Make Style/RedundantPercentQ handle multiline source safely

### DIFF
--- a/changelog/fix_make_redundant_percent_q_safe_on_multiline_strings.md
+++ b/changelog/fix_make_redundant_percent_q_safe_on_multiline_strings.md
@@ -1,0 +1,1 @@
+* [#12789](https://github.com/rubocop/rubocop/pull/12789): Make `Style/RedundantPercentQ` safe on multiline strings. ([@boardfish][])

--- a/lib/rubocop/cop/style/redundant_percent_q.rb
+++ b/lib/rubocop/cop/style/redundant_percent_q.rb
@@ -53,7 +53,7 @@ module RuboCop
           return if interpolated_quotes?(node) || allowed_percent_q?(node)
 
           add_offense(node) do |corrector|
-            delimiter = /^%Q[^"]+$|'/.match?(node.source) ? QUOTE : SINGLE_QUOTE
+            delimiter = /\A%Q[^"]+\z|'/.match?(node.source) ? QUOTE : SINGLE_QUOTE
 
             corrector.replace(node.loc.begin, delimiter)
             corrector.replace(node.loc.end, delimiter)

--- a/spec/rubocop/cop/style/redundant_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/redundant_percent_q_spec.rb
@@ -142,6 +142,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantPercentQ, :config do
           'boogers'
       RUBY
     end
+
+    it 'autocorrects safely for multiline strings containing double quotes' do
+      expect_offense(<<~RUBY)
+        %Q(
+        ^^^ Use `%Q` only for strings that contain both single [...]
+          Quoth the Raven "Nevermore."
+        )
+      RUBY
+
+      expect_correction(<<~RUBY)
+        '
+          Quoth the Raven "Nevermore."
+        '
+      RUBY
+    end
   end
 
   it 'accepts a heredoc string that contains %q' do


### PR DESCRIPTION
The regex used in `Style/RedundantPercentQ` is not resilient to multiline input, meaning that its autocorrect would unsafely operate on strings defined across multiple lines with `%Q` where these used quotes. This PR changes the anchors on the regex used by the cop so that its autocorrect determines the correct delimiter safely.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
