### PR TITLE
Also suggest rubocop-rspec for those using rspec-rails

### DIFF
--- a/changelog/change_add_back_rubocop_rspec_to_suggested_extensions.md
+++ b/changelog/change_add_back_rubocop_rspec_to_suggested_extensions.md
@@ -1,0 +1,1 @@
+* [#12908](https://github.com/rubocop/rubocop/pull/12908): Add rubocop-rspec back to suggested extensions when rspec-rails is in use. ([@pirj][])

--- a/changelog/changelog/change_add_back_rubocop_rspec_to_suggested_extensions.md
+++ b/changelog/changelog/change_add_back_rubocop_rspec_to_suggested_extensions.md
@@ -1,1 +1,0 @@
-* [#12908](https://github.com/rubocop/rubocop/pull/12908): Add rubocop-rspec back to suggested extensions when rspec-rails is in use. ([@pirj][])

--- a/changelog/changelog/change_add_back_rubocop_rspec_to_suggested_extensions.md
+++ b/changelog/changelog/change_add_back_rubocop_rspec_to_suggested_extensions.md
@@ -1,0 +1,1 @@
+* [#12908](https://github.com/rubocop/rubocop/pull/12908): Add rubocop-rspec back to suggested extensions when rspec-rails is in use. ([@pirj][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -156,7 +156,7 @@ AllCops:
   # included.
   SuggestExtensions:
     rubocop-rails: [rails]
-    rubocop-rspec: [rspec]
+    rubocop-rspec: [rspec, rspec-rails]
     rubocop-minitest: [minitest]
     rubocop-sequel: [sequel]
     rubocop-rake: [rake]


### PR DESCRIPTION
rubocop-rspec_rails provides rspec-rails specific cops, but generic rspec cops still apply, as rspec-rails depends on rspec (core, expectations and mocks)

This partially reverts #12813 

Also see https://github.com/rubocop/rubocop-rspec_rails/issues/28

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
