### PR TITLE
Add Exclude per constant settings for Lint/DeprecatedConstants cop

### DIFF
--- a/changelog/change_add_exclude_settings_for_lint_deprecated_constants.md
+++ b/changelog/change_add_exclude_settings_for_lint_deprecated_constants.md
@@ -1,0 +1,1 @@
+* [#12940](https://github.com/rubocop/rubocop/pull/12940): Add `Exclude` settings for `Lint/DeprecatedConstants` per constant. ([@r4do][])

--- a/spec/rubocop/cop/lint/deprecated_constants_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_constants_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedConstants, :config do
         'Struct::Passwd' => { 'Alternative' => 'Etc::Passwd', 'DeprecatedVersion' => '3.0' },
         'Triple::Nested::Constant' => { 'Alternative' => 'Value', 'DeprecatedVersion' => '2.4' },
         'Have::No::Alternative' => { 'DeprecatedVersion' => '2.4' },
-        'Have::No::DeprecatedVersion' => { 'Alternative' => 'Value' }
+        'Have::No::DeprecatedVersion' => { 'Alternative' => 'Value' },
+        'Struct::DeprecatedInFile' => { 'Exclude' => ['app/models/not_deprecated.rb'] }
       }
     }
   end
@@ -213,6 +214,19 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedConstants, :config do
   it 'does not register an offense when using `__ENCODING__' do
     expect_no_offenses(<<~RUBY)
       __ENCODING__
+    RUBY
+  end
+
+  it 'registers an offense when Exclude is specified' do
+    expect_offense(<<~RUBY, 'app/models/deprecated.rb')
+      Struct::DeprecatedInFile
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `Struct::DeprecatedInFile`.
+    RUBY
+  end
+
+  it 'does not register an offense when Exclude is specified and file is excluded' do
+    expect_no_offenses(<<~RUBY, 'app/models/not_deprecated.rb')
+      Struct::DeprecatedInFile
     RUBY
   end
 end


### PR DESCRIPTION
Adds `Exclude` settings per specific deprecated constant for `Lint/DeprecatedConstants`.
Usecase example: monorepo in decomposition state.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
