### PR TITLE
Use `support_autocorrect?` class method instead of the instance method

### DIFF
--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -70,7 +70,7 @@ module RuboCop
         # template file, we convert it to location info in the original file.
         range = range_for_original(range)
 
-        if block.nil? && !support_autocorrect?
+        if block.nil? && !self.class.support_autocorrect?
           super(range, message: message, severity: severity)
         else
           super(range, message: message, severity: severity) do |corrector|
@@ -154,7 +154,7 @@ module RuboCop
       end
 
       def correction_lambda
-        return unless support_autocorrect?
+        return unless self.class.support_autocorrect?
 
         dedupe_on_node(@v0_argument) { autocorrect(@v0_argument) }
       end


### PR DESCRIPTION
This PR changes to use the `support_autocorrect?` class method instead of the `support_autocorrent?` instance method. A warning message was added in #13032 when using the `support_autocorrect?` instance method. This PR addresses the remaining codes that were missed.

When executing rubocop commad, show the following warning message

```
/bundle/ruby/3.3.0/gems/rubocop-1.65.0/lib/rubocop/cop/cop.rb:73: warning: `support_autocorrect?` is deprecated. Use `cop.class.support_autocorrect?`.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
