### PR TITLE
Consider Sorbet signatures in `Style/DocumentationMethod` cop

### DIFF
--- a/changelog/change_documentation_method_to_accept_sorbet_method_signatures.md
+++ b/changelog/change_documentation_method_to_accept_sorbet_method_signatures.md
@@ -1,0 +1,1 @@
+* [#13038](https://github.com/rubocop/rubocop/pull/13038): Change `Style/DocumentationMethod` to accept Sorbet method signatures and keep compatibility with [rubocop-sorbet](https://github.com/Shopify/rubocop-sorbet/blob/main/manual/cops_sorbet.md#sorbetemptylineaftersig). ([@wpolicarpo][])

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -2321,7 +2321,7 @@ items.include?
 
 | PreferredMethods
 | `{"collect" => "map", "collect!" => "map!", "collect_concat" => "flat_map", "inject" => "reduce", "detect" => "find", "find_all" => "select", "member?" => "include?"}`
-| 
+|
 
 | MethodsAcceptingSymbol
 | `inject`, `reduce`
@@ -3738,6 +3738,10 @@ NOTE: This cop allows `initialize` method because `initialize` is
 a special method called from `new`. In some programming languages
 they are called constructor to distinguish it from method.
 
+NOTE: To keep compatibility with Sorbet's https://sorbet.org/docs/sigs[method signatures]
+and https://github.com/Shopify/rubocop-sorbet/blob/main/manual/cops_sorbet.md#sorbetemptylineaftersig[Sorbet/EmptyLineAfterSig],
+this cop allows the special `sig` keyword before the method definition as shown below.
+
 [#examples-styledocumentationmethod]
 === Examples
 
@@ -3780,6 +3784,14 @@ end
 # Documentation
 def foo.bar
   puts baz
+end
+
+class Foo
+  # Documentation
+  sig { void }
+  def bar
+    puts baz
+  end
 end
 ----
 
@@ -7752,11 +7764,11 @@ end
 
 | InverseMethods
 | `{any?: :none?, even?: :odd?, "==": :!=, "=~": :!~, "<": :>=, ">": :<=}`
-| 
+|
 
 | InverseBlocks
 | `{select: :reject, select!: :reject!}`
-| 
+|
 |===
 
 [#styleinvertibleunlesscondition]
@@ -7834,7 +7846,7 @@ foo if !condition
 
 | InverseMethods
 | `{"!=": :==, ">": :<=, "<=": :>, "<": :>=, ">=": :<, "!~": :=~, zero?: :nonzero?, nonzero?: :zero?, any?: :none?, none?: :any?, even?: :odd?, odd?: :even?}`
-| 
+|
 |===
 
 [#styleipaddresses]
@@ -8369,7 +8381,7 @@ end
 
 | ValueCapitalization
 | `<none>`
-| 
+|
 |===
 
 [#stylemapcompactwithconditionalblock]
@@ -12139,7 +12151,7 @@ default.
 
 | PreferredDelimiters
 | `{"default" => "()", "%i" => "[]", "%I" => "[]", "%r" => "{}", "%w" => "[]", "%W" => "[]"}`
-| 
+|
 |===
 
 [#references-stylepercentliteraldelimiters]
@@ -12625,7 +12637,7 @@ A.foo
 
 | Methods
 | `{"join" => "", "sum" => 0, "exit" => true, "exit!" => false, "split" => " ", "chomp" => "\n", "chomp!" => "\n"}`
-| 
+|
 |===
 
 [#styleredundantarrayconstructor]
@@ -16693,7 +16705,7 @@ from the `String` class.
 
 | PreferredMethods
 | `{"intern" => "to_sym"}`
-| 
+|
 |===
 
 [#stylestrip]
@@ -18815,7 +18827,7 @@ array of 2 or fewer elements.
 
 | WordRegex
 | `(?-mix:\A(?:\p{Word}\|\p{Word}-\p{Word}\|\n\|\t)+\z)`
-| 
+|
 |===
 
 [#references-stylewordarray]

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -269,559 +269,721 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
       end
     end
 
-    context 'when declaring methods in a class' do
-      context 'without documentation comment' do
-        context 'when method is public' do
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              class Foo
-                def bar
-                ^^^^^^^ Missing method documentation comment.
-                  puts 'baz'
-                end
-              end
-            RUBY
-          end
-
-          it 'registers an offense with `end` on the same line' do
-            expect_offense(<<~RUBY)
-              class Foo
-                def method; end
-                ^^^^^^^^^^^^^^^ Missing method documentation comment.
-              end
-            RUBY
-          end
-        end
-
-        context 'when method is private' do
-          it 'does not register an offense' do
-            expect_no_offenses(<<~RUBY)
-              class Foo
-                private
-
-                def bar
-                  puts 'baz'
-                end
-              end
-            RUBY
-          end
-
-          it 'does not register an offense with inline `private`' do
-            expect_no_offenses(<<~RUBY)
-              class Foo
-                private def bar
-                  puts 'baz'
-                end
-              end
-            RUBY
-          end
-
-          it 'does not register an offense with `end` on the same line' do
-            expect_no_offenses(<<~RUBY)
-              class Foo
-                private
-
-                def bar; end
-              end
-            RUBY
-          end
-
-          it 'does not register an offense with inline `private` and `end`' do
-            expect_no_offenses(<<~RUBY)
-              class Foo
-                private def bar; end
-              end
-            RUBY
-          end
-
-          context 'when required for non-public methods' do
-            let(:require_for_non_public_methods) { true }
-
-            it 'registers an offense' do
-              expect_offense(<<~RUBY)
-                class Foo
-                  private
-
-                  def bar
-                  ^^^^^^^ Missing method documentation comment.
-                    puts 'baz'
-                  end
-                end
-              RUBY
-            end
-
-            it 'registers an offense with inline `private`' do
-              expect_offense(<<~RUBY)
-                class Foo
-                  private def bar
-                          ^^^^^^^ Missing method documentation comment.
-                    puts 'baz'
-                  end
-                end
-              RUBY
-            end
-
-            it 'registers an offense with `end` on the same line' do
-              expect_offense(<<~RUBY)
-                class Foo
-                  private
-
-                  def bar; end
-                  ^^^^^^^^^^^^ Missing method documentation comment.
-                end
-              RUBY
-            end
-
-            it 'registers an offense with inline `private` and `end`' do
-              expect_offense(<<~RUBY)
-                class Foo
-                  private def bar; end
-                          ^^^^^^^^^^^^ Missing method documentation comment.
-                end
-              RUBY
-            end
-          end
-        end
-      end
-
-      context 'with documentation comment' do
-        context 'when method is public' do
-          it 'does not register an offense' do
-            expect_no_offenses(<<~RUBY)
-              class Foo
-                # Documentation
-                def bar
-                  puts 'baz'
-                end
-              end
-            RUBY
-          end
-
-          it 'does not register an offense with `end` on the same line' do
-            expect_no_offenses(<<~RUBY)
-              class Foo
-                # Documentation
-                def bar; end
-              end
-            RUBY
-          end
-        end
-      end
-
-      context 'with annotation comment' do
+    context 'with Sorbet signatures' do
+      context 'and without documentation comment' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
-            class Foo
-              # FIXME: offense
-              def bar
-              ^^^^^^^ Missing method documentation comment.
-                puts 'baz'
-              end
-            end
-          RUBY
-        end
-      end
-
-      context 'with directive comment' do
-        it 'registers an offense' do
-          expect_offense(<<~RUBY)
-            class Foo
-              # rubocop:disable Style/For
-              def bar
-              ^^^^^^^ Missing method documentation comment.
-                puts 'baz'
-              end
-            end
-          RUBY
-        end
-      end
-
-      context 'with both public and private methods' do
-        context 'when the public method has no documentation' do
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              class Foo
-                def bar
-                ^^^^^^^ Missing method documentation comment.
-                  puts 'baz'
-                end
-
-                private
-
-                def baz
-                  puts 'baz'
-                end
-              end
-            RUBY
-          end
-        end
-
-        context 'when the public method has documentation' do
-          it 'does not register an offense' do
-            expect_no_offenses(<<~RUBY)
-              class Foo
-                # Documentation
-                def bar
-                  puts 'baz'
-                end
-
-                private
-
-                def baz
-                  puts 'baz'
-                end
-              end
-            RUBY
-          end
-        end
-
-        context 'when required for non-public methods' do
-          let(:require_for_non_public_methods) { true }
-
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              class Foo
-                # Documentation
-                def bar
-                  puts 'baz'
-                end
-
-                private
-
-                def baz
-                ^^^^^^^ Missing method documentation comment.
-                  puts 'baz'
-                end
-              end
-            RUBY
-          end
-        end
-      end
-    end
-
-    context 'when declaring methods in a module' do
-      context 'without documentation comment' do
-        context 'when method is public' do
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              module Foo
-                def bar
-                ^^^^^^^ Missing method documentation comment.
-                  puts 'baz'
-                end
-              end
-            RUBY
-          end
-
-          it 'registers an offense with `end` on the same line' do
-            expect_offense(<<~RUBY)
-              module Foo
-                def method; end
-                ^^^^^^^^^^^^^^^ Missing method documentation comment.
-              end
-            RUBY
-          end
-        end
-
-        context 'when method is private' do
-          it 'does not register an offense' do
-            expect_no_offenses(<<~RUBY)
-              module Foo
-                private
-
-                def bar
-                  puts 'baz'
-                end
-              end
-            RUBY
-          end
-
-          it 'does not register an offense with inline `private`' do
-            expect_no_offenses(<<~RUBY)
-              module Foo
-                private def bar
-                  puts 'baz'
-                end
-              end
-            RUBY
-          end
-
-          it 'does not register an offense with `end` on the same line' do
-            expect_no_offenses(<<~RUBY)
-              module Foo
-                private
-
-                def bar; end
-              end
-            RUBY
-          end
-
-          it 'does not register an offense with inline `private` and `end`' do
-            expect_no_offenses(<<~RUBY)
-              module Foo
-                private def bar; end
-              end
-            RUBY
-          end
-
-          context 'when required for non-public methods' do
-            let(:require_for_non_public_methods) { true }
-
-            it 'registers an offense' do
-              expect_offense(<<~RUBY)
-                module Foo
-                  private
-
-                  def bar
-                  ^^^^^^^ Missing method documentation comment.
-                    puts 'baz'
-                  end
-                end
-              RUBY
-            end
-
-            it 'registers an offense with inline `private`' do
-              expect_offense(<<~RUBY)
-                module Foo
-                  private def bar
-                          ^^^^^^^ Missing method documentation comment.
-                    puts 'baz'
-                  end
-                end
-              RUBY
-            end
-
-            it 'registers an offense with `end` on the same line' do
-              expect_offense(<<~RUBY)
-                module Foo
-                  private
-
-                  def bar; end
-                  ^^^^^^^^^^^^ Missing method documentation comment.
-                end
-              RUBY
-            end
-
-            it 'registers an offense with inline `private` and `end`' do
-              expect_offense(<<~RUBY)
-                module Foo
-                  private def bar; end
-                          ^^^^^^^^^^^^ Missing method documentation comment.
-                end
-              RUBY
-            end
-          end
-        end
-
-        context 'when method is module_function' do
-          it 'registers an offense for inline def' do
-            expect_offense(<<~RUBY)
-              module Foo
-                module_function def bar
-                ^^^^^^^^^^^^^^^^^^^^^^^ Missing method documentation comment.
-                end
-              end
-            RUBY
-          end
-
-          it 'registers an offense for separate def' do
-            expect_offense(<<~RUBY)
-              module Foo
-                def bar
-                ^^^^^^^ Missing method documentation comment.
-                end
-
-                module_function :bar
-              end
-            RUBY
-          end
-        end
-
-        it 'registers an offense for inline def with ruby2_keywords' do
-          expect_offense(<<~RUBY)
-            module Foo
-              ruby2_keywords def bar
-              ^^^^^^^^^^^^^^^^^^^^^^ Missing method documentation comment.
-              end
-            end
-          RUBY
-        end
-      end
-
-      context 'with documentation comment' do
-        context 'when method is public' do
-          it 'does not register an offense' do
-            expect_no_offenses(<<~RUBY)
-              module Foo
-                # Documentation
-                def bar
-                  puts 'baz'
-                end
-              end
-            RUBY
-          end
-
-          it 'does not register an offense with `end` on the same line' do
-            expect_no_offenses(<<~RUBY)
-              module Foo
-                # Documentation
-                def bar; end
-              end
-            RUBY
-          end
-        end
-
-        context 'when method is module_function' do
-          it 'does not register an offense for inline def' do
-            expect_no_offenses(<<~RUBY)
-              module Foo
-                # Documentation
-                module_function def bar; end
-              end
-            RUBY
-          end
-
-          it 'does not register an offense for separate def' do
-            expect_no_offenses(<<~RUBY)
-              module Foo
-                # Documentation
-                def bar; end
-
-                module_function :bar
-              end
-            RUBY
-          end
-        end
-
-        it 'does not register an offense for inline def with ruby2_keywords' do
-          expect_no_offenses(<<~RUBY)
-            module Foo
-              # Documentation
-              ruby2_keywords def bar
-              end
-            end
-          RUBY
-        end
-      end
-
-      context 'with both public and private methods' do
-        context 'when the public method has no documentation' do
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              module Foo
-                def bar
-                ^^^^^^^ Missing method documentation comment.
-                  puts 'baz'
-                end
-
-                private
-
-                def baz
-                  puts 'baz'
-                end
-              end
-            RUBY
-          end
-        end
-
-        context 'when the public method has documentation' do
-          it 'does not register an offense' do
-            expect_no_offenses(<<~RUBY)
-              module Foo
-                # Documentation
-                def bar
-                  puts 'baz'
-                end
-
-                private
-
-                def baz
-                  puts 'baz'
-                end
-              end
-            RUBY
-          end
-        end
-
-        context 'when required for non-public methods' do
-          let(:require_for_non_public_methods) { true }
-
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              module Foo
-                # Documentation
-                def bar
-                  puts 'baz'
-                end
-
-                private
-
-                def baz
-                ^^^^^^^ Missing method documentation comment.
-                  puts 'baz'
-                end
-              end
-            RUBY
-          end
-        end
-      end
-    end
-
-    context 'when declaring methods for class instance' do
-      context 'without documentation comment' do
-        it 'registers an offense' do
-          expect_offense(<<~RUBY)
-            class Foo; end
-
-            foo = Foo.new
-
-            def foo.bar
-            ^^^^^^^^^^^ Missing method documentation comment.
+            sig { void }
+            def bar
+            ^^^^^^^ Missing method documentation comment.
               puts 'baz'
+            end
+          RUBY
+        end
+      end
+
+      context 'and with documentation comment' do
+        context 'and with single line signature' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              # Documentation
+              sig { void }
+              def bar
+                puts 'baz'
+              end
+            RUBY
+          end
+        end
+
+        context 'and with multi-line signature' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              # Documentation
+              sig do
+                void
+              end
+              def bar
+                puts 'baz'
+              end
+            RUBY
+          end
+        end
+      end
+    end
+  end
+
+  context 'when declaring methods in a class' do
+    context 'without documentation comment' do
+      context 'when method is public' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            class Foo
+              def bar
+              ^^^^^^^ Missing method documentation comment.
+                puts 'baz'
+              end
             end
           RUBY
         end
 
         it 'registers an offense with `end` on the same line' do
           expect_offense(<<~RUBY)
-            class Foo; end
-
-            foo = Foo.new
-
-            def foo.bar; end
-            ^^^^^^^^^^^^^^^^ Missing method documentation comment.
+            class Foo
+              def method; end
+              ^^^^^^^^^^^^^^^ Missing method documentation comment.
+            end
           RUBY
         end
       end
 
-      context 'with documentation comment' do
+      context 'when method is private' do
         it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)
-            class Foo; end
+            class Foo
+              private
 
-            foo = Foo.new
+              def bar
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
 
-            # Documentation
-            def foo.bar
-              puts 'baz'
+        it 'does not register an offense with inline `private`' do
+          expect_no_offenses(<<~RUBY)
+            class Foo
+              private def bar
+                puts 'baz'
+              end
             end
           RUBY
         end
 
         it 'does not register an offense with `end` on the same line' do
           expect_no_offenses(<<~RUBY)
+            class Foo
+              private
+
+              def bar; end
+            end
+          RUBY
+        end
+
+        it 'does not register an offense with inline `private` and `end`' do
+          expect_no_offenses(<<~RUBY)
+            class Foo
+              private def bar; end
+            end
+          RUBY
+        end
+
+        context 'when required for non-public methods' do
+          let(:require_for_non_public_methods) { true }
+
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              class Foo
+                private
+
+                def bar
+                ^^^^^^^ Missing method documentation comment.
+                  puts 'baz'
+                end
+              end
+            RUBY
+          end
+
+          it 'registers an offense with inline `private`' do
+            expect_offense(<<~RUBY)
+              class Foo
+                private def bar
+                        ^^^^^^^ Missing method documentation comment.
+                  puts 'baz'
+                end
+              end
+            RUBY
+          end
+
+          it 'registers an offense with `end` on the same line' do
+            expect_offense(<<~RUBY)
+              class Foo
+                private
+
+                def bar; end
+                ^^^^^^^^^^^^ Missing method documentation comment.
+              end
+            RUBY
+          end
+
+          it 'registers an offense with inline `private` and `end`' do
+            expect_offense(<<~RUBY)
+              class Foo
+                private def bar; end
+                        ^^^^^^^^^^^^ Missing method documentation comment.
+              end
+            RUBY
+          end
+        end
+      end
+    end
+
+    context 'with documentation comment' do
+      context 'when method is public' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            class Foo
+              # Documentation
+              def bar
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
+
+        it 'does not register an offense with `end` on the same line' do
+          expect_no_offenses(<<~RUBY)
+            class Foo
+              # Documentation
+              def bar; end
+            end
+          RUBY
+        end
+      end
+    end
+
+    context 'with annotation comment' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          class Foo
+            # FIXME: offense
+            def bar
+            ^^^^^^^ Missing method documentation comment.
+              puts 'baz'
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'with directive comment' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          class Foo
+            # rubocop:disable Style/For
+            def bar
+            ^^^^^^^ Missing method documentation comment.
+              puts 'baz'
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'with both public and private methods' do
+      context 'when the public method has no documentation' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            class Foo
+              def bar
+              ^^^^^^^ Missing method documentation comment.
+                puts 'baz'
+              end
+
+              private
+
+              def baz
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'when the public method has documentation' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            class Foo
+              # Documentation
+              def bar
+                puts 'baz'
+              end
+
+              private
+
+              def baz
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'when required for non-public methods' do
+        let(:require_for_non_public_methods) { true }
+
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            class Foo
+              # Documentation
+              def bar
+                puts 'baz'
+              end
+
+              private
+
+              def baz
+              ^^^^^^^ Missing method documentation comment.
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
+      end
+    end
+
+    context 'with Sorbet signatures' do
+      context 'and without documentation comment' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            class Foo
+              extend T::Sig
+
+              sig { void }
+              def bar
+              ^^^^^^^ Missing method documentation comment.
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'and with documentation comment' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            class Foo
+              extend T::Sig
+
+              # Documentation
+              sig { void }
+              def bar
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
+      end
+    end
+  end
+
+  context 'when declaring methods in a module' do
+    context 'without documentation comment' do
+      context 'when method is public' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            module Foo
+              def bar
+              ^^^^^^^ Missing method documentation comment.
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
+
+        it 'registers an offense with `end` on the same line' do
+          expect_offense(<<~RUBY)
+            module Foo
+              def method; end
+              ^^^^^^^^^^^^^^^ Missing method documentation comment.
+            end
+          RUBY
+        end
+      end
+
+      context 'when method is private' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              private
+
+              def bar
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
+
+        it 'does not register an offense with inline `private`' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              private def bar
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
+
+        it 'does not register an offense with `end` on the same line' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              private
+
+              def bar; end
+            end
+          RUBY
+        end
+
+        it 'does not register an offense with inline `private` and `end`' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              private def bar; end
+            end
+          RUBY
+        end
+
+        context 'when required for non-public methods' do
+          let(:require_for_non_public_methods) { true }
+
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              module Foo
+                private
+
+                def bar
+                ^^^^^^^ Missing method documentation comment.
+                  puts 'baz'
+                end
+              end
+            RUBY
+          end
+
+          it 'registers an offense with inline `private`' do
+            expect_offense(<<~RUBY)
+              module Foo
+                private def bar
+                        ^^^^^^^ Missing method documentation comment.
+                  puts 'baz'
+                end
+              end
+            RUBY
+          end
+
+          it 'registers an offense with `end` on the same line' do
+            expect_offense(<<~RUBY)
+              module Foo
+                private
+
+                def bar; end
+                ^^^^^^^^^^^^ Missing method documentation comment.
+              end
+            RUBY
+          end
+
+          it 'registers an offense with inline `private` and `end`' do
+            expect_offense(<<~RUBY)
+              module Foo
+                private def bar; end
+                        ^^^^^^^^^^^^ Missing method documentation comment.
+              end
+            RUBY
+          end
+        end
+      end
+
+      context 'when method is module_function' do
+        it 'registers an offense for inline def' do
+          expect_offense(<<~RUBY)
+            module Foo
+              module_function def bar
+              ^^^^^^^^^^^^^^^^^^^^^^^ Missing method documentation comment.
+              end
+            end
+          RUBY
+        end
+
+        it 'registers an offense for separate def' do
+          expect_offense(<<~RUBY)
+            module Foo
+              def bar
+              ^^^^^^^ Missing method documentation comment.
+              end
+
+              module_function :bar
+            end
+          RUBY
+        end
+      end
+
+      it 'registers an offense for inline def with ruby2_keywords' do
+        expect_offense(<<~RUBY)
+          module Foo
+            ruby2_keywords def bar
+            ^^^^^^^^^^^^^^^^^^^^^^ Missing method documentation comment.
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'with documentation comment' do
+      context 'when method is public' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              # Documentation
+              def bar
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
+
+        it 'does not register an offense with `end` on the same line' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              # Documentation
+              def bar; end
+            end
+          RUBY
+        end
+      end
+
+      context 'when method is module_function' do
+        it 'does not register an offense for inline def' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              # Documentation
+              module_function def bar; end
+            end
+          RUBY
+        end
+
+        it 'does not register an offense for separate def' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              # Documentation
+              def bar; end
+
+              module_function :bar
+            end
+          RUBY
+        end
+      end
+
+      it 'does not register an offense for inline def with ruby2_keywords' do
+        expect_no_offenses(<<~RUBY)
+          module Foo
+            # Documentation
+            ruby2_keywords def bar
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'with both public and private methods' do
+      context 'when the public method has no documentation' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            module Foo
+              def bar
+              ^^^^^^^ Missing method documentation comment.
+                puts 'baz'
+              end
+
+              private
+
+              def baz
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'when the public method has documentation' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              # Documentation
+              def bar
+                puts 'baz'
+              end
+
+              private
+
+              def baz
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'when required for non-public methods' do
+        let(:require_for_non_public_methods) { true }
+
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            module Foo
+              # Documentation
+              def bar
+                puts 'baz'
+              end
+
+              private
+
+              def baz
+              ^^^^^^^ Missing method documentation comment.
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
+      end
+    end
+
+    context 'with Sorbet signatures' do
+      context 'and without documentation comment' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            module Foo
+              extend T::Sig
+
+              sig { void }
+              def bar
+              ^^^^^^^ Missing method documentation comment.
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'and with documentation comment' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              extend T::Sig
+
+              # Documentation
+              sig { void }
+              def bar
+                puts 'baz'
+              end
+            end
+          RUBY
+        end
+      end
+    end
+  end
+
+  context 'when declaring methods for class instance' do
+    context 'without documentation comment' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          class Foo; end
+
+          foo = Foo.new
+
+          def foo.bar
+          ^^^^^^^^^^^ Missing method documentation comment.
+            puts 'baz'
+          end
+        RUBY
+      end
+
+      it 'registers an offense with `end` on the same line' do
+        expect_offense(<<~RUBY)
+          class Foo; end
+
+          foo = Foo.new
+
+          def foo.bar; end
+          ^^^^^^^^^^^^^^^^ Missing method documentation comment.
+        RUBY
+      end
+    end
+
+    context 'with documentation comment' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          class Foo; end
+
+          foo = Foo.new
+
+          # Documentation
+          def foo.bar
+            puts 'baz'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense with `end` on the same line' do
+        expect_no_offenses(<<~RUBY)
+          class Foo; end
+
+          foo = Foo.new
+
+          # Documentation
+          def foo.bar; end
+        RUBY
+      end
+
+      context 'when method is private' do
+        it 'does not register an offense with `end` on the same line' do
+          expect_no_offenses(<<~RUBY)
             class Foo; end
 
-            foo = Foo.new
+            foo = Foo.bar
 
-            # Documentation
+            private
+
             def foo.bar; end
           RUBY
         end
 
-        context 'when method is private' do
-          it 'does not register an offense with `end` on the same line' do
-            expect_no_offenses(<<~RUBY)
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            class Foo; end
+
+            foo = Foo.new
+
+            private
+
+            def foo.bar
+              puts 'baz'
+            end
+          RUBY
+        end
+
+        it 'does not register an offense with inline `private` and `end`' do
+          expect_no_offenses(<<~RUBY)
+            class Foo; end
+
+            foo = Foo.new
+
+            private def foo.bar; end
+          RUBY
+        end
+
+        it 'does not register an offense with inline `private`' do
+          expect_no_offenses(<<~RUBY)
+            class Foo; end
+
+            foo = Foo.new
+
+            private def foo.bar
+              puts 'baz'
+            end
+          RUBY
+        end
+
+        context 'when required for non-public methods' do
+          let(:require_for_non_public_methods) { true }
+
+          it 'registers an offense with `end` on the same line' do
+            expect_offense(<<~RUBY)
               class Foo; end
 
               foo = Foo.bar
@@ -829,11 +991,12 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
               private
 
               def foo.bar; end
+              ^^^^^^^^^^^^^^^^ Missing method documentation comment.
             RUBY
           end
 
-          it 'does not register an offense' do
-            expect_no_offenses(<<~RUBY)
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
               class Foo; end
 
               foo = Foo.new
@@ -841,170 +1004,117 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
               private
 
               def foo.bar
+              ^^^^^^^^^^^ Missing method documentation comment.
                 puts 'baz'
               end
             RUBY
           end
 
-          it 'does not register an offense with inline `private` and `end`' do
-            expect_no_offenses(<<~RUBY)
+          it 'registers an offense with inline `private` and `end`' do
+            expect_offense(<<~RUBY)
               class Foo; end
 
               foo = Foo.new
 
               private def foo.bar; end
+                      ^^^^^^^^^^^^^^^^ Missing method documentation comment.
             RUBY
           end
 
-          it 'does not register an offense with inline `private`' do
-            expect_no_offenses(<<~RUBY)
+          it 'registers an offense with inline `private`' do
+            expect_offense(<<~RUBY)
               class Foo; end
 
               foo = Foo.new
 
               private def foo.bar
+                      ^^^^^^^^^^^ Missing method documentation comment.
                 puts 'baz'
               end
             RUBY
           end
-
-          context 'when required for non-public methods' do
-            let(:require_for_non_public_methods) { true }
-
-            it 'registers an offense with `end` on the same line' do
-              expect_offense(<<~RUBY)
-                class Foo; end
-
-                foo = Foo.bar
-
-                private
-
-                def foo.bar; end
-                ^^^^^^^^^^^^^^^^ Missing method documentation comment.
-              RUBY
-            end
-
-            it 'registers an offense' do
-              expect_offense(<<~RUBY)
-                class Foo; end
-
-                foo = Foo.new
-
-                private
-
-                def foo.bar
-                ^^^^^^^^^^^ Missing method documentation comment.
-                  puts 'baz'
-                end
-              RUBY
-            end
-
-            it 'registers an offense with inline `private` and `end`' do
-              expect_offense(<<~RUBY)
-                class Foo; end
-
-                foo = Foo.new
-
-                private def foo.bar; end
-                        ^^^^^^^^^^^^^^^^ Missing method documentation comment.
-              RUBY
-            end
-
-            it 'registers an offense with inline `private`' do
-              expect_offense(<<~RUBY)
-                class Foo; end
-
-                foo = Foo.new
-
-                private def foo.bar
-                        ^^^^^^^^^^^ Missing method documentation comment.
-                  puts 'baz'
-                end
-              RUBY
-            end
-          end
-        end
-
-        context 'with both public and private methods' do
-          context 'when the public method has no documentation' do
-            it 'registers an offense' do
-              expect_offense(<<~RUBY)
-                class Foo; end
-
-                foo = Foo.new
-
-                def foo.bar
-                ^^^^^^^^^^^ Missing method documentation comment.
-                  puts 'baz'
-                end
-
-                private
-
-                def foo.baz
-                  puts 'baz'
-                end
-              RUBY
-            end
-          end
-
-          context 'when the public method has documentation' do
-            it 'does not register an offense' do
-              expect_no_offenses(<<~RUBY)
-                class Foo; end
-
-                foo = Foo.new
-
-                # Documentation
-                def foo.bar
-                  puts 'baz'
-                end
-
-                private
-
-                def foo.baz
-                  puts 'baz'
-                end
-              RUBY
-            end
-          end
-
-          context 'when required for non-public methods' do
-            let(:require_for_non_public_methods) { true }
-
-            it 'registers an offense' do
-              expect_offense(<<~RUBY)
-                class Foo; end
-
-                foo = Foo.new
-
-                # Documentation
-                def foo.bar
-                  puts 'baz'
-                end
-
-                private
-
-                def foo.baz
-                ^^^^^^^^^^^ Missing method documentation comment.
-                  puts 'baz'
-                end
-              RUBY
-            end
-          end
         end
       end
 
-      describe 'when AllowedMethods is configured' do
-        before { config['Style/DocumentationMethod'] = { 'AllowedMethods' => ['method_missing'] } }
+      context 'with both public and private methods' do
+        context 'when the public method has no documentation' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              class Foo; end
 
-        it 'ignores the methods in the config' do
-          expect_no_offenses(<<~RUBY)
-            class Foo
-              def method_missing(name, *args)
+              foo = Foo.new
+
+              def foo.bar
+              ^^^^^^^^^^^ Missing method documentation comment.
+                puts 'baz'
               end
-            end
-          RUBY
+
+              private
+
+              def foo.baz
+                puts 'baz'
+              end
+            RUBY
+          end
         end
+
+        context 'when the public method has documentation' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              class Foo; end
+
+              foo = Foo.new
+
+              # Documentation
+              def foo.bar
+                puts 'baz'
+              end
+
+              private
+
+              def foo.baz
+                puts 'baz'
+              end
+            RUBY
+          end
+        end
+
+        context 'when required for non-public methods' do
+          let(:require_for_non_public_methods) { true }
+
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              class Foo; end
+
+              foo = Foo.new
+
+              # Documentation
+              def foo.bar
+                puts 'baz'
+              end
+
+              private
+
+              def foo.baz
+              ^^^^^^^^^^^ Missing method documentation comment.
+                puts 'baz'
+              end
+            RUBY
+          end
+        end
+      end
+    end
+
+    describe 'when AllowedMethods is configured' do
+      before { config['Style/DocumentationMethod'] = { 'AllowedMethods' => ['method_missing'] } }
+
+      it 'ignores the methods in the config' do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            def method_missing(name, *args)
+            end
+          end
+        RUBY
       end
     end
   end


### PR DESCRIPTION
The `Style/DocumentationMethod` cop does not support Sorbet's `sig` blocks when both sig and docs are present, making it incompatible with [Sorbet/EmptyLineAfterSig](https://github.com/Shopify/rubocop-sorbet/blob/main/manual/cops_sorbet.md#sorbetemptylineaftersig) cop.

I think it makes more sense for the docs to be above the signature than the opposite. 

```ruby
# This should be good
class Foo
  extend T::Sig

  # Documentation
  sig { void }
  def bar
    do_something
  end
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
