### PR TITLE
Added ability to skip some lines while calculating length

### DIFF
--- a/changelog/change_added_ability_to_skip_some_lines_while_calculating.md
+++ b/changelog/change_added_ability_to_skip_some_lines_while_calculating.md
@@ -1,0 +1,1 @@
+* [#13053](https://github.com/rubocop/rubocop/pull/13053): Added ability to skip some lines while calculating length. ([@AsbahIshaq][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2613,6 +2613,7 @@ Metrics/BlockLength:
   CountComments: false  # count full line comments?
   Max: 25
   CountAsOne: []
+  SkipableLines: []
   AllowedMethods:
     # By default, exclude the `#refine` method, as it tends to have larger
     # associated blocks.
@@ -2639,6 +2640,7 @@ Metrics/ClassLength:
   CountComments: false  # count full line comments?
   Max: 100
   CountAsOne: []
+  SkipableLines: []
 
 Metrics/CollectionLiteralLength:
   Description: 'Checks for `Array` or `Hash` literals with many entries.'
@@ -2669,6 +2671,7 @@ Metrics/MethodLength:
   CountAsOne: []
   AllowedMethods: []
   AllowedPatterns: []
+  SkipableLines: []
 
 Metrics/ModuleLength:
   Description: 'Avoid modules longer than 100 lines of code.'
@@ -2678,6 +2681,7 @@ Metrics/ModuleLength:
   CountComments: false  # count full line comments?
   Max: 100
   CountAsOne: []
+  SkipableLines: []
 
 Metrics/ParameterLists:
   Description: 'Avoid parameter lists longer than three or four parameters.'

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -13,9 +13,10 @@ module RuboCop
           CLASSLIKE_TYPES = %i[class module].freeze
           private_constant :FOLDABLE_TYPES, :CLASSLIKE_TYPES
 
-          def initialize(node, processed_source, count_comments: false, foldable_types: [])
+          def initialize(node, processed_source, count_comments: false, skipable_lines_patterns: [], foldable_types: [])
             @node = node
             @processed_source = processed_source
+            @skipable_lines_patterns = skipable_lines_patterns
             @count_comments = count_comments
             @foldable_checks = build_foldable_checks(foldable_types)
             @foldable_types = normalize_foldable_types(foldable_types)
@@ -157,11 +158,15 @@ module RuboCop
 
           # Returns true for lines that shall not be included in the count.
           def irrelevant_line?(source_line)
-            source_line.blank? || (!count_comments? && comment_line?(source_line))
+            source_line.blank? || (!count_comments? && comment_line?(source_line)) || (is_skipable_line?(source_line))
           end
 
           def count_comments?
             @count_comments
+          end
+
+          def is_skipable_line?(source_line)
+            @skipable_lines_patterns.any? { |pattern| Regexp.new(pattern).match?(source_line) }
           end
 
           def omit_length(descendant)

--- a/lib/rubocop/cop/mixin/code_length.rb
+++ b/lib/rubocop/cop/mixin/code_length.rb
@@ -24,6 +24,14 @@ module RuboCop
         cop_config['CountComments']
       end
 
+      def skipable_lines_patterns
+        cop_config['SkipableLines']
+      end
+
+      def is_skipable_line?(source_line)
+        skipable_lines_patterns.any? { |pattern| Regexp.new(pattern).match?(source_line) }
+      end
+
       def count_as_one
         Array(cop_config['CountAsOne']).map(&:to_sym)
       end
@@ -43,7 +51,7 @@ module RuboCop
 
       # Returns true for lines that shall not be included in the count.
       def irrelevant_line(source_line)
-        source_line.blank? || (!count_comments? && comment_line?(source_line))
+        source_line.blank? || (!count_comments? && comment_line?(source_line)) || (is_skipable_line?(source_line))
       end
 
       def build_code_length_calculator(node)
@@ -51,6 +59,7 @@ module RuboCop
           node,
           processed_source,
           count_comments: count_comments?,
+          skipable_lines_patterns: skipable_lines_patterns,
           foldable_types: count_as_one
         )
       end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1010,7 +1010,8 @@ RSpec.describe RuboCop::ConfigLoader do
               'Max' => 5,
               'CountAsOne' => [],
               'AllowedMethods' => [],
-              'AllowedPatterns' => []
+              'AllowedPatterns' => [],
+              'SkipableLines' => []
             }
           )
         expect { expect(configuration_from_file.to_h).to eq(config) }.not_to output.to_stderr

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -291,6 +291,20 @@ RSpec.describe RuboCop::Cop::Metrics::BlockLength, :config do
     end
   end
 
+  context 'when SkipableLines is enabled' do
+    before { cop_config['SkipableLines'] = [/\bputs\b/]  }
+
+    it 'does not count matching lines' do
+      expect_no_offenses(<<~RUBY)
+        something do
+          a = 1
+          puts '2'
+          a = 2
+        end
+      RUBY
+    end
+  end
+
   context 'when methods to allow are defined' do
     context 'when AllowedMethods is enabled' do
       it_behaves_like('allow an offense on an allowed method', 'foo', 'AllowedMethods')

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -216,6 +216,23 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
     end
   end
 
+  context 'when SkipableLines is enabled' do
+    before { cop_config['SkipableLines'] = [/\bputs\b/]  }
+
+    it 'does not count matching lines' do
+      expect_no_offenses(<<~RUBY)
+        class Test
+          a = 1
+          puts '2'
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+        end
+      RUBY
+    end
+  end
+
   context 'when `CountAsOne` is not empty' do
     before { cop_config['CountAsOne'] = ['array'] }
 

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -279,6 +279,23 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
         RUBY
       end
     end
+
+    context 'when SkipableLines is enabled' do
+      before { cop_config['SkipableLines'] = [/\bputs\b/]  }
+
+      it 'does not count matching lines' do
+        expect_no_offenses(<<~RUBY)
+          def m
+            a = 1
+            puts '2'
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+        RUBY
+      end
+    end
   end
 
   context 'when `CountAsOne` is not empty' do

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -262,6 +262,23 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
     end
   end
 
+  context 'when SkipableLines is enabled' do
+    before { cop_config['SkipableLines'] = [/\bputs\b/]  }
+
+    it 'does not count matching lines' do
+      expect_no_offenses(<<~RUBY)
+        module Test
+          a = 1
+          puts '2'
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+        end
+      RUBY
+    end
+  end
+
   context 'when `CountAsOne` is not empty' do
     before { cop_config['CountAsOne'] = ['array'] }
 

--- a/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
@@ -52,6 +52,22 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::CodeLengthCalculator do
         expect(length).to eq(6)
       end
 
+      it 'skips skipable lines' do
+        source = parse_source(<<~RUBY)
+          def test
+            a = 1
+            puts '2'
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+        RUBY
+
+        length = described_class.new(source.ast, source, count_comments: true, skipable_lines_patterns: [/\bputs\b/]).calculate
+        expect(length).to eq(5)
+      end
+
       it 'folds arrays if asked' do
         source = parse_source(<<~RUBY)
           def test


### PR DESCRIPTION
The PR adds the ability to skip certain lines while calculating lengths of class, method, module or block.

cops affectted:
```
Metrics/BlockLength
Metrics/ClassLength
Metrics/MethodLength
Metrics/ModuleLength
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
