### PR TITLE
Fix an incorrect autocorrect for `Style/IfWithSemicolon`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_if_with_semicolon.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_if_with_semicolon.md
@@ -1,0 +1,1 @@
+* [#13116](https://github.com/rubocop/rubocop/pull/13116): Fix an incorrect autocorrect for `Style/IfWithSemicolon` when a single-line `if/;/end` has an argument in the then body expression. ([@koic][])

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -55,8 +55,8 @@ module RuboCop
         def replacement(node)
           return correct_elsif(node) if node.else_branch&.if_type?
 
-          then_code = node.if_branch ? node.if_branch.source : 'nil'
-          else_code = node.else_branch ? node.else_branch.source : 'nil'
+          then_code = node.if_branch ? build_expression(node.if_branch) : 'nil'
+          else_code = node.else_branch ? build_expression(node.else_branch) : 'nil'
 
           "#{node.condition.source} ? #{then_code} : #{else_code}"
         end
@@ -69,6 +69,17 @@ module RuboCop
             end
           RUBY
         end
+
+        # rubocop:disable Metrics/AbcSize
+        def build_expression(expr)
+          return expr.source if !expr.call_type? || expr.parenthesized? || expr.arguments.empty?
+
+          method = expr.source_range.begin.join(expr.loc.selector.end)
+          arguments = expr.first_argument.source_range.begin.join(expr.source_range.end)
+
+          "#{method.source}(#{arguments.source})"
+        end
+        # rubocop:enable Metrics/AbcSize
 
         def build_else_branch(second_condition)
           result = <<~RUBY

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -34,6 +34,72 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects a single-line `if/;/end` when the then body contains a parenthesized method call with an argument' do
+    expect_offense(<<~RUBY)
+      if cond;do_something(arg) end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      cond ? do_something(arg) : nil
+    RUBY
+  end
+
+  it 'registers an offense and corrects a single-line `if/;/end` when the then body contains an array literal with an argument' do
+    expect_offense(<<~RUBY)
+      if cond;[] end
+      ^^^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      cond ? [] : nil
+    RUBY
+  end
+
+  it 'registers an offense and corrects a single-line `if/;/end` when the then body contains a method call with an argument' do
+    expect_offense(<<~RUBY)
+      if cond;do_something arg end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      cond ? do_something(arg) : nil
+    RUBY
+  end
+
+  it 'registers an offense and corrects a single-line `if/;/end` when the then body contains a safe navigation method call with an argument' do
+    expect_offense(<<~RUBY)
+      if cond;obj&.do_something arg end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      cond ? obj&.do_something(arg) : nil
+    RUBY
+  end
+
+  it 'registers an offense and corrects a single-line `if/;/else/end` when the then body contains a method call with an argument' do
+    expect_offense(<<~RUBY)
+      if cond;foo foo_arg else bar bar_arg end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      cond ? foo(foo_arg) : bar(bar_arg)
+    RUBY
+  end
+
+  it 'registers an offense and corrects a single-line `if/;/else/end` when the then body contains a safe navigation method call with an argument' do
+    expect_offense(<<~RUBY)
+      if cond;foo obj&.foo_arg else bar obj&.bar_arg end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      cond ? foo(obj&.foo_arg) : bar(obj&.bar_arg)
+    RUBY
+  end
+
   it 'can handle modifier conditionals' do
     expect_no_offenses(<<~RUBY)
       class Hash


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Style/IfWithSemicolon` when a single-line `if/;/end` has an argument in the then body expression:

```ruby
$ cat example.rb
if cond;do_something arg end

$ bundle exec rubocop --only `Style/IfWithSemicolon` -a
```

## Before

It results in an autocorrection of the syntax error:

```ruby
cond ? do_something arg : nil
```

## After

No syntax errors:

```ruby
cond ? do_something(arg) : nil
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
