### PR TITLE
[Fix #12975] Fix an error for `gem_config_path` when bundler is loaded and no Gemfile exists

### DIFF
--- a/changelog/fix_error_for_inherit_gem_without_gemfile.md
+++ b/changelog/fix_error_for_inherit_gem_without_gemfile.md
@@ -1,0 +1,1 @@
+* [#12975](https://github.com/rubocop/rubocop/issues/12975): Fix an error for the `inherit_gem` config when running RuboCop without bundler and no Gemfile exists. ([@earlopain][])

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -6,7 +6,7 @@ require 'yaml'
 module RuboCop
   # A help class for ConfigLoader that handles configuration resolution.
   # @api private
-  class ConfigLoaderResolver
+  class ConfigLoaderResolver # rubocop:disable Metrics/ClassLength
     def resolve_requires(path, hash)
       config_dir = File.dirname(path)
       hash.delete('require').tap do |loaded_features|
@@ -267,8 +267,12 @@ module RuboCop
 
     def gem_config_path(gem_name, relative_config_path)
       if defined?(Bundler)
-        gem = Bundler.load.specs[gem_name].first
-        gem_path = gem.full_gem_path if gem
+        begin
+          gem = Bundler.load.specs[gem_name].first
+          gem_path = gem.full_gem_path if gem
+        rescue Bundler::GemfileNotFound
+          # No Gemfile found. Bundler may be loaded manually
+        end
       end
 
       gem_path ||= Gem::Specification.find_by_name(gem_name).gem_dir

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1221,6 +1221,30 @@ RSpec.describe RuboCop::ConfigLoader do
               .to_set.superset?(expected.to_set)
           ).to be(true)
         end
+
+        # Workaround for https://github.com/rubocop/rubocop/issues/12978,
+        # there should already be no gemfile in the temp directory
+        context 'when no gemfile exists' do
+          around do |example|
+            # No bundler env and reset cached gemfile path
+            Bundler.with_unbundled_env do
+              old_values = Bundler.instance_variables.to_h do |name|
+                [name, Bundler.instance_variable_get(name)]
+              end
+              Bundler.instance_variables.each { |name| Bundler.remove_instance_variable(name) }
+              example.call
+            ensure
+              Bundler.instance_variables.each { |name| Bundler.remove_instance_variable(name) }
+              old_values.each do |name, value|
+                Bundler.instance_variable_set(name, value)
+              end
+            end
+          end
+
+          it 'loads' do
+            expect { configuration_from_file }.not_to raise_error
+          end
+        end
       end
 
       context 'and the gem is bundled' do


### PR DESCRIPTION
Fixes #12975

https://github.com/rubocop/rubocop/blob/10d115f168ac61e07a3715ef3b72eb4c7518bf6e/lib/rubocop/lockfile.rb#L3-L10 Bundler may be loaded because the LockFile parsers needs it.

With the improvement to the isolated environment, 4 tests fail. Previously they operated on the gemfile from the project folder.

The two autogen tests relied on modified env, which now is not visible anymore.

-------

This uses `Bundler.with_unbundled_env` because bundler adds some variables that would otherwise make this hard to test. `Bundler.reset!` is needed because a bunch of paths are memoized which would cause bundler to always return the Gemfile path of the rubocop folder instead of the tempfile/pwd. I added a test for that.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
