### PR TITLE
[Fix #12823] Fix uninitialized constant error

### DIFF
--- a/changelog/fix_uninitialized_constant_bundler.md
+++ b/changelog/fix_uninitialized_constant_bundler.md
@@ -1,0 +1,1 @@
+* [#12823](https://github.com/rubocop/rubocop/issues/12823): Fixed "uninitialized constant `RuboCop::Lockfile::Bundler`", caused when running RuboCop without `bundler exec` on codebases that use `rubocop-rails`. ([@amomchilov][])

--- a/lib/rubocop/lockfile.rb
+++ b/lib/rubocop/lockfile.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+begin
+  require 'bundler'
+rescue LoadError
+  nil
+end
+
 module RuboCop
   # Encapsulation of a lockfile for use when checking for gems.
   # Does not actually resolve gems, just parses the lockfile.

--- a/lib/rubocop/lockfile.rb
+++ b/lib/rubocop/lockfile.rb
@@ -59,12 +59,15 @@ module RuboCop
     # @return [Bundler::LockfileParser, nil]
     def parser
       return @parser if defined?(@parser)
-      return unless @lockfile_path
 
-      lockfile = Bundler.read_file(@lockfile_path)
-      @parser = lockfile ? Bundler::LockfileParser.new(lockfile) : nil
-    rescue Bundler::BundlerError
-      nil
+      @parser = if defined?(::Bundler) && @lockfile_path
+                  begin
+                    lockfile = ::Bundler.read_file(@lockfile_path)
+                    lockfile ? ::Bundler::LockfileParser.new(lockfile) : nil
+                  rescue ::Bundler::BundlerError
+                    nil
+                  end
+                end
     end
   end
 end


### PR DESCRIPTION
Fixes #12823

The bug originates from #12186, which changed the `defined?` check in a way that didn't cover this broken reference to `Bundler` on line 66:

https://github.com/rubocop/rubocop/blob/a4447ea10744d65b8ea781ec5fbe591c1b514e92/lib/rubocop/lockfile.rb#L59-L68

This wasn't caught in CI, because none of the cops used by Rubocop (to check its own source code in CI) use Rails cops, so `RuboCop::Config#target_rails_version_from_bundler_lock_file` was never called in CI.

# Validation

An easy way to reproduce this is to just modify a gem used by Rubocop itself (e.g. `RuboCop::Cop::Layout::IndentationStyle`), adding `requires_gem 'rubocop'` to its body. This triggers the `target_rails_version_from_bundler_lock_file` code path when you run `exe/rubycop .` to run rubocop on its own codebase.

<details><summary><code>code_to_reproduce.patch</code></summary>

```diff
diff --git a/lib/rubocop/cop/layout/indentation_style.rb b/lib/rubocop/cop/layout/indentation_style.rb
index e2b936f73..5e4a152b7 100644
--- a/lib/rubocop/cop/layout/indentation_style.rb
+++ b/lib/rubocop/cop/layout/indentation_style.rb
@@ -37,6 +37,8 @@ module RuboCop
         include RangeHelp
         extend AutoCorrector

+        requires_gem 'rubocop'
+
         MSG = '%<type>s detected in indentation.'

         def on_new_investigation
```

</details>

It fails on `1.63.0`, and passes with this PR's changes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] ~Added tests.~
     * I don't think we have an easy way to test this, since CI will always have `Bundler` defined, given that it returns tests in the bundle, that's the whole point).
     
         There's probably some way to test it by spawning a fresh process, but I'm not smart enough to figure that out quickly enough to get this bugfix out :)
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
