### PR TITLE
Consistently use the console mock helper in tests

### DIFF
--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -25,16 +25,15 @@ RSpec.describe RuboCop::Config do
     let(:configuration_path) { '.rubocop.yml' }
 
     context 'when the configuration includes any unrecognized cop name' do
+      include_context 'mock console output'
+
       before do
         create_file(configuration_path, <<~YAML)
           LyneLenth:
             Enabled: true
             Max: 100
         YAML
-        $stderr = StringIO.new
       end
-
-      after { $stderr = STDERR }
 
       it 'raises an validation error' do
         expect { configuration }.to raise_error(
@@ -46,6 +45,8 @@ RSpec.describe RuboCop::Config do
 
     context 'when the configuration includes any unrecognized cop name and given `--ignore-unrecognized-cops` option' do
       context 'there is unrecognized cop' do
+        include_context 'mock console output'
+
         before do
           create_file(configuration_path, <<~YAML)
             LyneLenth:
@@ -53,12 +54,10 @@ RSpec.describe RuboCop::Config do
               Max: 100
           YAML
           RuboCop::ConfigLoader.ignore_unrecognized_cops = true
-          $stderr = StringIO.new
         end
 
         after do
           RuboCop::ConfigLoader.ignore_unrecognized_cops = nil
-          $stderr = STDERR
         end
 
         it 'prints a warning about the cop' do
@@ -70,18 +69,18 @@ RSpec.describe RuboCop::Config do
       end
 
       context 'there are no unrecognized cops' do
+        include_context 'mock console output'
+
         before do
           create_file(configuration_path, <<~YAML)
             Layout/LineLength:
               Enabled: true
           YAML
           RuboCop::ConfigLoader.ignore_unrecognized_cops = true
-          $stderr = StringIO.new
         end
 
         after do
           RuboCop::ConfigLoader.ignore_unrecognized_cops = nil
-          $stderr = STDERR
         end
 
         it 'does not print any warnings' do
@@ -128,16 +127,15 @@ RSpec.describe RuboCop::Config do
     end
 
     context 'when the configuration includes any unrecognized parameter' do
+      include_context 'mock console output'
+
       before do
         create_file(configuration_path, <<~YAML)
           Layout/LineLength:
             Enabled: true
             Min: 10
         YAML
-        $stderr = StringIO.new
       end
-
-      after { $stderr = STDERR }
 
       it 'prints a warning message' do
         configuration # ConfigLoader.load_file will validate config
@@ -524,9 +522,7 @@ RSpec.describe RuboCop::Config do
   end
 
   describe '#file_to_exclude?' do
-    before { $stderr = StringIO.new }
-
-    after { $stderr = STDERR }
+    include_context 'mock console output'
 
     let(:hash) { { 'AllCops' => { 'Exclude' => ["#{Dir.pwd}/log/**/*", '**/bar.rb'] } } }
 
@@ -655,11 +651,9 @@ RSpec.describe RuboCop::Config do
     let(:loaded_path) { 'example/.rubocop.yml' }
 
     context 'when a deprecated configuration is detected' do
+      include_context 'mock console output'
+
       let(:hash) { { 'AllCops' => { 'Includes' => [] } } }
-
-      before { $stderr = StringIO.new }
-
-      after { $stderr = STDERR }
 
       it 'prints a warning message for the loaded path' do
         configuration.check

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -11,9 +11,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
   end
 
   describe '.qualified_cop_name' do
-    before { $stderr = StringIO.new }
-
-    after { $stderr = STDERR }
+    include_context 'mock console output'
 
     it 'adds namespace if the cop name is found in exactly one namespace' do
       expect(described_class.qualified_cop_name('LineLength', '--only')).to eq('Layout/LineLength')

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
     let(:offenses) { [] }
     let(:cop) { cop_class.new(config, cop_options, offenses) }
 
-    before { $stderr = StringIO.new } # rubocop:disable RSpec/ExpectOutput
-
     context 'when there are no disabled lines' do
       let(:source) { '' }
 
@@ -203,6 +201,8 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
           end
 
           context 'multiple cops, with abbreviated names' do
+            include_context 'mock console output'
+
             context 'one of them has offenses' do
               let(:offenses) do
                 [

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
 
   subject(:formatter) { described_class.new(output) }
 
+  include_context 'mock console output'
+
   let(:output) do
     io = StringIO.new
 
@@ -36,19 +38,6 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
   let(:expected_heading_timestamp) { "on #{Time.now} " }
   let(:config_store) { instance_double(RuboCop::ConfigStore) }
   let(:options) { { config_store: config_store } }
-
-  around do |example|
-    original_stdout = $stdout
-    original_stderr = $stderr
-
-    $stdout = StringIO.new
-    $stderr = StringIO.new
-
-    example.run
-
-    $stdout = original_stdout
-    $stderr = original_stderr
-  end
 
   before do
     stub_cop_class('Test::Cop1')

--- a/spec/rubocop/formatter/formatter_set_spec.rb
+++ b/spec/rubocop/formatter/formatter_set_spec.rb
@@ -77,19 +77,14 @@ RSpec.describe RuboCop::Formatter::FormatterSet do
   end
 
   describe '#close_output_files' do
+    include_context 'mock console output'
+
     before do
       2.times do
         output_path = Tempfile.new('').path
         formatter_set.add_formatter('simple', output_path)
       end
       formatter_set.add_formatter('simple')
-    end
-
-    around do |example|
-      $stdout = StringIO.new
-      example.run
-    ensure
-      $stdout = STDOUT
     end
 
     it 'closes all output files' do

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -5,15 +5,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
 
   subject(:options) { described_class.new }
 
-  before do
-    $stdout = StringIO.new
-    $stderr = StringIO.new
-  end
-
-  after do
-    $stdout = STDOUT
-    $stderr = STDERR
-  end
+  include_context 'mock console output'
 
   def abs(path)
     File.expand_path(path)

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -43,15 +43,7 @@ RSpec.describe RuboCop::RakeTask do
   end
 
   describe 'running tasks' do
-    before do
-      $stdout = StringIO.new
-      $stderr = StringIO.new
-    end
-
-    after do
-      $stdout = STDOUT
-      $stderr = STDERR
-    end
+    include_context 'mock console output'
 
     it 'runs with default options' do
       described_class.new

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -604,15 +604,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
     end
 
     context 'when an exception is raised while reading file' do
-      around do |example|
-        original_stderr = $stderr
-        $stderr = StringIO.new
-        begin
-          example.run
-        ensure
-          $stderr = original_stderr
-        end
-      end
+      include_context 'mock console output'
 
       before { allow_any_instance_of(File).to receive(:readline).and_raise(EOFError) }
 


### PR DESCRIPTION
The only places in tests that still write to these do so to reset the output

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
