### PR TITLE
[Fix #7189] Fix a false positive for `Style/Copyright`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_copyright.md
+++ b/changelog/fix_a_false_positive_for_style_copyright.md
@@ -1,0 +1,1 @@
+* [#7189](https://github.com/rubocop/rubocop/issues/7189): Fix a false positive for `Style/Copyright` when using multiline copyright notice. ([@koic][])

--- a/spec/rubocop/cop/style/copyright_spec.rb
+++ b/spec/rubocop/cop/style/copyright_spec.rb
@@ -32,6 +32,59 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
     RUBY
   end
 
+  context 'when multiline copyright notice' do
+    let(:cop_config) do
+      {
+        'Notice' => <<~'COPYRIGHT'
+          Copyright (\(c\) )?2015 Acme Inc.
+
+          License details\.\.\.
+        COPYRIGHT
+      }
+    end
+
+    it 'does not register an offense when the multiline copyright notice is present' do
+      cop_config['AutocorrectNotice'] = <<~COPYRIGHT
+        # Copyright (c) 2015 Acme Inc.
+        #
+        # License details...
+      COPYRIGHT
+
+      expect_no_offenses(<<~RUBY)
+        # Copyright 2015 Acme Inc.
+        #
+        # License details...
+        class Foo
+        end
+      RUBY
+    end
+
+    it 'registers an offense when the multiline copyright notice is missing' do
+      cop_config['AutocorrectNotice'] = <<~COPYRIGHT
+        # Copyright (c) 2015 Acme Inc.
+        #
+        # License details...
+      COPYRIGHT
+
+      expect_offense(<<~RUBY)
+        # Comment
+        ^ Include a copyright notice matching [...]
+        class Foo
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # Copyright (c) 2015 Acme Inc.
+        #
+        # License details...
+
+        # Comment
+        class Foo
+        end
+      RUBY
+    end
+  end
+
   context 'when the copyright notice is missing' do
     let(:source) { <<~RUBY }
       # test


### PR DESCRIPTION
Fixes #7189.

This PR fixes a false positive for `Style/Copyright` when using multiline copyright notice.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
