### PR TITLE
[Fix #13035] Support autocorrect for `Lint/ImplicitStringConcatenation`

### DIFF
--- a/changelog/change_support_autocorrect_for_lint_implicit_string_concatenation.md
+++ b/changelog/change_support_autocorrect_for_lint_implicit_string_concatenation.md
@@ -1,0 +1,1 @@
+* [#13035](https://github.com/rubocop/rubocop/issues/13035): Support autocorrect for `Lint/ImplicitStringConcatenation`. ([@koic][])

--- a/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
+++ b/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe RuboCop::Cop::Lint::ImplicitStringConcatenation, :config do
         class B; 'ghi' 'jkl'; end
                  ^^^^^^^^^^^ Combine 'ghi' and 'jkl' into a single string literal, rather than using implicit string concatenation.
       RUBY
+
+      expect_correction(<<~RUBY)
+        class A; "abc" + "def"; end
+        class B; 'ghi' + 'jkl'; end
+      RUBY
     end
   end
 
@@ -36,6 +41,14 @@ RSpec.describe RuboCop::Cop::Lint::ImplicitStringConcatenation, :config do
           "ab
           ^^^ Combine "ab\nc" and "de\nf" into a single string literal, [...]
         c" "de
+        f"
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def method
+          "ab
+        c" + "de
         f"
         end
       RUBY
@@ -61,6 +74,10 @@ RSpec.describe RuboCop::Cop::Lint::ImplicitStringConcatenation, :config do
         array = ["abc" "def"]
                  ^^^^^^^^^^^ Combine "abc" and "def" into a single string literal, rather than using implicit string concatenation. Or, if they were intended to be separate array elements, separate them with a comma.
       RUBY
+
+      expect_correction(<<~RUBY)
+        array = ["abc" + "def"]
+      RUBY
     end
   end
 
@@ -69,6 +86,10 @@ RSpec.describe RuboCop::Cop::Lint::ImplicitStringConcatenation, :config do
       expect_offense(<<~RUBY)
         method("abc" "def")
                ^^^^^^^^^^^ Combine "abc" and "def" into a single string literal, rather than using implicit string concatenation. Or, if they were intended to be separate method arguments, separate them with a comma.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        method("abc" + "def")
       RUBY
     end
   end


### PR DESCRIPTION
Resolves #13035.

This PR supports autocorrect for `Lint/ImplicitStringConcatenation`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
