### PR TITLE
[Fix #12970] Add `CountModifierForms` option to `Metrics/BlockNesting`

### DIFF
--- a/changelog/change_add_count_blocks_to_metrics_block_nesting.md
+++ b/changelog/change_add_count_blocks_to_metrics_block_nesting.md
@@ -1,0 +1,1 @@
+* [#12970](https://github.com/rubocop/rubocop/issues/12970): Add `CountModifierForms` option to `Metrics/BlockNesting` and set it to `false` by default. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2617,8 +2617,9 @@ Metrics/BlockNesting:
   StyleGuide: '#three-is-the-number-thou-shalt-count'
   Enabled: true
   VersionAdded: '0.25'
-  VersionChanged: '0.47'
+  VersionChanged: '<<next>>'
   CountBlocks: false
+  CountModifierForms: false
   Max: 3
 
 Metrics/ClassLength:

--- a/lib/rubocop/cop/metrics/block_nesting.rb
+++ b/lib/rubocop/cop/metrics/block_nesting.rb
@@ -3,12 +3,12 @@
 module RuboCop
   module Cop
     module Metrics
-      # Checks for excessive nesting of conditional and looping
-      # constructs.
+      # Checks for excessive nesting of conditional and looping constructs.
       #
-      # You can configure if blocks are considered using the `CountBlocks`
-      # option. When set to `false` (the default) blocks are not counted
-      # towards the nesting level. Set to `true` to count blocks as well.
+      # You can configure if blocks are considered using the `CountBlocks` and `CountModifierForms`
+      # options. When both are set to `false` (the default) blocks and modifier forms are not
+      # counted towards the nesting level. Set them to `true` to include these in the nesting level
+      # calculation as well.
       #
       # The maximum level of nesting allowed is configurable.
       class BlockNesting < Base
@@ -27,7 +27,7 @@ module RuboCop
 
         def check_nesting_level(node, max, current_level)
           if consider_node?(node)
-            current_level += 1 unless node.if_type? && node.elsif?
+            current_level += 1 if count_if_block?(node)
             if current_level > max
               self.max = current_level
               unless part_of_ignored_node?(node)
@@ -41,6 +41,14 @@ module RuboCop
           end
         end
 
+        def count_if_block?(node)
+          return true unless node.if_type?
+          return false if node.elsif?
+          return count_modifier_forms? if node.modifier_form?
+
+          true
+        end
+
         def consider_node?(node)
           return true if NESTING_BLOCKS.include?(node.type)
 
@@ -52,7 +60,11 @@ module RuboCop
         end
 
         def count_blocks?
-          cop_config['CountBlocks']
+          cop_config.fetch('CountBlocks', false)
+        end
+
+        def count_modifier_forms?
+          cop_config.fetch('CountModifierForms', false)
         end
       end
     end

--- a/spec/rubocop/cop/metrics/block_nesting_spec.rb
+++ b/spec/rubocop/cop/metrics/block_nesting_spec.rb
@@ -314,4 +314,48 @@ RSpec.describe RuboCop::Cop::Metrics::BlockNesting, :config do
       end
     end
   end
+
+  context 'when CountModifierForms is false' do
+    let(:cop_config) { { 'Max' => 2, 'CountModifierForms' => false } }
+
+    it 'accepts nested modifier forms' do
+      expect_no_offenses(<<~RUBY)
+        if a
+          if b
+            puts 'hello' if c
+          end
+        end
+      RUBY
+    end
+
+    it 'registers nested if expressions' do
+      expect_offense(<<~RUBY)
+        if a
+          if b
+            if c
+            ^^^^ Avoid more than 2 levels of block nesting.
+              puts 'hello'
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when CountModifierForms is true' do
+    let(:cop_config) { { 'Max' => 2, 'CountModifierForms' => true } }
+
+    context 'nested modifier forms' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          if a
+            if b
+              puts 'hello' if c
+              ^^^^^^^^^^^^^^^^^ Avoid more than 2 levels of block nesting.
+            end
+          end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #12970.

This PR adds `CountModifierForms` option to `Metrics/BlockNesting`.

Similar to the existing `CountBlocks`, the default is `false`. This means that existing modifier form code will not be detected by default, but this seems reasonable as part of the block nesting functionality. If user require the previous behavior, user can achieve it by setting `CountBlocks` to `true`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
