### PR TITLE
[Fix #13023] Fix an error for `Style/SymbolProc`

### DIFF
--- a/changelog/fix_an_error_for_style_symbol_proc.md
+++ b/changelog/fix_an_error_for_style_symbol_proc.md
@@ -1,0 +1,1 @@
+* [#13023](https://github.com/rubocop/rubocop/issues/13023): Fix an error for `Style/SymbolProc` when using lambda `->` with one argument and multiline `do`...`end` block. ([@koic][])

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -223,7 +223,14 @@ module RuboCop
         end
 
         def autocorrect_without_args(corrector, node)
-          autocorrect_lambda_block(corrector, node) if node.send_node.lambda_literal?
+          if node.send_node.lambda_literal?
+            if node.send_node.loc.selector.source == '->'
+              corrector.replace(node, "lambda(&:#{node.body.method_name})")
+              return
+            else
+              autocorrect_lambda_block(corrector, node)
+            end
+          end
 
           corrector.replace(block_range_with_space(node), "(&:#{node.body.method_name})")
         end

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -87,6 +87,19 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
       RUBY
     end
 
+    it 'registers lambda `->` with 1 argument and multiline `do`...`end` block' do
+      expect_offense(<<~RUBY)
+        ->(arg) do
+                ^^ Pass `&:do_something` as an argument to `lambda` instead of a block.
+          arg.do_something
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        lambda(&:do_something)
+      RUBY
+    end
+
     it 'registers proc with 1 argument' do
       expect_offense(<<~RUBY)
         proc { |x| x.method }


### PR DESCRIPTION
Fixes #13023.

This PR fixes an error for `Style/SymbolProc` when using lambda `->` with one argument and multiline `do`...`end` block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
