### PR TITLE
[Fix #12807] Fix false positives for `Naming/BlockForwarding`

### DIFF
--- a/changelog/fix_false_positives_for_naming_block_forwarding.md
+++ b/changelog/fix_false_positives_for_naming_block_forwarding.md
@@ -1,0 +1,1 @@
+* [#12807](https://github.com/rubocop/rubocop/issues/12807): Fix false positives for `Naming/BlockForwarding` when using explicit block forwarding in block method and others. ([@koic][])

--- a/spec/rubocop/cop/naming/block_forwarding_spec.rb
+++ b/spec/rubocop/cop/naming/block_forwarding_spec.rb
@@ -230,6 +230,54 @@ RSpec.describe RuboCop::Cop::Naming::BlockForwarding, :config do
         RUBY
       end
 
+      it 'does not register an offense when using explicit block forwarding in block method and after' do
+        # Prevents the following syntax error:
+        #
+        # # foo.rb
+        # def foo(&)
+        #   block_method do
+        #     bar(&)
+        #   end
+        # end
+        #
+        # $ ruby -vc foo.rb
+        # ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
+        # foo.rb: foo.rb:4: anonymous block parameter is also used within block (SyntaxError)
+        #
+        expect_no_offenses(<<~RUBY)
+          def foo(&block)
+            block_method do
+              bar(&block)
+            end
+            baz(&block)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using explicit block forwarding in block method and before' do
+        # Prevents the following syntax error:
+        #
+        # # foo.rb
+        # def foo(&)
+        #   block_method do
+        #     bar(&)
+        #   end
+        # end
+        #
+        # $ ruby -vc foo.rb
+        # ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
+        # foo.rb: foo.rb:4: anonymous block parameter is also used within block (SyntaxError)
+        #
+        expect_no_offenses(<<~RUBY)
+          def foo(&block)
+            bar(&block)
+            block_method do
+              baz(&block)
+            end
+          end
+        RUBY
+      end
+
       it 'does not register an offense when defining no arguments method' do
         expect_no_offenses(<<~RUBY)
           def foo


### PR DESCRIPTION
Fixes #12807.

This PR fixes false positives for `Naming/BlockForwarding` when using explicit block forwarding in block method and others.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
