### PR TITLE
Small tweaks to profiling docs

### DIFF
--- a/docs/modules/ROOT/pages/usage/profiling.adoc
+++ b/docs/modules/ROOT/pages/usage/profiling.adoc
@@ -4,8 +4,8 @@ NOTE: Profiling was introduced in RuboCop 1.45.
 
 RuboCop comes with the ability to profile itself while running. It has 2 CLI options:
 
-* the `--profile` option will use a https://github.com/tmm1/stackprof[stackprof gem](you need to have it in `Gemfile`) to profile wall time and print a report at the `tmp/rubocop-stackprof.dump` location of the project. See the gem's documentation on how to interpret the results
-* the `--memory` option will additionally profile memory usage using https://github.com/SamSaffron/memory_profiler[memory_profiler gem](you need to have it in `Gemfile`) and print a report at the `tmp/rubocop-memory_profiler.txt` location of the project
+* the `--profile` option will use the https://github.com/tmm1/stackprof[stackprof gem] (you need to have it in `Gemfile`) to profile wall time and print a report at the `tmp/rubocop-stackprof.dump` location of the project. See the gem's documentation on how to interpret the results
+* the `--memory` option will additionally profile memory usage using https://github.com/SamSaffron/memory_profiler[memory_profiler gem] (you need to have it in `Gemfile`) and print a report at the `tmp/rubocop-memory_profiler.txt` location of the project
 
 NOTE: Profiling memory can be very costly and time consuming when run on a large codebase. In this case, it is recommended to use it over a limited set of files (`app/` directory, for example) or use a limited set of cops (with `--only`, for example).
 


### PR DESCRIPTION
Two missing spaces, plus the `a` sounds awkward (there's only one stackprof gem).
