### PR TITLE
Fix misleading spec

### DIFF
--- a/spec/rubocop/cop/naming/file_name_spec.rb
+++ b/spec/rubocop/cop/naming/file_name_spec.rb
@@ -392,7 +392,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
   end
 
   context 'when Regex is set' do
-    let(:cop_config) { { 'Regex' => /\A[aeiou]\z/i } }
+    let(:cop_config) { { 'Regex' => '\A[aeiou]\z' } }
 
     context 'with a matching name' do
       it 'does not register an offense' do
@@ -406,7 +406,7 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY, 'z.rb')
           print 1
-          ^{} `z.rb` should match `(?i-mx:\\A[aeiou]\\z)`.
+          ^{} `z.rb` should match `\\A[aeiou]\\z`.
         RUBY
       end
     end


### PR DESCRIPTION
Our users can only configure the 'Regex' key as a String object, not as a Regexp instance.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] ~Added tests.~
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
