### PR TITLE
[Fix #13076] Fix an incorrect autocorrect for `Naming/RescuedExceptionsVariableName`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_naming_rescued_exceptions_variable_name.md
+++ b/changelog/fix_incorrect_autocorrect_for_naming_rescued_exceptions_variable_name.md
@@ -1,0 +1,1 @@
+* [#13076](https://github.com/rubocop/rubocop/issues/13076): Fix an incorrect autocorrect for `Naming/RescuedExceptionsVariableName` when using hash value omission. ([@koic][])

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -85,6 +85,40 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
           RUBY
         end
 
+        it 'registers an offense when using `error` for an explicit hash value' do
+          expect_offense(<<~RUBY)
+            begin
+            rescue => error
+                      ^^^^^ Use `e` instead of `error`.
+              do_something(error: error)
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            begin
+            rescue => e
+              do_something(error: e)
+            end
+          RUBY
+        end
+
+        it 'registers an offense when using `error` for an omitted hash value', :ruby31 do
+          expect_offense(<<~RUBY)
+            begin
+            rescue => error
+                      ^^^^^ Use `e` instead of `error`.
+              do_something(error:)
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            begin
+            rescue => e
+              do_something(error: e)
+            end
+          RUBY
+        end
+
         it 'does not register an offense when using `e`' do
           expect_no_offenses(<<~RUBY)
             begin


### PR DESCRIPTION
Fixes #13076.

This PR fixes an incorrect autocorrect for `Naming/RescuedExceptionsVariableName` when using `error` for an omitted hash value.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
