### PR TITLE
[Fix #12769] Fix a false positive for `Lint/RedundantWithIndex`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_redundant_with_index.md
+++ b/changelog/fix_a_false_positive_for_lint_redundant_with_index.md
@@ -1,0 +1,1 @@
+* [#12769](https://github.com/rubocop/rubocop/issues/12769): Fix a false positive for `Lint/RedundantWithIndex` when calling `with_index` with receiver and a block. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_with_index.rb
+++ b/lib/rubocop/cop/lint/redundant_with_index.rb
@@ -33,8 +33,10 @@ module RuboCop
         MSG_EACH_WITH_INDEX = 'Use `each` instead of `each_with_index`.'
         MSG_WITH_INDEX = 'Remove redundant `with_index`.'
 
+        # rubocop:disable Metrics/AbcSize
         def on_block(node)
           return unless node.receiver
+          return if node.method?(:with_index) && !node.receiver.receiver
           return unless (send = redundant_with_index?(node))
 
           range = with_index_range(send)
@@ -48,6 +50,7 @@ module RuboCop
             end
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         alias on_numblock on_block
 

--- a/spec/rubocop/cop/lint/redundant_with_index_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_with_index_spec.rb
@@ -101,6 +101,10 @@ RSpec.describe RuboCop::Cop::Lint::RedundantWithIndex, :config do
       expect_no_offenses('ary.each_with_index { _1; _2 }')
     end
 
+    it 'accepts with_index with receiver and a block' do
+      expect_no_offenses('ary.with_index { |v| v }')
+    end
+
     it 'accepts with_index without receiver with a block' do
       expect_no_offenses('with_index { |v| v }')
     end


### PR DESCRIPTION
Fixes #12769.

This PR fixes a false positive for `Lint/RedundantWithIndex` when calling `with_index` with receiver and a block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
