### PR TITLE
[Fix #13107] Fix an error for `Lint/ImplicitStringConcatenation`

### DIFF
--- a/changelog/fix_error_for_lint_implicit_string_concatenation.md
+++ b/changelog/fix_error_for_lint_implicit_string_concatenation.md
@@ -1,0 +1,1 @@
+* [#13107](https://github.com/rubocop/rubocop/issues/13107): Fix an error for `Lint/ImplicitStringConcatenation` when there are multiple adjacent string interpolation literals on the same line. ([@koic][])

--- a/lib/rubocop/cop/lint/implicit_string_concatenation.rb
+++ b/lib/rubocop/cop/lint/implicit_string_concatenation.rb
@@ -40,9 +40,9 @@ module RuboCop
             end
 
             add_offense(range, message: message) do |corrector|
-              preferred  = "#{lhs_node.source} + #{rhs_node.source}"
+              range = lhs_node.source_range.end.join(rhs_node.source_range.begin)
 
-              corrector.replace(range, preferred)
+              corrector.replace(range, ' + ')
             end
           end
         end

--- a/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
+++ b/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
@@ -36,6 +36,20 @@ RSpec.describe RuboCop::Cop::Lint::ImplicitStringConcatenation, :config do
     end
   end
 
+  context 'on adjacent string interpolation literals on the same line with multiple concatenations' do
+    it 'registers an offense' do
+      expect_offense(<<~'RUBY')
+        "foo""string#{interpolation}""bar"
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Combine "string#{interpolation}" and "bar" into a single string literal, rather than using implicit string concatenation.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Combine "foo" and "string#{interpolation}" into a single string literal, rather than using implicit string concatenation.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "foo" + "string#{interpolation}" + "bar"
+      RUBY
+    end
+  end
+
   context 'on adjacent string literals on different lines' do
     it 'does not register an offense' do
       expect_no_offenses(<<~'RUBY')


### PR DESCRIPTION
Fixes #13107.

This PR fixes an error for `Lint/ImplicitStringConcatenation` when there are multiple adjacent string interpolation literals on the same line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
