### PR TITLE
Fix an error for the `Lockfile` parser when it contains incompatible `BUNDLED WITH` versions

### DIFF
--- a/changelog/fix_lockfile_parser_with_old_bundler.md
+++ b/changelog/fix_lockfile_parser_with_old_bundler.md
@@ -1,0 +1,1 @@
+* [#13109](https://github.com/rubocop/rubocop/pull/13109): Fix an error for the `Lockfile` parser when it contains incompatible `BUNDLED WITH` versions. ([@earlopain][])

--- a/lib/rubocop/lockfile.rb
+++ b/lib/rubocop/lockfile.rb
@@ -16,7 +16,7 @@ module RuboCop
     # @param [String, Pathname, nil] lockfile_path
     def initialize(lockfile_path = nil)
       lockfile_path ||= begin
-        ::Bundler.default_lockfile if bundler_lock_parser_defined?
+        ::Bundler.default_lockfile if use_bundler_lock_parser?
       rescue ::Bundler::GemfileNotFound
         nil # We might not be a folder with a Gemfile, but that's okay.
       end
@@ -72,7 +72,7 @@ module RuboCop
     def parser
       return @parser if defined?(@parser)
 
-      @parser = if @lockfile_path && File.exist?(@lockfile_path) && bundler_lock_parser_defined?
+      @parser = if @lockfile_path && File.exist?(@lockfile_path) && use_bundler_lock_parser?
                   begin
                     lockfile = ::Bundler.read_file(@lockfile_path)
                     ::Bundler::LockfileParser.new(lockfile) if lockfile
@@ -82,8 +82,10 @@ module RuboCop
                 end
     end
 
-    def bundler_lock_parser_defined?
-      Object.const_defined?(:Bundler) && Bundler.const_defined?(:LockfileParser)
+    def use_bundler_lock_parser?
+      return false unless Object.const_defined?(:Bundler)
+
+      Bundler.const_defined?(:LockfileParser) && Bundler::VERSION >= '2.0'
     end
   end
 end


### PR DESCRIPTION
I recently found myself running rubocop against a folder with a lockfile generated with bundler v1. Bundler automatically loads the bundler version that is contained in the gemfile, even if locally you may have something more modern.

Bundler changed something between v1 and v2. In v1 `parser.dependencies` it used to return an array. Simply don't use the parser then, v2 is already 5 years old.

<details><summary>Stacktrace</summary>
<p>

```
undefined method 'values' for an instance of Array
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/lib/rubocop/lockfile.rb:32:in 'RuboCop::Lockfile#dependencies'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/lib/rubocop/cli/command/suggest_extensions.rb:74:in 'RuboCop::CLI::Command::SuggestExtensions#all_extensions'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/lib/rubocop/cli/command/suggest_extensions.rb:96:in 'RuboCop::CLI::Command::SuggestExtensions#not_installed_extensions'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/lib/rubocop/cli/command/suggest_extensions.rb:88:in 'RuboCop::CLI::Command::SuggestExtensions#extensions'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/lib/rubocop/cli/command/suggest_extensions.rb:18:in 'RuboCop::CLI::Command::SuggestExtensions#run'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/lib/rubocop/cli/command.rb:11:in 'RuboCop::CLI::Command.run'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/lib/rubocop/cli/environment.rb:18:in 'RuboCop::CLI::Environment#run'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/lib/rubocop/cli.rb:122:in 'RuboCop::CLI#run_command'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/lib/rubocop/cli.rb:134:in 'RuboCop::CLI#suggest_extensions'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/lib/rubocop/cli.rb:129:in 'block in RuboCop::CLI#execute_runners'
<internal:kernel>:91:in 'Kernel#tap'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/lib/rubocop/cli.rb:129:in 'RuboCop::CLI#execute_runners'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/lib/rubocop/cli.rb:51:in 'block in RuboCop::CLI#run'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/lib/rubocop/cli.rb:81:in 'RuboCop::CLI#profile_if_needed'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/lib/rubocop/cli.rb:43:in 'RuboCop::CLI#run'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/exe/rubocop:19:in 'block in <top (required)>'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/3.4.0+0/benchmark.rb:313:in 'Benchmark.realtime'
/home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/rubocop-1.64.1/exe/rubocop:19:in '<top (required)>'
/home/earlopain/.rbenv/versions/3.4-dev/bin/rubocop:25:in 'Kernel#load'
/home/earlopain/.rbenv/versions/3.4-dev/bin/rubocop:25:in '<main>'
```

</p>
</details> 

I'm not sure how to add worthfile tests for this. I think its fine without.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
