### PR TITLE
Fix detection of ruby versions through the gemfile below 2.7

### DIFF
--- a/changelog/fix_ruby_version_detection_gemfile.md
+++ b/changelog/fix_ruby_version_detection_gemfile.md
@@ -1,0 +1,1 @@
+* [#13112](https://github.com/rubocop/rubocop/pull/13112): Fix detection of `TargetRubyVersion` through the gemfile if the gemfile ruby version is below 2.7. ([@earlopain][])

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -80,7 +80,7 @@ module RuboCop
         right_hand_side = version_from_gemspec_file(file)
         return if right_hand_side.nil?
 
-        find_default_minimal_known_ruby(right_hand_side)
+        find_minimal_known_ruby(right_hand_side)
       end
 
       def gemspec_filename
@@ -118,12 +118,14 @@ module RuboCop
         array.children.map(&:value)
       end
 
-      def find_default_minimal_known_ruby(right_hand_side)
+      def find_minimal_known_ruby(right_hand_side)
         version = version_from_right_hand_side(right_hand_side)
+        return unless version
+
         requirement = Gem::Requirement.new(version)
 
         KNOWN_RUBIES.detect do |v|
-          v >= DEFAULT_VERSION && requirement.satisfied_by?(Gem::Version.new("#{v}.99"))
+          requirement.satisfied_by?(Gem::Version.new("#{v}.99"))
         end
       end
     end

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -89,7 +89,18 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           HEREDOC
 
           create_file(gemspec_file_path, content)
-          expect(target_ruby.version).to eq default_version
+          expect(target_ruby.version).to eq 2.3
+        end
+
+        it 'falls back to the minimal supported analysable ruby version' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.required_ruby_version = '>= 1.9.0'
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq 2.0
         end
 
         it 'sets first known ruby version that satisfies requirement' do
@@ -102,7 +113,7 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           HEREDOC
 
           create_file(gemspec_file_path, content)
-          expect(target_ruby.version).to eq default_version
+          expect(target_ruby.version).to eq 2.0
         end
 
         it 'sets first known ruby version that satisfies range requirement' do
@@ -115,7 +126,7 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           HEREDOC
 
           create_file(gemspec_file_path, content)
-          expect(target_ruby.version).to eq default_version
+          expect(target_ruby.version).to eq 2.3
         end
 
         it 'sets first known ruby version that satisfies range requirement in array notation' do
@@ -128,7 +139,7 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           HEREDOC
 
           create_file(gemspec_file_path, content)
-          expect(target_ruby.version).to eq default_version
+          expect(target_ruby.version).to eq 2.3
         end
 
         it 'sets first known ruby version that satisfies range requirement with frozen strings' do
@@ -141,7 +152,7 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           HEREDOC
 
           create_file(gemspec_file_path, content)
-          expect(target_ruby.version).to eq default_version
+          expect(target_ruby.version).to eq 2.3
         end
 
         it 'sets first known ruby version that satisfies range requirement in array notation with frozen strings' do
@@ -154,7 +165,7 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           HEREDOC
 
           create_file(gemspec_file_path, content)
-          expect(target_ruby.version).to eq default_version
+          expect(target_ruby.version).to eq 2.3
         end
       end
 


### PR DESCRIPTION
Some things going on here:

If I have a gemspec saying `target_ruby_version ">= 2.6"`, what RuboCop will actually use is 2.7 because it is the default version. All versions prior are simply discarded, even if rubocop is able to provide accurate results for these older versions.

There were tests for this but I believe that they lost what they actually were testing against during some refactor, somewhere here: #9515, #10629, and the PRs removing and reading analysis for older rubies.

This test for example used to check that the returned ruby version is 2.4 and not 2.3 which it didn't know how to analyse at one point (i.e. don't select versions below what we are currently supporting):

```rb

          it 'sets target_ruby from required_ruby_version from inclusive requirement range' do
            content = <<~HEREDOC
              Gem::Specification.new do |s|
                s.name = 'test'
                s.required_ruby_version = Gem::Requirement.new('>= 2.3.1')
                s.licenses = ['MIT']
              end
            HEREDOC

            create_file(gemspec_file_path, content)
            expect(target_ruby.version).to eq default_version
          end
```

Now it checks that 2.7 is the returned version, which doesn't make much sense since older versions are able to be analysed.

For the `< 3.0.0` case, I think its ok to select the earliest version supported (currently 2.0). Selecting 2.7 (or whatever the default may be in the future) surely isn't the intention.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
