### PR TITLE
Fix a false positive for `Lint/AssignmentInConditional` if assigning inside a method call

### DIFF
--- a/changelog/fix_false_positive_for_assignment_in_conditional.md
+++ b/changelog/fix_false_positive_for_assignment_in_conditional.md
@@ -1,0 +1,1 @@
+* [#12828](https://github.com/rubocop/rubocop/pull/12828): Fix a false positive for `Lint/AssignmentInCondition` if assigning inside a method call. ([@earlopain][])

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -88,7 +88,9 @@ module RuboCop
         end
 
         def skip_children?(asgn_node)
-          empty_condition?(asgn_node) || (safe_assignment_allowed? && safe_assignment?(asgn_node))
+          (asgn_node.call_type? && !asgn_node.assignment_method?) ||
+            empty_condition?(asgn_node) ||
+            (safe_assignment_allowed? && safe_assignment?(asgn_node))
         end
 
         def traverse_node(node, &block)

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -209,6 +209,12 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     RUBY
   end
 
+  it 'does not register an offense for assignment in method call' do
+    expect_no_offenses(<<~RUBY)
+      return unless %i[asc desc].include?(order = params[:order])
+    RUBY
+  end
+
   context 'safe assignment is allowed' do
     it 'accepts = in condition surrounded with braces' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This reverts d0828e532e1845ce44e522e05a2d978b87a890f1 and adds a testcase.

The correction is `return unless %i[asc desc].include?((order = params[:order]))` which just doesn't look right.

cc @jonas054 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
