### PR TITLE
CI: Fix config for linting.yml

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,6 +12,8 @@ concurrency:
 
 jobs:
   lint-ruby:
+    name: Ruby
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Fixing the configuration for linting.yml on CI.

Currently CI is failing ([e.g. here](https://github.com/rubocop/rubocop/actions/runs/9366635974)) with
```
Invalid workflow file: .github/workflows/linting.yml#L15
The workflow is not valid. .github/workflows/linting.yml (Line: 15, Col: 5): Required property is missing: runs-on
```