### PR TITLE
[Fix #13022] Handle relative path handling in TargetFinder

### DIFF
--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -105,6 +105,9 @@ module RuboCop
 
     def combined_exclude_glob_patterns(base_dir)
       exclude = @config_store.for(base_dir).for_all_cops['Exclude'] || []
+      # base_dir can be relative path, so convert it to absoute here.
+      # see issue https://github.com/rubocop/rubocop/issues/13022
+      base_dir = File.expand_path(base_dir)
       patterns = exclude.select { |pattern| pattern.is_a?(String) && pattern.end_with?('/**/*') }
                         .map { |pattern| pattern.sub("#{base_dir}/", '') }
       "#{base_dir}/{#{patterns.join(',')}}"


### PR DESCRIPTION
- Address issue where combined_exclude_glob_patterns produced incorrect patterns for relative paths.
- Convert base_dir to an absolute path to handle relative paths correctly.

Resolves: 13022

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
