### PR TITLE
[Fix #11438] Explicitly load `fileutils` before calculating `before_us`

### DIFF
--- a/changelog/fix_explicitly_load_fileutils_before_calculating.md
+++ b/changelog/fix_explicitly_load_fileutils_before_calculating.md
@@ -1,0 +1,1 @@
+* [#11438](https://github.com/rubocop/rubocop/issues/11438): Explicitly load `fileutils` before calculating `before_us`. ([@r7kamura][])

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 require 'English'
+
+# fileutils is autoloaded by pathname,
+# but must be explicitly loaded here for inclusion in `$LOADED_FEATURES`.
+require 'fileutils'
+
 before_us = $LOADED_FEATURES.dup
 require 'rainbow'
 


### PR DESCRIPTION
Related:

- https://github.com/rubocop/rubocop/issues/11438
- https://github.com/rubocop/rubocop/pull/11676

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
