### PR TITLE
[Fix #13065] Fix an error for `Lint/UselessAssignment`

### DIFF
--- a/changelog/fix_an_error_for_lint_useless_assignment_cop.md
+++ b/changelog/fix_an_error_for_lint_useless_assignment_cop.md
@@ -1,0 +1,1 @@
+* [#13065](https://github.com/rubocop/rubocop/issues/13065): Fix an error for `Lint/UselessAssignment` when same name variables are assigned using chained assignment. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_assignment.rb
+++ b/lib/rubocop/cop/lint/useless_assignment.rb
@@ -57,7 +57,7 @@ module RuboCop
         def check_for_unused_assignments(variable)
           return if variable.should_be_unused?
 
-          variable.assignments.each do |assignment|
+          variable.assignments.reverse_each do |assignment|
             next if assignment.used? || part_of_ignored_node?(assignment.node)
 
             message = message_for_useless_assignment(assignment)

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1215,6 +1215,23 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when same name variables are assigned using chained assignment' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        def some_method
+          foo = foo = do_something
+          ^^^ Useless assignment to variable - `foo`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          foo = do_something
+        end
+      RUBY
+    end
+  end
+
   context 'when variables are assigned with sequential assignment using the comma operator and unreferenced' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #13065.

This PR fixes an error for `Lint/UselessAssignment` when same name variables are assigned using chained assignment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
