### PR TITLE
Tweak the infinite loop error message

### DIFF
--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -20,10 +20,11 @@ module RuboCop
         message = 'Infinite loop detected'
         message += " in #{path}" if path
         message += " and caused by #{root_cause}" if root_cause
-        message += ' Hint: Please update to the latest RuboCop version if not already in use,'
-        message += ' and report a bug if the issue still occurs on this version.'
-        message += ' Please check the latest version at https://rubygems.org/gems/rubocop'
-        super(message)
+        message += "\n"
+        hint = 'Hint: Please update to the latest RuboCop version if not already in use, ' \
+               "and report a bug if the issue still occurs on this version.\n" \
+               'Please check the latest version at https://rubygems.org/gems/rubocop.'
+        super(Rainbow(message).red + Rainbow(hint).yellow)
       end
     end
 

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -315,10 +315,10 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
           end.to raise_error(
             described_class::InfiniteCorrectionLoop,
             "Infinite loop detected in #{source_file_path} and caused by " \
-            'Test/ClassMustBeAModuleCop -> Test/ModuleMustBeAClassCop ' \
+            "Test/ClassMustBeAModuleCop -> Test/ModuleMustBeAClassCop\n" \
             'Hint: Please update to the latest RuboCop version if not already in use, ' \
-            'and report a bug if the issue still occurs on this version. ' \
-            'Please check the latest version at https://rubygems.org/gems/rubocop'
+            "and report a bug if the issue still occurs on this version.\n" \
+            'Please check the latest version at https://rubygems.org/gems/rubocop.'
           )
         end
       end
@@ -338,10 +338,10 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
           end.to raise_error(
             described_class::InfiniteCorrectionLoop,
             "Infinite loop detected in #{source_file_path} and caused by " \
-            'Test/ClassMustBeAModuleCop -> Test/ModuleMustBeAClassCop ' \
+            "Test/ClassMustBeAModuleCop -> Test/ModuleMustBeAClassCop\n" \
             'Hint: Please update to the latest RuboCop version if not already in use, ' \
-            'and report a bug if the issue still occurs on this version. ' \
-            'Please check the latest version at https://rubygems.org/gems/rubocop'
+            "and report a bug if the issue still occurs on this version.\n" \
+            'Please check the latest version at https://rubygems.org/gems/rubocop.'
           )
         end
       end
@@ -377,11 +377,10 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
           end.to raise_error(
             described_class::InfiniteCorrectionLoop,
             "Infinite loop detected in #{source_file_path} and caused by " \
-            'Test/ClassMustBeAModuleCop, Test/AtoB ' \
-            '-> Test/ModuleMustBeAClassCop, Test/BtoA ' \
+            "Test/ClassMustBeAModuleCop, Test/AtoB -> Test/ModuleMustBeAClassCop, Test/BtoA\n" \
             'Hint: Please update to the latest RuboCop version if not already in use, ' \
-            'and report a bug if the issue still occurs on this version. ' \
-            'Please check the latest version at https://rubygems.org/gems/rubocop'
+            "and report a bug if the issue still occurs on this version.\n" \
+            'Please check the latest version at https://rubygems.org/gems/rubocop.'
           )
         end
       end
@@ -415,10 +414,10 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
             end.to raise_error(
               described_class::InfiniteCorrectionLoop,
               "Infinite loop detected in #{source_file_path} and caused by " \
-              'Test/AtoB -> Test/BtoC -> Test/CtoA ' \
+              "Test/AtoB -> Test/BtoC -> Test/CtoA\n" \
               'Hint: Please update to the latest RuboCop version if not already in use, ' \
-              'and report a bug if the issue still occurs on this version. ' \
-              'Please check the latest version at https://rubygems.org/gems/rubocop'
+              "and report a bug if the issue still occurs on this version.\n" \
+              'Please check the latest version at https://rubygems.org/gems/rubocop.'
             )
           end
         end


### PR DESCRIPTION
This PR tweaks the infinite loop error message.

The single-line, monochromatic error message will be separated into error and hint sections, with each section color-coded to enhance visibility.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
