### PR TITLE
Add new `Gemspec/AddRuntimeDependency` cop

### DIFF
--- a/changelog/new_add_new_gemspec_add_runtime_dependency_cop.md
+++ b/changelog/new_add_new_gemspec_add_runtime_dependency_cop.md
@@ -1,0 +1,1 @@
+* [#13030](https://github.com/rubocop/rubocop/pull/13030): Add new `Gemspec/AddRuntimeDependency` cop. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -262,6 +262,15 @@ Bundler/OrderedGems:
 
 #################### Gemspec ###############################
 
+Gemspec/AddRuntimeDependency:
+  Description: 'Prefer `add_dependency` over `add_runtime_dependency`.'
+  StyleGuide: '#add_dependency_vs_add_runtime_dependency'
+  Reference: https://github.com/rubygems/rubygems/issues/7799#issuecomment-2192720316
+  Enabled: pending
+  VersionAdded: '<<next>>'
+  Include:
+    - '**/*.gemspec'
+
 Gemspec/DependencyVersion:
   Description: 'Requires or forbids specifying gem dependency versions.'
   Enabled: false

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -169,6 +169,7 @@ require_relative 'rubocop/cop/bundler/gem_version'
 require_relative 'rubocop/cop/bundler/insecure_protocol_source'
 require_relative 'rubocop/cop/bundler/ordered_gems'
 
+require_relative 'rubocop/cop/gemspec/add_runtime_dependency'
 require_relative 'rubocop/cop/gemspec/dependency_version'
 require_relative 'rubocop/cop/gemspec/deprecated_attribute_assignment'
 require_relative 'rubocop/cop/gemspec/development_dependencies'

--- a/lib/rubocop/cop/gemspec/add_runtime_dependency.rb
+++ b/lib/rubocop/cop/gemspec/add_runtime_dependency.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Gemspec
+      # Prefer `add_dependency` over `add_runtime_dependency` as the latter is
+      # considered soft-deprecated.
+      #
+      # @example
+      #
+      #   # bad
+      #   Gem::Specification.new do |spec|
+      #     spec.add_runtime_dependency('rubocop')
+      #   end
+      #
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.add_dependency('rubocop')
+      #   end
+      #
+      class AddRuntimeDependency < Base
+        extend AutoCorrector
+
+        MSG = 'Use `add_dependency` instead of `add_runtime_dependency`.'
+
+        RESTRICT_ON_SEND = %i[add_runtime_dependency].freeze
+
+        def on_send(node)
+          return if !node.receiver || node.arguments.empty?
+
+          add_offense(node.loc.selector) do |corrector|
+            corrector.replace(node.loc.selector, 'add_dependency')
+          end
+        end
+      end
+    end
+  end
+end

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -31,14 +31,14 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.add_runtime_dependency('json', '~> 2.3')
-  s.add_runtime_dependency('language_server-protocol', '>= 3.17.0')
-  s.add_runtime_dependency('parallel', '~> 1.10')
-  s.add_runtime_dependency('parser', '>= 3.3.0.2')
-  s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
-  s.add_runtime_dependency('regexp_parser', '>= 2.4', '< 3.0')
-  s.add_runtime_dependency('rexml', '>= 3.2.5', '< 4.0')
-  s.add_runtime_dependency('rubocop-ast', '>= 1.31.1', '< 2.0')
-  s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
-  s.add_runtime_dependency('unicode-display_width', '>= 2.4.0', '< 3.0')
+  s.add_dependency('json', '~> 2.3')
+  s.add_dependency('language_server-protocol', '>= 3.17.0')
+  s.add_dependency('parallel', '~> 1.10')
+  s.add_dependency('parser', '>= 3.3.0.2')
+  s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
+  s.add_dependency('regexp_parser', '>= 2.4', '< 3.0')
+  s.add_dependency('rexml', '>= 3.2.5', '< 4.0')
+  s.add_dependency('rubocop-ast', '>= 1.31.1', '< 2.0')
+  s.add_dependency('ruby-progressbar', '~> 1.7')
+  s.add_dependency('unicode-display_width', '>= 2.4.0', '< 3.0')
 end

--- a/spec/rubocop/cop/gemspec/add_runtime_dependency_spec.rb
+++ b/spec/rubocop/cop/gemspec/add_runtime_dependency_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Gemspec::AddRuntimeDependency, :config do
+  it 'registers an offense when using `add_runtime_dependency`' do
+    expect_offense(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.add_runtime_dependency('rubocop')
+             ^^^^^^^^^^^^^^^^^^^^^^ Use `add_dependency` instead of `add_runtime_dependency`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.add_dependency('rubocop')
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `add_dependency`' do
+    expect_no_offenses(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.add_dependency('rubocop')
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `add_development_dependency`' do
+    expect_no_offenses(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.add_development_dependency('rubocop')
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `add_runtime_dependency` without receiver' do
+    expect_no_offenses(<<~RUBY)
+      add_runtime_dependency('rubocop')
+    RUBY
+  end
+
+  it 'does not register an offense when using `add_runtime_dependency` without arguments' do
+    expect_no_offenses(<<~RUBY)
+      spec.add_runtime_dependency
+    RUBY
+  end
+end


### PR DESCRIPTION
Follow up https://github.com/rubygems/rubygems/issues/7799#issuecomment-2192720316.

Prefer `add_dependency` over `add_runtime_dependency` as the latter is considered soft-deprecated.

```ruby
# bad
Gem::Specification.new do |spec|
  spec.add_runtime_dependency('rubocop')
end

# good
Gem::Specification.new do |spec|
  spec.add_dependency('rubocop')
end
```

https://github.com/rubocop/ruby-style-guide/pull/943 has been opened for the Style Guide.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
