### PR TITLE
Ignore latest `memory_profiler` version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'bundler', '>= 1.15.0', '< 3.0'
 # https://github.com/lsegal/yard/pull/1546
 # Please remove this dependency when the issue is resolved.
 gem 'logger'
-gem 'memory_profiler', platform: :mri
+gem 'memory_profiler', '!= 1.0.2', platform: :mri
 # FIXME: This is a workaround to prevent the following warning in YARD:
 # https://github.com/lsegal/yard/pull/1545
 # Please remove this dependency when the issue is resolved.

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2182,10 +2182,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect(File).to exist(cpu_profile)
       end
 
-      # FIXME: https://github.com/rubocop/rubocop/actions/runs/9542192514/job/26296594698
-      # It is necessary to investigate and resolve the error that occurred with Ruby 3.4-dev in
-      # https://github.com/rubocop/rubocop/pull/12999.
-      it 'creates memory profile file', broken_on: :ruby_head do
+      it 'creates memory profile file' do
         expect(cli.run(['--profile', '--memory', 'example1.rb'])).to eq(0)
         expect($stdout.string).to include('Building memory report...')
         expect(File).to exist(memory_profile)


### PR DESCRIPTION
https://github.com/rubocop/rubocop/pull/13002
https://github.com/SamSaffron/memory_profiler/pull/118

This causes issues in CI since it accidentally added a dependency on base64. The next release will fix that error