### PR TITLE
Remove warnings during tests when overwriting encoding

### DIFF
--- a/spec/rubocop/cop/layout/end_of_line_spec.rb
+++ b/spec/rubocop/cop/layout/end_of_line_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
+  include EncodingHelper
+
   shared_examples 'all configurations' do
     it 'accepts an empty file' do
       expect_no_offenses('')
@@ -93,10 +95,7 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
 
     context 'and the default external encoding is US_ASCII' do
       around do |example|
-        orig_encoding = Encoding.default_external
-        Encoding.default_external = Encoding::US_ASCII
-        example.run
-        Encoding.default_external = orig_encoding
+        with_default_external_encoding(Encoding::US_ASCII) { example.run }
       end
 
       it 'does not crash on UTF-8 encoded non-ascii characters' do
@@ -155,10 +154,7 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
 
     context 'and the default external encoding is US_ASCII' do
       around do |example|
-        orig_encoding = Encoding.default_external
-        Encoding.default_external = Encoding::US_ASCII
-        example.run
-        Encoding.default_external = orig_encoding
+        with_default_external_encoding(Encoding::US_ASCII) { example.run }
       end
 
       it 'does not crash on UTF-8 encoded non-ascii characters' do

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -3,6 +3,8 @@
 require 'timeout'
 
 RSpec.describe RuboCop::Cop::Style::WordArray, :config do
+  include EncodingHelper
+
   before do
     # Reset data which is shared by all instances of WordArray
     described_class.largest_brackets = -Float::INFINITY
@@ -60,10 +62,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
 
     context 'when the default external encoding is UTF-8' do
       around do |example|
-        orig_encoding = Encoding.default_external
-        Encoding.default_external = Encoding::UTF_8
-        example.run
-        Encoding.default_external = orig_encoding
+        with_default_external_encoding(Encoding::UTF_8) { example.run }
       end
 
       it 'registers an offense for arrays of unicode word characters' do
@@ -80,10 +79,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
 
     context 'when the default external encoding is US-ASCII' do
       around do |example|
-        orig_encoding = Encoding.default_external
-        Encoding.default_external = Encoding::US_ASCII
-        example.run
-        Encoding.default_external = orig_encoding
+        with_default_external_encoding(Encoding::US_ASCII) { example.run }
       end
 
       it 'registers an offense for arrays of unicode word characters' do

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::ResultCache, :isolated_environment do
+  include EncodingHelper
   include FileHelper
 
   subject(:cache) { described_class.new(file, team, options, config_store, cache_root) }
@@ -296,9 +297,9 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
         end
       end
 
-      before { Encoding.default_internal = Encoding::UTF_8 }
-
-      after { Encoding.default_internal = nil }
+      around do |example|
+        with_default_internal_encoding(Encoding::UTF_8) { example.run }
+      end
 
       it 'writes non UTF-8 encodable data to file with no exception' do
         expect { cache.save(offenses) }.not_to raise_error

--- a/spec/support/encoding_helper.rb
+++ b/spec/support/encoding_helper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Overwrite the default internal/external encoding for the duration of a block.
+# Ruby discourages this by emitting a warning when modifying, these helpers exist
+# to suppress these warnings during tests.
+module EncodingHelper
+  def with_default_internal_encoding(encoding)
+    orig_encoding = Encoding.default_internal
+    RuboCop::Util.silence_warnings { Encoding.default_internal = encoding }
+    yield
+  ensure
+    RuboCop::Util.silence_warnings { Encoding.default_internal = orig_encoding }
+  end
+
+  def with_default_external_encoding(encoding)
+    orig_encoding = Encoding.default_external
+    RuboCop::Util.silence_warnings { Encoding.default_external = encoding }
+    yield
+  ensure
+    RuboCop::Util.silence_warnings { Encoding.default_external = orig_encoding }
+  end
+end


### PR DESCRIPTION
Just setting this is enough to emit a warning:
> warning: setting Encoding.default_internal

Use helpers to set internal/external encoding for the duration of a block without emitting these warnings.

Part of #12910

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
