### PR TITLE
Reconfigure `RSpec/PredicateMatcher` for better expectation failure messages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -142,7 +142,8 @@ RSpec:
       - expect_offense
 
 RSpec/PredicateMatcher:
-  EnforcedStyle: explicit
+  # Also consider `be(true)` and `be(false)` as offenses, instead of only `be_truthy` and `be_falsy`
+  Strict: false
 
 RSpec/SpecFilePathFormat:
   CustomTransform:

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -173,7 +173,9 @@ module RuboCop
       def same_line?(node1, node2)
         line1 = line(node1)
         line2 = line(node2)
-        line1 && line2 && line1 == line2
+        return false unless line1 && line2
+
+        line1 == line2
       end
 
       def indent(node, offset: 0)

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'RuboCop Project', type: :feature do
         description = config.dig(name, 'Description')
         expect(description.nil?).to(be(false),
                                     "`Description` configuration is required for `#{name}`.")
-        expect(description.include?("\n")).to be(false)
+        expect(description).not_to include("\n")
 
         start_with_subject = description.match(/\AThis cop (?<verb>.+?) .*/)
         suggestion = start_with_subject[:verb]&.capitalize if start_with_subject
@@ -194,7 +194,7 @@ RSpec.describe 'RuboCop Project', type: :feature do
     let(:non_reference_lines) { lines.take_while { |line| !line.start_with?('[@') } }
 
     it 'has newline at end of file' do
-      expect(changelog.end_with?("\n")).to be true
+      expect(changelog).to end_with("\n")
     end
 
     it 'has either entries, headers, empty lines, or comments' do
@@ -224,7 +224,7 @@ RSpec.describe 'RuboCop Project', type: :feature do
         end
 
         it 'has a reference' do
-          issues.each { |issue| expect(issue[:ref].blank?).to be(false) }
+          issues.each { |issue| expect(issue[:ref]).not_to be_blank }
         end
 
         it 'has a valid issue number prefixed with #' do
@@ -306,7 +306,7 @@ RSpec.describe 'RuboCop Project', type: :feature do
       dir = File.expand_path('../changelog', __dir__)
 
       it 'does not have a directory' do
-        expect(Dir["#{dir}/*"].none? { |path| File.directory?(path) }).to be(true)
+        expect(Dir["#{dir}/*"]).to be_none { |path| File.directory?(path) }
       end
 
       Dir["#{dir}/*.md"].each do |path|

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           $stdout = StringIO.new
           expect(RuboCop::CLI.new.run([])).to eq(0)
           expect($stderr.string).to eq('')
-          expect($stdout.string.include?('no offenses detected')).to be(true)
+          expect($stdout.string).to include('no offenses detected')
         end
       end
     end
@@ -148,7 +148,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
         it "bases other cops' configuration on the overridden LineLength:Max" do
           expect(cli.run(['--auto-gen-config'])).to eq(0)
-          expect($stdout.string.include?(<<~YAML)).to be(true)
+          expect($stdout.string).to include(<<~YAML)
             Added inheritance from `.rubocop_todo.yml` in `.rubocop.yml`.
             Phase 1 of 2: run Layout/LineLength cop (skipped because the default Layout/LineLength:Max is overridden)
             Phase 2 of 2: run all cops
@@ -194,7 +194,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
         it 'skips the cop from both phases of the run' do
           expect(cli.run(['--auto-gen-config'])).to eq(0)
-          expect($stdout.string.include?(<<~YAML)).to be(true)
+          expect($stdout.string).to include(<<~YAML)
             Added inheritance from `.rubocop_todo.yml` in `.rubocop.yml`.
             Phase 1 of 2: run Layout/LineLength cop (skipped because Layout/LineLength is disabled)
             Phase 2 of 2: run all cops
@@ -244,7 +244,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
         it "bases other cops' configuration on the overridden LineLength:Max" do
           expect(cli.run(['--auto-gen-config'])).to eq(0)
-          expect($stdout.string.include?(<<~YAML)).to be(true)
+          expect($stdout.string).to include(<<~YAML)
             Added inheritance from `.rubocop_todo.yml` in `.rubocop.yml`.
             Phase 1 of 2: run Layout/LineLength cop (skipped because the default Layout/LineLength:Max is overridden)
             Phase 2 of 2: run all cops
@@ -511,7 +511,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             Max: 95
         YAML
         expect(cli.run(%w[--auto-gen-config --config dir/cop_config.yml])).to eq(0)
-        expect(Dir['.*'].include?('.rubocop_todo.yml')).to be(true)
+        expect(Dir['.*']).to include('.rubocop_todo.yml')
         todo_contents = File.read('.rubocop_todo.yml').lines[8..].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
@@ -552,7 +552,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         create_empty_file('cop_config.yml')
 
         expect(cli.run(%w[--auto-gen-config --config cop_config.yml])).to eq(0)
-        expect(Dir['.*'].include?('.rubocop_todo.yml')).to be(true)
+        expect(Dir['.*']).to include('.rubocop_todo.yml')
         todo_contents = File.read('.rubocop_todo.yml').lines[8..].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
@@ -597,7 +597,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         expect(cli.run(%w[--auto-gen-config])).to eq(0)
         expect($stderr.string).to eq('')
         # expect($stdout.string).to include('Created .rubocop_todo.yml.')
-        expect(Dir['.*'].include?('.rubocop_todo.yml')).to be(true)
+        expect(Dir['.*']).to include('.rubocop_todo.yml')
         todo_contents = File.read('.rubocop_todo.yml').lines[8..].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
@@ -639,7 +639,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         YAML
         expect(cli.run(%w[--auto-gen-config])).to eq(0)
         expect($stderr.string).to eq('')
-        expect(Dir['.*'].include?('.rubocop_todo.yml')).to be(true)
+        expect(Dir['.*']).to include('.rubocop_todo.yml')
         todo_contents = File.read('.rubocop_todo.yml').lines[8..].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
@@ -673,7 +673,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         YAML
         expect(cli.run(%w[--auto-gen-config])).to eq(0)
         expect($stderr.string).to eq('')
-        expect(Dir['.*'].include?('.rubocop_todo.yml')).to be(true)
+        expect(Dir['.*']).to include('.rubocop_todo.yml')
         todo_contents = File.read('.rubocop_todo.yml').lines[8..].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
@@ -711,7 +711,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         Dir.chdir('dir') { expect(cli.run(%w[--auto-gen-config])).to eq(0) }
         expect($stderr.string).to eq('')
         # expect($stdout.string).to include('Created .rubocop_todo.yml.')
-        expect(Dir['dir/.*'].include?('dir/.rubocop_todo.yml')).to be(true)
+        expect(Dir['dir/.*']).to include('dir/.rubocop_todo.yml')
         todo_contents = File.read('dir/.rubocop_todo.yml').lines[8..].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
@@ -752,7 +752,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           YAML
           expect(cli.run(%w[--auto-gen-config])).to eq(0)
           expect($stderr.string).to eq('')
-          expect($stdout.string.include?(<<~YAML)).to be(true)
+          expect($stdout.string).to include(<<~YAML)
             Added inheritance from `.rubocop_todo.yml` in `.rubocop.yml`.
           YAML
           expect(File.read('.rubocop.yml')).to eq(<<~YAML)
@@ -772,7 +772,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           YAML
           expect(cli.run(%w[--auto-gen-config])).to eq(0)
           expect($stderr.string).to eq('')
-          expect($stdout.string.include?(<<~YAML)).to be(true)
+          expect($stdout.string).to include(<<~YAML)
             Added inheritance from `.rubocop_todo.yml` in `.rubocop.yml`.
           YAML
           expect(File.read('.rubocop.yml')).to eq(<<~YAML)
@@ -808,7 +808,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
       expect(cli.run(['--auto-gen-config'])).to eq(0)
       expect($stderr.string).to eq('')
-      expect($stdout.string.include?('Created .rubocop_todo.yml.')).to be(true)
+      expect($stdout.string).to include('Created .rubocop_todo.yml.')
       expected =
         ['# This configuration was generated by',
          '# `rubocop --auto-gen-config`',
@@ -1215,7 +1215,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
       expect(cli.run(['--auto-gen-config', '--no-offense-counts'])).to eq(0)
       expect($stderr.string).to eq('')
-      expect($stdout.string.include?('Created .rubocop_todo.yml.')).to be(true)
+      expect($stdout.string).to include('Created .rubocop_todo.yml.')
       expected =
         ['# This configuration was generated by',
          '# `rubocop --auto-gen-config --no-offense-counts`',
@@ -1310,7 +1310,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
       $stdout = StringIO.new
       expect(cli.run(['--auto-gen-config', '--auto-gen-only-exclude',
                       '--exclude-limit', '1'])).to eq(0)
-      expect($stdout.string.include?(<<~STRING)).to be(true)
+      expect($stdout.string).to include(<<~STRING)
         Phase 1 of 2: run Layout/LineLength cop (skipped because only excludes will be generated due to `--auto-gen-only-exclude` flag)
         Phase 2 of 2: run all cops
       STRING
@@ -1481,7 +1481,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
       it 'displays report summary but no offenses' do
         expect(cli.run(['--auto-gen-config'])).to eq(0)
 
-        expect($stdout.string.include?(<<~OUTPUT)).to be(true)
+        expect($stdout.string).to include(<<~OUTPUT)
           Inspecting 1 file
           C
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -875,7 +875,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     expect(
       cli.run(['-a', '--only', 'Layout/SpaceAroundKeyword,Layout/SpaceInsideRangeLiteral'])
     ).to eq(0)
-    expect($stdout.string.include?('no offenses detected')).to be(true)
+    expect($stdout.string).to include('no offenses detected')
     expect(File.read('example.rb')).to eq(source)
   end
 
@@ -1363,7 +1363,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     uncorrected = $stdout.string.split($RS).select do |line|
       line.include?('example.rb:') && !line.include?('[Corrected]')
     end
-    expect(uncorrected.empty?).to be(true) # Hence exit code 0.
+    expect(uncorrected).to be_empty # Hence exit code 0.
   end
 
   it 'corrects only IndentationWidth without crashing' do
@@ -1401,7 +1401,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
         Enabled: false
     YAML
     expect(cli.run(['--autocorrect-all'])).to eq(0)
-    expect($stdout.string.include?('no offenses detected')).to be(true)
+    expect($stdout.string).to include('no offenses detected')
     expect(File.read('example.rb')).to eq("#{source}\n")
   end
 
@@ -1590,7 +1590,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     uncorrected = $stdout.string.split($RS).select do |line|
       line.include?('example.rb:') && !line.include?('[Corrected]')
     end
-    expect(uncorrected.empty?).to be(false) # Hence exit code 1.
+    expect(uncorrected).not_to be_empty # Hence exit code 1.
   end
 
   it 'can correct single line methods' do

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
         it 'prints a warning' do
           cli.run ['-P']
-          expect($stderr.string.include?('Process.fork is not supported by this Ruby')).to be(true)
+          expect($stderr.string).to include('Process.fork is not supported by this Ruby')
         end
       end
     else
@@ -30,10 +30,9 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
         it 'fails with an error message' do
           cli.run %w[-P]
-          expect($stderr.string.include?('-P/--parallel uses caching to speed up execution, ' \
-                                         'so combining with AllCops: UseCache: false is not ' \
-                                         'allowed.'))
-            .to be(true)
+          expect($stderr.string)
+            .to include('-P/--parallel uses caching to speed up execution, so ' \
+                        'combining with AllCops: UseCache: false is not allowed.')
         end
       end
 
@@ -117,7 +116,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
           options = '--no-server --only Style/FrozenStringLiteralComment,Style/StringLiterals'
           output = `ruby -I . "#{rubocop}" #{options}`
           expect(output).not_to match(/RuboCop server starting on \d+\.\d+\.\d+\.\d+:\d+\./)
-          expect(output.include?(<<~RESULT)).to be(true)
+          expect(output).to include(<<~RESULT)
             Inspecting 1 file
             C
 
@@ -207,7 +206,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
             0 files inspected, no offenses detected
           RESULT
-          expect(stderr.include?("RuboCop server is not supported by this Ruby.\n")).to be(false)
+          expect(stderr).not_to include("RuboCop server is not supported by this Ruby.\n")
           expect(status.exitstatus).to eq 0
         end
       end
@@ -216,7 +215,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         it 'displays an warning message' do
           stdout, stderr, status = Open3.capture3("ruby -I . \"#{rubocop}\" --start-server")
           expect(stdout).to eq ''
-          expect(stderr.include?("RuboCop server is not supported by this Ruby.\n")).to be(true)
+          expect(stderr).to include("RuboCop server is not supported by this Ruby.\n")
           expect(status.exitstatus).to eq 2
         end
       end
@@ -227,12 +226,12 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
     context 'when there are no files' do
       it 'prints nothing with -L' do
         cli.run ['-L']
-        expect($stdout.string.empty?).to be(true)
+        expect($stdout.string).to be_empty
       end
 
       it 'prints nothing with --list-target-files' do
         cli.run ['--list-target-files']
-        expect($stdout.string.empty?).to be(true)
+        expect($stdout.string).to be_empty
       end
     end
 
@@ -291,7 +290,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
   describe '-V' do
     it 'exits cleanly' do
       expect(cli.run(['-V'])).to eq(0)
-      expect($stdout.string.include?(RuboCop::Version::STRING)).to be(true)
+      expect($stdout.string).to include(RuboCop::Version::STRING)
       expect($stdout.string).to match(/Parser \d+\.\d+\.\d+/)
       expect($stdout.string).to match(/rubocop-ast \d+\.\d+\.\d+/)
     end
@@ -309,7 +308,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         # Run in different process that requiring rubocop-performance and rubocop-rspec
         # does not affect other testing processes.
         output = `ruby -I . "#{rubocop}" -V --disable-pending-cops`
-        expect(output.include?(RuboCop::Version::STRING)).to be(true)
+        expect(output).to include(RuboCop::Version::STRING)
         expect(output).to match(/Parser \d+\.\d+\.\d+/)
         expect(output).to match(/rubocop-ast \d+\.\d+\.\d+/)
         expect(output).to match(/rubocop-performance \d+\.\d+\.\d+/)
@@ -335,7 +334,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         # Run in different process that requiring rubocop-performance and rubocop-rspec
         # does not affect other testing processes.
         output = `ruby -I . "#{rubocop}" -V --disable-pending-cops`
-        expect(output.include?(RuboCop::Version::STRING)).to be(true)
+        expect(output).to include(RuboCop::Version::STRING)
         expect(output).to match(/Parser \d+\.\d+\.\d+/)
         expect(output).to match(/rubocop-ast \d+\.\d+\.\d+/)
         expect(output).to match(/rubocop-performance \d+\.\d+\.\d+/)
@@ -359,7 +358,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
       it 'shows with version of each extension cop once' do
         output = `ruby -I . "#{rubocop}" -V --disable-pending-cops`
-        expect(output.include?(RuboCop::Version::STRING)).to be(true)
+        expect(output).to include(RuboCop::Version::STRING)
         expect(output).to match(/Parser \d+\.\d+\.\d+/)
         expect(output).to match(/rubocop-ast \d+\.\d+\.\d+/)
         expect(output).to match(
@@ -402,10 +401,10 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
       it 'does not show warnings for pending cops' do
         output = `ruby -I . "#{rubocop}" --require redirect.rb -V`
-        expect(output.include?(RuboCop::Version::STRING)).to be(true)
+        expect(output).to include(RuboCop::Version::STRING)
         expect(output).to match(/Parser \d+\.\d+\.\d+/)
         expect(output).to match(/rubocop-ast \d+\.\d+\.\d+/)
-        expect(output.include?(pending_cop_warning)).to be(false)
+        expect(output).not_to include(pending_cop_warning)
       end
     end
 
@@ -419,7 +418,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
       it 'exits cleanly' do
         expect(cli.run(['-V'])).to eq(0)
-        expect($stdout.string.include?(RuboCop::Version::STRING)).to be(true)
+        expect($stdout.string).to include(RuboCop::Version::STRING)
       end
     end
   end
@@ -448,36 +447,35 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       it 'exits with error if an incorrect cop name is passed' do
         create_file('example.rb', ['if x== 0 ', "\ty", 'end'])
         expect(cli.run(['--only', 'Style/123'])).to eq(2)
-        expect($stderr.string.include?('Unrecognized cop or department: Style/123.')).to be(true)
+        expect($stderr.string).to include('Unrecognized cop or department: Style/123.')
       end
 
       it 'displays correction candidate if an incorrect cop name is given' do
         create_file('example.rb', ['x'])
         expect(cli.run(['--only', 'Style/BlockComment'])).to eq(2)
-        expect($stderr.string.include?('Unrecognized cop or department: Style/BlockComment.'))
-          .to be(true)
-        expect($stderr.string.include?('Did you mean? Style/BlockComments')).to be(true)
+        expect($stderr.string).to include('Unrecognized cop or department: Style/BlockComment.')
+        expect($stderr.string).to include('Did you mean? Style/BlockComments')
       end
 
       it 'exits with error if an empty string is given' do
         create_file('example.rb', 'x')
         expect(cli.run(['--only', ''])).to eq(2)
-        expect($stderr.string.include?('Unrecognized cop or department: .')).to be(true)
+        expect($stderr.string).to include('Unrecognized cop or department: .')
       end
 
       it '`Lint/Syntax` must be enabled even if `--only` is given `Style/StringLiterals` only' do
         create_file('example.rb', '1 /// 2')
         expect(cli.run(['--only', 'Style/StringLiterals', 'example.rb'])).to eq(1)
         expect(
-          $stdout.string.include?('example.rb:1:7: F: Lint/Syntax: unexpected token tINTEGER')
-        ).to be(true)
+          $stdout.string
+        ).to include('example.rb:1:7: F: Lint/Syntax: unexpected token tINTEGER')
       end
 
       %w[Syntax Lint/Syntax].each do |name|
         it "only checks syntax if #{name} is given" do
           create_file('example.rb', 'x ')
           expect(cli.run(['--only', name])).to eq(0)
-          expect($stdout.string.include?('no offenses detected')).to be(true)
+          expect($stdout.string).to include('no offenses detected')
         end
       end
 
@@ -486,10 +484,10 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         it "exits with error if cop name #{name} is passed" do
           create_file('example.rb', ['if x== 0 ', "\ty", 'end'])
           expect(cli.run(['--only', 'RedundantCopDisableDirective'])).to eq(2)
-          expect($stderr.string.include?(
-                   'Lint/RedundantCopDisableDirective cannot be used with --only.'
-                 ))
-            .to be(true)
+          expect($stderr.string)
+            .to include(
+              'Lint/RedundantCopDisableDirective cannot be used with --only.'
+            )
         end
       end
 
@@ -590,8 +588,8 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
               remaining_range = pending_cop_warning.length..-(inspected_output.length + 1)
               pending_cops = output[remaining_range]
 
-              expect(pending_cops.include?("Style/SomeCop: # new in 0.80\n  Enabled: true"))
-                .to be(true)
+              expect(pending_cops)
+                .to include("Style/SomeCop: # new in 0.80\n  Enabled: true")
 
               manual_url = output[remaining_range].split("\n").last
 
@@ -609,8 +607,8 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
               remaining_range = pending_cop_warning.length..-(inspected_output.length + 1)
               pending_cops = output[remaining_range]
 
-              expect(pending_cops.include?("Style/SomeCop: # new in N/A\n  Enabled: true"))
-                .to be(true)
+              expect(pending_cops)
+                .to include("Style/SomeCop: # new in N/A\n  Enabled: true")
 
               manual_url = output[remaining_range].split("\n").last
 
@@ -918,28 +916,27 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       it 'exits with error if the cop name is incorrect' do
         create_file('example.rb', ['if x== 0 ', "\ty", 'end'])
         expect(cli.run(['--except', 'Style/123'])).to eq(2)
-        expect($stderr.string.include?('Unrecognized cop or department: Style/123.')).to be(true)
+        expect($stderr.string).to include('Unrecognized cop or department: Style/123.')
       end
 
       it 'exits with error if an empty string is given' do
         create_file('example.rb', 'x')
         expect(cli.run(['--except', ''])).to eq(2)
-        expect($stderr.string.include?('Unrecognized cop or department: .')).to be(true)
+        expect($stderr.string).to include('Unrecognized cop or department: .')
       end
 
       it 'displays correction candidate if an incorrect cop name is given' do
         create_file('example.rb', 'x')
         expect(cli.run(['--except', 'Style/BlockComment'])).to eq(2)
-        expect($stderr.string.include?('Unrecognized cop or department: Style/BlockComment.'))
-          .to be(true)
-        expect($stderr.string.include?('Did you mean? Style/BlockComments')).to be(true)
+        expect($stderr.string).to include('Unrecognized cop or department: Style/BlockComment.')
+        expect($stderr.string).to include('Did you mean? Style/BlockComments')
       end
 
       %w[Syntax Lint/Syntax].each do |name|
         it "exits with error if #{name} is given" do
           create_file('example.rb', 'x ')
           expect(cli.run(['--except', name])).to eq(2)
-          expect($stderr.string.include?('Syntax checking cannot be turned off.')).to be(true)
+          expect($stderr.string).to include('Syntax checking cannot be turned off.')
         end
       end
     end
@@ -1291,15 +1288,15 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
       it 'prints all available cops and their description' do
         cops.each do |cop|
-          expect(stdout.include?(cop.cop_name)).to be(true)
+          expect(stdout).to include(cop.cop_name)
           # Because of line breaks, we will only find the beginning.
-          expect(stdout.include?(short_description_of_cop(cop)[0..60])).to be(true)
+          expect(stdout).to include(short_description_of_cop(cop)[0..60])
         end
       end
 
       it 'prints all departments' do
         registry.departments.each do |department|
-          expect(stdout.include?(department.to_s)).to be(true)
+          expect(stdout).to include(department.to_s)
         end
       end
 
@@ -1311,13 +1308,13 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
           # all cops in their department listing
           registry.with_department(current).each do |cop|
-            expect(slice.any? { |l| l.include? cop.cop_name }).to be_truthy
+            expect(slice).to be_any { |l| l.include? cop.cop_name }
           end
 
           # no cop in wrong department listing
           departments.each do |department|
             registry.with_department(department).each do |cop|
-              expect(slice.any? { |l| l.include? cop.cop_name }).to be_falsey
+              expect(slice).not_to be_any { |l| l.include? cop.cop_name }
             end
           end
         end
@@ -1532,7 +1529,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       context 'when simple format is specified' do
         it 'outputs with simple format' do
           cli.run(['--format', 'simple', 'example.rb'])
-          expect($stdout.string.include?(<<~RESULT)).to be(true)
+          expect($stdout.string).to include(<<~RESULT)
             == #{target_file} ==
             C:  1:  1: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
             C:  1:121: Layout/LineLength: Line is too long. [130/120]
@@ -1715,16 +1712,14 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       context 'when unknown format name is specified' do
         it 'aborts with error message' do
           expect(cli.run(['--format', 'unknown', 'example.rb'])).to eq(2)
-          expect($stderr.string.include?('Formatter "unknown" not found')).to be(true)
+          expect($stderr.string).to include('Formatter "unknown" not found')
         end
       end
 
       context 'when wrong similar format name is specified' do
         it 'aborts with error message' do
           expect(cli.run(['--format', 'quite', 'example.rb'])).to eq(2)
-          expect(
-            $stderr.string.include?('Formatter "quite" not found. Did you mean? "quiet"')
-          ).to be(true)
+          expect($stderr.string).to include('Formatter "quite" not found. Did you mean? "quiet"')
         end
       end
     end
@@ -1767,14 +1762,14 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         it 'aborts with error message' do
           args = '--format UnknownFormatter example.rb'
           expect(cli.run(args.split)).to eq(2)
-          expect($stderr.string.include?('UnknownFormatter')).to be(true)
+          expect($stderr.string).to include('UnknownFormatter')
         end
       end
     end
 
     it 'can be used multiple times' do
       cli.run(['--format', 'simple', '--format', 'emacs', 'example.rb'])
-      expect($stdout.string.include?(<<~RESULT)).to be(true)
+      expect($stdout.string).to include(<<~RESULT)
         == #{target_file} ==
         C:  1:  1: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
         C:  1:121: Layout/LineLength: Line is too long. [130/120]
@@ -1791,7 +1786,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
     it 'redirects output to the specified file' do
       cli.run(['--out', 'output.txt', target_file])
-      expect(File.read('output.txt').include?('Line is too long.')).to be(true)
+      expect(File.read('output.txt')).to include('Line is too long.')
     end
 
     it 'is applied to the previously specified formatter' do
@@ -1826,8 +1821,8 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
     def expect_offense_detected
       expect($stderr.string).to eq('')
-      expect($stdout.string.include?('1 file inspected, 1 offense detected')).to be(true)
-      expect($stdout.string.include?('Layout/IndentationWidth')).to be(true)
+      expect($stdout.string).to include('1 file inspected, 1 offense detected')
+      expect($stdout.string).to include('Layout/IndentationWidth')
     end
 
     it 'fails when option is less than the severity level' do
@@ -1870,8 +1865,8 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
                         '--only', 'Layout/LineLength',
                         target_file])).to eq(0)
         expect($stderr.string).to eq('')
-        expect($stdout.string.include?('1 file inspected, 1 offense detected')).to be(true)
-        expect($stdout.string.include?('Layout/LineLength')).to be(true)
+        expect($stdout.string).to include('1 file inspected, 1 offense detected')
+        expect($stdout.string).to include('Layout/LineLength')
       end
     end
 
@@ -1901,8 +1896,8 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
                         '--only', 'Layout/IndentationWidth',
                         target_file])).to eq 0
         expect($stderr.string).to eq('')
-        expect($stdout.string.include?('1 file inspected, no offenses detected')).to be(true)
-        expect($stdout.string.include?('Layout/IndentationWidth')).to be(false)
+        expect($stdout.string).to include('1 file inspected, no offenses detected')
+        expect($stdout.string).not_to include('Layout/IndentationWidth')
       end
 
       context 'with disabled line' do
@@ -1917,9 +1912,9 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
                           '--display-only-fail-level-offenses',
                           target_file])).to eq 0
           expect($stderr.string).to eq('')
-          expect($stdout.string.include?('1 file inspected, no offenses detected')).to be(true)
-          expect($stdout.string.include?('Layout/IndentationWidth')).to be(false)
-          expect($stdout.string.include?('Lint/RedundantCopDisableDirective')).to be(false)
+          expect($stdout.string).to include('1 file inspected, no offenses detected')
+          expect($stdout.string).not_to include('Layout/IndentationWidth')
+          expect($stdout.string).not_to include('Lint/RedundantCopDisableDirective')
         end
 
         it "still checks unprinted offense if they're a redundant disable" do
@@ -1933,8 +1928,8 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
                           '--display-only-fail-level-offenses',
                           target_file])).to eq 1
           expect($stderr.string).to eq('')
-          expect($stdout.string.include?('1 file inspected, 1 offense detected')).to be(true)
-          expect($stdout.string.include?('RedundantCopDisableDirective')).to be(true)
+          expect($stdout.string).to include('1 file inspected, 1 offense detected')
+          expect($stdout.string).to include('RedundantCopDisableDirective')
         end
       end
     end
@@ -2168,7 +2163,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       $stdin = StringIO.new('p $/')
       argv   = ['--only=Style/SpecialGlobalVars', '--format=simple', '--stdin']
       expect(cli.run(argv)).to eq(2)
-      expect($stderr.string.include?('missing argument: --stdin')).to be(true)
+      expect($stderr.string).to include('missing argument: --stdin')
     ensure
       $stdin = STDIN
     end
@@ -2181,7 +2176,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
                 'fake1.rb',
                 'fake2.rb']
       expect(cli.run(argv)).to eq(2)
-      expect($stderr.string.include?('-s/--stdin requires exactly one path')).to be(true)
+      expect($stderr.string).to include('-s/--stdin requires exactly one path')
     ensure
       $stdin = STDIN
     end

--- a/spec/rubocop/cli/suggest_extensions_spec.rb
+++ b/spec/rubocop/cli/suggest_extensions_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'RuboCop::CLI SuggestExtensions', :isolated_environment do # rubo
 
       it 'does not show the suggestion' do
         expect { cli.run(['example.rb']) }.not_to suggest_extensions
-        expect($stderr.string.blank?).to be(true)
+        expect($stderr.string).to be_blank
       end
     end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             puts 'hello'
           RUBY
           expect(cli.run(['--debug'])).to eq(0)
-          expect($stdout.string.include?('Use parallel by default.')).to be(true)
+          expect($stdout.string).to include('Use parallel by default.')
         end
       end
 
@@ -240,7 +240,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           RUBY
           create_empty_file('.rubocop.yml')
           expect(cli.run(['--debug', '--config', '.rubocop.yml'])).to eq(0)
-          expect($stdout.string.include?('Use parallel by default.')).to be(true)
+          expect($stdout.string).to include('Use parallel by default.')
         end
       end
 
@@ -252,7 +252,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             puts "hello"
           RUBY
           expect(cli.run(['--debug', '-a'])).to eq(0)
-          expect($stdout.string.include?('Use parallel by default.')).to be(true)
+          expect($stdout.string).to include('Use parallel by default.')
           expect(File.read('example1.rb')).to eq(<<~RUBY)
             # frozen_string_literal: true
 
@@ -273,7 +273,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               UseCache: true
           YAML
           expect(cli.run(['--debug'])).to eq(0)
-          expect($stdout.string.include?('Use parallel by default.')).to be(true)
+          expect($stdout.string).to include('Use parallel by default.')
         end
       end
 
@@ -289,7 +289,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               UseCache: false
           YAML
           expect(cli.run(['--debug'])).to eq(0)
-          expect($stdout.string.include?('Use parallel by default.')).to be(false)
+          expect($stdout.string).not_to include('Use parallel by default.')
         end
       end
     end
@@ -348,9 +348,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       RUBY
 
       expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
-      expect(
-        $stdout.string.include?('F:  1:  7: Lint/Syntax: unexpected token tINTEGER')
-      ).to be(true)
+      expect($stdout.string).to include('F:  1:  7: Lint/Syntax: unexpected token tINTEGER')
     end
 
     it '`Lint/Syntax` must be enabled when `DisabledByDefault: true`' do
@@ -364,9 +362,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       RUBY
 
       expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
-      expect(
-        $stdout.string.include?('F:  1:  7: Lint/Syntax: unexpected token tINTEGER')
-      ).to be(true)
+      expect($stdout.string).to include('F:  1:  7: Lint/Syntax: unexpected token tINTEGER')
     end
 
     it '`Lint/Syntax` must be enabled when disabled by directive comment' do
@@ -376,9 +372,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       RUBY
 
       expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
-      expect(
-        $stdout.string.include?('F:  2:  7: Lint/Syntax: unexpected token tINTEGER')
-      ).to be(true)
+      expect($stdout.string).to include('F:  2:  7: Lint/Syntax: unexpected token tINTEGER')
     end
 
     it '`Lint/Syntax` must be enabled when disabled by directive department comment' do
@@ -388,9 +382,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       RUBY
 
       expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
-      expect(
-        $stdout.string.include?('F:  2:  7: Lint/Syntax: unexpected token tINTEGER')
-      ).to be(true)
+      expect($stdout.string).to include('F:  2:  7: Lint/Syntax: unexpected token tINTEGER')
     end
 
     it '`Lint/Syntax` must be enabled when disabled by directive all comment' do
@@ -400,9 +392,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       RUBY
 
       expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
-      expect(
-        $stdout.string.include?('F:  2:  7: Lint/Syntax: unexpected token tINTEGER')
-      ).to be(true)
+      expect($stdout.string).to include('F:  2:  7: Lint/Syntax: unexpected token tINTEGER')
     end
 
     it '`Naming/FileName` must be be disabled for global offenses' do
@@ -411,7 +401,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       RUBY
 
       expect(cli.run(['--format', 'simple', 'Example.rb'])).to eq(1)
-      expect($stdout.string.include?('Naming/FileName:')).to be(false)
+      expect($stdout.string).not_to include('Naming/FileName:')
     end
 
     it '`Naming/FileName` must be be enabled if directive comment is on unrelated line' do
@@ -421,7 +411,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       RUBY
 
       expect(cli.run(['--format', 'simple', 'Example.rb'])).to eq(1)
-      expect($stdout.string.include?('C:  1:  1: Naming/FileName:')).to be(true)
+      expect($stdout.string).to include('C:  1:  1: Naming/FileName:')
     end
   end
 
@@ -538,7 +528,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     it 'can disable all cops on a single line' do
       create_file('example.rb', 'y("123", 123456) # rubocop:disable all')
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(0)
-      expect($stdout.string.empty?).to be(true)
+      expect($stdout.string).to be_empty
     end
 
     it 'can disable selected cops on a single line' do
@@ -619,7 +609,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             assert_equal nil, combinator {}.call # rubocop:disable Lint/EmptyBlock'
           RUBY
           expect(cli.run(['example.rb'])).to eq(0)
-          expect($stdout.string.include?('1 file inspected, no offenses detected')).to be(true)
+          expect($stdout.string).to include('1 file inspected, no offenses detected')
         end
       end
 
@@ -639,7 +629,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             end
           RUBY
           expect(cli.run(['example.rb'])).to eq(0)
-          expect($stdout.string.include?('1 file inspected, no offenses detected')).to be(true)
+          expect($stdout.string).to include('1 file inspected, no offenses detected')
         end
       end
 
@@ -982,10 +972,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               - "="
         YAML
         expect(cli.run([])).to eq(2)
-        expect($stderr.string.include?('obsolete parameter ' \
-                                       '`MultiSpaceAllowedForOperators` ' \
-                                       '(for `Layout/SpaceAroundOperators`) ' \
-                                       'found')).to be(true)
+        expect($stderr.string).to include('obsolete parameter `MultiSpaceAllowedForOperators` ' \
+                                          '(for `Layout/SpaceAroundOperators`) found')
       end
     end
 
@@ -1389,8 +1377,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           Enabled: false
       YAML
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(2)
-      expect($stderr.string.include?('Error: configuration for Lint/Syntax cop found')).to be(true)
-      expect($stderr.string.include?('It\'s not possible to disable this cop.')).to be(true)
+      expect($stderr.string).to include('Error: configuration for Lint/Syntax cop found')
+      expect($stderr.string).to include('It\'s not possible to disable this cop.')
     end
 
     it 'can be configured to merge a parameter that is a hash' do
@@ -2131,8 +2119,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       it 'is an invalid configuration' do
         expect(cli.run(['--format', 'simple', 'test.rb'])).to eq(2)
         expect(
-          $stderr.string.include?('Error: configuration for Lint/Syntax cop found in .rubocop.yml')
-        ).to be(true)
+          $stderr.string
+        ).to include('Error: configuration for Lint/Syntax cop found in .rubocop.yml')
       end
     end
 
@@ -2152,9 +2140,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
       it '`Lint/Syntax` severity `fatal` cannot be changed by configuration' do
         expect(cli.run(['--format', 'simple', 'test.rb'])).to eq(1)
-        expect(
-          $stdout.string.include?('F:  1:  7: Lint/Syntax: unexpected token tINTEGER')
-        ).to be(true)
+        expect($stdout.string).to include('F:  1:  7: Lint/Syntax: unexpected token tINTEGER')
       end
     end
   end
@@ -2186,13 +2172,13 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
       it 'does not create profile files by default' do
         expect(cli.run(['example1.rb'])).to eq(0)
-        expect($stdout.string.include?('Profile report generated')).to be(false)
+        expect($stdout.string).not_to include('Profile report generated')
         expect(File).not_to exist(cpu_profile)
       end
 
       it 'creates cpu profile file' do
         expect(cli.run(['--profile', 'example1.rb'])).to eq(0)
-        expect($stdout.string.include?('Profile report generated')).to be(true)
+        expect($stdout.string).to include('Profile report generated')
         expect(File).to exist(cpu_profile)
       end
 
@@ -2201,7 +2187,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       # https://github.com/rubocop/rubocop/pull/12999.
       it 'creates memory profile file', broken_on: :ruby_head do
         expect(cli.run(['--profile', '--memory', 'example1.rb'])).to eq(0)
-        expect($stdout.string.include?('Building memory report...')).to be(true)
+        expect($stdout.string).to include('Building memory report...')
         expect(File).to exist(memory_profile)
       end
     end

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -120,24 +120,24 @@ RSpec.describe RuboCop::CommentConfig do
     it 'just ignores unpaired enabling directives' do
       void_disabled_lines = disabled_lines_of_cop('Lint/Void')
       expected_part = (25..source.size).to_a
-      expect((void_disabled_lines & expected_part).empty?).to be(true)
+      expect((void_disabled_lines & expected_part)).to be_empty
     end
 
     it 'supports disabling single line with a directive at end of line' do
       eval_disabled_lines = disabled_lines_of_cop('Security/Eval')
-      expect(eval_disabled_lines.include?(12)).to be(true)
-      expect(eval_disabled_lines.include?(13)).to be(false)
+      expect(eval_disabled_lines).to include(12)
+      expect(eval_disabled_lines).not_to include(13)
     end
 
     it 'handles indented single line' do
       line_length_disabled_lines = disabled_lines_of_cop('Layout/LineLength')
-      expect(line_length_disabled_lines.include?(16)).to be(true)
-      expect(line_length_disabled_lines.include?(18)).to be(false)
+      expect(line_length_disabled_lines).to include(16)
+      expect(line_length_disabled_lines).not_to include(18)
     end
 
     it 'does not confuse a comment directive embedded in a string literal with a real comment' do
       loop_disabled_lines = disabled_lines_of_cop('Loop')
-      expect(loop_disabled_lines.include?(20)).to be(false)
+      expect(loop_disabled_lines).not_to include(20)
     end
 
     it 'supports disabling all cops except Lint/RedundantCopDisableDirective and Lint/Syntax with keyword all' do
@@ -153,7 +153,7 @@ RSpec.describe RuboCop::CommentConfig do
 
     it 'does not confuse a cop name including "all" with all cops' do
       alias_disabled_lines = disabled_lines_of_cop('Alias')
-      expect(alias_disabled_lines.include?(23)).to be(false)
+      expect(alias_disabled_lines).not_to include(23)
     end
 
     it 'can handle double disable of one cop' do
@@ -161,11 +161,11 @@ RSpec.describe RuboCop::CommentConfig do
     end
 
     it 'supports disabling cops with multiple uppercase letters' do
-      expect(disabled_lines_of_cop('RSpec/Example').include?(47)).to be(true)
+      expect(disabled_lines_of_cop('RSpec/Example')).to include(47)
     end
 
     it 'supports disabling cops with numbers in their name' do
-      expect(disabled_lines_of_cop('Custom2/Number9').include?(48)).to be(true)
+      expect(disabled_lines_of_cop('Custom2/Number9')).to include(48)
     end
 
     it 'supports disabling cops on a comment line with an EOL comment' do
@@ -210,7 +210,7 @@ RSpec.describe RuboCop::CommentConfig do
     it 'has keys as instances of Parser::Source::Comment for extra enabled comments' do
       key = extra.keys.first
 
-      expect(key.is_a?(Parser::Source::Comment)).to be true
+      expect(key).to be_a(Parser::Source::Comment)
       expect(key.text).to eq '# rubocop:enable Metrics/MethodLength, Security/Eval'
     end
 
@@ -236,7 +236,7 @@ RSpec.describe RuboCop::CommentConfig do
     context 'when line contains only comment' do
       [1, 5].each do |line_number|
         it 'returns true' do
-          expect(comment_config.comment_only_line?(line_number)).to be true
+          expect(comment_config).to be_comment_only_line(line_number)
         end
       end
     end
@@ -244,7 +244,7 @@ RSpec.describe RuboCop::CommentConfig do
     context 'when line is empty' do
       [6].each do |line_number|
         it 'returns true' do
-          expect(comment_config.comment_only_line?(line_number)).to be true
+          expect(comment_config).to be_comment_only_line(line_number)
         end
       end
     end
@@ -252,7 +252,7 @@ RSpec.describe RuboCop::CommentConfig do
     context 'when line contains only code' do
       [2, 3, 4, 7].each do |line_number|
         it 'returns false' do
-          expect(comment_config.comment_only_line?(line_number)).to be false
+          expect(comment_config).not_to be_comment_only_line(line_number)
         end
       end
     end
@@ -260,7 +260,7 @@ RSpec.describe RuboCop::CommentConfig do
     context 'when line contains code and comment' do
       [8].each do |line_number|
         it 'returns false' do
-          expect(comment_config.comment_only_line?(line_number)).to be false
+          expect(comment_config).not_to be_comment_only_line(line_number)
         end
       end
     end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -360,8 +360,8 @@ RSpec.describe RuboCop::ConfigLoader do
 
         configuration = config_loader.configuration_from_file(sub_file_path)
         excludes = configuration['AllCops']['Exclude']
-        expect(excludes.include?(File.expand_path('vendor/**'))).to be(false)
-        expect(excludes.include?(File.expand_path('vendor/foo'))).to be(true)
+        expect(excludes).not_to include(File.expand_path('vendor/**'))
+        expect(excludes).to include(File.expand_path('vendor/foo'))
       end
     end
 
@@ -1052,7 +1052,7 @@ RSpec.describe RuboCop::ConfigLoader do
                      'Max' => 200 }            # special.yml takes precedence
         expect do
           expect(configuration_from_file['Metrics/MethodLength']
-                   .to_set.superset?(expected.to_set)).to be(true)
+                   .to_set).to be_superset(expected.to_set)
         end.to output(Regexp.new(<<~OUTPUT)).to_stdout
           .rubocop.yml: Metrics/MethodLength:Enabled overrides the same parameter in special.yml
           .rubocop.yml: Metrics/MethodLength:Enabled overrides the same parameter in normal.yml
@@ -1209,7 +1209,7 @@ RSpec.describe RuboCop::ConfigLoader do
                        'Max' => 200 }            # inherited from somegem
           expect do
             expect(configuration_from_file['Metrics/MethodLength']
-                    .to_set.superset?(expected.to_set)).to be(true)
+                    .to_set).to be_superset(expected.to_set)
           end.not_to output.to_stderr
 
           expected = { 'Enabled' => true, # gemtwo/config/default.yml
@@ -1218,8 +1218,8 @@ RSpec.describe RuboCop::ConfigLoader do
                        'AllowURI' => false }     # overridden in .rubocop.yml
           expect(
             configuration_from_file['Layout/LineLength']
-              .to_set.superset?(expected.to_set)
-          ).to be(true)
+              .to_set
+          ).to be_superset(expected.to_set)
         end
 
         context 'bundler isolated', :isolated_bundler do
@@ -1264,7 +1264,7 @@ RSpec.describe RuboCop::ConfigLoader do
                        'Max' => 200 }            # inherited from somegem
           expect do
             expect(configuration_from_file['Metrics/MethodLength']
-                    .to_set.superset?(expected.to_set)).to be(true)
+                    .to_set).to be_superset(expected.to_set)
           end.not_to output.to_stderr
 
           expected = { 'Enabled' => true, # gemtwo/config/default.yml
@@ -1273,8 +1273,8 @@ RSpec.describe RuboCop::ConfigLoader do
                        'AllowURI' => false }     # overridden in .rubocop.yml
           expect(
             configuration_from_file['Layout/LineLength']
-              .to_set.superset?(expected.to_set)
-          ).to be(true)
+              .to_set
+          ).to be_superset(expected.to_set)
         end
       end
     end
@@ -1334,7 +1334,7 @@ RSpec.describe RuboCop::ConfigLoader do
 
       it 'creates the cached file alongside the owning file' do
         expect { configuration_from_file }.not_to output.to_stderr
-        expect(File.exist?(cache_file)).to be true
+        expect(File).to exist(cache_file)
       end
     end
 
@@ -1361,8 +1361,8 @@ RSpec.describe RuboCop::ConfigLoader do
 
       it 'downloads the inherited file from the same url and caches it' do
         configuration_from_file
-        expect(File.exist?(cache_file)).to be true
-        expect(File.exist?(cache_file2)).to be true
+        expect(File).to exist(cache_file)
+        expect(File).to exist(cache_file2)
       end
     end
 

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -511,14 +511,14 @@ RSpec.describe RuboCop::Config do
     context 'when the passed path matches any of patterns to include' do
       it 'returns true' do
         file_path = '/home/foo/project/Gemfile'
-        expect(configuration.file_to_include?(file_path)).to be_truthy
+        expect(configuration).to be_file_to_include(file_path)
       end
     end
 
     context 'when the passed path does not match any of patterns to include' do
       it 'returns false' do
         file_path = '/home/foo/project/Gemfile.lock'
-        expect(configuration.file_to_include?(file_path)).to be_falsey
+        expect(configuration).not_to be_file_to_include(file_path)
       end
     end
   end
@@ -535,22 +535,22 @@ RSpec.describe RuboCop::Config do
     context 'when the passed path matches any of patterns to exclude' do
       it 'returns true' do
         file_path = "#{Dir.pwd}/log/foo.rb"
-        expect(configuration.file_to_exclude?(file_path)).to be_truthy
+        expect(configuration).to be_file_to_exclude(file_path)
 
-        expect(configuration.file_to_exclude?('log/foo.rb')).to be_truthy
+        expect(configuration).to be_file_to_exclude('log/foo.rb')
 
-        expect(configuration.file_to_exclude?('bar.rb')).to be_truthy
+        expect(configuration).to be_file_to_exclude('bar.rb')
       end
     end
 
     context 'when the passed path does not match any of patterns to exclude' do
       it 'returns false' do
         file_path = "#{Dir.pwd}/log_file.rb"
-        expect(configuration.file_to_exclude?(file_path)).to be_falsey
+        expect(configuration).not_to be_file_to_exclude(file_path)
 
-        expect(configuration.file_to_exclude?('app/controller.rb')).to be_falsey
+        expect(configuration).not_to be_file_to_exclude('app/controller.rb')
 
-        expect(configuration.file_to_exclude?('baz.rb')).to be_falsey
+        expect(configuration).not_to be_file_to_exclude('baz.rb')
       end
     end
   end
@@ -610,25 +610,25 @@ RSpec.describe RuboCop::Config do
     it 'returns true when Include config only includes regular paths' do
       configuration['AllCops'] = { 'Include' => ['**/Gemfile', 'config/unicorn.rb.example'] }
 
-      expect(configuration.possibly_include_hidden?).to be(false)
+      expect(configuration).not_to be_possibly_include_hidden
     end
 
     it 'returns true when Include config includes a regex' do
       configuration['AllCops'] = { 'Include' => [/foo/] }
 
-      expect(configuration.possibly_include_hidden?).to be(true)
+      expect(configuration).to be_possibly_include_hidden
     end
 
     it 'returns true when Include config includes a toplevel dotfile' do
       configuration['AllCops'] = { 'Include' => ['.foo'] }
 
-      expect(configuration.possibly_include_hidden?).to be(true)
+      expect(configuration).to be_possibly_include_hidden
     end
 
     it 'returns true when Include config includes a dotfile in a path' do
       configuration['AllCops'] = { 'Include' => ['foo/.bar'] }
 
-      expect(configuration.possibly_include_hidden?).to be(true)
+      expect(configuration).to be_possibly_include_hidden
     end
   end
 
@@ -663,7 +663,7 @@ RSpec.describe RuboCop::Config do
 
       it 'prints a warning message for the loaded path' do
         configuration.check
-        expect($stderr.string.include?("#{loaded_path} - AllCops/Includes was renamed")).to be(true)
+        expect($stderr.string).to include("#{loaded_path} - AllCops/Includes was renamed")
       end
     end
   end
@@ -870,7 +870,7 @@ RSpec.describe RuboCop::Config do
 
     context 'and neither Gemfile.lock nor gems.locked exist' do
       it 'returns nil' do
-        expect(configuration.gem_versions_in_target.nil?).to be(true)
+        expect(configuration.gem_versions_in_target).to be_nil
       end
     end
   end

--- a/spec/rubocop/cop/badge_spec.rb
+++ b/spec/rubocop/cop/badge_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::Cop::Badge do
     badge1 = described_class.new(%w[Foo Bar])
     badge2 = described_class.new(%w[Foo Bar])
 
-    expect(Set.new([badge1, badge2]).one?).to be(true)
+    expect(Set.new([badge1, badge2])).to be_one
   end
 
   it 'can be converted to a string with the Department/CopName format' do
@@ -70,15 +70,15 @@ RSpec.describe RuboCop::Cop::Badge do
 
   describe '#qualified?' do
     it 'says `CopName` is not qualified' do
-      expect(described_class.parse('Bar').qualified?).to be(false)
+      expect(described_class.parse('Bar')).not_to be_qualified
     end
 
     it 'says `Department/CopName` is qualified' do
-      expect(described_class.parse('Department/Bar').qualified?).to be(true)
+      expect(described_class.parse('Department/Bar')).to be_qualified
     end
 
     it 'says `Deep/Department/CopName` is qualified' do
-      expect(described_class.parse('Deep/Department/Bar').qualified?).to be(true)
+      expect(described_class.parse('Deep/Department/Bar')).to be_qualified
     end
   end
 

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe RuboCop::Cop::Commissioner do
 
       expect(offenses).to eq []
       expect(errors.size).to eq(1)
-      expect(errors[0].cause.instance_of?(RuntimeError)).to be(true)
+      expect(errors[0].cause).to be_an_instance_of(RuntimeError)
       expect(errors[0].line).to eq 2
       expect(errors[0].column).to eq 0
     end

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
   before { cop.send(:begin_investigation, processed_source) }
 
   it 'initially has 0 offenses' do
-    expect(cop.offenses.empty?).to be(true)
+    expect(cop.offenses).to be_empty
   end
 
   describe '.qualified_cop_name' do
@@ -156,7 +156,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
   it 'reports registered offenses' do
     cop.add_offense(nil, location: location, message: 'message')
 
-    expect(cop.offenses.empty?).to be(false)
+    expect(cop.offenses).not_to be_empty
   end
 
   it 'sets default severity' do
@@ -220,7 +220,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
 
       it 'is not specified (set to nil)' do
         cop.add_offense(nil, location: location, message: 'message')
-        expect(cop.offenses.first.corrected?).to be(false)
+        expect(cop.offenses.first).not_to be_corrected
       end
 
       context 'when autocorrect is requested' do
@@ -228,7 +228,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
 
         it 'is not specified (set to nil)' do
           cop.add_offense(nil, location: location, message: 'message')
-          expect(cop.offenses.first.corrected?).to be(false)
+          expect(cop.offenses.first).not_to be_corrected
         end
 
         context 'when disable_uncorrectable is enabled' do
@@ -243,7 +243,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
 
           it 'is set to true' do
             cop.add_offense(node, location: location, message: 'message')
-            expect(cop.offenses.first.corrected?).to be(true)
+            expect(cop.offenses.first).to be_corrected
             expect(cop.offenses.first.status).to be(:corrected_with_todo)
           end
         end
@@ -266,7 +266,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
 
         it 'is set to true' do
           cop.add_offense(nil, location: location, message: 'message')
-          expect(cop.offenses.first.corrected?).to be(true)
+          expect(cop.offenses.first).to be_corrected
         end
       end
 
@@ -275,7 +275,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
 
         it 'is set to false' do
           cop.add_offense(nil, location: location, message: 'message')
-          expect(cop.offenses.first.corrected?).to be(false)
+          expect(cop.offenses.first).not_to be_corrected
         end
       end
 
@@ -286,7 +286,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
 
         it 'is set to false' do
           cop.add_offense(nil, location: location, message: 'message')
-          expect(cop.offenses.first.corrected?).to be(false)
+          expect(cop.offenses.first).not_to be_corrected
         end
       end
     end

--- a/spec/rubocop/cop/generator/require_file_injector_spec.rb
+++ b/spec/rubocop/cop/generator/require_file_injector_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe RuboCop::Cop::Generator::RequireFileInjector do
       injector.inject
 
       expect(File.read(root_file_path)).to eq source
-      expect(stdout.string.empty?).to be(true)
+      expect(stdout.string).to be_empty
     end
   end
 

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -346,8 +346,8 @@ RSpec.describe RuboCop::Cop::Generator do
       expect(File).to receive(:write).with('spec/rubocop/cop/plugin/style/fake_cop_spec.rb',
                                            an_instance_of(String))
       generator.write_spec
-      expect(stdout.string.include?("[create] spec/rubocop/cop/plugin/style/fake_cop_spec.rb\n"))
-        .to be(true)
+      expect(stdout.string)
+        .to include("[create] spec/rubocop/cop/plugin/style/fake_cop_spec.rb\n")
     end
   end
 

--- a/spec/rubocop/cop/lint/script_permission_spec.rb
+++ b/spec/rubocop/cop/lint/script_permission_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission, :config do
         RUBY
 
         expect_no_corrections
-        expect(file.stat.executable?).to be_truthy
+        expect(file.stat).to be_executable
       end
 
       context 'if autocorrection is off' do
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission, :config do
           RUBY
 
           expect_no_corrections
-          expect(file.stat.executable?).to be false
+          expect(file.stat).not_to be_executable
         end
       end
     end

--- a/spec/rubocop/cop/message_annotator_spec.rb
+++ b/spec/rubocop/cop/message_annotator_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::MessageAnnotator do
       end
 
       it 'adds style guide url' do
-        expect(annotate.include?('http://example.org/styleguide')).to be(true)
+        expect(annotate).to include('http://example.org/styleguide')
       end
     end
 
@@ -86,7 +86,7 @@ RSpec.describe RuboCop::Cop::MessageAnnotator do
 
       it 'combines correctly with a target-based setting' do
         config['Cop/Cop'] = { 'StyleGuide' => '#target_based_url' }
-        expect(annotate.include?('http://example.org/styleguide#target_based_url')).to be(true)
+        expect(annotate).to include('http://example.org/styleguide#target_based_url')
       end
 
       context 'when a department other than AllCops is specified' do
@@ -135,7 +135,7 @@ RSpec.describe RuboCop::Cop::MessageAnnotator do
 
       it 'can use a path-based setting' do
         config['Cop/Cop'] = { 'StyleGuide' => 'cop/path/rule#target_based_url' }
-        expect(annotate.include?('http://example.org/cop/path/rule#target_based_url')).to be(true)
+        expect(annotate).to include('http://example.org/cop/path/rule#target_based_url')
       end
 
       it 'can accept relative paths if base has a full path' do
@@ -143,13 +143,12 @@ RSpec.describe RuboCop::Cop::MessageAnnotator do
           'StyleGuideBaseURL' => 'https://github.com/rubocop/ruby-style-guide/'
         }
         config['Cop/Cop'] = { 'StyleGuide' => '../rails-style-guide#target_based_url' }
-        expect(annotate.include?('https://github.com/rubocop/rails-style-guide#target_based_url'))
-          .to be(true)
+        expect(annotate).to include('https://github.com/rubocop/rails-style-guide#target_based_url')
       end
 
       it 'allows absolute URLs in the cop config' do
         config['Cop/Cop'] = { 'StyleGuide' => 'http://other.org#absolute_url' }
-        expect(annotate.include?('http://other.org#absolute_url')).to be(true)
+        expect(annotate).to include('http://other.org#absolute_url')
       end
     end
   end
@@ -161,7 +160,7 @@ RSpec.describe RuboCop::Cop::MessageAnnotator do
     end
 
     it 'returns an empty array without StyleGuide URL' do
-      expect(urls.empty?).to be(true)
+      expect(urls).to be_empty
     end
 
     it 'returns style guide url when it is specified' do
@@ -177,7 +176,7 @@ RSpec.describe RuboCop::Cop::MessageAnnotator do
     it 'returns an empty array if the reference url is blank' do
       config['Cop/Cop'] = { 'Reference' => '' }
 
-      expect(urls.empty?).to be(true)
+      expect(urls).to be_empty
     end
 
     it 'returns multiple reference urls' do

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe RuboCop::Cop::Offense do
     expect(offense.line).to eq(1)
     expect(offense.message).to eq('message')
     expect(offense.cop_name).to eq('CopName')
-    expect(offense.correctable?).to be_truthy
-    expect(offense.corrected?).to be_truthy
+    expect(offense).to be_correctable
+    expect(offense).to be_corrected
     expect(offense.highlighted_area.source).to eq('a')
   end
 
@@ -39,13 +39,13 @@ RSpec.describe RuboCop::Cop::Offense do
   end
 
   it 'is frozen' do
-    expect(offense.frozen?).to be(true)
+    expect(offense).to be_frozen
   end
 
   %i[severity location message cop_name].each do |a|
     describe "##{a}" do
       it 'is frozen' do
-        expect(offense.public_send(a).frozen?).to be(true)
+        expect(offense.public_send(a)).to be_frozen
       end
     end
   end

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe RuboCop::Cop::Registry do
     klass = RuboCop::Cop::Metrics::AbcSize
     copy = registry.dup
     copy.enlist(klass)
-    expect(copy.cops.include?(klass)).to be(true)
-    expect(registry.cops.include?(klass)).to be(false)
+    expect(copy.cops).to include(klass)
+    expect(registry.cops).not_to include(klass)
   end
 
   context 'when dismissing a cop class' do
@@ -43,19 +43,19 @@ RSpec.describe RuboCop::Cop::Registry do
 
     it 'allows it if done rapidly' do
       registry.dismiss(cop_class)
-      expect(registry.cops.include?(cop_class)).to be(false)
+      expect(registry.cops).not_to include(cop_class)
     end
 
     it 'disallows it if done too late' do
-      expect(registry.cops.include?(cop_class)).to be(true)
+      expect(registry.cops).to include(cop_class)
       expect { registry.dismiss(cop_class) }.to raise_error(RuntimeError)
     end
 
     it 'allows re-listing' do
       registry.dismiss(cop_class)
-      expect(registry.cops.include?(cop_class)).to be(false)
+      expect(registry.cops).not_to include(cop_class)
       registry.enlist(cop_class)
-      expect(registry.cops.include?(cop_class)).to be(true)
+      expect(registry.cops).to include(cop_class)
     end
   end
 
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::Registry do
     end
 
     it 'returns false for cops not included in the store' do
-      expect(registry.contains_cop_matching?(['Style/NotReal'])).to be(false)
+      expect(registry).not_to be_contains_cop_matching(['Style/NotReal'])
     end
   end
 
@@ -204,14 +204,14 @@ RSpec.describe RuboCop::Cop::Registry do
 
     it 'selects only safe cops if :safe passed' do
       options[:safe] = true
-      expect(enabled_cops.include?(RuboCop::Cop::RSpec::Foo)).to be(false)
+      expect(enabled_cops).not_to include(RuboCop::Cop::RSpec::Foo)
     end
 
     context 'when new cops are introduced' do
       let(:config) { RuboCop::Config.new('Lint/BooleanSymbol' => { 'Enabled' => 'pending' }) }
 
       it 'does not include them' do
-        expect(enabled_cops.include?(RuboCop::Cop::Lint::BooleanSymbol)).to be(false)
+        expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
       end
 
       it 'overrides config if :only includes the cop' do
@@ -223,7 +223,7 @@ RSpec.describe RuboCop::Cop::Registry do
         let(:options) { { disable_pending_cops: true } }
 
         it 'does not include them' do
-          expect(enabled_cops.include?(RuboCop::Cop::Lint::BooleanSymbol)).to be(false)
+          expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
         end
 
         context 'when specifying `NewCops: enable` option in .rubocop.yml' do
@@ -236,7 +236,7 @@ RSpec.describe RuboCop::Cop::Registry do
 
           it 'does not include them because command-line option takes ' \
              'precedence over .rubocop.yml' do
-            expect(enabled_cops.include?(RuboCop::Cop::Lint::BooleanSymbol)).to be(false)
+            expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
           end
         end
       end
@@ -245,7 +245,7 @@ RSpec.describe RuboCop::Cop::Registry do
         let(:options) { { enable_pending_cops: true } }
 
         it 'includes them' do
-          expect(enabled_cops.include?(RuboCop::Cop::Lint::BooleanSymbol)).to be(true)
+          expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
         end
 
         context 'when specifying `NewCops: disable` option in .rubocop.yml' do
@@ -257,7 +257,7 @@ RSpec.describe RuboCop::Cop::Registry do
           end
 
           it 'includes them because command-line option takes precedence over .rubocop.yml' do
-            expect(enabled_cops.include?(RuboCop::Cop::Lint::BooleanSymbol)).to be(true)
+            expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
           end
         end
       end
@@ -271,7 +271,7 @@ RSpec.describe RuboCop::Cop::Registry do
         end
 
         it 'does not include them' do
-          expect(enabled_cops.include?(RuboCop::Cop::Lint::BooleanSymbol)).to be(false)
+          expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
         end
       end
 
@@ -284,7 +284,7 @@ RSpec.describe RuboCop::Cop::Registry do
         end
 
         it 'does not include them' do
-          expect(enabled_cops.include?(RuboCop::Cop::Lint::BooleanSymbol)).to be(false)
+          expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
         end
       end
 
@@ -297,7 +297,7 @@ RSpec.describe RuboCop::Cop::Registry do
         end
 
         it 'includes them' do
-          expect(enabled_cops.include?(RuboCop::Cop::Lint::BooleanSymbol)).to be(true)
+          expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
         end
       end
     end
@@ -318,11 +318,11 @@ RSpec.describe RuboCop::Cop::Registry do
 
   describe '#department?' do
     it 'returns true for department name' do
-      expect(registry.department?('Lint')).to be true
+      expect(registry).to be_department('Lint')
     end
 
     it 'returns false for other names' do
-      expect(registry.department?('Foo')).to be false
+      expect(registry).not_to be_department('Foo')
     end
   end
 

--- a/spec/rubocop/cop/severity_spec.rb
+++ b/spec/rubocop/cop/severity_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::Severity do
   end
 
   it 'is frozen' do
-    expect(convention.frozen?).to be(true)
+    expect(convention).to be_frozen
   end
 
   describe '#code' do

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
         RUBY
 
         expect(min_digits).to eq(21)
-        expect(enabled.nil?).to be(true)
+        expect(enabled).to be_nil
       end
 
       it 'sets the right value if one is disabled inline' do
@@ -194,7 +194,7 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
         RUBY
 
         expect(min_digits).to eq(13)
-        expect(enabled.nil?).to be(true)
+        expect(enabled).to be_nil
       end
     end
 
@@ -206,7 +206,7 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
         RUBY
 
         expect(enabled).to be(false)
-        expect(min_digits.nil?).to be(true)
+        expect(min_digits).to be_nil
       end
 
       it 'does not disable the cop if the line is disabled' do
@@ -214,8 +214,8 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
           1234_5678_90 # rubocop:disable Style/NumericLiterals
         RUBY
 
-        expect(enabled.nil?).to be(true)
-        expect(min_digits.nil?).to be(true)
+        expect(enabled).to be_nil
+        expect(min_digits).to be_nil
       end
     end
   end

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe RuboCop::Cop::Team do
     before { create_file(file_path, ['#' * 90, 'puts test;']) }
 
     it 'returns offenses' do
-      expect(offenses.empty?).to be(false)
+      expect(offenses).not_to be_empty
       expect(offenses).to all(be_a(RuboCop::Cop::Offense))
     end
 
@@ -112,11 +112,11 @@ RSpec.describe RuboCop::Cop::Team do
       let(:cop_names) { offenses.map(&:cop_name) }
 
       it 'returns Parser warning offenses' do
-        expect(cop_names.include?('Lint/AmbiguousOperator')).to be(true)
+        expect(cop_names).to include('Lint/AmbiguousOperator')
       end
 
       it 'returns offenses from cops' do
-        expect(cop_names.include?('Layout/LineLength')).to be(true)
+        expect(cop_names).to include('Layout/LineLength')
       end
 
       context 'when a cop has no interest in the file' do
@@ -124,8 +124,8 @@ RSpec.describe RuboCop::Cop::Team do
           allow_any_instance_of(RuboCop::Cop::Layout::LineLength)
             .to receive(:excluded_file?).and_return(true)
 
-          expect(cop_names.include?('Lint/AmbiguousOperator')).to be(true)
-          expect(cop_names.include?('Layout/LineLength')).to be(false)
+          expect(cop_names).to include('Lint/AmbiguousOperator')
+          expect(cop_names).not_to include('Layout/LineLength')
         end
       end
     end
@@ -162,7 +162,7 @@ RSpec.describe RuboCop::Cop::Team do
       it 'no error occurs' do
         team.inspect_file(source)
 
-        expect(team.errors.empty?).to be(true)
+        expect(team.errors).to be_empty
       end
     end
 
@@ -184,7 +184,7 @@ RSpec.describe RuboCop::Cop::Team do
         team.inspect_file(source)
 
         expect(team.errors).to eq([error_message])
-        expect($stderr.string.include?(error_message)).to be(true)
+        expect($stderr.string).to include(error_message)
       end
     end
 
@@ -207,8 +207,8 @@ RSpec.describe RuboCop::Cop::Team do
         team.inspect_file(source)
 
         expect(team.errors).to eq([error_message])
-        expect($stderr.string.include?(error_message)).to be(true)
-        expect($stdout.string.include?(exception_message)).to be(true)
+        expect($stderr.string).to include(error_message)
+        expect($stdout.string).to include(exception_message)
       end
     end
 
@@ -238,7 +238,7 @@ RSpec.describe RuboCop::Cop::Team do
 
       it 'records Team#errors' do
         team.inspect_file(source)
-        expect($stderr.string.include?(error_message)).to be(true)
+        expect($stderr.string).to include(error_message)
       end
     end
 
@@ -266,8 +266,8 @@ RSpec.describe RuboCop::Cop::Team do
     subject(:cops) { team.cops }
 
     it 'returns cop instances' do
-      expect(cops.empty?).to be(false)
-      expect(cops.all?(RuboCop::Cop::Base)).to be_truthy
+      expect(cops).not_to be_empty
+      expect(cops).to be_all(RuboCop::Cop::Base)
     end
 
     context 'when only some cop classes are passed to .new' do
@@ -290,9 +290,9 @@ RSpec.describe RuboCop::Cop::Team do
     let(:cop_classes) { RuboCop::Cop::Registry.global }
 
     it 'returns force instances' do
-      expect(forces.empty?).to be(false)
+      expect(forces).not_to be_empty
 
-      forces.each { |force| expect(force.is_a?(RuboCop::Cop::Force)).to be(true) }
+      expect(forces).to all(be_a(RuboCop::Cop::Force))
     end
 
     context 'when a cop joined a force' do
@@ -300,7 +300,7 @@ RSpec.describe RuboCop::Cop::Team do
 
       it 'returns the force' do
         expect(forces.size).to eq(1)
-        expect(forces.first.is_a?(RuboCop::Cop::VariableForce)).to be(true)
+        expect(forces.first).to be_a(RuboCop::Cop::VariableForce)
       end
     end
 
@@ -323,7 +323,7 @@ RSpec.describe RuboCop::Cop::Team do
       let(:cop_classes) { RuboCop::Cop::Registry.new([RuboCop::Cop::Style::For]) }
 
       it 'returns nothing' do
-        expect(forces.empty?).to be(true)
+        expect(forces).to be_empty
       end
     end
   end
@@ -332,14 +332,14 @@ RSpec.describe RuboCop::Cop::Team do
     let(:cop_classes) { RuboCop::Cop::Registry.new }
 
     it 'does not error with no cops' do
-      expect(team.external_dependency_checksum.is_a?(String)).to be(true)
+      expect(team.external_dependency_checksum).to be_a(String)
     end
 
     context 'when a cop joins' do
       let(:cop_classes) { RuboCop::Cop::Registry.new([RuboCop::Cop::Lint::UselessAssignment]) }
 
       it 'returns string' do
-        expect(team.external_dependency_checksum.is_a?(String)).to be(true)
+        expect(team.external_dependency_checksum).to be_a(String)
       end
     end
 
@@ -354,7 +354,7 @@ RSpec.describe RuboCop::Cop::Team do
       end
 
       it 'returns string' do
-        expect(team.external_dependency_checksum.is_a?(String)).to be(true)
+        expect(team.external_dependency_checksum).to be_a(String)
       end
     end
 

--- a/spec/rubocop/cop/util_spec.rb
+++ b/spec/rubocop/cop/util_spec.rb
@@ -60,20 +60,20 @@ RSpec.describe RuboCop::Cop::Util do
     let(:ivar_baz_node) { nodes[2] }
 
     it 'returns true when two nodes are on the same line' do
-      expect(described_class.same_line?(ivar_foo_node, ivar_bar_node)).to be(true)
+      expect(described_class).to be_same_line(ivar_foo_node, ivar_bar_node)
     end
 
     it 'returns false when two nodes are not on the same line' do
-      expect(described_class.same_line?(ivar_foo_node, ivar_baz_node)).to be_falsey
+      expect(described_class).not_to be_same_line(ivar_foo_node, ivar_baz_node)
     end
 
     it 'can use ranges' do
-      expect(described_class.same_line?(ivar_foo_node.source_range, ivar_bar_node)).to be(true)
+      expect(described_class).to be_same_line(ivar_foo_node.source_range, ivar_bar_node)
     end
 
     it 'returns false if an argument is not a node or range' do
-      expect(described_class.same_line?(ivar_foo_node, 5)).to be_falsey
-      expect(described_class.same_line?(5, ivar_bar_node)).to be_falsey
+      expect(described_class).not_to be_same_line(ivar_foo_node, 5)
+      expect(described_class).not_to be_same_line(5, ivar_bar_node)
     end
   end
 end

--- a/spec/rubocop/cop/utils/format_string_spec.rb
+++ b/spec/rubocop/cop/utils/format_string_spec.rb
@@ -37,14 +37,14 @@ RSpec.describe RuboCop::Cop::Utils::FormatString do
   describe '#named_interpolation?' do
     shared_examples 'named format sequence' do |format_string|
       it 'detects named format sequence' do
-        expect(described_class.new(format_string).named_interpolation?).to be_truthy
+        expect(described_class.new(format_string)).to be_named_interpolation
       end
 
       it 'does not detect escaped named format sequence' do
         escaped = format_string.gsub('%', '%%')
 
-        expect(described_class.new(escaped).named_interpolation?).to be_falsey
-        expect(described_class.new("prefix:#{escaped}").named_interpolation?).to be_falsey
+        expect(described_class.new(escaped)).not_to be_named_interpolation
+        expect(described_class.new("prefix:#{escaped}")).not_to be_named_interpolation
       end
     end
 
@@ -57,37 +57,37 @@ RSpec.describe RuboCop::Cop::Utils::FormatString do
   describe '#valid?' do
     it 'returns true when there are only unnumbered formats' do
       fs = described_class.new('%s %d')
-      expect(fs.valid?).to be true
+      expect(fs).to be_valid
     end
 
     it 'returns true when there are only numbered formats' do
       fs = described_class.new('%1$s %2$d')
-      expect(fs.valid?).to be true
+      expect(fs).to be_valid
     end
 
     it 'returns true when there are only named formats' do
       fs = described_class.new('%{foo}s')
-      expect(fs.valid?).to be true
+      expect(fs).to be_valid
     end
 
     it 'returns true when there are only named with escaped `%` formats' do
       fs = described_class.new('%%%{foo}d')
-      expect(fs.valid?).to be true
+      expect(fs).to be_valid
     end
 
     it 'returns false when there are unnumbered and numbered formats' do
       fs = described_class.new('%s %1$d')
-      expect(fs.valid?).to be false
+      expect(fs).not_to be_valid
     end
 
     it 'returns false when there are unnumbered and named formats' do
       fs = described_class.new('%s %{foo}d')
-      expect(fs.valid?).to be false
+      expect(fs).not_to be_valid
     end
 
     it 'returns false when there are numbered and named formats' do
       fs = described_class.new('%1$s %{foo}d')
-      expect(fs.valid?).to be false
+      expect(fs).not_to be_valid
     end
   end
 end

--- a/spec/rubocop/cop/variable_force/variable_table_spec.rb
+++ b/spec/rubocop/cop/variable_force/variable_table_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe RuboCop::Cop::VariableForce::VariableTable do
     it 'adds variable to current scope with its name as key' do
       node = s(:lvasgn, :foo)
       variable_table.declare_variable(:foo, node)
-      expect(variable_table.current_scope.variables.key?(:foo)).to be(true)
-      expect(variable_table.scope_stack[-2].variables.empty?).to be(true)
+      expect(variable_table.current_scope.variables).to be_key(:foo)
+      expect(variable_table.scope_stack[-2].variables).to be_empty
       variable = variable_table.current_scope.variables[:foo]
       expect(variable.declaration_node).to equal(node)
     end
@@ -95,8 +95,8 @@ RSpec.describe RuboCop::Cop::VariableForce::VariableTable do
           it 'returns the current scope variable' do
             found_variable = variable_table.find_variable(:bar)
             expect(found_variable.name).to equal(:bar)
-            expect(variable_table.current_scope.variables.value?(found_variable)).to be(true)
-            expect(variable_table.scope_stack[-2].variables.value?(found_variable)).to be(false)
+            expect(variable_table.current_scope.variables).to be_value(found_variable)
+            expect(variable_table.scope_stack[-2].variables).not_to be_value(found_variable)
           end
         end
       end
@@ -128,7 +128,7 @@ RSpec.describe RuboCop::Cop::VariableForce::VariableTable do
           context 'when the direct outer scope is not block' do
             it 'returns nil' do
               found_variable = variable_table.find_variable(:baz)
-              expect(found_variable.nil?).to be(true)
+              expect(found_variable).to be_nil
             end
           end
         end
@@ -136,7 +136,7 @@ RSpec.describe RuboCop::Cop::VariableForce::VariableTable do
         context 'and does not exist in all outer scopes' do
           it 'returns nil' do
             found_variable = variable_table.find_variable(:non)
-            expect(found_variable.nil?).to be(true)
+            expect(found_variable).to be_nil
           end
         end
       end
@@ -159,8 +159,8 @@ RSpec.describe RuboCop::Cop::VariableForce::VariableTable do
           it 'returns the current scope variable' do
             found_variable = variable_table.find_variable(:foo)
             expect(found_variable.name).to equal(:foo)
-            expect(variable_table.current_scope.variables.value?(found_variable)).to be(true)
-            expect(variable_table.scope_stack[-2].variables.value?(found_variable)).to be(false)
+            expect(variable_table.current_scope.variables).to be_value(found_variable)
+            expect(variable_table.scope_stack[-2].variables).not_to be_value(found_variable)
           end
         end
       end
@@ -169,14 +169,14 @@ RSpec.describe RuboCop::Cop::VariableForce::VariableTable do
         context 'but exists in the direct outer scope' do
           it 'returns nil' do
             found_variable = variable_table.find_variable(:bar)
-            expect(found_variable.nil?).to be(true)
+            expect(found_variable).to be_nil
           end
         end
 
         context 'and does not exist in all outer scopes' do
           it 'returns nil' do
             found_variable = variable_table.find_variable(:non)
-            expect(found_variable.nil?).to be(true)
+            expect(found_variable).to be_nil
           end
         end
       end
@@ -186,7 +186,7 @@ RSpec.describe RuboCop::Cop::VariableForce::VariableTable do
   describe '#find_variable with an empty scope stack' do
     it 'returns nil' do
       found_variable = variable_table.find_variable(:unknown)
-      expect(found_variable.nil?).to be(true)
+      expect(found_variable).to be_nil
     end
   end
 
@@ -197,7 +197,7 @@ RSpec.describe RuboCop::Cop::VariableForce::VariableTable do
 
     context 'when there are no variables' do
       it 'returns empty array' do
-        expect(variable_table.accessible_variables.empty?).to be(true)
+        expect(variable_table.accessible_variables).to be_empty
       end
     end
 

--- a/spec/rubocop/ext/regexp_node_spec.rb
+++ b/spec/rubocop/ext/regexp_node_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Ext::RegexpNode do
       it 'returns the expected tree' do
         tree = node.parsed_tree
 
-        expect(tree.is_a?(Regexp::Expression::Root)).to be(true)
+        expect(tree).to be_a(Regexp::Expression::Root)
         expect(tree.map(&:token)).to eq(%i[literal whitespace comment])
       end
     end
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Ext::RegexpNode do
       it 'returns the expected blanked tree' do
         tree = node.parsed_tree
 
-        expect(tree.is_a?(Regexp::Expression::Root)).to be(true)
+        expect(tree).to be_a(Regexp::Expression::Root)
         expect(tree.to_s).to eq('foo      baz')
       end
     end
@@ -74,7 +74,7 @@ RSpec.describe RuboCop::Ext::RegexpNode do
       it 'returns the expected blanked tree' do
         tree = node.parsed_tree
 
-        expect(tree.is_a?(Regexp::Expression::Root)).to be(true)
+        expect(tree).to be_a(Regexp::Expression::Root)
         expect(tree.to_s.split("\n")).to eq(['', '  foo', ' ' * 32, '  baz'])
       end
     end
@@ -85,7 +85,7 @@ RSpec.describe RuboCop::Ext::RegexpNode do
       it 'returns the expected tree' do
         tree = node.parsed_tree
 
-        expect(tree.is_a?(Regexp::Expression::Root)).to be(true)
+        expect(tree).to be_a(Regexp::Expression::Root)
         expect(tree.to_s).to eq('foobaz')
       end
     end

--- a/spec/rubocop/file_finder_spec.rb
+++ b/spec/rubocop/file_finder_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::FileFinder, :isolated_environment do
     end
 
     it 'returns nil when file is not found' do
-      expect(finder.find_file_upwards('file2', 'dir').nil?).to be(true)
+      expect(finder.find_file_upwards('file2', 'dir')).to be_nil
     end
   end
 
@@ -27,7 +27,7 @@ RSpec.describe RuboCop::FileFinder, :isolated_environment do
     end
 
     it 'returns nil when file is not found' do
-      expect(finder.find_last_file_upwards('xyz', 'dir').nil?).to be(true)
+      expect(finder.find_last_file_upwards('xyz', 'dir')).to be_nil
     end
   end
 end

--- a/spec/rubocop/formatter/auto_gen_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/auto_gen_config_formatter_spec.rb
@@ -84,12 +84,12 @@ RSpec.describe RuboCop::Formatter::AutoGenConfigFormatter do
 
       it 'does not report offenses' do
         formatter.finished(files)
-        expect(output.string.include?('Offenses:')).to be(false)
+        expect(output.string).not_to include('Offenses:')
       end
 
       it 'outputs report summary' do
         formatter.finished(files)
-        expect(output.string.include?(<<~OUTPUT)).to be(true)
+        expect(output.string).to include(<<~OUTPUT)
           3 files inspected, 1 offense detected, 1 offense autocorrectable
         OUTPUT
       end
@@ -105,13 +105,13 @@ RSpec.describe RuboCop::Formatter::AutoGenConfigFormatter do
 
       it 'does not report offenses' do
         formatter.finished(files)
-        expect(output.string.include?('Offenses:')).to be(false)
+        expect(output.string).not_to include('Offenses:')
       end
     end
 
     it 'calls #report_summary' do
       formatter.finished(files)
-      expect(output.string.include?(<<~OUTPUT)).to be(true)
+      expect(output.string).to include(<<~OUTPUT)
         3 files inspected, no offenses detected
       OUTPUT
     end

--- a/spec/rubocop/formatter/clang_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/clang_style_formatter_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Formatter::ClangStyleFormatter, :config do
 
       it 'prints message as-is' do
         formatter.report_file(file, [offense])
-        expect(output.string.include?(': This is a message.')).to be(true)
+        expect(output.string).to include(': This is a message.')
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::Formatter::ClangStyleFormatter, :config do
 
       it 'prints message as-is' do
         formatter.report_file(file, [offense])
-        expect(output.string.include?(': [Correctable] This is a message.')).to be(true)
+        expect(output.string).to include(': [Correctable] This is a message.')
       end
     end
 
@@ -102,7 +102,7 @@ RSpec.describe RuboCop::Formatter::ClangStyleFormatter, :config do
 
       it 'prints [Corrected] along with message' do
         formatter.report_file(file, [offense])
-        expect(output.string.include?(': [Corrected] This is a message.')).to be(true)
+        expect(output.string).to include(': [Corrected] This is a message.')
       end
     end
 

--- a/spec/rubocop/formatter/emacs_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/emacs_style_formatter_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Formatter::EmacsStyleFormatter, :config do
 
       it 'prints [Corrected] along with message' do
         formatter.file_finished(file, [offense])
-        expect(output.string.include?(': [Corrected] This is a message.')).to be(true)
+        expect(output.string).to include(': [Corrected] This is a message.')
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::Formatter::EmacsStyleFormatter, :config do
 
       it 'prints [Todo] along with message' do
         formatter.file_finished(file, [offense])
-        expect(output.string.include?(': [Todo] This is a message.')).to be(true)
+        expect(output.string).to include(': [Todo] This is a message.')
       end
     end
 
@@ -94,7 +94,7 @@ RSpec.describe RuboCop::Formatter::EmacsStyleFormatter, :config do
   describe '#finished' do
     it 'does not report summary' do
       formatter.finished(['/path/to/file'])
-      expect(output.string.empty?).to be(true)
+      expect(output.string).to be_empty
     end
   end
 end

--- a/spec/rubocop/formatter/formatter_set_spec.rb
+++ b/spec/rubocop/formatter/formatter_set_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Formatter::FormatterSet do
 
   it 'responds to all formatter API methods' do
     %i[started file_started file_finished finished].each do |method|
-      expect(formatter_set.respond_to?(method)).to be(true)
+      expect(formatter_set).to respond_to(method)
     end
   end
 
@@ -94,12 +94,12 @@ RSpec.describe RuboCop::Formatter::FormatterSet do
 
     it 'closes all output files' do
       formatter_set.close_output_files
-      formatter_set[0..1].each { |formatter| expect(formatter.output.closed?).to be(true) }
+      formatter_set[0..1].each { |formatter| expect(formatter.output).to be_closed }
       win_close.call(formatter_set) if RuboCop::Platform.windows?
     end
 
     it 'does not close non file output' do
-      expect(formatter_set[2].output.closed?).to be(false)
+      expect(formatter_set[2].output).not_to be_closed
       win_close.call(formatter_set) if RuboCop::Platform.windows?
     end
   end

--- a/spec/rubocop/formatter/github_actions_formatter_spec.rb
+++ b/spec/rubocop/formatter/github_actions_formatter_spec.rb
@@ -30,8 +30,7 @@ RSpec.describe RuboCop::Formatter::GitHubActionsFormatter, :config do
 
     context 'when offenses are detected' do
       it 'reports offenses as errors' do
-        expect(output.string.include?("::error file=#{file},line=1,col=1::This is a message."))
-          .to be(true)
+        expect(output.string).to include("::error file=#{file},line=1,col=1::This is a message.")
       end
     end
 
@@ -39,8 +38,8 @@ RSpec.describe RuboCop::Formatter::GitHubActionsFormatter, :config do
       let(:file) { "#{Dir.pwd}/path/to/file" }
 
       it 'reports offenses as error with the relative path' do
-        expect(output.string.include?('::error file=path/to/file,line=1,col=1::This is a message.'))
-          .to be(true)
+        expect(output.string)
+          .to include('::error file=path/to/file,line=1,col=1::This is a message.')
       end
     end
 
@@ -56,8 +55,7 @@ RSpec.describe RuboCop::Formatter::GitHubActionsFormatter, :config do
       let(:message) { "All occurrences of %, \r and \n must be escaped" }
 
       it 'escapes message' do
-        expect(output.string.include?('::All occurrences of %25, %0D and %0A must be escaped'))
-          .to be(true)
+        expect(output.string).to include('::All occurrences of %25, %0D and %0A must be escaped')
       end
     end
 
@@ -77,13 +75,11 @@ RSpec.describe RuboCop::Formatter::GitHubActionsFormatter, :config do
       end
 
       it 'reports offenses above or at fail level as errors' do
-        expect(output.string.include?("::error file=#{file},line=1,col=1::This is a message."))
-          .to be(true)
+        expect(output.string).to include("::error file=#{file},line=1,col=1::This is a message.")
       end
 
       it 'reports offenses below fail level as warnings' do
-        expect(output.string.include?("::warning file=#{file},line=1,col=3::This is a warning."))
-          .to be(true)
+        expect(output.string).to include("::warning file=#{file},line=1,col=3::This is a warning.")
       end
     end
   end

--- a/spec/rubocop/formatter/json_formatter_spec.rb
+++ b/spec/rubocop/formatter/json_formatter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Formatter::JSONFormatter do
     let(:summary) { formatter.output_hash[:summary] }
 
     it 'sets target file count in summary' do
-      expect(summary[:target_file_count].nil?).to be(true)
+      expect(summary[:target_file_count]).to be_nil
       formatter.started(%w[/path/to/file1 /path/to/file2])
       expect(summary[:target_file_count]).to eq(2)
     end
@@ -47,10 +47,10 @@ RSpec.describe RuboCop::Formatter::JSONFormatter do
     end
 
     it 'adds value of #hash_for_file to #output_hash[:files]' do
-      expect(formatter.output_hash[:files].empty?).to be(true)
+      expect(formatter.output_hash[:files]).to be_empty
 
       formatter.file_started(files[0], {})
-      expect(formatter.output_hash[:files].empty?).to be(true)
+      expect(formatter.output_hash[:files]).to be_empty
       formatter.file_finished(files[0], [])
       expect(formatter.output_hash[:files]).to eq([1])
 
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Formatter::JSONFormatter do
     let(:summary) { formatter.output_hash[:summary] }
 
     it 'sets inspected file count in summary' do
-      expect(summary[:inspected_file_count].nil?).to be(true)
+      expect(summary[:inspected_file_count]).to be_nil
       formatter.finished(%w[/path/to/file1 /path/to/file2])
       expect(summary[:inspected_file_count]).to eq(2)
     end

--- a/spec/rubocop/formatter/junit_formatter_spec.rb
+++ b/spec/rubocop/formatter/junit_formatter_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Formatter::JUnitFormatter, :config do
     end
 
     it "displays an offense for `classname='test_1` in parsable text" do
-      expect(output.string.include?(<<-XML)).to be(true)
+      expect(output.string).to include(<<-XML)
     <testcase classname='test_1' name='Layout/SpaceInsideBlockBraces'>
       <failure type='Layout/SpaceInsideBlockBraces' message='message 1'>
         test:1:1
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Formatter::JUnitFormatter, :config do
     end
 
     it "displays an offense for `classname='test_2` in parsable text" do
-      expect(output.string.include?(<<-XML)).to be(true)
+      expect(output.string).to include(<<-XML)
     <testcase classname='test_2' name='Layout/SpaceInsideBlockBraces'>
       <failure type='Layout/SpaceInsideBlockBraces' message='message 1'>
         test:1:1
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Formatter::JUnitFormatter, :config do
     end
 
     it 'displays a non-offense element in parsable text' do
-      expect(output.string.include?(<<~XML)).to be(true)
+      expect(output.string).to include(<<~XML)
         <testcase classname='test_1' name='Style/Alias'/>
       XML
     end

--- a/spec/rubocop/formatter/progress_formatter_spec.rb
+++ b/spec/rubocop/formatter/progress_formatter_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe RuboCop::Formatter::ProgressFormatter do
 
       it 'reports all detected offenses for all failed files' do
         formatter.finished(files)
-        expect(output.string.include?(<<~OUTPUT)).to be(true)
+        expect(output.string).to include(<<~OUTPUT)
           Offenses:
 
           lib/rubocop.rb:2:3: C: [Correctable] foo
@@ -163,7 +163,7 @@ RSpec.describe RuboCop::Formatter::ProgressFormatter do
 
       it 'does not report offenses' do
         formatter.finished(files)
-        expect(output.string.include?('Offenses:')).to be(false)
+        expect(output.string).not_to include('Offenses:')
       end
     end
 

--- a/spec/rubocop/formatter/quiet_formatter_spec.rb
+++ b/spec/rubocop/formatter/quiet_formatter_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Formatter::QuietFormatter do
       let(:file) { File.expand_path('spec/spec_helper.rb') }
 
       it 'prints as relative path' do
-        expect(output.string.include?('== spec/spec_helper.rb ==')).to be(true)
+        expect(output.string).to include('== spec/spec_helper.rb ==')
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Formatter::QuietFormatter do
       end
 
       it 'prints as absolute path' do
-        expect(output.string.include?("== #{file} ==")).to be(true)
+        expect(output.string).to include("== #{file} ==")
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Formatter::QuietFormatter do
       let(:status) { :unsupported }
 
       it 'prints message as-is' do
-        expect(output.string.include?(': This is a message with colored text.')).to be(true)
+        expect(output.string).to include(': This is a message with colored text.')
       end
     end
 
@@ -60,8 +60,7 @@ RSpec.describe RuboCop::Formatter::QuietFormatter do
       let(:status) { :uncorrected }
 
       it 'prints message as-is' do
-        expect(output.string.include?(': [Correctable] This is a message with colored text.'))
-          .to be(true)
+        expect(output.string).to include(': [Correctable] This is a message with colored text.')
       end
     end
 
@@ -69,8 +68,7 @@ RSpec.describe RuboCop::Formatter::QuietFormatter do
       let(:status) { :corrected }
 
       it 'prints [Corrected] along with message' do
-        expect(output.string.include?(': [Corrected] This is a message with colored text.'))
-          .to be(true)
+        expect(output.string).to include(': [Corrected] This is a message with colored text.')
       end
     end
   end
@@ -79,14 +77,14 @@ RSpec.describe RuboCop::Formatter::QuietFormatter do
     context 'when no files inspected' do
       it 'handles pluralization correctly' do
         formatter.report_summary(0, 0, 0, 0)
-        expect(output.string.empty?).to be(true)
+        expect(output.string).to be_empty
       end
     end
 
     context 'when a file inspected and no offenses detected' do
       it 'handles pluralization correctly' do
         formatter.report_summary(1, 0, 0, 0)
-        expect(output.string.empty?).to be(true)
+        expect(output.string).to be_empty
       end
     end
 

--- a/spec/rubocop/formatter/simple_text_formatter_spec.rb
+++ b/spec/rubocop/formatter/simple_text_formatter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
       let(:file) { File.expand_path('spec/spec_helper.rb') }
 
       it 'prints as relative path' do
-        expect(output.string.include?('== spec/spec_helper.rb ==')).to be(true)
+        expect(output.string).to include('== spec/spec_helper.rb ==')
       end
     end
 
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
       end
 
       it 'prints as absolute path' do
-        expect(output.string.include?("== #{file} ==")).to be(true)
+        expect(output.string).to include("== #{file} ==")
       end
     end
 
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
       let(:status) { :unsupported }
 
       it 'prints message as-is' do
-        expect(output.string.include?(': This is a message with colored text.')).to be(true)
+        expect(output.string).to include(': This is a message with colored text.')
       end
     end
 
@@ -48,8 +48,7 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
       let(:status) { :uncorrected }
 
       it 'prints message as-is' do
-        expect(output.string.include?(': [Correctable] This is a message with colored text.'))
-          .to be(true)
+        expect(output.string).to include(': [Correctable] This is a message with colored text.')
       end
     end
 
@@ -57,8 +56,7 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
       let(:status) { :corrected }
 
       it 'prints [Corrected] along with message' do
-        expect(output.string.include?(': [Corrected] This is a message with colored text.'))
-          .to be(true)
+        expect(output.string).to include(': [Corrected] This is a message with colored text.')
       end
     end
 
@@ -66,7 +64,7 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
       let(:status) { :corrected_with_todo }
 
       it 'prints [Todo] along with message' do
-        expect(output.string.include?(': [Todo] This is a message with colored text.')).to be(true)
+        expect(output.string).to include(': [Todo] This is a message with colored text.')
       end
     end
   end

--- a/spec/rubocop/formatter/tap_formatter_spec.rb
+++ b/spec/rubocop/formatter/tap_formatter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe RuboCop::Formatter::TapFormatter do
       let(:offenses) { [] }
 
       it 'prints "ok"' do
-        expect(output.string.include?('ok 1')).to be(true)
+        expect(output.string).to include('ok 1')
       end
     end
 
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Formatter::TapFormatter do
       end
 
       it 'prints "not ok"' do
-        expect(output.string.include?('not ok 1')).to be(true)
+        expect(output.string).to include('not ok 1')
       end
     end
   end
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Formatter::TapFormatter do
 
       it 'reports all detected offenses for all failed files' do
         formatter.finished(files)
-        expect(output.string.include?(<<~OUTPUT)).to be(true)
+        expect(output.string).to include(<<~OUTPUT)
           1..3
           not ok 1 - lib/rubocop.rb
           # lib/rubocop.rb:2:3: C: [Correctable] foo
@@ -133,7 +133,7 @@ RSpec.describe RuboCop::Formatter::TapFormatter do
 
       it 'does not report offenses' do
         formatter.finished(files)
-        expect(output.string.include?('not ok')).to be(false)
+        expect(output.string).not_to include('not ok')
       end
     end
   end

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -977,7 +977,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
 
     it 'handles requests' do
       expect(stderr).to eq('')
-      expect(messages.empty?).to be(true)
+      expect(messages).to be_empty
     end
   end
 

--- a/spec/rubocop/lsp_spec.rb
+++ b/spec/rubocop/lsp_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::LSP, :lsp do
       before { described_class.enable }
 
       it 'returns true' do
-        expect(described_class.enabled?).to be(true)
+        expect(described_class).to be_enabled
       end
     end
 
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::LSP, :lsp do
       before { described_class.disable }
 
       it 'returns false' do
-        expect(described_class.enabled?).to be(false)
+        expect(described_class).not_to be_enabled
       end
     end
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -289,8 +289,8 @@ RSpec.describe RuboCop::Options, :isolated_environment do
         it 'ignores --parallel' do
           msg = '-P/--parallel is being ignored because it is not compatible with --cache false'
           options.parse %w[--parallel --cache false]
-          expect($stdout.string.include?(msg)).to be(true)
-          expect(options.instance_variable_get(:@options).key?(:parallel)).to be(false)
+          expect($stdout.string).to include(msg)
+          expect(options.instance_variable_get(:@options)).not_to be_key(:parallel)
         end
       end
 
@@ -298,24 +298,24 @@ RSpec.describe RuboCop::Options, :isolated_environment do
         context 'combined with --fix-layout' do
           it 'allows --parallel' do
             options.parse %w[--parallel --fix-layout]
-            expect($stdout.string.include?('-P/--parallel is being ignored')).to be(false)
-            expect(options.instance_variable_get(:@options).key?(:parallel)).to be(true)
+            expect($stdout.string).not_to include('-P/--parallel is being ignored')
+            expect(options.instance_variable_get(:@options)).to be_key(:parallel)
           end
         end
 
         context 'combined with --autocorrect' do
           it 'allows --parallel' do
             options.parse %w[--parallel --autocorrect]
-            expect($stdout.string.include?('-P/--parallel is being ignored')).to be(false)
-            expect(options.instance_variable_get(:@options).key?(:parallel)).to be(true)
+            expect($stdout.string).not_to include('-P/--parallel is being ignored')
+            expect(options.instance_variable_get(:@options)).to be_key(:parallel)
           end
         end
 
         context 'combined with --autocorrect-all' do
           it 'allows --parallel' do
             options.parse %w[--parallel --autocorrect-all]
-            expect($stdout.string.include?('-P/--parallel is being ignored')).to be(false)
-            expect(options.instance_variable_get(:@options).key?(:parallel)).to be(true)
+            expect($stdout.string).not_to include('-P/--parallel is being ignored')
+            expect(options.instance_variable_get(:@options)).to be_key(:parallel)
           end
         end
       end
@@ -324,8 +324,8 @@ RSpec.describe RuboCop::Options, :isolated_environment do
         it 'ignores --parallel' do
           msg = '-P/--parallel is being ignored because it is not compatible with --auto-gen-config'
           options.parse %w[--parallel --auto-gen-config]
-          expect($stdout.string.include?(msg)).to be(true)
-          expect(options.instance_variable_get(:@options).key?(:parallel)).to be(false)
+          expect($stdout.string).to include(msg)
+          expect(options.instance_variable_get(:@options)).not_to be_key(:parallel)
         end
       end
 
@@ -333,17 +333,17 @@ RSpec.describe RuboCop::Options, :isolated_environment do
         it 'ignores --parallel' do
           msg = '-P/--parallel is being ignored because it is not compatible with -F/--fail-fast'
           options.parse %w[--parallel --fail-fast]
-          expect($stdout.string.include?(msg)).to be(true)
-          expect(options.instance_variable_get(:@options).key?(:parallel)).to be(false)
+          expect($stdout.string).to include(msg)
+          expect(options.instance_variable_get(:@options)).not_to be_key(:parallel)
         end
       end
 
       context 'combined with two incompatible arguments' do
         it 'ignores --parallel and lists both incompatible arguments' do
           options.parse %w[--parallel --fail-fast --autocorrect]
-          expect($stdout.string.include?('-P/--parallel is being ignored because it is not ' \
-                                         'compatible with -F/--fail-fast')).to be(true)
-          expect(options.instance_variable_get(:@options).key?(:parallel)).to be(false)
+          expect($stdout.string).to include('-P/--parallel is being ignored because it is not ' \
+                                            'compatible with -F/--fail-fast')
+          expect(options.instance_variable_get(:@options)).not_to be_key(:parallel)
         end
       end
     end
@@ -491,7 +491,9 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
 
       it 'fails if given alone without argument' do
-        expect { options.parse %w[--exclude-limit] }.to raise_error(OptionParser::MissingArgument)
+        expect do
+          options.parse %w[--exclude-limit]
+        end.to raise_error(OptionParser::MissingArgument)
       end
 
       it 'fails if given first without argument' do
@@ -500,7 +502,9 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
 
       it 'fails if given without --auto-gen-config' do
-        expect { options.parse %w[--exclude-limit 10] }.to raise_error(RuboCop::OptionArgumentError)
+        expect do
+          options.parse %w[--exclude-limit 10]
+        end.to raise_error(RuboCop::OptionArgumentError)
       end
     end
 
@@ -548,7 +552,9 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       let(:config_regeneration) do
         instance_double(RuboCop::ConfigRegeneration, options: todo_options)
       end
-      let(:todo_options) { { auto_gen_config: true, exclude_limit: '100', offense_counts: false } }
+      let(:todo_options) do
+        { auto_gen_config: true, exclude_limit: '100', offense_counts: false }
+      end
 
       before do
         allow(RuboCop::ConfigRegeneration).to receive(:new).and_return(config_regeneration)
@@ -627,7 +633,9 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
 
       it 'fails if more than one path is given' do
-        expect { options.parse %w[--stdin foo bar] }.to raise_error(RuboCop::OptionArgumentError)
+        expect do
+          options.parse %w[--stdin foo bar]
+        end.to raise_error(RuboCop::OptionArgumentError)
       end
     end
 
@@ -636,9 +644,8 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       describe '--auto-correct' do
         it 'emits a warning and sets the correct options instead' do
           options.parse %w[--auto-correct]
-          expect($stderr.string.include?('--auto-correct is deprecated; use --autocorrect'))
-            .to be(true)
-          expect(options.instance_variable_get(:@options).key?(:auto_correct)).to be(false)
+          expect($stderr.string).to include('--auto-correct is deprecated; use --autocorrect')
+          expect(options.instance_variable_get(:@options)).not_to be_key(:auto_correct)
           expect_autocorrect_options_for_autocorrect
         end
       end
@@ -646,9 +653,8 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       describe '--safe-auto-correct' do
         it 'emits a warning and sets the correct options instead' do
           options.parse %w[--safe-auto-correct]
-          expect($stderr.string.include?('--safe-auto-correct is deprecated; use --autocorrect'))
-            .to be(true)
-          expect(options.instance_variable_get(:@options).key?(:safe_auto_correct)).to be(false)
+          expect($stderr.string).to include('--safe-auto-correct is deprecated; use --autocorrect')
+          expect(options.instance_variable_get(:@options)).not_to be_key(:safe_auto_correct)
           expect_autocorrect_options_for_autocorrect
         end
       end
@@ -656,40 +662,38 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       describe '--auto-correct-all' do
         it 'emits a warning and sets the correct options instead' do
           options.parse %w[--auto-correct-all]
-          expect($stderr.string.include?('--auto-correct-all is deprecated; ' \
-                                         'use --autocorrect-all')).to be(true)
-          expect(options.instance_variable_get(:@options).key?(:auto_correct_all)).to be(false)
+          expect($stderr.string).to include('--auto-correct-all is deprecated; ' \
+                                            'use --autocorrect-all')
+          expect(options.instance_variable_get(:@options)).not_to be_key(:auto_correct_all)
           expect_autocorrect_options_for_autocorrect_all
         end
       end
     end
     # rubocop:enable Naming/InclusiveLanguage
 
-    # rubocop:disable Metrics/AbcSize
     def expect_autocorrect_options_for_fix_layout
       options_keys = options.instance_variable_get(:@options).keys
-      expect(options_keys.include?(:fix_layout)).to be(true)
-      expect(options_keys.include?(:autocorrect)).to be(true)
-      expect(options_keys.include?(:safe_autocorrect)).to be(false)
-      expect(options_keys.include?(:autocorrect_all)).to be(false)
+      expect(options_keys).to include(:fix_layout)
+      expect(options_keys).to include(:autocorrect)
+      expect(options_keys).not_to include(:safe_autocorrect)
+      expect(options_keys).not_to include(:autocorrect_all)
     end
 
     def expect_autocorrect_options_for_autocorrect
       options_keys = options.instance_variable_get(:@options).keys
-      expect(options_keys.include?(:fix_layout)).to be(false)
-      expect(options_keys.include?(:autocorrect)).to be(true)
-      expect(options_keys.include?(:safe_autocorrect)).to be(true)
-      expect(options_keys.include?(:autocorrect_all)).to be(false)
+      expect(options_keys).not_to include(:fix_layout)
+      expect(options_keys).to include(:autocorrect)
+      expect(options_keys).to include(:safe_autocorrect)
+      expect(options_keys).not_to include(:autocorrect_all)
     end
 
     def expect_autocorrect_options_for_autocorrect_all
       options_keys = options.instance_variable_get(:@options).keys
-      expect(options_keys.include?(:fix_layout)).to be(false)
-      expect(options_keys.include?(:autocorrect)).to be(true)
-      expect(options_keys.include?(:safe_autocorrect)).to be(false)
-      expect(options_keys.include?(:autocorrect_all)).to be(true)
+      expect(options_keys).not_to include(:fix_layout)
+      expect(options_keys).to include(:autocorrect)
+      expect(options_keys).not_to include(:safe_autocorrect)
+      expect(options_keys).to include(:autocorrect_all)
     end
-    # rubocop:enable Metrics/AbcSize
   end
 
   describe 'options precedence' do

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -24,20 +24,20 @@ RSpec.describe RuboCop::PathUtil do
 
   describe '#absolute?' do
     it 'returns a truthy value for a path beginning with slash' do
-      expect(described_class.absolute?('/Users/foo')).to be_truthy
+      expect(described_class).to be_absolute('/Users/foo')
     end
 
     it 'returns a falsey value for a path beginning with a directory name' do
-      expect(described_class.absolute?('Users/foo')).to be_falsey
+      expect(described_class).not_to be_absolute('Users/foo')
     end
 
     if RuboCop::Platform.windows?
       it 'returns a truthy value for a path beginning with an upper case drive letter' do
-        expect(described_class.absolute?('C:/Users/foo')).to be_truthy
+        expect(described_class).to be_absolute('C:/Users/foo')
       end
 
       it 'returns a truthy value for a path beginning with a lower case drive letter' do
-        expect(described_class.absolute?('d:/Users/foo')).to be_truthy
+        expect(described_class).to be_absolute('d:/Users/foo')
       end
     end
   end
@@ -56,53 +56,53 @@ RSpec.describe RuboCop::PathUtil do
     end
 
     it 'does not match dir/** for file in hidden dir' do
-      expect(described_class.match_path?('dir/**', 'dir/.hidden/file')).to be(false)
+      expect(described_class).not_to be_match_path('dir/**', 'dir/.hidden/file')
     end
 
     it 'matches dir/** for hidden file' do
-      expect(described_class.match_path?('dir/**', 'dir/.hidden_file')).to be(true)
+      expect(described_class).to be_match_path('dir/**', 'dir/.hidden_file')
     end
 
     it 'does not match file in a subdirectory' do
-      expect(described_class.match_path?('file', 'dir/files')).to be(false)
-      expect(described_class.match_path?('dir', 'dir/file')).to be(false)
+      expect(described_class).not_to be_match_path('file', 'dir/files')
+      expect(described_class).not_to be_match_path('dir', 'dir/file')
     end
 
     it 'matches strings to the full path' do
-      expect(described_class.match_path?("#{Dir.pwd}/dir/file", "#{Dir.pwd}/dir/file")).to be(true)
-      expect(described_class.match_path?(
-               "#{Dir.pwd}/dir/file",
-               "#{Dir.pwd}/dir/dir/file"
-             )).to be(false)
+      expect(described_class).to be_match_path("#{Dir.pwd}/dir/file", "#{Dir.pwd}/dir/file")
+      expect(described_class).not_to be_match_path(
+        "#{Dir.pwd}/dir/file",
+        "#{Dir.pwd}/dir/dir/file"
+      )
     end
 
     it 'matches glob expressions' do
-      expect(described_class.match_path?('dir/*', 'dir/file')).to be(true)
-      expect(described_class.match_path?('dir/**/*', 'dir/sub/file')).to be(true)
-      expect(described_class.match_path?('dir/**/*', 'dir/file')).to be(true)
-      expect(described_class.match_path?('**/*', 'dir/sub/file')).to be(true)
-      expect(described_class.match_path?('**/file', 'file')).to be(true)
+      expect(described_class).to be_match_path('dir/*', 'dir/file')
+      expect(described_class).to be_match_path('dir/**/*', 'dir/sub/file')
+      expect(described_class).to be_match_path('dir/**/*', 'dir/file')
+      expect(described_class).to be_match_path('**/*', 'dir/sub/file')
+      expect(described_class).to be_match_path('**/file', 'file')
 
-      expect(described_class.match_path?('sub/*', 'dir/sub/file')).to be(false)
+      expect(described_class).not_to be_match_path('sub/*', 'dir/sub/file')
 
-      expect(described_class.match_path?('**/*', 'dir/.hidden/file')).to be(false)
-      expect(described_class.match_path?('**/*', 'dir/.hidden_file')).to be(true)
-      expect(described_class.match_path?('**/.*/*', 'dir/.hidden/file')).to be(true)
-      expect(described_class.match_path?('**/.*', 'dir/.hidden_file')).to be(true)
+      expect(described_class).not_to be_match_path('**/*', 'dir/.hidden/file')
+      expect(described_class).to be_match_path('**/*', 'dir/.hidden_file')
+      expect(described_class).to be_match_path('**/.*/*', 'dir/.hidden/file')
+      expect(described_class).to be_match_path('**/.*', 'dir/.hidden_file')
 
-      expect(described_class.match_path?('c{at,ub}s', 'cats')).to be(true)
-      expect(described_class.match_path?('c{at,ub}s', 'cubs')).to be(true)
-      expect(described_class.match_path?('c{at,ub}s', 'gorillas')).to be(false)
-      expect(described_class.match_path?('**/*.{rb,txt}', 'dir/foo.txt')).to be(true)
+      expect(described_class).to be_match_path('c{at,ub}s', 'cats')
+      expect(described_class).to be_match_path('c{at,ub}s', 'cubs')
+      expect(described_class).not_to be_match_path('c{at,ub}s', 'gorillas')
+      expect(described_class).to be_match_path('**/*.{rb,txt}', 'dir/foo.txt')
     end
 
     it 'matches regexps' do
-      expect(described_class.match_path?(/^d.*e$/, 'dir/file')).to be(true)
-      expect(described_class.match_path?(/^d.*e$/, 'dir/filez')).to be(false)
+      expect(described_class).to be_match_path(/^d.*e$/, 'dir/file')
+      expect(described_class).not_to be_match_path(/^d.*e$/, 'dir/filez')
     end
 
     it 'does not match invalid UTF-8 paths' do
-      expect(described_class.match_path?(/^d.*$/, "dir/file\xBF")).to be(false)
+      expect(described_class).not_to be_match_path(/^d.*$/, "dir/file\xBF")
     end
   end
 end

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -15,30 +15,30 @@ RSpec.describe RuboCop::RakeTask do
     it 'creates a rubocop task and a rubocop auto_correct task' do
       described_class.new
 
-      expect(Rake::Task.task_defined?(:rubocop)).to be true
-      expect(Rake::Task.task_defined?('rubocop:auto_correct')).to be true
+      expect(Rake::Task).to be_task_defined(:rubocop)
+      expect(Rake::Task).to be_task_defined('rubocop:auto_correct')
     end
 
     it 'creates a named task and a named auto_correct task' do
       described_class.new(:lint_lib)
 
-      expect(Rake::Task.task_defined?(:lint_lib)).to be true
-      expect(Rake::Task.task_defined?('lint_lib:auto_correct')).to be true
+      expect(Rake::Task).to be_task_defined(:lint_lib)
+      expect(Rake::Task).to be_task_defined('lint_lib:auto_correct')
     end
     # rubocop:enable Naming/InclusiveLanguage
 
     it 'creates a rubocop task and a rubocop autocorrect task' do
       described_class.new
 
-      expect(Rake::Task.task_defined?(:rubocop)).to be true
-      expect(Rake::Task.task_defined?('rubocop:autocorrect')).to be true
+      expect(Rake::Task).to be_task_defined(:rubocop)
+      expect(Rake::Task).to be_task_defined('rubocop:autocorrect')
     end
 
     it 'creates a named task and a named autocorrect task' do
       described_class.new(:lint_lib)
 
-      expect(Rake::Task.task_defined?(:lint_lib)).to be true
-      expect(Rake::Task.task_defined?('lint_lib:autocorrect')).to be true
+      expect(Rake::Task).to be_task_defined(:lint_lib)
+      expect(Rake::Task).to be_task_defined('lint_lib:autocorrect')
     end
   end
 

--- a/spec/rubocop/remote_config_spec.rb
+++ b/spec/rubocop/remote_config_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe RuboCop::RemoteConfig do
   describe '.file' do
     it 'downloads the file if the file does not exist' do
       expect(remote_config).to eq(cached_file_path)
-      expect(File.exist?(cached_file_path)).to be_truthy
+      expect(File).to exist(cached_file_path)
     end
 
     it 'does not download the file if cache lifetime has not been reached' do
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::RemoteConfig do
 
       it 'downloads the file if the file does not exist' do
         expect(remote_config).to eq(cached_file_path)
-        expect(File.exist?(cached_file_path)).to be_truthy
+        expect(File).to exist(cached_file_path)
       end
 
       it 'does not download the file if cache lifetime has not been reached' do
@@ -97,7 +97,7 @@ RSpec.describe RuboCop::RemoteConfig do
 
       it 'downloads the file if the file does not exist' do
         expect(remote_config).to eq(cached_file_path)
-        expect(File.exist?(cached_file_path)).to be_truthy
+        expect(File).to exist(cached_file_path)
       end
 
       it 'does not download the file if cache lifetime has not been reached' do
@@ -151,7 +151,7 @@ RSpec.describe RuboCop::RemoteConfig do
 
       it 'follows the redirect and downloads the file' do
         expect(remote_config).to eq(cached_file_path)
-        expect(File.exist?(cached_file_path)).to be_truthy
+        expect(File).to exist(cached_file_path)
       end
     end
 

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
       it 'is valid and can be loaded' do
         cache.save(offenses)
         cache2 = described_class.new(file, team, options2, config_store, cache_root)
-        expect(cache2.valid?).to be(true)
+        expect(cache2).to be_valid
         saved_offenses = cache2.load
         expect(saved_offenses).to eq(offenses)
       end
@@ -139,7 +139,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
           cache.save(offenses)
           create_file('example.rb', ['x = 2'])
           cache2 = described_class.new(file, team, options, config_store, cache_root)
-          expect(cache2.valid?).to be(false)
+          expect(cache2).not_to be_valid
         end
       end
 
@@ -149,7 +149,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
             cache.save(offenses)
             FileUtils.chmod('+x', file)
             cache2 = described_class.new(file, team, options, config_store, cache_root)
-            expect(cache2.valid?).to be(false)
+            expect(cache2).not_to be_valid
           end
         end
       end
@@ -166,7 +166,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
             end
           end
           cache2 = described_class.new(file, team, options, config_store, cache_root)
-          expect(cache2.valid?).to be(false)
+          expect(cache2).not_to be_valid
         end
       end
 
@@ -175,7 +175,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
           cache.save(offenses)
           allow(team).to(receive(:external_dependency_checksum).and_return('bar'))
           cache2 = described_class.new(file, team, options, config_store, cache_root)
-          expect(cache2.valid?).to be(false)
+          expect(cache2).not_to be_valid
         end
       end
 
@@ -184,7 +184,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
           cache.save(offenses)
           allow(team).to(receive(:external_dependency_checksum).and_return('foo'))
           cache2 = described_class.new(file, team, options, config_store, cache_root)
-          expect(cache2.valid?).to be(true)
+          expect(cache2).to be_valid
         end
       end
 
@@ -216,7 +216,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
             cache2.save(offenses)
             # The cache file has not been created because there was a symlink in
             # its path.
-            expect(cache2.valid?).to be(false)
+            expect(cache2).not_to be_valid
             expect($stderr.string).to match(/Warning: .* is a symlink, which is not allowed.\n/)
           end
         end
@@ -235,7 +235,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
           it 'permits caching and prints no warning' do
             cache2.save(offenses)
 
-            expect(cache2.valid?).to be(true)
+            expect(cache2).to be_valid
             expect($stderr.string).not_to match(/Warning: .* is a symlink, which is not allowed.\n/)
           end
         end
@@ -262,7 +262,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
         cache2 = described_class.new(file, team,
                                      { only: ['Layout/LineLength'] },
                                      config_store, cache_root)
-        expect(cache2.valid?).to be(false)
+        expect(cache2).not_to be_valid
       end
     end
 
@@ -271,7 +271,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
         cache.save(offenses)
         cache2 = described_class.new(file, team, { display_cop_names: true },
                                      config_store, cache_root)
-        expect(cache2.valid?).to be(false)
+        expect(cache2).not_to be_valid
       end
     end
 
@@ -351,7 +351,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
       underscore_dir = Dir["#{cache_root}/*/*"].first
       expect(Dir["#{underscore_dir}/*"].size).to eq(2)
       cache.class.cleanup(config_store, :verbose, cache_root)
-      expect(File.exist?(underscore_dir)).to be_falsey
+      expect(File).not_to exist(underscore_dir)
       expect($stdout.string).to eq("Removing the 2 oldest files from #{cache_root}\n")
     end
   end

--- a/spec/rubocop/runner_formatter_invocation_spec.rb
+++ b/spec/rubocop/runner_formatter_invocation_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
       describe 'the passed files paths' do
         it 'is frozen' do
           expect(formatter).to receive(method_name) do |all_files|
-            all_files.each { |path| expect(path.frozen?).to be(true) }
+            expect(all_files).to all(be_frozen)
           end
 
           run
@@ -131,7 +131,7 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
       describe 'the passed path' do
         it 'is frozen' do
           expect(formatter).to receive(method_name).exactly(3).times do |path|
-            expect(path.frozen?).to be(true)
+            expect(path).to be_frozen
           end
 
           run
@@ -161,7 +161,7 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
           when '5_offenses.rb'
             expect(offenses.size).to eq(5)
           when 'no_offense.rb'
-            expect(offenses.empty?).to be(true)
+            expect(offenses).to be_empty
           else
             raise
           end

--- a/spec/rubocop/server/cache_spec.rb
+++ b/spec/rubocop/server/cache_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe RuboCop::Server::Cache do
           described_class.dir.rmtree # server stopping behavior
           result
         end
-        expect(described_class.pid_running?).to be(false)
+        expect(described_class).not_to be_pid_running
       end
 
       it 'works properly when insufficient permissions to server cache dir are granted' do
@@ -290,7 +290,7 @@ RSpec.describe RuboCop::Server::Cache do
           described_class.dir.chmod(0o644) # Make insufficient permissions.
           result
         end
-        expect(described_class.pid_running?).to be(false)
+        expect(described_class).not_to be_pid_running
       end
 
       it 'works properly when the file system is read-only' do
@@ -299,7 +299,7 @@ RSpec.describe RuboCop::Server::Cache do
           allow(result).to receive(:read).and_raise(Errno::EROFS)
           result
         end
-        expect(described_class.pid_running?).to be(false)
+        expect(described_class).not_to be_pid_running
       end
     end
   end

--- a/spec/rubocop/server/cli_spec.rb
+++ b/spec/rubocop/server/cli_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
           puts x
         RUBY
         expect(cli.run(['--server', '--format', 'simple', 'example.rb'])).to eq(0)
-        expect(cli.exit?).to be(false)
+        expect(cli).not_to be_exit
         expect($stdout.string).to start_with 'RuboCop server starting on '
         expect($stderr.string).to eq ''
       end
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
           puts x
         RUBY
         expect(cli.run(['--no-server', '--format', 'simple', 'example.rb'])).to eq(0)
-        expect(cli.exit?).to be(false)
+        expect(cli).not_to be_exit
         expect($stdout.string).to eq ''
         expect($stderr.string).to eq ''
       end
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
     context 'when using `--start-server` option' do
       it 'returns exit status 0 and display an information message' do
         expect(cli.run(['--start-server'])).to eq(0)
-        expect(cli.exit?).to be(true)
+        expect(cli).to be_exit
         expect($stdout.string).to start_with 'RuboCop server starting on '
         expect($stderr.string).to eq ''
       end
@@ -56,7 +56,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
     context 'when using `--start-server` option with `--no-detach`' do
       it 'returns exit status 0 and display an information message' do
         expect(cli.run(['--start-server', '--no-detach'])).to eq(0)
-        expect(cli.exit?).to be(true)
+        expect(cli).to be_exit
         expect($stdout.string).to match(/RuboCop server starting on/)
         expect($stderr.string).to eq ''
       end
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
     context 'when using `--stop-server` option' do
       it 'returns exit status 0 and display a warning message' do
         expect(cli.run(['--stop-server'])).to eq(0)
-        expect(cli.exit?).to be(true)
+        expect(cli).to be_exit
         expect($stdout.string).to eq ''
         expect($stderr.string).to eq "RuboCop server is not running.\n"
       end
@@ -74,7 +74,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
     context 'when using `--restart-server` option' do
       it 'returns exit status 0 and display an information and a warning messages' do
         expect(cli.run(['--restart-server'])).to eq(0)
-        expect(cli.exit?).to be(true)
+        expect(cli).to be_exit
         expect($stdout.string).to start_with 'RuboCop server starting on '
         expect($stderr.string).to eq "RuboCop server is not running.\n"
       end
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
     context 'when using `--restart-server` option with `--no-detach`' do
       it 'returns exit status 0 and display an information message' do
         expect(cli.run(['--restart-server', '--no-detach'])).to eq(0)
-        expect(cli.exit?).to be(true)
+        expect(cli).to be_exit
         expect($stdout.string).to match(/RuboCop server starting on/)
         expect($stderr.string).to eq "RuboCop server is not running.\n"
       end
@@ -92,7 +92,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
     context 'when using `--server-status` option' do
       it 'returns exit status 0 and display an information message' do
         expect(cli.run(['--server-status'])).to eq(0)
-        expect(cli.exit?).to be(true)
+        expect(cli).to be_exit
         expect($stdout.string).to eq "RuboCop server is not running.\n"
         expect($stderr.string).to eq ''
       end
@@ -107,9 +107,9 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
           puts x
         RUBY
         expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(0)
-        expect(cli.exit?).to be(false)
-        expect($stdout.string.blank?).to be(true)
-        expect($stderr.string.blank?).to be(true)
+        expect(cli).not_to be_exit
+        expect($stdout.string).to be_blank
+        expect($stderr.string).to be_blank
       end
     end
 
@@ -124,7 +124,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
           puts x
         RUBY
         expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(0)
-        expect(cli.exit?).to be(false)
+        expect(cli).not_to be_exit
         expect($stdout.string).to start_with 'RuboCop server starting on '
         expect($stderr.string).to eq ''
       end
@@ -148,7 +148,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
           puts x
         RUBY
         expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(0)
-        expect(cli.exit?).to be(false)
+        expect(cli).not_to be_exit
         expect($stdout.string).to start_with 'RuboCop server starting on '
         expect($stderr.string).to eq ''
       end
@@ -163,7 +163,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
           puts x
         RUBY
         expect(cli.run(['--server', '--no-server', '--format', 'simple', 'example.rb'])).to eq(2)
-        expect(cli.exit?).to be(true)
+        expect(cli).to be_exit
         expect($stdout.string).to eq ''
         expect($stderr.string).to eq "--server, --no-server cannot be specified together.\n"
       end
@@ -172,7 +172,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
     context 'when using exclusive `--restart-server` option' do
       it 'returns exit status 2 and display an error message' do
         expect(cli.run(['--restart-server', '--format', 'simple'])).to eq(2)
-        expect(cli.exit?).to be(true)
+        expect(cli).to be_exit
         expect($stdout.string).to eq ''
         expect($stderr.string).to eq "--restart-server cannot be combined with --format.\n"
       end
@@ -181,7 +181,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
     context 'when using exclusive `--start-server` option' do
       it 'returns exit status 2 and display an error message' do
         expect(cli.run(['--start-server', '--format', 'simple'])).to eq(2)
-        expect(cli.exit?).to be(true)
+        expect(cli).to be_exit
         expect($stdout.string).to eq ''
         expect($stderr.string).to eq "--start-server cannot be combined with --format.\n"
       end
@@ -190,7 +190,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
     context 'when using exclusive `--stop-server` option' do
       it 'returns exit status 2 and display an error message' do
         expect(cli.run(['--stop-server', '--format', 'simple'])).to eq(2)
-        expect(cli.exit?).to be(true)
+        expect(cli).to be_exit
         expect($stdout.string).to eq ''
         expect($stderr.string).to eq "--stop-server cannot be combined with --format.\n"
       end
@@ -199,7 +199,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
     context 'when using exclusive `--server-status` option' do
       it 'returns exit status 2 and display an error message' do
         expect(cli.run(['--server-status', '--format', 'simple'])).to eq(2)
-        expect(cli.exit?).to be(true)
+        expect(cli).to be_exit
         expect($stdout.string).to eq ''
         expect($stderr.string).to eq "--server-status cannot be combined with --format.\n"
       end
@@ -208,7 +208,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
     context 'when using server option with `--no-detach` option' do
       it 'returns exit status 2 and display an error message' do
         expect(cli.run(['--server-status', '--no-detach'])).to eq(2)
-        expect(cli.exit?).to be(true)
+        expect(cli).to be_exit
         expect($stdout.string).to eq ''
         expect($stderr.string).to eq "--server-status cannot be combined with --no-detach.\n"
       end
@@ -217,7 +217,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
     context 'when using server option with `--cache-root path` option' do
       it 'returns exit status 0 and display an error message' do
         expect(cli.run(['--server-status', '--cache-root', '/tmp'])).to eq(0)
-        expect(cli.exit?).to be(true)
+        expect(cli).to be_exit
         expect($stdout.string).to eq "RuboCop server is not running.\n"
         expect($stderr.string).not_to eq "--server-status cannot be combined with other options.\n"
       end
@@ -226,7 +226,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
     context 'when using server option with `--cache-root=path` option' do
       it 'returns exit status 0 and display an information message' do
         expect(cli.run(['--server-status', '--cache-root=/tmp'])).to eq(0)
-        expect(cli.exit?).to be(true)
+        expect(cli).to be_exit
         expect($stdout.string).to eq "RuboCop server is not running.\n"
         expect($stderr.string).not_to eq "--server-status cannot be combined with other options.\n"
       end
@@ -235,7 +235,7 @@ RSpec.describe RuboCop::Server::CLI, :isolated_environment do
     context 'when using `--server` option' do
       it 'returns exit status 2 and display an error message' do
         expect(cli.run(['--server', '--format', 'simple'])).to eq(2)
-        expect(cli.exit?).to be(true)
+        expect(cli).to be_exit
         expect($stdout.string).to eq ''
         expect($stderr.string).to eq "RuboCop server is not supported by this Ruby.\n"
       end

--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
           '--stdin', 'example.rb',
           stdin_data: 'puts 0'
         )
-        expect(status.success?).to be true
+        expect(status).to be_success
         expect(stdout).to eq(<<~RUBY)
           # frozen_string_literal: true
 

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -176,12 +176,12 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
     end
 
     it 'returns absolute paths' do
-      expect(found_files.empty?).to be(false)
-      found_files.each { |file| expect(Pathname.new(file).absolute?).to be(true) }
+      expect(found_files).not_to be_empty
+      found_files.each { |file| expect(Pathname.new(file)).to be_absolute }
     end
 
     it 'does not find hidden files' do
-      expect(found_files.include?('.hidden/ruby4.rb')).to be(false)
+      expect(found_files).not_to include('.hidden/ruby4.rb')
     end
 
     context 'when no argument is passed' do
@@ -189,10 +189,10 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
 
       it 'finds files under the current directory' do
         Dir.chdir('dir1') do
-          expect(found_files.empty?).to be(false)
+          expect(found_files).not_to be_empty
           found_files.each do |file|
-            expect(file.include?('/dir1/')).to be(true)
-            expect(file.include?('/dir2/')).to be(false)
+            expect(file).to include('/dir1/')
+            expect(file).not_to include('/dir2/')
           end
         end
       end
@@ -203,10 +203,10 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
 
       it 'finds files under the specified directory' do
         Dir.chdir('dir1') do
-          expect(found_files.empty?).to be(false)
+          expect(found_files).not_to be_empty
           found_files.each do |file|
-            expect(file.include?('/dir2/')).to be(true)
-            expect(file.include?('/dir1/')).to be(false)
+            expect(file).to include('/dir2/')
+            expect(file).not_to include('/dir1/')
           end
         end
       end
@@ -217,7 +217,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
 
       it 'finds files under the specified directory' do
         expect(found_files.size).to be(1)
-        expect(found_files.first.include?('.hidden/ruby4.rb')).to be(true)
+        expect(found_files.first).to include('.hidden/ruby4.rb')
       end
     end
 
@@ -267,7 +267,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
 
       it 'finds files under the specified directory' do
         expect(found_files.size).to be(1)
-        expect(found_files.first.include?('.hidden/ruby4.rb')).to be(true)
+        expect(found_files.first).to include('.hidden/ruby4.rb')
       end
     end
 
@@ -275,7 +275,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       let(:args) { ['dir2/file'] }
 
       it "doesn't pick the file" do
-        expect(found_basenames.empty?).to be(true)
+        expect(found_basenames).to be_empty
       end
     end
 
@@ -430,8 +430,8 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       allow(config).to receive(:for_all_cops).and_return(exclude_property)
       allow(config_store).to receive(:for).and_return(config)
 
-      expect(found_basenames.include?('ruby1.rb')).to be(false)
-      expect(found_basenames.include?('ruby3.rb')).to be(true)
+      expect(found_basenames).not_to include('ruby1.rb')
+      expect(found_basenames).to include('ruby3.rb')
     end
 
     it 'works also if a folder is named ","' do
@@ -442,9 +442,9 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       allow(config).to receive(:for_all_cops).and_return(exclude_property)
       allow(config_store).to receive(:for).and_return(config)
 
-      expect(found_basenames.include?('ruby1.rb')).to be(false)
-      expect(found_basenames.include?('ruby3.rb')).to be(true)
-      expect(found_basenames.include?('ruby4.rb')).to be(true)
+      expect(found_basenames).not_to include('ruby1.rb')
+      expect(found_basenames).to include('ruby3.rb')
+      expect(found_basenames).to include('ruby4.rb')
     end
 
     it 'works also if a folder is named "{}"' do
@@ -455,9 +455,9 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       allow(config).to receive(:for_all_cops).and_return(exclude_property)
       allow(config_store).to receive(:for).and_return(config)
 
-      expect(found_basenames.include?('ruby1.rb')).to be(false)
-      expect(found_basenames.include?('ruby3.rb')).to be(true)
-      expect(found_basenames.include?('ruby4.rb')).to be(true)
+      expect(found_basenames).not_to include('ruby1.rb')
+      expect(found_basenames).to include('ruby3.rb')
+      expect(found_basenames).to include('ruby4.rb')
     end
 
     it 'works also if a folder is named "{foo}"' do
@@ -468,9 +468,9 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       allow(config).to receive(:for_all_cops).and_return(exclude_property)
       allow(config_store).to receive(:for).and_return(config)
 
-      expect(found_basenames.include?('ruby1.rb')).to be(false)
-      expect(found_basenames.include?('ruby3.rb')).to be(true)
-      expect(found_basenames.include?('ruby4.rb')).to be(true)
+      expect(found_basenames).not_to include('ruby1.rb')
+      expect(found_basenames).to include('ruby3.rb')
+      expect(found_basenames).to include('ruby4.rb')
     end
 
     it 'works also if a folder is named "[...something]"' do
@@ -481,9 +481,9 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       allow(config).to receive(:for_all_cops).and_return(exclude_property)
       allow(config_store).to receive(:for).and_return(config)
 
-      expect(found_basenames.include?('ruby1.rb')).to be(false)
-      expect(found_basenames.include?('ruby3.rb')).to be(true)
-      expect(found_basenames.include?('ruby4.rb')).to be(true)
+      expect(found_basenames).not_to include('ruby1.rb')
+      expect(found_basenames).to include('ruby3.rb')
+      expect(found_basenames).to include('ruby4.rb')
     end
 
     it 'works if patterns are empty' do
@@ -512,7 +512,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
         allow(config).to receive(:for_all_cops).and_return(exclude_property)
         allow(config_store).to receive(:for).and_return(config)
 
-        expect(found_basenames.include?('ruby5.rb')).to be(true)
+        expect(found_basenames).to include('ruby5.rb')
       end
     end
 
@@ -530,8 +530,8 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       allow(config).to receive(:for_all_cops).and_return(exclude_property)
       allow(config_store).to receive(:for).and_return(config)
 
-      expect(found_basenames.include?('ruby1.rb')).to be(false)
-      expect(found_basenames.include?('ruby3.rb')).to be(true)
+      expect(found_basenames).not_to include('ruby1.rb')
+      expect(found_basenames).to include('ruby3.rb')
     end
 
     it 'can exclude symlinks as well as directories' do
@@ -543,8 +543,8 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       allow(config).to receive(:for_all_cops).and_return(exclude_property)
       allow(config_store).to receive(:for).and_return(config)
 
-      expect(found_basenames.include?('ruby5.rb')).to be(false)
-      expect(found_basenames.include?('ruby3.rb')).to be(true)
+      expect(found_basenames).not_to include('ruby5.rb')
+      expect(found_basenames).to include('ruby3.rb')
     end
   end
 
@@ -559,17 +559,17 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
     end
 
     it 'picks ruby executable files with no extension' do
-      expect(found_basenames.include?('executable')).to be(true)
+      expect(found_basenames).to include('executable')
     end
 
     it 'does not pick files with no extension and no ruby shebang' do
-      expect(found_basenames.include?('file')).to be(false)
+      expect(found_basenames).not_to include('file')
     end
 
     it 'does not pick directories' do
       found_basenames = found_files.map { |f| File.basename(f) }
       allow(config_store).to receive(:for).and_return({})
-      expect(found_basenames.include?('dir1')).to be(false)
+      expect(found_basenames).not_to include('dir1')
     end
 
     it 'picks files specified to be included in config' do
@@ -585,7 +585,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
 
       allow(config_store).to receive(:for).and_return(config)
 
-      expect(found_basenames.include?('file')).to be(true)
+      expect(found_basenames).to include('file')
     end
 
     it 'does not pick files specified to be excluded in config' do
@@ -600,7 +600,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       end
       allow(config_store).to receive(:for).and_return(config)
 
-      expect(found_basenames.include?('ruby2.rb')).to be(false)
+      expect(found_basenames).not_to include('ruby2.rb')
     end
 
     context 'when an exception is raised while reading file' do
@@ -621,7 +621,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
 
         it 'outputs error message' do
           found_files
-          expect($stderr.string.include?('Unprocessable file')).to be(true)
+          expect($stderr.string).to include('Unprocessable file')
         end
       end
 
@@ -630,7 +630,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
 
         it 'outputs nothing' do
           found_files
-          expect($stderr.string.empty?).to be(true)
+          expect($stderr.string).to be_empty
         end
       end
     end


### PR DESCRIPTION
This is something that has bothered me for a while. There is an rspec cop for this to enforce better failure messages. I changed the config an let RuboCop autocorrect.

Changed expectations would previously output messages like this:
```
     Failure/Error: expect(options_keys.include?(:aautocorrect)).to be(true)

       expected true
            got false
```

The new expectations print the actual vs expected value:
```
     Failure/Error: expect(options_keys).to include(:aautocorrect)

       expected [:autocorrect_all, :autocorrect] to include :aautocorrect
       Diff:
       @@ -1 +1 @@
       -[:aautocorrect]
       +[:autocorrect_all, :autocorrect]
```

The same improvement also applies to something like `expect($stderr.string.include?("whatever).to be(true)` or `expect(foo.nil?).to be(true)` (and probably more)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
