### PR TITLE
Add ExemptHashRocketPairs config option to Style/RedundantDoubleSplatHashBraces

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -4952,7 +4952,7 @@ Style/RedundantDoubleSplatHashBraces:
   Description: 'Checks for redundant uses of double splat hash braces.'
   Enabled: pending
   VersionAdded: '1.41'
-  ExemptHashRocketPairs: false
+  ExemptHashRocketPairs: true
 
 Style/RedundantEach:
   Description: 'Checks for redundant `each`.'

--- a/config/default.yml
+++ b/config/default.yml
@@ -4952,6 +4952,7 @@ Style/RedundantDoubleSplatHashBraces:
   Description: 'Checks for redundant uses of double splat hash braces.'
   Enabled: pending
   VersionAdded: '1.41'
+  ExemptHashRocketPairs: false
 
 Style/RedundantEach:
   Description: 'Checks for redundant `each`.'

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -140,6 +140,7 @@ module RuboCop
 
         def autocorrect_hash_rockets(corrector, parent)
           parent.children.each do |pair_node|
+            next unless pair_node.type == :pair
             key = pair_node.key.value
             value = pair_node.value.source
             corrector.replace(pair_node, "#{key}: #{value}")

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -132,7 +132,6 @@ module RuboCop
         end
 
         def exempt_hash_rocket_pairs
-          return true if cop_config['ExemptHashRocketPairs'].nil?
           cop_config['ExemptHashRocketPairs']
         end
 

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -140,9 +140,9 @@ module RuboCop
 
         def autocorrect_hash_rockets(corrector, parent)
           parent.children.each do |pair_node|
-            key_without_leading_colon = pair_node.key.source.delete_prefix(':')
+            key = pair_node.key.value
             value = pair_node.value.source
-            corrector.replace(pair_node, "#{key_without_leading_colon}: #{value}")
+            corrector.replace(pair_node, "#{key}: #{value}")
           end
         end
       end

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -137,12 +137,14 @@ module RuboCop
 
         def allowed_hash_rocket(node)
           return true if exempt_hash_rocket_pairs && node.pairs.any?(&:hash_rocket?)
+
           node.pairs.map(&:key).any? { |key| !key.literal? }
         end
 
         def autocorrect_hash_rockets(corrector, parent)
           parent.children.each do |pair_node|
-            next unless pair_node.type == :pair
+            next unless pair_node.pair_type?
+
             corrector.replace(pair_node, convert_hash_rocket_to_json_style(pair_node))
           end
         end

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -25,7 +25,7 @@ module RuboCop
         MSG = 'Remove the redundant double splat and braces, use keyword arguments directly.'
         MERGE_METHODS = %i[merge merge!].freeze
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_hash(node)
           return if node.pairs.empty? || allowed_hash_rocket(node)
           return unless (parent = node.parent)
@@ -38,7 +38,7 @@ module RuboCop
             autocorrect(corrector, node, kwsplat)
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         private
 

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -244,9 +244,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
   end
 
   context 'when exempt hash rocket pairs is false' do
-    let(:cop_config) {
-      { 'ExemptHashRocketPairs' => false }
-    }
+    let(:cop_config) { { 'ExemptHashRocketPairs' => false } }
 
     it 'register an offense when using hash rocket double splat hash braces arguments' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -185,6 +185,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
 
   it 'does not register an offense when using hash rocket double splat hash braces arguments' do
     expect_no_offenses(<<~RUBY)
+      do_something(**{:foo => bar})
+    RUBY
+  end
+
+  it 'does not register an offense when using hash rocket double splat hash braces arguments with send node' do
+    expect_no_offenses(<<~RUBY)
       do_something(**{foo => bar})
     RUBY
   end

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -141,6 +141,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
     RUBY
   end
 
+
+  context 'when exempt hash rocket pairs is false' do
+    let(:cop_config) {
+      { 'ExemptHashRocketPairs' => false }
+    }
+
+    it 'register an offense when using hash rocket double splat hash braces arguments' do
+      expect_offense(<<~RUBY)
+        block do
+          do_something(**{:foo => bar, :baz => qux})
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        block do
+          do_something(foo: bar, baz: qux)
+        end
+      RUBY
+    end
+  end
+
   it 'does not register an offense when using keyword arguments' do
     expect_no_offenses(<<~RUBY)
       do_something(foo: bar, baz: qux)

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -141,70 +141,6 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
     RUBY
   end
 
-
-  context 'when exempt hash rocket pairs is false' do
-    let(:cop_config) {
-      { 'ExemptHashRocketPairs' => false }
-    }
-
-    it 'register an offense when using hash rocket double splat hash braces arguments' do
-      expect_offense(<<~RUBY)
-        block do
-          do_something(**{:foo => bar, :baz => qux})
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        block do
-          do_something(foo: bar, baz: qux)
-        end
-      RUBY
-    end
-
-    it 'registers an offense when using mixed hash double splat hash braces arguments' do
-      expect_offense(<<~RUBY)
-        block do
-          do_something(**{:foo => bar, baz: qux})
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        block do
-          do_something(foo: bar, baz: qux)
-        end
-      RUBY
-    end
-
-    it 'registers an offense when using hash rocket double splat hash braces arguments when key is a string' do
-      expect_offense(<<~RUBY)
-        block do
-          do_something(**{'foo' => bar, "baz" => qux})
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        block do
-          do_something(foo: bar, baz: qux)
-        end
-      RUBY
-    end
-
-    it 'registers an offense when using nested double splat hash braces' do
-      expect_offense(<<~RUBY)
-        do_something(**{foo: bar, **{:baz => qux}})
-                                  ^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        do_something(foo: bar, baz: qux)
-      RUBY
-    end
-  end
-
   it 'does not register an offense when using keyword arguments' do
     expect_no_offenses(<<~RUBY)
       do_something(foo: bar, baz: qux)
@@ -305,5 +241,68 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
     expect_no_offenses(<<~RUBY)
       do_something(**(foo ? {bar: bar} : baz))
     RUBY
+  end
+
+  context 'when exempt hash rocket pairs is false' do
+    let(:cop_config) {
+      { 'ExemptHashRocketPairs' => false }
+    }
+
+    it 'register an offense when using hash rocket double splat hash braces arguments' do
+      expect_offense(<<~RUBY)
+        block do
+          do_something(**{:foo => bar, :baz => qux})
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        block do
+          do_something(foo: bar, baz: qux)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using mixed hash double splat hash braces arguments' do
+      expect_offense(<<~RUBY)
+        block do
+          do_something(**{:foo => bar, baz: qux})
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        block do
+          do_something(foo: bar, baz: qux)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using hash rocket double splat hash braces arguments when key is a string' do
+      expect_offense(<<~RUBY)
+        block do
+          do_something(**{'foo' => bar, "baz" => qux})
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        block do
+          do_something(foo: bar, baz: qux)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using nested double splat hash braces' do
+      expect_offense(<<~RUBY)
+        do_something(**{foo: bar, **{:baz => qux}})
+                                  ^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something(foo: bar, baz: qux)
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -191,6 +191,18 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
         end
       RUBY
     end
+
+    it 'registers an offense when using nested double splat hash braces' do
+      expect_offense(<<~RUBY)
+        do_something(**{foo: bar, **{:baz => qux}})
+                                  ^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something(foo: bar, baz: qux)
+      RUBY
+    end
   end
 
   it 'does not register an offense when using keyword arguments' do

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -265,16 +265,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
 
     it 'registers an offense when using mixed hash double splat hash braces arguments' do
       expect_offense(<<~RUBY)
-        block do
           do_something(**{:foo => bar, baz: qux})
                        ^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
-        end
       RUBY
 
       expect_correction(<<~RUBY)
-        block do
           do_something(foo: bar, baz: qux)
-        end
       RUBY
     end
 
@@ -315,5 +311,190 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
       do_something(foo: bar, **options)
     RUBY
     end
+
+    it 'registers an offense when using double splat hash braces with `merge` method call' do
+      expect_offense(<<~RUBY)
+        do_something(**{:foo => bar, :baz => qux}.merge(options))
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something(foo: bar, baz: qux, **options)
+      RUBY
+    end
+
+    it 'registers an offense when using double splat hash braces with `merge!` method call' do
+      expect_offense(<<~RUBY)
+        do_something(**{:foo => bar, :baz => qux}.merge!(options))
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something(foo: bar, baz: qux, **options)
+      RUBY
+    end
+
+    it 'registers an offense when using double splat hash braces with `merge` pair arguments method call' do
+      expect_offense(<<~RUBY)
+        do_something(**{:foo => bar, :baz => qux}.merge(:x => y))
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something(foo: bar, baz: qux, x: y)
+      RUBY
+    end
+
+    it 'registers an offense when using double splat hash braces with `merge` safe navigation method call' do
+      expect_offense(<<~RUBY)
+        do_something(**{:foo => bar, :baz => qux}&.merge(options))
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something(foo: bar, baz: qux, **options)
+      RUBY
+    end
+
+    it 'registers an offense when using double splat hash braces with `merge` method call twice' do
+      expect_offense(<<~RUBY)
+        do_something(**{ :foo => bar }.merge(options))
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+        do_something(**{ :baz => qux }.merge(options))
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something(foo: bar, **options)
+        do_something(baz: qux, **options)
+      RUBY
+    end
+
+    it 'registers an offense when using double splat hash braces with `merge` multiple arguments method call' do
+      expect_offense(<<~RUBY)
+        do_something(**{:foo => bar, :baz => qux}.merge(options1, options2))
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something(foo: bar, baz: qux, **options1, **options2)
+      RUBY
+    end
+
+    it 'registers an offense when using double splat hash braces with `merge` method chain' do
+      expect_offense(<<~RUBY)
+        do_something(**{:foo => bar, :baz => qux}.merge(options1, options2).merge(options3))
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something(foo: bar, baz: qux, **options1, **options2, **options3)
+      RUBY
+    end
+
+    it 'registers an offense when using double splat hash braces with complex `merge` method chain' do
+      expect_offense(<<~RUBY)
+        do_something(**{:foo => bar, :baz => qux}.merge(options1, options2)&.merge!(options3))
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something(foo: bar, baz: qux, **options1, **options2, **options3)
+      RUBY
+    end
+
+    it 'registers an offense when using double splat hash braces inside block' do
+      expect_offense(<<~RUBY)
+        block do
+          do_something(**{:foo => bar, :baz => qux})
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        block do
+          do_something(foo: bar, baz: qux)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using no hash brace' do
+      expect_no_offenses(<<~RUBY)
+        do_something(**options.merge(:foo => bar, :baz => qux))
+      RUBY
+    end
+
+    it 'does not register an offense when method call for no hash braced double splat receiver' do
+      expect_no_offenses(<<~RUBY)
+        do_something(**options.merge({:foo => bar}))
+      RUBY
+    end
+
+    it 'does not register an offense when safe navigation method call for no hash braced double splat receiver' do
+      expect_no_offenses(<<~RUBY)
+        do_something(**options&.merge({:foo => bar}))
+      RUBY
+    end
+
+    it 'does not register an offense when method call for parenthesized no hash double double splat' do
+      expect_no_offenses(<<~RUBY)
+        do_something(**(options.merge(:foo => bar)))
+      RUBY
+    end
+
+    it 'does not register an offense when using hash rocket double splat hash braces arguments when key is a send node' do
+      expect_no_offenses(<<~RUBY)
+        do_something(**{foo => bar})
+      RUBY
+    end
+
+    it 'does not register an offense when using method call that is not `merge` for double splat hash braces arguments' do
+      expect_no_offenses(<<~RUBY)
+        do_something(**{:foo => bar}.invert)
+      RUBY
+    end
+
+    it 'does not register an offense when using double splat hash braces with `merge` and method chain' do
+      expect_no_offenses(<<~RUBY)
+        do_something(**{:foo => bar, :baz => qux}.merge(options).compact_blank)
+      RUBY
+    end
+
+    it 'does not register an offense when using hash braces arguments' do
+      expect_no_offenses(<<~RUBY)
+        do_something({:foo => bar, :baz => qux})
+      RUBY
+    end
+
+    it 'does not register an offense when using hash literal' do
+      expect_no_offenses(<<~RUBY)
+        { :a => a }
+      RUBY
+    end
+
+    it 'does not register an offense when using double splat within block argument containing a hash literal in an array literal' do
+      expect_no_offenses(<<~RUBY)
+        do_something(**x.do_something { [:foo => bar] })
+      RUBY
+    end
+
+    it 'does not register an offense when using double splat within block argument containing a nested hash literal' do
+      expect_no_offenses(<<~RUBY)
+        do_something(**x.do_something { {:foo => {:bar => baz}} })
+      RUBY
+    end
+
+    it 'does not register an offense when using double splat within numbered block argument containing a nested hash literal' do
+      expect_no_offenses(<<~RUBY)
+        do_something(**x.do_something { {:foo => {:bar => _1}} })
+      RUBY
+    end
+
+    it 'does not register an offense when using double splat with a hash literal enclosed in parenthesized ternary operator' do
+      expect_no_offenses(<<~RUBY)
+        do_something(**(foo ? {:bar => bar} : baz))
+      RUBY
+    end
+
   end
 end

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -250,42 +250,34 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
 
     it 'register an offense when using hash rocket double splat hash braces arguments' do
       expect_offense(<<~RUBY)
-        block do
-          do_something(**{:foo => bar, :baz => qux})
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
-        end
+        do_something(**{:foo => bar, :baz => qux})
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
       RUBY
 
       expect_correction(<<~RUBY)
-        block do
-          do_something(foo: bar, baz: qux)
-        end
+        do_something(foo: bar, baz: qux)
       RUBY
     end
 
     it 'registers an offense when using mixed hash double splat hash braces arguments' do
       expect_offense(<<~RUBY)
-          do_something(**{:foo => bar, baz: qux})
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+        do_something(**{:foo => bar, baz: qux})
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
       RUBY
 
       expect_correction(<<~RUBY)
-          do_something(foo: bar, baz: qux)
+        do_something(foo: bar, baz: qux)
       RUBY
     end
 
     it 'registers an offense when using hash rocket double splat hash braces arguments when key is a string' do
       expect_offense(<<~RUBY)
-        block do
-          do_something(**{'foo' => bar, "baz" => qux})
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
-        end
+        do_something(**{'foo' => bar, "baz" => qux})
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
       RUBY
 
       expect_correction(<<~RUBY)
-        block do
-          do_something(foo: bar, baz: qux)
-        end
+        do_something(foo: bar, baz: qux)
       RUBY
     end
 
@@ -303,13 +295,13 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
 
     it 'registers an offense when using double splat in double splat hash braces' do
       expect_offense(<<~RUBY)
-      do_something(**{:foo => bar, **options})
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
-    RUBY
+        do_something(**{:foo => bar, **options})
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+      RUBY
 
       expect_correction(<<~RUBY)
-      do_something(foo: bar, **options)
-    RUBY
+        do_something(foo: bar, **options)
+      RUBY
     end
 
     it 'registers an offense when using double splat hash braces with `merge` method call' do

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -304,5 +304,16 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
         do_something(foo: bar, baz: qux)
       RUBY
     end
+
+    it 'registers an offense when using double splat in double splat hash braces' do
+      expect_offense(<<~RUBY)
+      do_something(**{:foo => bar, **options})
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+    RUBY
+
+      expect_correction(<<~RUBY)
+      do_something(foo: bar, **options)
+    RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -161,6 +161,36 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
         end
       RUBY
     end
+
+    it 'registers an offense when using mixed hash double splat hash braces arguments' do
+      expect_offense(<<~RUBY)
+        block do
+          do_something(**{:foo => bar, baz: qux})
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        block do
+          do_something(foo: bar, baz: qux)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using hash rocket double splat hash braces arguments when key is a string' do
+      expect_offense(<<~RUBY)
+        block do
+          do_something(**{'foo' => bar, "baz" => qux})
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        block do
+          do_something(foo: bar, baz: qux)
+        end
+      RUBY
+    end
   end
 
   it 'does not register an offense when using keyword arguments' do

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -485,6 +485,5 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
         do_something(**(foo ? {:bar => bar} : baz))
       RUBY
     end
-
   end
 end


### PR DESCRIPTION
Our team currently uses the Style/RedundantDoubleSplatHashBraces cop, but found that it does not prevent the double splatting of hash rocket hash literals. While this may be advantage to some, we prefer to dissallow it.

This PR introduces a config option for the cop ExemptHashRocketPairs. This option defaults to true to maintain existing behavior.
When the config option is set to false most redundant double splats on hash rocket hashes where all keys are literals will fail.

```yml
ExemptHashRocketPairs: true
```

```rb
#bad
do_something(**{ foo: 'bar' })

#good
do_something(**{ :foo => 'bar' })
```

```yml
ExemptHashRocketPairs: false
```

```rb
#bad
do_something(**{ foo: 'bar' })

#bad
do_something(**{ :foo => 'bar' })

#good
foo = :my_sym
do_something(** { foo => 'bar')
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
