### PR TITLE
[Fix #12931] Fix false positives for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_line_continuation.md
+++ b/changelog/fix_false_positives_for_style_redundant_line_continuation.md
@@ -1,0 +1,1 @@
+* [#12931](https://github.com/rubocop/rubocop/issues/12931): Fix false positives for `Style/RedundantLineContinuation` when line continuations involve `break`, `next`, or `yield` with a return value. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -74,6 +74,7 @@ module RuboCop
           kFALSE kNIL kSELF kTRUE tCONSTANT tCVAR tFLOAT tGVAR tIDENTIFIER tINTEGER tIVAR
           tLBRACK tLCURLY tLPAREN_ARG tSTRING tSTRING_BEG tSYMBOL tXSTRING_BEG
         ].freeze
+        ARGUMENT_TAKING_FLOW_TOKEN_TYPES = %i[tIDENTIFIER kRETURN kBREAK kNEXT kYIELD].freeze
 
         def on_new_investigation
           return unless processed_source.ast
@@ -137,7 +138,7 @@ module RuboCop
         #   do_something \
         #     argument
         def method_with_argument?(current_token, next_token)
-          return false if current_token.type != :tIDENTIFIER && current_token.type != :kRETURN
+          return false unless ARGUMENT_TAKING_FLOW_TOKEN_TYPES.include?(current_token.type)
 
           ARGUMENT_TYPES.include?(next_token.type)
         end

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -136,6 +136,33 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'does not register an offense when line continuations involve `break` with a return value' do
+    expect_no_offenses(<<~'RUBY')
+      foo do
+        break \
+          bar
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when line continuations involve `next` with a return value' do
+    expect_no_offenses(<<~'RUBY')
+      foo do
+        next \
+          bar
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when line continuations involve `yield` with a return value' do
+    expect_no_offenses(<<~'RUBY')
+      def foo
+        yield \
+          bar
+      end
+    RUBY
+  end
+
   it 'registers an offense when line continuations with `if`' do
     expect_offense(<<~'RUBY')
       if foo \


### PR DESCRIPTION
Fixes #12931.

This PR fixes false positives for `Style/RedundantLineContinuation` when line continuations involve `break`, `next`, or `yield` with a return value.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
