### PR TITLE
Fix an error for `Style/GuardClause` when if clause is empty and correction would not fit on single line

### DIFF
--- a/changelog/fix_error_for_style_guard_clause.md
+++ b/changelog/fix_error_for_style_guard_clause.md
@@ -1,0 +1,1 @@
+* [#13111](https://github.com/rubocop/rubocop/pull/13111): Fix an error for `Style/GuardClause` when if clause is empty and correction would not fit on single line because of `Layout/LineLength`. ([@earlopain][])

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -277,6 +277,8 @@ module RuboCop
         end
 
         def trivial?(node)
+          return false unless node.if_branch
+
           node.branches.one? && !node.if_branch.if_type? && !node.if_branch.begin_type?
         end
 

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -823,6 +823,27 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
           RUBY
         end
       end
+
+      context 'with an empty `if` node and `raise` in else' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            if foo?
+            ^^ Use a guard clause (`unless foo?; raise 'very long and detailed description of the error that makes it too long to fit on one line'; end`) instead of wrapping the code inside a conditional expression.
+            else
+              raise 'very long and detailed description of the error that makes it too long to fit on one line'
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            unless foo?
+              raise 'very long and detailed description of the error that makes it too long to fit on one line'
+            end
+
+             #{trailing_whitespace}
+
+          RUBY
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Erroring snippet:

```rb
if foo?
else
  raise 'very long and detailed description of the error that makes it too long to fit on one line'
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
