### PR TITLE
Return global offenses for `Style/Copyright` when the file is empty

### DIFF
--- a/changelog/fix_return_global_offenses_for_style_copyright.md
+++ b/changelog/fix_return_global_offenses_for_style_copyright.md
@@ -1,0 +1,1 @@
+* [#12804](https://github.com/rubocop/rubocop/pull/12804): Return global offenses for `Style/Copyright` when the file is empty. ([@earlopain][])

--- a/lib/rubocop/formatter/clang_style_formatter.rb
+++ b/lib/rubocop/formatter/clang_style_formatter.rb
@@ -24,14 +24,10 @@ module RuboCop
           message: message(offense)
         )
 
-        begin
-          return unless valid_line?(offense)
+        return unless valid_line?(offense)
 
-          report_line(offense.location)
-          report_highlighted_area(offense.highlighted_area)
-        rescue IndexError
-          # range is not on a valid line; perhaps the source file is empty
-        end
+        report_line(offense.location)
+        report_highlighted_area(offense.highlighted_area)
       end
 
       def valid_line?(offense)

--- a/lib/rubocop/formatter/tap_formatter.rb
+++ b/lib/rubocop/formatter/tap_formatter.rb
@@ -53,14 +53,10 @@ module RuboCop
           message: message(offense)
         )
 
-        begin
-          return unless valid_line?(offense)
+        return unless valid_line?(offense)
 
-          report_line(offense.location)
-          report_highlighted_area(offense.highlighted_area)
-        rescue IndexError
-          # range is not on a valid line; perhaps the source file is empty
-        end
+        report_line(offense.location)
+        report_highlighted_area(offense.highlighted_area)
       end
 
       def annotate_message(msg)

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -111,6 +111,7 @@ module RuboCop
         source
       end
 
+      # rubocop:disable Metrics/AbcSize
       def expect_offense(source, file = nil, severity: nil, chomp: false, **replacements)
         expected_annotations = parse_annotations(source, **replacements)
         source = expected_annotations.plain_source
@@ -123,8 +124,15 @@ module RuboCop
         expect(actual_annotations).to eq(expected_annotations), ''
         expect(@offenses.map(&:severity).uniq).to eq([severity]) if severity
 
+        # Validate that all offenses have a range that formatters can display
+        expect do
+          @offenses.each { |offense| offense.location.source_line }
+        end.not_to raise_error, 'One of the offenses has a misconstructed range, for ' \
+                                'example if the offense is on line 1 and the source is empty'
+
         @offenses
       end
+      # rubocop:enable Metrics/AbcSize
 
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
       def expect_correction(correction, loop: true, source: nil)

--- a/spec/rubocop/cop/style/copyright_spec.rb
+++ b/spec/rubocop/cop/style/copyright_spec.rb
@@ -93,12 +93,10 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
       cop_config['AutocorrectNotice'] = '# Copyright (c) 2015 Acme Inc.'
 
       expect_offense(<<~RUBY)
-        ^ Include a copyright notice matching [...]
+        ^{} Include a copyright notice matching [...]
       RUBY
 
-      expect_correction(<<~RUBY)
-        # Copyright (c) 2015 Acme Inc.
-      RUBY
+      expect_no_corrections
     end
   end
 


### PR DESCRIPTION
Very similar to #12802

This adds a check that the returned offenses have a location that formatters can display. While the standard formatter catched the `IndexError`, barely any others did.

Since it is not possible to autocorrect global offenses, just don't do that. Adding autocorrect support would be a bunch more work. I've kept autocorrect for cases where the file isn't empty since, while the offense location isn't technically correct, it works.

---

Note that I removed the catching of `IndexError` for the default formatter. Barely any others, except for Tap did that. Formatters like html and markdown would raise when inspecting a empty file with `Style/Copyright`.

The added extra expectations would have caught the `Style/Copyright` and `Naming/FileName` cases, and it also raises for `Naming/InclusiveLanguage` with the test modifications I did in my previous PR.

If this change is considered too dangerous I can remove it. The added assertions should already be pretty good. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
