### PR TITLE
Fix false negatives for `Lint/UnreachableCode`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_unreachable_code.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_unreachable_code.md
@@ -1,0 +1,1 @@
+* [#12857](https://github.com/rubocop/rubocop/pull/12857): Fix false negatives for `Lint/UnreachableCode` when using pattern matching. ([@koic][])

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -71,7 +71,7 @@ module RuboCop
             expressions.any? { |expr| flow_expression?(expr) }
           when :if
             check_if(node)
-          when :case
+          when :case, :case_match
             check_case(node)
           else
             false
@@ -89,7 +89,9 @@ module RuboCop
           return false unless else_branch
           return false unless flow_expression?(else_branch)
 
-          node.when_branches.all? { |branch| branch.body && flow_expression?(branch.body) }
+          branches = node.case_type? ? node.when_branches : node.in_pattern_branches
+
+          branches.all? { |branch| branch.body && flow_expression?(branch.body) }
         end
       end
     end

--- a/spec/rubocop/cop/lint/unreachable_code_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_code_spec.rb
@@ -97,6 +97,24 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableCode, :config do
       RUBY
     end
 
+    it "registers an offense for `#{t}` in all `case` pattern branches" do
+      expect_offense(wrap(<<~RUBY))
+        case cond
+        in 1
+          something
+          #{t}
+        in 2
+          something2
+          #{t}
+        else
+          something3
+          #{t}
+        end
+        bar
+        ^^^ Unreachable code detected.
+      RUBY
+    end
+
     it "accepts code with conditional `#{t}`" do
       expect_no_offenses(wrap(<<~RUBY))
         #{t} if cond
@@ -176,6 +194,20 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableCode, :config do
           something
           #{t}
         when 2
+          something2
+          #{t}
+        end
+        bar
+      RUBY
+    end
+
+    it "accepts `#{t}` is in `case` pattern branch without else" do
+      expect_no_offenses(wrap(<<~RUBY))
+        case cond
+        in 1
+          something
+          #{t}
+        in 2
           something2
           #{t}
         end


### PR DESCRIPTION
This PR fixes false negatives for `Lint/UnreachableCode` when using pattern matching.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
