### PR TITLE
Enable YJIT by default in server mode

### DIFF
--- a/changelog/change_enable_yjit_by_default_in_server_mode.md
+++ b/changelog/change_enable_yjit_by_default_in_server_mode.md
@@ -1,0 +1,1 @@
+* [#13031](https://github.com/rubocop/rubocop/pull/13031): Enable YJIT by default in server mode. ([@koic][])

--- a/lib/rubocop/server/core.rb
+++ b/lib/rubocop/server/core.rb
@@ -44,6 +44,10 @@ module RuboCop
         write_port_and_token_files
 
         pid = fork do
+          if defined?(RubyVM::YJIT.enable)
+            RubyVM::YJIT.enable
+          end
+
           Process.daemon(true)
           $stderr.reopen(Cache.stderr_path, 'w')
           process_input


### PR DESCRIPTION
YJIT tends to increase memory consumption as a trade-off for speed, but `--server` mode is usually used to speed up the execution of `rubocop` command locally. This patch is based on the hypothesis that it is acceptable to always enable YJIT by default in server mode to prioritize performance.

Therefore, this patch doesn't provide an option to disable YJIT in server mode. Whether this is truly necessary can be considered based on user feedback.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
