### PR TITLE
Fix `Layout/CommentIndentation` for comment-only pattern matching

### DIFF
--- a/changelog/fix_fix_layout_comment_indentation_for_comment_only.md
+++ b/changelog/fix_fix_layout_comment_indentation_for_comment_only.md
@@ -1,0 +1,1 @@
+* [#12882](https://github.com/rubocop/rubocop/pull/12882): Fix `Layout/CommentIndentation` for comment-only pattern matching. ([@nekketsuuu][])

--- a/lib/rubocop/cop/layout/comment_indentation.rb
+++ b/lib/rubocop/cop/layout/comment_indentation.rb
@@ -160,7 +160,7 @@ module RuboCop
         end
 
         def two_alternatives?(line)
-          /^\s*(else|elsif|when|rescue|ensure)\b/.match?(line)
+          /^\s*(else|elsif|when|in|rescue|ensure)\b/.match?(line)
         end
       end
     end

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -113,6 +113,13 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation, :config do
               b
             end
             # this is accepted
+            case a
+            # this is accepted
+            in 0
+              #
+              b
+            end
+            # this is accepted
           rescue
           # this is accepted
           ensure
@@ -196,6 +203,19 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation, :config do
              #
              ^ Incorrect indentation detected (column 5 instead of 4).
             b
+          when 2
+            # this is also accepted
+          end
+          case a
+          # this is accepted
+          in 0
+            # so is this
+          in 1
+          #
+          ^ Incorrect indentation detected (column 2 instead of 4).
+            b
+          in 2
+            # this is also accepted
           end
       RUBY
 
@@ -225,6 +245,18 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation, :config do
           when 1
             #
             b
+          when 2
+            # this is also accepted
+          end
+          case a
+          # this is accepted
+          in 0
+            # so is this
+          in 1
+            #
+            b
+          in 2
+            # this is also accepted
           end
       RUBY
     end


### PR DESCRIPTION
I'd like to allow the following code which uses pattern matching:

```ruby
case instruction
in :nop
  # do nothing
in :inc
  ret += 1
end
```

Before this patch, the indentation of "do nothing" comment is corrected to the same indent level as that of `in`, which is inconsistent with the indentation rule of `case ... when ... end`.

```console
$ ruby --version
ruby 3.3.1 (2024-04-23 revision c56cd86388) [x86_64-linux]
$ bundle show rubocop
/home/nek/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/rubocop-1.63.4
$ cat test.rb
case instruction
in :nop
  # do nothing
in :inc
  ret += 1
end
$ bundle exec rubocop test.rb --only Layout/CommentIndentation
Inspecting 1 file
C

Offenses:

test.rb:3:3: C: [Correctable] Layout/CommentIndentation: Incorrect indentation detected (column 2 instead of 0).
  # do nothing
  ^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense autocorrectable
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
    * No related issues
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
