### PR TITLE
[Fix #12989] Fix an error for the `inherit_gem` config when the Gemfile contains an uninstalled git gem

### DIFF
--- a/changelog/fix_error_for_inherit_gem_git_gem.md
+++ b/changelog/fix_error_for_inherit_gem_git_gem.md
@@ -1,0 +1,1 @@
+* [#12989](https://github.com/rubocop/rubocop/issues/12989): Fix an error for the `inherit_gem` config when the Gemfile contains an uninstalled git gem. ([@earlopain][])

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -272,6 +272,8 @@ module RuboCop
           gem_path = gem.full_gem_path if gem
         rescue Bundler::GemfileNotFound
           # No Gemfile found. Bundler may be loaded manually
+        rescue Bundler::GitError
+          # The Gemfile exists but contains an uninstalled git source
         end
       end
 

--- a/lib/rubocop/rspec/support.rb
+++ b/lib/rubocop/rspec/support.rb
@@ -13,6 +13,7 @@ RSpec.configure do |config|
   config.include HostEnvironmentSimulatorHelper
   config.include_context 'config', :config
   config.include_context 'isolated environment', :isolated_environment
+  config.include_context 'isolated bundler', :isolated_bundler
   config.include_context 'lsp', :lsp
   config.include_context 'maintain registry', :restore_registry
   config.include_context 'ruby 2.0', :ruby20

--- a/spec/isolated_environment_spec.rb
+++ b/spec/isolated_environment_spec.rb
@@ -23,4 +23,11 @@ RSpec.describe 'isolated environment', :isolated_environment, type: :feature do
     # A return value of 0 means that the erroneous config file was not read.
     expect(cli.run([])).to eq(0)
   end
+
+  context 'bundler is isolated', :isolated_bundler do
+    it 'has a Gemfile path in the temporary directory' do
+      create_empty_file('Gemfile')
+      expect(Bundler::SharedHelpers.root.to_s).to eq(Dir.pwd)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #12989

I also move the bundler isolation into the shared context and add a test for it

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
