### PR TITLE
[Fix #12873] Fix an error for `Metrics/BlockLength`

### DIFF
--- a/changelog/fix_an_error_for_metrics_block_length.md
+++ b/changelog/fix_an_error_for_metrics_block_length.md
@@ -1,0 +1,1 @@
+* [#12873](https://github.com/rubocop/rubocop/issues/12873): Fix an error for `Metrics/BlockLength` when the `CountAsOne` config is invalid. ([@koic][])

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -51,8 +51,8 @@ module RuboCop
               when :method_call
                 ->(node) { node.call_type? }
               else
-                raise ArgumentError, "Unknown foldable type: #{type.inspect}. " \
-                                     "Valid foldable types are: #{FOLDABLE_TYPES.join(', ')}."
+                raise Warning, "Unknown foldable type: #{type.inspect}. " \
+                               "Valid foldable types are: #{FOLDABLE_TYPES.join(', ')}."
               end
             end
           end

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -72,6 +72,25 @@ RSpec.describe RuboCop::Cop::Metrics::BlockLength, :config do
     RUBY
   end
 
+  context 'when the `CountAsOne` config is invalid' do
+    before do
+      cop_config['CountAsOne'] = 'config'
+    end
+
+    let(:source) { <<~RUBY }
+      something do
+      ^^^^^^^^^^^^ Block has too many lines. [3/2]
+        a = 1
+        a = 2
+        a = 3
+      end
+    RUBY
+
+    it 'raises `RuboCop::Warning`' do
+      expect { expect_offense(source) }.to raise_error(RuboCop::Warning)
+    end
+  end
+
   context 'when using numbered parameter', :ruby27 do
     it 'rejects a block with more than 5 lines' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
@@ -469,7 +469,7 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::CodeLengthCalculator do
 
       expect do
         described_class.new(source.ast, source, foldable_types: %i[unknown]).calculate
-      end.to raise_error(ArgumentError, /Unknown foldable type/)
+      end.to raise_error(RuboCop::Warning, /Unknown foldable type/)
     end
   end
 end


### PR DESCRIPTION
Fixes #12873.

This PR fixes an error for `Metrics/BlockLength` when the `CountAsOne` config is invalid.

## Before

Without the `-d` option, the cause is unclear:

```console
$ bundle exec rubocop --only Metrics/BlockLength
Inspecting 1 file
An error occurred while Metrics/BlockLength cop was inspecting /Users/koic/src/github.com/koic/rubocop-issues/12873/example.rb:2:2.
To see the complete backtrace run rubocop -d.
.

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Metrics/BlockLength cop was inspecting /Users/koic/src/github.com/koic/rubocop-issues/12873/example.rb:2:2.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop/rubocop/issues

Mention the following information in the issue report:
1.63.4 (using Parser 3.3.0.5, rubocop-ast 1.31.2, running on ruby 3.3.0) [x86_64-darwin22]
```

When the `-d` option is used, hint appears hidden within the backtrace:

```console
$ bundle exec rubocop --only Metrics/BlockLength -d
For /Users/koic/src/github.com/koic/rubocop-issues/12873: configuration from /Users/koic/src/github.com/koic/rubocop-issues/12873/.rubocop.yml
Default configuration from /Users/koic/src/github.com/rubocop/rubocop/config/default.yml
AllCops/Exclude configuration from /Users/koic/src/github.com/koic/rubocop-issues/.rubocop.yml
configuration from /Users/koic/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rubocop-minitest-0.35.0/config/default.yml
configuration from /Users/koic/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rubocop-minitest-0.35.0/config/default.yml
configuration from /Users/koic/src/github.com/rubocop/rubocop-performance/config/default.yml
configuration from /Users/koic/src/github.com/rubocop/rubocop-performance/config/default.yml
configuration from /Users/koic/src/github.com/rubocop/rubocop-rails/config/default.yml
configuration from /Users/koic/src/github.com/rubocop/rubocop-rails/config/default.yml
Use parallel by default.
Skipping parallel inspection: only a single file needs inspection
Inspecting 1 file
Scanning /Users/koic/src/github.com/koic/rubocop-issues/12873/example.rb
An error occurred while Metrics/BlockLength cop was inspecting /Users/koic/src/github.com/koic/rubocop-issues/12873/example.rb:2:2.
Unknown foldable type: :config. Valid foldable types are: array, hash, heredoc, send, csend.
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/metrics/utils/code_length_calculator.rb:54:in `block in build_foldable_checks'
```

## After

Even without the `-d` option, only the hint is displayed:

```console
$ bundle exec rubocop --only Metrics/BlockLength
Inspecting 1 file
Unknown foldable type: :config. Valid foldable types are: array, hash, heredoc, send, csend.
(from file: /Users/koic/src/github.com/koic/rubocop-issues/12873/example.rb:2:2)
.

1 file inspected, no offenses detected
```

This behavior is the same as when the `Notice` config in `Style/Copyright` cop is not valid. This clarifies what needs to be addressed first to achieve the expected behavior.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
