### PR TITLE
[Fix #12843] Fix an error for `Lint/MixedCaseRange`

### DIFF
--- a/changelog/fix_an_error_for_lint_mixed_case_range.md
+++ b/changelog/fix_an_error_for_lint_mixed_case_range.md
@@ -1,0 +1,1 @@
+* [#12843](https://github.com/rubocop/rubocop/issues/12843): Fix an error for `Lint/MixedCaseRange` when a character between `Z` and `a` is used in the regexp range. ([@koic][])

--- a/lib/rubocop/cop/lint/mixed_case_range.rb
+++ b/lib/rubocop/cop/lint/mixed_case_range.rb
@@ -47,8 +47,10 @@ module RuboCop
 
         def on_regexp(node)
           each_unsafe_regexp_range(node) do |loc|
+            next unless (replacement = regexp_range(loc.source))
+
             add_offense(loc) do |corrector|
-              corrector.replace(loc, rewrite_regexp_range(loc.source))
+              corrector.replace(loc, replacement)
             end
           end
         end
@@ -99,10 +101,13 @@ module RuboCop
           end
         end
 
-        def rewrite_regexp_range(source)
+        def regexp_range(source)
           open, close = source.split('-')
-          first = [open, range_for(open).end]
-          second = [range_for(close).begin, close]
+          return unless (open_range = range_for(open))
+          return unless (close_range = range_for(close))
+
+          first = [open, open_range.end]
+          second = [close_range.begin, close]
           "#{first.uniq.join('-')}#{second.uniq.join('-')}"
         end
       end

--- a/spec/rubocop/cop/lint/mixed_case_range_spec.rb
+++ b/spec/rubocop/cop/lint/mixed_case_range_spec.rb
@@ -228,6 +228,18 @@ RSpec.describe RuboCop::Cop::Lint::MixedCaseRange, :config do
     RUBY
   end
 
+  it 'does not register an offense when a character between `Z` and `a` is at the start of range.' do
+    expect_no_offenses(<<~RUBY)
+      foo = /[_-a]/
+    RUBY
+  end
+
+  it 'does not register an offense when a character between `Z` and `a` is at the end of range.' do
+    expect_no_offenses(<<~RUBY)
+      foo = /[A-_]/
+    RUBY
+  end
+
   it 'does not register an offense with invalid byte sequence in UTF-8' do
     expect_no_offenses(<<~'RUBY')
       foo = /[\–]/


### PR DESCRIPTION
Fixes #12843.

This PR fixes an error for `Lint/MixedCaseRange` when a character between `Z` and `a` is used in the regexp range.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
