### PR TITLE
Workaround for incompatibilities between Prism 0.25.0 and 0.26.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,11 @@ gem 'asciidoctor'
 gem 'bump', require: false
 gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'memory_profiler', platform: :mri
-gem 'prism', '>= 0.25.0'
+# FIXME: This is a workaround for incompatibilities between Prism 0.25.0 and 0.26.0.
+# To upgrade to Prism 0.26+, it is necessary to investigate the following build error
+# and provide feedback to Prism:
+# https://github.com/rubocop/rubocop/actions/runs/8748485587/job/24008584735?pr=12855
+gem 'prism', '0.25.0'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.21.0'


### PR DESCRIPTION
This is a workaround for incompatibilities between Prism 0.25.0 and 0.26.0. To upgrade to Prism 0.26+, it is necessary to investigate the following build error and provide feedback to Prism: https://github.com/rubocop/rubocop/actions/runs/8748485587/job/24008584735?pr=12855

I will proceed with these separately.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
