### PR TITLE
Fix an error for `rubocop -V` when `.rubocop.yml` contains ERB

### DIFF
--- a/changelog/fix_error_for_rubocop_cli.md
+++ b/changelog/fix_error_for_rubocop_cli.md
@@ -1,0 +1,1 @@
+* [#12871](https://github.com/rubocop/rubocop/pull/12871): Fix an error for `rubocop -V` when `.rubocop.yml` contains ERB. ([@earlopain][])

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -42,9 +42,9 @@ module RuboCop
     # @api private
     def self.parser_version
       config_path = ConfigFinder.find_config_path(Dir.pwd)
-      yaml = YAML.safe_load(
-        File.read(config_path), permitted_classes: [Regexp, Symbol], aliases: true
-      )
+      yaml = Util.silence_warnings do
+        ConfigLoader.load_yaml_configuration(config_path)
+      end
 
       if yaml.dig('AllCops', 'ParserEngine') == 'parser_prism'
         require 'prism'

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -408,6 +408,20 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         expect(output.include?(pending_cop_warning)).to be(false)
       end
     end
+
+    context 'when the config contains erb' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          <% if true %>
+          <% end %>
+        YAML
+      end
+
+      it 'exits cleanly' do
+        expect(cli.run(['-V'])).to eq(0)
+        expect($stdout.string.include?(RuboCop::Version::STRING)).to be(true)
+      end
+    end
   end
 
   describe '--only' do


### PR DESCRIPTION
The config file is allowed to include ERB syntax which was being parsed as YAML as is without being resolved.

Uses `Util.silence_warnings` to supress the potential warnings from `check_duplication`. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
