### PR TITLE
[Fix #13010] Fix an error for `Style/SuperArguments`

### DIFF
--- a/changelog/fix_an_error_for_style_super_arguments.md
+++ b/changelog/fix_an_error_for_style_super_arguments.md
@@ -1,0 +1,1 @@
+* [#13010](https://github.com/rubocop/rubocop/issues/13010): Fix an error for `Style/SuperArguments` when the hash argument is or-assigned. ([@koic][])

--- a/lib/rubocop/cop/style/super_arguments.rb
+++ b/lib/rubocop/cop/style/super_arguments.rb
@@ -146,6 +146,11 @@ module RuboCop
         # https://bugs.ruby-lang.org/issues/20505
         def block_reassigned?(def_node, block_arg_name)
           def_node.each_node(*ASSIGN_TYPES).any? do |assign_node|
+            # TODO: Since `Symbol#name` is supported from Ruby 3.0, the inheritance check for
+            # `AST::Node` can be removed when requiring Ruby 3.0+.
+            lhs = assign_node.node_parts[0]
+            next if lhs.is_a?(AST::Node) && !lhs.respond_to?(:name)
+
             assign_node.name == block_arg_name
           end
         end

--- a/spec/rubocop/cop/style/super_arguments_spec.rb
+++ b/spec/rubocop/cop/style/super_arguments_spec.rb
@@ -122,6 +122,25 @@ RSpec.describe RuboCop::Cop::Style::SuperArguments, :config do
     RUBY
   end
 
+  it 'registers an offense when the hash argument is or-assigned' do
+    expect_offense(<<~RUBY)
+      def foo(options, &block)
+        options[:key] ||= default
+
+        super(options, &block)
+        ^^^^^^^^^^^^^^^^^^^^^^ Call `super` without arguments and parentheses when the signature is identical.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo(options, &block)
+        options[:key] ||= default
+
+        super
+      end
+    RUBY
+  end
+
   it 'registers no offense when calling super in a dsl method' do
     expect_no_offenses(<<~RUBY)
       describe 'example' do


### PR DESCRIPTION
Fixes #13010.

This PR fixes an error for `Style/SuperArguments` when the hash argument is or-assigned.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
