### PR TITLE
Workaround for Ruby's warning in YARD

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,10 @@ gemspec
 gem 'asciidoctor'
 gem 'bump', require: false
 gem 'bundler', '>= 1.15.0', '< 3.0'
+# FIXME: This is a workaround to prevent the following warning in YARD:
+# https://github.com/lsegal/yard/pull/1546
+# Please remove this dependency when the issue is resolved.
+gem 'logger'
 gem 'memory_profiler', platform: :mri
 # FIXME: This is a workaround to prevent the following warning in YARD:
 # https://github.com/lsegal/yard/pull/1545


### PR DESCRIPTION
This is a workaround to prevent the following warning in YARD:

```console
$ ruby -v
ruby 3.4.0dev (2024-06-14T03:14:32Z master 2677ab1607) [x86_64-darwin23]
$ cd path/to/rubocop
$ bundle exec rake
/Users/koic/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/yard-0.9.36/lib/yard/logging.rb:3:
warning: logger was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0.
Add logger to your Gemfile or gemspec.
```

The fundamental resolution will likely be addressed in https://github.com/lsegal/yard/pull/1546.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
