### PR TITLE
[Fix #12557] Make server mode aware of auto-restart for `bundle update`

### DIFF
--- a/changelog/change_make_server_mode_aware-of_auto_restart_for_bundle_update.md
+++ b/changelog/change_make_server_mode_aware-of_auto_restart_for_bundle_update.md
@@ -1,0 +1,1 @@
+* [#12557](https://github.com/rubocop/rubocop/issues/12557): Make server mode aware of auto-restart for `bundle update`. ([@koic][])

--- a/docs/modules/ROOT/pages/usage/server.adoc
+++ b/docs/modules/ROOT/pages/usage/server.adoc
@@ -49,7 +49,7 @@ user             16060   0.0  0.0  5078568   2264   ??  S     7:54AM   0:00.00 r
 user             16337   0.0  0.0  5331560   2396   ??  S    23:51PM   0:00.00 rubocop --server /Users/user/src/github.com/rubocop/rubocop-rails
 ```
 
-When you update and run `rubocop`, the server process will restart automatically.
+When you `bundle update` and run `rubocop`, the server process will restart automatically.
 
 ```console
 $ rubocop --server

--- a/lib/rubocop/server/cache.rb
+++ b/lib/rubocop/server/cache.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'digest'
 require 'pathname'
 require_relative '../cache_config'
 require_relative '../config_finder'
@@ -19,6 +20,7 @@ module RuboCop
     # @api private
     class Cache
       GEMFILE_NAMES = %w[Gemfile gems.rb].freeze
+      LOCKFILE_NAMES = %w[Gemfile.lock gems.locked].freeze
 
       class << self
         attr_accessor :cache_root_path
@@ -39,6 +41,14 @@ module RuboCop
 
         def project_dir_cache_key
           @project_dir_cache_key ||= project_dir[1..].tr('/', '+')
+        end
+
+        def restart_key
+          lockfile_path = LOCKFILE_NAMES.map do |lockfile_name|
+            Pathname(project_dir).join(lockfile_name)
+          end.find(&:exist?)
+
+          Digest::SHA1.hexdigest(lockfile_path&.read || RuboCop::Version::STRING)
         end
 
         def dir

--- a/lib/rubocop/server/client_command/exec.rb
+++ b/lib/rubocop/server/client_command/exec.rb
@@ -41,7 +41,7 @@ module RuboCop
         end
 
         def incompatible_version?
-          Cache.version_path.read != RuboCop::Version::STRING
+          Cache.version_path.read != Cache.restart_key
         end
 
         def stderr

--- a/lib/rubocop/server/client_command/start.rb
+++ b/lib/rubocop/server/client_command/start.rb
@@ -34,7 +34,7 @@ module RuboCop
               exit 0
             end
 
-            Cache.write_version_file(RuboCop::Version::STRING)
+            Cache.write_version_file(Cache.restart_key)
 
             host = ENV.fetch('RUBOCOP_SERVER_HOST', '127.0.0.1')
             port = ENV.fetch('RUBOCOP_SERVER_PORT', 0)

--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -32,9 +32,8 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
 
         options = '--server --only Style/FrozenStringLiteralComment,Style/StringLiterals'
         expect(`ruby -I . "#{rubocop}" #{options}`).to start_with('RuboCop server starting on')
-        # Emulating RuboCop updates. `0.99.9` is a version value for testing that
-        # will never be used in the real world RuboCop version.
-        RuboCop::Server::Cache.write_version_file('0.99.9')
+        # Emulating the SHA1 value of Gemfile.lock.
+        RuboCop::Server::Cache.write_version_file('615dfedabfe01face6557b935510309ae550f74f')
 
         expect(`ruby -I . "#{rubocop}" --server-status`).to match(/RuboCop server .* is running/)
         _stdout, stderr, _status = Open3.capture3("ruby -I . \"#{rubocop}\" #{options}")


### PR DESCRIPTION
Resolves #12557.

Currently, the server mode only auto-restarts due to incompatible versions of RuboCop core. This PR will enable auto-restart when the SHA1 value of Gemfile.lock becomes incompatible. If Gemfile.lock is missing, it will continue to refer to the RuboCop core version as before.

The advantage is that it can cover cases of version incompatibility caused by `bundle update`, which will likely cover many scenarios like those in #12557.

The disadvantage is that the server mode may become slightly slower. However, it is unlikely to be slow enough for users to notice. The trade-off is considered acceptable.

In the future, it might be possible to detect changes in rubocop configuration as well, but for now, I'd like to see how things go with this change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
