### PR TITLE
Return global offenses for `Naming/FileName` and `Naming/InclusiveLanguage`

### DIFF
--- a/changelog/fix_return_global_offenses_for_inclusive_naming_and_file_name.md
+++ b/changelog/fix_return_global_offenses_for_inclusive_naming_and_file_name.md
@@ -1,0 +1,1 @@
+* [#12802](https://github.com/rubocop/rubocop/pull/12802): Return global offenses for `Naming/FileName` and `Naming/InclusiveLanguage` for empty files. ([@earlopain][])

--- a/lib/rubocop/cop/naming/file_name.rb
+++ b/lib/rubocop/cop/naming/file_name.rb
@@ -57,7 +57,7 @@ module RuboCop
           file_path = processed_source.file_path
           return if config.file_to_exclude?(file_path) || config.allowed_camel_case_file?(file_path)
 
-          for_bad_filename(file_path) { |range, msg| add_offense(range, message: msg) }
+          for_bad_filename(file_path)
         end
 
         private
@@ -71,7 +71,7 @@ module RuboCop
             msg = other_message(basename) unless bad_filename_allowed?
           end
 
-          yield source_range(processed_source.buffer, 1, 0), msg if msg
+          add_global_offense(msg) if msg
         end
 
         def perform_class_and_module_naming_checks(file_path, basename)

--- a/lib/rubocop/cop/naming/inclusive_language.rb
+++ b/lib/rubocop/cop/naming/inclusive_language.rb
@@ -207,8 +207,7 @@ module RuboCop
             message = create_multiple_word_message_for_file(words)
           end
 
-          range = source_range(processed_source.buffer, 1, 0)
-          add_offense(range, message: message)
+          add_global_offense(message)
         end
 
         def create_single_word_message_for_file(word)

--- a/spec/rubocop/cop/naming/file_name_spec.rb
+++ b/spec/rubocop/cop/naming/file_name_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
     it 'registers an offense' do
       expect_offense(<<~RUBY, '/some/dir/testCase.rb')
         print 1
-        ^ The name of this source file (`testCase.rb`) should use snake_case.
+        ^{} The name of this source file (`testCase.rb`) should use snake_case.
       RUBY
     end
   end
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
     it 'registers an offense' do
       expect_offense(<<~RUBY, '/some/dir/testCase')
         print 1
-        ^ The name of this source file (`testCase`) should use snake_case.
+        ^{} The name of this source file (`testCase`) should use snake_case.
       RUBY
     end
   end
@@ -99,7 +99,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY, '/some/dir/test-case')
           #!/usr/bin/env ruby
-          ^ The name of this source file (`test-case`) should use snake_case.
+          ^{} The name of this source file (`test-case`) should use snake_case.
           print 1
         RUBY
       end
@@ -127,7 +127,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
           it 'registers an offense' do
             expect_offense(<<~RUBY, "/some/dir/#{dir}/file/test_case.rb")
               print 1
-              ^ `test_case.rb` should define a class or module called `File::TestCase`.
+              ^{} `test_case.rb` should define a class or module called `File::TestCase`.
             RUBY
           end
         end
@@ -139,7 +139,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
         it 'registers an offense' do
           expect_offense(<<~RUBY, '/some/other/dir/test_case.rb')
             print 1
-            ^ `test_case.rb` should define a class or module called `TestCase`.
+            ^{} `test_case.rb` should define a class or module called `TestCase`.
           RUBY
         end
       end
@@ -148,7 +148,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
         it 'registers an offense' do
           expect_offense(<<~RUBY, '/some/other/dir/test_case.rb')
             print 1
-            ^ `test_case.rb` should define a class or module called `TestCase`.
+            ^{} `test_case.rb` should define a class or module called `TestCase`.
           RUBY
         end
       end
@@ -157,7 +157,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
     context 'on an empty file' do
       it 'registers an offense' do
         expect_offense(<<~RUBY, '/lib/rubocop/blah.rb')
-          ^ `blah.rb` should define a class or module called `Rubocop::Blah`.
+          ^{} `blah.rb` should define a class or module called `Rubocop::Blah`.
         RUBY
       end
     end
@@ -165,7 +165,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
     context 'on an empty file with a space in its filename' do
       it 'registers an offense' do
         expect_offense(<<~RUBY, 'a file.rb')
-          ^ The name of this source file (`a file.rb`) should use snake_case.
+          ^{} The name of this source file (`a file.rb`) should use snake_case.
         RUBY
       end
     end
@@ -184,7 +184,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
           it 'registers an offense' do
             expect_offense(<<~RUBY, "/some/dir/#{dir}/c/b.rb")
               # b.rb
-              ^ `b.rb` should define a class or module called `C::B`.
+              ^{} `b.rb` should define a class or module called `C::B`.
               #{source}
             RUBY
           end
@@ -211,7 +211,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
         it 'registers an offense' do
           expect_offense(<<~RUBY, '/some/dir/e.rb')
             # start of file
-            ^ `e.rb` should define a class or module called `E`.
+            ^{} `e.rb` should define a class or module called `E`.
             #{source}
           RUBY
         end
@@ -296,7 +296,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY, '/lib/image_collection.rb')
           begin
-          ^ `image_collection.rb` should define a class or module called `ImageCollection`.
+          ^{} `image_collection.rb` should define a class or module called `ImageCollection`.
             class PictureCollection
             end
           end
@@ -316,7 +316,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY, '/lib/image_collection.rb')
           PictureCollection = Struct.new
-          ^ `image_collection.rb` should define a class or module called `ImageCollection`.
+          ^{} `image_collection.rb` should define a class or module called `ImageCollection`.
         RUBY
       end
     end
@@ -324,7 +324,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
     context 'on an empty file' do
       it 'registers an offense' do
         expect_offense(<<~RUBY, '/lib/rubocop/foo.rb')
-          ^ `foo.rb` should define a class or module called `Foo`.
+          ^{} `foo.rb` should define a class or module called `Foo`.
         RUBY
       end
     end
@@ -406,7 +406,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY, 'z.rb')
           print 1
-          ^ `z.rb` should match `(?i-mx:\\A[aeiou]\\z)`.
+          ^{} `z.rb` should match `(?i-mx:\\A[aeiou]\\z)`.
         RUBY
       end
     end

--- a/spec/rubocop/cop/naming/inclusive_language_spec.rb
+++ b/spec/rubocop/cop/naming/inclusive_language_spec.rb
@@ -440,22 +440,15 @@ RSpec.describe RuboCop::Cop::Naming::InclusiveLanguage, :config do
   end
 
   context 'filepath' do
-    let(:source) { 'print 1' }
-    let(:processed_source) { parse_source(source) }
-    let(:offenses) { _investigate(cop, processed_source) }
-    let(:messages) { offenses.sort.map(&:message) }
-
-    before { allow(processed_source.buffer).to receive(:name).and_return(filename) }
-
     context 'one offense in filename' do
       let(:cop_config) do
         { 'FlaggedTerms' => { 'master' => { 'Suggestions' => 'main' } } }
       end
-      let(:filename) { '/some/dir/master.rb' }
 
       it 'registers an offense' do
-        expect(offenses.size).to eq(1)
-        expect(messages).to eq(["Consider replacing 'master' in file path with 'main'."])
+        expect_offense(<<~RUBY, '/some/dir/master.rb')
+          ^{} Consider replacing 'master' in file path with 'main'.
+        RUBY
       end
     end
 
@@ -466,9 +459,9 @@ RSpec.describe RuboCop::Cop::Naming::InclusiveLanguage, :config do
       let(:filename) { '/some/config/master-slave.rb' }
 
       it 'registers an offense with all problematic words' do
-        expect(offenses.size).to eq(1)
-        expect(messages)
-          .to eq(["Consider replacing 'master', 'slave' in file path with other terms."])
+        expect_offense(<<~RUBY, '/some/config/master-slave.rb')
+          ^{} Consider replacing 'master', 'slave' in file path with other terms.
+        RUBY
       end
     end
 
@@ -476,11 +469,11 @@ RSpec.describe RuboCop::Cop::Naming::InclusiveLanguage, :config do
       let(:cop_config) do
         { 'FlaggedTerms' => { 'master' => {} } }
       end
-      let(:filename) { '/db/master/config.yml' }
 
       it 'registers an offense for a director' do
-        expect(offenses.size).to eq(1)
-        expect(messages).to eq(["Consider replacing 'master' in file path with another term."])
+        expect_offense(<<~RUBY, '/db/master/config.yml')
+          ^{} Consider replacing 'master' in file path with another term.
+        RUBY
       end
     end
 
@@ -488,11 +481,9 @@ RSpec.describe RuboCop::Cop::Naming::InclusiveLanguage, :config do
       let(:cop_config) do
         { 'CheckFilepaths' => false, 'FlaggedTerms' => { 'master' => {} } }
       end
-      let(:filename) { '/some/dir/master.rb' }
 
       it 'does not register an offense' do
-        expect(offenses.size).to eq(0)
-        expect(messages.empty?).to be(true)
+        expect_no_offenses('', '/some/dir/master.rb')
       end
     end
   end


### PR DESCRIPTION
When checking against filenames, a global offense should be added. The current behaviour causes problems in things like LSPs that inspect the offense for location information since some operations on these offenses will raise a `IndexError`.

I've tweaked the specs for `InclusiveLanguage` since they just passed without any changes. With the annotation expectations, it actually checks the offense location (or lack thereof).

```rb
require "rubocop"

processed_source = RuboCop::ProcessedSource.new("", 3.3)
range = Class.new.extend(RuboCop::Cop::RangeHelp).send(:source_range, processed_source.buffer, 1, 0)
offense = RuboCop::Cop::Offense.new(:info, range, "global offense", "Naming/FileName", :unsupported)
offense.highlighted_area.begin_pos
=> # .../gems/parser-3.3.0.5/lib/parser/source/buffer.rb:274:in `fetch': index 0 outside of array bounds: 0...0 (IndexError)
```

As a note, `Style/Copyright` can add a offense in exactly the same way. However, since it supports autocorrect just switching to `add_global_offense` is not possible.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
