### PR TITLE
[Fix #12716] Fix false negatives for `Lint/Void`

### DIFF
--- a/changelog/fix_false_negatives_for_lint_void_cop.md
+++ b/changelog/fix_false_negatives_for_lint_void_cop.md
@@ -1,0 +1,1 @@
+* [#12716](https://github.com/rubocop/rubocop/issues/12716): Fix false negatives for `Lint/Void` when using parenthesized void operators. ([@koic][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -123,6 +123,7 @@ module RuboCop
         end
 
         def check_void_op(node, &block)
+          node = node.children.first while node.begin_type?
           return unless node.send_type? && OPERATORS.include?(node.method_name)
           return if block && yield(node)
 

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -30,6 +30,36 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     it "accepts void op #{op} by itself without a begin block" do
       expect_no_offenses("a #{op} b")
     end
+
+    it "registers an offense for parenthesized void op #{op} if not on last line" do
+      expect_offense(<<~RUBY, op: op)
+        (a %{op} b)
+           ^{op} Operator `#{op}` used in void context.
+        ((a %{op} b))
+            ^{op} Operator `#{op}` used in void context.
+        (((a %{op} b)))
+      RUBY
+
+      # NOTE: Redundant parentheses in `(var)` are left to `Style/RedundantParentheses` to fix.
+      expect_correction(<<~RUBY)
+        (a
+        b)
+        ((a
+        b))
+        (((a #{op} b)))
+      RUBY
+    end
+
+    it "accepts parenthesized void op #{op} if on last line" do
+      expect_no_offenses(<<~RUBY)
+        something
+        (a #{op} b)
+      RUBY
+    end
+
+    it "accepts parenthesized void op #{op} by itself without a begin block" do
+      expect_no_offenses("(a #{op} b)")
+    end
   end
 
   sign_unary_operators = %i[+ -]


### PR DESCRIPTION
Fixes #12716.

This PR fixes false negatives for `Lint/Void` when using parenthesized void operators.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
