### PR TITLE
Run tests with Prism 0.25+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,11 +8,7 @@ gem 'asciidoctor'
 gem 'bump', require: false
 gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'memory_profiler', platform: :mri
-# FIXME: This is a workaround for incompatibilities between Prism 0.24.0 and 0.25.0.
-# To upgrade to Prism 0.25+, it is necessary to investigate the following build error
-# and provide feedback to Prism:
-# https://github.com/rubocop/rubocop/actions/runs/8578707777/job/23512878899
-gem 'prism', '0.24.0'
+gem 'prism', '>= 0.25.0'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.21.0'

--- a/spec/rubocop/cop/alignment_corrector_spec.rb
+++ b/spec/rubocop/cop/alignment_corrector_spec.rb
@@ -69,8 +69,7 @@ RSpec.describe RuboCop::Cop::AlignmentCorrector, :config do
         it_behaves_like 'heredoc indenter', '<<DOC', 20
       end
 
-      # FIXME: https://github.com/ruby/prism/issues/2498
-      context 'with heredoc in backticks (<<``)', broken_on: :prism do
+      context 'with heredoc in backticks (<<``)' do
         it_behaves_like 'heredoc indenter', '<<`DOC`', 20
       end
     end

--- a/spec/rubocop/cop/internal_affairs/location_line_equality_comparison_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/location_line_equality_comparison_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-# FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-# the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-# rubocop:disable Layout/LineLength
-RSpec.describe RuboCop::Cop::InternalAffairs::LocationLineEqualityComparison, :config, broken_on: :prism do
-  # rubocop:enable Layout/LineLength
+RSpec.describe RuboCop::Cop::InternalAffairs::LocationLineEqualityComparison, :config do
   it 'registers and corrects an offense when comparing `#loc.line` with LHS and RHS' do
     expect_offense(<<~RUBY)
       node.loc.line == node.parent.loc.line

--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -130,21 +130,23 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
           RUBY
         end
 
-        it "accepts a `when` clause that's equally indented with `case`" do
-          expect_no_offenses(<<~RUBY)
-            y = case a
-                when 0 then break
-                when 0 then return
-                else
-                  z = case b
-                      when 1 then return
-                      when 1 then break
-                      end
-                end
-            case c
-            when 2 then encoding
-            end
-          RUBY
+        context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+          it "accepts a `when` clause that's equally indented with `case`" do
+            expect_no_offenses(<<~RUBY)
+              y = case a
+                  when 0 then break
+                  when 0 then return
+                  else
+                    z = case b
+                        when 1 then return
+                        when 1 then break
+                        end
+                  end
+              case c
+              when 2 then encoding
+              end
+            RUBY
+          end
         end
 
         it "doesn't get confused by strings with `case` in them" do
@@ -310,21 +312,23 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
           RUBY
         end
 
-        it "accepts an `in` clause that's equally indented with `case`" do
-          expect_no_offenses(<<~RUBY)
-            y = case a
-                in 0 then break
-                in 0 then return
-                else
-                  z = case b
-                      in 1 then return
-                      in 1 then break
-                      end
-                end
-            case c
-            in 2 then encoding
-            end
-          RUBY
+        context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+          it "accepts an `in` clause that's equally indented with `case`" do
+            expect_no_offenses(<<~RUBY)
+              y = case a
+                  in 0 then break
+                  in 0 then return
+                  else
+                    z = case b
+                        in 1 then return
+                        in 1 then break
+                        end
+                  end
+              case c
+              in 2 then encoding
+              end
+            RUBY
+          end
         end
 
         it "doesn't get confused by strings with `case` in them" do
@@ -428,39 +432,41 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
           RUBY
         end
 
-        it 'registers an offense and corrects a `when` clause that is equally indented with `case`' do
-          expect_offense(<<~RUBY)
-            y = case a
-                when 0 then break
-                ^^^^ Indent `when` one step more than `case`.
-                when 0 then return
-                ^^^^ Indent `when` one step more than `case`.
-                  z = case b
-                      when 1 then return
-                      ^^^^ Indent `when` one step more than `case`.
-                      when 1 then break
-                      ^^^^ Indent `when` one step more than `case`.
-                      end
-                end
-            case c
-            when 2 then encoding
-            ^^^^ Indent `when` one step more than `case`.
-            end
-          RUBY
-
-          expect_correction(<<~RUBY)
-            y = case a
+        context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+          it 'registers an offense and corrects a `when` clause that is equally indented with `case`' do
+            expect_offense(<<~RUBY)
+              y = case a
                   when 0 then break
+                  ^^^^ Indent `when` one step more than `case`.
                   when 0 then return
-                  z = case b
+                  ^^^^ Indent `when` one step more than `case`.
+                    z = case b
                         when 1 then return
+                        ^^^^ Indent `when` one step more than `case`.
                         when 1 then break
-                      end
-                end
-            case c
+                        ^^^^ Indent `when` one step more than `case`.
+                        end
+                  end
+              case c
               when 2 then encoding
-            end
-          RUBY
+              ^^^^ Indent `when` one step more than `case`.
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              y = case a
+                    when 0 then break
+                    when 0 then return
+                    z = case b
+                          when 1 then return
+                          when 1 then break
+                        end
+                  end
+              case c
+                when 2 then encoding
+              end
+            RUBY
+          end
         end
 
         context 'when indentation width is overridden for this cop only' do
@@ -538,39 +544,41 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
           RUBY
         end
 
-        it 'registers an offense and corrects an `in` clause that is equally indented with `case`' do
-          expect_offense(<<~RUBY)
-            y = case a
-                in 0 then break
-                ^^ Indent `in` one step more than `case`.
-                in 0 then return
-                ^^ Indent `in` one step more than `case`.
-                  z = case b
-                      in 1 then return
-                      ^^ Indent `in` one step more than `case`.
-                      in 1 then break
-                      ^^ Indent `in` one step more than `case`.
-                      end
-                end
-            case c
-            in 2 then encoding
-            ^^ Indent `in` one step more than `case`.
-            end
-          RUBY
-
-          expect_correction(<<~RUBY)
-            y = case a
+        context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+          it 'registers an offense and corrects an `in` clause that is equally indented with `case`' do
+            expect_offense(<<~RUBY)
+              y = case a
                   in 0 then break
+                  ^^ Indent `in` one step more than `case`.
                   in 0 then return
-                  z = case b
+                  ^^ Indent `in` one step more than `case`.
+                    z = case b
                         in 1 then return
+                        ^^ Indent `in` one step more than `case`.
                         in 1 then break
-                      end
-                end
-            case c
+                        ^^ Indent `in` one step more than `case`.
+                        end
+                  end
+              case c
               in 2 then encoding
-            end
-          RUBY
+              ^^ Indent `in` one step more than `case`.
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              y = case a
+                    in 0 then break
+                    in 0 then return
+                    z = case b
+                          in 1 then return
+                          in 1 then break
+                        end
+                  end
+              case c
+                in 2 then encoding
+              end
+            RUBY
+          end
         end
 
         context 'when indentation width is overridden for this cop only' do

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -362,8 +362,7 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
     RUBY
   end
 
-  # FIXME: https://github.com/ruby/prism/issues/2498
-  it 'registers an offense and corrects when xstr heredoc constant is defined after public method', broken_on: :prism do
+  it 'registers an offense and corrects when xstr heredoc constant is defined after public method' do
     expect_offense(<<~RUBY)
       class Foo
         def do_something

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -25,22 +25,24 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects `next` guard clause not followed by empty line' do
-    expect_offense(<<~RUBY)
-      def foo
-        next unless need_next? # comment
-        ^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
-        foobar
-      end
-    RUBY
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    it 'registers an offense and corrects `next` guard clause not followed by empty line' do
+      expect_offense(<<~RUBY)
+        def foo
+          next unless need_next? # comment
+          ^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+          foobar
+        end
+      RUBY
 
-    expect_correction(<<~RUBY)
-      def foo
-        next unless need_next? # comment
+      expect_correction(<<~RUBY)
+        def foo
+          next unless need_next? # comment
 
-        foobar
-      end
-    RUBY
+          foobar
+        end
+      RUBY
+    end
   end
 
   it 'registers an offense and corrects a guard clause is before `begin`' do
@@ -528,42 +530,44 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects a method starting with end_' do
-    expect_offense(<<~RUBY)
-      def foo
-        next unless need_next?
-        ^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
-        end_this!
-      end
-    RUBY
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    it 'registers an offense and corrects a method starting with end_' do
+      expect_offense(<<~RUBY)
+        def foo
+          next unless need_next?
+          ^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+          end_this!
+        end
+      RUBY
 
-    expect_correction(<<~RUBY)
-      def foo
-        next unless need_next?
+      expect_correction(<<~RUBY)
+        def foo
+          next unless need_next?
 
-        end_this!
-      end
-    RUBY
-  end
+          end_this!
+        end
+      RUBY
+    end
 
-  it 'registers an offense and corrects only the last guard clause' do
-    expect_offense(<<~RUBY)
-      def foo
-        next if foo?
-        next if bar?
-        ^^^^^^^^^^^^ Add empty line after guard clause.
-        foobar
-      end
-    RUBY
+    it 'registers an offense and corrects only the last guard clause' do
+      expect_offense(<<~RUBY)
+        def foo
+          next if foo?
+          next if bar?
+          ^^^^^^^^^^^^ Add empty line after guard clause.
+          foobar
+        end
+      RUBY
 
-    expect_correction(<<~RUBY)
-      def foo
-        next if foo?
-        next if bar?
+      expect_correction(<<~RUBY)
+        def foo
+          next if foo?
+          next if bar?
 
-        foobar
-      end
-    RUBY
+          foobar
+        end
+      RUBY
+    end
   end
 
   it 'registers no offenses using heredoc with `and return` before guard condition with empty line' do

--- a/spec/rubocop/cop/layout/empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_spec.rb
@@ -30,8 +30,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLines, :config do
     RUBY
   end
 
-  # FIXME: https://github.com/ruby/prism/issues/2515
-  it 'does not register an offense for empty lines in a string', broken_on: :prism do
+  it 'does not register an offense for empty lines in a string' do
     expect_no_offenses(<<~RUBY)
       result = "test
 
@@ -41,8 +40,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLines, :config do
     RUBY
   end
 
-  # FIXME: https://github.com/ruby/prism/issues/2512
-  it 'does not register an offense for heredocs with empty lines inside', broken_on: :prism do
+  it 'does not register an offense for heredocs with empty lines inside' do
     expect_no_offenses(<<~RUBY)
       str = <<-TEXT
       line 1

--- a/spec/rubocop/cop/layout/end_of_line_spec.rb
+++ b/spec/rubocop/cop/layout/end_of_line_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
       expect_no_offenses('x=0')
     end
 
-    it 'does not register offenses after __END__', broken_on: :prism do
+    it 'does not register offenses after __END__' do
       expect_no_offenses(<<~RUBY)
         x=0\r
         __END__

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -120,30 +120,32 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    it 'registers an offense and corrects misaligned keys in implicit hash for yield' do
-      expect_offense(<<~RUBY)
-        yield(a: 0,
-          b: 1)
-          ^^^^ Align the keys of a hash literal if they span more than one line.
-      RUBY
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+      it 'registers an offense and corrects misaligned keys in implicit hash for yield' do
+        expect_offense(<<~RUBY)
+          yield(a: 0,
+            b: 1)
+            ^^^^ Align the keys of a hash literal if they span more than one line.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        yield(a: 0,
-              b: 1)
-      RUBY
-    end
+        expect_correction(<<~RUBY)
+          yield(a: 0,
+                b: 1)
+        RUBY
+      end
 
-    it 'registers an offense and corrects misaligned keys in explicit hash for yield' do
-      expect_offense(<<~RUBY)
-        yield({a: 0,
-          b: 1})
-          ^^^^ Align the keys of a hash literal if they span more than one line.
-      RUBY
+      it 'registers an offense and corrects misaligned keys in explicit hash for yield' do
+        expect_offense(<<~RUBY)
+          yield({a: 0,
+            b: 1})
+            ^^^^ Align the keys of a hash literal if they span more than one line.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        yield({a: 0,
-               b: 1})
-      RUBY
+        expect_correction(<<~RUBY)
+          yield({a: 0,
+                 b: 1})
+        RUBY
+      end
     end
 
     context 'when using hash value omission', :ruby31 do
@@ -301,18 +303,20 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    it 'accepts misaligned keys in implicit hash for yield' do
-      expect_no_offenses(<<~RUBY)
-        yield(a: 0,
-          b: 1)
-      RUBY
-    end
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+      it 'accepts misaligned keys in implicit hash for yield' do
+        expect_no_offenses(<<~RUBY)
+          yield(a: 0,
+            b: 1)
+        RUBY
+      end
 
-    it 'accepts misaligned keys in explicit hash for yield' do
-      expect_no_offenses(<<~RUBY)
-        yield({a: 0,
-          b: 1})
-      RUBY
+      it 'accepts misaligned keys in explicit hash for yield' do
+        expect_no_offenses(<<~RUBY)
+          yield({a: 0,
+            b: 1})
+        RUBY
+      end
     end
   end
 
@@ -359,24 +363,26 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    it 'accepts misaligned keys in implicit hash for yield' do
-      expect_no_offenses(<<~RUBY)
-        yield(a: 0,
-          b: 1)
-      RUBY
-    end
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+      it 'accepts misaligned keys in implicit hash for yield' do
+        expect_no_offenses(<<~RUBY)
+          yield(a: 0,
+            b: 1)
+        RUBY
+      end
 
-    it 'registers an offense and corrects misaligned keys in explicit hash for yield' do
-      expect_offense(<<~RUBY)
-        yield({a: 0,
-          b: 1})
-          ^^^^ Align the keys of a hash literal if they span more than one line.
-      RUBY
+      it 'registers an offense and corrects misaligned keys in explicit hash for yield' do
+        expect_offense(<<~RUBY)
+          yield({a: 0,
+            b: 1})
+            ^^^^ Align the keys of a hash literal if they span more than one line.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        yield({a: 0,
-               b: 1})
-      RUBY
+        expect_correction(<<~RUBY)
+          yield({a: 0,
+                 b: 1})
+        RUBY
+      end
     end
   end
 
@@ -445,24 +451,26 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    it 'registers an offense and corrects misaligned keys in implicit hash for yield' do
-      expect_offense(<<~RUBY)
-        yield(a: 0,
-          b: 1)
-          ^^^^ Align the keys of a hash literal if they span more than one line.
-      RUBY
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+      it 'registers an offense and corrects misaligned keys in implicit hash for yield' do
+        expect_offense(<<~RUBY)
+          yield(a: 0,
+            b: 1)
+            ^^^^ Align the keys of a hash literal if they span more than one line.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        yield(a: 0,
-              b: 1)
-      RUBY
-    end
+        expect_correction(<<~RUBY)
+          yield(a: 0,
+                b: 1)
+        RUBY
+      end
 
-    it 'accepts misaligned keys in explicit hash for yield' do
-      expect_no_offenses(<<~RUBY)
-        yield({a: 0,
-          b: 1})
-      RUBY
+      it 'accepts misaligned keys in explicit hash for yield' do
+        expect_no_offenses(<<~RUBY)
+          yield({a: 0,
+            b: 1})
+        RUBY
+      end
     end
   end
 
@@ -1323,8 +1331,10 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
     expect_no_offenses('super')
   end
 
-  it 'registers no offense for yield without args' do
-    expect_no_offenses('yield')
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+    it 'registers no offense for yield without args' do
+      expect_no_offenses('yield')
+    end
   end
 
   context 'with `EnforcedColonStyle`: `table`' do

--- a/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
@@ -5,10 +5,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
   let(:other_cops) { { 'Layout/LineLength' => { 'Max' => 5, 'AllowHeredoc' => allow_heredoc } } }
 
   shared_examples 'all heredoc type' do |quote|
-    # FIXME: https://github.com/ruby/prism/issues/2498
-    # Once the above will be resolved, the `options` can be removed.
-    options = quote == '`' ? { broken_on: :prism } : {}
-    context "quoted by #{quote}", options do
+    context "quoted by #{quote}" do
       it 'does not register an offense when not indented but with whitespace, with `-`' do
         expect_no_offenses(<<-RUBY)
           def foo

--- a/spec/rubocop/cop/layout/indentation_style_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_style_spec.rb
@@ -45,8 +45,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationStyle, :config do
       RUBY
     end
 
-    # FIXME: https://github.com/ruby/prism/issues/2510
-    it 'registers offenses before __END__ but not after', broken_on: :prism do
+    it 'registers offenses before __END__ but not after' do
       expect_offense(<<~RUBY)
         \tx = 0
         ^ Tab detected in indentation.
@@ -138,8 +137,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationStyle, :config do
       RUBY
     end
 
-    # FIXME: https://github.com/ruby/prism/issues/2510
-    it 'registers offenses before __END__ but not after', broken_on: :prism do
+    it 'registers offenses before __END__ but not after' do
       expect_offense(<<~RUBY)
           x = 0
         ^^ Space detected in indentation.

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -39,8 +39,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
     RUBY
   end
 
-  # FIXME: https://github.com/ruby/prism/issues/2510
-  it 'registers an offense for long line before __END__ but not after', broken_on: :prism do
+  it 'registers an offense for long line before __END__ but not after' do
     maximum_string = '#' * 80
     expect_offense(<<~RUBY, maximum_string: maximum_string)
       #{maximum_string}#{'#' * 70}

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -551,11 +551,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation, :config do
         RUBY
       end
 
-      it "accepts indentation of next #{keyword} condition" do
-        expect_no_offenses(<<~RUBY)
-          next #{keyword} 5 ||
-            7
-        RUBY
+      context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+        it "accepts indentation of next #{keyword} condition" do
+          expect_no_offenses(<<~RUBY)
+            next #{keyword} 5 ||
+              7
+          RUBY
+        end
       end
     end
 

--- a/spec/rubocop/cop/layout/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_keyword_spec.rb
@@ -48,9 +48,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   it_behaves_like 'missing before', 'and', '1and 2', '1 and 2'
   it_behaves_like 'missing after', 'and', '1 and(2)', '1 and (2)'
   it_behaves_like 'missing after', 'begin', 'begin"" end', 'begin "" end'
-  it_behaves_like 'missing after', 'break', 'break""', 'break ""'
-  it_behaves_like 'accept after', '(', 'break(1)'
+
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    it_behaves_like 'missing after', 'break', 'break""', 'break ""'
+    it_behaves_like 'accept after', '(', 'break(1)'
+  end
+
   it_behaves_like 'missing after', 'case', 'case"" when 1; end', 'case "" when 1; end'
+
   context '>= Ruby 2.7', :ruby27 do # rubocop:disable RSpec/RepeatedExampleGroupDescription
     it_behaves_like 'missing after', 'case', 'case""; in 1; end', 'case ""; in 1; end'
   end
@@ -102,8 +107,12 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   it_behaves_like 'missing after', 'ensure', 'begin ensure"" end', 'begin ensure "" end'
 
   it_behaves_like 'missing after', 'if', 'if""; end', 'if ""; end'
-  it_behaves_like 'missing after', 'next', 'next""', 'next ""'
-  it_behaves_like 'accept after', '(', 'next(1)'
+
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    it_behaves_like 'missing after', 'next', 'next""', 'next ""'
+    it_behaves_like 'accept after', '(', 'next(1)'
+  end
+
   it_behaves_like 'missing after', 'not', 'not""', 'not ""'
   it_behaves_like 'accept after', '(', 'not(1)'
   it_behaves_like 'missing before', 'or', '1or 2', '1 or 2'
@@ -127,8 +136,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   it_behaves_like 'missing after', 'until', '1 until""', '1 until ""'
   it_behaves_like 'missing before', 'when', 'case ""when a; end', 'case "" when a; end'
   it_behaves_like 'missing after', 'when', 'case a when""; end', 'case a when ""; end'
-  # FIXME: https://github.com/ruby/prism/pull/2525
-  context '>= Ruby 2.7', :ruby27, broken_on: :prism do
+
+  context '>= Ruby 2.7', :ruby27 do # rubocop:disable RSpec/RepeatedExampleGroupDescription
     # TODO: `case ""in a; end` is syntax error in Ruby 3.0.1.
     #       This syntax is confirmed: https://bugs.ruby-lang.org/issues/17925
     #       The answer will determine whether to enable or discard the test in the future.
@@ -146,8 +155,11 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
 
   it_behaves_like 'missing before', 'while', '1while ""', '1 while ""'
   it_behaves_like 'missing after', 'while', '1 while""', '1 while ""'
-  it_behaves_like 'missing after', 'yield', 'yield""', 'yield ""'
-  it_behaves_like 'accept after', '(', 'yield(1)'
+
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    it_behaves_like 'missing after', 'yield', 'yield""', 'yield ""'
+    it_behaves_like 'accept after', '(', 'yield(1)'
+  end
 
   it_behaves_like 'accept after', '+', '+begin end'
   it_behaves_like 'missing after', 'begin', 'begin+1 end', 'begin +1 end'
@@ -155,20 +167,30 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   # Common exceptions
   it_behaves_like 'accept after', '\\', "test do\\\nend"
   it_behaves_like 'accept after', '\n', "test do\nend"
-  it_behaves_like 'accept around', '()', '(next)'
-  it_behaves_like 'accept before', '!', '!yield'
-  it_behaves_like 'accept after', '.', 'yield.method'
-  it_behaves_like 'accept before', '!', '!yield.method'
+
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    it_behaves_like 'accept around', '()', '(next)'
+    it_behaves_like 'accept before', '!', '!yield'
+    it_behaves_like 'accept after', '.', 'yield.method'
+    it_behaves_like 'accept before', '!', '!yield.method'
+  end
+
   it_behaves_like 'accept before', '!', '!super.method'
   it_behaves_like 'accept after', '::', 'super::ModuleName'
 
   context '&.' do
     it_behaves_like 'accept after', '&.', 'super&.foo'
-    it_behaves_like 'accept after', '&.', 'yield&.foo'
+
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+      it_behaves_like 'accept after', '&.', 'yield&.foo'
+    end
   end
 
   it_behaves_like 'accept after', '[', 'super[1]'
-  it_behaves_like 'accept after', '[', 'yield[1]'
+
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    it_behaves_like 'accept after', '[', 'yield[1]'
+  end
 
   # Layout/SpaceAroundBlockParameters
   it_behaves_like 'accept before', '|', 'loop { |x|break }'
@@ -198,8 +220,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   # Layout/SpaceBeforeComma, Layout/SpaceAfterComma
   it_behaves_like 'accept around', ',', 'a 1,foo,1'
 
-  # Layout/SpaceBeforeComment
-  it_behaves_like 'accept after', '#', 'next#comment'
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    # Layout/SpaceBeforeComment
+    it_behaves_like 'accept after', '#', 'next#comment'
+  end
 
   # Layout/SpaceBeforeSemicolon, Layout/SpaceAfterSemicolon
   it_behaves_like 'accept around', ';', 'test do;end'

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -162,9 +162,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
     RUBY
   end
 
-  # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-  # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-  it 'accepts vertical alignment with operator', broken_on: :prism do
+  it 'accepts vertical alignment with operator' do
     expect_no_offenses(<<~RUBY)
       down? && !migrated.include?(migration.version.to_i)
       up?   &&  migrated.include?(migration.version.to_i)

--- a/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# FIXME: https://github.com/ruby/prism/issues/2467
-RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config, broken_on: :prism do
+RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
   let(:cop_config) { { 'EnforcedStyle' => 'space' } }
 
   context 'with space inside empty braces not allowed' do

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
     RUBY
   end
 
-  # FIXME: https://github.com/ruby/prism/issues/2510
-  it 'registers offenses before __END__ but not after', broken_on: :prism do
+  it 'registers offenses before __END__ but not after' do
     expect_offense(<<~RUBY)
       x = 0\t
            ^ Trailing whitespace detected.

--- a/spec/rubocop/cop/lint/ambiguous_operator_precedence_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_operator_precedence_spec.rb
@@ -121,10 +121,12 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousOperatorPrecedence, :config do
     RUBY
   end
 
-  it 'allows an operator with `and`' do
-    expect_no_offenses(<<~RUBY)
-      array << i and next
-    RUBY
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+    it 'allows an operator with `and`' do
+      expect_no_offenses(<<~RUBY)
+        array << i and next
+      RUBY
+    end
   end
 
   it 'allows an operator with `or`' do

--- a/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# FIXME: https://github.com/ruby/prism/issues/2513 and https://github.com/ruby/prism/issues/2514
-RSpec.describe RuboCop::Cop::Lint::AmbiguousOperator, :config, broken_on: :prism do
+RSpec.describe RuboCop::Cop::Lint::AmbiguousOperator, :config do
   context 'with `+` unary operator in the first argument' do
     context 'without parentheses' do
       context 'without whitespaces on the right of the operator' do

--- a/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # FIXME: https://github.com/ruby/prism/issues/2513
-RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral, :config, broken_on: :prism do
+RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral, :config do
   shared_examples 'with a regexp literal in the first argument' do
     context 'without parentheses' do
       it 'registers an offense and corrects when single argument' do

--- a/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
@@ -62,9 +62,7 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedClassMethods, :config do
   end
 
   context 'prefer `block_given?` over `iterator?`' do
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers an offense and corrects iterator?', broken_on: :prism do
+    it 'registers an offense and corrects iterator?' do
       expect_offense(<<~RUBY)
         iterator?
         ^^^^^^^^^ `iterator?` is deprecated in favor of `block_given?`.
@@ -75,9 +73,7 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedClassMethods, :config do
       RUBY
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'does not register an offense for block_given?', broken_on: :prism do
+    it 'does not register an offense for block_given?' do
       expect_no_offenses('block_given?')
     end
 

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression, :config do
     RUBY
   end
 
-  # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-  # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-  it 'registers an offense and corrects for predicate method call with space before the parenthesis', broken_on: :prism do
+  it 'registers an offense and corrects for predicate method call with space before the parenthesis' do
     expect_offense(<<~RUBY)
       is? (x)
          ^ `(x)` interpreted as grouped expression.

--- a/spec/rubocop/cop/lint/require_parentheses_spec.rb
+++ b/spec/rubocop/cop/lint/require_parentheses_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe RuboCop::Cop::Lint::RequireParentheses, :config do
     RUBY
   end
 
-  # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-  # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-  it 'registers an offense for missing parentheses around expression with || operator', broken_on: :prism do
+  it 'registers an offense for missing parentheses around expression with || operator' do
     expect_offense(<<~RUBY)
       day_is? 'tuesday' || true
       ^^^^^^^^^^^^^^^^^^^^^^^^^ Use parentheses in the method call to avoid confusion about precedence.

--- a/spec/rubocop/cop/lint/unreachable_code_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_code_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableCode, :config do
   end
 
   %w[return next break retry redo throw raise fail exit exit! abort].each do |t|
+    # The syntax using `retry` is not supported in Ruby 3.3 and later.
+    next if t == 'retry' && ENV['PARSER_ENGINE'] == 'parser_prism'
+
     it "registers an offense for `#{t}` before other statements" do
       expect_offense(wrap(<<~RUBY))
         #{t}

--- a/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
+++ b/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
@@ -124,8 +124,7 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
         end
       end
 
-      # FIXME: https://github.com/ruby/prism/issues/2498
-      context 'when using back tick delimiters', broken_on: :prism do
+      context 'when using back tick delimiters' do
         it 'registers an offense and corrects with a lowercase delimiter' do
           expect_offense(<<~RUBY)
             <<-`sql`

--- a/spec/rubocop/cop/naming/heredoc_delimiter_naming_spec.rb
+++ b/spec/rubocop/cop/naming/heredoc_delimiter_naming_spec.rb
@@ -61,8 +61,7 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterNaming, :config do
       end
     end
 
-    # FIXME: https://github.com/ruby/prism/issues/2498
-    context 'when using back tick delimiters', broken_on: :prism do
+    context 'when using back tick delimiters' do
       it 'registers an offense with a non-meaningful delimiter' do
         expect_offense(<<~RUBY)
           <<-`END`

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -163,15 +163,11 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       expect_no_offenses('return if any? { |x| x }')
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'accepts a single line block with {} if used in a logical or', broken_on: :prism do
+    it 'accepts a single line block with {} if used in a logical or' do
       expect_no_offenses('any? { |c| c } || foo')
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'accepts a single line block with {} if used in a logical and', broken_on: :prism do
+    it 'accepts a single line block with {} if used in a logical and' do
       expect_no_offenses('any? { |c| c } && foo')
     end
 

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -76,8 +76,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
   describe 'heredoc commands' do
     let(:cop_config) { { 'EnforcedStyle' => 'backticks' } }
 
-    # FIXME: https://github.com/ruby/prism/issues/2498
-    it 'is ignored', broken_on: :prism do
+    it 'is ignored' do
       expect_no_offenses(<<~RUBY)
         <<`COMMAND`
           ls

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -2,9 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
   shared_examples 'all variable types' do |variable|
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers an offense assigning any variable type to ternary', broken_on: :prism do
+    it 'registers an offense assigning any variable type to ternary' do
       expect_offense(<<~RUBY, variable: variable)
         %{variable} = foo? ? 1 : 2
         ^{variable}^^^^^^^^^^^^^^^ Assign variables inside of conditionals
@@ -167,9 +165,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
   end
 
   shared_examples 'all assignment types' do |assignment|
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers an offense for any assignment to ternary', broken_on: :prism do
+    it 'registers an offense for any assignment to ternary' do
       expect_offense(<<~RUBY, assignment: assignment)
         bar %{assignment} (foo? ? 1 : 2)
         ^^^^^{assignment}^^^^^^^^^^^^^^^ Assign variables inside of conditionals
@@ -702,9 +698,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
       RUBY
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'corrects assignment to a ternary operator', broken_on: :prism do
+    it 'corrects assignment to a ternary operator' do
       expect_offense(<<~RUBY)
         bar = foo? ? 1 : 2
         ^^^^^^^^^^^^^^^^^^ Assign variables inside of conditionals
@@ -796,9 +790,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
       expect_no_offenses('bar << foo? ? 1 : 2')
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers an offense for assignment using a method that ends with an equal sign', broken_on: :prism do
+    it 'registers an offense for assignment using a method that ends with an equal sign' do
       expect_offense(<<~RUBY)
         self.attributes = foo? ? 1 : 2
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Assign variables inside of conditionals

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -132,9 +132,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
     expect_no_offenses('bar = foo? ? "a" : "b"')
   end
 
-  # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-  # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-  it 'registers an offense for assignment in ternary operation using strings', broken_on: :prism do
+  it 'registers an offense for assignment in ternary operation using strings' do
     expect_offense(<<~RUBY)
       foo? ? bar = "a" : bar = "b"
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
@@ -191,9 +189,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
   end
 
   shared_examples 'comparison methods' do |method|
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers an offense for comparison methods in ternary operations', broken_on: :prism do
+    it 'registers an offense for comparison methods in ternary operations' do
       source = "foo? ? bar #{method} 1 : bar #{method} 2"
       expect_offense(<<~RUBY, source: source)
         %{source}
@@ -566,9 +562,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
   end
 
   shared_examples 'all variable types' do |variable, add_parens: false|
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers an offense assigning any variable type in ternary', broken_on: :prism do
+    it 'registers an offense assigning any variable type in ternary' do
       source = "foo? ? #{variable} = 1 : #{variable} = 2"
       expect_offense(<<~RUBY, source: source)
         %{source}
@@ -667,9 +661,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
 
     variable_types.each do |type, name|
       context "for a #{type} lval" do
-        # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-        # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-        it "registers an offense for assignment using #{assignment} in ternary", broken_on: :prism do
+        it "registers an offense for assignment using #{assignment} in ternary" do
           source = "foo? ? #{name} #{assignment} 1 : #{name} #{assignment} 2"
           expect_offense(<<~RUBY, source: source)
             %{source}
@@ -1238,9 +1230,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
   end
 
   describe 'autocorrect' do
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'corrects =~ in ternary operations', broken_on: :prism do
+    it 'corrects =~ in ternary operations' do
       expect_offense(<<~RUBY)
         foo? ? bar =~ /a/ : bar =~ /b/
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
@@ -2248,9 +2238,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
                           })
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'allows assignment in ternary operation', broken_on: :prism do
+    it 'allows assignment in ternary operation' do
       expect_no_offenses('foo? ? bar = "a" : bar = "b"')
     end
   end

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -356,29 +356,31 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition, :config do
       end
     end
 
-    context 'when using `break` before empty case condition' do
-      it 'does not register an offense' do
-        expect_no_offenses(<<~RUBY)
-          break case
-                when foo
-                  1
-                else
-                  2
-                end
-        RUBY
+    context 'target ruby version <= 3.2', :ruby32, unsupported_on: :prism do
+      context 'when using `break` before empty case condition' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            break case
+                  when foo
+                    1
+                  else
+                    2
+                  end
+          RUBY
+        end
       end
-    end
 
-    context 'when using `next` before empty case condition' do
-      it 'does not register an offense' do
-        expect_no_offenses(<<~RUBY)
-          next case
-               when foo
-                 1
-               else
-                 2
-               end
-        RUBY
+      context 'when using `next` before empty case condition' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            next case
+                 when foo
+                   1
+                 else
+                   2
+                 end
+          RUBY
+        end
       end
     end
 

--- a/spec/rubocop/cop/style/explicit_block_argument_spec.rb
+++ b/spec/rubocop/cop/style/explicit_block_argument_spec.rb
@@ -184,12 +184,14 @@ RSpec.describe RuboCop::Cop::Style::ExplicitBlockArgument, :config do
     RUBY
   end
 
-  it 'does not register an offense when code is called outside of a method' do
-    expect_no_offenses(<<~RUBY)
-      render("partial") do
-        yield
-      end
-    RUBY
+  context 'target ruby version <= 3.2', :ruby32, unsupported_on: :prism do
+    it 'does not register an offense when code is called outside of a method' do
+      expect_no_offenses(<<~RUBY)
+        render("partial") do
+          yield
+        end
+      RUBY
+    end
   end
 
   it 'does not add extra parens when correcting' do

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -460,8 +460,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
     RUBY
   end
 
-  # FIXME: https://github.com/ruby/prism/issues/2498
-  it 'registers an offense when using xstr heredoc as an argument of raise in `else` branch', broken_on: :prism do
+  it 'registers an offense when using xstr heredoc as an argument of raise in `else` branch' do
     expect_offense(<<~RUBY)
       def func
         unless condition
@@ -644,117 +643,119 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
   end
 
   shared_examples 'on if nodes which exit current scope' do |kw|
-    it "registers an error with #{kw} in the if branch" do
-      expect_offense(<<~RUBY)
-        if something
-        ^^ Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression.
-          #{kw}
-        else
-          puts "hello"
-        end
-      RUBY
+    context 'target ruby version <= 3.2', :ruby32, unsupported_on: :prism do
+      it "registers an error with #{kw} in the if branch" do
+        expect_offense(<<~RUBY)
+          if something
+          ^^ Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression.
+            #{kw}
+          else
+            puts "hello"
+          end
+        RUBY
 
-      expect_correction(<<~RUBY)
-        #{kw} if something
-         #{trailing_whitespace}
+        expect_correction(<<~RUBY)
+          #{kw} if something
+           #{trailing_whitespace}
 
-          puts "hello"
+            puts "hello"
 
-      RUBY
-    end
+        RUBY
+      end
 
-    it "registers an error with #{kw} in the else branch" do
-      expect_offense(<<~RUBY)
-        if something
-        ^^ Use a guard clause (`#{kw} unless something`) instead of wrapping the code inside a conditional expression.
-         puts "hello"
-        else
-          #{kw}
-        end
-      RUBY
+      it "registers an error with #{kw} in the else branch" do
+        expect_offense(<<~RUBY)
+          if something
+          ^^ Use a guard clause (`#{kw} unless something`) instead of wrapping the code inside a conditional expression.
+           puts "hello"
+          else
+            #{kw}
+          end
+        RUBY
 
-      expect_correction(<<~RUBY)
-        #{kw} unless something
-         puts "hello"
+        expect_correction(<<~RUBY)
+          #{kw} unless something
+           puts "hello"
 
-         #{trailing_whitespace}
+           #{trailing_whitespace}
 
-      RUBY
-    end
+        RUBY
+      end
 
-    it "doesn't register an error if condition has multiple lines" do
-      expect_no_offenses(<<~RUBY)
-        if something &&
-             something_else
-          #{kw}
-        else
-          puts "hello"
-        end
-      RUBY
-    end
+      it "doesn't register an error if condition has multiple lines" do
+        expect_no_offenses(<<~RUBY)
+          if something &&
+               something_else
+            #{kw}
+          else
+            puts "hello"
+          end
+        RUBY
+      end
 
-    it "does not report an offense if #{kw} is inside elsif" do
-      expect_no_offenses(<<~RUBY)
-        if something
-          a
-        elsif something_else
-          #{kw}
-        end
-      RUBY
-    end
+      it "does not report an offense if #{kw} is inside elsif" do
+        expect_no_offenses(<<~RUBY)
+          if something
+            a
+          elsif something_else
+            #{kw}
+          end
+        RUBY
+      end
 
-    it "does not report an offense if #{kw} is inside then body of if..elsif..end" do
-      expect_no_offenses(<<~RUBY)
-        if something
-          #{kw}
-        elsif something_else
-          a
-        end
-      RUBY
-    end
+      it "does not report an offense if #{kw} is inside then body of if..elsif..end" do
+        expect_no_offenses(<<~RUBY)
+          if something
+            #{kw}
+          elsif something_else
+            a
+          end
+        RUBY
+      end
 
-    it "does not report an offense if #{kw} is inside if..elsif..else..end" do
-      expect_no_offenses(<<~RUBY)
-        if something
-          a
-        elsif something_else
-          b
-        else
-          #{kw}
-        end
-      RUBY
-    end
+      it "does not report an offense if #{kw} is inside if..elsif..else..end" do
+        expect_no_offenses(<<~RUBY)
+          if something
+            a
+          elsif something_else
+            b
+          else
+            #{kw}
+          end
+        RUBY
+      end
 
-    it "doesn't register an error if control flow expr has multiple lines" do
-      expect_no_offenses(<<~RUBY)
-        if something
-          #{kw} 'blah blah blah' \\
-                'blah blah blah'
-        else
-          puts "hello"
-        end
-      RUBY
-    end
+      it "doesn't register an error if control flow expr has multiple lines" do
+        expect_no_offenses(<<~RUBY)
+          if something
+            #{kw} 'blah blah blah' \\
+                  'blah blah blah'
+          else
+            puts "hello"
+          end
+        RUBY
+      end
 
-    it 'registers an error if non-control-flow branch has multiple lines' do
-      expect_offense(<<~RUBY)
-        if something
-        ^^ Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression.
-          #{kw}
-        else
-          puts "hello" \\
-               "blah blah blah"
-        end
-      RUBY
+      it 'registers an error if non-control-flow branch has multiple lines' do
+        expect_offense(<<~RUBY)
+          if something
+          ^^ Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression.
+            #{kw}
+          else
+            puts "hello" \\
+                 "blah blah blah"
+          end
+        RUBY
 
-      expect_correction(<<~RUBY)
-        #{kw} if something
-         #{trailing_whitespace}
+        expect_correction(<<~RUBY)
+          #{kw} if something
+           #{trailing_whitespace}
 
-          puts "hello" \\
-               "blah blah blah"
+            puts "hello" \\
+                 "blah blah blah"
 
-      RUBY
+        RUBY
+      end
     end
   end
 

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1120,17 +1120,6 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
-      it 'registers an offense in chained calls with dispatch keywords' do
-        expect_offense(<<~RUBY)
-          yield(:foo, bar: bar).baz
-                           ^^^ Omit the hash value.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          yield(:foo, bar:).baz
-        RUBY
-      end
-
       it 'registers an offense when without parentheses call expr follows after nested method call' do
         # Add parentheses to prevent syntax errors shown in the URL: https://bugs.ruby-lang.org/issues/18396
         expect_offense(<<~RUBY)
@@ -1252,43 +1241,56 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
-      it 'registers an offense when one line `if` condition follows yield (with parentheses)' do
-        expect_offense(<<~RUBY)
-          yield(value: value) unless foo
-                       ^^^^^ Omit the hash value.
-        RUBY
+      context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+        it 'registers an offense in chained calls with dispatch keywords' do
+          expect_offense(<<~RUBY)
+            yield(:foo, bar: bar).baz
+                             ^^^ Omit the hash value.
+          RUBY
 
-        expect_correction(<<~RUBY)
-          yield(value:) unless foo
-        RUBY
-      end
+          expect_correction(<<~RUBY)
+            yield(:foo, bar:).baz
+          RUBY
+        end
 
-      it 'registers an offense in yield followed by ivar assignment (without parentheses)' do
-        expect_offense(<<~RUBY)
-          yield value: value, other: other
-                                     ^^^^^ Omit the hash value.
-                       ^^^^^ Omit the hash value.
-          @ivar = ivar
-        RUBY
+        it 'registers an offense when one line `if` condition follows yield (with parentheses)' do
+          expect_offense(<<~RUBY)
+            yield(value: value) unless foo
+                         ^^^^^ Omit the hash value.
+          RUBY
 
-        expect_correction(<<~RUBY)
-          yield(value:, other:)
-          @ivar = ivar
-        RUBY
-      end
+          expect_correction(<<~RUBY)
+            yield(value:) unless foo
+          RUBY
+        end
 
-      it 'registers an offense in yield followed by expr without parentheses' do
-        expect_offense(<<~RUBY)
-          yield value: value, other: other
-                                     ^^^^^ Omit the hash value.
-                       ^^^^^ Omit the hash value.
-          foo baz
-        RUBY
+        it 'registers an offense in yield followed by ivar assignment (without parentheses)' do
+          expect_offense(<<~RUBY)
+            yield value: value, other: other
+                                       ^^^^^ Omit the hash value.
+                         ^^^^^ Omit the hash value.
+            @ivar = ivar
+          RUBY
 
-        expect_correction(<<~RUBY)
-          yield(value:, other:)
-          foo baz
-        RUBY
+          expect_correction(<<~RUBY)
+            yield(value:, other:)
+            @ivar = ivar
+          RUBY
+        end
+
+        it 'registers an offense in yield followed by expr without parentheses' do
+          expect_offense(<<~RUBY)
+            yield value: value, other: other
+                                       ^^^^^ Omit the hash value.
+                         ^^^^^ Omit the hash value.
+            foo baz
+          RUBY
+
+          expect_correction(<<~RUBY)
+            yield(value:, other:)
+            foo baz
+          RUBY
+        end
       end
 
       it 'does not register an offense when one line `if` condition follows (without parentheses)' do

--- a/spec/rubocop/cop/style/if_with_boolean_literal_branches_spec.rb
+++ b/spec/rubocop/cop/style/if_with_boolean_literal_branches_spec.rb
@@ -381,9 +381,7 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
   end
 
   context 'when complex condition' do
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers and corrects an offense when using `if foo? && bar && baz?` with boolean literal branches', broken_on: :prism do
+    it 'registers and corrects an offense when using `if foo? && bar && baz?` with boolean literal branches' do
       expect_offense(<<~RUBY)
         if foo? && bar && baz?
         ^^ Remove redundant `if` with boolean literal branches.
@@ -408,9 +406,7 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
       RUBY
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers and corrects an offense when using `if foo? || bar && baz?` with boolean literal branches', broken_on: :prism do
+    it 'registers and corrects an offense when using `if foo? || bar && baz?` with boolean literal branches' do
       expect_offense(<<~RUBY)
         if foo? || bar && baz?
         ^^ Remove redundant `if` with boolean literal branches.
@@ -425,9 +421,7 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
       RUBY
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers and corrects an offense when using `if foo? || (bar && baz)?` with boolean literal branches', broken_on: :prism do
+    it 'registers and corrects an offense when using `if foo? || (bar && baz)?` with boolean literal branches' do
       expect_offense(<<~RUBY)
         if foo? || (bar && baz?)
         ^^ Remove redundant `if` with boolean literal branches.
@@ -489,9 +483,7 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
   end
 
   context 'when condition is a logical operator and all operands are predicate methods' do
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers and corrects an offense when using `if foo? && bar?` with boolean literal branches', broken_on: :prism do
+    it 'registers and corrects an offense when using `if foo? && bar?` with boolean literal branches' do
       expect_offense(<<~RUBY)
         if foo? && bar?
         ^^ Remove redundant `if` with boolean literal branches.
@@ -521,9 +513,7 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
       RUBY
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers and corrects an offense when using `unless foo? || bar?` with boolean literal branches', broken_on: :prism do
+    it 'registers and corrects an offense when using `unless foo? || bar?` with boolean literal branches' do
       expect_offense(<<~RUBY)
         unless foo? || bar?
         ^^^^^^ Remove redundant `unless` with boolean literal branches.
@@ -553,9 +543,7 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
       RUBY
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers and corrects an offense when using `if foo? && bar? && baz?` with boolean literal branches', broken_on: :prism do
+    it 'registers and corrects an offense when using `if foo? && bar? && baz?` with boolean literal branches' do
       expect_offense(<<~RUBY)
         if foo? && bar? && baz?
         ^^ Remove redundant `if` with boolean literal branches.
@@ -570,9 +558,7 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
       RUBY
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers and corrects an offense when using `if foo? && bar? || baz?` with boolean literal branches', broken_on: :prism do
+    it 'registers and corrects an offense when using `if foo? && bar? || baz?` with boolean literal branches' do
       expect_offense(<<~RUBY)
         if foo? && bar? || baz?
         ^^ Remove redundant `if` with boolean literal branches.

--- a/spec/rubocop/cop/style/infinite_loop_spec.rb
+++ b/spec/rubocop/cop/style/infinite_loop_spec.rb
@@ -61,26 +61,28 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop, :config do
     RUBY
   end
 
-  it 'accepts modifier while true if loop {} would change semantics' do
-    expect_no_offenses(<<~RUBY)
-      a = next_value or break while true
-      p a
-    RUBY
-  end
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+    it 'accepts modifier while true if loop {} would change semantics' do
+      expect_no_offenses(<<~RUBY)
+        a = next_value or break while true
+        p a
+      RUBY
+    end
 
-  it 'registers an offense for modifier until false if loop {} would not change semantics' do
-    expect_offense(<<~RUBY)
-      a = nil
-      a = next_value or break until false
-                              ^^^^^ Use `Kernel#loop` for infinite loops.
-      p a
-    RUBY
+    it 'registers an offense for modifier until false if loop {} would not change semantics' do
+      expect_offense(<<~RUBY)
+        a = nil
+        a = next_value or break until false
+                                ^^^^^ Use `Kernel#loop` for infinite loops.
+        p a
+      RUBY
 
-    expect_correction(<<~RUBY)
-      a = nil
-      loop { a = next_value or break }
-      p a
-    RUBY
+      expect_correction(<<~RUBY)
+        a = nil
+        loop { a = next_value or break }
+        p a
+      RUBY
+    end
   end
 
   it 'registers an offense for until false if loop {} would work because of ' \

--- a/spec/rubocop/cop/style/map_compact_with_conditional_block_spec.rb
+++ b/spec/rubocop/cop/style/map_compact_with_conditional_block_spec.rb
@@ -342,13 +342,15 @@ RSpec.describe RuboCop::Cop::Style::MapCompactWithConditionalBlock, :config do
       RUBY
     end
 
-    it 'does not register offenses if there are multiple guard clauses' do
-      expect_no_offenses(<<~RUBY)
-        next unless item.bar?
-        next unless item.baz?
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+      it 'does not register offenses if there are multiple guard clauses' do
+        expect_no_offenses(<<~RUBY)
+          next unless item.bar?
+          next unless item.baz?
 
-        item
-      RUBY
+          item
+        RUBY
+      end
     end
   end
 

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -154,8 +154,10 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('super')
     end
 
-    it 'registers no offense for yield without args' do
-      expect_no_offenses('yield')
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+      it 'registers no offense for yield without args' do
+        expect_no_offenses('yield')
+      end
     end
 
     it 'registers no offense for superclass call with parens' do
@@ -836,9 +838,15 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('foo &block')
     end
 
-    it 'accepts parens in yield argument method calls' do
-      expect_no_offenses('yield File.basepath(path)')
-      expect_no_offenses('yield path, File.basepath(path)')
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+      it 'accepts parens in yield argument method calls' do
+        expect_no_offenses('yield File.basepath(path)')
+        expect_no_offenses('yield path, File.basepath(path)')
+      end
+
+      it 'accepts parens in super calls with braced blocks' do
+        expect_no_offenses('super(foo(bar)) { yield }')
+      end
     end
 
     it 'accepts parens in super without args' do
@@ -847,10 +855,6 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
 
     it 'accepts parens in super method calls as arguments' do
       expect_no_offenses('super foo(bar)')
-    end
-
-    it 'accepts parens in super calls with braced blocks' do
-      expect_no_offenses('super(foo(bar)) { yield }')
     end
 
     it 'accepts parens in camel case method without args' do
@@ -1093,14 +1097,16 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         RUBY
       end
 
-      it 'accepts parens in yield argument call with blocks' do
-        expect_no_offenses(<<~RUBY)
-          yield(
-            bar.new(quux) do
-              pass
-            end
-          )
-        RUBY
+      context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+        it 'accepts parens in yield argument call with blocks' do
+          expect_no_offenses(<<~RUBY)
+            yield(
+              bar.new(quux) do
+                pass
+              end
+            )
+          RUBY
+        end
       end
     end
 

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -50,9 +50,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineTernaryOperator, :config do
     RUBY
   end
 
-  # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-  # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-  it 'registers an offense and corrects when nesting multiline ternary operators', broken_on: :prism do
+  it 'registers an offense and corrects when nesting multiline ternary operators' do
     expect_offense(<<~RUBY)
       cond_a? ? foo :
       ^^^^^^^^^^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
@@ -170,30 +168,32 @@ RSpec.describe RuboCop::Cop::Style::MultilineTernaryOperator, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects when returning a multiline ternary operator expression with `break`' do
-    expect_offense(<<~RUBY)
-      break cond ?
-            ^^^^^^ Avoid multi-line ternary operators, use single-line instead.
-            foo :
-            bar
-    RUBY
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+    it 'registers an offense and corrects when returning a multiline ternary operator expression with `break`' do
+      expect_offense(<<~RUBY)
+        break cond ?
+              ^^^^^^ Avoid multi-line ternary operators, use single-line instead.
+              foo :
+              bar
+      RUBY
 
-    expect_correction(<<~RUBY)
-      break cond ? foo : bar
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        break cond ? foo : bar
+      RUBY
+    end
 
-  it 'registers an offense and corrects when returning a multiline ternary operator expression with `next`' do
-    expect_offense(<<~RUBY)
-      next cond ?
-           ^^^^^^ Avoid multi-line ternary operators, use single-line instead.
-           foo :
-           bar
-    RUBY
+    it 'registers an offense and corrects when returning a multiline ternary operator expression with `next`' do
+      expect_offense(<<~RUBY)
+        next cond ?
+             ^^^^^^ Avoid multi-line ternary operators, use single-line instead.
+             foo :
+             bar
+      RUBY
 
-    expect_correction(<<~RUBY)
-      next cond ? foo : bar
-    RUBY
+      expect_correction(<<~RUBY)
+        next cond ? foo : bar
+      RUBY
+    end
   end
 
   it 'registers an offense and corrects when returning a multiline ternary operator expression with method call' do

--- a/spec/rubocop/cop/style/multiline_when_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_when_then_spec.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MultilineWhenThen, :config do
-  # FIXME: https://github.com/ruby/prism/issues/2508
-  it 'registers an offense for empty when statement with then', broken_on: :prism do
+  it 'registers an offense for empty when statement with then' do
     expect_offense(<<~RUBY)
       case foo
       when bar then
@@ -134,8 +133,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineWhenThen, :config do
     RUBY
   end
 
-  # FIXME: https://github.com/ruby/prism/issues/2508
-  it 'registers an offense when one line for multiple candidate values of `when`', broken_on: :prism do
+  it 'registers an offense when one line for multiple candidate values of `when`' do
     expect_offense(<<~RUBY)
       case foo
       when bar, baz then

--- a/spec/rubocop/cop/style/nil_comparison_spec.rb
+++ b/spec/rubocop/cop/style/nil_comparison_spec.rb
@@ -63,9 +63,7 @@ RSpec.describe RuboCop::Cop::Style::NilComparison, :config do
       RUBY
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers no offense when there is no receiver', broken_on: :prism do
+    it 'registers no offense when there is no receiver' do
       expect_no_offenses('nil?')
     end
   end

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -116,8 +116,7 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
     RUBY
   end
 
-  # FIXME: https://github.com/ruby/prism/issues/2501
-  it 'autocorrects numbers with spaces between leading minus and numbers', broken_on: :prism do
+  it 'autocorrects numbers with spaces between leading minus and numbers' do
     expect_offense(<<~RUBY)
       a = -
           ^ Use underscores(_) as thousands separator and separate every 3 digits with them.

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -102,7 +102,11 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
 
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'puts 1'
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'defined? :A'
-    it_behaves_like 'if/then/else/end with constructs changing precedence', 'yield a'
+
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+      it_behaves_like 'if/then/else/end with constructs changing precedence', 'yield a'
+    end
+
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'super b'
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'not a'
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'a and b'
@@ -122,16 +126,18 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
       RUBY
     end
 
-    it 'registers and corrects an offense with ternary operator without adding parentheses for ' \
-       'if/then/else/end that contains method calls with parenthesized arguments' do
-      expect_offense(<<~RUBY)
-        if a(0) then puts(1) else yield(2) end
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{if_offense_message}
-      RUBY
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+      it 'registers and corrects an offense with ternary operator without adding parentheses for ' \
+         'if/then/else/end that contains method calls with parenthesized arguments' do
+        expect_offense(<<~RUBY)
+          if a(0) then puts(1) else yield(2) end
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{if_offense_message}
+        RUBY
 
-      expect_correction(<<~RUBY)
-        a(0) ? puts(1) : yield(2)
-      RUBY
+        expect_correction(<<~RUBY)
+          a(0) ? puts(1) : yield(2)
+        RUBY
+      end
     end
 
     it 'registers and corrects an offense with ternary operator without adding parentheses for ' \
@@ -160,8 +166,11 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
       end
     end
 
-    it_behaves_like 'if/then/else/end with keyword', 'retry'
-    it_behaves_like 'if/then/else/end with keyword', 'break'
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+      it_behaves_like 'if/then/else/end with keyword', 'retry'
+      it_behaves_like 'if/then/else/end with keyword', 'break'
+    end
+
     it_behaves_like 'if/then/else/end with keyword', 'self'
     it_behaves_like 'if/then/else/end with keyword', 'raise'
 
@@ -334,7 +343,11 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
 
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'puts 1'
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'defined? :A'
-    it_behaves_like 'if/then/else/end with constructs changing precedence', 'yield a'
+
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+      it_behaves_like 'if/then/else/end with constructs changing precedence', 'yield a'
+    end
+
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'super b'
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'not a'
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'a and b'
@@ -358,20 +371,22 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
       RUBY
     end
 
-    it 'registers and corrects an offense with multi-line construct without adding parentheses for ' \
-       'if/then/else/end that contains method calls with parenthesized arguments' do
-      expect_offense(<<~RUBY)
-        if a(0) then puts(1) else yield(2) end
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{if_offense_message}
-      RUBY
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+      it 'registers and corrects an offense with multi-line construct without adding parentheses for ' \
+         'if/then/else/end that contains method calls with parenthesized arguments' do
+        expect_offense(<<~RUBY)
+          if a(0) then puts(1) else yield(2) end
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{if_offense_message}
+        RUBY
 
-      expect_correction(<<~RUBY)
-        if a(0)
-          puts(1)
-        else
-          yield(2)
-        end
-      RUBY
+        expect_correction(<<~RUBY)
+          if a(0)
+            puts(1)
+          else
+            yield(2)
+          end
+        RUBY
+      end
     end
 
     it 'registers and corrects an offense with multi-line construct without adding parentheses for ' \
@@ -408,8 +423,11 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
       end
     end
 
-    it_behaves_like 'if/then/else/end with keyword', 'retry'
-    it_behaves_like 'if/then/else/end with keyword', 'break'
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+      it_behaves_like 'if/then/else/end with keyword', 'retry'
+      it_behaves_like 'if/then/else/end with keyword', 'break'
+    end
+
     it_behaves_like 'if/then/else/end with keyword', 'self'
     it_behaves_like 'if/then/else/end with keyword', 'raise'
 

--- a/spec/rubocop/cop/style/quoted_symbols_spec.rb
+++ b/spec/rubocop/cop/style/quoted_symbols_spec.rb
@@ -63,8 +63,7 @@ RSpec.describe RuboCop::Cop::Style::QuotedSymbols, :config do
       RUBY
     end
 
-    # FIXME: https://github.com/ruby/prism/issues/2506
-    it 'accepts double quotes with line breaks', broken_on: :prism do
+    it 'accepts double quotes with line breaks' do
       expect_no_offenses(<<~RUBY)
         :"a
           bc"
@@ -217,16 +216,14 @@ RSpec.describe RuboCop::Cop::Style::QuotedSymbols, :config do
       RUBY
     end
 
-    # FIXME: https://github.com/ruby/prism/issues/2506
-    it 'accepts single quotes with line breaks', broken_on: :prism do
+    it 'accepts single quotes with line breaks' do
       expect_no_offenses(<<~RUBY)
         :'a
           bc'
       RUBY
     end
 
-    # FIXME: https://github.com/ruby/prism/issues/2506
-    it 'accepts double quotes with line breaks', broken_on: :prism do
+    it 'accepts double quotes with line breaks' do
       expect_no_offenses(<<~RUBY)
         :'a
           bc'

--- a/spec/rubocop/cop/style/redundant_heredoc_delimiter_quotes_spec.rb
+++ b/spec/rubocop/cop/style/redundant_heredoc_delimiter_quotes_spec.rb
@@ -61,8 +61,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantHeredocDelimiterQuotes, :config do
     RUBY
   end
 
-  # FIXME: https://github.com/ruby/prism/issues/2498
-  it 'does not register an offense when using the redundant heredoc delimiter backquotes', broken_on: :prism do
+  it 'does not register an offense when using the redundant heredoc delimiter backquotes' do
     expect_no_offenses(<<~RUBY)
       do_something(<<~`EOS`)
         command

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -53,8 +53,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   it_behaves_like 'redundant', '(__FILE__)', '__FILE__', 'a keyword'
   it_behaves_like 'redundant', '(__LINE__)', '__LINE__', 'a keyword'
   it_behaves_like 'redundant', '(__ENCODING__)', '__ENCODING__', 'a keyword'
-  it_behaves_like 'redundant', '(redo)', 'redo', 'a keyword'
-  it_behaves_like 'redundant', '(retry)', 'retry', 'a keyword'
+
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    it_behaves_like 'redundant', '(redo)', 'redo', 'a keyword'
+    it_behaves_like 'redundant', '(retry)', 'retry', 'a keyword'
+  end
+
   it_behaves_like 'redundant', '(self)', 'self', 'a keyword'
 
   context 'ternaries' do
@@ -118,12 +122,15 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     end
   end
 
-  it_behaves_like 'keyword with return value', 'break'
-  it_behaves_like 'keyword with return value', 'next'
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    it_behaves_like 'keyword with return value', 'break'
+    it_behaves_like 'keyword with return value', 'next'
+    it_behaves_like 'keyword with arguments', 'yield'
+  end
+
   it_behaves_like 'keyword with return value', 'return'
 
   it_behaves_like 'keyword with arguments', 'super'
-  it_behaves_like 'keyword with arguments', 'yield'
 
   it_behaves_like 'redundant', '(defined?(:A))', 'defined?(:A)', 'a keyword'
   it_behaves_like 'plausible', '(defined? :A)'
@@ -769,12 +776,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
-  it 'accepts parentheses in yield call with hash' do
-    expect_no_offenses(<<~RUBY)
-      yield ({
-        foo: bar,
-      })
-    RUBY
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    it 'accepts parentheses in yield call with hash' do
+      expect_no_offenses(<<~RUBY)
+        yield ({
+          foo: bar,
+        })
+      RUBY
+    end
   end
 
   it 'accepts parentheses in super call with multiline style argument' do
@@ -785,12 +794,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
-  it 'accepts parentheses in yield call with multiline style argument' do
-    expect_no_offenses(<<~RUBY)
-      yield (
-        42
-      )
-    RUBY
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    it 'accepts parentheses in yield call with multiline style argument' do
+      expect_no_offenses(<<~RUBY)
+        yield (
+          42
+        )
+      RUBY
+    end
   end
 
   it 'accepts parentheses in `return` with multiline style argument' do
@@ -812,42 +823,44 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
-  it 'accepts parentheses in `next` with multiline style argument' do
-    expect_no_offenses(<<~RUBY)
-      next (
-        42
-      )
-    RUBY
-  end
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    it 'accepts parentheses in `next` with multiline style argument' do
+      expect_no_offenses(<<~RUBY)
+        next (
+          42
+        )
+      RUBY
+    end
 
-  it 'registers an offense when parentheses in `next` with single style argument' do
-    expect_offense(<<~RUBY)
-      next (42)
-           ^^^^ Don't use parentheses around a literal.
-    RUBY
+    it 'registers an offense when parentheses in `next` with single style argument' do
+      expect_offense(<<~RUBY)
+        next (42)
+             ^^^^ Don't use parentheses around a literal.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      next 42
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        next 42
+      RUBY
+    end
 
-  it 'accepts parentheses in `break` with multiline style argument' do
-    expect_no_offenses(<<~RUBY)
-      break (
-        42
-      )
-    RUBY
-  end
+    it 'accepts parentheses in `break` with multiline style argument' do
+      expect_no_offenses(<<~RUBY)
+        break (
+          42
+        )
+      RUBY
+    end
 
-  it 'registers an offense when parentheses in `break` with single style argument' do
-    expect_offense(<<~RUBY)
-      break (42)
-            ^^^^ Don't use parentheses around a literal.
-    RUBY
+    it 'registers an offense when parentheses in `break` with single style argument' do
+      expect_offense(<<~RUBY)
+        break (42)
+              ^^^^ Don't use parentheses around a literal.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      break 42
-    RUBY
+      expect_correction(<<~RUBY)
+        break 42
+      RUBY
+    end
   end
 
   it 'registers an offense and corrects when method arguments are unnecessarily parenthesized' do
@@ -905,8 +918,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
 
   context 'pin operator', :ruby31 do
     shared_examples 'redundant parentheses' do |variable, description|
-      # FIXME: https://github.com/ruby/prism/issues/2499
-      it "registers an offense and corrects #{description}", broken_on: :prism do
+      it "registers an offense and corrects #{description}" do
         expect_offense(<<~RUBY, variable: variable)
           var = 0
           foo in { bar: ^(%{variable}) }

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -25,8 +25,7 @@ RSpec.describe RuboCop::Cop::Style::RescueModifier, :config do
     RUBY
   end
 
-  # FIXME: https://github.com/ruby/prism/issues/2500
-  it 'registers an offense for modifier rescue around parallel assignment', :ruby27, broken_on: :prism do
+  it 'registers an offense for modifier rescue around parallel assignment', :ruby27 do
     expect_offense(<<~RUBY)
       a, b = 1, 2 rescue nil
              ^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -195,7 +195,10 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
       it_behaves_like 'safe guarding logical break keywords', 'raise'
       it_behaves_like 'safe guarding logical break keywords', 'return'
       it_behaves_like 'safe guarding logical break keywords', 'throw'
-      it_behaves_like 'safe guarding logical break keywords', 'yield'
+
+      context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
+        it_behaves_like 'safe guarding logical break keywords', 'yield'
+      end
 
       it 'registers an offense for a method call that nil responds to ' \
          'safe guarded by an object check' do

--- a/spec/rubocop/cop/style/single_argument_dig_spec.rb
+++ b/spec/rubocop/cop/style/single_argument_dig_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::Style::SingleArgumentDig, :config do
     end
   end
 
-  context '>= Ruby 3.2', :ruby32 do
+  context 'Ruby <= 3.2', :ruby32 do
     context 'when using dig with anonymous rest argument forwarding' do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -240,20 +240,22 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
         RUBY
       end
 
-      it 'does not to an endless class method definition when using `break`' do
-        expect_correction(<<~RUBY.strip, source: 'def foo(argument) break bar(argument); end')
-          def foo(argument)#{trailing_whitespace}
-            break bar(argument);#{trailing_whitespace}
-          end
-        RUBY
-      end
+      context 'target ruby version <= 3.2', :ruby32, unsupported_on: :prism do
+        it 'does not to an endless class method definition when using `break`' do
+          expect_correction(<<~RUBY.strip, source: 'def foo(argument) break bar(argument); end')
+            def foo(argument)#{trailing_whitespace}
+              break bar(argument);#{trailing_whitespace}
+            end
+          RUBY
+        end
 
-      it 'does not to an endless class method definition when using `next`' do
-        expect_correction(<<~RUBY.strip, source: 'def foo(argument) next bar(argument); end')
-          def foo(argument)#{trailing_whitespace}
-            next bar(argument);#{trailing_whitespace}
-          end
-        RUBY
+        it 'does not to an endless class method definition when using `next`' do
+          expect_correction(<<~RUBY.strip, source: 'def foo(argument) next bar(argument); end')
+            def foo(argument)#{trailing_whitespace}
+              next bar(argument);#{trailing_whitespace}
+            end
+          RUBY
+        end
       end
 
       # NOTE: Setter method cannot be defined in the endless method definition.

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -338,8 +338,7 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
         }
       end
 
-      # FIXME: https://github.com/ruby/prism/issues/2515
-      it 'registers an offense for strings with line breaks in them', broken_on: :prism do
+      it 'registers an offense for strings with line breaks in them' do
         expect_offense(<<~RUBY)
           "--
           ^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -47,15 +47,17 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
         RUBY
       end
 
-      it 'registers an offense for yield in condition' do
-        expect_offense(<<~RUBY)
-          foo = yield ? a : b
-                ^^^^^^^^^^^^^ Use parentheses for ternary conditions.
-        RUBY
+      context 'target ruby version <= 3.2', :ruby32, unsupported_on: :prism do
+        it 'registers an offense for yield in condition' do
+          expect_offense(<<~RUBY)
+            foo = yield ? a : b
+                  ^^^^^^^^^^^^^ Use parentheses for ternary conditions.
+          RUBY
 
-        expect_correction(<<~RUBY)
-          foo = (yield) ? a : b
-        RUBY
+          expect_correction(<<~RUBY)
+            foo = (yield) ? a : b
+          RUBY
+        end
       end
 
       it 'registers an offense for accessor in condition' do
@@ -248,15 +250,17 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
         RUBY
       end
 
-      it 'registers an offense for yield in condition' do
-        expect_offense(<<~RUBY)
-          foo = (yield) ? a : b
-                ^^^^^^^^^^^^^^^ Omit parentheses for ternary conditions.
-        RUBY
+      context 'target ruby version <= 3.2', :ruby32, unsupported_on: :prism do
+        it 'registers an offense for yield in condition' do
+          expect_offense(<<~RUBY)
+            foo = (yield) ? a : b
+                  ^^^^^^^^^^^^^^^ Omit parentheses for ternary conditions.
+          RUBY
 
-        expect_correction(<<~RUBY)
-          foo = yield ? a : b
-        RUBY
+          expect_correction(<<~RUBY)
+            foo = yield ? a : b
+          RUBY
+        end
       end
 
       it 'registers an offense for accessor in condition' do
@@ -409,13 +413,7 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
       end
     end
 
-    # In Ruby 3.0, `match-pattern-p` node represents one line pattern matching.
-    #
-    # $ ruby-parse --30 -e 'foo in bar'
-    # (match-pattern-p (send nil :foo) (match-var :bar))
-    #
-    # FIXME: https://github.com/ruby/prism/pull/2525
-    context 'with one line pattern matching', :ruby30, broken_on: :prism do
+    context 'with one line pattern matching', :ruby30 do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)
           (foo in bar) ? a : b
@@ -549,15 +547,17 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
         RUBY
       end
 
-      it 'registers an offense for yield in condition' do
-        expect_offense(<<~RUBY)
-          foo = (yield) ? a : b
-                ^^^^^^^^^^^^^^^ Only use parentheses for ternary expressions with complex conditions.
-        RUBY
+      context 'target ruby version <= 3.2', :ruby32, unsupported_on: :prism do
+        it 'registers an offense for yield in condition' do
+          expect_offense(<<~RUBY)
+            foo = (yield) ? a : b
+                  ^^^^^^^^^^^^^^^ Only use parentheses for ternary expressions with complex conditions.
+          RUBY
 
-        expect_correction(<<~RUBY)
-          foo = yield ? a : b
-        RUBY
+          expect_correction(<<~RUBY)
+            foo = yield ? a : b
+          RUBY
+        end
       end
 
       it 'registers an offense for accessor in condition' do

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -109,9 +109,7 @@ RSpec.describe RuboCop::Cop::Style::YodaCondition, :config do
       RUBY
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers an offense for boolean literal on left', broken_on: :prism do
+    it 'registers an offense for boolean literal on left' do
       expect_offense(<<~RUBY)
         false == active?
         ^^^^^^^^^^^^^^^^ Reverse the order of the operands `false == active?`.
@@ -352,9 +350,7 @@ RSpec.describe RuboCop::Cop::Style::YodaCondition, :config do
       RUBY
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers an offense for boolean literal on right', broken_on: :prism do
+    it 'registers an offense for boolean literal on right' do
       expect_offense(<<~RUBY)
         active? == false
         ^^^^^^^^^^^^^^^^ Reverse the order of the operands `active? == false`.

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -111,8 +111,7 @@ RSpec.describe RuboCop::Cop::Team do
 
       let(:cop_names) { offenses.map(&:cop_name) }
 
-      # FIXME: https://github.com/ruby/prism/issues/2513
-      it 'returns Parser warning offenses', broken_on: :prism do
+      it 'returns Parser warning offenses' do
         expect(cop_names.include?('Lint/AmbiguousOperator')).to be(true)
       end
 
@@ -121,8 +120,7 @@ RSpec.describe RuboCop::Cop::Team do
       end
 
       context 'when a cop has no interest in the file' do
-        # FIXME: https://github.com/ruby/prism/issues/2513
-        it 'returns all offenses except the ones of the cop', broken_on: :prism do
+        it 'returns all offenses except the ones of the cop' do
           allow_any_instance_of(RuboCop::Cop::Layout::LineLength)
             .to receive(:excluded_file?).and_return(true)
 


### PR DESCRIPTION
The tests are being updated to use Prism 0.25+ from Prism 0.24. Prism 0.25 has fixed many issues, allowing for the execution of tests that were previously skipped due to `broken_on: :prism`. For future purposes, `broken_on: :prism` is intentionally left in the spec_helper.rb.

Furthermore, Prism 0.25 appropriately addresses the following syntax as an error:

```console
$ ruby -ve "break"
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
-e:1: Invalid break
break
-e: compile error (SyntaxError)
```

However, the Parser gem incorrectly parses it:

```console
$ ruby-parse --33 -e "break"
(break)
```

This issue is expected to be reported to the Parser gem separately.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
