### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ bin/*
 
 # For stackprof or others
 tmp/*
+
+# For vscode:
+.vscode


### PR DESCRIPTION
This PR exclude .vscode directory created by vscode Follow up: https://github.com/rubocop/rubocop-rspec/pull/1804

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
