### PR TITLE
[Fix #12801] Fix incorrect autocorrect for `Style/CollectionCompact`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_collection_compact.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_collection_compact.md
@@ -1,0 +1,1 @@
+* [#12801](https://github.com/rubocop/rubocop/issues/12801): Fix incorrect autocorrect for `Style/CollectionCompact` when using `delete_if`. ([@koic][])

--- a/lib/rubocop/cop/style/collection_compact.rb
+++ b/lib/rubocop/cop/style/collection_compact.rb
@@ -19,9 +19,7 @@ module RuboCop
       # @example
       #   # bad
       #   array.reject(&:nil?)
-      #   array.delete_if(&:nil?)
       #   array.reject { |e| e.nil? }
-      #   array.delete_if { |e| e.nil? }
       #   array.select { |e| !e.nil? }
       #   array.grep_v(nil)
       #   array.grep_v(NilClass)
@@ -31,7 +29,9 @@ module RuboCop
       #
       #   # bad
       #   hash.reject!(&:nil?)
+      #   array.delete_if(&:nil?)
       #   hash.reject! { |k, v| v.nil? }
+      #   array.delete_if { |e| e.nil? }
       #   hash.select! { |k, v| !v.nil? }
       #
       #   # good
@@ -127,7 +127,7 @@ module RuboCop
         end
 
         def good_method_name(node)
-          if node.bang_method?
+          if node.bang_method? || node.method?(:delete_if)
             'compact!'
           else
             'compact'

--- a/spec/rubocop/cop/style/collection_compact_spec.rb
+++ b/spec/rubocop/cop/style/collection_compact_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
       array.reject { |e| e.nil? }
             ^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `reject { |e| e.nil? }`.
       array.delete_if { |e| e.nil? }
-            ^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `delete_if { |e| e.nil? }`.
+            ^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact!` instead of `delete_if { |e| e.nil? }`.
       array.reject! { |e| e.nil? }
             ^^^^^^^^^^^^^^^^^^^^^^ Use `compact!` instead of `reject! { |e| e.nil? }`.
     RUBY
 
     expect_correction(<<~RUBY)
       array.compact
-      array.compact
+      array.compact!
       array.compact!
     RUBY
   end
@@ -23,14 +23,14 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
       array&.reject { |e| e&.nil? }
              ^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `reject { |e| e&.nil? }`.
       array&.delete_if { |e| e&.nil? }
-             ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `delete_if { |e| e&.nil? }`.
+             ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact!` instead of `delete_if { |e| e&.nil? }`.
       array&.reject! { |e| e&.nil? }
              ^^^^^^^^^^^^^^^^^^^^^^^ Use `compact!` instead of `reject! { |e| e&.nil? }`.
     RUBY
 
     expect_correction(<<~RUBY)
       array&.compact
-      array&.compact
+      array&.compact!
       array&.compact!
     RUBY
   end
@@ -40,14 +40,14 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
       array.reject(&:nil?)
             ^^^^^^^^^^^^^^ Use `compact` instead of `reject(&:nil?)`.
       array.delete_if(&:nil?)
-            ^^^^^^^^^^^^^^^^^ Use `compact` instead of `delete_if(&:nil?)`.
+            ^^^^^^^^^^^^^^^^^ Use `compact!` instead of `delete_if(&:nil?)`.
       array.reject!(&:nil?)
             ^^^^^^^^^^^^^^^ Use `compact!` instead of `reject!(&:nil?)`.
     RUBY
 
     expect_correction(<<~RUBY)
       array.compact
-      array.compact
+      array.compact!
       array.compact!
     RUBY
   end
@@ -57,14 +57,14 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
       array&.reject(&:nil?)
              ^^^^^^^^^^^^^^ Use `compact` instead of `reject(&:nil?)`.
       array&.delete_if(&:nil?)
-             ^^^^^^^^^^^^^^^^^ Use `compact` instead of `delete_if(&:nil?)`.
+             ^^^^^^^^^^^^^^^^^ Use `compact!` instead of `delete_if(&:nil?)`.
       array&.reject!(&:nil?)
              ^^^^^^^^^^^^^^^ Use `compact!` instead of `reject!(&:nil?)`.
     RUBY
 
     expect_correction(<<~RUBY)
       array&.compact
-      array&.compact
+      array&.compact!
       array&.compact!
     RUBY
   end
@@ -74,12 +74,12 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
       array.reject &:nil?
             ^^^^^^^^^^^^^ Use `compact` instead of `reject &:nil?`.
       array.delete_if &:nil?
-            ^^^^^^^^^^^^^^^^ Use `compact` instead of `delete_if &:nil?`.
+            ^^^^^^^^^^^^^^^^ Use `compact!` instead of `delete_if &:nil?`.
     RUBY
 
     expect_correction(<<~RUBY)
       array.compact
-      array.compact
+      array.compact!
     RUBY
   end
 
@@ -88,14 +88,14 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
       hash.reject { |k, v| v.nil? }
            ^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `reject { |k, v| v.nil? }`.
       hash.delete_if { |k, v| v.nil? }
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `delete_if { |k, v| v.nil? }`.
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact!` instead of `delete_if { |k, v| v.nil? }`.
       hash.reject! { |k, v| v.nil? }
            ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact!` instead of `reject! { |k, v| v.nil? }`.
     RUBY
 
     expect_correction(<<~RUBY)
       hash.compact
-      hash.compact
+      hash.compact!
       hash.compact!
     RUBY
   end
@@ -134,14 +134,14 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
         params.reject { |_k, v| v.nil? }
                ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `reject { |_k, v| v.nil? }`.
         params.delete_if { |_k, v| v.nil? }
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `delete_if { |_k, v| v.nil? }`.
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact!` instead of `delete_if { |_k, v| v.nil? }`.
       end
     RUBY
 
     expect_correction(<<~RUBY)
       def foo(params)
         params.compact
-        params.compact
+        params.compact!
       end
     RUBY
   end


### PR DESCRIPTION
Fixes #12801.

This PR fixes incorrect autocorrect for `Style/CollectionCompact` when using `delete_if`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
