### PR TITLE
Make `Style/RedundantParentheses` allow parentheses in assignment

### DIFF
--- a/changelog/change_make_style_redundant_parentheses_allow_parentheses_in_assignment.md
+++ b/changelog/change_make_style_redundant_parentheses_allow_parentheses_in_assignment.md
@@ -1,0 +1,1 @@
+* [#12892](https://github.com/rubocop/rubocop/pull/12892): Make `Style/RedundantParentheses` allow parentheses around conditional expressions in assignment. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -5,6 +5,13 @@ module RuboCop
     module Style
       # Checks for redundant parentheses.
       #
+      # Parentheses are allowed in the following cases for readability:
+      #
+      # [source,ruby]
+      # ----
+      # var ||= (foo || bar)
+      # ----
+      #
       # @example
       #
       #   # bad
@@ -160,6 +167,7 @@ module RuboCop
             return if node.semantic_operator? && begin_node.parent
             return if node.multiline? && allow_in_multiline_conditions?
             return if ALLOWED_NODE_TYPES.include?(begin_node.parent&.type)
+            return if begin_node.parent&.assignment?
             return if begin_node.parent&.if_type? && begin_node.parent&.ternary?
 
             'a logical expression'

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -515,25 +515,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
-  it 'registers an offense when the use of parentheses around `&&` expressions in assignment' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when the use of parentheses around `&&` expressions in assignment' do
+    # Parentheses are redundant, but respect user's intentions for readability.
+    expect_no_offenses(<<~RUBY)
       var = (foo && bar)
-            ^^^^^^^^^^^^ Don't use parentheses around a logical expression.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      var = foo && bar
     RUBY
   end
 
-  it 'registers an offense when the use of parentheses around `||` expressions in assignment' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when the use of parentheses around `||` expressions in assignment' do
+    # Parentheses are redundant, but respect user's intentions for readability.
+    expect_no_offenses(<<~RUBY)
       var = (foo || bar)
-            ^^^^^^^^^^^^ Don't use parentheses around a logical expression.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      var = foo || bar
     RUBY
   end
 


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/12511#issuecomment-1852817131.

This PR makes `Style/RedundantParentheses` allow parentheses around conditional expressions in assignment to respect user's intentions for readability:

```ruby
var = (foo || bar)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
