### PR TITLE
Fix an error for `Lint/UnmodifiedReduceAccumulator` when the block is empty

### DIFF
--- a/changelog/fix_error_for_lint_unmodified_reduce_accumulator.md
+++ b/changelog/fix_error_for_lint_unmodified_reduce_accumulator.md
@@ -1,0 +1,1 @@
+* [#12997](https://github.com/rubocop/rubocop/pull/12997): Fix an error for `Lint/UnmodifiedReduceAccumulator` when the block is empty. ([@earlopain][])

--- a/lib/rubocop/cop/lint/unmodified_reduce_accumulator.rb
+++ b/lib/rubocop/cop/lint/unmodified_reduce_accumulator.rb
@@ -113,6 +113,7 @@ module RuboCop
         PATTERN
 
         def on_block(node)
+          return unless node.body
           return unless reduce_with_block?(node)
           return unless node.argument_list.length >= 2
 

--- a/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
+++ b/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe RuboCop::Cop::Lint::UnmodifiedReduceAccumulator, :config do
       RUBY
     end
 
+    it "does not affect #{method} called with an empty block" do
+      expect_no_offenses(<<~RUBY)
+        values.#{method}(:+) { |result, value| }
+      RUBY
+    end
+
     context "given a #{method} block" do
       it 'does not register an offense when returning a literal' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Very simple fix

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
