### PR TITLE
Support `AllCops:ActiveSupportExtensionsEnabled` for `Style/SymbolProc`

### DIFF
--- a/changelog/change_support_active_support_extensions_enabled_for_style_symbol_proc.md
+++ b/changelog/change_support_active_support_extensions_enabled_for_style_symbol_proc.md
@@ -1,0 +1,1 @@
+* [#12890](https://github.com/rubocop/rubocop/issues/12890): Support `ActiveSupportExtensionsEnabled` for `Style/SymbolProc`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5449,7 +5449,7 @@ Style/SymbolProc:
   Enabled: true
   Safe: false
   VersionAdded: '0.26'
-  VersionChanged: '1.40'
+  VersionChanged: '<<next>>'
   AllowMethodsWithArguments: false
   # A list of method names to be always allowed by the check.
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -43,13 +43,13 @@ module RuboCop
             types.map do |type|
               case type
               when :array
-                ->(node) { node.array_type? }
+                lambda(&:array_type?)
               when :hash
-                ->(node) { node.hash_type? }
+                lambda(&:hash_type?)
               when :heredoc
                 ->(node) { heredoc_node?(node) }
               when :method_call
-                ->(node) { node.call_type? }
+                lambda(&:call_type?)
               else
                 raise Warning, "Unknown foldable type: #{type.inspect}. " \
                                "Valid foldable types are: #{FOLDABLE_TYPES.join(', ')}."

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
     RUBY
   end
 
+  it 'registers an offense for a block with parameterless method call on param and no space between method name and opening brace' do
+    expect_offense(<<~RUBY)
+      foo.map{ |a| a.nil? }
+             ^^^^^^^^^^^^^^ Pass `&:nil?` as an argument to `map` instead of a block.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.map(&:nil?)
+    RUBY
+  end
+
   it 'registers an offense for safe navigation operator' do
     expect_offense(<<~RUBY)
       coll&.map { |e| e.upcase }
@@ -38,20 +49,76 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
     expect_no_offenses('something { |x, y| x.method }')
   end
 
-  it 'accepts lambda with 1 argument' do
-    expect_no_offenses('->(x) { x.method }')
+  context 'when `AllCops/ActiveSupportExtensionsEnabled: true`' do
+    let(:config) do
+      RuboCop::Config.new('AllCops' => { 'ActiveSupportExtensionsEnabled' => true })
+    end
+
+    it 'accepts lambda with 1 argument' do
+      expect_no_offenses('->(x) { x.method }')
+    end
+
+    it 'accepts proc with 1 argument' do
+      expect_no_offenses('proc { |x| x.method }')
+    end
+
+    it 'accepts Proc.new with 1 argument' do
+      expect_no_offenses('Proc.new { |x| x.method }')
+    end
+
+    it 'accepts ::Proc.new with 1 argument' do
+      expect_no_offenses('::Proc.new { |x| x.method }')
+    end
   end
 
-  it 'accepts proc with 1 argument' do
-    expect_no_offenses('proc { |x| x.method }')
-  end
+  context 'when `AllCops/ActiveSupportExtensionsEnabled: false`' do
+    let(:config) do
+      RuboCop::Config.new('AllCops' => { 'ActiveSupportExtensionsEnabled' => false })
+    end
 
-  it 'accepts Proc.new with 1 argument' do
-    expect_no_offenses('Proc.new { |x| x.method }')
-  end
+    it 'registers lambda `->` with 1 argument' do
+      expect_offense(<<~RUBY)
+        ->(x) { x.method }
+              ^^^^^^^^^^^^ Pass `&:method` as an argument to `lambda` instead of a block.
+      RUBY
 
-  it 'accepts ::Proc.new with 1 argument' do
-    expect_no_offenses('::Proc.new { |x| x.method }')
+      expect_correction(<<~RUBY)
+        lambda(&:method)
+      RUBY
+    end
+
+    it 'registers proc with 1 argument' do
+      expect_offense(<<~RUBY)
+        proc { |x| x.method }
+             ^^^^^^^^^^^^^^^^ Pass `&:method` as an argument to `proc` instead of a block.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        proc(&:method)
+      RUBY
+    end
+
+    it 'registers Proc.new with 1 argument' do
+      expect_offense(<<~RUBY)
+        Proc.new { |x| x.method }
+                 ^^^^^^^^^^^^^^^^ Pass `&:method` as an argument to `new` instead of a block.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Proc.new(&:method)
+      RUBY
+    end
+
+    it 'registers ::Proc.new with 1 argument' do
+      expect_offense(<<~RUBY)
+        ::Proc.new { |x| x.method }
+                   ^^^^^^^^^^^^^^^^ Pass `&:method` as an argument to `new` instead of a block.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ::Proc.new(&:method)
+      RUBY
+    end
   end
 
   context 'when AllowedMethods is enabled' do
@@ -412,24 +479,86 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
       expect_no_offenses('something { _1 + _2 }')
     end
 
-    it 'accepts lambda with 1 numbered parameter' do
-      expect_no_offenses('-> { _1.method }')
+    context 'when `AllCops/ActiveSupportExtensionsEnabled: true`' do
+      let(:config) do
+        RuboCop::Config.new('AllCops' => { 'ActiveSupportExtensionsEnabled' => true })
+      end
+
+      it 'accepts lambda with 1 numbered parameter' do
+        expect_no_offenses('-> { _1.method }')
+      end
+
+      it 'accepts proc with 1 numbered parameter' do
+        expect_no_offenses('proc { _1.method }')
+      end
+
+      it 'accepts block with only second numbered parameter' do
+        expect_no_offenses('something { _2.first }')
+      end
+
+      it 'accepts Proc.new with 1 numbered parameter' do
+        expect_no_offenses('Proc.new { _1.method }')
+      end
+
+      it 'accepts ::Proc.new with 1 numbered parameter' do
+        expect_no_offenses('::Proc.new { _1.method }')
+      end
     end
 
-    it 'accepts proc with 1 numbered parameter' do
-      expect_no_offenses('proc { _1.method }')
-    end
+    context 'when `AllCops/ActiveSupportExtensionsEnabled: false`' do
+      let(:config) do
+        RuboCop::Config.new('AllCops' => { 'ActiveSupportExtensionsEnabled' => false })
+      end
 
-    it 'accepts block with only second numbered parameter' do
-      expect_no_offenses('something { _2.first }')
-    end
+      it 'registers lambda with 1 numbered parameter' do
+        expect_offense(<<~RUBY)
+          -> { _1.method }
+             ^^^^^^^^^^^^^ Pass `&:method` as an argument to `lambda` instead of a block.
+        RUBY
 
-    it 'accepts Proc.new with 1 numbered parameter' do
-      expect_no_offenses('Proc.new { _1.method }')
-    end
+        expect_correction(<<~RUBY)
+          lambda(&:method)
+        RUBY
+      end
 
-    it 'accepts ::Proc.new with 1 numbered parameter' do
-      expect_no_offenses('::Proc.new { _1.method }')
+      it 'registers proc with 1 numbered parameter' do
+        expect_offense(<<~RUBY)
+          proc { _1.method }
+               ^^^^^^^^^^^^^ Pass `&:method` as an argument to `proc` instead of a block.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          proc(&:method)
+        RUBY
+      end
+
+      it 'does not register block with only second numbered parameter' do
+        expect_no_offenses(<<~RUBY)
+          something { _2.first }
+        RUBY
+      end
+
+      it 'registers Proc.new with 1 numbered parameter' do
+        expect_offense(<<~RUBY)
+          Proc.new { _1.method }
+                   ^^^^^^^^^^^^^ Pass `&:method` as an argument to `new` instead of a block.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Proc.new(&:method)
+        RUBY
+      end
+
+      it 'registers ::Proc.new with 1 numbered parameter' do
+        expect_offense(<<~RUBY)
+          ::Proc.new { _1.method }
+                     ^^^^^^^^^^^^^ Pass `&:method` as an argument to `new` instead of a block.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          ::Proc.new(&:method)
+        RUBY
+      end
     end
 
     context 'AllowComments: true' do


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/commit/d39f07376d7928f7b6ee1df12cdba086cb552e5e.

This PR supports `AllCops:ActiveSupportExtensionsEnabled` instead of a TODO comment in `Style/SymbolProc` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
