### PR TITLE
[Fix #13105] Fix false positives for `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/fix_false_positives_for_style_arguments_forwarding.md
+++ b/changelog/fix_false_positives_for_style_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#13105](https://github.com/rubocop/rubocop/issues/13105): Fix false positives for `Style/ArgumentsForwarding` when forwarding kwargs/block arg with non-matching additional args. ([@koic][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -334,13 +334,18 @@ module RuboCop
           end
         end
 
+        # rubocop:disable Metrics/AbcSize
         def arguments_range(node, first_node)
-          arguments = node.arguments.reject { |arg| ADDITIONAL_ARG_TYPES.include?(arg.type) }
+          arguments = node.arguments.reject do |arg|
+            next true if ADDITIONAL_ARG_TYPES.include?(arg.type) || arg.variable? || arg.call_type?
+
+            arg.literal? && arg.each_descendant(:kwsplat).none?
+          end
 
           start_node = first_node || arguments.first
-
-          range_between(start_node.source_range.begin_pos, arguments.last.source_range.end_pos)
+          start_node.source_range.begin.join(arguments.last.source_range.end)
         end
+        # rubocop:enable Metrics/AbcSize
 
         def allow_only_rest_arguments?
           cop_config.fetch('AllowOnlyRestArgument', true)

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -1012,6 +1012,22 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
+    it 'registers an offense when forwarding kwargs/block arg with non-matching additional args', unsupported_on: :prism do
+      expect_offense(<<~RUBY)
+        def foo(**kwargs, &block)
+                ^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+          bar(baz, 'qux', quux&.corge, @grault, 42, **kwargs, &block)
+                                                    ^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(...)
+          bar(baz, 'qux', quux&.corge, @grault, 42, ...)
+        end
+      RUBY
+    end
+
     context 'AllowOnlyRestArgument: false' do
       let(:cop_config) { { 'AllowOnlyRestArgument' => false } }
 


### PR DESCRIPTION
Fixes #13105.

This PR fixes false positives for `Style/ArgumentsForwarding` when forwarding kwargs/block arg with non-matching additional args.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
