### PR TITLE
[Fix #12894] Fix false positives for `Style/MapIntoArray`

### DIFF
--- a/changelog/fix_false_positives_for_style_map_into_array.md
+++ b/changelog/fix_false_positives_for_style_map_into_array.md
@@ -1,0 +1,1 @@
+* [#12894](https://github.com/rubocop/rubocop/issues/12894): Fix false positives for `Style/MapIntoArray` when using `each` without receiver with `<<` to build an array. ([@koic][])

--- a/lib/rubocop/cop/style/map_into_array.rb
+++ b/lib/rubocop/cop/style/map_into_array.rb
@@ -57,7 +57,7 @@ module RuboCop
         def_node_matcher :each_block_with_push?, <<-PATTERN
           [
             ^({begin kwbegin} ...)
-            ({block numblock} (send _ :each) _
+            ({block numblock} (send !{nil? self} :each) _
               (send (lvar _) {:<< :push :append} _))
           ]
         PATTERN

--- a/spec/rubocop/cop/style/map_into_array_spec.rb
+++ b/spec/rubocop/cop/style/map_into_array_spec.rb
@@ -147,6 +147,20 @@ RSpec.describe RuboCop::Cop::Style::MapIntoArray, :config do
     RUBY
   end
 
+  it 'does not register an offense and corrects when using `each` without receiver with `<<` to build an array' do
+    expect_no_offenses(<<~RUBY)
+      dest = []
+      each { |e| dest << e * 2 }
+    RUBY
+  end
+
+  it 'does not register an offense and corrects when using `each` with `self` receiver with `<<` to build an array' do
+    expect_no_offenses(<<~RUBY)
+      dest = []
+      self.each { |e| dest << e * 2 }
+    RUBY
+  end
+
   it 'does not register an offense when the parent node of an `each` call is not a begin node' do
     expect_no_offenses(<<~RUBY)
       [


### PR DESCRIPTION
Fixes #12894.

This PR fixes false positives for `Style/MapIntoArray` when using `each` without receiver with `<<` to build an array.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
