### PR TITLE
Fix asciidoc syntax

### DIFF
--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -5839,12 +5839,12 @@ NOTE: Shadowing of variables in block passed to `Ractor.new` is allowed
 because `Ractor` should not access outer variables.
 eg. following style is encouraged:
 
-  [source,ruby]
-  ----
-  worker_id, pipe = env
-  Ractor.new(worker_id, pipe) do |worker_id, pipe|
-  end
-  ----
+[source,ruby]
+----
+worker_id, pipe = env
+Ractor.new(worker_id, pipe) do |worker_id, pipe|
+end
+----
 
 === Examples
 


### PR DESCRIPTION
Remove unintended indent in the doc of  `Lint/ShadowingOuterLocalVariable` to show the code block as expected
https://docs.rubocop.org/rubocop/cops_lint.html#lintshadowingouterlocalvariable 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
