### PR TITLE
Tweak autocorrect for `Style/SoleNestedConditional`

### DIFF
--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -696,10 +696,27 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
         RUBY
 
         expect_correction(<<~RUBY)
-          if foo && (ok? bar)
+          if foo && ok?(bar)
             do_something
           end
         RUBY
+      end
+
+      context 'with a `csend` node' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            if foo
+              do_something if obj&.ok? bar
+                           ^^ Consider merging nested conditions into outer `if` conditions.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            if foo && obj&.ok?(bar)
+              do_something
+            end
+          RUBY
+        end
       end
     end
 
@@ -715,7 +732,7 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
         RUBY
 
         expect_correction(<<~RUBY)
-          if foo && (ok? bar)
+          if foo && ok?(bar)
               do_something
             end
         RUBY
@@ -733,7 +750,7 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
           RUBY
 
           expect_correction(<<~RUBY)
-            if foo && (bar&.baz quux)
+            if foo && bar&.baz(quux)
                 do_something
               end
           RUBY


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/9178/files#r537218932

This PR tweaks autocorrection for `Style/SoleNestedConditional` to more appropriately add parentheses to method calls when arguments are present.

No changelog entry will be added due to the minor update to autocorrection.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
