### PR TITLE
Fix false negatives for `Lint/UnreachableLoop`

### DIFF
--- a/changelog/fix_false_negatives_for_lint_unreachable_loop.md
+++ b/changelog/fix_false_negatives_for_lint_unreachable_loop.md
@@ -1,0 +1,1 @@
+* [#12841](https://github.com/rubocop/rubocop/pull/12841): Fix false negatives for `Lint/UnreachableLoop` when using pattern matching. ([@koic][])

--- a/lib/rubocop/cop/lint/unreachable_loop.rb
+++ b/lib/rubocop/cop/lint/unreachable_loop.rb
@@ -160,7 +160,7 @@ module RuboCop
             break_statement && !preceded_by_continue_statement?(break_statement)
           when :if
             check_if(node)
-          when :case
+          when :case, :case_match
             check_case(node)
           else
             false
@@ -178,7 +178,13 @@ module RuboCop
           return false unless else_branch
           return false unless break_statement?(else_branch)
 
-          node.when_branches.all? { |branch| branch.body && break_statement?(branch.body) }
+          branches = if node.case_type?
+                       node.when_branches
+                     else
+                       node.in_pattern_branches
+                     end
+
+          branches.all? { |branch| branch.body && break_statement?(branch.body) }
         end
 
         def preceded_by_continue_statement?(break_statement)

--- a/spec/rubocop/cop/lint/unreachable_loop_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_loop_spec.rb
@@ -90,6 +90,46 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableLoop, :config do
         end
       RUBY
     end
+
+    it 'registers an offense when using `case-in-else` with all break branches' do
+      expect_offense(<<~RUBY)
+        while x > 0
+        ^^^^^^^^^^^ This loop will have at most one iteration.
+          case x
+          in 1
+            break
+          else
+            raise MyError
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using `case` match without `else`' do
+      expect_no_offenses(<<~RUBY)
+        while x > 0
+          case x
+          in 1
+            break
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using `case-in-else` and not all branches are breaking' do
+      expect_no_offenses(<<~RUBY)
+        while x > 0
+          case x
+          in 1
+            break
+          in 2
+            do_something
+          else
+            raise MyError
+          end
+        end
+      RUBY
+    end
   end
 
   context 'with preceding continue statements' do
@@ -123,6 +163,21 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableLoop, :config do
 
           case x
           when 1
+            break
+          else
+            raise MyError
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using `case-in-else` with all break branches' do
+      expect_no_offenses(<<~RUBY)
+        while x > 0
+          redo if x.odd?
+
+          case x
+          in 1
             break
           else
             raise MyError


### PR DESCRIPTION
This PR fixes false negatives for `Lint/UnreachableLoop` when using pattern matching.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
