### PR TITLE
CI: Optimize for faster results and lower resource use

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -54,7 +54,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', 'mingw']
+        ruby:
+          - '2.7'  # Oldest supported version
+          - 'ruby' # Latest stable CRuby version
 
     steps:
       - uses: actions/checkout@v4
@@ -97,15 +99,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows]
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', 'head']
-        include:
-          - os: ubuntu
-            ruby: jruby-9.4
-          - os: windows
-            ruby: mingw
-        exclude:
-          - os: windows
-            ruby: head
+        ruby:
+          - '2.7'  # Oldest supported version
+          - 'ruby' # Latest stable CRuby version
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -49,6 +49,7 @@ jobs:
           if-no-files-found: error
 
   spec-windows:
+    needs: spec-ubuntu # Don't spend CI resources on slow Windows specs if CI won't pass anyway.
     name: Spec - windows ${{ matrix.ruby }}
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -15,22 +15,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  spec:
-    name: Spec - ${{ matrix.os }} ${{ matrix.ruby }}
-    runs-on: ${{ matrix.os }}-latest
+  spec-ubuntu:
+    name: Spec - ubuntu ${{ matrix.ruby }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, windows]
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', 'head']
-        include:
-          - os: ubuntu
-            ruby: jruby-9.4
-          - os: windows
-            ruby: mingw
-        exclude:
-          - os: windows
-            ruby: head
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', 'head', 'jruby-9.4']
 
     steps:
       - uses: actions/checkout@v4
@@ -43,23 +34,45 @@ jobs:
         run: ruby -I lib -r bundler/setup -r rubocop -e 'exit 0'
       - name: Set up Coverage
         # Only collect coverage data on ubuntu runners with CRuby
-        if: matrix.os == 'ubuntu' && !startsWith(matrix.ruby, 'jruby-')
+        if: ${{ !startsWith(matrix.ruby, 'jruby-') }}
         run: echo "COVERAGE=true" >> $GITHUB_ENV
       - name: spec
         env:
           CI_RUBY_VERSION: ${{ matrix.ruby }}
         run: bundle exec rake spec
       - name: Upload Coverage Artifact
-        if: matrix.os == 'ubuntu' && !startsWith(matrix.ruby, 'jruby-')
+        if: ${{ !startsWith(matrix.ruby, 'jruby-') }}
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.os }}-${{ matrix.ruby }}
+          name: coverage-ubuntu-${{ matrix.ruby }}
           path: coverage/.resultset.json
           if-no-files-found: error
 
+  spec-windows:
+    name: Spec - windows ${{ matrix.ruby }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', 'mingw']
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Check requiring libraries successfully
+        # See https://github.com/rubocop/rubocop/pull/4523#issuecomment-309136113
+        run: ruby -I lib -r bundler/setup -r rubocop -e 'exit 0'
+      - name: spec
+        env:
+          CI_RUBY_VERSION: ${{ matrix.ruby }}
+        run: bundle exec rake spec
+
   upload_coverage:
     name: Upload Coverage
-    needs: spec
+    needs: spec-ubuntu
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Three commits:

1. Split specs running on ubuntu and windows.
   We'll have some duplication, but it allows for some optimization.
2. Reduce some test matrixes
   Reduce the test matrix for ascii_spec from 13 combinations to just four, and for windows specs from six to three.
   Based on discussion in https://github.com/rubocop/rubocop/pull/12967#discussion_r1626082395 and https://github.com/rubocop/rubocop/pull/12965#issuecomment-2147419092.
3. Only run windows specs after ubuntu specs pass.
   We don't _require_ windows specs to pass, and windows specs are very slow. By only running them _after_ ubuntu specs pass, we get the most important results first - and in case of failing specs, we'll save 30 minutes of CI use.
