### PR TITLE
[Fix #12835] Allow global offenses to be disabled by directive comments

### DIFF
--- a/changelog/fix_global_offenses_directive_comments.md
+++ b/changelog/fix_global_offenses_directive_comments.md
@@ -1,0 +1,1 @@
+* [#12835](https://github.com/rubocop/rubocop/issues/12835): Allow global offenses to be disabled by directive comments. ([@earlopain][])

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -186,7 +186,9 @@ module RuboCop
       def add_global_offense(message = nil, severity: nil)
         severity = find_severity(nil, severity)
         message = find_message(nil, message)
-        current_offenses << Offense.new(severity, Offense::NO_LOCATION, message, name, :unsupported)
+        range = Offense::NO_LOCATION
+        status = enabled_line?(range.line) ? :unsupported : :disabled
+        current_offenses << Offense.new(severity, range, message, name, status)
       end
 
       # Adds an offense on the specified range (or node with an expression)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -404,6 +404,25 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         $stdout.string.include?('F:  2:  7: Lint/Syntax: unexpected token tINTEGER')
       ).to be(true)
     end
+
+    it '`Naming/FileName` must be be disabled for global offenses' do
+      create_file('Example.rb', <<~RUBY)
+        # rubocop:disable Naming/FileName
+      RUBY
+
+      expect(cli.run(['--format', 'simple', 'Example.rb'])).to eq(1)
+      expect($stdout.string.include?('Naming/FileName:')).to be(false)
+    end
+
+    it '`Naming/FileName` must be be enabled if directive comment is on unrelated line' do
+      create_file('Example.rb', <<~RUBY)
+        # Prelude
+        # rubocop:disable Naming/FileName
+      RUBY
+
+      expect(cli.run(['--format', 'simple', 'Example.rb'])).to eq(1)
+      expect($stdout.string.include?('C:  1:  1: Naming/FileName:')).to be(true)
+    end
   end
 
   describe 'rubocop:disable comment' do


### PR DESCRIPTION
Fix #12835

`Naming/FileName` now returns global offenses but there are quite a few projects that disable the cop with a comment, see https://github.com/search?q=%22rubocop%3Adisable+Naming%2FFileName%22&type=code. The change to global offenses in #12802 broke that behaviour.

While this is technically a new feature I classify this as a bugfix to restore previous behaviour.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
