### PR TITLE
Add rubocop-rspec_rails to suggested extensions and extension doc

### DIFF
--- a/changelog/change_add_rubocop_rspec_rails_to_suggested_extensions.md
+++ b/changelog/change_add_rubocop_rspec_rails_to_suggested_extensions.md
@@ -1,0 +1,1 @@
+* [#12813](https://github.com/rubocop/rubocop/pull/12813): Add rubocop-rspec_rails to suggested extensions and extension doc. ([@ydah][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -156,13 +156,14 @@ AllCops:
   # included.
   SuggestExtensions:
     rubocop-rails: [rails]
-    rubocop-rspec: [rspec, rspec-rails]
+    rubocop-rspec: [rspec]
     rubocop-minitest: [minitest]
     rubocop-sequel: [sequel]
     rubocop-rake: [rake]
     rubocop-graphql: [graphql]
     rubocop-capybara: [capybara]
     rubocop-factory_bot: [factory_bot, factory_bot_rails]
+    rubocop-rspec_rails: [rspec-rails]
   # Enable/Disable checking the methods extended by Active Support.
   ActiveSupportExtensionsEnabled: false
 

--- a/docs/modules/ROOT/pages/extensions.adoc
+++ b/docs/modules/ROOT/pages/extensions.adoc
@@ -88,6 +88,8 @@ Thread-safety analysis
 Capybara-specific analysis
 * https://github.com/rubocop/rubocop-factory_bot[rubocop-factory_bot] -
 factory_bot-specific analysis
+* https://github.com/rubocop/rubocop-rspec_rails[rubocop-rspec_rails] -
+RSpec Rails-specific analysis
 
 ==== Third-party Extensions
 

--- a/spec/rubocop/cli/suggest_extensions_spec.rb
+++ b/spec/rubocop/cli/suggest_extensions_spec.rb
@@ -284,7 +284,9 @@ RSpec.describe 'RuboCop::CLI SuggestExtensions', :isolated_environment do # rubo
       end
 
       it 'shows the suggestion' do
-        expect { cli.run(['example.rb']) }.to suggest_extensions.to_install('rubocop-rspec')
+        expect { cli.run(['example.rb']) }.to suggest_extensions.to_install(
+          'rubocop-rspec', 'rubocop-rspec_rails'
+        )
       end
     end
 
@@ -326,7 +328,9 @@ RSpec.describe 'RuboCop::CLI SuggestExtensions', :isolated_environment do # rubo
       end
 
       it 'shows the suggestion' do
-        expect { cli.run(['example.rb']) }.to suggest_extensions.to_install('rubocop-rspec')
+        expect { cli.run(['example.rb']) }.to suggest_extensions.to_install(
+          'rubocop-rspec', 'rubocop-rspec_rails'
+        )
       end
     end
 


### PR DESCRIPTION
This PR adds [rubocop-rspec_rails](https://github.com/rubocop/rubocop-rspec_rails) to the `SuggestExtensions` list and extension doc.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
