### PR TITLE
[Fix #13098] Fix an error for `Style/IdenticalConditionalBranches`

### DIFF
--- a/changelog/fix_an_error_for_style_identical_conditional_branches.md
+++ b/changelog/fix_an_error_for_style_identical_conditional_branches.md
@@ -1,0 +1,1 @@
+* [#13098](https://github.com/rubocop/rubocop/issues/13098): Fix an error for `Style/IdenticalConditionalBranches` when handling empty case branches. ([@koic][])

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -155,7 +155,7 @@ module RuboCop
           condition_variable = assignable_condition_value(node)
 
           head = heads.first
-          if head.assignment?
+          if head.respond_to?(:assignment?) && head.assignment?
             # The `send` node is used instead of the `indexasgn` node, so `name` cannot be used.
             # https://github.com/rubocop/rubocop-ast/blob/v1.29.0/lib/rubocop/ast/node/indexasgn_node.rb
             #

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -405,6 +405,40 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
     end
   end
 
+  context 'on case with identical leading lines when handling nil case branches' do
+    it 'registers and corrects an offense' do
+      expect_no_offenses(<<~RUBY)
+        case something
+        when :a
+          nil
+        when :b
+          do_x
+          x1
+        else
+          do_x
+          x2
+        end
+      RUBY
+    end
+  end
+
+  context 'on case with identical leading lines when handling empty case branches' do
+    it 'registers and corrects an offense' do
+      expect_no_offenses(<<~RUBY)
+        case something
+        when :a
+          ()
+        when :b
+          do_x
+          x1
+        else
+          do_x
+          x2
+        end
+      RUBY
+    end
+  end
+
   context 'on case with identical leading lines, single child branch and last node of the parent' do
     it "doesn't register an offense" do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #13098.

This PR fixes an error for `Style/IdenticalConditionalBranches` when handling empty case branches.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
