### PR TITLE
Workaround for rubocop-rspec_rails 2.28

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,10 @@ gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.21.0'
 gem 'rubocop-rake', '~> 0.6.0'
 gem 'rubocop-rspec', '~> 2.29.1'
+# This is a workaround to prevent the following error in rubocop-rspec_rails 2.28.3:
+# https://github.com/rubocop/rubocop/actions/runs/8656558784/job/23737409762
+# Please remove this dependency when the issue is resolved.
+gem 'rubocop-rspec_rails', '2.28.2'
 # Workaround for cc-test-reporter with SimpleCov 0.18.
 # Stop upgrading SimpleCov until the following issue will be resolved.
 # https://github.com/codeclimate/test-reporter/issues/418

--- a/lib/rubocop/cop/badge.rb
+++ b/lib/rubocop/cop/badge.rb
@@ -49,10 +49,6 @@ module RuboCop
       end
 
       def match?(other)
-        # Prevents the following error:
-        # https://github.com/rubocop/rubocop/actions/runs/8656558784/job/23737409762
-        return false if other.nil?
-
         cop_name == other.cop_name && (!qualified? || department == other.department)
       end
 

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -297,7 +297,7 @@ module RuboCop
       end
 
       def resolve_badge(given_badge, real_badge, source_path)
-        if real_badge && !given_badge.match?(real_badge)
+        unless given_badge.match?(real_badge)
           path = PathUtil.smart_path(source_path)
           warn "#{path}: #{given_badge} has the wrong namespace - " \
                "replace it with #{given_badge.with_department(real_badge.department)}"

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -98,13 +98,6 @@ RSpec.describe RuboCop::CommentConfig do
     end
 
     it 'supports disabling cops with multiple levels in department name' do
-      # Workaround for the following build error:
-      # https://app.circleci.com/pipelines/github/rubocop/rubocop/11035/workflows/d1f7575e-614f-437b-9d83-494fc94c78b4/jobs/309630
-      #
-      # Fix to the rubocop-rspec_rails monkey patch is required.
-      # https://github.com/rubocop/rubocop-rspec_rails/pull/14
-      skip 'Fix to the rubocop-rspec-rails monkey patch is required.'
-
       disabled_lines = disabled_lines_of_cop('RSpec/Rails/HttpStatus')
       expected_part = (51..53).to_a
       expect(disabled_lines & expected_part).to eq(expected_part)


### PR DESCRIPTION
The fix for #12836 will be improved.
This issue is related to the development dependency rubocop-rspec_rails, and modifying RuboCop's production code was not appropriate. The version will be locked in the Gemfile until a correction can be made to rubocop-rspec_rails.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
