### PR TITLE
Fix an incorrect autocorrect for `Layout/EmptyLineBetweenDefs`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_empty_line_between_defs.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_empty_line_between_defs.md
@@ -1,0 +1,1 @@
+* [#13092](https://github.com/rubocop/rubocop/pull/13092): Fix an incorrect autocorrect for `Layout/EmptyLineBetweenDefs` when two method definitions are on the same line separated by a semicolon. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/layout/empty_line_between_defs.rb
@@ -149,7 +149,8 @@ module RuboCop
           newline_pos = source_buffer.source.index("\n", end_pos)
 
           # Handle the case when multiple one-liners are on the same line.
-          newline_pos = end_pos + 1 if newline_pos > node.source_range.begin_pos
+          begin_pos = node.source_range.begin_pos
+          newline_pos = begin_pos - 1 if newline_pos > begin_pos
 
           if count > maximum_empty_lines
             autocorrect_remove_lines(corrector, newline_pos, count)

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -225,6 +225,23 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     RUBY
   end
 
+  it 'registers an offense when two method definitions are on the same line separated by a semicolon' do
+    expect_offense(<<~RUBY)
+      def a
+      end;def b
+          ^^^^^ Expected 1 empty line between method definitions; found 0.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def a
+      end;
+
+      def b
+      end
+    RUBY
+  end
+
   it 'autocorrects when there are too many new lines' do
     expect_offense(<<~RUBY)
       def a; end


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for `Layout/EmptyLineBetweenDefs` when two method definitions are on the same line separated by a semicolon:

```console
$ cat example.rb
def a
end;def b
end

$ bundle exec rubocop --only Layout/EmptyLineBetweenDefs -a
```

## Before

It results in an autocorrection of the syntax error:

```ruby
def a
end;d
ef b
end
```

## After

No syntax errors:

```ruby
def a
end;

def b
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
