### PR TITLE
Fix an incorrect autocorrect for `Style/MultipleComparison` when statement with more comparisons precedes a statement with less comparisons

### DIFF
--- a/changelog/fix_autocorrect_for_style_multiple_comparison.md
+++ b/changelog/fix_autocorrect_for_style_multiple_comparison.md
@@ -1,0 +1,1 @@
+* [#13087](https://github.com/rubocop/rubocop/pull/13087): Fix an incorrect autocorrect for `Style/MultipleComparison` when expression with more comparisons precedes an expression with less comparisons. ([@fatkodima][])

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -56,12 +56,10 @@ module RuboCop
               'in a conditional, use `Array#include?` instead.'
 
         def on_new_investigation
-          @last_comparison = nil
+          reset_comparison
         end
 
         def on_or(node)
-          reset_comparison if switch_comparison?(node)
-
           root_of_or_node = root_of_or_node(node)
 
           return unless node == root_of_or_node
@@ -74,9 +72,9 @@ module RuboCop
             prefer_method = "[#{elements}].include?(#{variables_in_node(node).first})"
 
             corrector.replace(node, prefer_method)
-          end
 
-          @last_comparison = node
+            reset_comparison
+          end
         end
 
         private
@@ -145,12 +143,6 @@ module RuboCop
           else
             or_node
           end
-        end
-
-        def switch_comparison?(node)
-          return true if @last_comparison.nil?
-
-          @last_comparison.descendants.none?(node)
         end
 
         def reset_comparison

--- a/spec/rubocop/cop/style/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/style/multiple_comparison_spec.rb
@@ -116,6 +116,22 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when expression with more comparisons precedes an expression with less comparisons' do
+    expect_offense(<<~RUBY)
+      a = 1
+      a == 1 || a == 2 || a == 3
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+      a == 1 || a == 2
+      ^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a = 1
+      [1, 2, 3].include?(a)
+      [1, 2].include?(a)
+    RUBY
+  end
+
   it 'does not register an offense for comparing multiple literal strings' do
     expect_no_offenses(<<~RUBY)
       if "a" == "a" || "a" == "c"


### PR DESCRIPTION
I caught an edge case for `Style/MultipleComparison` cop, when we have an expression with more comparisons that is followed by an expression with less comparisons.

```ruby
x = 1
x == 1 || x == 2 || x == 3  # <=== more comparisons
x == 1 || x == 2            # <=== less comparisons
```

Is corrected to
```ruby
x = 1
[1, 2, 3].include?(x)
[1, 2, 3, 1, 2, 3, 1, 2].include?(x)
```

But should be
```ruby
x = 1
[1, 2, 3].include?(x)
[1, 2].include?(x)
```