### PR TITLE
Fix a false positive for `Style/ZeroLengthPredicate` when using safe navigation and non-zero comparison

### DIFF
--- a/changelog/fix_false_positive_zero_length_predicate.md
+++ b/changelog/fix_false_positive_zero_length_predicate.md
@@ -1,0 +1,1 @@
+* [#13081](https://github.com/rubocop/rubocop/pull/13081): Fix a false positive for `Style/ZeroLengthPredicate` when using safe navigation and non-zero comparison. ([@fatkodima][])

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -47,7 +47,11 @@ module RuboCop
           check_zero_length_comparison(node)
           check_nonzero_length_comparison(node)
         end
-        alias on_csend on_send
+
+        def on_csend(node)
+          check_zero_length_predicate(node)
+          check_zero_length_comparison(node)
+        end
 
         private
 

--- a/spec/rubocop/cop/style/zero_length_predicate_spec.rb
+++ b/spec/rubocop/cop/style/zero_length_predicate_spec.rb
@@ -178,14 +178,9 @@ RSpec.describe RuboCop::Cop::Style::ZeroLengthPredicate, :config do
       RUBY
     end
 
-    it 'registers an offense for `array&.length > 0`' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense for `array&.length > 0`' do
+      expect_no_offenses(<<~RUBY)
         [1, 2, 3]&.length > 0
-        ^^^^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `length > 0`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        ![1, 2, 3]&.empty?
       RUBY
     end
 


### PR DESCRIPTION
Follow up to #13009.

Currently, the cop suggests changing `foo&.size&.>(0)` to `!foo&.empty?`. But this is not correct, because when `foo` is `nil`, original version returned `nil`, while the new version now returns `true` 😱 Imagine using this in a condition.