### PR TITLE
Respect user's intentions with `workspace/executeCommand` LSP method

### DIFF
--- a/changelog/change_update_workspace_execute_command_lsp_method.md
+++ b/changelog/change_update_workspace_execute_command_lsp_method.md
@@ -1,0 +1,1 @@
+* [#12897](https://github.com/rubocop/rubocop/pull/12897): Respect user's intentions with `workspace/executeCommand` LSP method. ([@koic][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -601,7 +601,9 @@ Style/PerlBackrefs:
   AutoCorrect: contextual
 ----
 
-This setting prevents autocorrection during editing in the editor.
+This setting prevents autocorrection during editing in the editor. e.g, with `textDocument/formatting` LSP method.
+However `workspace/executeCommand` LSP method, which is triggered by intentional user actions, respects the user's intention for autocorrection.
+
 Additionally, for cases like `Metrics` cops where the highlight range extends over the entire body of classes, modules, methods, or blocks
 offending range will be confined to only name. This approach helps to avoid redundant and noisy offenses in editor display.
 

--- a/docs/modules/ROOT/pages/usage/lsp.adoc
+++ b/docs/modules/ROOT/pages/usage/lsp.adoc
@@ -290,6 +290,7 @@ NOTE: `rubocop --lsp` is for starting LSP client, so users don't manually execut
 RuboCop provides APIs for developers of original language server or tools analogous to LSP, using RuboCop as the backend, instead of the RuboCop's built-in LSP.
 
 - `RuboCop::LSP.enable` enables LSP mode, customizing for LSP-specific features such as autocorrection and short offense message.
-- `RuboCop::LSP.disable` disables LSP mode, which can be particularly useful for testing.
+- `RuboCop::LSP.disable` disables LSP mode, which can be particularly useful for testing. And intentional autocorrection by the user can be specified.
+e.g, `workspace/executeCommand` and `textDocument/codeAction` LSP methods.
 
 When implementing custom cops, `RuboCop::LSP.enabled?` can be used to achieve behavior that considers these states.

--- a/lib/rubocop/lsp.rb
+++ b/lib/rubocop/lsp.rb
@@ -22,8 +22,15 @@ module RuboCop
     # Disable LSP.
     #
     # @return [void]
-    def disable
-      @enabled = false
+    def disable(&block)
+      if block
+        original = @enabled
+        @enabled = false
+        yield
+        @enabled = original
+      else
+        @enabled = false
+      end
     end
   end
 end

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -125,6 +125,12 @@ module RuboCop
         end
 
         uri = request[:params][:arguments][0][:uri]
+        formatted = nil
+
+        # The `workspace/executeCommand` is an LSP method triggered by intentional user actions,
+        # so the user's intention for autocorrection is respected.
+        LSP.disable { formatted = format_file(uri, command: command) }
+
         @server.write(
           id: request[:id],
           method: 'workspace/applyEdit',
@@ -132,7 +138,7 @@ module RuboCop
             label: label,
             edit: {
               changes: {
-                uri => format_file(uri, command: command)
+                uri => formatted
               }
             }
           }

--- a/spec/rubocop/lsp_spec.rb
+++ b/spec/rubocop/lsp_spec.rb
@@ -17,5 +17,37 @@ RSpec.describe RuboCop::LSP, :lsp do
         expect(described_class.enabled?).to be(false)
       end
     end
+
+    context 'when `RuboCop::LSP.disable` with block is called after `RuboCop::LSP.enable`' do
+      before do
+        described_class.enable
+        described_class.disable { @inner = described_class.enabled? }
+        @outer = described_class.enabled?
+      end
+
+      it 'returns false within block' do
+        expect(@inner).to be(false) # rubocop:disable RSpec/InstanceVariable
+      end
+
+      it 'returns true without block' do
+        expect(@outer).to be(true) # rubocop:disable RSpec/InstanceVariable
+      end
+    end
+
+    context 'when `RuboCop::LSP.disable` with block is called after `RuboCop::LSP.disable`' do
+      before do
+        described_class.disable
+        described_class.disable { @inner = described_class.enabled? }
+        @outer = described_class.enabled?
+      end
+
+      it 'returns false within block' do
+        expect(@inner).to be(false) # rubocop:disable RSpec/InstanceVariable
+      end
+
+      it 'returns false without block' do
+        expect(@outer).to be(false) # rubocop:disable RSpec/InstanceVariable
+      end
+    end
   end
 end


### PR DESCRIPTION
Context: https://github.com/Shopify/ruby-lsp/pull/1453#issuecomment-1980179500

The `workspace/executeCommand` is an LSP method triggered by intentional user actions, so the user's intention for autocorrection is respected.

It has not yet been implemented in RuboCop's built-in LSP, but the same could be said for `textDocument/codeAction` LSP method, which might be implemented in the future.

This change slightly alters the behavior of `AutoCorrect: contextual` when using LSP (or the `--editor-mode` option), and this has been documented accordingly.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
