### PR TITLE
Add a configuration option to NonLocalExitFromIterator to handle return values.

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2114,6 +2114,7 @@ Lint/NonLocalExitFromIterator:
   Description: 'Do not use return in iterator to cause non-local exit.'
   Enabled: true
   VersionAdded: '0.30'
+  AllowReturnValue: true
 
 Lint/NumberConversion:
   Description: 'Checks unsafe usage of number conversion methods.'

--- a/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
+++ b/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
@@ -119,6 +119,22 @@ RSpec.describe RuboCop::Cop::Lint::NonLocalExitFromIterator, :config do
     RUBY
   end
 
+  context 'when AllowReturnValue is set to false' do
+    let(:cop_config) { { 'AllowReturnValue' => false } }
+
+    it 'registers an offense, even when returning a value' do
+      expect_offense(<<~RUBY)
+        def find_first_sold_out_item(items)
+          items.each do |item|
+            return item if item.stock == 0
+            ^^^^^^ Non-local exit from iterator, [...]
+            item.foobar!
+          end
+        end
+      RUBY
+    end
+  end
+
   it 'allows return in define_method' do
     expect_no_offenses(<<~RUBY)
       [:method_one, :method_two].each do |method_name|


### PR DESCRIPTION
Fixes #4064.

This solves a long-standing (August 2017) issue. An explicit `return` in a block has unintuitive behavior where the `yield`-ing code is skipped.

NonLocalExitFromIterator _almost_ catches this error, it just needs a setting to make it more aggressive.

Example of the type of bug I'm trying to catch:

```
def execute_with_block
  result = yield
  puts "The result was #{result}"
  result
end

def handle_thing
  execute_with_block do 
    return 3
  end

foo = handle_thing # foo is 3, but the `puts` line never executes
```

Related: https://github.com/rubocop/rubocop/pull/12971

This is my first PR to Rubocop, so please let me know if I need additional work on this change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
