### PR TITLE
Move `documentation-check` to GitHub actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,25 +215,10 @@ jobs:
             ./tmp/cc-test-reporter sum-coverage tmp/codeclimate.*.json --parts 5 --output tmp/codeclimate.total.json
             ./tmp/cc-test-reporter upload-coverage --input tmp/codeclimate.total.json
 
-  # Miscellaneous tasks
-  documentation-checks:
-    docker:
-      # Specify the latest version to prevent "cimg/ruby:latest not found: manifest unknown: manifest unknown" error.
-      - image: cimg/ruby:3.3
-    environment:
-      <<: *common_env
-    steps:
-      - checkout
-      - run: bundle install
-      - run:
-          name: Check documentation syntax
-          command: bundle exec rake documentation_syntax_check
-
 workflows:
   version: 2
   build:
     jobs:
-      - documentation-checks
       - cc-setup
       - ruby-2.7-spec:
           requires:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -58,6 +58,20 @@ jobs:
       - name: internal_investigation
         run: bundle exec rake internal_investigation
 
+  documentation_check:
+    name: Documentation Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+          bundler-cache: true
+      - name: Check documentation syntax
+        run: bundle exec rake documentation_syntax_check
+
   jruby:
     name: JRuby 9.4
     runs-on: ubuntu-latest


### PR DESCRIPTION
Working towards https://github.com/rubocop/rubocop/issues/8363

I'll do this in smaller steps since the workflow is somewhat large. Should be overall rather simple, though the codeclimate integration will need some extra work.

Newly added job output: https://github.com/rubocop/rubocop/actions/runs/9273549841/job/25513896170?pr=12941

------------------

Question: Is CodeClimate even still in use? The badges in the readme show some stats but the link gives 404.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
