### PR TITLE
Add partial autocorrect support for `Lint/LiteralAsCondition`

### DIFF
--- a/changelog/change_add_partial_autocorrect_for_lint_literal_as_condition.md
+++ b/changelog/change_add_partial_autocorrect_for_lint_literal_as_condition.md
@@ -1,0 +1,1 @@
+* [#13117](https://github.com/rubocop/rubocop/issues/13117): Add partial autocorrect support to `Lint/LiteralAsCondition` cop to check for redundant conditions. ([@zopolis4][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2046,6 +2046,7 @@ Lint/LambdaWithoutLiteralBlock:
 Lint/LiteralAsCondition:
   Description: 'Checks of literals used in conditions.'
   Enabled: true
+  AutoCorrect: contextual
   VersionAdded: '0.51'
 
 Lint/LiteralAssignmentInCondition:

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1077,9 +1077,9 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       expect($stdout.string)
         .to eq(<<~RESULT)
           == example.rb ==
-          W:  1:  4: Lint/LiteralAsCondition: Literal 0 appeared as a condition.
+          W:  1:  4: [Correctable] Lint/LiteralAsCondition: Literal 0 appeared as a condition.
 
-          1 file inspected, 1 offense detected
+          1 file inspected, 1 offense detected, 1 offense autocorrectable
         RESULT
     end
   end

--- a/spec/rubocop/cop/lint/literal_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_as_condition_spec.rb
@@ -2,48 +2,118 @@
 
 RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
   %w(1 2.0 [1] {} :sym :"#{a}").each do |lit|
-    it "registers an offense for literal #{lit} in if" do
+    it "registers an offense for truthy literal #{lit} in if" do
       expect_offense(<<~RUBY, lit: lit)
         if %{lit}
            ^{lit} Literal `#{lit}` appeared as a condition.
           top
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        top
+      RUBY
     end
 
-    it "registers an offense for literal #{lit} in while" do
+    it "registers an offense for truthy literal #{lit} in modifier if" do
+      expect_offense(<<~RUBY, lit: lit)
+        top if %{lit}
+               ^{lit} Literal `#{lit}` appeared as a condition.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        top
+      RUBY
+    end
+
+    it "registers an offense for truthy literal #{lit} in ternary" do
+      expect_offense(<<~RUBY, lit: lit)
+        %{lit} ? top : bar
+        ^{lit} Literal `#{lit}` appeared as a condition.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        top
+      RUBY
+    end
+
+    it "registers an offense for truthy literal #{lit} in unless" do
+      expect_offense(<<~RUBY, lit: lit)
+        unless %{lit}
+               ^{lit} Literal `#{lit}` appeared as a condition.
+          top
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+
+      RUBY
+    end
+
+    it "registers an offense for truthy literal #{lit} in modifier unless" do
+      expect_offense(<<~RUBY, lit: lit)
+        top unless %{lit}
+                   ^{lit} Literal `#{lit}` appeared as a condition.
+      RUBY
+
+      expect_correction(<<~RUBY)
+
+      RUBY
+    end
+
+    it "registers an offense for truthy literal #{lit} in while" do
       expect_offense(<<~RUBY, lit: lit)
         while %{lit}
               ^{lit} Literal `#{lit}` appeared as a condition.
           top
         end
       RUBY
-    end
 
-    it "registers an offense for literal #{lit} in post-loop while" do
-      expect_offense(<<~RUBY, lit: lit)
-        begin
+      expect_correction(<<~RUBY)
+        while true
           top
-        end while(%{lit})
-                  ^{lit} Literal `#{lit}` appeared as a condition.
+        end
       RUBY
     end
 
-    it "registers an offense for literal #{lit} in until" do
+    it "registers an offense for truthy literal #{lit} in post-loop while" do
+      expect_offense(<<~RUBY, lit: lit)
+        begin
+          top
+        end while %{lit}
+                  ^{lit} Literal `#{lit}` appeared as a condition.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          top
+        end while true
+      RUBY
+    end
+
+    it "registers an offense for truthy literal #{lit} in until" do
       expect_offense(<<~RUBY, lit: lit)
         until %{lit}
               ^{lit} Literal `#{lit}` appeared as a condition.
           top
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+
+      RUBY
     end
 
-    it "registers an offense for literal #{lit} in post-loop until" do
+    it "registers an offense for truthy literal #{lit} in post-loop until" do
       expect_offense(<<~RUBY, lit: lit)
         begin
           top
         end until %{lit}
                   ^{lit} Literal `#{lit}` appeared as a condition.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        top
       RUBY
     end
 
@@ -54,6 +124,8 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
         when x then top
         end
       RUBY
+
+      expect_no_corrections
     end
 
     it "registers an offense for literal #{lit} in a when " \
@@ -64,6 +136,8 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
              ^{lit} Literal `#{lit}` appeared as a condition.
         end
       RUBY
+
+      expect_no_corrections
     end
 
     it "accepts literal #{lit} in a when of a case with something after case keyword" do
@@ -90,6 +164,8 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
           in CONST then top
           end
         RUBY
+
+        expect_no_corrections
       end
 
       it "accepts literal #{lit} in a when of a case match" do
@@ -101,19 +177,31 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
       end
     end
 
-    it "registers an offense for literal #{lit} in &&" do
+    it "registers an offense for truthy literal #{lit} in &&" do
       expect_offense(<<~RUBY, lit: lit)
         if x && %{lit}
                 ^{lit} Literal `#{lit}` appeared as a condition.
           top
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        if x
+          top
+        end
+      RUBY
     end
 
-    it "registers an offense for literal #{lit} in complex cond" do
+    it "registers an offense for truthy literal #{lit} in complex cond" do
       expect_offense(<<~RUBY, lit: lit)
         if x && !(a && %{lit}) && y && z
                        ^{lit} Literal `#{lit}` appeared as a condition.
+          top
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if x && !(a) && y && z
           top
         end
       RUBY
@@ -126,12 +214,20 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
           top
         end
       RUBY
+
+      expect_no_corrections
     end
 
-    it "registers an offense for literal #{lit} in complex !" do
+    it "registers an offense for truthy literal #{lit} in complex !" do
       expect_offense(<<~RUBY, lit: lit)
         if !(x && (y && %{lit}))
                         ^{lit} Literal `#{lit}` appeared as a condition.
+          top
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if !(x && (y))
           top
         end
       RUBY
@@ -158,6 +254,8 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
         !%{lit}
          ^{lit} Literal `#{lit}` appeared as a condition.
       RUBY
+
+      expect_no_corrections
     end
 
     it "registers an offense for `not #{lit}`" do
@@ -165,6 +263,8 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
         not(%{lit})
             ^{lit} Literal `#{lit}` appeared as a condition.
       RUBY
+
+      expect_no_corrections
     end
   end
 
@@ -191,6 +291,8 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
       when [1, 2, 5] then top
       end
     RUBY
+
+    expect_no_corrections
   end
 
   it 'accepts dstr literal in case' do
@@ -225,6 +327,8 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
         in [1, 2, 5] then top
         end
       RUBY
+
+      expect_no_corrections
     end
 
     it 'accepts an offense for case match with a match var' do
@@ -272,6 +376,170 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
     expect_no_offenses(<<~RUBY)
       begin
         break if condition
+      end until false
+    RUBY
+  end
+
+  %w[nil false].each do |lit|
+    it "registers an offense for falsey literal #{lit} in `if`" do
+      expect_offense(<<~RUBY, lit: lit)
+        if %{lit}
+           ^{lit} Literal `#{lit}` appeared as a condition.
+          top
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+
+      RUBY
+    end
+
+    it "registers an offense for falsey literal #{lit} in if-else" do
+      expect_offense(<<~RUBY, lit: lit)
+        if %{lit}
+           ^{lit} Literal `#{lit}` appeared as a condition.
+          top
+        else
+          foo
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo
+      RUBY
+    end
+
+    it "registers an offense for falsey literal #{lit} in if-elsif" do
+      expect_offense(<<~RUBY, lit: lit)
+        if %{lit}
+           ^{lit} Literal `#{lit}` appeared as a condition.
+          top
+        elsif condition
+          foo
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if condition
+          foo
+        end
+      RUBY
+    end
+
+    it "registers an offense for falsey literal #{lit} in modifier `if`" do
+      expect_offense(<<~RUBY, lit: lit)
+        top if %{lit}
+               ^{lit} Literal `#{lit}` appeared as a condition.
+      RUBY
+
+      expect_correction(<<~RUBY)
+
+      RUBY
+    end
+
+    it "registers an offense for falsey literal #{lit} in ternary" do
+      expect_offense(<<~RUBY, lit: lit)
+        %{lit} ? top : bar
+        ^{lit} Literal `#{lit}` appeared as a condition.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        bar
+      RUBY
+    end
+
+    it "registers an offense for falsey literal #{lit} in `unless`" do
+      expect_offense(<<~RUBY, lit: lit)
+        unless %{lit}
+               ^{lit} Literal `#{lit}` appeared as a condition.
+          top
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        top
+      RUBY
+    end
+
+    it "registers an offense for falsey literal #{lit} in modifier `unless`" do
+      expect_offense(<<~RUBY, lit: lit)
+        top unless %{lit}
+                   ^{lit} Literal `#{lit}` appeared as a condition.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        top
+      RUBY
+    end
+
+    it "registers an offense for falsey literal #{lit} in `while`" do
+      expect_offense(<<~RUBY, lit: lit)
+        while %{lit}
+              ^{lit} Literal `#{lit}` appeared as a condition.
+          top
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+
+      RUBY
+    end
+
+    it "registers an offense for falsey literal #{lit} in post-loop `while`" do
+      expect_offense(<<~RUBY, lit: lit)
+        begin
+          top
+        end while %{lit}
+                  ^{lit} Literal `#{lit}` appeared as a condition.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        top
+      RUBY
+    end
+
+    it "registers an offense for falsey literal #{lit} in complex post-loop `while`" do
+      expect_offense(<<~RUBY, lit: lit)
+        begin
+          top
+          foo
+        end while %{lit}
+                  ^{lit} Literal `#{lit}` appeared as a condition.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        top
+        foo
+      RUBY
+    end
+  end
+
+  it 'registers an offense for `nil` literal in `until`' do
+    expect_offense(<<~RUBY)
+      until nil
+            ^^^ Literal `nil` appeared as a condition.
+        top
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      until false
+        top
+      end
+    RUBY
+  end
+
+  it 'registers an offense for `nil` literal in post-loop `until`' do
+    expect_offense(<<~RUBY)
+      begin
+        top
+      end until nil
+                ^^^ Literal `nil` appeared as a condition.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        top
       end until false
     RUBY
   end


### PR DESCRIPTION
Makes progress on #12840.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
