### PR TITLE
[Fix #12793] Fix false positives for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_line_continuation_cop.md
+++ b/changelog/fix_false_positives_for_style_redundant_line_continuation_cop.md
@@ -1,0 +1,1 @@
+* [#12793](https://github.com/rubocop/rubocop/issues/12793): Fix false positives for `Style/RedundantLineContinuation` when multi-line continuations with operators. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -544,6 +544,22 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'does not register an offense when multi-line continuations with &' do
+    expect_no_offenses(<<~'RUBY')
+      foo \
+        & bar \
+        & baz
+    RUBY
+  end
+
+  it 'does not register an offense when multi-line continuations with |' do
+    expect_no_offenses(<<~'RUBY')
+      foo \
+        | bar \
+        | baz
+    RUBY
+  end
+
   it 'does not register an offense when line continuations with ternary operator' do
     expect_no_offenses(<<~'RUBY')
       foo \


### PR DESCRIPTION
Fixes #12793.

This PR fixes false positives for `Style/RedundantLineContinuation` when multi-line continuations with operators.

In #12678, the use of `RuboCop::Cop::Base#parse` method was avoided due to errors in Prism. Now, the error in Prism have been fixed:
https://github.com/rubocop/rubocop/pull/12677#issuecomment-1932189221

And given redundant line continuation patterns is too varied, this PR have reverted to a simpler implementation using the `parse` method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
