### PR TITLE
[Fix #13085] Fix a false positive for `Style/EmptyElse`

### DIFF
--- a/changelog/fix_false_positive_for_style_empty_else.md
+++ b/changelog/fix_false_positive_for_style_empty_else.md
@@ -1,0 +1,1 @@
+* [#13085](https://github.com/rubocop/rubocop/issues/13085): Fix a false positive for `Style/EmptyElse` when a comment-only `else` is used after `elsif` and `AllowComments: true` is set. ([@koic][])

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -143,7 +143,7 @@ module RuboCop
         private
 
         def check(node)
-          return if cop_config['AllowComments'] && comment_in_else?(node.loc)
+          return if cop_config['AllowComments'] && comment_in_else?(node)
 
           empty_check(node) if empty_style?
           nil_check(node) if nil_style?
@@ -171,16 +171,16 @@ module RuboCop
 
         def autocorrect(corrector, node)
           return false if autocorrect_forbidden?(node.type.to_s)
-          return false if comment_in_else?(node.loc)
+          return false if comment_in_else?(node)
 
           end_pos = base_node(node).loc.end.begin_pos
           corrector.remove(range_between(node.loc.else.begin_pos, end_pos))
         end
 
-        def comment_in_else?(loc)
-          return false if loc.else.nil? || loc.end.nil?
+        def comment_in_else?(node)
+          node = node.parent while node.if_type? && node.elsif?
 
-          processed_source.contains_comment?(loc.else.join(loc.end))
+          processed_source.contains_comment?(node.loc.else.join(node.source_range.end))
         end
 
         def base_node(node)

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -553,7 +553,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
         end
       end
 
-      context 'with not comment and nil else-clause' do
+      context 'with no comment and nil else-clause' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             if condition
@@ -589,10 +589,67 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
           RUBY
         end
       end
+
+      context 'with no comment and empty else-clause after `elsif`' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            if condition
+              foo
+            elsif condition2
+              bar
+            else
+            ^^^^ Redundant `else`-clause.
+            end
+          RUBY
+        end
+      end
+
+      context 'with no comment and nil else-clause after `elsif`' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            if condition
+              foo
+            elsif condition2
+              bar
+            else
+            ^^^^ Redundant `else`-clause.
+              nil
+            end
+          RUBY
+        end
+      end
+
+      context 'with comment and empty else-clause after `elsif`' do
+        it "doesn't register an offense" do
+          expect_no_offenses(<<~RUBY)
+            if condition
+              foo
+            elsif condition2
+              bar
+            else
+              # some comment
+            end
+          RUBY
+        end
+      end
+
+      context 'with comment and nil else-clause after `elsif`' do
+        it "doesn't register an offense" do
+          expect_no_offenses(<<~RUBY)
+            if condition
+              foo
+            elsif condition2
+              bar
+            else
+              nil # some comment
+            end
+          RUBY
+        end
+      end
     end
 
     context 'given an unless-statement' do
-      context 'with not comment and empty else-clause' do
+      context 'with no comment and empty else-clause' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             unless condition
@@ -604,7 +661,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
         end
       end
 
-      context 'with not comment and nil else-clause' do
+      context 'with no comment and nil else-clause' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             unless condition
@@ -643,7 +700,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
     end
 
     context 'given a case statement' do
-      context 'with not comment and empty else-clause' do
+      context 'with no comment and empty else-clause' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             case a
@@ -656,7 +713,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
         end
       end
 
-      context 'with not comment and nil else-clause' do
+      context 'with no comment and nil else-clause' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             case a


### PR DESCRIPTION
Fixes #13085.

This PR fixes a false positive for `Style/EmptyElse` when a comment-only `else` is used after `elsif` and `AllowComments: true` is set.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
