### PR TITLE
[Fix #12471] Fix false negatives for `Style/ZeroLengthPredicate`

### DIFF
--- a/changelog/fix_false_negatives_for_style_zero_length_predicate.md
+++ b/changelog/fix_false_negatives_for_style_zero_length_predicate.md
@@ -1,0 +1,1 @@
+* [#12471](https://github.com/rubocop/rubocop/issues/12471): Fix false negatives for `Style/ZeroLengthPredicate` when using safe navigation operator. ([@koic][])

--- a/spec/rubocop/cop/style/zero_length_predicate_spec.rb
+++ b/spec/rubocop/cop/style/zero_length_predicate_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe RuboCop::Cop::Style::ZeroLengthPredicate, :config do
       RUBY
     end
 
+    it 'registers an offense for `array&.length == 0`' do
+      expect_offense(<<~RUBY)
+        [1, 2, 3]&.length == 0
+        ^^^^^^^^^^^^^^^^^^^^^^ Use `empty?` instead of `length == 0`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3]&.empty?
+      RUBY
+    end
+
     it 'registers an offense for `array.size == 0`' do
       expect_offense(<<~RUBY)
         [1, 2, 3].size == 0
@@ -32,6 +43,28 @@ RSpec.describe RuboCop::Cop::Style::ZeroLengthPredicate, :config do
 
       expect_correction(<<~RUBY)
         [1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `array&.length.zero?`' do
+      expect_offense(<<~RUBY)
+        [1, 2, 3]&.length.zero?
+                   ^^^^^^^^^^^^ Use `empty?` instead of `length.zero?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3]&.empty?
+      RUBY
+    end
+
+    it 'registers an offense for `array&.length&.zero?`' do
+      expect_offense(<<~RUBY)
+        [1, 2, 3]&.length&.zero?
+                   ^^^^^^^^^^^^^ Use `empty?` instead of `length&.zero?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3]&.empty?
       RUBY
     end
 
@@ -79,6 +112,17 @@ RSpec.describe RuboCop::Cop::Style::ZeroLengthPredicate, :config do
       RUBY
     end
 
+    it 'registers an offense for `array&.length < 1`' do
+      expect_offense(<<~RUBY)
+        array&.length < 1
+        ^^^^^^^^^^^^^^^^^ Use `empty?` instead of `length < 1`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array&.empty?
+      RUBY
+    end
+
     it 'registers an offense for `array.size < 1`' do
       expect_offense(<<~RUBY)
         [1, 2, 3].size < 1
@@ -101,6 +145,17 @@ RSpec.describe RuboCop::Cop::Style::ZeroLengthPredicate, :config do
       RUBY
     end
 
+    it 'registers an offense for `1 > array&.length`' do
+      expect_offense(<<~RUBY)
+        1 > array&.length
+        ^^^^^^^^^^^^^^^^^ Use `empty?` instead of `1 > length`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array&.empty?
+      RUBY
+    end
+
     it 'registers an offense for `1 > array.size`' do
       expect_offense(<<~RUBY)
         1 > [1, 2, 3].size
@@ -120,6 +175,17 @@ RSpec.describe RuboCop::Cop::Style::ZeroLengthPredicate, :config do
 
       expect_correction(<<~RUBY)
         ![1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `array&.length > 0`' do
+      expect_offense(<<~RUBY)
+        [1, 2, 3]&.length > 0
+        ^^^^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `length > 0`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ![1, 2, 3]&.empty?
       RUBY
     end
 


### PR DESCRIPTION
Fixes #12471.

This PR fixes false negatives for `Style/ZeroLengthPredicate` when using safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
