### PR TITLE
Display warning messages for deprecated APIs

### DIFF
--- a/changelog/change_display_warning_messages_for_deprecated_api.md
+++ b/changelog/change_display_warning_messages_for_deprecated_api.md
@@ -1,0 +1,1 @@
+* [#13032](https://github.com/rubocop/rubocop/pull/13032): Display warning messages for deprecated APIs. ([@koic][])

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -164,7 +164,7 @@ module RuboCop
       # searches will go past this directory.
       # @deprecated Use `RuboCop::ConfigFinder.project_root` instead.
       def project_root
-        warn Rainbow(<<~WARNING).yellow
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
           `RuboCop::ConfigLoader.project_root` is deprecated and will be removed in RuboCop 2.0. \
           Use `RuboCop::ConfigFinder.project_root` instead.
         WARNING

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -37,16 +37,28 @@ module RuboCop
 
       # @deprecated Use Registry.global
       def self.registry
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
+          `Cop.registry` is deprecated. Use `Registry.global` instead.
+        WARNING
+
         Registry.global
       end
 
       # @deprecated Use Registry.all
       def self.all
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
+          `Cop.all` is deprecated. Use `Registry.all` instead.
+        WARNING
+
         Registry.all
       end
 
       # @deprecated Use Registry.qualified_cop_name
       def self.qualified_cop_name(name, origin)
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
+          `Cop.qualified_cop_name` is deprecated. Use `Registry.qualified_cop_name` instead.
+        WARNING
+
         Registry.qualified_cop_name(name, origin)
       end
 
@@ -74,13 +86,19 @@ module RuboCop
 
       # @deprecated Use class method
       def support_autocorrect?
-        # warn 'deprecated, use cop.class.support_autocorrect?' TODO
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
+          `support_autocorrect?` is deprecated. Use `cop.class.support_autocorrect?`.
+        WARNING
+
         self.class.support_autocorrect?
       end
 
       # @deprecated
       def corrections
-        # warn 'Cop#corrections is deprecated' TODO
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
+          `Cop#corrections` is deprecated.
+        WARNING
+
         return [] unless @last_corrector
 
         Legacy::CorrectionsProxy.new(@last_corrector)

--- a/lib/rubocop/cop/legacy/corrector.rb
+++ b/lib/rubocop/cop/legacy/corrector.rb
@@ -12,13 +12,23 @@ module RuboCop
           if corr.is_a?(CorrectionsProxy)
             merge!(corr.send(:corrector))
           else
-            # warn "Corrector.new with corrections is deprecated." unless corr.empty? TODO
+            unless corr.empty?
+              warn Rainbow(<<~WARNING).yellow, uplevel: 1
+                `Corrector.new` with corrections is deprecated.
+                See https://docs.rubocop.org/rubocop/v1_upgrade_notes.html
+              WARNING
+            end
+
             corr.each { |c| corrections << c }
           end
         end
 
         def corrections
-          # warn "#corrections is deprecated. Open an issue if you have a valid usecase." TODO
+          warn Rainbow(<<~WARNING).yellow, uplevel: 1
+            `Corrector#corrections` is deprecated. Open an issue if you have a valid usecase.
+            See https://docs.rubocop.org/rubocop/v1_upgrade_notes.html
+          WARNING
+
           CorrectionsProxy.new(self)
         end
       end

--- a/lib/rubocop/cop/mixin/alignment.rb
+++ b/lib/rubocop/cop/mixin/alignment.rb
@@ -65,8 +65,12 @@ module RuboCop
         inner.begin_pos >= outer.begin_pos && inner.end_pos <= outer.end_pos
       end
 
-      # @deprecated Use processed_source.comment_at_line(line)
+      # @deprecated Use processed_source.line_with_comment?(line)
       def end_of_line_comment(line)
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
+          `end_of_line_comment` is deprecated. Use `processed_source.line_with_comment?` instead.
+        WARNING
+
         processed_source.line_with_comment?(line)
       end
 

--- a/lib/rubocop/cop/mixin/allowed_methods.rb
+++ b/lib/rubocop/cop/mixin/allowed_methods.rb
@@ -15,7 +15,13 @@ module RuboCop
       end
 
       # @deprecated Use allowed_method? instead
-      alias ignored_method? allowed_method?
+      def ignored_method?
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
+          `ignored_method?` is deprecated. Use `allowed_method?` instead.
+        WARNING
+
+        allowed_method?
+      end
 
       # @api public
       def allowed_methods

--- a/lib/rubocop/cop/mixin/allowed_pattern.rb
+++ b/lib/rubocop/cop/mixin/allowed_pattern.rb
@@ -18,14 +18,26 @@ module RuboCop
       end
 
       # @deprecated Use allowed_line? instead
-      alias ignored_line? allowed_line?
+      def ignored_line?
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
+          `ignored_line?` is deprecated. Use `allowed_line?` instead.
+        WARNING
+
+        allowed_line?
+      end
 
       def matches_allowed_pattern?(line)
         allowed_patterns.any? { |pattern| Regexp.new(pattern).match?(line) }
       end
 
-      # @deprecated Use matches_allowed_pattern?? instead
-      alias matches_ignored_pattern? matches_allowed_pattern?
+      # @deprecated Use matches_allowed_pattern? instead
+      def matches_ignored_pattern?
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
+          `matches_ignored_pattern?` is deprecated. Use `matches_allowed_pattern?` instead.
+        WARNING
+
+        matches_allowed_pattern?
+      end
 
       def allowed_patterns
         # Since there could be a pattern specified in the default config, merge the two

--- a/lib/rubocop/cop/mixin/configurable_max.rb
+++ b/lib/rubocop/cop/mixin/configurable_max.rb
@@ -4,11 +4,15 @@ module RuboCop
   module Cop
     # Handles `Max` configuration parameters, especially setting them to an
     # appropriate value with --auto-gen-config.
-    # @deprecated Use `exclude_limit ParameterName` instead.
+    # @deprecated Use `exclude_limit <ParameterName>` instead.
     module ConfigurableMax
       private
 
       def max=(value)
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
+          `max=` is deprecated. Use `exclude_limit <ParameterName>` instead.
+        WARNING
+
         cfg = config_to_allow_offenses
         cfg[:exclude_limit] ||= {}
         current_max = cfg[:exclude_limit][max_parameter_name]

--- a/lib/rubocop/cop/mixin/rescue_node.rb
+++ b/lib/rubocop/cop/mixin/rescue_node.rb
@@ -18,6 +18,10 @@ module RuboCop
 
       # @deprecated Use ResbodyNode#exceptions instead
       def rescued_exceptions(resbody)
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
+          `rescued_exceptions` is deprecated. Use `ResbodyNode#exceptions` instead.
+        WARNING
+
         rescue_group, = *resbody
         if rescue_group
           rescue_group.values

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -74,6 +74,10 @@ module RuboCop
       # @deprecated. Use investigate
       # @return Array<offenses>
       def inspect_file(processed_source)
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
+          `inspect_file` is deprecated. Use `investigate` instead.
+        WARNING
+
         investigate(processed_source).offenses
       end
 
@@ -108,6 +112,10 @@ module RuboCop
 
       # @deprecated
       def forces
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
+          `forces` is deprecated.
+        WARNING
+
         @forces ||= self.class.forces_for(cops)
       end
 

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -20,6 +20,10 @@ module RuboCop
 
       # @deprecated Use `ProcessedSource#line_with_comment?`, `contains_comment?` or similar
       def comment_lines?(node)
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
+          `comment_lines?` is deprecated. Use `ProcessedSource#line_with_comment?`, `contains_comment?` or similar instead.
+        WARNING
+
         processed_source[line_range(node)].any? { |line| comment_line?(line) }
       end
 

--- a/spec/support/strict_warnings.rb
+++ b/spec/support/strict_warnings.rb
@@ -16,7 +16,11 @@ module StrictWarnings
     /Float.*out of range/, # also from the parser gem
     /`Process` does not respond to `fork` method/, # JRuby
     /File#readline accesses caller method's state and should not be aliased/, # JRuby, test stub
-    /instance variable @.* not initialized/ # Ruby 2.7
+    /instance variable @.* not initialized/, # Ruby 2.7
+    /`inspect_file` is deprecated\. Use `investigate` instead\./, # RuboCop's deprecated API in spec
+    /`forces` is deprecated./, # RuboCop's deprecated API in spec
+    /`support_autocorrect\?` is deprecated\./, # RuboCop's deprecated API in spec
+    /`Cop\.registry` is deprecated\./ # RuboCop's deprecated API in spec
   )
 
   def warn(message, ...)


### PR DESCRIPTION
This PR displays warning messages for deprecated APIs.

The deprecated APIs are only soft-deprecated as explicitly mentioned in the documentation. Over three years have passed since RuboCop 1.0 was released: https://rubygems.org/gems/rubocop/versions/1.0.0

So it seems appropriate to start displaying deprecation warnings.

This aims to prepare for RuboCop 2.0 by providing users with the opportunity to become aware of the deprecated APIs and encouraging them to take action to avoid deprecated APIs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
