### PR TITLE
Set custom program name for the built-in LSP server

### DIFF
--- a/changelog/change_set_custom_program_name_for_the_builtin_lsp_server.md
+++ b/changelog/change_set_custom_program_name_for_the_builtin_lsp_server.md
@@ -1,0 +1,1 @@
+* [#12855](https://github.com/rubocop/rubocop/pull/12855): Set custom program name for the built-in LSP server. ([@koic][])

--- a/docs/modules/ROOT/pages/usage/lsp.adoc
+++ b/docs/modules/ROOT/pages/usage/lsp.adoc
@@ -254,8 +254,8 @@ Run `rubocop --lsp` command from LSP client.
 When the language server is started, the command displays the language server's PID:
 
 ```console
-$ ps aux | grep rubocop
-user             17414   0.0  0.2  5557716 144376   ??  Ss    4:48PM   0:02.13 /Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/bin/rubocop --lsp
+$ ps aux | grep 'rubocop --lsp'
+user             17414   0.0  0.2  5557716 144376   ??  Ss    4:48PM   0:02.13 rubocop --lsp /Users/user/src/github.com/rubocop/rubocop
 ```
 
 NOTE: `rubocop --lsp` is for starting LSP client, so users don't manually execute it.

--- a/lib/rubocop/lsp/server.rb
+++ b/lib/rubocop/lsp/server.rb
@@ -21,6 +21,8 @@ module RuboCop
     # @api private
     class Server
       def initialize(config_store)
+        $PROGRAM_NAME = "rubocop --lsp #{ConfigFinder.project_root}"
+
         RuboCop::LSP.enable
 
         @reader = LanguageServer::Protocol::Transport::Io::Reader.new($stdin)


### PR DESCRIPTION
This PR sets custom program name for the built-in LSP server.

Before:

```console
$ ps aux | grep rubocop
user  17414  0.0  0.2  5557716 144376  ??  Ss  4:48PM  0:02.13 /Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/bin/rubocop --lsp
```

After:

```console
$ ps aux | grep 'rubocop'
user  17414  0.0  0.2  5557716 144376  ??  Ss  4:48PM  0:02.13 rubocop --lsp /Users/user/src/github.com/rubocop/rubocop
```

When searching for the LSP server process, it is helpful to display the path to the project root instead of the Ruby command path. This approach is already being implemented in server mode: https://github.com/rubocop/rubocop/blob/v1.63.2/lib/rubocop/server/core.rb#L31

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
