### PR TITLE
[Fix #12876] Fix lockfile parsing if only the gemfile exists

### DIFF
--- a/changelog/fix_lockfile_parser_without_lockfile.md
+++ b/changelog/fix_lockfile_parser_without_lockfile.md
@@ -1,0 +1,1 @@
+* [#12876](https://github.com/rubocop/rubocop/issues/12876): Fix an error for the lockfile parser if a gemfile exists but a lockfile doesn't. ([@earlopain][])

--- a/lib/rubocop/lockfile.rb
+++ b/lib/rubocop/lockfile.rb
@@ -72,7 +72,7 @@ module RuboCop
     def parser
       return @parser if defined?(@parser)
 
-      @parser = if @lockfile_path && bundler_lock_parser_defined?
+      @parser = if @lockfile_path && File.exist?(@lockfile_path) && bundler_lock_parser_defined?
                   begin
                     lockfile = ::Bundler.read_file(@lockfile_path)
                     ::Bundler::LockfileParser.new(lockfile) if lockfile

--- a/spec/rubocop/lockfile_spec.rb
+++ b/spec/rubocop/lockfile_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe RuboCop::Lockfile, :isolated_environment do
 
       it { is_expected.to eq([]) }
     end
+
+    context 'when there is a gemfile without lockfile' do
+      let(:lockfile) { nil }
+
+      before do
+        allow(Bundler).to receive(:default_lockfile).and_return('Gemfile.lock')
+        create_file('Gemfile', <<~GEMFILE)
+          gem 'rubocop', '~> 1.65.0'
+        GEMFILE
+      end
+
+      it { is_expected.to eq([]) }
+    end
   end
 
   describe '#dependencies' do


### PR DESCRIPTION
Fixes #12876

If a gemfile exists a lockfile path will be returned, even if no lockfile exists.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
