### PR TITLE
[Fix #13099] Make `Style/RedundantRegexpArgument` respect the `EnforcedStyle` of `Style/StringLiterals`

### DIFF
--- a/changelog/change_make_style_redundant_regexp_argument_respect_enforced_style_of_style_string_literals.md
+++ b/changelog/change_make_style_redundant_regexp_argument_respect_enforced_style_of_style_string_literals.md
@@ -1,0 +1,1 @@
+* [#13099](https://github.com/rubocop/rubocop/issues/13099): Make `Style/RedundantRegexpArgument` respect the `EnforcedStyle` of `Style/StringLiterals`. ([@koic][])

--- a/lib/rubocop/cop/mixin/string_literals_help.rb
+++ b/lib/rubocop/cop/mixin/string_literals_help.rb
@@ -16,6 +16,18 @@ module RuboCop
           !/" | \\[^'\\] | \#[@{$]/x.match?(src)
         end
       end
+
+      def preferred_string_literal
+        enforce_double_quotes? ? '""' : "''"
+      end
+
+      def enforce_double_quotes?
+        string_literals_config['EnforcedStyle'] == 'double_quotes'
+      end
+
+      def string_literals_config
+        config.for_cop('Style/StringLiterals')
+      end
     end
   end
 end

--- a/lib/rubocop/cop/style/empty_heredoc.rb
+++ b/lib/rubocop/cop/style/empty_heredoc.rb
@@ -36,6 +36,7 @@ module RuboCop
       class EmptyHeredoc < Base
         include Heredoc
         include RangeHelp
+        include StringLiteralsHelp
         extend AutoCorrector
 
         MSG = 'Use an empty string literal instead of heredoc.'
@@ -52,20 +53,6 @@ module RuboCop
             corrector.remove(range_by_whole_lines(heredoc_body, include_final_newline: true))
             corrector.remove(range_by_whole_lines(heredoc_end, include_final_newline: true))
           end
-        end
-
-        private
-
-        def preferred_string_literal
-          enforce_double_quotes? ? '""' : "''"
-        end
-
-        def enforce_double_quotes?
-          string_literals_config['EnforcedStyle'] == 'double_quotes'
-        end
-
-        def string_literals_config
-          config.for_cop('Style/StringLiterals')
         end
       end
     end

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -19,6 +19,7 @@ module RuboCop
       class EmptyLiteral < Base
         include FrozenStringLiteral
         include RangeHelp
+        include StringLiteralsHelp
         extend AutoCorrector
 
         ARR_MSG = 'Use array literal `[]` instead of `Array.new`.'
@@ -65,18 +66,6 @@ module RuboCop
           elsif str_node(node) && !frozen_strings?
             format(STR_MSG, prefer: preferred_string_literal)
           end
-        end
-
-        def preferred_string_literal
-          enforce_double_quotes? ? '""' : "''"
-        end
-
-        def enforce_double_quotes?
-          string_literals_config['EnforcedStyle'] == 'double_quotes'
-        end
-
-        def string_literals_config
-          config.for_cop('Style/StringLiterals')
         end
 
         def first_argument_unparenthesized?(node)

--- a/lib/rubocop/cop/style/quoted_symbols.rb
+++ b/lib/rubocop/cop/style/quoted_symbols.rb
@@ -98,8 +98,6 @@ module RuboCop
 
         def style
           return super unless super == :same_as_string_literals
-
-          string_literals_config = config.for_cop('Style/StringLiterals')
           return :single_quotes unless string_literals_config['Enabled']
 
           string_literals_config['EnforcedStyle'].to_sym

--- a/lib/rubocop/cop/style/redundant_regexp_argument.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_argument.rb
@@ -33,6 +33,7 @@ module RuboCop
       #   'foo'.sub('f', 'x')
       #   'foo'.sub!('f', 'x')
       class RedundantRegexpArgument < Base
+        include StringLiteralsHelp
         extend AutoCorrector
 
         MSG = 'Use string `%<prefer>s` as argument instead of regexp `%<current>s`.'
@@ -71,8 +72,10 @@ module RuboCop
           if new_argument.include?('"')
             new_argument.gsub!("'", "\\\\'")
             quote = "'"
-          else
+          elsif new_argument.include?('\\')
             quote = '"'
+          else
+            quote = enforce_double_quotes? ? '"' : "'"
           end
 
           "#{quote}#{new_argument}#{quote}"

--- a/spec/fixtures/html_formatter/expected.html
+++ b/spec/fixtures/html_formatter/expected.html
@@ -647,7 +647,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
             <div class="meta">
               <span class="location">Line #4</span> –
               <span class="severity convention">convention:</span>
-              <span class="message">Style/RedundantRegexpArgument: Use string <code>&quot;&amp;amp;&amp;lt;&quot;</code> as argument instead of regexp <code>/&amp;amp;&amp;lt;/</code>.</span>
+              <span class="message">Style/RedundantRegexpArgument: Use string <code>&#39;&amp;amp;&amp;lt;&#39;</code> as argument instead of regexp <code>/&amp;amp;&amp;lt;/</code>.</span>
             </div>
 
             <pre><code>    qux(quux.scan(<span class="highlight convention">/&amp;amp;&amp;lt;/</span>))</code></pre>

--- a/spec/rubocop/cop/style/redundant_regexp_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_argument_spec.rb
@@ -5,22 +5,22 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpArgument, :config do
     it "registers an offense and corrects when the method is `#{method}`" do
       expect_offense(<<~RUBY, method: method)
         'foo'.#{method}(/f/)
-              _{method} ^^^ Use string `"f"` as argument instead of regexp `/f/`.
+              _{method} ^^^ Use string `'f'` as argument instead of regexp `/f/`.
       RUBY
 
       expect_correction(<<~RUBY)
-        'foo'.#{method}("f")
+        'foo'.#{method}('f')
       RUBY
     end
 
     it "registers an offense and corrects when the method with safe navigation operator is `#{method}`" do
       expect_offense(<<~RUBY, method: method)
         'foo'&.#{method}(/f/)
-               _{method} ^^^ Use string `"f"` as argument instead of regexp `/f/`.
+               _{method} ^^^ Use string `'f'` as argument instead of regexp `/f/`.
       RUBY
 
       expect_correction(<<~RUBY)
-        'foo'&.#{method}("f")
+        'foo'&.#{method}('f')
       RUBY
     end
   end
@@ -61,11 +61,11 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpArgument, :config do
   it 'registers an offense and corrects when using escaping characters' do
     expect_offense(<<~'RUBY')
       'a,b,c'.split(/\./)
-                    ^^^^ Use string `"."` as argument instead of regexp `/\./`.
+                    ^^^^ Use string `'.'` as argument instead of regexp `/\./`.
     RUBY
 
     expect_correction(<<~RUBY)
-      'a,b,c'.split(".")
+      'a,b,c'.split('.')
     RUBY
   end
 
@@ -127,11 +127,11 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpArgument, :config do
   it 'registers an offense and corrects when using two or more spaces regexp' do
     expect_offense(<<~RUBY)
       'foo         bar'.split(/  /)
-                              ^^^^ Use string `"  "` as argument instead of regexp `/  /`.
+                              ^^^^ Use string `'  '` as argument instead of regexp `/  /`.
     RUBY
 
     expect_correction(<<~RUBY)
-      'foo         bar'.split("  ")
+      'foo         bar'.split('  ')
     RUBY
   end
 
@@ -167,5 +167,46 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpArgument, :config do
     expect_no_offenses(<<~RUBY)
       'foo         bar'.split(/ /)
     RUBY
+  end
+
+  context 'when `Style/StringLiterals` is configured with `single_quotes`' do
+    let(:other_cops) { { 'Style/StringLiterals' => { 'EnforcedStyle' => 'single_quotes' } } }
+
+    it 'registers an offense and corrects to single quoted string when using non-backquoted regexp' do
+      expect_offense(<<~RUBY)
+        'foo'.split(/f/)
+                    ^^^ Use string `'f'` as argument instead of regexp `/f/`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        'foo'.split('f')
+      RUBY
+    end
+
+    it 'registers an offense and corrects to double quoted string when using backquoted regexp' do
+      expect_offense(<<~'RUBY')
+        'foo'.split(/\n/)
+                    ^^^^ Use string `"\n"` as argument instead of regexp `/\n/`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        'foo'.split("\n")
+      RUBY
+    end
+  end
+
+  context 'when `Style/StringLiterals` is configured with `double_quotes`' do
+    let(:other_cops) { { 'Style/StringLiterals' => { 'EnforcedStyle' => 'double_quotes' } } }
+
+    it 'registers an offense and corrects to double quoted string when using non-backquoted regexp' do
+      expect_offense(<<~RUBY)
+        'foo'.split(/f/)
+                    ^^^ Use string `"f"` as argument instead of regexp `/f/`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        'foo'.split("f")
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fixes #13099.

This PR makes `Style/RedundantRegexpArgument` respect the `EnforcedStyle` of `Style/StringLiterals`. Also, combine the way to get the `EnforcedStyle` from `Style/StringLiterals` into `StringLiteralHelp`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
