### PR TITLE
[Fix #13051] Fix an error for `Lint/FloatComparison`

### DIFF
--- a/changelog/fix_an_error_for_lint_float_comparison.md
+++ b/changelog/fix_an_error_for_lint_float_comparison.md
@@ -1,0 +1,1 @@
+* [#13051](https://github.com/rubocop/rubocop/issues/13051): Fix an error for `Lint/FloatComparison` when comparing with rational literal. ([@koic][])

--- a/lib/rubocop/cop/lint/float_comparison.rb
+++ b/lib/rubocop/cop/lint/float_comparison.rb
@@ -66,7 +66,9 @@ module RuboCop
         end
 
         def literal_zero?(node)
-          node&.numeric_type? && node.value.zero?
+          # TODO: https://github.com/rubocop/rubocop-ast/pull/304 is released,
+          # replace this condition with `node&.numeric_type? && node.value.zero?`.
+          node&.numeric_type? && node.node_parts[0].zero?
         end
 
         # rubocop:disable Metrics/PerceivedComplexity

--- a/spec/rubocop/cop/lint/float_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/float_comparison_spec.rb
@@ -68,6 +68,12 @@ RSpec.describe RuboCop::Cop::Lint::FloatComparison, :config do
     RUBY
   end
 
+  it 'does not register an offense when comparing with rational literal' do
+    expect_no_offenses(<<~RUBY)
+      value == 0.2r
+    RUBY
+  end
+
   it 'does not register an offense when comparing against zero' do
     expect_no_offenses(<<~RUBY)
       x == 0.0


### PR DESCRIPTION
Fixes #13051.

This PR fixes an error for `Lint/FloatComparison`
when comparing with rational literal.

NOTE: Using https://github.com/rubocop/rubocop-ast/pull/304 in the future will allow for a more fundamental resolution of the issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
