### PR TITLE
Require RuboCop AST 1.32.0+ to use `RuboCop::AST::RationalNode`

### DIFF
--- a/changelog/change_require_rubocop_ast_1_32_0_to_use_rubocop_ast_rational_api.md
+++ b/changelog/change_require_rubocop_ast_1_32_0_to_use_rubocop_ast_rational_api.md
@@ -1,0 +1,1 @@
+* [#13090](https://github.com/rubocop/rubocop/pull/13090): Require RuboCop AST 1.32.0+ to use `RuboCop::AST::RationalNode`. ([@koic][])

--- a/lib/rubocop/cop/lint/float_comparison.rb
+++ b/lib/rubocop/cop/lint/float_comparison.rb
@@ -66,9 +66,7 @@ module RuboCop
         end
 
         def literal_zero?(node)
-          # TODO: https://github.com/rubocop/rubocop-ast/pull/304 is released,
-          # replace this condition with `node&.numeric_type? && node.value.zero?`.
-          node&.numeric_type? && node.node_parts[0].zero?
+          node&.numeric_type? && node.value.zero?
         end
 
         # rubocop:disable Metrics/PerceivedComplexity

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.4', '< 3.0')
   s.add_dependency('rexml', '>= 3.2.5', '< 4.0')
-  s.add_dependency('rubocop-ast', '>= 1.31.1', '< 2.0')
+  s.add_dependency('rubocop-ast', '>= 1.32.0', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 3.0')
 end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-ast/pull/304

This PR requires RuboCop AST 1.32.0+ to use `RuboCop::AST::RationalNode` instead of workaround logic.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
