### PR TITLE
[Fix #12985] Fix an error for `Style/RedundantRegexpCharacterClass`

### DIFF
--- a/changelog/fix_an_error_for_style_redundant_regexp_character_class.md
+++ b/changelog/fix_an_error_for_style_redundant_regexp_character_class.md
@@ -1,0 +1,1 @@
+* [#12985](https://github.com/rubocop/rubocop/issues/12985): Fix an error for `Style/RedundantRegexpCharacterClass` when using regexp_parser gem 2.3.1 or older. ([@koic][])

--- a/lib/rubocop/ext/regexp_parser.rb
+++ b/lib/rubocop/ext/regexp_parser.rb
@@ -22,26 +22,9 @@ module RuboCop
         module Base
           attr_accessor :origin
 
-          if Gem::Version.new(Regexp::Parser::VERSION) >= Gem::Version.new('2.0')
-            # Shortcut to `loc.expression`
-            def expression
-              @expression ||= origin.adjust(begin_pos: ts, end_pos: ts + full_length)
-            end
-          # Please remove this `else` branch when support for regexp_parser 1.8 will be dropped.
-          # It's for compatibility with regexp_parser 1.8 and will never be maintained.
-          else
-            attr_accessor :source
-
-            def start_index
-              # ts is a byte index; convert it to a character index
-              @start_index ||= source.byteslice(0, ts).length
-            end
-
-            # Shortcut to `loc.expression`
-            def expression
-              end_pos = start_index + full_length
-              @expression ||= origin.adjust(begin_pos: start_index, end_pos: end_pos)
-            end
+          # Shortcut to `loc.expression`
+          def expression
+            @expression ||= origin.adjust(begin_pos: ts, end_pos: ts + full_length)
           end
 
           # @returns a location map like `parser` does, with:
@@ -69,8 +52,8 @@ module RuboCop
 
             body = expression.adjust(end_pos: -q.text.length)
             q.origin = origin
-            q.source = source if q.respond_to?(:source=) # for regexp_parser 1.8
             q_loc = q.expression
+
             { body: body, quantifier: q_loc }
           end
         end

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('parallel', '~> 1.10')
   s.add_runtime_dependency('parser', '>= 3.3.0.2')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
-  s.add_runtime_dependency('regexp_parser', '>= 1.8', '< 3.0')
+  s.add_runtime_dependency('regexp_parser', '>= 2.4', '< 3.0')
   s.add_runtime_dependency('rexml', '>= 3.2.5', '< 4.0')
   s.add_runtime_dependency('rubocop-ast', '>= 1.31.1', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')


### PR DESCRIPTION
Fixes #12985.

This PR fixes an error for `Style/RedundantRegexpCharacterClass` when using regexp_parser gem 2.3.1 or older. This issue has already been resolved in regexp_parser gem 2.4.

In the past, there was an issue with compatibility with regexp_parser 1.x due to the following:
https://github.com/rubocop-hq/rubocop/pull/9102#issuecomment-737487246

Currently, many dependent gems including Capybara have permitted upgrading to regexp_parser 2.x:
https://rubygems.org/gems/regexp_parser/reverse_dependencies

Therefore, it would be a good time to specify `spec.runtime_dependency` as regexp_parser 2.4+.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
