### PR TITLE
Fix false positives for `Style/EvalWithLocation`

### DIFF
--- a/changelog/fix_false_positives_for_style_eval_with_location.md
+++ b/changelog/fix_false_positives_for_style_eval_with_location.md
@@ -1,0 +1,1 @@
+* [#12796](https://github.com/rubocop/rubocop/pull/12796): Fix false positives for `Style/EvalWithLocation` when using `eval` with a line number from a method call or a variable. ([@koic][])

--- a/lib/rubocop/cop/style/eval_with_location.rb
+++ b/lib/rubocop/cop/style/eval_with_location.rb
@@ -155,6 +155,8 @@ module RuboCop
 
         def check_line(node, code)
           line_node = node.last_argument
+          return if line_node.variable? || (line_node.send_type? && !line_node.method?(:+))
+
           line_diff = line_difference(line_node, code)
           if line_diff.zero?
             add_offense_for_same_line(node, line_node)

--- a/spec/rubocop/cop/style/eval_with_location_spec.rb
+++ b/spec/rubocop/cop/style/eval_with_location_spec.rb
@@ -315,4 +315,22 @@ RSpec.describe RuboCop::Cop::Style::EvalWithLocation, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense when using eval with a line number from a method call' do
+    expect_no_offenses(<<~RUBY)
+      module_eval(<<~CODE, __FILE__, lineno)
+        do_something
+      CODE
+    RUBY
+  end
+
+  it 'does not register an offense when using eval with a line number from a variable' do
+    expect_no_offenses(<<~RUBY)
+      lineno = calc
+
+      module_eval(<<~CODE, __FILE__, lineno)
+        do_something
+      CODE
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes false positives for `Style/EvalWithLocation` when using eval with a line number from a method call or a variable.
These cases should be respected under the assumption that they are intentional.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
