### PR TITLE
Suppress `Interrupt` exception for LSP

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -57,6 +57,10 @@ module RuboCop
     rescue RuboCop::Error => e
       warn Rainbow("Error: #{e.message}").red
       STATUS_ERROR
+    rescue Interrupt
+      warn ''
+      warn 'Exiting...'
+      STATUS_INTERRUPTED
     rescue Finished
       STATUS_SUCCESS
     rescue OptionParser::InvalidOption => e


### PR DESCRIPTION
This PR suppresses the following backtrace of `Interrupt` exception for LSP:

## Before

```console
$ bundle exec rubocop --lsp
^C/Users/koic/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/language_server-protocol-3.17.0.3/
lib/language_server/protocol/transport/io/reader.rb:16:in 'IO#gets': Interrupt
from /Users/koic/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/language_server-protocol-3.17.0.3/
lib/language_server/protocol/transport/io/reader.rb:16:in 'LanguageServer::Protocol::Transport::Io::Reader#read'
        from /Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/lsp/server.rb:35:in 'RuboCop::LSP::Server#start'
(snip)
```

## After

```console
$ bundle exec rubocop --lsp
^C
Exiting...
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
