### PR TITLE
[Fix #12865] `require 'bundler'` if possible and rescue `Bundler::GemfileNotFound`

### DIFF
--- a/changelog/fix_rails_cops_outside_bundler_exec.md
+++ b/changelog/fix_rails_cops_outside_bundler_exec.md
@@ -1,0 +1,1 @@
+* [#12865](https://github.com/rubocop/rubocop/issues/12865): Fix Rails Cops, which weren't reporting any violations unless running with `bundle exec`. ([@amomchilov][])


### PR DESCRIPTION
Closes #12865

This PR improves upon #12826, which tried to `require 'bundler'` if it's available, we we reverted after #12846.

The issue _wasn't_ the attempt to require Bundler. It was that we were calling `Bundler.default_lockfile`, which raises `Bundler::GemfileNotFound` when you're in a folder with no `Gemfile.lock`.

I can't test this right now, so this is just "blind coding". Can you try it out, @AmShaegar13

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
