### PR TITLE
Fix incorrect autocorrect when `Style/NumericPredicate` is used with negations

### DIFF
--- a/changelog/fix_autocorrect_for_numeric_predicate_and_negations.md
+++ b/changelog/fix_autocorrect_for_numeric_predicate_and_negations.md
@@ -1,0 +1,1 @@
+* [#12881](https://github.com/rubocop/rubocop/pull/12881): Fix incorrect autocorrect when `Style/NumericPredicate` is used with negations. ([@fatkodima][])

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -118,12 +118,14 @@ module RuboCop
 
           return unless numeric && operator && replacement_supported?(operator)
 
-          [numeric, replacement(numeric, operator)]
+          [numeric, replacement(node, numeric, operator)]
         end
 
-        def replacement(numeric, operation)
+        def replacement(node, numeric, operation)
           if style == :predicate
             [parenthesized_source(numeric), REPLACEMENTS.invert[operation.to_s]].join('.')
+          elsif negated?(node)
+            "(#{numeric.source} #{REPLACEMENTS[operation.to_s]} 0)"
           else
             [numeric.source, REPLACEMENTS[operation.to_s], 0].join(' ')
           end
@@ -155,6 +157,12 @@ module RuboCop
 
             [numeric, comparison]
           end
+        end
+
+        def negated?(node)
+          return false unless (parent = node.parent)
+
+          parent.send_type? && parent.method?(:!)
         end
 
         # @!method predicate(node)

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -215,6 +215,17 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
       RUBY
     end
 
+    it 'registers an offense for checking if a number is not zero' do
+      expect_offense(<<~RUBY)
+        !number.zero?
+         ^^^^^^^^^^^^ Use `(number == 0)` instead of `number.zero?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        !(number == 0)
+      RUBY
+    end
+
     it 'allows checking if a number is not zero' do
       expect_no_offenses('number.nonzero?')
     end


### PR DESCRIPTION
When using `Style/NumericPredicate` cop with `EnforcedStyle: comparison` and having some negations, rubocop suggests invalid autocorrections. 

For example:
```ruby
!foo.zero?

# Suggests to convert to
!foo == 0

# But should be
foo != 0
```

In this PR, I did the simplest change possible to just wrap the autocorrected code in the parentheses and it is assumed then after this other cops will convert it from `!(foo == 0)` to something like `foo != 0`. Which is actually the case.