### PR TITLE
Reassignment in a block shouldn't silence UselessAssignment

### DIFF
--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -415,10 +415,11 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
   end
 
   context 'when a referenced variable is reassigned in a block' do
-    it 'accepts' do
-      expect_no_offenses(<<~RUBY)
+    it 'registers an offense for the unreferenced assignment' do
+      expect_offense(<<~RUBY)
         def some_method
           foo = 1
+          ^^^ Useless assignment to variable - `foo`.
           puts foo
           1.times do
             foo = 2


### PR DESCRIPTION
```ruby
foo = 1
1.times do
  foo = 2
end
```

The above code does trigger Ruby parser's warning:

```
$ ruby -c -W /tmp/foo.rb
/tmp/foo.rb:1: warning: assigned but unused variable - foo
Syntax OK
```

I found quite a bit of dead code in our app when looking at Ruby warnings that rubocop didn't find, but enforcing this with rubocop would be preferable.

I'd love to also submit a fix, but I couldn't figure out how to fix this without breaking many other tests :/