### PR TITLE
Fix end position of diagnostic for LSP

### DIFF
--- a/changelog/fix_end_position_of_diagnostic_for_lsp.md
+++ b/changelog/fix_end_position_of_diagnostic_for_lsp.md
@@ -1,0 +1,1 @@
+* [#12932](https://github.com/rubocop/rubocop/pull/12932): Fix end position of diagnostic for LSP. ([@ksss][])

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -235,7 +235,7 @@ module RuboCop
       def to_range(location)
         {
           start: { character: location[:start_column] - 1, line: location[:start_line] - 1 },
-          end: { character: location[:last_column] - 1, line: location[:last_line] - 1 }
+          end: { character: location[:last_column], line: location[:last_line] - 1 }
         }
       end
     end

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
               code: 'Style/FrozenStringLiteralComment',
               message: 'Missing frozen string literal comment.',
               range: {
-                start: { character: 0, line: 0 }, end: { character: 0, line: 0 }
+                start: { character: 0, line: 0 }, end: { character: 1, line: 0 }
               },
               severity: 3,
               source: 'rubocop'
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
               code: 'Layout/SpaceInsideArrayLiteralBrackets',
               message: 'Do not use space inside array brackets.',
               range: {
-                start: { character: 4, line: 2 }, end: { character: 5, line: 2 }
+                start: { character: 4, line: 2 }, end: { character: 6, line: 2 }
               },
               severity: 3,
               source: 'rubocop'


### PR DESCRIPTION
I noticed that the diagnostics were always one character short when using vscode-rubocop, so I fixed it.

`character` of `Position` is zero-based
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position
> Character offset on a line in a document (zero-based).

And, `Parser::Source::Range` is also zero-based
https://github.com/whitequark/parser/blob/3e260d2e37bcb3de8705489d1c2799c26c7a2215/lib/parser/source/range.rb#L104
> zero-based column number of the end of this range.

Therefore, `-1` is not necessary.

# Operation check on VSCode (with [vscode-rubocop](https://github.com/rubocop/vscode-rubocop))


<details>

<summary>rubocop output json</summary>

demo.rb

```rb
require "rubocop"

class Foo
  def foo
    variable = 1
      b = 2
  end
end
```

```console
$ bundle exec rubocop -f json demo.rb 2>/dev/null | jq
```

```json
{
  "metadata": {
    "rubocop_version": "1.64.0",
    "ruby_engine": "ruby",
    "ruby_version": "3.3.1",
    "ruby_patchlevel": "55",
    "ruby_platform": "arm64-darwin22"
  },
  "files": [
    {
      "path": "demo.rb",
      "offenses": [
        {
          "severity": "convention",
          "message": "Missing frozen string literal comment.",
          "cop_name": "Style/FrozenStringLiteralComment",
          "corrected": false,
          "correctable": true,
          "location": {
            "start_line": 1,
            "start_column": 1,
            "last_line": 1,
            "last_column": 1,
            "length": 1,
            "line": 1,
            "column": 1
          }
        },
        {
          "severity": "convention",
          "message": "Missing top-level documentation comment for `class Foo`.",
          "cop_name": "Style/Documentation",
          "corrected": false,
          "correctable": false,
          "location": {
            "start_line": 3,
            "start_column": 1,
            "last_line": 3,
            "last_column": 9,
            "length": 9,
            "line": 3,
            "column": 1
          }
        },
        {
          "severity": "warning",
          "message": "Useless assignment to variable - `variable`.",
          "cop_name": "Lint/UselessAssignment",
          "corrected": false,
          "correctable": true,
          "location": {
            "start_line": 5,
            "start_column": 5,
            "last_line": 5,
            "last_column": 12,
            "length": 8,
            "line": 5,
            "column": 5
          }
        },
        {
          "severity": "convention",
          "message": "Inconsistent indentation detected.",
          "cop_name": "Layout/IndentationConsistency",
          "corrected": false,
          "correctable": true,
          "location": {
            "start_line": 6,
            "start_column": 7,
            "last_line": 6,
            "last_column": 11,
            "length": 5,
            "line": 6,
            "column": 7
          }
        },
        {
          "severity": "warning",
          "message": "Useless assignment to variable - `b`.",
          "cop_name": "Lint/UselessAssignment",
          "corrected": false,
          "correctable": true,
          "location": {
            "start_line": 6,
            "start_column": 7,
            "last_line": 6,
            "last_column": 7,
            "length": 1,
            "line": 6,
            "column": 7
          }
        }
      ]
    }
  ],
  "summary": {
    "offense_count": 5,
    "target_file_count": 1,
    "inspected_file_count": 1
  }
}
```

</details>

Before

<img width="307" alt="image" src="https://github.com/rubocop/rubocop/assets/935310/36fb4c3c-2240-4ece-a1b3-5abf39d0abed">

After

<img width="273" alt="image" src="https://github.com/rubocop/rubocop/assets/935310/e400ff51-8331-4c13-ae87-dca081fc5f0e">

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/

