### PR TITLE
Avoid a ruby warning in `Lint/ErbNewArguments`

### DIFF
--- a/lib/rubocop/cop/lint/erb_new_arguments.rb
+++ b/lib/rubocop/cop/lint/erb_new_arguments.rb
@@ -65,17 +65,15 @@ module RuboCop
 
         minimum_target_ruby_version 2.6
 
-        MESSAGES = [
-          'Passing safe_level with the 2nd argument of `ERB.new` is ' \
-          'deprecated. Do not use it, and specify other arguments as ' \
-          'keyword arguments.',
-          'Passing trim_mode with the 3rd argument of `ERB.new` is ' \
-          'deprecated. Use keyword argument like ' \
-          '`ERB.new(str, trim_mode: %<arg_value>s)` instead.',
-          'Passing eoutvar with the 4th argument of `ERB.new` is ' \
-          'deprecated. Use keyword argument like ' \
-          '`ERB.new(str, eoutvar: %<arg_value>s)` instead.'
-        ].freeze
+        MESSAGE_SAFE_LEVEL = 'Passing safe_level with the 2nd argument of `ERB.new` is ' \
+                             'deprecated. Do not use it, and specify other arguments as ' \
+                             'keyword arguments.'
+        MESSAGE_TRIM_MODE =  'Passing trim_mode with the 3rd argument of `ERB.new` is ' \
+                             'deprecated. Use keyword argument like ' \
+                             '`ERB.new(str, trim_mode: %<arg_value>s)` instead.'
+        MESSAGE_EOUTVAR =    'Passing eoutvar with the 4th argument of `ERB.new` is ' \
+                             'deprecated. Use keyword argument like ' \
+                             '`ERB.new(str, eoutvar: %<arg_value>s)` instead.'
 
         RESTRICT_ON_SEND = %i[new].freeze
 
@@ -92,10 +90,8 @@ module RuboCop
             arguments[1..3].each_with_index do |argument, i|
               next if !argument || argument.hash_type?
 
-              message = format(MESSAGES[i], arg_value: argument.source)
-
               add_offense(
-                argument.source_range, message: message
+                argument.source_range, message: message(i, argument.source)
               ) do |corrector|
                 autocorrect(corrector, node)
               end
@@ -104,6 +100,17 @@ module RuboCop
         end
 
         private
+
+        def message(positional_argument_index, arg_value)
+          case positional_argument_index
+          when 0
+            MESSAGE_SAFE_LEVEL
+          when 1
+            format(MESSAGE_TRIM_MODE, arg_value: arg_value)
+          when 2
+            format(MESSAGE_EOUTVAR, arg_value: arg_value)
+          end
+        end
 
         def autocorrect(corrector, node)
           str_arg = node.first_argument.source


### PR DESCRIPTION
For #12910. Always passing the format argument warns since the first message takes no arguments. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
