### PR TITLE
Add a spec for the changelog that cops in backticks have a department

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -346,6 +346,16 @@ RSpec.describe 'RuboCop Project', type: :feature do
               end
             end
           end
+
+          it 'has cops in backticks with department', :aggregate_failures do
+            cop_names_without_department = allowed_cop_names.map { |name| name.split('/').last }
+            entries.each do |entry|
+              entry.scan(/`([A-Z]\w+)`/) do |cop_name, *|
+                expect(cop_names_without_department.include?(cop_name))
+                  .to be(false), "Missing department for #{cop_name}."
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Check that if text in backticks is encountered and that text looks like a cop name, that the cops department is specified.

Not specifically for this repo but something I saw in `rubocop-rails`:

* https://github.com/rubocop/rubocop-rails/blob/02597007171ab3913a3559f9b8052f691759e4de/changelog/change_where_range_unsafe_autocorrect.md
* https://github.com/rubocop/rubocop-rails/blob/02597007171ab3913a3559f9b8052f691759e4de/changelog/fix_change_column_null_in_bulk_change_table.md
* https://github.com/rubocop/rubocop-rails/blob/02597007171ab3913a3559f9b8052f691759e4de/changelog/fix_where_range_complex_expressions.md
* https://github.com/rubocop/rubocop-rails/blob/02597007171ab3913a3559f9b8052f691759e4de/changelog/fix_where_range_spaces.md

It doesn't run the same checks on changelog as this does here so its not really helping that. But perhaps one day it will.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
