### PR TITLE
Update `Lint/Void` to recognize more nonmutating methods

### DIFF
--- a/changelog/change_lint_void_to_recognize_more_nonmutating_methods.md
+++ b/changelog/change_lint_void_to_recognize_more_nonmutating_methods.md
@@ -1,0 +1,1 @@
+* [#12913](https://github.com/rubocop/rubocop/pull/12913): Update `Lint/Void` to recognize ActiveSupport nonmutating methods when `CheckForMethodsWithNoSideEffects: true`. ([@vlad-pisanov][])

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -372,6 +372,44 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         42
       RUBY
     end
+
+    context 'when using ActiveSupport extensions' do
+      let(:config) do
+        RuboCop::Config.new(
+          'Lint/Void' => { 'CheckForMethodsWithNoSideEffects' => true },
+          'AllCops' => { 'ActiveSupportExtensionsEnabled' => true }
+        )
+      end
+
+      it 'registers an offense for ActiveSupport-specific methods' do
+        expect_offense(<<~RUBY)
+          x.deep_stringify_keys
+          ^^^^^^^^^^^^^^^^^^^^^ Method `#deep_stringify_keys` used in void context. Did you mean `#deep_stringify_keys!`?
+          top(x)
+        RUBY
+
+        expect_correction(<<~RUBY)
+          x.deep_stringify_keys!
+          top(x)
+        RUBY
+      end
+    end
+
+    context 'when not using ActiveSupport extensions' do
+      let(:config) do
+        RuboCop::Config.new(
+          'Lint/Void' => { 'CheckForMethodsWithNoSideEffects' => true },
+          'AllCops' => { 'ActiveSupportExtensionsEnabled' => false }
+        )
+      end
+
+      it 'does not register an offense for ActiveSupport-specific methods' do
+        expect_no_offenses(<<~RUBY)
+          x.deep_stringify_keys
+          top(x)
+        RUBY
+      end
+    end
   end
 
   context 'when not checking for methods with no side effects' do


### PR DESCRIPTION
Update `Lint/Void` to recognize more nonmutating methods when the `CheckForMethodsWithNoSideEffects` option is used.

This PR adds one (now)-native `transform_keys` method, and about a dozen common ActiveSupport methods such as `stringify_keys`, `compact_blank` and `squish`.

The ActiveSupport methods are only recognized when `AllCops/ActiveSupportExtensionsEnabled: true` (such as in a Rails project)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
