### PR TITLE
Add documentation and log information for enabling YJIT in LSP

### DIFF
--- a/docs/modules/ROOT/pages/usage/lsp.adoc
+++ b/docs/modules/ROOT/pages/usage/lsp.adoc
@@ -247,6 +247,31 @@ For detailed instructions on setting the parameter, please refer to the configur
 
 NOTE: The `layoutMode` parameter was introduced in RuboCop 1.55.
 
+== Enable YJIT
+
+YJIT, a Ruby JIT compiler, has been supported since Ruby 3.1.
+In an LSP client, you can enable YJIT by launching `rubocop --lsp` with the `RUBY_YJIT_ENABLE=1` environment variable using the `env` command:
+
+```sh
+env RUBY_YJIT_ENABLE=1 bundle exec rubocop --lsp
+```
+
+Below is an example for Emacs's Eglot:
+
+```lisp
+(add-to-list 'eglot-server-programs '(ruby-mode . ("env" "RUBY_YJIT_ENABLE=1" "bundle" "exec" "rubocop" "--lsp")))
+```
+
+The console of the LSP client will display `+YJIT`:
+
+```console
+RuboCop 1.63.4 language server +YJIT initialized, PID 13501
+```
+
+For more details, please refer to the respective LSP configuration documentation.
+In some cases, like with vscode-rubocop, it may be available as a built-in option:
+https://github.com/rubocop/vscode-rubocop#rubocopyjitenabled
+
 == Run as a Language Server
 
 Run `rubocop --lsp` command from LSP client.

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -60,8 +60,9 @@ module RuboCop
 
       handle 'initialized' do |_request|
         version = RuboCop::Version::STRING
+        yjit = Object.const_defined?('RubyVM::YJIT') && RubyVM::YJIT.enabled? ? ' +YJIT' : ''
 
-        Logger.log("RuboCop #{version} language server initialized, PID #{Process.pid}")
+        Logger.log("RuboCop #{version} language server#{yjit} initialized, PID #{Process.pid}")
       end
 
       handle 'shutdown' do |request|


### PR DESCRIPTION
This PR adds documentation on enabling YJIT for LSP client to the LSP documentation. It also includes an update to display whether YJIT is enabled or not during LSP startup.

Although it has not been measured, due to its nature as a server, there is a potential for improved execution efficiency with YJIT.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
