### PR TITLE
Fix an error for `Style/InvertibleUnlessCondition` when using empty parenthesis as condition

### DIFF
--- a/changelog/fix_an_error_for_style_invertible_unless_condition.md
+++ b/changelog/fix_an_error_for_style_invertible_unless_condition.md
@@ -1,0 +1,1 @@
+* [#13062](https://github.com/rubocop/rubocop/pull/13062): Fix an error for `Style/InvertibleUnlessCondition` when using empty parenthesis as condition. ([@earlopain][])

--- a/lib/rubocop/cop/style/invertible_unless_condition.rb
+++ b/lib/rubocop/cop/style/invertible_unless_condition.rb
@@ -72,8 +72,8 @@ module RuboCop
 
         private
 
-        def invertible?(node)
-          case node.type
+        def invertible?(node) # rubocop:disable Metrics/CyclomaticComplexity
+          case node&.type
           when :begin
             invertible?(node.children.first)
           when :send

--- a/spec/rubocop/cop/style/invertible_unless_condition_spec.rb
+++ b/spec/rubocop/cop/style/invertible_unless_condition_spec.rb
@@ -147,4 +147,16 @@ RSpec.describe RuboCop::Cop::Style::InvertibleUnlessCondition, :config do
       foo if !condition
     RUBY
   end
+
+  it 'does not register an offense when using empty braces with `unless`' do
+    expect_no_offenses(<<~RUBY)
+      foo unless ()
+    RUBY
+  end
+
+  it 'does not register an offense when using empty braces with inverted `if`' do
+    expect_no_offenses(<<~RUBY)
+      foo if !()
+    RUBY
+  end
 end


### PR DESCRIPTION
As it happens when you type something like `return unless (foo = bar)`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
