### PR TITLE
Ensure RuboCop runs warning-free

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@
 require 'rainbow'
 Rainbow.enabled = false
 
+require_relative 'support/strict_warnings'
+StrictWarnings.enable!
+
 require 'rubocop'
 require 'rubocop/cop/internal_affairs'
 require 'rubocop/server'

--- a/spec/support/strict_warnings.rb
+++ b/spec/support/strict_warnings.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Ensure that RuboCop runs warning-free. This hooks into Ruby's `warn`
+# method and raises when an unexpected warning is encountered.
+module StrictWarnings
+  class WarningError < StandardError; end
+
+  # Warnings from 3rd-party gems, or other things that are unactionable
+  SUPPRESSED_WARNINGS = Regexp.union(
+    %r{lib/parser/builders/default.*Unknown escape},
+    %r{lib/parser/builders/default.*character class has duplicated range},
+    /Float.*out of range/, # also from the parser gem
+    /`Process` does not respond to `fork` method/, # JRuby
+    /File#readline accesses caller method's state and should not be aliased/, # JRuby, test stub
+    /instance variable @.* not initialized/ # Ruby 2.7
+  )
+
+  def warn(message, ...)
+    return if SUPPRESSED_WARNINGS.match?(message)
+
+    super
+    # RuboCop uses `warn` to display some of its output and tests assert against
+    # that. Assume that warnings are intentional when stderr is redirected.
+    return if $stderr.is_a?(StringIO)
+    # Ignore warnings from dev/rc ruby versions. Things are subject to change and
+    # contributors should not be bothered by them with red CI.
+    return if RUBY_PATCHLEVEL == -1
+
+    raise WarningError, message
+  end
+
+  def self.enable!
+    $VERBOSE = true
+    Warning[:deprecated] = true
+    Warning.singleton_class.prepend(self)
+  end
+end


### PR DESCRIPTION
Closes #12910

This is inspired by how Rails approaches this. Depending on if https://github.com/whitequark/parser/pull/1013 gets merged or not, the `SUPPRESSED_WARNINGS` can be emptied in the future.

I also disable this when running on nightly/rc ruby. Recently there has been a bit of movement on warning regarding unused block args and that got dialed back a bit since they were very frequent. CI should not fail because ruby introduces new warnings, these can be fixed later and shouldn't bother other contributors.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
