### PR TITLE
[Fix #13033] Fix a false positive for `Layout/SpaceAroundOperators`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_space_around_operators.md
+++ b/changelog/fix_a_false_positive_for_layout_space_around_operators.md
@@ -1,0 +1,1 @@
+* [#13033](https://github.com/rubocop/rubocop/issues/13033): Fix a false positive for `Layout/SpaceAroundOperators` when using multiple spaces between an operator and a tailing comment. ([@koic][])

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -180,6 +180,9 @@ module RuboCop
           with_space = range_with_surrounding_space(operator)
           return if with_space.source.start_with?("\n")
 
+          comment = processed_source.comment_at_line(operator.line)
+          return if comment && with_space.last_column == comment.loc.column
+
           offense(type, operator, with_space, right_operand) do |msg|
             add_offense(operator, message: msg) do |corrector|
               autocorrect(corrector, with_space, right_operand)

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
     expect_no_offenses('x = 2/3r')
   end
 
+  it 'accepts multiple spaces between an operator and a tailing comment' do
+    expect_no_offenses(<<~RUBY)
+      foo +  # comment
+        bar
+    RUBY
+  end
+
   it 'accepts scope operator' do
     expect_no_offenses('@io.class == Zlib::GzipWriter')
   end


### PR DESCRIPTION
Fixes #13033.

This PR fixes a false positive for `Layout/SpaceAroundOperators` when using multiple spaces between an operator and a tailing comment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
