### PR TITLE
Suggest correct formatter name

### DIFF
--- a/changelog/new_suggest_correct_formatter_name.md
+++ b/changelog/new_suggest_correct_formatter_name.md
@@ -1,0 +1,1 @@
+* [#12917](https://github.com/rubocop/rubocop/pull/12917): Suggest correct formatter name for `--format` command line option. ([@koic][])

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -27,6 +27,7 @@ module RuboCop
         '[t]ap'         => 'TapFormatter',
         '[w]orst'       => 'WorstOffendersFormatter'
       }.freeze
+      BUILTIN_FORMATTER_NAMES = BUILTIN_FORMATTERS_FOR_KEYS.keys.map { |key| key.delete('[]') }
 
       FORMATTER_APIS = %i[started finished].freeze
 
@@ -88,7 +89,12 @@ module RuboCop
           /^\[#{specified_key}\]/.match?(key) || specified_key == key.delete('[]')
         end
 
-        raise %(No formatter for "#{specified_key}") if matching_keys.empty?
+        if matching_keys.empty?
+          similar_name = NameSimilarity.find_similar_name(specified_key, BUILTIN_FORMATTER_NAMES)
+          suggestion = %( Did you mean? "#{similar_name}") if similar_name
+
+          raise Rainbow(%(Formatter "#{specified_key}" not found.#{suggestion})).red
+        end
 
         raise %(Cannot determine formatter for "#{specified_key}") if matching_keys.size > 1
 

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1715,7 +1715,16 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       context 'when unknown format name is specified' do
         it 'aborts with error message' do
           expect(cli.run(['--format', 'unknown', 'example.rb'])).to eq(2)
-          expect($stderr.string.include?('No formatter for "unknown"')).to be(true)
+          expect($stderr.string.include?('Formatter "unknown" not found')).to be(true)
+        end
+      end
+
+      context 'when wrong similar format name is specified' do
+        it 'aborts with error message' do
+          expect(cli.run(['--format', 'quite', 'example.rb'])).to eq(2)
+          expect(
+            $stderr.string.include?('Formatter "quite" not found. Did you mean? "quiet"')
+          ).to be(true)
         end
       end
     end


### PR DESCRIPTION
This PR suggests correct formatter name when wrong similar format name is specified.

## Before

```console
$ bundle exec rubocop --format=quite
No formatter for "quite"
(snip)
```

## After

```console
$ bundle exec rubocop --format=quite
Formatter "quite" not formatter. Did you mean? "quiet"
(snip)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
