### PR TITLE
[Fix #12924] Fix false positives for `Style/SendWithLiteralMethodName`

### DIFF
--- a/changelog/fix_false_positives_for_style_send_with_literal_method_name.md
+++ b/changelog/fix_false_positives_for_style_send_with_literal_method_name.md
@@ -1,0 +1,1 @@
+* [#12924](https://github.com/rubocop/rubocop/issues/12924): Fix false positives for `Style/SendWithLiteralMethodName` when `public_send` argument is a method name that cannot be autocorrected. ([@koic][])

--- a/lib/rubocop/cop/style/send_with_literal_method_name.rb
+++ b/lib/rubocop/cop/style/send_with_literal_method_name.rb
@@ -43,8 +43,14 @@ module RuboCop
         MSG = 'Use `%<method_name>s` method call directly instead.'
         RESTRICT_ON_SEND = %i[public_send send __send__].freeze
         STATIC_METHOD_NAME_NODE_TYPES = %i[sym str].freeze
+        METHOD_NAME_PATTERN = /\A[a-zA-Z_][a-zA-Z0-9_]*[!?=]?\z/.freeze
+        RESERVED_WORDS = %i[
+          BEGIN END alias and begin break case class def defined? do else elsif end ensure
+          false for if in module next nil not or redo rescue retry return self super then true
+          undef unless until when while yield
+        ].freeze
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_send(node)
           return if allow_send? && !node.method?(:public_send)
           return unless (first_argument = node.first_argument)
@@ -52,6 +58,7 @@ module RuboCop
 
           offense_range = offense_range(node)
           method_name = first_argument.value
+          return if !METHOD_NAME_PATTERN.match?(method_name) || RESERVED_WORDS.include?(method_name)
 
           add_offense(offense_range, message: format(MSG, method_name: method_name)) do |corrector|
             if node.arguments.one?
@@ -62,7 +69,7 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         private
 

--- a/spec/rubocop/cop/style/send_with_literal_method_name_spec.rb
+++ b/spec/rubocop/cop/style/send_with_literal_method_name_spec.rb
@@ -56,6 +56,17 @@ RSpec.describe RuboCop::Cop::Style::SendWithLiteralMethodName, :config do
     RUBY
   end
 
+  it 'registers an offense when using `public_send` with method name with underscore' do
+    expect_offense(<<~RUBY)
+      obj.public_send("name_with_underscore")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `name_with_underscore` method call directly instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      obj.name_with_underscore
+    RUBY
+  end
+
   it 'does not register an offense when using `public_send` with variable argument' do
     expect_no_offenses(<<~RUBY)
       obj.public_send(variable)
@@ -66,6 +77,38 @@ RSpec.describe RuboCop::Cop::Style::SendWithLiteralMethodName, :config do
     expect_no_offenses(<<~'RUBY')
       obj.public_send("#{interpolated}string")
     RUBY
+  end
+
+  it 'does not register an offense when using `public_send` with method name with space' do
+    expect_no_offenses(<<~RUBY)
+      obj.public_send("name with space")
+    RUBY
+  end
+
+  it 'does not register an offense when using `public_send` with method name with hyphen' do
+    expect_no_offenses(<<~RUBY)
+      obj.public_send("name-with-hyphen")
+    RUBY
+  end
+
+  it 'does not register an offense when using `public_send` with method name with brackets' do
+    expect_no_offenses(<<~RUBY)
+      obj.public_send("{brackets}")
+    RUBY
+  end
+
+  it 'does not register an offense when using `public_send` with method name with square brackets' do
+    expect_no_offenses(<<~RUBY)
+      obj.public_send("[square_brackets]")
+    RUBY
+  end
+
+  it 'does not register an offense when using `public_send` with reserved word argument' do
+    described_class::RESERVED_WORDS.each do |reserved_word|
+      expect_no_offenses(<<~RUBY)
+        obj.public_send(:#{reserved_word})
+      RUBY
+    end
   end
 
   it 'does not register an offense when using `public_send` with integer literal argument' do


### PR DESCRIPTION
Fixes #12924.

This PR fixes false positives for `Style/SendWithLiteralMethodName` when `public_send` argument is a method name that cannot be autocorrected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
