### PR TITLE
[Fix #12676] Adjust offending range in LSP

### DIFF
--- a/changelog/change_adjust_offending_range_in_lsp.md
+++ b/changelog/change_adjust_offending_range_in_lsp.md
@@ -1,0 +1,1 @@
+* [#12676](https://github.com/rubocop/rubocop/issues/12676): Adjust offending range in LSP. ([@koic][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -602,6 +602,8 @@ Style/PerlBackrefs:
 ----
 
 This setting prevents autocorrection during editing in the editor.
+Additionally, for cases like `Metrics` cops where the highlight range extends over the entire body of classes, modules, methods, or blocks
+offending range will be confined to only name. This approach helps to avoid redundant and noisy offenses in editor display.
 
 ==== `disabled`
 

--- a/lib/rubocop/cop/mixin/code_length.rb
+++ b/lib/rubocop/cop/mixin/code_length.rb
@@ -36,7 +36,7 @@ module RuboCop
         length = calculator.calculate
         return if length <= max_length
 
-        location = node.casgn_type? ? node.loc.name : node.source_range
+        location = location(node)
 
         add_offense(location, message: message(length, max_length)) { self.max = length }
       end
@@ -53,6 +53,17 @@ module RuboCop
           count_comments: count_comments?,
           foldable_types: count_as_one
         )
+      end
+
+      def location(node)
+        return node.loc.name if node.casgn_type?
+
+        if LSP.enabled?
+          end_range = node.loc.respond_to?(:name) ? node.loc.name : node.loc.begin
+          node.source_range.begin.join(end_range)
+        else
+          node.source_range
+        end
       end
     end
   end

--- a/lib/rubocop/cop/mixin/method_complexity.rb
+++ b/lib/rubocop/cop/mixin/method_complexity.rb
@@ -49,13 +49,13 @@ module RuboCop
 
         return unless complexity > max
 
-        msg = format(self.class::MSG,
-                     method: method_name,
-                     complexity: complexity,
-                     abc_vector: abc_vector,
-                     max: max)
+        msg = format(
+          self.class::MSG,
+          method: method_name, complexity: complexity, abc_vector: abc_vector, max: max
+        )
+        location = location(node)
 
-        add_offense(node, message: msg) { self.max = complexity.ceil }
+        add_offense(location, message: msg) { self.max = complexity.ceil }
       end
 
       def complexity(body)
@@ -68,6 +68,15 @@ module RuboCop
           end
         end
         score
+      end
+
+      def location(node)
+        if LSP.enabled?
+          end_range = node.loc.respond_to?(:name) ? node.loc.name : node.loc.begin
+          node.source_range.begin.join(end_range)
+        else
+          node.source_range
+        end
       end
     end
   end

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -28,12 +28,14 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
     end
 
     it 'registers an offense for an assignment of a local variable' do
-      expect_offense(<<~RUBY)
+      offenses = expect_offense(<<~RUBY)
         def method_name
         ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [<1, 0, 0> 1/0]
           x = 1
         end
       RUBY
+      offense = offenses.first
+      expect(offense.location.last_line).to eq(3)
     end
 
     it 'registers an offense for an assignment of an element' do
@@ -85,6 +87,19 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
           object&.do_something
         end
       RUBY
+    end
+
+    context 'with `--lsp` option', :lsp do
+      it 'registers an offense for an assignment of a local variable' do
+        offenses = expect_offense(<<~RUBY)
+          def method_name
+          ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [<1, 0, 0> 1/0]
+            x = 1
+          end
+        RUBY
+        offense = offenses.first
+        expect(offense.location.last_line).to eq(1)
+      end
     end
 
     context 'when method is in list of allowed methods' do

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -226,6 +226,21 @@ RSpec.describe RuboCop::Cop::Metrics::BlockLength, :config do
     end
   end
 
+  context 'with `--lsp` option', :lsp do
+    it 'reports the correct beginning and end lines' do
+      offenses = expect_offense(<<~RUBY)
+        something do
+        ^^^^^^^^^^^^ Block has too many lines. [3/2]
+          a = _1
+          a = _2
+          a = _3
+        end
+      RUBY
+      offense = offenses.first
+      expect(offense.location.last_line).to eq(1)
+    end
+  end
+
   context 'when CountComments is enabled' do
     before { cop_config['CountComments'] = true }
 

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -150,6 +150,25 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
     end
   end
 
+  context 'with `--lsp` option', :lsp do
+    it 'reports the correct beginning and end lines' do
+      offenses = expect_offense(<<~RUBY)
+        class Test
+        ^^^^^^^^^^ Class has too many lines. [6/5]
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+
+      offense = offenses.first
+      expect(offense.location.last_line).to eq(1)
+    end
+  end
+
   context 'when CountComments is disabled' do
     it 'accepts classes that only contain comments' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
@@ -49,12 +49,14 @@ RSpec.describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     end
 
     it 'registers an offense for an unless modifier' do
-      expect_offense(<<~RUBY)
+      offenses = expect_offense(<<~RUBY)
         def method_name
         ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [2/1]
           call_foo unless some_condition
         end
       RUBY
+      offense = offenses.first
+      expect(offense.location.last_line).to eq(3)
     end
 
     it 'registers an offense for an elsif block' do
@@ -317,6 +319,19 @@ RSpec.describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
           end
         end
       RUBY
+    end
+
+    context 'with `--lsp` option', :lsp do
+      it 'registers an offense for an unless modifier' do
+        offenses = expect_offense(<<~RUBY)
+          def method_name
+          ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [2/1]
+            call_foo unless some_condition
+          end
+        RUBY
+        offense = offenses.first
+        expect(offense.location.last_line).to eq(1)
+      end
     end
   end
 

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -226,6 +226,24 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
     end
   end
 
+  context 'with `--lsp` option', :lsp do
+    it 'reports the correct beginning and end lines' do
+      offenses = expect_offense(<<~RUBY)
+        module Test
+        ^^^^^^^^^^^ Module has too many lines. [6/5]
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+      offense = offenses.first
+      expect(offense.location.last_line).to eq(1)
+    end
+  end
+
   context 'when CountComments is enabled' do
     before { cop_config['CountComments'] = true }
 


### PR DESCRIPTION
Fixes #12676.

Highlighting offenses for entire classes, modules, and methods is considered noisy in LSP. Instead, highlighting will be applied only to the class names or method names for offenses.

To maintain compatibility for uses outside of LSP, such as with `--disable-uncorrectable`, the behavior will be changed only when `RuboCop::LSP.enabled?` is true.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
