### PR TITLE
Tweak an exception message of `RSpec.shared_context` for development

### DIFF
--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -86,9 +86,9 @@ RSpec.shared_context 'config' do # rubocop:disable Metrics/BlockLength
 
   let(:cop_class) do
     unless described_class.is_a?(Class) && described_class < RuboCop::Cop::Base
-      raise 'Specify which cop class to use (e.g `let(:cop_class) { RuboCop::Cop::Base }`, ' \
-            'or RuboCop::Cop::Cop for legacy)'
+      raise 'Specify which cop class to use (e.g `let(:cop_class) { RuboCop::Cop::Base }`)'
     end
+
     described_class
   end
 


### PR DESCRIPTION
`RuboCop::Cop::Cop` is already deprecated:
https://github.com/rubocop/rubocop/blob/v1.65.1/lib/rubocop/cop/cop.rb#L8-L10

It should not be recommended in exception message.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
