### PR TITLE
[Fix #13041] Fix false positives for `Lint/UselessAssignment`

### DIFF
--- a/changelog/fix_false_positives_for_lint_useless_assignment.md
+++ b/changelog/fix_false_positives_for_lint_useless_assignment.md
@@ -1,0 +1,1 @@
+* [#13041](https://github.com/rubocop/rubocop/issues/13041): Fix false positives for `Lint/UselessAssignment` when pattern match variable is assigned and used in a block. ([@koic][])

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -27,7 +27,10 @@ module RuboCop
     class VariableForce < Force # rubocop:disable Metrics/ClassLength
       VARIABLE_ASSIGNMENT_TYPE = :lvasgn
       REGEXP_NAMED_CAPTURE_TYPE = :match_with_lvasgn
-      VARIABLE_ASSIGNMENT_TYPES = [VARIABLE_ASSIGNMENT_TYPE, REGEXP_NAMED_CAPTURE_TYPE].freeze
+      PATTERN_MATCH_VARIABLE_TYPE = :match_var
+      VARIABLE_ASSIGNMENT_TYPES = [
+        VARIABLE_ASSIGNMENT_TYPE, REGEXP_NAMED_CAPTURE_TYPE, PATTERN_MATCH_VARIABLE_TYPE
+      ].freeze
 
       ARGUMENT_DECLARATION_TYPES = [
         :arg, :optarg, :restarg,
@@ -112,6 +115,7 @@ module RuboCop
       NODE_HANDLER_METHOD_NAMES = [
         [VARIABLE_ASSIGNMENT_TYPE, :process_variable_assignment],
         [REGEXP_NAMED_CAPTURE_TYPE, :process_regexp_named_captures],
+        [PATTERN_MATCH_VARIABLE_TYPE, :process_pattern_match_variable],
         [MULTIPLE_ASSIGNMENT_TYPE, :process_variable_multiple_assignment],
         [VARIABLE_REFERENCE_TYPE, :process_variable_referencing],
         [RESCUE_TYPE, :process_rescue],
@@ -171,6 +175,14 @@ module RuboCop
         process_node(regexp_node)
 
         variable_names.each { |name| variable_table.assign_to_variable(name, node) }
+
+        skip_children!
+      end
+
+      def process_pattern_match_variable(node)
+        name = node.children.first
+
+        variable_table.declare_variable(name, node) unless variable_table.variable_exist?(name)
 
         skip_children!
       end

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1718,6 +1718,56 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when a pattern match variable is assigned with `in` and referenced in a block', :ruby27 do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        def some_method
+          foo in { bar: bar }
+          baz { bar -= 1 }
+          foo
+        end
+      RUBY
+    end
+  end
+
+  context 'when a pattern match variable is assigned with `in` and unreferenced in a block', :ruby27 do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        def some_method
+          foo in { bar: bar }
+          baz { qux -= 1 }
+                ^^^ Useless assignment to variable - `qux`. Use `-` instead of `-=`.
+          foo
+        end
+      RUBY
+    end
+  end
+
+  context 'when a pattern match variable is assigned with `=>` and referenced in a block', :ruby30 do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        def some_method
+          foo => { bar: bar }
+          baz { bar -= 1 }
+          foo
+        end
+      RUBY
+    end
+  end
+
+  context 'when a pattern match variable is assigned with `=>` and unreferenced in a block', :ruby30 do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        def some_method
+          foo => { bar: bar }
+          baz { qux -= 1 }
+                ^^^ Useless assignment to variable - `qux`. Use `-` instead of `-=`.
+          foo
+        end
+      RUBY
+    end
+  end
+
   context 'when a variable is assigned in begin and referenced outside' do
     it 'accepts' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #13041.

This PR fixes false positives for `Lint/UselessAssignment` when pattern match variable is assigned and used in a block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
