### PR TITLE
[Fix #12884] Allow `cop_class.documentation_url` to take a config

### DIFF
--- a/changelog/change_allow_cop_documentation_url_to_take_config.md
+++ b/changelog/change_allow_cop_documentation_url_to_take_config.md
@@ -1,0 +1,1 @@
+* [#12884](https://github.com/rubocop/rubocop/issues/12884): Align output from `cop.documentation_url` with `--show-docs-url` when passing a config as argument. ([@earlopain][])

--- a/lib/rubocop/cli/command/show_docs_url.rb
+++ b/lib/rubocop/cli/command/show_docs_url.rb
@@ -26,10 +26,10 @@ module RuboCop
 
           cops_array.each do |cop_name|
             cop = registry_hash[cop_name]
-
             next if cop.empty?
 
-            puts Cop::Documentation.url_for(cop.first, @config)
+            url = Cop::Documentation.url_for(cop.first, @config)
+            puts url if url
           end
 
           puts

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -60,12 +60,15 @@ module RuboCop
         []
       end
 
-      # Cops (other than builtin) are encouraged to implement this
+      # Returns an url to view this cops documentation online.
+      # Requires 'DocumentationBaseURL' to be set for your department.
+      # Will follow the convention of RuboCops own documentation structure,
+      # overwrite this method to accommodate your custom layout.
       # @return [String, nil]
       #
       # @api public
-      def self.documentation_url
-        Documentation.url_for(self) if builtin?
+      def self.documentation_url(config = nil)
+        Documentation.url_for(self, config)
       end
 
       def self.inherited(subclass)
@@ -397,16 +400,6 @@ module RuboCop
       end
 
       ### Actually private methods
-
-      # rubocop:disable Layout/ClassStructure
-      def self.builtin?
-        return false unless (m = instance_methods(false).first) # any custom method will do
-
-        path, _line = instance_method(m).source_location
-        path.start_with?(__dir__)
-      end
-      private_class_method :builtin?
-      # rubocop:enable Layout/ClassStructure
 
       def reset_investigation
         @currently_disabled_lines = @current_offenses = @processed_source = @current_corrector = nil

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1488,6 +1488,38 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
           RESULT
         end
       end
+
+      context 'with a custom cop without DocumentationBaseURL specified' do
+        let(:arguments) { ['Layout/IndentationStyle,Test/AlignmentDirective'] }
+
+        it 'skips the cop without documentation url' do
+          cmd
+          expect(stdout).to eq(<<~RESULT)
+            https://docs.rubocop.org/rubocop/cops_layout.html#layoutindentationstyle
+
+          RESULT
+        end
+      end
+
+      context 'with a custom cop with DocumentationBaseURL specified' do
+        let(:arguments) { ['Layout/IndentationStyle,Test/AlignmentDirective'] }
+
+        before do
+          create_file('.rubocop.yml', <<~YAML)
+            Test:
+              DocumentationBaseURL: https://example.com
+          YAML
+        end
+
+        it 'builds the doc urls' do
+          cmd
+          expect(stdout).to eq(<<~RESULT)
+            https://docs.rubocop.org/rubocop/cops_layout.html#layoutindentationstyle
+            https://example.com/cops_test.html#testalignmentdirective
+
+          RESULT
+        end
+      end
     end
   end
 

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -49,18 +49,49 @@ RSpec.describe RuboCop::Cop::Cop, :config do
   end
 
   describe '.documentation_url' do
-    subject(:url) { cop_class.documentation_url }
+    context 'without passing a config' do
+      subject(:url) { cop_class.documentation_url }
 
-    describe 'for a builtin cop class' do
-      let(:cop_class) { RuboCop::Cop::Layout::BlockEndNewline }
+      describe 'for a builtin cop class' do
+        let(:cop_class) { RuboCop::Cop::Layout::BlockEndNewline }
 
-      it { is_expected.to eq 'https://docs.rubocop.org/rubocop/cops_layout.html#layoutblockendnewline' } # rubocop:disable Layout/LineLength
+        it { is_expected.to eq 'https://docs.rubocop.org/rubocop/cops_layout.html#layoutblockendnewline' } # rubocop:disable Layout/LineLength
+      end
+
+      describe 'for a custom cop class without DocumentationBaseURL', :restore_registry do
+        let(:cop_class) { stub_cop_class('Some::Cop') { def foo; end } }
+
+        it { is_expected.to be_nil }
+      end
     end
 
-    describe 'for a custom cop class', :restore_registry do
-      let(:cop_class) { stub_cop_class('Some::Cop') { def foo; end } }
+    context 'when passing a config' do
+      subject(:url) { cop_class.documentation_url(config) }
 
-      it { is_expected.to be_nil }
+      describe 'for a builtin cop class' do
+        let(:cop_class) { RuboCop::Cop::Layout::BlockEndNewline }
+
+        it { is_expected.to eq 'https://docs.rubocop.org/rubocop/cops_layout.html#layoutblockendnewline' } # rubocop:disable Layout/LineLength
+      end
+
+      describe 'for a custom cop class without DocumentationBaseURL', :restore_registry do
+        let(:cop_class) { stub_cop_class('Some::Cop') { def foo; end } }
+
+        it { is_expected.to be_nil }
+      end
+
+      describe 'for a custom cop class with DocumentationBaseURL', :restore_registry do
+        let(:cop_class) { stub_cop_class('Rails::Exit') { def foo; end } }
+        let(:config) do
+          RuboCop::Config.new(
+            'Rails' => {
+              'DocumentationBaseURL' => 'https://docs.rubocop.org/rubocop-rails'
+            }
+          )
+        end
+
+        it { is_expected.to eq 'https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsexit' }
+      end
     end
   end
 


### PR DESCRIPTION
Fix #12884 (almost). It requires passing in a config object but that seems ok to require.

The current implementation is not very useful to consumers since it requires every extension to overwrite this method.
No official extension currenty does that.

The behaviour of `--show-docs-url` is almost what's required. It takes a config to construct this url and returns correct results for all official extensions.

The url it provides falls back to the default RuboCop docs url which is undesirable in all cases I can think about. That behaviour has been removed. No 3rd-party extension cops will be found on the RuboCop docs website. Only buildin cops will be found there.

All extensions that provide `DocumentationBaseURL` will now have result returned by `documentation_url` without needing to do something themselves (as long as proper config object is passed in)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
