### PR TITLE
Use the latest Prism for development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,7 @@ gem 'memory_profiler', platform: :mri
 # https://github.com/lsegal/yard/pull/1545
 # Please remove this dependency when the issue is resolved.
 gem 'ostruct'
-# FIXME: This is a workaround for incompatibilities between Prism 0.25.0 and 0.26.0.
-# To upgrade to Prism 0.26+, it is necessary to investigate the following build error
-# and provide feedback to Prism:
-# https://github.com/rubocop/rubocop/actions/runs/8748485587/job/24008584735?pr=12855
-gem 'prism', '0.25.0'
+gem 'prism'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.21.0'

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -117,9 +117,10 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
+  # FIXME: https://github.com/rubocop/rubocop/issues/12869
   it 'registers an offense and corrects a next guard clause not followed by ' \
      'empty line when guard clause is after heredoc ' \
-     'including string interpolation' do
+     'including string interpolation', broken_on: :prism do
     expect_offense(<<~'RUBY')
       raise(<<-FAIL) unless true
         #{1 + 1}
@@ -458,7 +459,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  it 'accepts a guard clause that is after a multiline heredoc with chained calls' do
+  # FIXME: https://github.com/rubocop/rubocop/issues/12869
+  it 'accepts a guard clause that is after a multiline heredoc with chained calls', broken_on: :prism do
     expect_no_offenses(<<~RUBY)
       def foo
         raise ArgumentError, <<~END.squish.it.good unless guard
@@ -471,7 +473,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  it 'accepts a guard clause that is after a multiline heredoc nested argument call' do
+  # FIXME: https://github.com/rubocop/rubocop/issues/12869
+  it 'accepts a guard clause that is after a multiline heredoc nested argument call', broken_on: :prism do
     expect_no_offenses(<<~RUBY)
       def foo
         raise ArgumentError, call(<<~END.squish) unless guard
@@ -570,7 +573,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     end
   end
 
-  it 'registers no offenses using heredoc with `and return` before guard condition with empty line' do
+  # FIXME: https://github.com/rubocop/rubocop/issues/12869
+  it 'registers no offenses using heredoc with `and return` before guard condition with empty line', broken_on: :prism do
     expect_no_offenses(<<~RUBY)
       def foo
         puts(<<~MSG) and return if bar
@@ -583,7 +587,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects using heredoc with `and return` before guard condition' do
+  # FIXME: https://github.com/rubocop/rubocop/issues/12869
+  it 'registers an offense and corrects using heredoc with `and return` before guard condition', broken_on: :prism do
     expect_offense(<<~RUBY)
       def foo
         puts(<<~MSG) and return if bar

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -259,7 +259,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
     context 'and only certain heredoc delimiters are permitted' do
       let(:cop_config) { { 'Max' => 80, 'AllowHeredoc' => %w[SQL OK], 'AllowedPatterns' => [] } }
 
-      it 'rejects long lines in heredocs with not permitted delimiters' do
+      # FIXME: https://github.com/rubocop/rubocop/issues/12869
+      it 'rejects long lines in heredocs with not permitted delimiters', broken_on: :prism do
         expect_offense(<<-RUBY)
           foo(<<-DOC, <<-SQL, <<-FOO)
             1st offense: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.


### PR DESCRIPTION
This PR usees the latest Prism for development.

Tests that fail due to Prism use `broken_on: :prism` to indicate unresolved issues. This clarifies which tests have issues caused by Prism.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
