### PR TITLE
[Fix #13093] Fix an error for `Lint/ImplicitStringConcatenation`

### DIFF
--- a/changelog/fix_an_error_for_lint_implicit_string_concatenation.md
+++ b/changelog/fix_an_error_for_lint_implicit_string_concatenation.md
@@ -1,0 +1,1 @@
+* [#13093](https://github.com/rubocop/rubocop/issues/13093): Fix an error for `Lint/ImplicitStringConcatenation` when implicitly concatenating a string literal with a line break and string interpolation. ([@koic][])

--- a/lib/rubocop/cop/lint/implicit_string_concatenation.rb
+++ b/lib/rubocop/cop/lint/implicit_string_concatenation.rb
@@ -92,6 +92,8 @@ module RuboCop
         end
 
         def str_content(node)
+          return unless node.respond_to?(:str_type?)
+
           if node.str_type?
             node.children[0]
           else

--- a/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
+++ b/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
@@ -47,6 +47,21 @@ RSpec.describe RuboCop::Cop::Lint::ImplicitStringConcatenation, :config do
     end
   end
 
+  context 'when implicitly concatenating a string literal with a line break and string interpolation' do
+    it 'registers an offense' do
+      expect_offense(<<~'RUBY')
+        'single-quoted string'"string
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Combine 'single-quoted string' and "string\n" into a single string literal, rather than using implicit string concatenation.
+        #{interpolation}"
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        'single-quoted string' + "string
+        #{interpolation}"
+      RUBY
+    end
+  end
+
   context 'when the string literals contain newlines' do
     it 'registers an offense' do
       expect_offense(<<~'RUBY')


### PR DESCRIPTION
Fixes #13093.

This PR fixes an error for `Lint/ImplicitStringConcatenation` when implicitly concatenating a string literal with a line break and string interpolation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
