### PR TITLE
[Fix #12832] Fix an error for `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/fix_an_error_for_style_arguments_forwarding.md
+++ b/changelog/fix_an_error_for_style_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#12832](https://github.com/rubocop/rubocop/issues/12832): Fix an error for `Style/ArgumentsForwarding` when using block arg in nested method definitions. ([@koic][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -312,7 +312,8 @@ module RuboCop
         end
 
         def register_forward_block_arg_offense(add_parens, def_arguments_or_send, block_arg)
-          return if target_ruby_version <= 3.0 || block_arg.source == '&' || explicit_block_name?
+          return if target_ruby_version <= 3.0 ||
+                    block_arg.nil? || block_arg.source == '&' || explicit_block_name?
 
           add_offense(block_arg, message: BLOCK_MSG) do |corrector|
             add_parens_if_missing(def_arguments_or_send, corrector) if add_parens

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -205,6 +205,18 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
+    it 'does not register an offense when using block arg in nested method definitions', :ruby32 do
+      expect_no_offenses(<<~RUBY)
+        def foo(x)
+          class << x
+            def bar(y, &)
+              baz.qux(&)
+            end
+          end
+        end
+      RUBY
+    end
+
     context 'when `RedundantBlockArgumentNames: [meaningless_block_name]`' do
       let(:redundant_block_argument_names) { ['meaningless_block_name'] }
 


### PR DESCRIPTION
Fixes #12832.

This PR fixes an error for `Style/ArgumentsForwarding` when using block arg in nested method definitions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
