### PR TITLE
Fix error message when exception occurs during force callback

### DIFF
--- a/lib/rubocop/cop/force.rb
+++ b/lib/rubocop/cop/force.rb
@@ -4,6 +4,16 @@ module RuboCop
   module Cop
     # A scaffold for concrete forces.
     class Force
+      # @api private
+      class HookError < StandardError
+        attr_reader :joining_cop
+
+        def initialize(joining_cop)
+          super
+          @joining_cop = joining_cop
+        end
+      end
+
       attr_reader :cops
 
       def self.all
@@ -32,6 +42,8 @@ module RuboCop
           next unless cop.respond_to?(method_name)
 
           cop.public_send(method_name, *args)
+        rescue StandardError
+          raise HookError, cop
         end
       end
 

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -240,6 +240,8 @@ module RuboCop
 
           if cause.is_a?(Warning)
             handle_warning(cause, location)
+          elsif cause.is_a?(Force::HookError)
+            handle_error(cause.cause, location, cause.joining_cop)
           else
             handle_error(cause, location, error.cop)
           end

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -188,6 +188,30 @@ RSpec.describe RuboCop::Cop::Team do
       end
     end
 
+    context 'when a cops joining forces callback raises an error' do
+      include_context 'mock console output'
+      before do
+        allow_any_instance_of(RuboCop::Cop::Lint::ShadowedArgument)
+          .to receive(:after_leaving_scope).and_raise(exception_message)
+
+        create_file(file_path, 'foo { |bar| bar = 42 }')
+      end
+
+      let(:options) { { debug: true } }
+      let(:exception_message) { 'my message' }
+      let(:error_message) do
+        'An error occurred while Lint/ShadowedArgument cop was inspecting example.rb.'
+      end
+
+      it 'records Team#errors' do
+        team.inspect_file(source)
+
+        expect(team.errors).to eq([error_message])
+        expect($stderr.string.include?(error_message)).to be(true)
+        expect($stdout.string.include?(exception_message)).to be(true)
+      end
+    end
+
     context 'when a correction raises an error' do
       include_context 'mock console output'
 


### PR DESCRIPTION
When a cop errors during a force callback, the following message would be logged:
> An error occurred while VariableForce cop was inspecting

This is not very helpful to figure out what is going on. Catch this error and package the cop into it so that it can later be unpacked to show the cop that is erroring.

Before:

```
An error occurred while VariableForce cop was inspecting /home/earlopain/Documents/rubocop/test.rb.
I'm broken!
/home/earlopain/Documents/rubocop/lib/rubocop/cop/lint/shadowed_argument.rb:77:in `after_leaving_scope'
/home/earlopain/Documents/rubocop/lib/rubocop/cop/force.rb:34:in `public_send'
...
```

After:

```
An error occurred while Lint/ShadowedArgument cop was inspecting /home/earlopain/Documents/rubocop/test.rb.
I'm broken!
/home/earlopain/Documents/rubocop/lib/rubocop/cop/lint/shadowed_argument.rb:77:in `after_leaving_scope'
/home/earlopain/Documents/rubocop/lib/rubocop/cop/force.rb:44:in `public_send'
...
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
