### PR TITLE
Remove redundant method overwrite in spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,15 +64,3 @@ RSpec.configure do |config|
   # Prism supports Ruby 3.3+ parsing.
   config.filter_run_excluding unsupported_on: :prism if ENV['PARSER_ENGINE'] == 'parser_prism'
 end
-
-module ::RSpec
-  module Core
-    class ExampleGroup
-      # Override `failure_count` from test-queue to prevent RSpec deprecation notice
-      # Treating `metadata[:execution_result]` as a hash is deprecated.
-      def self.failure_count
-        examples.map { |e| e.execution_result.status == 'failed' }.length
-      end
-    end
-  end
-end


### PR DESCRIPTION
These implementations are now identical since at least https://github.com/tmm1/test-queue/pull/124

> /home/user/Documents/rubocop/spec/spec_helper.rb:73: warning: method redefined; discarding old failure_count
/home/user/rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/test-queue-0.11.1/lib/test_queue/runner/rspec_ext.rb:4: warning: previous definition of failure_count was here

https://github.com/tmm1/test-queue/blob/e1674e1ec49e76cbbf68d83d2bc03aef83ce4e68/lib/test_queue/runner/rspec_ext.rb#L5

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
