### PR TITLE
[Fix #12898] Fix parsing of `TargetRailsVersion` for prerelases

### DIFF
--- a/changelog/fix_target_rails_version_for_prereleases.md
+++ b/changelog/fix_target_rails_version_for_prereleases.md
@@ -1,0 +1,1 @@
+* [#12898](https://github.com/rubocop/rubocop/issues/12898): Fix an error for `TargetRailsVersion` when parsing from the lockfile with prerelease rails. ([@earlopain][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -319,9 +319,8 @@ module RuboCop
     # @param [Gem::Version] gem_version an object like `Gem::Version.new("7.1.2.3")`
     # @return [Float] The major and minor version, like `7.1`
     def gem_version_to_major_minor_float(gem_version)
-      segments = gem_version.canonical_segments
-      # segments.fetch(0).to_f + (segments.fetch(1, 0.0).to_f / 10)
-      Float("#{segments.fetch(0)}.#{segments.fetch(1, 0)}")
+      segments = gem_version.segments
+      Float("#{segments[0]}.#{segments[1]}")
     end
 
     # @returns [Hash{String => Gem::Version}] The locked gem versions, keyed by the gems' names.


### PR DESCRIPTION
`canonical_segments` removes trailing zeroes, which is also why there's this `fetch(1, 0)`.

```rb
Gem::Version.new("7.0.0").canonical_segments
=> [7]
Gem::Version.new("8.0.0.alpha").canonical_segments
=> [8, "alpha"]
```

The `segments` method seems to do exactly what we want:

```rb
Gem::Version.new("7.0.0").segments
=> [7, 0, 0]
Gem::Version.new("8.0.0.alpha").segments
=> [8, 0, 0, "alpha"]
```

Taking the first two entries will always work.

-------

I've started adding some tests for this since there were absolutely none here beforehand. I understand that this rails-specific stuff should eventually be moved to `rubocop-rails`, but until then lets ensure everything works as expected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
