### PR TITLE
Bump `simplecov`

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -35,12 +35,13 @@ jobs:
       - name: spec
         env:
           CI_RUBY_VERSION: ${{ matrix.ruby }}
+          CC_TEST_REPORTER_ID: dummy # Value doesn't matter, enables json formatter
         run: COVERAGE=true bundle exec rake spec
       - name: Upload Coverage Artifact
         uses: actions/upload-artifact@v4
         with:
           name: coverage-ubuntu-${{ matrix.ruby }}
-          path: coverage/.resultset.json
+          path: coverage/coverage.json
           if-no-files-found: error
 
   spec-jruby:
@@ -97,7 +98,7 @@ jobs:
         if: ${{ env.CC_TEST_REPORTER_ID != '' }}
         with:
           coverageLocations: |
-            ${{github.workspace}}/coverage-*/.resultset.json:simplecov
+            ${{github.workspace}}/coverage-*/coverage.json:simplecov
 
   ascii_spec:
     name: Ascii Spec - ${{ matrix.os }} ${{ matrix.ruby }}

--- a/Gemfile
+++ b/Gemfile
@@ -22,10 +22,7 @@ gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.21.0'
 gem 'rubocop-rake', '~> 0.6.0'
 gem 'rubocop-rspec', '~> 3.0.0'
-# Workaround for cc-test-reporter with SimpleCov 0.18.
-# Stop upgrading SimpleCov until the following issue will be resolved.
-# https://github.com/codeclimate/test-reporter/issues/418
-gem 'simplecov', '~> 0.10', '< 0.18'
+gem 'simplecov', '~> 0.20'
 gem 'stackprof', platform: :mri
 gem 'test-queue'
 gem 'yard', '~> 0.9'


### PR DESCRIPTION
"Recent" simplecov versions have issues with the codeclimate reporter. To fix this:

* Bump to at least 0.20 (https://github.com/codeclimate/test-reporter/issues/413#issuecomment-1079155787)
* Use the new json formatter by setting `CC_TEST_REPORTER_ID`
* Use the produced coverage file instead of the internal `.resultset.json`

Coverage upload will not run here in this PR but I confirmed in my fork that this works: https://github.com/Earlopain/rubocop/actions/runs/10112313435/job/27966211379?pr=5

![image](https://github.com/user-attachments/assets/84e8b669-db4a-4ca1-8a09-079147a5f4a8)

![image](https://github.com/user-attachments/assets/f7a22ab7-eb9b-45cf-b26e-7c7ea7bff7ed)
