### PR TITLE
[Fix #12979] Fix false negatives for `Lint/Void`

### DIFF
--- a/changelog/fix_false_negatives_for_lint_void.md
+++ b/changelog/fix_false_negatives_for_lint_void.md
@@ -1,0 +1,1 @@
+* [#12979](https://github.com/rubocop/rubocop/issues/12979): Fix false negatives for `Lint/Void` when void expression with guard clause is not on last line. ([@koic][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -111,6 +111,8 @@ module RuboCop
         end
 
         def check_expression(expr)
+          expr = expr.body if expr.if_type? && expr.modifier_form?
+
           check_literal(expr)
           check_var(expr)
           check_self(expr)
@@ -211,6 +213,8 @@ module RuboCop
         end
 
         def autocorrect_void_expression(corrector, node)
+          return if node.parent.if_type? && node.parent.modifier_form?
+
           corrector.remove(range_with_surrounding_space(range: node.source_range, side: :left))
         end
 

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -99,6 +99,19 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         top
       RUBY
     end
+
+    it "registers an offense for void var #{var} with guard clause if not on last line" do
+      expect_offense(<<~RUBY, var: var)
+        %{var} = 5
+        %{var} unless condition
+        ^{var} Variable `#{var}` used in void context.
+        top
+      RUBY
+
+      # `var unless condition` might indicate missing `return` in `return var unless condition`,
+      # so for convenience, the code will not be autocorrected by deletion.
+      expect_no_corrections
+    end
   end
 
   it 'registers an offense for void constant `CONST` if not on last line' do
@@ -115,6 +128,19 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     RUBY
   end
 
+  it 'registers an offense for void constant `CONST` with guard condition if not on last line' do
+    expect_offense(<<~RUBY)
+      CONST = 5
+      CONST unless condition
+      ^^^^^ Constant `CONST` used in void context.
+      top
+    RUBY
+
+    # `CONST unless condition` might indicate missing `return` in `return CONST unless condition`,
+    # so for convenience, the code will not be autocorrected by deletion.
+    expect_no_corrections
+  end
+
   %w(1 2.0 :test /test/ [1] {}).each do |lit|
     it "registers an offense for void lit #{lit} if not on last line" do
       expect_offense(<<~RUBY, lit: lit)
@@ -127,6 +153,18 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         #{''}
         top
       RUBY
+    end
+
+    it "registers an offense for void lit #{lit} with guard condition if not on last line" do
+      expect_offense(<<~RUBY, lit: lit)
+        %{lit} unless condition
+        ^{lit} Literal `#{lit}` used in void context.
+        top
+      RUBY
+
+      # `42 unless condition` might indicate missing `return` in `return 42 unless condition`,
+      # so for convenience, the code will not be autocorrected by deletion.
+      expect_no_corrections
     end
   end
 


### PR DESCRIPTION
Fixes #12979.

This PR fixes false negatives for `Lint/Void` when void expression with guard clause is not on last line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
