### PR TITLE
[Fix #11585] Support `AllowedMethods` for `Style/DocumentationMethod`

### DIFF
--- a/changelog/new_support_allowed_methods_for_style_documentation_method.md
+++ b/changelog/new_support_allowed_methods_for_style_documentation_method.md
@@ -1,0 +1,1 @@
+* [#11585](https://github.com/rubocop/rubocop/issues/11585): Support `AllowedMethods` for `Style/DocumentationMethod`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3687,6 +3687,7 @@ Style/DocumentationMethod:
   Description: 'Checks for missing documentation comment for public methods.'
   Enabled: false
   VersionAdded: '0.43'
+  AllowedMethods: []
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'

--- a/lib/rubocop/cop/style/documentation_method.rb
+++ b/lib/rubocop/cop/style/documentation_method.rb
@@ -95,6 +95,17 @@ module RuboCop
       #     end
       #   end
       #
+      # @example AllowedMethods: ['method_missing', 'respond_to_missing?']
+      #
+      #    # good
+      #    class Foo
+      #      def method_missing(name, *args)
+      #      end
+      #
+      #      def respond_to_missing?(symbol, include_private)
+      #      end
+      #    end
+      #
       class DocumentationMethod < Base
         include DocumentationComment
         include DefNode
@@ -119,12 +130,21 @@ module RuboCop
         def check(node)
           return if non_public?(node) && !require_for_non_public_methods?
           return if documentation_comment?(node)
+          return if method_allowed?(node)
 
           add_offense(node)
         end
 
         def require_for_non_public_methods?
           cop_config['RequireForNonPublicMethods']
+        end
+
+        def method_allowed?(node)
+          allowed_methods.include?(node.method_name)
+        end
+
+        def allowed_methods
+          @allowed_methods ||= cop_config.fetch('AllowedMethods', []).map(&:to_sym)
         end
       end
     end

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -993,6 +993,19 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
           end
         end
       end
+
+      describe 'when AllowedMethods is configured' do
+        before { config['Style/DocumentationMethod'] = { 'AllowedMethods' => ['method_missing'] } }
+
+        it 'ignores the methods in the config' do
+          expect_no_offenses(<<~RUBY)
+            class Foo
+              def method_missing(name, *args)
+              end
+            end
+          RUBY
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #11585.

This PR supports `AllowedMethods` for `Style/DocumentationMethod`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
