### PR TITLE
Fix false positives for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_false_positive_for_style_redundant_line_continuation.md
+++ b/changelog/fix_false_positive_for_style_redundant_line_continuation.md
@@ -1,0 +1,1 @@
+* [#12793](https://github.com/rubocop/rubocop/issues/12793): Fix false positives for `Style/RedundantLineContinuation` when using line continuation with modifier. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -120,15 +120,17 @@ module RuboCop
           processed_source[range.line].strip.empty?
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def redundant_line_continuation?(range)
           return true unless (node = find_node_for_line(range.line))
-          return false if argument_newline?(node)
+          return false if modifier_form?(node) || argument_newline?(node)
 
           continuation_node = node.assignment? ? node.expression : (node.parent || node)
           return false if allowed_type?(node) || allowed_type?(continuation_node)
 
           continuation_node.source.match?(/(\n|\\\n")/)
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def inside_string_literal?(range, token)
           ALLOWED_STRING_TOKENS.include?(token.type) && token.pos.overlaps?(range)
@@ -140,6 +142,12 @@ module RuboCop
         #     argument
         def method_with_argument?(current_token, next_token)
           current_token.type == :tIDENTIFIER && ARGUMENT_TYPES.include?(next_token.type)
+        end
+
+        def modifier_form?(node)
+          return false unless node.if_type? || node.while_type? || node.until_type?
+
+          node.modifier_form?
         end
 
         # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -129,6 +129,34 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'does not register an offense when line continuations with `if` modifier' do
+    expect_no_offenses(<<~'RUBY')
+      bar \
+        if foo
+    RUBY
+  end
+
+  it 'does not register an offense when line continuations with `unless` modifier' do
+    expect_no_offenses(<<~'RUBY')
+      bar \
+        unless foo
+    RUBY
+  end
+
+  it 'does not register an offense when line continuations with `while` modifier' do
+    expect_no_offenses(<<~'RUBY')
+      bar \
+        while foo
+    RUBY
+  end
+
+  it 'does not register an offense when line continuations with `until` modifier' do
+    expect_no_offenses(<<~'RUBY')
+      bar \
+        until foo
+    RUBY
+  end
+
   it 'does not register an offense when required line continuations for multiline leading dot method chain with an empty line' do
     expect_no_offenses(<<~'RUBY')
       obj


### PR DESCRIPTION
Part of #12793.

This PR fixes false positives for `Style/RedundantLineContinuation` when using line continuation with modifier.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
