### PR TITLE
[Fix #13097] Fix an error for `Style/InPatternThen`

### DIFF
--- a/changelog/fix_an_error_for_style_in_pattern_then.md
+++ b/changelog/fix_an_error_for_style_in_pattern_then.md
@@ -1,0 +1,1 @@
+* [#13097](https://github.com/rubocop/rubocop/issues/13097): Fix an error for `Style/InPatternThen` when using alternative pattern matching deeply. ([@koic][])

--- a/lib/rubocop/cop/style/in_pattern_then.rb
+++ b/lib/rubocop/cop/style/in_pattern_then.rb
@@ -44,11 +44,15 @@ module RuboCop
         private
 
         def alternative_pattern_source(pattern)
+          collect_alternative_patterns(pattern).join(' | ')
+        end
+
+        def collect_alternative_patterns(pattern)
           return pattern.children.map(&:source) unless pattern.children.first.match_alt_type?
 
-          pattern_sources = alternative_pattern_source(pattern.children.first)
+          pattern_sources = collect_alternative_patterns(pattern.children.first)
 
-          (pattern_sources << pattern.children[1].source).join(' | ')
+          pattern_sources << pattern.children[1].source
         end
       end
     end

--- a/spec/rubocop/cop/style/in_pattern_then_spec.rb
+++ b/spec/rubocop/cop/style/in_pattern_then_spec.rb
@@ -47,6 +47,21 @@ RSpec.describe RuboCop::Cop::Style::InPatternThen, :config do
       RUBY
     end
 
+    it 'registers an offense for `in b | c | d | e;` (alternative pattern)' do
+      expect_offense(<<~RUBY)
+        case a
+        in b | c | d | e; f
+                        ^ Do not use `in b | c | d | e;`. Use `in b | c | d | e then` instead.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        case a
+        in b | c | d | e then f
+        end
+      RUBY
+    end
+
     it 'registers an offense for `in b, c | d;`' do
       expect_offense(<<~RUBY)
         case a


### PR DESCRIPTION
Fixes #13097.

This PR fixes an error for `Style/InPatternThen` when using alternative pattern matching deeply.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
