### PR TITLE
Move `ascii_spec`, `internal_investigation` to GitHub actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,6 @@ spec_steps: &spec_steps
       paths:
         - codeclimate.*.json
 
-ascii_spec_steps: &ascii_spec_steps
-  - checkout
-  - run: bundle install
-  - run: bundle exec rake ascii_spec
-
 jobs:
   # Ruby 2.7
   ruby-2.7-spec:
@@ -36,13 +31,6 @@ jobs:
       <<: *common_env
     steps:
       *spec_steps
-  ruby-2.7-ascii_spec:
-    docker:
-      - image: cimg/ruby:2.7
-    environment:
-      <<: *common_env
-    steps:
-      *ascii_spec_steps
 
   # Ruby 3.0
   ruby-3.0-spec:
@@ -52,13 +40,6 @@ jobs:
       <<: *common_env
     steps:
       *spec_steps
-  ruby-3.0-ascii_spec:
-    docker:
-      - image: cimg/ruby:3.0
-    environment:
-      <<: *common_env
-    steps:
-      *ascii_spec_steps
 
   # Ruby 3.1
   ruby-3.1-spec:
@@ -68,13 +49,6 @@ jobs:
       <<: *common_env
     steps:
       *spec_steps
-  ruby-3.1-ascii_spec:
-    docker:
-      - image: cimg/ruby:3.1
-    environment:
-      <<: *common_env
-    steps:
-      *ascii_spec_steps
 
   # Ruby 3.2
   ruby-3.2-spec:
@@ -84,13 +58,6 @@ jobs:
       <<: *common_env
     steps:
       *spec_steps
-  ruby-3.2-ascii_spec:
-    docker:
-      - image: cimg/ruby:3.2
-    environment:
-      <<: *common_env
-    steps:
-      *ascii_spec_steps
 
   # Ruby 3.3
   ruby-3.3-spec:
@@ -100,13 +67,6 @@ jobs:
       <<: *common_env
     steps:
       *spec_steps
-  ruby-3.3-ascii_spec:
-    docker:
-      - image: cimg/ruby:3.3
-    environment:
-      <<: *common_env
-    steps:
-      *ascii_spec_steps
 
   # ruby-head (nightly snapshot build)
   ruby-head-spec:
@@ -116,13 +76,6 @@ jobs:
       <<: *common_env
     steps:
       *spec_steps
-  ruby-head-ascii_spec:
-    docker:
-      - image: rubocophq/circleci-ruby-snapshot:latest
-    environment:
-      <<: *common_env
-    steps:
-      *ascii_spec_steps
 
   # Job for downloading the Code Climate test reporter
   cc-setup:
@@ -169,27 +122,21 @@ workflows:
       - ruby-2.7-spec:
           requires:
             - cc-setup
-      - ruby-2.7-ascii_spec
       - ruby-3.0-spec:
           requires:
             - cc-setup
-      - ruby-3.0-ascii_spec
       - ruby-3.1-spec:
           requires:
             - cc-setup
-      - ruby-3.1-ascii_spec
       - ruby-3.2-spec:
           requires:
             - cc-setup
-      - ruby-3.2-ascii_spec
       - ruby-3.3-spec:
           requires:
             - cc-setup
-      - ruby-3.3-ascii_spec
       - ruby-head-spec:
           requires:
             - cc-setup
-      - ruby-head-ascii_spec
 
       - cc-upload-coverage:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,16 +27,6 @@ ascii_spec_steps: &ascii_spec_steps
   - run: bundle install
   - run: bundle exec rake ascii_spec
 
-rubocop_steps: &rubocop_steps
-  - checkout
-  - run: bundle install
-  - run: bundle exec rake internal_investigation
-  - run:
-      name: Check requiring libraries successfully
-      # See https://github.com/rubocop/rubocop/pull/4523#issuecomment-309136113
-      command: |
-        ruby -I lib -r bundler/setup -r rubocop -e 'exit 0'
-
 jobs:
   # Ruby 2.7
   ruby-2.7-spec:
@@ -53,13 +43,6 @@ jobs:
       <<: *common_env
     steps:
       *ascii_spec_steps
-  ruby-2.7-rubocop:
-    docker:
-      - image: cimg/ruby:2.7
-    environment:
-      <<: *common_env
-    steps:
-      *rubocop_steps
 
   # Ruby 3.0
   ruby-3.0-spec:
@@ -76,13 +59,6 @@ jobs:
       <<: *common_env
     steps:
       *ascii_spec_steps
-  ruby-3.0-rubocop:
-    docker:
-      - image: cimg/ruby:3.0
-    environment:
-      <<: *common_env
-    steps:
-      *rubocop_steps
 
   # Ruby 3.1
   ruby-3.1-spec:
@@ -99,13 +75,6 @@ jobs:
       <<: *common_env
     steps:
       *ascii_spec_steps
-  ruby-3.1-rubocop:
-    docker:
-      - image: cimg/ruby:3.1
-    environment:
-      <<: *common_env
-    steps:
-      *rubocop_steps
 
   # Ruby 3.2
   ruby-3.2-spec:
@@ -122,13 +91,6 @@ jobs:
       <<: *common_env
     steps:
       *ascii_spec_steps
-  ruby-3.2-rubocop:
-    docker:
-      - image: cimg/ruby:3.2
-    environment:
-      <<: *common_env
-    steps:
-      *rubocop_steps
 
   # Ruby 3.3
   ruby-3.3-spec:
@@ -145,13 +107,6 @@ jobs:
       <<: *common_env
     steps:
       *ascii_spec_steps
-  ruby-3.3-rubocop:
-    docker:
-      - image: cimg/ruby:3.3
-    environment:
-      <<: *common_env
-    steps:
-      *rubocop_steps
 
   # ruby-head (nightly snapshot build)
   ruby-head-spec:
@@ -168,13 +123,6 @@ jobs:
       <<: *common_env
     steps:
       *ascii_spec_steps
-  ruby-head-rubocop:
-    docker:
-      - image: rubocophq/circleci-ruby-snapshot:latest
-    environment:
-      <<: *common_env
-    steps:
-      *rubocop_steps
 
   # Job for downloading the Code Climate test reporter
   cc-setup:
@@ -222,32 +170,26 @@ workflows:
           requires:
             - cc-setup
       - ruby-2.7-ascii_spec
-      - ruby-2.7-rubocop
       - ruby-3.0-spec:
           requires:
             - cc-setup
       - ruby-3.0-ascii_spec
-      - ruby-3.0-rubocop
       - ruby-3.1-spec:
           requires:
             - cc-setup
       - ruby-3.1-ascii_spec
-      - ruby-3.1-rubocop
       - ruby-3.2-spec:
           requires:
             - cc-setup
       - ruby-3.2-ascii_spec
-      - ruby-3.2-rubocop
       - ruby-3.3-spec:
           requires:
             - cc-setup
       - ruby-3.3-ascii_spec
-      - ruby-3.3-rubocop
       - ruby-head-spec:
           requires:
             - cc-setup
       - ruby-head-ascii_spec
-      - ruby-head-rubocop
 
       - cc-upload-coverage:
           requires:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -36,12 +36,6 @@ jobs:
             ruby: head
 
     steps:
-      - name: windows misc
-        if: matrix.os == 'windows'
-        run: |
-          # set TMPDIR, git core.autocrlf
-          echo "TMPDIR=$env:RUNNER_TEMP" >> $GITHUB_ENV
-          git config --system core.autocrlf false
       - name: checkout
         uses: actions/checkout@v4
       - name: set up Ruby
@@ -53,8 +47,43 @@ jobs:
         run: bundle exec rake spec
       - name: ascii_spec
         run: bundle exec rake ascii_spec
+
+  internal_investigation:
+    name: Internal Investigation - ${{ matrix.os }} ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, windows]
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', 'head']
+        include:
+          - os: ubuntu
+            ruby: jruby-9.4
+          - os: windows
+            ruby: mingw
+        exclude:
+          - os: windows
+            ruby: head
+
+    steps:
+      - name: Windows Specific
+        if: matrix.os == 'windows'
+        run: |
+          # Work around `Layout/EndOfLine: Carriage return character detected`
+          git config --system core.autocrlf false
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
       - name: internal_investigation
         run: bundle exec rake internal_investigation
+      - name: Check requiring libraries successfully
+        # See https://github.com/rubocop/rubocop/pull/4523#issuecomment-309136113
+        run: ruby -I lib -r bundler/setup -r rubocop -e 'exit 0'
 
   documentation_check:
     name: Documentation Check
@@ -85,8 +114,6 @@ jobs:
         run: bundle exec rake spec
       - name: ascii_spec
         run: bundle exec rake ascii_spec
-      - name: internal_investigation
-        run: bundle exec rake internal_investigation
 
   prism:
     runs-on: ubuntu-latest

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -45,6 +45,33 @@ jobs:
           bundler-cache: true
       - name: spec
         run: bundle exec rake spec
+
+  ascii_spec:
+    name: Ascii Spec - ${{ matrix.os }} ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, windows]
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', 'head']
+        include:
+          - os: ubuntu
+            ruby: jruby-9.4
+          - os: windows
+            ruby: mingw
+        exclude:
+          - os: windows
+            ruby: head
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
       - name: ascii_spec
         run: bundle exec rake ascii_spec
 
@@ -112,8 +139,6 @@ jobs:
           bundler-cache: true
       - name: spec
         run: bundle exec rake spec
-      - name: ascii_spec
-        run: bundle exec rake ascii_spec
 
   prism:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The only thing left after this are the "normal" specs.

Unfortunatly GitHub doesn't support yml anchors so the matrix is duplicated. There are ways to have the matrix generated/reusable but that results in complex/unreadable actions from my experience. This ain't so bad, CircleCI didn't use/have matrix, you win some you loose some.

---------------

I'm moving the jruby job to the different jobs. I don't see why Jurby should have its own section instead of being part of the matrix. This also should speed up green CI by a bit. JRuby does take the longest and now it can execute these in parallel if there are enough available workers.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
