### PR TITLE
[Fix #12797] Fix false positives for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_line_continuation.md
+++ b/changelog/fix_false_positives_for_style_redundant_line_continuation.md
@@ -1,0 +1,1 @@
+* [#12797](https://github.com/rubocop/rubocop/issues/12797): Fix false positives for `Style/RedundantLineContinuation` when using line continuations with `&&` or `||` operator in assignment. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -124,10 +124,10 @@ module RuboCop
           return true unless (node = find_node_for_line(range.line))
           return false if argument_newline?(node)
 
-          continuation_node = node.parent || node
+          continuation_node = node.assignment? ? node.expression : (node.parent || node)
           return false if allowed_type?(node) || allowed_type?(continuation_node)
 
-          continuation_node.source.include?("\n") || continuation_node.source.include?("\\\n")
+          continuation_node.source.match?(/(\n|\\\n")/)
         end
 
         def inside_string_literal?(range, token)

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -484,6 +484,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'does not register an offense when line continuations with `&&` in assignments' do
+    expect_no_offenses(<<~'RUBY')
+      foo = bar\
+        && baz
+    RUBY
+  end
+
+  it 'does not register an offense when line continuations with `||` in assignments' do
+    expect_no_offenses(<<~'RUBY')
+      foo = bar\
+        || baz
+    RUBY
+  end
+
   it 'does not register an offense when line continuations with `&&` in method definition' do
     expect_no_offenses(<<~'RUBY')
       def do_something


### PR DESCRIPTION
Fixes #12797.

This PR fixes false positives for `Style/RedundantLineContinuation` when using line continuations with `&&` or `||` operator in assignment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
