### PR TITLE
Drop `regexp_parser` < 2.0 compatibility code

### DIFF
--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -95,30 +95,14 @@ module RuboCop
           delimiters.include?(char)
         end
 
-        if Gem::Version.new(Regexp::Parser::VERSION) >= Gem::Version.new('2.0')
-          def each_escape(node)
-            node.parsed_tree&.traverse&.reduce(0) do |char_class_depth, (event, expr)|
-              yield(expr.text[1], expr.ts, !char_class_depth.zero?) if expr.type == :escape
+        def each_escape(node)
+          node.parsed_tree&.traverse&.reduce(0) do |char_class_depth, (event, expr)|
+            yield(expr.text[1], expr.ts, !char_class_depth.zero?) if expr.type == :escape
 
-              if expr.type == :set
-                char_class_depth + (event == :enter ? 1 : -1)
-              else
-                char_class_depth
-              end
-            end
-          end
-        # Please remove this `else` branch when support for regexp_parser 1.8 will be dropped.
-        # It's for compatibility with regexp_parser 1.8 and will never be maintained.
-        else
-          def each_escape(node)
-            node.parsed_tree&.traverse&.reduce(0) do |char_class_depth, (event, expr)|
-              yield(expr.text[1], expr.start_index, !char_class_depth.zero?) if expr.type == :escape
-
-              if expr.type == :set
-                char_class_depth + (event == :enter ? 1 : -1)
-              else
-                char_class_depth
-              end
+            if expr.type == :set
+              char_class_depth + (event == :enter ? 1 : -1)
+            else
+              char_class_depth
             end
           end
         end

--- a/lib/rubocop/ext/regexp_node.rb
+++ b/lib/rubocop/ext/regexp_node.rb
@@ -15,39 +15,17 @@ module RuboCop
       # see `ext/regexp_parser`.
       attr_reader :parsed_tree
 
-      if Gem::Version.new(Regexp::Parser::VERSION) >= Gem::Version.new('2.0')
-        def assign_properties(*)
-          super
+      def assign_properties(*)
+        super
 
-          str = with_interpolations_blanked
-          @parsed_tree = begin
-            Regexp::Parser.parse(str, options: options)
-          rescue StandardError
-            nil
-          end
-          origin = loc.begin.end
-          @parsed_tree&.each_expression(true) { |e| e.origin = origin }
+        str = with_interpolations_blanked
+        @parsed_tree = begin
+          Regexp::Parser.parse(str, options: options)
+        rescue StandardError
+          nil
         end
-      # Please remove this `else` branch when support for regexp_parser 1.8 will be dropped.
-      # It's for compatibility with regexp_parser 1.8 and will never be maintained.
-      else
-        def assign_properties(*)
-          super
-
-          str = with_interpolations_blanked
-          begin
-            @parsed_tree = Regexp::Parser.parse(str, options: options)
-          rescue StandardError
-            @parsed_tree = nil
-          else
-            origin = loc.begin.end
-            source = @parsed_tree.to_s
-            @parsed_tree.each_expression(true) do |e|
-              e.origin = origin
-              e.source = source
-            end
-          end
-        end
+        origin = loc.begin.end
+        @parsed_tree&.each_expression(true) { |e| e.origin = origin }
       end
 
       def each_capture(named: ANY)


### PR DESCRIPTION
The version got bumped in https://github.com/rubocop/rubocop/pull/12987

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
