### PR TITLE
Exclude `debug/open_nonstop` from `Lint/Debugger`

### DIFF
--- a/changelog/change_exclude_debug_open_nonstop_from_lint_debugger.md
+++ b/changelog/change_exclude_debug_open_nonstop_from_lint_debugger.md
@@ -1,0 +1,1 @@
+* [#12845](https://github.com/rubocop/rubocop/pull/12845): Exclude `debug/open_nonstop` from `Lint/Debugger` by default. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1703,7 +1703,6 @@ Lint/Debugger:
   DebuggerRequires:
     debug.rb:
       - debug/open
-      - debug/open_nonstop
       - debug/start
 
 Lint/DeprecatedClassMethods:


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/issues/12721#issuecomment-2056997601.

This PR excludes `debug/open_nonstop` from `Lint/Debugger` by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
