### PR TITLE
Add new `DocumentationFormat` to serve documentation with extensions different than `html`

### DIFF
--- a/changelog/new_documentation_extension.md
+++ b/changelog/new_documentation_extension.md
@@ -1,0 +1,1 @@
+* [#13078](https://github.com/rubocop/rubocop/pull/13078): Add new `DocumentationExtension` global option to serve documentation with extensions different than `.html`. ([@earlopain][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -82,6 +82,8 @@ AllCops:
   StyleGuideBaseURL: https://rubystyle.guide
   # Documentation URLs will be constructed using the base URL.
   DocumentationBaseURL: https://docs.rubocop.org/rubocop
+  # Documentation URLs will end with this extension.
+  DocumentationExtension: .html
   # Extra details are not displayed in offense messages by default. Change
   # behavior by overriding ExtraDetails, or by giving the
   # `-E/--extra-details` option.

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -976,6 +976,21 @@ Rails:
   DocumentationBaseURL: https://docs.rubocop.org/rubocop-rails
 ----
 
+By default, documentation is expected to be served as HTML but if you prefer
+to use something else like markdown you can set `DocumentationExtension`.
+
+With markdown as the documentation format you are able to host it directly through
+GitHub without having to own a domain or using GitHub Pages. The `rubocop-sorbet`
+extension is an example of this, its docs are available
+https://github.com/Shopify/rubocop-sorbet/blob/main/manual[here].
+
+[source,yaml]
+----
+Sorbet:
+  DocumentationBaseURL: https://github.com/Shopify/rubocop-sorbet/blob/main/manual
+  DocumentationExtension: .md
+----
+
 == Enable checking Active Support extensions
 
 Some cops for checking specified methods (e.g. `Style/HashExcept`) supports Active Support extensions.

--- a/lib/rubocop/cop/documentation.rb
+++ b/lib/rubocop/cop/documentation.rb
@@ -16,8 +16,9 @@ module RuboCop
         base = department_to_basename(cop_class.department)
         fragment = cop_class.cop_name.downcase.gsub(/[^a-z]/, '')
         base_url = base_url_for(cop_class, config)
+        extension = extension_for(cop_class, config)
 
-        "#{base_url}/#{base}.html##{fragment}" if base_url
+        "#{base_url}/#{base}#{extension}##{fragment}" if base_url
       end
 
       # @api private
@@ -32,8 +33,24 @@ module RuboCop
       end
 
       # @api private
+      def extension_for(cop_class, config)
+        if config
+          department_name = cop_class.department
+          extension = config.for_department(department_name)['DocumentationExtension']
+          return extension if extension
+        end
+
+        default_extension
+      end
+
+      # @api private
       def default_base_url
         'https://docs.rubocop.org/rubocop'
+      end
+
+      # @api private
+      def default_extension
+        '.html'
       end
 
       # @api private

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -90,6 +90,20 @@ RSpec.describe RuboCop::Cop::Cop, :config do
 
         it { is_expected.to eq 'https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsexit' }
       end
+
+      describe 'for a custom cop class with DocumentationExtension', :restore_registry do
+        let(:cop_class) { stub_cop_class('Sorbet::FalseSigil') { def foo; end } }
+        let(:config) do
+          RuboCop::Config.new(
+            'Sorbet' => {
+              'DocumentationBaseURL' => 'https://github.com/Shopify/rubocop-sorbet/blob/main/manual',
+              'DocumentationExtension' => '.md'
+            }
+          )
+        end
+
+        it { is_expected.to eq 'https://github.com/Shopify/rubocop-sorbet/blob/main/manual/cops_sorbet.md#sorbetfalsesigil' }
+      end
     end
   end
 


### PR DESCRIPTION
The `rubocop-sorbet` extension hosts its documentation on GitHub in markdown format. This allows this extension to also benefit from providing documentation urls through RuboCop. It follows all the conventions that rubocop expects here, except for the file extension. GitHub doesn't render html files inline (for obvious reasons).

Documentation is available here as md: https://github.com/Shopify/rubocop-sorbet/blob/main/manual/cops_sorbet.md

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
