### PR TITLE
[Fix #13044] Fix false negatives for `Lint/ImplicitStringConcatenation`

### DIFF
--- a/changelog/fix_false_negatives_for_lint_implicit_string_concatenation.md
+++ b/changelog/fix_false_negatives_for_lint_implicit_string_concatenation.md
@@ -1,0 +1,1 @@
+* [#13044](https://github.com/rubocop/rubocop/issues/13044): Fix false negatives for `Lint/ImplicitStringConcatenation` when using adjacent string interpolation literals on the same line. ([@koic][])

--- a/lib/rubocop/cop/lint/implicit_string_concatenation.rb
+++ b/lib/rubocop/cop/lint/implicit_string_concatenation.rb
@@ -80,7 +80,7 @@ module RuboCop
         end
 
         def string_literal?(node)
-          node.str_type? || (node.dstr_type? && node.children.all? { |c| string_literal?(c) })
+          node.str_type? || node.dstr_type?
         end
 
         def string_literals?(node1, node2)

--- a/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
+++ b/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe RuboCop::Cop::Lint::ImplicitStringConcatenation, :config do
     end
   end
 
+  context 'on adjacent string interpolation literals on the same line' do
+    it 'registers an offense' do
+      expect_offense(<<~'RUBY')
+        "string#{interpolation}" "def"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Combine "string#{interpolation}" and "def" into a single string literal, rather than using implicit string concatenation.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "string#{interpolation}" + "def"
+      RUBY
+    end
+  end
+
   context 'on adjacent string literals on different lines' do
     it 'does not register an offense' do
       expect_no_offenses(<<~'RUBY')


### PR DESCRIPTION
Fixes #13044.

This PR fixes false negatives for `Lint/ImplicitStringConcatenation` when using adjacent string interpolation literals on the same line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
