### PR TITLE
[Fix #12983] Fix false positives for `Style/SendWithLiteralMethodName`

### DIFF
--- a/changelog/fix_false_positives_for_style_send_with_literal_method_name.md
+++ b/changelog/fix_false_positives_for_style_send_with_literal_method_name.md
@@ -1,0 +1,1 @@
+* [#12983](https://github.com/rubocop/rubocop/issues/12983): Fix false positives for `Style/SendWithLiteralMethodName` using `send` with writer method name. ([@koic][])

--- a/lib/rubocop/cop/style/send_with_literal_method_name.rb
+++ b/lib/rubocop/cop/style/send_with_literal_method_name.rb
@@ -7,6 +7,20 @@ module RuboCop
       # Since the `send` method can be used to call private methods, by default,
       # only the `public_send` method is detected.
       #
+      # NOTE: Writer methods with names ending in `=` are always permitted because their
+      # behavior differs as follows:
+      #
+      # [source,ruby]
+      # ----
+      # def foo=(foo)
+      #   @foo = foo
+      #   42
+      # end
+      #
+      # foo(1)         # => 1
+      # send(:foo=, 1) # => 42
+      # ----
+      #
       # @safety
       #   This cop is not safe because it can incorrectly detect based on the receiver.
       #   Additionally, when `AllowSend` is set to `true`, it cannot determine whether
@@ -43,7 +57,7 @@ module RuboCop
         MSG = 'Use `%<method_name>s` method call directly instead.'
         RESTRICT_ON_SEND = %i[public_send send __send__].freeze
         STATIC_METHOD_NAME_NODE_TYPES = %i[sym str].freeze
-        METHOD_NAME_PATTERN = /\A[a-zA-Z_][a-zA-Z0-9_]*[!?=]?\z/.freeze
+        METHOD_NAME_PATTERN = /\A[a-zA-Z_][a-zA-Z0-9_]*[!?]?\z/.freeze
         RESERVED_WORDS = %i[
           BEGIN END alias and begin break case class def defined? do else elsif end ensure
           false for if in module next nil not or redo rescue retry return self super then true

--- a/spec/rubocop/cop/style/send_with_literal_method_name_spec.rb
+++ b/spec/rubocop/cop/style/send_with_literal_method_name_spec.rb
@@ -91,6 +91,12 @@ RSpec.describe RuboCop::Cop::Style::SendWithLiteralMethodName, :config do
     RUBY
   end
 
+  it 'does not register an offense when using `public_send` with writer method name' do
+    expect_no_offenses(<<~RUBY)
+      obj.public_send("name=")
+    RUBY
+  end
+
   it 'does not register an offense when using `public_send` with method name with brackets' do
     expect_no_offenses(<<~RUBY)
       obj.public_send("{brackets}")


### PR DESCRIPTION
Fixes #12983.

This PR fixes false positives for `Style/SendWithLiteralMethodName` using `send` with writer method name.

Writer methods with names ending in `=` are always permitted because their behavior differs as follows:

```ruby
def foo=(foo)
  @foo = foo
  42
end

foo(1)         # => 1
send(:foo=, 1) # => 42
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
