### PR TITLE
[Fix #13012] Fix false positives for `Style/HashExcept`

### DIFF
--- a/changelog/fix_false_positives_for_style_hash_except.md
+++ b/changelog/fix_false_positives_for_style_hash_except.md
@@ -1,0 +1,1 @@
+* [#13012](https://github.com/rubocop/rubocop/issues/13012): Fix false positives for `Style/HashExcept` when using `reject` and calling `include?` method with bang. ([@koic][])

--- a/lib/rubocop/cop/style/hash_except.rb
+++ b/lib/rubocop/cop/style/hash_except.rb
@@ -73,8 +73,9 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          method_name = node.method_name
           block = node.parent
-          return unless bad_method?(block) && semantically_except_method?(node, block)
+          return unless bad_method?(method_name, block) && semantically_except_method?(node, block)
 
           except_key = except_key(block)
           return if except_key.nil? || !safe_to_register_offense?(block, except_key)
@@ -91,7 +92,7 @@ module RuboCop
         private
 
         # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-        def bad_method?(block)
+        def bad_method?(method_name, block)
           if active_support_extensions_enabled?
             bad_method_with_active_support?(block) do |key_arg, send_node|
               if send_node.method?(:in?) && send_node.receiver&.source != key_arg.source
@@ -103,6 +104,8 @@ module RuboCop
             end
           else
             bad_method_with_poro?(block) do |key_arg, send_node|
+              return false if method_name == :reject && block.body.method?(:!)
+
               !send_node.method?(:include?) || send_node.first_argument&.source == key_arg.source
             end
           end

--- a/spec/rubocop/cop/style/hash_except_spec.rb
+++ b/spec/rubocop/cop/style/hash_except_spec.rb
@@ -99,14 +99,9 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
     end
 
     context 'using `include?`' do
-      it 'registers and corrects an offense when using `reject` and calling `include?` method with symbol array' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense when using `reject` and calling `!include?` method with symbol array' do
+        expect_no_offenses(<<~RUBY)
           {foo: 1, bar: 2, baz: 3}.reject { |k, v| !%i[foo bar].include?(k) }
-                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `except(:foo, :bar)` instead.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          {foo: 1, bar: 2, baz: 3}.except(:foo, :bar)
         RUBY
       end
 
@@ -154,31 +149,20 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
         RUBY
       end
 
-      it 'registers and corrects an offense when using `reject` and calling `include?` method with variable' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense when using `reject` and calling `!include?` method with variable' do
+        expect_no_offenses(<<~RUBY)
           array = [:foo, :bar]
           {foo: 1, bar: 2, baz: 3}.reject { |k, v| !array.include?(k) }
-                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `except(*array)` instead.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          array = [:foo, :bar]
-          {foo: 1, bar: 2, baz: 3}.except(*array)
         RUBY
       end
 
-      it 'registers and corrects an offense when using `reject` and calling `include?` method with method call' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense when using `reject` and calling `!include?` method with method call' do
+        expect_no_offenses(<<~RUBY)
           {foo: 1, bar: 2, baz: 3}.reject { |k, v| !array.include?(k) }
-                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `except(*array)` instead.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          {foo: 1, bar: 2, baz: 3}.except(*array)
         RUBY
       end
 
-      it 'does not register an offense when using `reject` and calling `include?` method with symbol array and second block value' do
+      it 'does not register an offense when using `reject` and calling `!include?` method with symbol array and second block value' do
         expect_no_offenses(<<~RUBY)
           {foo: 1, bar: 2, baz: 3}.reject { |k, v| ![1, 2].include?(v) }
         RUBY


### PR DESCRIPTION
Fixes #13012.

This PR fixes false positives for `Style/HashExcept` when using `reject` and calling `include?` method with bang.

As the regression tests, the incorrect existing tests are being corrected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
