### PR TITLE
[Fix #13018] Fix a false positive for `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_method_call_with_args_parentheses.md
+++ b/changelog/fix_a_false_positive_for_style_method_call_with_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#13018](https://github.com/rubocop/rubocop/issues/13018): Fix a false positive for `Style/MethodCallWithArgsParentheses` when `EnforcedStyle: omit_parentheses` is set and parenthesized method call is used before constant resolution. ([@koic][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -18,6 +18,7 @@ module RuboCop
             return if inside_endless_method_def?(node)
             return if require_parentheses_for_hash_value_omission?(node)
             return if syntax_like_method_call?(node)
+            return if method_call_before_constant_resolution?(node)
             return if super_call_without_arguments?(node)
             return if legitimate_call_with_parentheses?(node)
             return if allowed_camel_case_method_call?(node)
@@ -61,6 +62,10 @@ module RuboCop
 
           def syntax_like_method_call?(node)
             node.implicit_call? || node.operator_method?
+          end
+
+          def method_call_before_constant_resolution?(node)
+            node.parent&.const_type?
           end
 
           def super_call_without_arguments?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -703,6 +703,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    it 'accepts parenthesized method calls before constant resolution' do
+      expect_no_offenses(<<~RUBY)
+        do_something(arg)::CONST
+      RUBY
+    end
+
     it 'accepts parens in single-line inheritance' do
       expect_no_offenses(<<-RUBY)
         class Point < Struct.new(:x, :y); end


### PR DESCRIPTION
Fixes #13018.

This PR fixes a false positive for `Style/MethodCallWithArgsParentheses` when `EnforcedStyle: omit_parentheses` is set and parenthesized method call is used before constant resolution.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
