### PR TITLE
[Fix #12926] Fix false positive for `Style/SuperArguments`

### DIFF
--- a/changelog/fix_false_positive_for_super_arguments.md
+++ b/changelog/fix_false_positive_for_super_arguments.md
@@ -1,0 +1,1 @@
+* [#12926](https://github.com/rubocop/rubocop/issues/12926): Fix a false positive for `Style/SuperArguments` when the methods block argument is reassigned before `super`. ([@earlopain][])

--- a/spec/rubocop/cop/style/super_arguments_spec.rb
+++ b/spec/rubocop/cop/style/super_arguments_spec.rb
@@ -217,4 +217,35 @@ RSpec.describe RuboCop::Cop::Style::SuperArguments, :config do
       end
     RUBY
   end
+
+  context 'block reassignment' do
+    it 'registers no offense when the block argument is reassigned' do
+      expect_no_offenses(<<~RUBY)
+        def test(&blk)
+          blk = proc {}
+          super(&blk)
+        end
+      RUBY
+    end
+
+    it 'registers no offense when the block argument is reassigned in a nested block' do
+      expect_no_offenses(<<~RUBY)
+        def test(&blk)
+          if foo
+            blk = proc {} if bar
+          end
+          super(&blk)
+        end
+      RUBY
+    end
+
+    it 'registers no offense when the block argument is or-assigned' do
+      expect_no_offenses(<<~RUBY)
+        def test(&blk)
+          blk ||= proc {}
+          super(&blk)
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #12926. The following snippet demonstrates the issue:

```rb
class A
  def positional_arg(a)
    puts a
  end

  def block_arg(&block)
    yield
  end
end

class B < A
  def positional_arg(a = nil)
    a = 'b'
    super
  end

  def block_arg(&block)
    block = proc { puts 'b' }
    super
  end
end

B.new.positional_arg('a')
B.new.positional_arg
B.new.block_arg { puts 'a' }
B.new.block_arg
```

Modifying a methods block argument passes along the original block to `super`.

This fix is overly defensive and will miss some cases that could be autocorrected. This however would make this very complicated:

```rb
def foo(&blk)
  super
  blk = proc {} # Technically fine
end
```

The same goes for nested method definitions

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
