### PR TITLE
[Fix #12957] Mark `Style/SuperArguments` as unsafe

### DIFF
--- a/changelog/change_mark_super_arguments_as_unsafe.md
+++ b/changelog/change_mark_super_arguments_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#12957](https://github.com/rubocop/rubocop/issues/12957): Mark `Style/SuperArguments` as unsafe. ([@earlopain][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5427,8 +5427,10 @@ Style/StructInheritance:
 
 Style/SuperArguments:
   Description: 'Call `super` without arguments and parentheses when the signature is identical.'
+  Safe: false
   Enabled: pending
   VersionAdded: '1.64'
+  VersionChanged: <<next>>
 
 Style/SuperWithArgsParentheses:
   Description: 'Use parentheses for `super` with arguments.'

--- a/lib/rubocop/cop/style/super_arguments.rb
+++ b/lib/rubocop/cop/style/super_arguments.rb
@@ -6,6 +6,11 @@ module RuboCop
       # Checks for redundant argument forwarding when calling super
       # with arguments identical to the method definition.
       #
+      # @safety
+      #   This cop is unsafe because super can't be implicitly called in the context of
+      #   `define_method` and `define_singleton_method`. Because of Ruby's dynamic nature any
+      #   entered block may change to this context, which will then raise an error at runtime.
+
       # @example
       #   # bad
       #   def method(*args, **kwargs)
@@ -25,6 +30,11 @@ module RuboCop
       #   # good - forwarding no arguments
       #   def method(*args, **kwargs)
       #     super()
+      #   end
+      #
+      #   # good - calling super in `define_method`
+      #   define_method(:method) do |foo|
+      #     super(foo)
       #   end
       #
       #   # good - assigning to the block variable before calling super


### PR DESCRIPTION
Here is a somewhat convoluted case in which autocomplete breaks the code:

```rb
class A
  def method(a)
  end

  def other_method(a)
    puts a
  end
end

class B < A
  def method(a)
    context_change { super(a) }
    other_method
  end

  def context_change(&)
    define_singleton_method(:other_method, &)
  end
end

B.new.method('foo')
#=> foo
```

With autocorrect:

```rb
class A
  def method(a)
  end

  def other_method(a)
    puts a
  end
end

class B < A
  def method(a)
    context_change { super }
    other_method
  end

  def context_change(&)
    define_singleton_method(:other_method, &)
  end
end

B.new.method('foo')
#=> test.rb:12:in 'block in method': implicit argument passing of super from method defined by define_method() is not supported. Specify all arguments explicitly. (RuntimeError)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
