### PR TITLE
Fix anchor if it contains two or more slashes

### DIFF
--- a/lib/rubocop/cops_documentation_generator.rb
+++ b/lib/rubocop/cops_documentation_generator.rb
@@ -306,7 +306,7 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
     filename = "#{department_to_basename(department)}.adoc"
     content = +"=== Department xref:#{filename}[#{type_title}]\n\n"
     cops_of_department(department).each do |cop|
-      anchor = cop.cop_name.sub('/', '').downcase
+      anchor = cop.cop_name.delete('/').downcase
       content << "* xref:#{filename}##{anchor}[#{cop.cop_name}]\n"
     end
 


### PR DESCRIPTION
Anchors are not generated correctly for cops containing two or more slashes.

For example, if you select `Capybara/RSpec/PredicateMatcher` from the link below, the anchor is not working.

https://github.com/rubocop/rubocop-capybara/blob/2e9e33a1feffab0c36f489387afa307a04318a66/docs/modules/ROOT/pages/cops.adoc

I have fixed it so that it does not matter how many slashes there are.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
