### PR TITLE
Handle empty obsoletion config

### DIFF
--- a/changelog/change_handle_empty_obsoletion_config.md
+++ b/changelog/change_handle_empty_obsoletion_config.md
@@ -1,0 +1,1 @@
+* [#12800](https://github.com/rubocop/rubocop/pull/12800): Handle empty obsoletion config. ([@sambostock][])

--- a/lib/rubocop/config_obsoletion.rb
+++ b/lib/rubocop/config_obsoletion.rb
@@ -52,7 +52,7 @@ module RuboCop
     def load_rules # rubocop:disable Metrics/AbcSize
       rules = LOAD_RULES_CACHE[self.class.files] ||=
         self.class.files.each_with_object({}) do |filename, hash|
-          hash.merge!(YAML.safe_load(File.read(filename))) do |_key, first, second|
+          hash.merge!(YAML.safe_load(File.read(filename)) || {}) do |_key, first, second|
             case first
             when Hash
               first.merge(second)

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -567,6 +567,12 @@ RSpec.describe RuboCop::ConfigObsoletion do
         YAML
       end
 
+      let(:file_with_comments_only) do
+        create_file('obsoletions3.yml', <<~YAML)
+          # Placeholder for eventual obsoletions, so we can hook up the file regardless
+        YAML
+      end
+
       let(:expected_message) do
         <<~OUTPUT.chomp
           The `Style/FlipFlop` cop has been moved to `Lint/FlipFlop`.
@@ -585,6 +591,7 @@ RSpec.describe RuboCop::ConfigObsoletion do
       it 'includes obsoletions from all sources' do
         described_class.files << file_with_renamed_config
         described_class.files << file_with_removed_and_split_config
+        described_class.files << file_with_comments_only
 
         begin
           config_obsoletion.reject_obsolete!


### PR DESCRIPTION
Extension maintainers may want to create a `config/obsoletion.yml` prior to having any obsoletions, just so it is hooked up and ready.

Prior to this change, this would result in a `TypeError`:

    no implicit conversion of nil into Hash

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
