### PR TITLE
[Fix #12848] Fix an error for `RuboCop::Lockfile`

### DIFF
--- a/changelog/fix_error_for_rubocop_lockfile.md
+++ b/changelog/fix_error_for_rubocop_lockfile.md
@@ -1,0 +1,1 @@
+* [#12848](https://github.com/rubocop/rubocop/issues/12848): Fix an error that occurs in `RuboCop::Lockfile` when the constant Bundler is uninitialized. ([@koic][])

--- a/lib/rubocop/lockfile.rb
+++ b/lib/rubocop/lockfile.rb
@@ -60,7 +60,7 @@ module RuboCop
     def parser
       return @parser if defined?(@parser)
 
-      @parser = if @lockfile_path
+      @parser = if @lockfile_path && bundler_lock_parser_defined?
                   begin
                     lockfile = ::Bundler.read_file(@lockfile_path)
                     ::Bundler::LockfileParser.new(lockfile) if lockfile


### PR DESCRIPTION
Fixes #12848.

This PR fixes an error that occurs in `RuboCop::Lockfile` when the constant Bundler is uninitialized.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
