### PR TITLE
[Fix #12949] Use the secret for the coverage reporter id

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -70,7 +70,8 @@ jobs:
           pattern: coverage-*
       - uses: paambaati/codeclimate-action@v6
         env:
-          CC_TEST_REPORTER_ID: a11b66bfbb1acdf220d5cb317b2e945a986fd85adebe29a76d411ad6d74ec31f
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        if: ${{ env.CC_TEST_REPORTER_ID != '' }}
         with:
           coverageLocations: |
             ${{github.workspace}}/coverage-*/.resultset.json:simplecov


### PR DESCRIPTION
Fixes #12949, this uses the configured secret (https://github.com/rubocop/rubocop/issues/12949#issuecomment-2139496033) instead of the hardcoded value which probably hasn't worked for quite some time.

As secrets are not available to forks the job will be skipped for this PR but it should hopefully work once merged. I tested both scenarios in my fork and that went ok. cc @bquorning 