### PR TITLE
[Fix #12846] Fix an error for `RuboCop::Lockfile`

### DIFF
--- a/changelog/fix_an_error_for_rubocop_lockfile.md
+++ b/changelog/fix_an_error_for_rubocop_lockfile.md
@@ -1,0 +1,1 @@
+* [#12846](https://github.com/rubocop/rubocop/issues/12846): Fix an error for `RuboCop::Lockfile` when there is no Bundler environment. ([@koic][])


### PR DESCRIPTION
Fixes #12846.

This PR fixes an error for `RuboCop::Lockfile` when there is no Bundler environment.

From a performance perspective as well, resolving through `require 'bundler'` is not optimal. This PR ensures that the necessary `Bundler::LockfileParser` exists as a constant. This approach reduces unnecessary loading caused by `require 'bundler'` and ensures the presence of the essential `Bundler::LockfileParser`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
