### PR TITLE
Enable branch coverage

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -3,4 +3,5 @@
 SimpleCov.start do
   add_filter '/spec/'
   add_filter '/vendor/bundle/'
+  enable_coverage :branch
 end


### PR DESCRIPTION
Now that simplecov >= 0.18 is unblocked, this can be enabled.