### PR TITLE
[Fix #11436] Add new `consistent_either` `SupportedShorthandSyntax` to `Style/HashSyntax`

### DIFF
--- a/changelog/new_add_new_consistent_either.md
+++ b/changelog/new_add_new_consistent_either.md
@@ -1,1 +1,1 @@
-* [#12904](https://github.com/rubocop/rubocop/pull/12904): Add new `consistent_either` `SupportedShorthandSyntax` to `Style/HashSyntax`. ([@pawelma][])
+* [#12904](https://github.com/rubocop/rubocop/pull/12904): Add new `either_consistent` `SupportedShorthandSyntax` to `Style/HashSyntax`. ([@pawelma][])

--- a/changelog/new_add_new_consistent_either.md
+++ b/changelog/new_add_new_consistent_either.md
@@ -1,0 +1,1 @@
+* [#12904](https://github.com/rubocop/rubocop/pull/12904): Add new `consistent_either` `SupportedShorthandSyntax` to `Style/HashSyntax`. ([@pawelma][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4068,6 +4068,8 @@ Style/HashSyntax:
     - either
     # forces use of the 3.1 syntax only if all values can be omitted in the hash.
     - consistent
+    # allow either (implicit or explicit) syntax but enforce consistency within a single hash
+    - consistent_either
   # Force hashes that have a symbol value to use hash rockets
   UseHashRocketsWithSymbolValues: false
   # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style

--- a/config/default.yml
+++ b/config/default.yml
@@ -4069,7 +4069,7 @@ Style/HashSyntax:
     # forces use of the 3.1 syntax only if all values can be omitted in the hash.
     - consistent
     # allow either (implicit or explicit) syntax but enforce consistency within a single hash
-    - consistent_either
+    - either_consistent
   # Force hashes that have a symbol value to use hash rockets
   UseHashRocketsWithSymbolValues: false
   # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -173,7 +173,7 @@ module RuboCop
         hash_value_type_breakdown[:value_needed]&.any?
       end
 
-      def ignore_explicit_ommitable_hash_shorthand_syntax?(hash_value_type_breakdown)
+      def ignore_explicit_omissible_hash_shorthand_syntax?(hash_value_type_breakdown)
         hash_value_type_breakdown.keys == [:value_omittable] &&
           enforced_shorthand_syntax == 'consistent_either'
       end
@@ -204,7 +204,7 @@ module RuboCop
 
       def no_mixed_shorthand_syntax_check(hash_value_type_breakdown)
         return if hash_with_values_that_cant_be_omitted?(hash_value_type_breakdown)
-        return if ignore_explicit_ommitable_hash_shorthand_syntax?(hash_value_type_breakdown)
+        return if ignore_explicit_omissible_hash_shorthand_syntax?(hash_value_type_breakdown)
 
         each_omittable_value_pair(hash_value_type_breakdown) do |pair_node|
           hash_key_source = pair_node.key.source

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -68,13 +68,13 @@ module RuboCop
 
       def ignore_mixed_hash_shorthand_syntax?(hash_node)
         target_ruby_version <= 3.0 ||
-          !%w[consistent consistent_either].include?(enforced_shorthand_syntax) ||
+          !%w[consistent either_consistent].include?(enforced_shorthand_syntax) ||
           !hash_node.hash_type?
       end
 
       def ignore_hash_shorthand_syntax?(pair_node)
         target_ruby_version <= 3.0 || enforced_shorthand_syntax == 'either' ||
-          %w[consistent consistent_either].include?(enforced_shorthand_syntax) ||
+          %w[consistent either_consistent].include?(enforced_shorthand_syntax) ||
           !pair_node.parent.hash_type?
       end
 
@@ -175,7 +175,7 @@ module RuboCop
 
       def ignore_explicit_omissible_hash_shorthand_syntax?(hash_value_type_breakdown)
         hash_value_type_breakdown.keys == [:value_omittable] &&
-          enforced_shorthand_syntax == 'consistent_either'
+          enforced_shorthand_syntax == 'either_consistent'
       end
 
       def each_omitted_value_pair(hash_value_type_breakdown, &block)

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -29,6 +29,8 @@ module RuboCop
       # * never - forces use of explicit hash literal value
       # * either - accepts both shorthand and explicit use of hash literal value
       # * consistent - forces use of the 3.1 syntax only if all values can be omitted in the hash
+      # * consistent_either - accepts both shorthand and explicit use of hash literal value,
+      #                       but they must be consistent
       #
       # @example EnforcedStyle: ruby19 (default)
       #   # bad
@@ -110,6 +112,22 @@ module RuboCop
       #   # good - can't omit `baz`
       #   {foo: foo, bar: baz}
       #
+      # @example EnforcedShorthandSyntax: consistent_either
+      #
+      #   # good - `foo` and `bar` values can be omitted, but they are consistent, so it's accepted
+      #   {foo: foo, bar: bar}
+      #
+      #   # bad - `bar` value can be omitted
+      #   {foo:, bar: bar}
+      #
+      #   # bad - mixed syntaxes
+      #   {foo:, bar: baz}
+      #
+      #   # good
+      #   {foo:, bar:}
+      #
+      #   # good - can't omit `baz`
+      #   {foo: foo, bar: baz}
       class HashSyntax < Base
         include ConfigurableEnforcedStyle
         include HashShorthandSyntax

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -29,7 +29,7 @@ module RuboCop
       # * never - forces use of explicit hash literal value
       # * either - accepts both shorthand and explicit use of hash literal value
       # * consistent - forces use of the 3.1 syntax only if all values can be omitted in the hash
-      # * consistent_either - accepts both shorthand and explicit use of hash literal value,
+      # * either_consistent - accepts both shorthand and explicit use of hash literal value,
       #                       but they must be consistent
       #
       # @example EnforcedStyle: ruby19 (default)
@@ -112,7 +112,7 @@ module RuboCop
       #   # good - can't omit `baz`
       #   {foo: foo, bar: baz}
       #
-      # @example EnforcedShorthandSyntax: consistent_either
+      # @example EnforcedShorthandSyntax: either_consistent
       #
       #   # good - `foo` and `bar` values can be omitted, but they are consistent, so it's accepted
       #   {foo: foo, bar: bar}

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -1465,7 +1465,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           .to eq(<<~YAML)
             # Configuration parameters: EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
             # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-            # SupportedShorthandSyntax: always, never, either, consistent
+            # SupportedShorthandSyntax: always, never, either, consistent, consistent_either
             Style/HashSyntax:
               EnforcedStyle: hash_rockets
           YAML
@@ -1479,7 +1479,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           .to eq(<<~YAML)
             # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
             # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-            # SupportedShorthandSyntax: always, never, either, consistent
+            # SupportedShorthandSyntax: always, never, either, consistent, consistent_either
             Style/HashSyntax:
               Exclude:
                 - 'example1.rb'
@@ -1496,7 +1496,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           .to eq(<<~YAML)
             # Configuration parameters: EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
             # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-            # SupportedShorthandSyntax: always, never, either, consistent
+            # SupportedShorthandSyntax: always, never, either, consistent, consistent_either
             Style/HashSyntax:
               Exclude:
                 - 'example1.rb'
@@ -1511,7 +1511,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           .to eq(<<~YAML)
             # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
             # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-            # SupportedShorthandSyntax: always, never, either, consistent
+            # SupportedShorthandSyntax: always, never, either, consistent, consistent_either
             Style/HashSyntax:
               Exclude:
                 - 'example1.rb'
@@ -1548,7 +1548,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           .to eq(<<~YAML)
             # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
             # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-            # SupportedShorthandSyntax: always, never, either, consistent
+            # SupportedShorthandSyntax: always, never, either, consistent, consistent_either
             Style/HashSyntax:
               Exclude:
                 - 'example1.rb'

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -1465,7 +1465,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           .to eq(<<~YAML)
             # Configuration parameters: EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
             # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-            # SupportedShorthandSyntax: always, never, either, consistent, consistent_either
+            # SupportedShorthandSyntax: always, never, either, consistent, either_consistent
             Style/HashSyntax:
               EnforcedStyle: hash_rockets
           YAML
@@ -1479,7 +1479,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           .to eq(<<~YAML)
             # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
             # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-            # SupportedShorthandSyntax: always, never, either, consistent, consistent_either
+            # SupportedShorthandSyntax: always, never, either, consistent, either_consistent
             Style/HashSyntax:
               Exclude:
                 - 'example1.rb'
@@ -1496,7 +1496,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           .to eq(<<~YAML)
             # Configuration parameters: EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
             # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-            # SupportedShorthandSyntax: always, never, either, consistent, consistent_either
+            # SupportedShorthandSyntax: always, never, either, consistent, either_consistent
             Style/HashSyntax:
               Exclude:
                 - 'example1.rb'
@@ -1511,7 +1511,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           .to eq(<<~YAML)
             # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
             # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-            # SupportedShorthandSyntax: always, never, either, consistent, consistent_either
+            # SupportedShorthandSyntax: always, never, either, consistent, either_consistent
             Style/HashSyntax:
               Exclude:
                 - 'example1.rb'
@@ -1548,7 +1548,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           .to eq(<<~YAML)
             # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
             # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-            # SupportedShorthandSyntax: always, never, either, consistent, consistent_either
+            # SupportedShorthandSyntax: always, never, either, consistent, either_consistent
             Style/HashSyntax:
               Exclude:
                 - 'example1.rb'

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1683,7 +1683,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       {
         'EnforcedStyle' => 'ruby19',
         'SupportedStyles' => %w[ruby19 hash_rockets],
-        'EnforcedShorthandSyntax' => 'consistent_either'
+        'EnforcedShorthandSyntax' => 'either_consistent'
       }
     end
 

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1606,7 +1606,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
     end
   end
 
-  context 'configured to disallow mixing of implicit and explicit hash literal value' do
+  context 'configured to disallow mixing of implicit and explicit hash literal value, but prefers shorthand syntax whenever possible' do
     let(:cop_config) do
       {
         'EnforcedStyle' => 'ruby19',
@@ -1671,6 +1671,72 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
 
     context 'Ruby <= 3.0', :ruby30, unsupported_on: :prism do
       it 'does not register an offense when all hash key and hash values are the same' do
+        expect_no_offenses(<<~RUBY)
+          {foo: foo, bar: bar}
+        RUBY
+      end
+    end
+  end
+
+  context 'configured to disallow mixing of implicit and explicit hash literal value' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'ruby19',
+        'SupportedStyles' => %w[ruby19 hash_rockets],
+        'EnforcedShorthandSyntax' => 'consistent_either'
+      }
+    end
+
+    context 'Ruby >= 3.1', :ruby31 do
+      it 'does not register an offense when all hash values are omitted' do
+        expect_no_offenses(<<~RUBY)
+          {foo:, bar:}
+        RUBY
+      end
+
+      it 'registers an offense when some hash values are omitted but they can all be omitted' do
+        expect_offense(<<~RUBY)
+          {foo:, bar: bar}
+                      ^^^ Do not mix explicit and implicit hash values. Omit the hash value.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {foo:, bar:}
+        RUBY
+      end
+
+      it 'registers an offense when some hash values are omitted but they cannot all be omitted' do
+        expect_offense(<<~RUBY)
+          {foo:, bar: baz}
+           ^^^ Do not mix explicit and implicit hash values. Include the hash value.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {foo: foo, bar: baz}
+        RUBY
+      end
+
+      it 'does not register an offense when all hash values are present, but no values can be omitted' do
+        expect_no_offenses(<<~RUBY)
+          {foo: bar, bar: foo}
+        RUBY
+      end
+
+      it 'does not register an offense when all hash values are present, but only some values can be omitted' do
+        expect_no_offenses(<<~RUBY)
+          {foo: baz, bar: bar}
+        RUBY
+      end
+
+      it 'does not register an offense when all hash values are present, but can all be omitted' do
+        expect_no_offenses(<<~RUBY)
+          {foo: foo, bar: bar}
+        RUBY
+      end
+    end
+
+    context 'Ruby <= 3.0', :ruby30, unsupported_on: :prism do
+      it 'does not register an offense when hash key and hash value are the same' do
         expect_no_offenses(<<~RUBY)
           {foo: foo, bar: bar}
         RUBY


### PR DESCRIPTION
Related to feature request: https://github.com/rubocop/rubocop/issues/11436
Based on: https://github.com/rubocop/rubocop/pull/10776

# WHAT

This commit adds a new `consistent_either` option to `EnforcedShorthandSyntax` in `Style/HashSyntax`.

This allows to use both explicit and shorthand syntax, similarly to existing `either` option, but with the difference that it enforces consistency within a single hash.

This PR extends existing `consistent` option, and skips the `no_mixed_shorthand_syntax_check` offences when all values in the hash are ommitable.

```diff
@example EnforcedShorthandSyntax: consistent_either

+  # good - `foo` and `bar` values can be omitted, but they are consistent, so it's accepted
+ {foo: foo, bar: bar}

-  # bad - `bar` value can be omitted
-  {foo:, bar: bar}

-  # bad - mixed syntaxes
-  {foo:, bar: baz}

+  # good
+  {foo:, bar:}
  
+  # good - can't omit `baz`
+  {foo: foo, bar: baz}
```

<details>

<summary>bundle exec rake default - output</summary>

```
bundle exec rake default
Files:         681
Modules:        92 (   13 undocumented)
Classes:       643 (    4 undocumented)
Constants:    1171 ( 1155 undocumented)
Attributes:     37 (    0 undocumented)
Methods:      1480 ( 1291 undocumented)
 28.05% documented
/Users/pawel.madejski/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/parser-3.3.1.0/lib/parser/builders/default.rb:2266: warning: regular expression has redundant nested repeat operator '+': /(?:x+)+/
/Users/pawel.madejski/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/parser-3.3.1.0/lib/parser/builders/default.rb:2266: warning: nested repeat operator '+' and '?' was replaced with '*' in regular expression: /(?:x+)?/
Starting test-queue master (/tmp/test_queue_62161_14840.sock)

==> Summary (10 workers in 110.4666s)

    [ 1]                            136 examples, 0 failures         1 suites in 110.4388s      (pid 62344 exit 0 )
    [ 2]                              9 examples, 0 failures         1 suites in 110.4381s      (pid 62345 exit 0 )
    [ 3]                            122 examples, 0 failures         1 suites in 110.4376s      (pid 62346 exit 0 )
    [ 4]                           2189 examples, 0 failures       103 suites in 110.4364s      (pid 62347 exit 0 )
    [ 5]                            119 examples, 0 failures         1 suites in 110.4375s      (pid 62348 exit 0 )
    [ 6]                           3745 examples, 0 failures       111 suites in 110.4375s      (pid 62349 exit 0 )
    [ 7]                           3377 examples, 0 failures       109 suites in 110.4383s      (pid 62350 exit 0 )
    [ 8]                           4569 examples, 0 failures       116 suites in 110.4392s      (pid 62351 exit 0 )
    [ 9]                           3997 examples, 0 failures       110 suites in 110.4377s      (pid 62352 exit 0 )
    [10]                4014 examples, 1 pending, 0 failures       117 suites in 110.4368s      (pid 62353 exit 0 )

PARSER_ENGINE=parser_prism bundle exec rake spec
Starting test-queue master (/tmp/test_queue_62664_5220.sock)

==> Summary (10 workers in 106.6212s)

    [ 1]                           3244 examples, 0 failures       109 suites in 35.3706s      (pid 62671 exit 0 )
    [ 2]                            122 examples, 0 failures         1 suites in 39.7622s      (pid 62672 exit 0 )
    [ 3]                            136 examples, 0 failures         1 suites in 106.5994s      (pid 62673 exit 0 )
    [ 4]                              9 examples, 0 failures         1 suites in 106.5998s      (pid 62674 exit 0 )
    [ 5]                            119 examples, 0 failures         1 suites in 106.6000s      (pid 62675 exit 0 )
    [ 6]                           2274 examples, 0 failures       102 suites in 106.5998s      (pid 62676 exit 0 )
    [ 7]                3827 examples, 1 pending, 0 failures       115 suites in 106.6022s      (pid 62677 exit 0 )
    [ 8]                           3530 examples, 0 failures       112 suites in 106.6020s      (pid 62678 exit 0 )
    [ 9]                           4008 examples, 0 failures       111 suites in 106.6021s      (pid 62680 exit 0 )
    [10]                           4393 examples, 0 failures       117 suites in 106.6007s      (pid 62681 exit 0 )

Running RuboCop...
Inspecting 1536 files
................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

1536 files inspected, no offenses detected
```

</details>

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
