### PR TITLE
Run tests with Prism 0.30.0+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'memory_profiler', platform: :mri
 # https://github.com/lsegal/yard/pull/1545
 # Please remove this dependency when the issue is resolved.
 gem 'ostruct'
-gem 'prism'
+gem 'prism', '>= 0.30.0'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.21.0'

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+  context 'Ruby <= 3.2', :ruby32 do
     it 'registers an offense and corrects `next` guard clause not followed by empty line' do
       expect_offense(<<~RUBY)
         def foo
@@ -117,10 +117,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  # FIXME: https://github.com/rubocop/rubocop/issues/12869
   it 'registers an offense and corrects a next guard clause not followed by ' \
-     'empty line when guard clause is after heredoc ' \
-     'including string interpolation', broken_on: :prism do
+     'empty line when guard clause is after heredoc including string interpolation' do
     expect_offense(<<~'RUBY')
       raise(<<-FAIL) unless true
         #{1 + 1}
@@ -459,8 +457,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  # FIXME: https://github.com/rubocop/rubocop/issues/12869
-  it 'accepts a guard clause that is after a multiline heredoc with chained calls', broken_on: :prism do
+  it 'accepts a guard clause that is after a multiline heredoc with chained calls' do
     expect_no_offenses(<<~RUBY)
       def foo
         raise ArgumentError, <<~END.squish.it.good unless guard
@@ -473,8 +470,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  # FIXME: https://github.com/rubocop/rubocop/issues/12869
-  it 'accepts a guard clause that is after a multiline heredoc nested argument call', broken_on: :prism do
+  it 'accepts a guard clause that is after a multiline heredoc nested argument call' do
     expect_no_offenses(<<~RUBY)
       def foo
         raise ArgumentError, call(<<~END.squish) unless guard
@@ -533,7 +529,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
     it 'registers an offense and corrects a method starting with end_' do
       expect_offense(<<~RUBY)
         def foo
@@ -573,8 +569,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     end
   end
 
-  # FIXME: https://github.com/rubocop/rubocop/issues/12869
-  it 'registers no offenses using heredoc with `and return` before guard condition with empty line', broken_on: :prism do
+  it 'registers no offenses using heredoc with `and return` before guard condition with empty line' do
     expect_no_offenses(<<~RUBY)
       def foo
         puts(<<~MSG) and return if bar
@@ -587,8 +582,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  # FIXME: https://github.com/rubocop/rubocop/issues/12869
-  it 'registers an offense and corrects using heredoc with `and return` before guard condition', broken_on: :prism do
+  it 'registers an offense and corrects using heredoc with `and return` before guard condition' do
     expect_offense(<<~RUBY)
       def foo
         puts(<<~MSG) and return if bar

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -259,8 +259,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
     context 'and only certain heredoc delimiters are permitted' do
       let(:cop_config) { { 'Max' => 80, 'AllowHeredoc' => %w[SQL OK], 'AllowedPatterns' => [] } }
 
-      # FIXME: https://github.com/rubocop/rubocop/issues/12869
-      it 'rejects long lines in heredocs with not permitted delimiters', broken_on: :prism do
+      it 'rejects long lines in heredocs with not permitted delimiters' do
         expect_offense(<<-RUBY)
           foo(<<-DOC, <<-SQL, <<-FOO)
             1st offense: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.


### PR DESCRIPTION
The tests are being updated to use Prism 0.30.0+. For future purposes, `broken_on: :prism` is intentionally left in the spec_helper.rb.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
