### PR TITLE
Avoid a ruby warning in `Layout/SpaceInsideStringInterpolation`

### DIFF
--- a/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
+++ b/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
@@ -25,8 +25,7 @@ module RuboCop
         include RangeHelp
         extend AutoCorrector
 
-        NO_SPACE_MSG = 'Space inside string interpolation detected.'
-        SPACE_MSG = 'Missing space inside string interpolation detected.'
+        MSG = '%<command>s space inside string interpolation.'
 
         def on_interpolation(begin_node)
           return if begin_node.multiline?
@@ -36,9 +35,9 @@ module RuboCop
           return if empty_brackets?(left, right, tokens: tokens)
 
           if style == :no_space
-            no_space_offenses(begin_node, left, right, NO_SPACE_MSG)
+            no_space_offenses(begin_node, left, right, MSG)
           else
-            space_offenses(begin_node, left, right, SPACE_MSG)
+            space_offenses(begin_node, left, right, MSG)
           end
         end
 

--- a/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
@@ -8,22 +8,22 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
       it 'registers offenses and autocorrects' do
         expect_offense(<<~'RUBY')
           "#{ var}"
-             ^ Space inside string interpolation detected.
+             ^ Do not use space inside string interpolation.
           "#{var }"
-                ^ Space inside string interpolation detected.
+                ^ Do not use space inside string interpolation.
           "#{   var   }"
-             ^^^ Space inside string interpolation detected.
-                   ^^^ Space inside string interpolation detected.
+             ^^^ Do not use space inside string interpolation.
+                   ^^^ Do not use space inside string interpolation.
           "#{var	}"
-                ^ Space inside string interpolation detected.
+                ^ Do not use space inside string interpolation.
           "#{	var	}"
-             ^ Space inside string interpolation detected.
-                 ^ Space inside string interpolation detected.
+             ^ Do not use space inside string interpolation.
+                 ^ Do not use space inside string interpolation.
           "#{	var}"
-             ^ Space inside string interpolation detected.
+             ^ Do not use space inside string interpolation.
           "#{ 	 var 	 	}"
-             ^^^ Space inside string interpolation detected.
-                   ^^^^ Space inside string interpolation detected.
+             ^^^ Do not use space inside string interpolation.
+                   ^^^^ Do not use space inside string interpolation.
         RUBY
 
         expect_correction(<<~'RUBY')
@@ -40,11 +40,11 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
       it 'finds interpolations in string-like contexts' do
         expect_offense(<<~'RUBY')
           /regexp #{ var}/
-                    ^ Space inside string interpolation detected.
+                    ^ Do not use space inside string interpolation.
           `backticks #{ var}`
-                       ^ Space inside string interpolation detected.
+                       ^ Do not use space inside string interpolation.
           :"symbol #{ var}"
-                     ^ Space inside string interpolation detected.
+                     ^ Do not use space inside string interpolation.
         RUBY
 
         expect_correction(<<~'RUBY')
@@ -59,8 +59,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
       it 'registers offenses and autocorrects' do
         expect_offense(<<~'RUBY')
           "#{ var }"
-             ^ Space inside string interpolation detected.
-                 ^ Space inside string interpolation detected.
+             ^ Do not use space inside string interpolation.
+                 ^ Do not use space inside string interpolation.
         RUBY
 
         expect_correction(<<~'RUBY')
@@ -72,8 +72,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
     it 'does not touch spaces inside the interpolated expression' do
       expect_offense(<<~'RUBY')
         "#{ a; b }"
-           ^ Space inside string interpolation detected.
-                ^ Space inside string interpolation detected.
+           ^ Do not use space inside string interpolation.
+                ^ Do not use space inside string interpolation.
       RUBY
 
       expect_correction(<<~'RUBY')
@@ -122,15 +122,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
       it 'registers offenses and autocorrects' do
         expect_offense(<<~'RUBY')
           "#{ var}"
-                 ^ Missing space inside string interpolation detected.
+                 ^ Use space inside string interpolation.
           "#{var }"
-           ^^ Missing space inside string interpolation detected.
+           ^^ Use space inside string interpolation.
           "#{   var   }"
           "#{var	}"
-           ^^ Missing space inside string interpolation detected.
+           ^^ Use space inside string interpolation.
           "#{	var	}"
           "#{	var}"
-                 ^ Missing space inside string interpolation detected.
+                 ^ Use space inside string interpolation.
           "#{ 	 var 	 	}"
         RUBY
 
@@ -151,8 +151,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
       it 'registers offenses and autocorrects' do
         expect_offense(<<~'RUBY')
           "#{var}"
-           ^^ Missing space inside string interpolation detected.
-                ^ Missing space inside string interpolation detected.
+           ^^ Use space inside string interpolation.
+                ^ Use space inside string interpolation.
         RUBY
 
         expect_correction(<<~'RUBY')


### PR DESCRIPTION
Also for #12910. `space_offenses`/`no_space_offenses` expect a command format argument. This necessitates a change to the offense message.

This aligns the message with with `SpaceInsideArrayLiteralBrackets` and `SpaceInsideReferenceBrackets` which also use the space_offenses methods.

---------

Last warning coming from RuboCop itself. This does change the offense message text, though I think this is not expected to be stable? Let me know if this is not an acceptable change and I'll think about solving this differently.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
