### PR TITLE
Add support more Capybara debugger entry points for `Lint/Debugger`

### DIFF
--- a/changelog/change_add_support_more_capybara_debugger_entry_points.md
+++ b/changelog/change_add_support_more_capybara_debugger_entry_points.md
@@ -1,0 +1,1 @@
+* [#12820](https://github.com/rubocop/rubocop/pull/12820): Add support more Capybara debugger entry points for `Lint/Debugger`. ([@ydah][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1671,8 +1671,14 @@ Lint/Debugger:
       - Kernel.byebug
       - Kernel.remote_byebug
     Capybara:
+      - page.save_and_open_page
+      - page.save_and_open_screenshot
+      - page.save_page
+      - page.save_screenshot
       - save_and_open_page
       - save_and_open_screenshot
+      - save_page
+      - save_screenshot
     debug.rb:
       - binding.b
       - binding.break

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -318,6 +318,20 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
       RUBY
     end
 
+    it 'registers an offense for save_page' do
+      expect_offense(<<~RUBY)
+        save_page
+        ^^^^^^^^^ Remove debugger entry point `save_page`.
+      RUBY
+    end
+
+    it 'registers an offense for save_screenshot' do
+      expect_offense(<<~RUBY)
+        save_screenshot
+        ^^^^^^^^^^^^^^^ Remove debugger entry point `save_screenshot`.
+      RUBY
+    end
+
     context 'with an argument' do
       it 'registers an offense for save_and_open_page' do
         expect_offense(<<~RUBY)
@@ -330,6 +344,50 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
         expect_offense(<<~RUBY)
           save_and_open_screenshot foo
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `save_and_open_screenshot foo`.
+        RUBY
+      end
+
+      it 'registers an offense for save_page' do
+        expect_offense(<<~RUBY)
+          save_page foo
+          ^^^^^^^^^^^^^ Remove debugger entry point `save_page foo`.
+        RUBY
+      end
+
+      it 'registers an offense for save_screenshot' do
+        expect_offense(<<~RUBY)
+          save_screenshot foo
+          ^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `save_screenshot foo`.
+        RUBY
+      end
+    end
+
+    context 'with a page receiver' do
+      it 'registers an offense for save_and_open_page' do
+        expect_offense(<<~RUBY)
+          page.save_and_open_page
+          ^^^^^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `page.save_and_open_page`.
+        RUBY
+      end
+
+      it 'registers an offense for save_and_open_screenshot' do
+        expect_offense(<<~RUBY)
+          page.save_and_open_screenshot
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `page.save_and_open_screenshot`.
+        RUBY
+      end
+
+      it 'registers an offense for save_page' do
+        expect_offense(<<~RUBY)
+          page.save_page
+          ^^^^^^^^^^^^^^ Remove debugger entry point `page.save_page`.
+        RUBY
+      end
+
+      it 'registers an offense for save_screenshot' do
+        expect_offense(<<~RUBY)
+          page.save_screenshot
+          ^^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `page.save_screenshot`.
         RUBY
       end
     end


### PR DESCRIPTION
This PR makes add support more Capybara debugger entry points for `Lint/Debugger`

- page.save_and_open_page
- page.save_and_open_screenshot
- page.save_page
- page.save_screenshot
- save_page
  - https://www.rubydoc.info/gems/capybara/Capybara%2FSession:save_page
- save_screenshot
  - https://www.rubydoc.info/gems/capybara/Capybara%2FSession:save_screenshot

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
