### PR TITLE
Fix an error for `Style/Copyright`

### DIFF
--- a/changelog/fix_an_error_for_style_copyright.md
+++ b/changelog/fix_an_error_for_style_copyright.md
@@ -1,0 +1,1 @@
+* [#12951](https://github.com/rubocop/rubocop/pull/12951): Fix an error for `Style/Copyright` when `AutocorrectNotice` is missing. ([@koic][])

--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -58,7 +58,9 @@ module RuboCop
         end
 
         def verify_autocorrect_notice!
-          raise Warning, "#{cop_name}: #{AUTOCORRECT_EMPTY_WARNING}" if autocorrect_notice.empty?
+          if autocorrect_notice.nil? || autocorrect_notice.empty?
+            raise Warning, "#{cop_name}: #{AUTOCORRECT_EMPTY_WARNING}"
+          end
 
           regex = Regexp.new(notice)
           return if autocorrect_notice.gsub(/^# */, '').match?(regex)

--- a/spec/rubocop/cop/style/copyright_spec.rb
+++ b/spec/rubocop/cop/style/copyright_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
     end
 
     it 'fails to autocorrect if no AutocorrectNotice is given' do
-      # cop_config['AutocorrectNotice'] = '# Copyleft (c) 2015 Acme Inc.'
+      cop_config['AutocorrectNotice'] = nil
       expect { expect_offense(source) }.to raise_error(RuboCop::Warning, %r{Style/Copyright:})
     end
   end


### PR DESCRIPTION
This PR fixes the following error for `Style/Copyright` when `AutocorrectNotice` is missing:

```console
$ cat .rubocop.yml
Style/Copyright:
  Enabled: true
  AutocorrectNotice: ~

$ bundle exec rubocop -d
(snip)

undefined method 'empty?' for nil
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/copyright.rb:61:
in 'RuboCop::Cop::Style::Copyright#verify_autocorrect_notice!'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
