### PR TITLE
Fix docs for `Style/SpecialGlobalVars` `use_builtin_english_names`

### DIFF
--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -58,7 +58,7 @@ module RuboCop
       #
       # @example EnforcedStyle: use_builtin_english_names
       #
-      # Like `use_perl_names` but allows builtin global vars.
+      #   Like `use_perl_names` but allows builtin global vars.
       #
       #   # good
       #   puts $LOAD_PATH


### PR DESCRIPTION
The code block is currently empty and moved to the top (above the safety section), I assume because of the bad indentation. https://docs.rubocop.org/rubocop/cops_style.html#enforcedstyle-use_builtin_english_names

I didn't figure out how to build the docs locally. So this is a speculative fix on my part.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
