### PR TITLE
[Fix #12731] Treat csend the same way as send for setter methods

### DIFF
--- a/changelog/fix_assignment_in_condition_safe_nav_setter.md
+++ b/changelog/fix_assignment_in_condition_safe_nav_setter.md
@@ -1,0 +1,1 @@
+* [#12731](https://github.com/rubocop/rubocop/pull/12731): Treat `&.` the same way as `.` for setter methods in `Lint/AssignmentInCondition`. ([@jonas054][])

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -88,9 +88,7 @@ module RuboCop
         end
 
         def skip_children?(asgn_node)
-          (asgn_node.send_type? && !asgn_node.assignment_method?) ||
-            empty_condition?(asgn_node) ||
-            (safe_assignment_allowed? && safe_assignment?(asgn_node))
+          empty_condition?(asgn_node) || (safe_assignment_allowed? && safe_assignment?(asgn_node))
         end
 
         def traverse_node(node, &block)

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -50,7 +50,7 @@ module RuboCop
         MSG_WITHOUT_SAFE_ASSIGNMENT_ALLOWED =
           'Use `==` if you meant to do a comparison or move the assignment ' \
           'up out of the condition.'
-        ASGN_TYPES = [:begin, *AST::Node::EQUALS_ASSIGNMENTS, :send].freeze
+        ASGN_TYPES = [:begin, *AST::Node::EQUALS_ASSIGNMENTS, :send, :csend].freeze
 
         def on_if(node)
           return if node.condition.block_type?

--- a/lib/rubocop/cop/mixin/safe_assignment.rb
+++ b/lib/rubocop/cop/mixin/safe_assignment.rb
@@ -14,7 +14,7 @@ module RuboCop
       def_node_matcher :empty_condition?, '(begin)'
 
       # @!method setter_method?(node)
-      def_node_matcher :setter_method?, '[(send ...) setter_method?]'
+      def_node_matcher :setter_method?, '[({send csend} ...) setter_method?]'
 
       # @!method safe_assignment?(node)
       def_node_matcher :safe_assignment?, '(begin {equals_asgn? #setter_method?})'

--- a/lib/rubocop/cop/mixin/safe_assignment.rb
+++ b/lib/rubocop/cop/mixin/safe_assignment.rb
@@ -14,7 +14,7 @@ module RuboCop
       def_node_matcher :empty_condition?, '(begin)'
 
       # @!method setter_method?(node)
-      def_node_matcher :setter_method?, '[({send csend} ...) setter_method?]'
+      def_node_matcher :setter_method?, '[(call ...) setter_method?]'
 
       # @!method safe_assignment?(node)
       def_node_matcher :safe_assignment?, '(begin {equals_asgn? #setter_method?})'

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -182,6 +182,19 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     RUBY
   end
 
+  it 'registers an offense for assignment methods with safe navigation operator' do
+    expect_offense(<<~RUBY)
+      if test&.method = 10
+                      ^ Use `==` if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if (test&.method = 10)
+      end
+    RUBY
+  end
+
   it 'does not blow up for empty if condition' do
     expect_no_offenses(<<~RUBY)
       if ()


### PR DESCRIPTION
In order to detect code like `if test&.method = 10` we need to find not only `send` nodes but also `csend` nodes.