### PR TITLE
[Fix #12852] Correctly deserialize a global offense

### DIFF
--- a/changelog/fix_error_for_lint_empty_file_with_cache.md
+++ b/changelog/fix_error_for_lint_empty_file_with_cache.md
@@ -1,0 +1,1 @@
+* [#12852](https://github.com/rubocop/rubocop/issues/12852): Fix an error for `Lint/EmptyFile` in formatters when using cache. ([@earlopain][])

--- a/lib/rubocop/cached_data.rb
+++ b/lib/rubocop/cached_data.rb
@@ -48,10 +48,18 @@ module RuboCop
       source_buffer = Parser::Source::Buffer.new(@filename)
       source_buffer.source = File.read(@filename, encoding: Encoding::UTF_8)
       offenses.map! do |o|
-        location = Parser::Source::Range.new(source_buffer,
-                                             o['location']['begin_pos'],
-                                             o['location']['end_pos'])
+        location = location_from_source_buffer(o, source_buffer)
         Cop::Offense.new(o['severity'], location, o['message'], o['cop_name'], o['status'].to_sym)
+      end
+    end
+
+    def location_from_source_buffer(offense, source_buffer)
+      begin_pos = offense['location']['begin_pos']
+      end_pos = offense['location']['end_pos']
+      if begin_pos.zero? && end_pos.zero?
+        Cop::Offense::NO_LOCATION
+      else
+        Parser::Source::Range.new(source_buffer, begin_pos, end_pos)
       end
     end
   end

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -113,6 +113,19 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
           expect(cache.load[0].status).to eq(:new_status)
         end
       end
+
+      context 'a global offense' do
+        let(:no_location) { RuboCop::Cop::Offense::NO_LOCATION }
+        let(:global_offense) do
+          RuboCop::Cop::Offense.new(:warning, no_location, 'empty file', 'Lint/EmptyFile',
+                                    :unsupported)
+        end
+
+        it 'serializes the range correctly' do
+          cache.save([global_offense])
+          expect(cache.load[0].location).to eq(no_location)
+        end
+      end
     end
 
     context 'when no option is given' do


### PR DESCRIPTION
Closes #12852.

A global offense goes into the cache but a range comes out. This results in errors when trying to display this range because begin/end at 0 is not valid. The global offense structure handles this, which is why only the second run will fail.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
