### PR TITLE
[Fix #12957] Fix false positives for `Style/SuperArguments`

### DIFF
--- a/changelog/fix_false_positives_for_style_super_arguments.md
+++ b/changelog/fix_false_positives_for_style_super_arguments.md
@@ -1,0 +1,1 @@
+* [#12957](https://github.com/rubocop/rubocop/issues/12957): Fix false positives for `Style/SuperArguments` when calling super in a block. ([@koic][])

--- a/spec/rubocop/cop/style/super_arguments_spec.rb
+++ b/spec/rubocop/cop/style/super_arguments_spec.rb
@@ -170,12 +170,11 @@ RSpec.describe RuboCop::Cop::Style::SuperArguments, :config do
     end
   end
 
-  it 'registers an offense when the scope changes because of a block' do
-    expect_offense(<<~RUBY)
+  it 'does not register offense when calling super in a block' do
+    expect_no_offenses(<<~RUBY)
       def foo(a)
-        bar do
+        delegate_to_define_method do
           super(a)
-          ^^^^^^^^ Call `super` without arguments and parentheses when the signature is identical.
         end
       end
     RUBY


### PR DESCRIPTION
Fixes #12957.

This PR fixes false positives for `Style/SuperArguments` when calling super in a block.

Using zero arity `super` within a `define_method` block results in `RuntimeError`:

```ruby
def m
  define_method(:foo) { super() } # => OK
end

def m
  define_method(:foo) { super }   # => RuntimeError
end
```

Furthermore, any arguments accompanied by a block may potentially be delegating to `define_method`, therefore, `super` used within these blocks will be allowed. This approach might result in false negatives, yet ensuring safe detection takes precedence.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
