### PR TITLE
Enable a bunch of tests for prism

### DIFF
--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -130,23 +130,21 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
           RUBY
         end
 
-        context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-          it "accepts a `when` clause that's equally indented with `case`" do
-            expect_no_offenses(<<~RUBY)
-              y = case a
-                  when 0 then break
-                  when 0 then return
-                  else
-                    z = case b
-                        when 1 then return
-                        when 1 then break
-                        end
-                  end
-              case c
-              when 2 then encoding
-              end
-            RUBY
-          end
+        it "accepts a `when` clause that's equally indented with `case`" do
+          expect_no_offenses(<<~RUBY)
+            y = case a
+                when 0 then break
+                when 0 then return
+                else
+                  z = case b
+                      when 1 then return
+                      when 1 then break
+                      end
+                end
+            case c
+            when 2 then encoding
+            end
+          RUBY
         end
 
         it "doesn't get confused by strings with `case` in them" do
@@ -312,23 +310,21 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
           RUBY
         end
 
-        context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-          it "accepts an `in` clause that's equally indented with `case`" do
-            expect_no_offenses(<<~RUBY)
-              y = case a
-                  in 0 then break
-                  in 0 then return
-                  else
-                    z = case b
-                        in 1 then return
-                        in 1 then break
-                        end
-                  end
-              case c
-              in 2 then encoding
-              end
-            RUBY
-          end
+        it "accepts an `in` clause that's equally indented with `case`" do
+          expect_no_offenses(<<~RUBY)
+            y = case a
+                in 0 then break
+                in 0 then return
+                else
+                  z = case b
+                      in 1 then return
+                      in 1 then break
+                      end
+                end
+            case c
+            in 2 then encoding
+            end
+          RUBY
         end
 
         it "doesn't get confused by strings with `case` in them" do
@@ -432,41 +428,39 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
           RUBY
         end
 
-        context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-          it 'registers an offense and corrects a `when` clause that is equally indented with `case`' do
-            expect_offense(<<~RUBY)
-              y = case a
-                  when 0 then break
-                  ^^^^ Indent `when` one step more than `case`.
-                  when 0 then return
-                  ^^^^ Indent `when` one step more than `case`.
-                    z = case b
-                        when 1 then return
-                        ^^^^ Indent `when` one step more than `case`.
-                        when 1 then break
-                        ^^^^ Indent `when` one step more than `case`.
-                        end
-                  end
-              case c
-              when 2 then encoding
-              ^^^^ Indent `when` one step more than `case`.
-              end
-            RUBY
+        it 'registers an offense and corrects a `when` clause that is equally indented with `case`' do
+          expect_offense(<<~RUBY)
+            y = case a
+                when 0 then break
+                ^^^^ Indent `when` one step more than `case`.
+                when 0 then return
+                ^^^^ Indent `when` one step more than `case`.
+                  z = case b
+                      when 1 then return
+                      ^^^^ Indent `when` one step more than `case`.
+                      when 1 then break
+                      ^^^^ Indent `when` one step more than `case`.
+                      end
+                end
+            case c
+            when 2 then encoding
+            ^^^^ Indent `when` one step more than `case`.
+            end
+          RUBY
 
-            expect_correction(<<~RUBY)
-              y = case a
-                    when 0 then break
-                    when 0 then return
-                    z = case b
-                          when 1 then return
-                          when 1 then break
-                        end
-                  end
-              case c
-                when 2 then encoding
-              end
-            RUBY
-          end
+          expect_correction(<<~RUBY)
+            y = case a
+                  when 0 then break
+                  when 0 then return
+                  z = case b
+                        when 1 then return
+                        when 1 then break
+                      end
+                end
+            case c
+              when 2 then encoding
+            end
+          RUBY
         end
 
         context 'when indentation width is overridden for this cop only' do
@@ -544,41 +538,39 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
           RUBY
         end
 
-        context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-          it 'registers an offense and corrects an `in` clause that is equally indented with `case`' do
-            expect_offense(<<~RUBY)
-              y = case a
-                  in 0 then break
-                  ^^ Indent `in` one step more than `case`.
-                  in 0 then return
-                  ^^ Indent `in` one step more than `case`.
-                    z = case b
-                        in 1 then return
-                        ^^ Indent `in` one step more than `case`.
-                        in 1 then break
-                        ^^ Indent `in` one step more than `case`.
-                        end
-                  end
-              case c
-              in 2 then encoding
-              ^^ Indent `in` one step more than `case`.
-              end
-            RUBY
+        it 'registers an offense and corrects an `in` clause that is equally indented with `case`' do
+          expect_offense(<<~RUBY)
+            y = case a
+                in 0 then break
+                ^^ Indent `in` one step more than `case`.
+                in 0 then return
+                ^^ Indent `in` one step more than `case`.
+                  z = case b
+                      in 1 then return
+                      ^^ Indent `in` one step more than `case`.
+                      in 1 then break
+                      ^^ Indent `in` one step more than `case`.
+                      end
+                end
+            case c
+            in 2 then encoding
+            ^^ Indent `in` one step more than `case`.
+            end
+          RUBY
 
-            expect_correction(<<~RUBY)
-              y = case a
-                    in 0 then break
-                    in 0 then return
-                    z = case b
-                          in 1 then return
-                          in 1 then break
-                        end
-                  end
-              case c
-                in 2 then encoding
-              end
-            RUBY
-          end
+          expect_correction(<<~RUBY)
+            y = case a
+                  in 0 then break
+                  in 0 then return
+                  z = case b
+                        in 1 then return
+                        in 1 then break
+                      end
+                end
+            case c
+              in 2 then encoding
+            end
+          RUBY
         end
 
         context 'when indentation width is overridden for this cop only' do

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -529,44 +529,42 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-    it 'registers an offense and corrects a method starting with end_' do
-      expect_offense(<<~RUBY)
-        def foo
-          next unless need_next?
-          ^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
-          end_this!
-        end
-      RUBY
+  it 'registers an offense and corrects a method starting with end_' do
+    expect_offense(<<~RUBY)
+      def foo
+        next unless need_next?
+        ^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+        end_this!
+      end
+    RUBY
 
-      expect_correction(<<~RUBY)
-        def foo
-          next unless need_next?
+    expect_correction(<<~RUBY)
+      def foo
+        next unless need_next?
 
-          end_this!
-        end
-      RUBY
-    end
+        end_this!
+      end
+    RUBY
+  end
 
-    it 'registers an offense and corrects only the last guard clause' do
-      expect_offense(<<~RUBY)
-        def foo
-          next if foo?
-          next if bar?
-          ^^^^^^^^^^^^ Add empty line after guard clause.
-          foobar
-        end
-      RUBY
+  it 'registers an offense and corrects only the last guard clause' do
+    expect_offense(<<~RUBY)
+      def foo
+        next if foo?
+        next if bar?
+        ^^^^^^^^^^^^ Add empty line after guard clause.
+        foobar
+      end
+    RUBY
 
-      expect_correction(<<~RUBY)
-        def foo
-          next if foo?
-          next if bar?
+    expect_correction(<<~RUBY)
+      def foo
+        next if foo?
+        next if bar?
 
-          foobar
-        end
-      RUBY
-    end
+        foobar
+      end
+    RUBY
   end
 
   it 'registers no offenses using heredoc with `and return` before guard condition with empty line' do

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -120,32 +120,30 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-      it 'registers an offense and corrects misaligned keys in implicit hash for yield' do
-        expect_offense(<<~RUBY)
-          yield(a: 0,
-            b: 1)
-            ^^^^ Align the keys of a hash literal if they span more than one line.
-        RUBY
+    it 'registers an offense and corrects misaligned keys in implicit hash for yield' do
+      expect_offense(<<~RUBY)
+        yield(a: 0,
+          b: 1)
+          ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
 
-        expect_correction(<<~RUBY)
-          yield(a: 0,
-                b: 1)
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        yield(a: 0,
+              b: 1)
+      RUBY
+    end
 
-      it 'registers an offense and corrects misaligned keys in explicit hash for yield' do
-        expect_offense(<<~RUBY)
-          yield({a: 0,
-            b: 1})
-            ^^^^ Align the keys of a hash literal if they span more than one line.
-        RUBY
+    it 'registers an offense and corrects misaligned keys in explicit hash for yield' do
+      expect_offense(<<~RUBY)
+        yield({a: 0,
+          b: 1})
+          ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
 
-        expect_correction(<<~RUBY)
-          yield({a: 0,
-                 b: 1})
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        yield({a: 0,
+               b: 1})
+      RUBY
     end
 
     context 'when using hash value omission', :ruby31 do
@@ -303,20 +301,18 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-      it 'accepts misaligned keys in implicit hash for yield' do
-        expect_no_offenses(<<~RUBY)
-          yield(a: 0,
-            b: 1)
-        RUBY
-      end
+    it 'accepts misaligned keys in implicit hash for yield' do
+      expect_no_offenses(<<~RUBY)
+        yield(a: 0,
+          b: 1)
+      RUBY
+    end
 
-      it 'accepts misaligned keys in explicit hash for yield' do
-        expect_no_offenses(<<~RUBY)
-          yield({a: 0,
-            b: 1})
-        RUBY
-      end
+    it 'accepts misaligned keys in explicit hash for yield' do
+      expect_no_offenses(<<~RUBY)
+        yield({a: 0,
+          b: 1})
+      RUBY
     end
   end
 
@@ -363,26 +359,24 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-      it 'accepts misaligned keys in implicit hash for yield' do
-        expect_no_offenses(<<~RUBY)
-          yield(a: 0,
-            b: 1)
-        RUBY
-      end
+    it 'accepts misaligned keys in implicit hash for yield' do
+      expect_no_offenses(<<~RUBY)
+        yield(a: 0,
+          b: 1)
+      RUBY
+    end
 
-      it 'registers an offense and corrects misaligned keys in explicit hash for yield' do
-        expect_offense(<<~RUBY)
-          yield({a: 0,
-            b: 1})
-            ^^^^ Align the keys of a hash literal if they span more than one line.
-        RUBY
+    it 'registers an offense and corrects misaligned keys in explicit hash for yield' do
+      expect_offense(<<~RUBY)
+        yield({a: 0,
+          b: 1})
+          ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
 
-        expect_correction(<<~RUBY)
-          yield({a: 0,
-                 b: 1})
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        yield({a: 0,
+               b: 1})
+      RUBY
     end
   end
 
@@ -451,26 +445,24 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-      it 'registers an offense and corrects misaligned keys in implicit hash for yield' do
-        expect_offense(<<~RUBY)
-          yield(a: 0,
-            b: 1)
-            ^^^^ Align the keys of a hash literal if they span more than one line.
-        RUBY
+    it 'registers an offense and corrects misaligned keys in implicit hash for yield' do
+      expect_offense(<<~RUBY)
+        yield(a: 0,
+          b: 1)
+          ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
 
-        expect_correction(<<~RUBY)
-          yield(a: 0,
-                b: 1)
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        yield(a: 0,
+              b: 1)
+      RUBY
+    end
 
-      it 'accepts misaligned keys in explicit hash for yield' do
-        expect_no_offenses(<<~RUBY)
-          yield({a: 0,
-            b: 1})
-        RUBY
-      end
+    it 'accepts misaligned keys in explicit hash for yield' do
+      expect_no_offenses(<<~RUBY)
+        yield({a: 0,
+          b: 1})
+      RUBY
     end
   end
 
@@ -1331,10 +1323,8 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
     expect_no_offenses('super')
   end
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-    it 'registers no offense for yield without args' do
-      expect_no_offenses('yield')
-    end
+  it 'registers no offense for yield without args' do
+    expect_no_offenses('yield')
   end
 
   context 'with `EnforcedColonStyle`: `table`' do

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -551,13 +551,11 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation, :config do
         RUBY
       end
 
-      context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-        it "accepts indentation of next #{keyword} condition" do
-          expect_no_offenses(<<~RUBY)
-            next #{keyword} 5 ||
-              7
-          RUBY
-        end
+      it "accepts indentation of next #{keyword} condition" do
+        expect_no_offenses(<<~RUBY)
+          next #{keyword} 5 ||
+            7
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/layout/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_keyword_spec.rb
@@ -49,10 +49,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   it_behaves_like 'missing after', 'and', '1 and(2)', '1 and (2)'
   it_behaves_like 'missing after', 'begin', 'begin"" end', 'begin "" end'
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
-    it_behaves_like 'missing after', 'break', 'break""', 'break ""'
-    it_behaves_like 'accept after', '(', 'break(1)'
-  end
+  it_behaves_like 'missing after', 'break', 'break""', 'break ""'
+  it_behaves_like 'accept after', '(', 'break(1)'
 
   it_behaves_like 'missing after', 'case', 'case"" when 1; end', 'case "" when 1; end'
 
@@ -108,10 +106,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
 
   it_behaves_like 'missing after', 'if', 'if""; end', 'if ""; end'
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
-    it_behaves_like 'missing after', 'next', 'next""', 'next ""'
-    it_behaves_like 'accept after', '(', 'next(1)'
-  end
+  it_behaves_like 'missing after', 'next', 'next""', 'next ""'
+  it_behaves_like 'accept after', '(', 'next(1)'
 
   it_behaves_like 'missing after', 'not', 'not""', 'not ""'
   it_behaves_like 'accept after', '(', 'not(1)'
@@ -156,10 +152,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   it_behaves_like 'missing before', 'while', '1while ""', '1 while ""'
   it_behaves_like 'missing after', 'while', '1 while""', '1 while ""'
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
-    it_behaves_like 'missing after', 'yield', 'yield""', 'yield ""'
-    it_behaves_like 'accept after', '(', 'yield(1)'
-  end
+  it_behaves_like 'missing after', 'yield', 'yield""', 'yield ""'
+  it_behaves_like 'accept after', '(', 'yield(1)'
 
   it_behaves_like 'accept after', '+', '+begin end'
   it_behaves_like 'missing after', 'begin', 'begin+1 end', 'begin +1 end'
@@ -168,29 +162,21 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   it_behaves_like 'accept after', '\\', "test do\\\nend"
   it_behaves_like 'accept after', '\n', "test do\nend"
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
-    it_behaves_like 'accept around', '()', '(next)'
-    it_behaves_like 'accept before', '!', '!yield'
-    it_behaves_like 'accept after', '.', 'yield.method'
-    it_behaves_like 'accept before', '!', '!yield.method'
-  end
+  it_behaves_like 'accept around', '()', '(next)'
+  it_behaves_like 'accept before', '!', '!yield'
+  it_behaves_like 'accept after', '.', 'yield.method'
+  it_behaves_like 'accept before', '!', '!yield.method'
 
   it_behaves_like 'accept before', '!', '!super.method'
   it_behaves_like 'accept after', '::', 'super::ModuleName'
 
   context '&.' do
     it_behaves_like 'accept after', '&.', 'super&.foo'
-
-    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-      it_behaves_like 'accept after', '&.', 'yield&.foo'
-    end
+    it_behaves_like 'accept after', '&.', 'yield&.foo'
   end
 
   it_behaves_like 'accept after', '[', 'super[1]'
-
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
-    it_behaves_like 'accept after', '[', 'yield[1]'
-  end
+  it_behaves_like 'accept after', '[', 'yield[1]'
 
   # Layout/SpaceAroundBlockParameters
   it_behaves_like 'accept before', '|', 'loop { |x|break }'
@@ -220,10 +206,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   # Layout/SpaceBeforeComma, Layout/SpaceAfterComma
   it_behaves_like 'accept around', ',', 'a 1,foo,1'
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
-    # Layout/SpaceBeforeComment
-    it_behaves_like 'accept after', '#', 'next#comment'
-  end
+  # Layout/SpaceBeforeComment
+  it_behaves_like 'accept after', '#', 'next#comment'
 
   # Layout/SpaceBeforeSemicolon, Layout/SpaceAfterSemicolon
   it_behaves_like 'accept around', ';', 'test do;end'

--- a/spec/rubocop/cop/lint/ambiguous_operator_precedence_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_operator_precedence_spec.rb
@@ -121,12 +121,10 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousOperatorPrecedence, :config do
     RUBY
   end
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-    it 'allows an operator with `and`' do
-      expect_no_offenses(<<~RUBY)
-        array << i and next
-      RUBY
-    end
+  it 'allows an operator with `and`' do
+    expect_no_offenses(<<~RUBY)
+      array << i and next
+    RUBY
   end
 
   it 'allows an operator with `or`' do

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -356,31 +356,29 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition, :config do
       end
     end
 
-    context 'target ruby version <= 3.2', :ruby32, unsupported_on: :prism do
-      context 'when using `break` before empty case condition' do
-        it 'does not register an offense' do
-          expect_no_offenses(<<~RUBY)
-            break case
-                  when foo
-                    1
-                  else
-                    2
-                  end
-          RUBY
-        end
+    context 'when using `break` before empty case condition' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          break case
+                when foo
+                  1
+                else
+                  2
+                end
+        RUBY
       end
+    end
 
-      context 'when using `next` before empty case condition' do
-        it 'does not register an offense' do
-          expect_no_offenses(<<~RUBY)
-            next case
-                 when foo
-                   1
-                 else
-                   2
-                 end
-          RUBY
-        end
+    context 'when using `next` before empty case condition' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          next case
+               when foo
+                 1
+               else
+                 2
+               end
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/style/explicit_block_argument_spec.rb
+++ b/spec/rubocop/cop/style/explicit_block_argument_spec.rb
@@ -184,14 +184,12 @@ RSpec.describe RuboCop::Cop::Style::ExplicitBlockArgument, :config do
     RUBY
   end
 
-  context 'target ruby version <= 3.2', :ruby32, unsupported_on: :prism do
-    it 'does not register an offense when code is called outside of a method' do
-      expect_no_offenses(<<~RUBY)
-        render("partial") do
-          yield
-        end
-      RUBY
-    end
+  it 'does not register an offense when code is called outside of a method' do
+    expect_no_offenses(<<~RUBY)
+      render("partial") do
+        yield
+      end
+    RUBY
   end
 
   it 'does not add extra parens when correcting' do

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -643,119 +643,117 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
   end
 
   shared_examples 'on if nodes which exit current scope' do |kw|
-    context 'target ruby version <= 3.2', :ruby32, unsupported_on: :prism do
-      it "registers an error with #{kw} in the if branch" do
-        expect_offense(<<~RUBY)
-          if something
-          ^^ Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression.
-            #{kw}
-          else
-            puts "hello"
-          end
-        RUBY
+    it "registers an error with #{kw} in the if branch" do
+      expect_offense(<<~RUBY)
+        if something
+        ^^ Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression.
+          #{kw}
+        else
+          puts "hello"
+        end
+      RUBY
 
-        expect_correction(<<~RUBY)
-          #{kw} if something
-           #{trailing_whitespace}
+      expect_correction(<<~RUBY)
+        #{kw} if something
+         #{trailing_whitespace}
 
-            puts "hello"
+          puts "hello"
 
-        RUBY
-      end
+      RUBY
+    end
 
-      it "registers an error with #{kw} in the else branch" do
-        expect_offense(<<~RUBY)
-          if something
-          ^^ Use a guard clause (`#{kw} unless something`) instead of wrapping the code inside a conditional expression.
-           puts "hello"
-          else
-            #{kw}
-          end
-        RUBY
+    it "registers an error with #{kw} in the else branch" do
+      expect_offense(<<~RUBY)
+        if something
+        ^^ Use a guard clause (`#{kw} unless something`) instead of wrapping the code inside a conditional expression.
+         puts "hello"
+        else
+          #{kw}
+        end
+      RUBY
 
-        expect_correction(<<~RUBY)
-          #{kw} unless something
-           puts "hello"
+      expect_correction(<<~RUBY)
+        #{kw} unless something
+         puts "hello"
 
-           #{trailing_whitespace}
+         #{trailing_whitespace}
 
-        RUBY
-      end
+      RUBY
+    end
 
-      it "doesn't register an error if condition has multiple lines" do
-        expect_no_offenses(<<~RUBY)
-          if something &&
-               something_else
-            #{kw}
-          else
-            puts "hello"
-          end
-        RUBY
-      end
+    it "doesn't register an error if condition has multiple lines" do
+      expect_no_offenses(<<~RUBY)
+        if something &&
+             something_else
+          #{kw}
+        else
+          puts "hello"
+        end
+      RUBY
+    end
 
-      it "does not report an offense if #{kw} is inside elsif" do
-        expect_no_offenses(<<~RUBY)
-          if something
-            a
-          elsif something_else
-            #{kw}
-          end
-        RUBY
-      end
+    it "does not report an offense if #{kw} is inside elsif" do
+      expect_no_offenses(<<~RUBY)
+        if something
+          a
+        elsif something_else
+          #{kw}
+        end
+      RUBY
+    end
 
-      it "does not report an offense if #{kw} is inside then body of if..elsif..end" do
-        expect_no_offenses(<<~RUBY)
-          if something
-            #{kw}
-          elsif something_else
-            a
-          end
-        RUBY
-      end
+    it "does not report an offense if #{kw} is inside then body of if..elsif..end" do
+      expect_no_offenses(<<~RUBY)
+        if something
+          #{kw}
+        elsif something_else
+          a
+        end
+      RUBY
+    end
 
-      it "does not report an offense if #{kw} is inside if..elsif..else..end" do
-        expect_no_offenses(<<~RUBY)
-          if something
-            a
-          elsif something_else
-            b
-          else
-            #{kw}
-          end
-        RUBY
-      end
+    it "does not report an offense if #{kw} is inside if..elsif..else..end" do
+      expect_no_offenses(<<~RUBY)
+        if something
+          a
+        elsif something_else
+          b
+        else
+          #{kw}
+        end
+      RUBY
+    end
 
-      it "doesn't register an error if control flow expr has multiple lines" do
-        expect_no_offenses(<<~RUBY)
-          if something
-            #{kw} 'blah blah blah' \\
-                  'blah blah blah'
-          else
-            puts "hello"
-          end
-        RUBY
-      end
+    it "doesn't register an error if control flow expr has multiple lines" do
+      expect_no_offenses(<<~RUBY)
+        if something
+          #{kw} 'blah blah blah' \\
+                'blah blah blah'
+        else
+          puts "hello"
+        end
+      RUBY
+    end
 
-      it 'registers an error if non-control-flow branch has multiple lines' do
-        expect_offense(<<~RUBY)
-          if something
-          ^^ Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression.
-            #{kw}
-          else
-            puts "hello" \\
-                 "blah blah blah"
-          end
-        RUBY
+    it 'registers an error if non-control-flow branch has multiple lines' do
+      expect_offense(<<~RUBY)
+        if something
+        ^^ Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression.
+          #{kw}
+        else
+          puts "hello" \\
+               "blah blah blah"
+        end
+      RUBY
 
-        expect_correction(<<~RUBY)
-          #{kw} if something
-           #{trailing_whitespace}
+      expect_correction(<<~RUBY)
+        #{kw} if something
+         #{trailing_whitespace}
 
-            puts "hello" \\
-                 "blah blah blah"
+          puts "hello" \\
+               "blah blah blah"
 
-        RUBY
-      end
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/style/infinite_loop_spec.rb
+++ b/spec/rubocop/cop/style/infinite_loop_spec.rb
@@ -61,28 +61,26 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop, :config do
     RUBY
   end
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-    it 'accepts modifier while true if loop {} would change semantics' do
-      expect_no_offenses(<<~RUBY)
-        a = next_value or break while true
-        p a
-      RUBY
-    end
+  it 'accepts modifier while true if loop {} would change semantics' do
+    expect_no_offenses(<<~RUBY)
+      a = next_value or break while true
+      p a
+    RUBY
+  end
 
-    it 'registers an offense for modifier until false if loop {} would not change semantics' do
-      expect_offense(<<~RUBY)
-        a = nil
-        a = next_value or break until false
-                                ^^^^^ Use `Kernel#loop` for infinite loops.
-        p a
-      RUBY
+  it 'registers an offense for modifier until false if loop {} would not change semantics' do
+    expect_offense(<<~RUBY)
+      a = nil
+      a = next_value or break until false
+                              ^^^^^ Use `Kernel#loop` for infinite loops.
+      p a
+    RUBY
 
-      expect_correction(<<~RUBY)
-        a = nil
-        loop { a = next_value or break }
-        p a
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      a = nil
+      loop { a = next_value or break }
+      p a
+    RUBY
   end
 
   it 'registers an offense for until false if loop {} would work because of ' \

--- a/spec/rubocop/cop/style/map_compact_with_conditional_block_spec.rb
+++ b/spec/rubocop/cop/style/map_compact_with_conditional_block_spec.rb
@@ -342,15 +342,13 @@ RSpec.describe RuboCop::Cop::Style::MapCompactWithConditionalBlock, :config do
       RUBY
     end
 
-    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-      it 'does not register offenses if there are multiple guard clauses' do
-        expect_no_offenses(<<~RUBY)
-          next unless item.bar?
-          next unless item.baz?
+    it 'does not register offenses if there are multiple guard clauses' do
+      expect_no_offenses(<<~RUBY)
+        next unless item.bar?
+        next unless item.baz?
 
-          item
-        RUBY
-      end
+        item
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -154,10 +154,8 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('super')
     end
 
-    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-      it 'registers no offense for yield without args' do
-        expect_no_offenses('yield')
-      end
+    it 'registers no offense for yield without args' do
+      expect_no_offenses('yield')
     end
 
     it 'registers no offense for superclass call with parens' do
@@ -838,15 +836,13 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('foo &block')
     end
 
-    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-      it 'accepts parens in yield argument method calls' do
-        expect_no_offenses('yield File.basepath(path)')
-        expect_no_offenses('yield path, File.basepath(path)')
-      end
+    it 'accepts parens in yield argument method calls' do
+      expect_no_offenses('yield File.basepath(path)')
+      expect_no_offenses('yield path, File.basepath(path)')
+    end
 
-      it 'accepts parens in super calls with braced blocks' do
-        expect_no_offenses('super(foo(bar)) { yield }')
-      end
+    it 'accepts parens in super calls with braced blocks' do
+      expect_no_offenses('super(foo(bar)) { yield }')
     end
 
     it 'accepts parens in super without args' do
@@ -1097,16 +1093,14 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         RUBY
       end
 
-      context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-        it 'accepts parens in yield argument call with blocks' do
-          expect_no_offenses(<<~RUBY)
-            yield(
-              bar.new(quux) do
-                pass
-              end
-            )
-          RUBY
-        end
+      it 'accepts parens in yield argument call with blocks' do
+        expect_no_offenses(<<~RUBY)
+          yield(
+            bar.new(quux) do
+              pass
+            end
+          )
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -102,10 +102,7 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
 
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'puts 1'
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'defined? :A'
-
-    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
-      it_behaves_like 'if/then/else/end with constructs changing precedence', 'yield a'
-    end
+    it_behaves_like 'if/then/else/end with constructs changing precedence', 'yield a'
 
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'super b'
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'not a'
@@ -126,18 +123,16 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
       RUBY
     end
 
-    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
-      it 'registers and corrects an offense with ternary operator without adding parentheses for ' \
-         'if/then/else/end that contains method calls with parenthesized arguments' do
-        expect_offense(<<~RUBY)
-          if a(0) then puts(1) else yield(2) end
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{if_offense_message}
-        RUBY
+    it 'registers and corrects an offense with ternary operator without adding parentheses for ' \
+       'if/then/else/end that contains method calls with parenthesized arguments' do
+      expect_offense(<<~RUBY)
+        if a(0) then puts(1) else yield(2) end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{if_offense_message}
+      RUBY
 
-        expect_correction(<<~RUBY)
-          a(0) ? puts(1) : yield(2)
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        a(0) ? puts(1) : yield(2)
+      RUBY
     end
 
     it 'registers and corrects an offense with ternary operator without adding parentheses for ' \
@@ -166,10 +161,11 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
       end
     end
 
-    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
       it_behaves_like 'if/then/else/end with keyword', 'retry'
-      it_behaves_like 'if/then/else/end with keyword', 'break'
     end
+
+    it_behaves_like 'if/then/else/end with keyword', 'break'
 
     it_behaves_like 'if/then/else/end with keyword', 'self'
     it_behaves_like 'if/then/else/end with keyword', 'raise'
@@ -344,9 +340,7 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'puts 1'
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'defined? :A'
 
-    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
-      it_behaves_like 'if/then/else/end with constructs changing precedence', 'yield a'
-    end
+    it_behaves_like 'if/then/else/end with constructs changing precedence', 'yield a'
 
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'super b'
     it_behaves_like 'if/then/else/end with constructs changing precedence', 'not a'
@@ -371,22 +365,20 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
       RUBY
     end
 
-    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
-      it 'registers and corrects an offense with multi-line construct without adding parentheses for ' \
-         'if/then/else/end that contains method calls with parenthesized arguments' do
-        expect_offense(<<~RUBY)
-          if a(0) then puts(1) else yield(2) end
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{if_offense_message}
-        RUBY
+    it 'registers and corrects an offense with multi-line construct without adding parentheses for ' \
+       'if/then/else/end that contains method calls with parenthesized arguments' do
+      expect_offense(<<~RUBY)
+        if a(0) then puts(1) else yield(2) end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{if_offense_message}
+      RUBY
 
-        expect_correction(<<~RUBY)
-          if a(0)
-            puts(1)
-          else
-            yield(2)
-          end
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        if a(0)
+          puts(1)
+        else
+          yield(2)
+        end
+      RUBY
     end
 
     it 'registers and corrects an offense with multi-line construct without adding parentheses for ' \
@@ -423,10 +415,11 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
       end
     end
 
-    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
+    context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
       it_behaves_like 'if/then/else/end with keyword', 'retry'
-      it_behaves_like 'if/then/else/end with keyword', 'break'
     end
+
+    it_behaves_like 'if/then/else/end with keyword', 'break'
 
     it_behaves_like 'if/then/else/end with keyword', 'self'
     it_behaves_like 'if/then/else/end with keyword', 'raise'

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   it_behaves_like 'redundant', '(__FILE__)', '__FILE__', 'a keyword'
   it_behaves_like 'redundant', '(__LINE__)', '__LINE__', 'a keyword'
   it_behaves_like 'redundant', '(__ENCODING__)', '__ENCODING__', 'a keyword'
+  it_behaves_like 'redundant', '(redo)', 'redo', 'a keyword'
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
-    it_behaves_like 'redundant', '(redo)', 'redo', 'a keyword'
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
     it_behaves_like 'redundant', '(retry)', 'retry', 'a keyword'
   end
 
@@ -122,11 +122,9 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     end
   end
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
-    it_behaves_like 'keyword with return value', 'break'
-    it_behaves_like 'keyword with return value', 'next'
-    it_behaves_like 'keyword with arguments', 'yield'
-  end
+  it_behaves_like 'keyword with return value', 'break'
+  it_behaves_like 'keyword with return value', 'next'
+  it_behaves_like 'keyword with arguments', 'yield'
 
   it_behaves_like 'keyword with return value', 'return'
 
@@ -776,14 +774,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
-    it 'accepts parentheses in yield call with hash' do
-      expect_no_offenses(<<~RUBY)
-        yield ({
-          foo: bar,
-        })
-      RUBY
-    end
+  it 'accepts parentheses in yield call with hash' do
+    expect_no_offenses(<<~RUBY)
+      yield ({
+        foo: bar,
+      })
+    RUBY
   end
 
   it 'accepts parentheses in super call with multiline style argument' do
@@ -794,14 +790,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
-    it 'accepts parentheses in yield call with multiline style argument' do
-      expect_no_offenses(<<~RUBY)
-        yield (
-          42
-        )
-      RUBY
-    end
+  it 'accepts parentheses in yield call with multiline style argument' do
+    expect_no_offenses(<<~RUBY)
+      yield (
+        42
+      )
+    RUBY
   end
 
   it 'accepts parentheses in `return` with multiline style argument' do
@@ -823,44 +817,42 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
-  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do # rubocop:disable RSpec/RepeatedExampleGroupDescription
-    it 'accepts parentheses in `next` with multiline style argument' do
-      expect_no_offenses(<<~RUBY)
-        next (
-          42
-        )
-      RUBY
-    end
+  it 'accepts parentheses in `next` with multiline style argument' do
+    expect_no_offenses(<<~RUBY)
+      next (
+        42
+      )
+    RUBY
+  end
 
-    it 'registers an offense when parentheses in `next` with single style argument' do
-      expect_offense(<<~RUBY)
-        next (42)
-             ^^^^ Don't use parentheses around a literal.
-      RUBY
+  it 'registers an offense when parentheses in `next` with single style argument' do
+    expect_offense(<<~RUBY)
+      next (42)
+           ^^^^ Don't use parentheses around a literal.
+    RUBY
 
-      expect_correction(<<~RUBY)
-        next 42
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      next 42
+    RUBY
+  end
 
-    it 'accepts parentheses in `break` with multiline style argument' do
-      expect_no_offenses(<<~RUBY)
-        break (
-          42
-        )
-      RUBY
-    end
+  it 'accepts parentheses in `break` with multiline style argument' do
+    expect_no_offenses(<<~RUBY)
+      break (
+        42
+      )
+    RUBY
+  end
 
-    it 'registers an offense when parentheses in `break` with single style argument' do
-      expect_offense(<<~RUBY)
-        break (42)
-              ^^^^ Don't use parentheses around a literal.
-      RUBY
+  it 'registers an offense when parentheses in `break` with single style argument' do
+    expect_offense(<<~RUBY)
+      break (42)
+            ^^^^ Don't use parentheses around a literal.
+    RUBY
 
-      expect_correction(<<~RUBY)
-        break 42
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      break 42
+    RUBY
   end
 
   it 'registers an offense and corrects when method arguments are unnecessarily parenthesized' do

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -195,10 +195,7 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
       it_behaves_like 'safe guarding logical break keywords', 'raise'
       it_behaves_like 'safe guarding logical break keywords', 'return'
       it_behaves_like 'safe guarding logical break keywords', 'throw'
-
-      context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
-        it_behaves_like 'safe guarding logical break keywords', 'yield'
-      end
+      it_behaves_like 'safe guarding logical break keywords', 'yield'
 
       it 'registers an offense for a method call that nil responds to ' \
          'safe guarded by an object check' do

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -240,22 +240,20 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
         RUBY
       end
 
-      context 'target ruby version <= 3.2', :ruby32, unsupported_on: :prism do
-        it 'does not to an endless class method definition when using `break`' do
-          expect_correction(<<~RUBY.strip, source: 'def foo(argument) break bar(argument); end')
-            def foo(argument)#{trailing_whitespace}
-              break bar(argument);#{trailing_whitespace}
-            end
-          RUBY
-        end
+      it 'does not to an endless class method definition when using `break`' do
+        expect_correction(<<~RUBY.strip, source: 'def foo(argument) break bar(argument); end')
+          def foo(argument)#{trailing_whitespace}
+            break bar(argument);#{trailing_whitespace}
+          end
+        RUBY
+      end
 
-        it 'does not to an endless class method definition when using `next`' do
-          expect_correction(<<~RUBY.strip, source: 'def foo(argument) next bar(argument); end')
-            def foo(argument)#{trailing_whitespace}
-              next bar(argument);#{trailing_whitespace}
-            end
-          RUBY
-        end
+      it 'does not to an endless class method definition when using `next`' do
+        expect_correction(<<~RUBY.strip, source: 'def foo(argument) next bar(argument); end')
+          def foo(argument)#{trailing_whitespace}
+            next bar(argument);#{trailing_whitespace}
+          end
+        RUBY
       end
 
       # NOTE: Setter method cannot be defined in the endless method definition.

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -47,17 +47,15 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
         RUBY
       end
 
-      context 'target ruby version <= 3.2', :ruby32, unsupported_on: :prism do
-        it 'registers an offense for yield in condition' do
-          expect_offense(<<~RUBY)
-            foo = yield ? a : b
-                  ^^^^^^^^^^^^^ Use parentheses for ternary conditions.
-          RUBY
+      it 'registers an offense for yield in condition' do
+        expect_offense(<<~RUBY)
+          foo = yield ? a : b
+                ^^^^^^^^^^^^^ Use parentheses for ternary conditions.
+        RUBY
 
-          expect_correction(<<~RUBY)
-            foo = (yield) ? a : b
-          RUBY
-        end
+        expect_correction(<<~RUBY)
+          foo = (yield) ? a : b
+        RUBY
       end
 
       it 'registers an offense for accessor in condition' do
@@ -250,17 +248,15 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
         RUBY
       end
 
-      context 'target ruby version <= 3.2', :ruby32, unsupported_on: :prism do
-        it 'registers an offense for yield in condition' do
-          expect_offense(<<~RUBY)
-            foo = (yield) ? a : b
-                  ^^^^^^^^^^^^^^^ Omit parentheses for ternary conditions.
-          RUBY
+      it 'registers an offense for yield in condition' do
+        expect_offense(<<~RUBY)
+          foo = (yield) ? a : b
+                ^^^^^^^^^^^^^^^ Omit parentheses for ternary conditions.
+        RUBY
 
-          expect_correction(<<~RUBY)
-            foo = yield ? a : b
-          RUBY
-        end
+        expect_correction(<<~RUBY)
+          foo = yield ? a : b
+        RUBY
       end
 
       it 'registers an offense for accessor in condition' do
@@ -547,17 +543,15 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
         RUBY
       end
 
-      context 'target ruby version <= 3.2', :ruby32, unsupported_on: :prism do
-        it 'registers an offense for yield in condition' do
-          expect_offense(<<~RUBY)
-            foo = (yield) ? a : b
-                  ^^^^^^^^^^^^^^^ Only use parentheses for ternary expressions with complex conditions.
-          RUBY
+      it 'registers an offense for yield in condition' do
+        expect_offense(<<~RUBY)
+          foo = (yield) ? a : b
+                ^^^^^^^^^^^^^^^ Only use parentheses for ternary expressions with complex conditions.
+        RUBY
 
-          expect_correction(<<~RUBY)
-            foo = yield ? a : b
-          RUBY
-        end
+        expect_correction(<<~RUBY)
+          foo = yield ? a : b
+        RUBY
       end
 
       it 'registers an offense for accessor in condition' do


### PR DESCRIPTION
Most of these got disabled in #12822

It is however rather important that these cases parse since some extensions rely on parsing code line by line. This is the case when extracting code from a templating language like erb or haml

Prism was changed to allow these cases in https://github.com/ruby/prism/pull/2741

`packwerk` ran into issue: https://github.com/Shopify/packwerk/issues/400
`syntax_tree-erb` as well: https://github.com/davidwessman/syntax_tree-erb/issues/81
I myself observed the same in `rubocop-erb`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
