### PR TITLE
Add missing periods on CLI options descriptions

### DIFF
--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -573,7 +573,7 @@ module RuboCop
                                          'cops. Only valid for --format junit.'],
       display_only_fail_level_offenses:
                                         ['Only output offense messages at',
-                                         'the specified --fail-level or above'],
+                                         'the specified --fail-level or above.'],
       display_only_correctable:         ['Only output correctable offense messages.'],
       display_only_safe_correctable:    ['Only output safe-correctable offense messages',
                                          'when combined with --display-only-correctable.'],
@@ -636,8 +636,8 @@ module RuboCop
       raise_cop_error:                  ['Raise cop-related errors with cause and location.',
                                          'This is used to prevent cops from failing silently.',
                                          'Default is false.'],
-      profile:                          'Profile rubocop',
-      memory:                           'Profile rubocop memory usage'
+      profile:                          'Profile rubocop.',
+      memory:                           'Profile rubocop memory usage.'
     }.freeze
   end
   # rubocop:enable Metrics/ModuleLength

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                cops. Only valid for --format junit.
                   --display-only-fail-level-offenses
                                                Only output offense messages at
-                                               the specified --fail-level or above
+                                               the specified --fail-level or above.
                   --display-only-correctable   Only output correctable offense messages.
                   --display-only-safe-correctable
                                                Only output safe-correctable offense messages
@@ -213,8 +213,8 @@ RSpec.describe RuboCop::Options, :isolated_environment do
           expected_help += <<~OUTPUT
 
             Profiling Options:
-                    --profile                    Profile rubocop
-                    --memory                     Profile rubocop memory usage
+                    --profile                    Profile rubocop.
+                    --memory                     Profile rubocop memory usage.
           OUTPUT
         end
 


### PR DESCRIPTION
While looking at the output from the command `rubocop -h`, I noticed that the description of 3 options had a missing period at the end of the line, while all the other descriptions had one.

This PR adds those 3 missing periods :)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
