### PR TITLE
[Fix #12794] Fix false positives for `Style/RedundantArgument`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_argument.md
+++ b/changelog/fix_false_positives_for_style_redundant_argument.md
@@ -1,0 +1,1 @@
+* [#12794](https://github.com/rubocop/rubocop/issues/12794): Fix false positives for `Style/RedundantArgument` when when single-quoted strings for cntrl character. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_argument_spec.rb
@@ -115,6 +115,13 @@ RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
     RUBY
   end
 
+  it 'does not register an offense when single-quoted strings for newline cntrl character' do
+    expect_no_offenses(<<~'RUBY')
+      foo.chomp('\n')
+      foo.chomp!('\n')
+    RUBY
+  end
+
   it 'does not register an offense when method called with no arguments' do
     expect_no_offenses(<<~RUBY)
       foo.join


### PR DESCRIPTION
Fixes #12794.

This PR fixes false positives for `Style/RedundantArgument` when when single-quoted strings for cntrl character.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
