### PR TITLE
Mark `broken_on: :prism` for broken specs using Ruby 3.4.0dev with Prism

### DIFF
--- a/spec/rubocop/cop/lint/percent_string_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_string_array_spec.rb
@@ -82,7 +82,8 @@ RSpec.describe RuboCop::Cop::Lint::PercentStringArray, :config do
   end
 
   context 'with binary encoded source' do
-    it 'adds an offense and corrects when tokens contain quotes' do
+    # FIXME: This spec should work with the latest Prism and Ruby 3.4.0dev.
+    it 'adds an offense and corrects when tokens contain quotes', broken_on: :prism do
       expect_offense(<<~RUBY.b)
         # encoding: BINARY
 
@@ -97,7 +98,8 @@ RSpec.describe RuboCop::Cop::Lint::PercentStringArray, :config do
       RUBY
     end
 
-    it 'accepts if tokens contain no quotes' do
+    # FIXME: This spec should work with the latest Prism and Ruby 3.4.0dev.
+    it 'accepts if tokens contain no quotes', broken_on: :prism do
       expect_no_offenses(<<~RUBY.b)
         # encoding: BINARY
 

--- a/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe RuboCop::Cop::Lint::PercentSymbolArray, :config do
     end
 
     context 'with binary encoded source' do
-      it 'registers an offense and corrects when tokens contain quotes' do
+      # FIXME: This spec should work with the latest Prism and Ruby 3.4.0dev.
+      it 'registers an offense and corrects when tokens contain quotes', broken_on: :prism do
         expect_offense(<<~RUBY.b)
           # encoding: BINARY
 
@@ -61,7 +62,8 @@ RSpec.describe RuboCop::Cop::Lint::PercentSymbolArray, :config do
         RUBY
       end
 
-      it 'accepts if tokens contain no quotes' do
+      # FIXME: This spec should work with the latest Prism and Ruby 3.4.0dev.
+      it 'accepts if tokens contain no quotes', broken_on: :prism do
         expect_no_offenses(<<~RUBY.b)
           # encoding: BINARY
 


### PR DESCRIPTION
This PR marks `broken_on: :prism` for broken specs using Ruby 3.4.0dev with Prism:

```console
$ ruby -v
ruby 3.4.0dev (2024-07-22T02:49:19Z master 3a16971c06) [x86_64-darwin23]
$ PARSER_ENGINE=parser_prism be rspec ./spec/rubocop/cop/lint/percent_symbol_array_spec.rb ./spec/rubocop/cop/lint/percent_string_array_spec.rb
(snip)

Failures:

  1) RuboCop::Cop::Lint::PercentStringArray with binary encoded source adds an offense and corrects when tokens contain quotes
     Failure/Error:
       raise 'Error parsing example code: ' \
             "#{processed_source.diagnostics.map(&:render).join("\n")}"

     RuntimeError:
       Error parsing example code: (string):3:4: error: invalid multibyte character 0xC0
       (string):3: %W[? "foo"]
       (string):3:    ^
     # ./lib/rubocop/rspec/expect_offense.rb:211:in 'RuboCop::RSpec::ExpectOffense#parse_processed_source'
     # ./lib/rubocop/rspec/expect_offense.rb:120:in 'RuboCop::RSpec::ExpectOffense#expect_offense'
     # ./spec/rubocop/cop/lint/percent_string_array_spec.rb:86:in 'block (3 levels) in <top (required)>'
```

It will be marked until it is investigated and resolved.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
