### PR TITLE
Workaround for Ruby's 3.4.0dev CI matrix error

### DIFF
--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2196,7 +2196,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect(File).to exist(cpu_profile)
       end
 
-      it 'creates memory profile file' do
+      # FIXME: https://github.com/rubocop/rubocop/actions/runs/9542192514/job/26296594698
+      # It is necessary to investigate and resolve the error that occurred with Ruby 3.4-dev in
+      # https://github.com/rubocop/rubocop/pull/12999.
+      it 'creates memory profile file', broken_on: :ruby_head do
         expect(cli.run(['--profile', '--memory', 'example1.rb'])).to eq(0)
         expect($stdout.string.include?('Building memory report...')).to be(true)
         expect(File).to exist(memory_profile)


### PR DESCRIPTION
This is a workaround to prevent the following error in 3.4.0dev CI matrix:

```console
==> Failures

  1) RuboCop::CLI profiling creates memory profile file
     Got 3 failures from failure aggregation block.
(snip)

     *.1) Failure/Error: expect(cli.run(['--profile', '--memory', 'example1.rb'])).to eq(0)

            expected: 0
                 got: 2

            (compared using ==)
          # ./spec/rubocop/cli_spec.rb:2200:in 'block (3 levels) in <top (required)>'

     *.2) Failure/Error: expect($stdout.string.include?('Building memory report...')).to be(true)

            expected true
                 got false
          # ./spec/rubocop/cli_spec.rb:2201:in 'block (3 levels) in <top (required)>'

     *.3) Failure/Error: expect(File).to exist(memory_profile)
            expected File to exist
          # ./spec/rubocop/cli_spec.rb:2202:in 'block (3 levels) in <top (required)>'
```

https://github.com/rubocop/rubocop/actions/runs/9542192514/job/26296594698

It is necessary to investigate and resolve the error that occurred with Ruby 3.4-dev in #12999 separately.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
