### PR TITLE
Ci lint once / actually run `internal_investigation`

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,33 +9,14 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+
 jobs:
   lint-ruby:
-    name: Ruby - ${{ matrix.os }} ${{ matrix.ruby }}
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu, windows]
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', 'head']
-        include:
-          - os: ubuntu
-            ruby: jruby-9.4
-          - os: windows
-            ruby: mingw
-        exclude:
-          - os: windows
-            ruby: head
     steps:
-      - name: Windows Specific
-        if: matrix.os == 'windows'
-        run: |
-          # Work around `Layout/EndOfLine: Carriage return character detected`
-          git config --system core.autocrlf false
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: '3.3'
           bundler-cache: true
       - name: internal_investigation
         run: bundle exec rake internal_investigation

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: ruby # Latest stable CRuby version
           bundler-cache: true
       - name: internal_investigation
         run: bundle exec rake internal_investigation

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,10 +1,11 @@
 name: Linting
 on:
+  push:
+    branches:
+      - master
   pull_request:
-    paths:
-      - '**/*.yaml'
-      - '**/*.yml'
   workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3
+          ruby-version: ruby # Latest stable CRuby version
           bundler-cache: true
       - name: Check documentation syntax
         run: bundle exec rake documentation_syntax_check


### PR DESCRIPTION
As per https://github.com/rubocop/rubocop/pull/12947#issuecomment-2147256882

This also fixes an issue with that PR where rubocop would only lint itself when a yaml file got changed. I only noticed this after opening this file, the diff unfortunately didn't make that very visible. I've copied the conditions for the main workflow file which means yaml will be linted every time now, that seems fine. cc @bquorning 