### PR TITLE
Make `rubocop -V` display rubocop-rspec_rails version when using it

### DIFF
--- a/changelog/change_make_rubocop_v_display_rubocop_rspec_rails_version.md
+++ b/changelog/change_make_rubocop_v_display_rubocop_rspec_rails_version.md
@@ -1,0 +1,1 @@
+* [#12817](https://github.com/rubocop/rubocop/pull/12817): Make `rubocop -V` display rubocop-rspec_rails version when using it. ([@ydah][])

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -11,7 +11,7 @@ module RuboCop
 
     CANONICAL_FEATURE_NAMES = {
       'Rspec' => 'RSpec', 'Graphql' => 'GraphQL', 'Md' => 'Markdown', 'Factory_bot' => 'FactoryBot',
-      'Thread_safety' => 'ThreadSafety'
+      'Thread_safety' => 'ThreadSafety', 'Rspec_rails' => 'RSpecRails'
     }.freeze
     EXTENSION_PATH_NAMES = {
       'rubocop-md' => 'markdown', 'rubocop-factory_bot' => 'factory_bot'

--- a/spec/rubocop/version_spec.rb
+++ b/spec/rubocop/version_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe RuboCop::Version do
           rubocop-thread_safety
           rubocop-capybara
           rubocop-factory_bot
+          rubocop-rspec_rails
         ]
       end
 
@@ -154,7 +155,8 @@ RSpec.describe RuboCop::Version do
           /- rubocop-md \d+\.\d+\.\d+/,
           /- rubocop-thread_safety \d+\.\d+\.\d+/,
           /- rubocop-capybara \d+\.\d+\.\d+/,
-          /- rubocop-factory_bot \d+\.\d+\.\d+/
+          /- rubocop-factory_bot \d+\.\d+\.\d+/,
+          /- rubocop-rspec_rails \d+\.\d+\.\d+/
         )
       end
     end


### PR DESCRIPTION
This PR makes `rubocop -V` display rubocop-rspec_rails version when using it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
