### PR TITLE
[Fix #12919] Fix false negatives for `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/fix_false_negatives_for_style_arguments_forwarding.md
+++ b/changelog/fix_false_negatives_for_style_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#12919](https://github.com/rubocop/rubocop/issues/12919): Fix false negatives for `Style/ArgumentsForwarding` when forward target is `super`. ([@koic][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -29,6 +29,8 @@ module RuboCop
       #
       # Names not on this list are likely to be meaningful and are allowed by default.
       #
+      # This cop handles not only method forwarding but also forwarding to `super`.
+      #
       # @example
       #   # bad
       #   def foo(*args, &block)
@@ -146,7 +148,7 @@ module RuboCop
 
           restarg, kwrestarg, blockarg = extract_forwardable_args(node.arguments)
           forwardable_args = redundant_forwardable_named_args(restarg, kwrestarg, blockarg)
-          send_nodes = node.each_descendant(:send).to_a
+          send_nodes = node.each_descendant(:send, :super).to_a
 
           send_classifications = classify_send_nodes(
             node, send_nodes, non_splat_or_block_pass_lvar_references(node.body), forwardable_args

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -664,6 +664,22 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
+    it 'registers an offense if an additional positional parameter is present in `super`', :ruby30 do
+      expect_offense(<<~RUBY)
+        def method_missing(m, *args, **kwargs, &block)
+                              ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+          super(m, *args, **kwargs, &block)
+                   ^^^^^^^^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def method_missing(m, ...)
+          super(m, ...)
+        end
+      RUBY
+    end
+
     it 'does not register an offense if kwargs are forwarded with a positional parameter', unsupported_on: :prism do
       expect_no_offenses(<<~RUBY)
         def foo(m, **kwargs, &block)
@@ -1461,6 +1477,24 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       expect_correction(<<~RUBY)
         def foo(m, *, &)
           bar(*, m, &)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when args are forwarded with a positional parameter last in `super`' do
+      expect_offense(<<~RUBY)
+        def foo(m, *args, &block)
+                   ^^^^^ Use anonymous positional arguments forwarding (`*`).
+                          ^^^^^^ Use anonymous block arguments forwarding (`&`).
+          super(*args, m, &block)
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
+                          ^^^^^^ Use anonymous block arguments forwarding (`&`).
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(m, *, &)
+          super(*, m, &)
         end
       RUBY
     end


### PR DESCRIPTION
Fixes #12919.

This PR fixes false negatives for `Style/ArgumentsForwarding` when forward target is `super`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
