### PR TITLE
Fix a false negative for `Layout/EmptyComment`

### DIFF
--- a/changelog/fix_false_negative_for_layout_empty_comment.md
+++ b/changelog/fix_false_negative_for_layout_empty_comment.md
@@ -1,0 +1,1 @@
+* [#12914](https://github.com/rubocop/rubocop/pull/12914): Fix a false negative for `Layout/EmptyComment` when using an empty comment next to code after comment line. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_comment.rb
+++ b/lib/rubocop/cop/layout/empty_comment.rb
@@ -106,7 +106,9 @@ module RuboCop
         end
 
         def concat_consecutive_comments(comments)
-          consecutive_comments = comments.chunk_while { |i, j| i.loc.line.succ == j.loc.line }
+          consecutive_comments = comments.chunk_while do |i, j|
+            i.loc.line.succ == j.loc.line && i.loc.column == j.loc.column
+          end
 
           consecutive_comments.map do |chunk|
             joined_text = chunk.map { |c| comment_text(c) }.join

--- a/spec/rubocop/cop/layout/empty_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_comment_spec.rb
@@ -38,6 +38,23 @@ RSpec.describe RuboCop::Cop::Layout::EmptyComment, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using an empty comment next to code after comment line' do
+    expect_offense(<<~RUBY)
+      # comment
+      def foo #
+              ^ Source code comment is empty.
+        something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # comment
+      def foo
+        something
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using comment text' do
     expect_no_offenses(<<~RUBY)
       # Description of `Foo` class.


### PR DESCRIPTION
This PR fixes a false negative for `Layout/EmptyComment` when using an empty comment next to code after comment line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
