### PR TITLE
Fix an error for `Style/IfWithSemicolon`

### DIFF
--- a/changelog/fix_an_error_for_style_if_with_semicolon.md
+++ b/changelog/fix_an_error_for_style_if_with_semicolon.md
@@ -1,0 +1,1 @@
+* [#13113](https://github.com/rubocop/rubocop/pull/13113): Fix an error for `Style/IfWithSemicolon` when a nested `if` with a semicolon is used. ([@koic][])

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -107,5 +107,23 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
         end
       RUBY
     end
+
+    it 'registers an offense when a nested `if` with a semicolon is used' do
+      expect_offense(<<~RUBY)
+        if cond; run
+        ^^^^^^^^^^^^ Do not use `if cond;` - use a newline instead.
+          if cond; run
+          ^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if cond
+         run
+          cond ? run : nil
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the following error for `Style/IfWithSemicolon` when a nested `if` with a semicolon is used:

```console
$ cat example.rb
if cond; run
  if cond; run
  end
end
```

## Before

The following error occurs:

```console
$ bundle exec rubocop --only Style/IfWithSemicolon -a -d
(snip)

An error occurred while Style/IfWithSemicolon cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/if_with_semicolon/example.rb:2:2.
Parser::Source::TreeRewriter detected clobbering
/Users/koic/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/parser-3.3.3.0/
lib/parser/source/tree_rewriter.rb:427:in `trigger_policy'
```

## After

This autocorrects to the following code without any errors:

```console
$ cat example.rb
if cond
 run
  cond ? run : nil
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
