### PR TITLE
[Fix #11977] Add new global `StringLiteralsFrozenByDefault` option

### DIFF
--- a/changelog/new_all_cops_string_literals_frozen_by_default.md
+++ b/changelog/new_all_cops_string_literals_frozen_by_default.md
@@ -1,0 +1,1 @@
+* [#13077](https://github.com/rubocop/rubocop/pull/13077): Add new global `StringLiteralsFrozenByDefault` option for correct analysis with `RUBYOPT=--enable=frozen-string-literal`. ([@earlopain][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -166,6 +166,11 @@ AllCops:
     rubocop-rspec_rails: [rspec-rails]
   # Enable/Disable checking the methods extended by Active Support.
   ActiveSupportExtensionsEnabled: false
+  # Future version of Ruby will freeze string literals by default.
+  # This allows to opt in early, for example when enabled through RUBYOPT.
+  # For now this will behave as if set to false but in future ruby versions
+  # (likely 4.0) it will be true by default.
+  StringLiteralsFrozenByDefault: ~
 
 #################### Bundler ###############################
 

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -986,3 +986,18 @@ This is off by default, but can be enabled by the `ActiveSupportExtensionsEnable
 AllCops:
   ActiveSupportExtensionsEnabled: true
 ----
+
+== Opting into globally frozen string literals
+
+Ruby continues to move into the direction of having all string literals frozen by default.
+Ruby 3.4 for example will show a warning if a non-frozen string literal from a file without
+the frozen string literal magic comment gets modified. By starting ruby with the environment
+variable `RUBYOPT` set to `--enable=frozen-string-literal` you can opt into that behaviour today.
+For RuboCop to provide accurate analysis you must also configure the `StringLiteralsFrozenByDefault`
+option.
+
+[source,yaml]
+----
+AllCops:
+  StringLiteralsFrozenByDefault: true
+----

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -171,6 +171,10 @@ module RuboCop
       for_all_cops['ActiveSupportExtensionsEnabled']
     end
 
+    def string_literals_frozen_by_default?
+      for_all_cops['StringLiteralsFrozenByDefault']
+    end
+
     def file_to_include?(file)
       relative_file_path = path_relative_to_config(file)
 

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -273,6 +273,10 @@ module RuboCop
         @config.active_support_extensions_enabled?
       end
 
+      def string_literals_frozen_by_default?
+        @config.string_literals_frozen_by_default?
+      end
+
       def relevant_file?(file)
         return false unless target_satisfies_all_gem_version_requirements?
         return true unless @config.clusivity_config_for_badge?(self.class.badge)

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -129,8 +129,10 @@ module RuboCop
         def frozen_strings?
           return true if frozen_string_literals_enabled?
 
-          frozen_string_cop_enabled = config.for_cop('Style/FrozenStringLiteral')['Enabled']
-          frozen_string_cop_enabled && !frozen_string_literals_disabled?
+          frozen_string_cop_enabled = config.for_cop('Style/FrozenStringLiteralComment')['Enabled']
+          frozen_string_cop_enabled &&
+            !frozen_string_literals_disabled? &&
+            string_literals_frozen_by_default?.nil?
         end
       end
     end

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
   end
 
   describe 'Empty String', :config do
-    let(:other_cops) { { 'Style/FrozenStringLiteral' => { 'Enabled' => false } } }
+    let(:other_cops) { { 'Style/FrozenStringLiteralComment' => { 'Enabled' => false } } }
 
     it 'registers an offense for String.new()' do
       expect_offense(<<~RUBY)
@@ -287,8 +287,8 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
       end
     end
 
-    context 'when Style/FrozenStringLiteral is enabled' do
-      let(:other_cops) { { 'Style/FrozenStringLiteral' => { 'Enabled' => true } } }
+    context 'when Style/FrozenStringLiteralComment is enabled' do
+      let(:other_cops) { { 'Style/FrozenStringLiteralComment' => { 'Enabled' => true } } }
 
       context 'and there is no magic comment' do
         it 'does not register an offense' do
@@ -300,6 +300,87 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
 
       context 'and there is a frozen_string_literal: false comment' do
         it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            # frozen_string_literal: false
+            test = String.new
+                   ^^^^^^^^^^ Use string literal `''` instead of `String.new`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            # frozen_string_literal: false
+            test = ''
+          RUBY
+        end
+      end
+    end
+
+    context 'when `AllCops/StringLiteralsFrozenByDefault: true`' do
+      let(:config) do
+        RuboCop::Config.new('AllCops' => { 'StringLiteralsFrozenByDefault' => true })
+      end
+
+      context 'when the frozen string literal comment is missing' do
+        it 'registers no offense' do
+          expect_no_offenses(<<~RUBY)
+            test = String.new
+          RUBY
+        end
+      end
+
+      context 'when the frozen string literal comment is true' do
+        it 'registers no offense' do
+          expect_no_offenses(<<~RUBY)
+            # frozen_string_literal: true
+              test = String.new
+          RUBY
+        end
+      end
+
+      context 'when the frozen string literal comment is false' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            # frozen_string_literal: false
+            test = String.new
+                   ^^^^^^^^^^ Use string literal `''` instead of `String.new`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            # frozen_string_literal: false
+            test = ''
+          RUBY
+        end
+      end
+    end
+
+    context 'when `AllCops/StringLiteralsFrozenByDefault: false`' do
+      let(:config) do
+        RuboCop::Config.new('AllCops' => { 'StringLiteralsFrozenByDefault' => false })
+      end
+
+      context 'when the frozen string literal comment is missing' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            test = String.new
+                   ^^^^^^^^^^ Use string literal `''` instead of `String.new`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            test = ''
+          RUBY
+        end
+      end
+
+      context 'when the frozen string literal comment is true' do
+        it 'registers no offense' do
+          expect_no_offenses(<<~RUBY)
+            # frozen_string_literal: true
+              test = String.new
+          RUBY
+        end
+      end
+
+      context 'when the frozen string literal comment is false' do
+        it 'registers an offense' do
           expect_offense(<<~RUBY)
             # frozen_string_literal: false
             test = String.new

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -49,6 +49,50 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze, :config do
     expect_no_offenses('TOP_TEST = Something.new.freeze')
   end
 
+  context 'when `AllCops/StringLiteralsFrozenByDefault: true`' do
+    let(:config) do
+      RuboCop::Config.new('AllCops' => { 'StringLiteralsFrozenByDefault' => true })
+    end
+
+    context 'when the frozen string literal comment is missing' do
+      it_behaves_like 'immutable objects', '""'
+    end
+
+    context 'when the frozen string literal comment is true' do
+      let(:prefix) { '# frozen_string_literal: true' }
+
+      it_behaves_like 'immutable objects', '""'
+    end
+
+    context 'when the frozen string literal comment is false' do
+      let(:prefix) { '# frozen_string_literal: false' }
+
+      it_behaves_like 'mutable objects', '""'
+    end
+  end
+
+  context 'when `AllCops/StringLiteralsFrozenByDefault: false`' do
+    let(:config) do
+      RuboCop::Config.new('AllCops' => { 'StringLiteralsFrozenByDefault' => false })
+    end
+
+    context 'when the frozen string literal comment is missing' do
+      it_behaves_like 'mutable objects', '""'
+    end
+
+    context 'when the frozen string literal comment is true' do
+      let(:prefix) { '# frozen_string_literal: true' }
+
+      it_behaves_like 'immutable objects', '""'
+    end
+
+    context 'when the frozen string literal comment is false' do
+      let(:prefix) { '# frozen_string_literal: false' }
+
+      it_behaves_like 'mutable objects', '""'
+    end
+  end
+
   context 'when the receiver is a string literal' do
     # TODO : It is not yet decided when frozen string will be the default.
     # It has been abandoned in the Ruby 3.0 period, but may default in


### PR DESCRIPTION
While Ruby continues to not have this the default, user can opt into it using the `RUBYOPT` environment variable. To make RuboCop behave correctly when doing that, offer a config value to say how literals behave by default.

The most egregious cop `Style/FrozenStringLiteralComment` can already be configured appropriately by setting `EnforcedStyle` to `never`. This makes if possible to also change behaviour about cops that concern themselves with string literals (primarily `MutableConstant`).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
