### PR TITLE
[Fix #12862] Fix a false positive for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_false_positive_for_style_redundant_line_continuation.md
+++ b/changelog/fix_false_positive_for_style_redundant_line_continuation.md
@@ -1,0 +1,1 @@
+* [#12862](https://github.com/rubocop/rubocop/issues/12862): Fix a false positive for `Style/RedundantLineContinuation` when line continuations involve `return` with a return value. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -137,7 +137,9 @@ module RuboCop
         #   do_something \
         #     argument
         def method_with_argument?(current_token, next_token)
-          current_token.type == :tIDENTIFIER && ARGUMENT_TYPES.include?(next_token.type)
+          return false if current_token.type != :tIDENTIFIER && current_token.type != :kRETURN
+
+          ARGUMENT_TYPES.include?(next_token.type)
         end
 
         # rubocop:disable Metrics/AbcSize

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -114,6 +114,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'does not register an offense when line continuations involve `return` with a return value' do
+    expect_no_offenses(<<~'RUBY')
+      return \
+        foo
+    RUBY
+  end
+
+  it 'registers an offense when line continuations involve `return` with a parenthesized return value' do
+    expect_offense(<<~'RUBY')
+      return(\
+             ^ Redundant line continuation.
+        foo
+      )
+    RUBY
+
+    expect_correction(<<~RUBY)
+      return(
+        foo
+      )
+    RUBY
+  end
+
   it 'registers an offense when line continuations with `if`' do
     expect_offense(<<~'RUBY')
       if foo \


### PR DESCRIPTION
Fixes #12862.

This PR fixes a false positive for `Style/RedundantLineContinuation` when line continuations involve `return` with a return value.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
