### PR TITLE
Fix false positive for `Style/GlobalStdStream` for namespaced constants

### DIFF
--- a/changelog/fix_false_positive_for_style_global_std_stream.md
+++ b/changelog/fix_false_positive_for_style_global_std_stream.md
@@ -1,0 +1,1 @@
+* [#13083](https://github.com/rubocop/rubocop/pull/13083): Fix a false positive for `Style/GlobalStdStream` when using namespaced constants like `Foo::STDOUT`. ([@earlopain][])

--- a/lib/rubocop/cop/style/global_std_stream.rb
+++ b/lib/rubocop/cop/style/global_std_stream.rb
@@ -44,7 +44,9 @@ module RuboCop
         PATTERN
 
         def on_const(node)
-          const_name = node.children[1]
+          return if namespaced?(node)
+
+          const_name = node.short_name
           return unless STD_STREAMS.include?(const_name)
 
           gvar_name = gvar_name(const_name).to_sym
@@ -59,6 +61,10 @@ module RuboCop
 
         def message(const_name)
           format(MSG, gvar_name: gvar_name(const_name), const_name: const_name)
+        end
+
+        def namespaced?(node)
+          !node.namespace.nil? && (node.relative? || !node.namespace.cbase_type?)
         end
 
         def gvar_name(const_name)

--- a/spec/rubocop/cop/style/global_std_stream_spec.rb
+++ b/spec/rubocop/cop/style/global_std_stream_spec.rb
@@ -26,6 +26,17 @@ RSpec.describe RuboCop::Cop::Style::GlobalStdStream, :config do
     RUBY
   end
 
+  it 'registers an offense when using redundant constant base' do
+    expect_offense(<<~RUBY)
+      ::STDOUT.puts('hello')
+      ^^^^^^^^ Use `$stdout` instead of `STDOUT`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      $stdout.puts('hello')
+    RUBY
+  end
+
   it 'does not register an offense when using non std stream const' do
     expect_no_offenses(<<~RUBY)
       SOME_CONST.puts('hello')
@@ -41,6 +52,16 @@ RSpec.describe RuboCop::Cop::Style::GlobalStdStream, :config do
   it 'does not register an offense when assigning other const to std stream gvar' do
     expect_no_offenses(<<~RUBY)
       $stdin = SOME_CONST
+    RUBY
+  end
+
+  it 'does not register an offense when using namespaced constant' do
+    expect_no_offenses(<<~RUBY)
+      Foo::STDOUT.puts('hello')
+      Foo::Bar::STDOUT.puts('hello')
+      ::Foo::STDOUT.puts('hello')
+      ::Foo::BaR::STDOUT.puts('hello')
+      foo::STDOUT.puts('hello')
     RUBY
   end
 end


### PR DESCRIPTION
I also added a test for redundant constant base since that currently works and I almost accidentally broke that.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
