### PR TITLE
[Fix #12960] Fix false positives for `Lint/NestedMethodDefinition`

### DIFF
--- a/changelog/fix_false_positives_for_lint_nested_method_definition.md
+++ b/changelog/fix_false_positives_for_lint_nested_method_definition.md
@@ -1,0 +1,1 @@
+* [#12960](https://github.com/rubocop/rubocop/issues/12960): Fix false positives for `Lint/NestedMethodDefinition` when definition of method on variable. ([@koic][])

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -102,7 +102,7 @@ module RuboCop
 
         def on_def(node)
           subject, = *node
-          return if node.defs_type? && subject.lvar_type?
+          return if node.defs_type? && subject.variable?
 
           def_ancestor = node.each_ancestor(:def, :defs).first
           return unless def_ancestor

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -88,6 +88,39 @@ RSpec.describe RuboCop::Cop::Lint::NestedMethodDefinition, :config do
     RUBY
   end
 
+  it 'does not register offense for definition of method on instance var' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        def x
+          def @obj.y
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register offense for definition of method on class var' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        def x
+          def @@obj.y
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register offense for definition of method on global var' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        def x
+          def $obj.y
+          end
+        end
+      end
+    RUBY
+  end
+
   it 'does not register offense for nested definition inside class_eval' do
     expect_no_offenses(<<~RUBY)
       class Foo


### PR DESCRIPTION
Fixes #12960.

This PR fixes false positives for `Lint/NestedMethodDefinition` when definition of method on variable.

Since method definitions using local variables such as `def obj.y` have already been accepted, the decision is to similarly accept method definitions using other variable types: https://github.com/rubocop/rubocop/blob/v1.64.1/spec/rubocop/cop/lint/nested_method_definition_spec.rb#L80-L89

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
