### PR TITLE
[Fix #13118] Fix a false positive for `Style/MapIntoArray` when splatting

### DIFF
--- a/changelog/fix_false_positive_for_style_map_into_array.md
+++ b/changelog/fix_false_positive_for_style_map_into_array.md
@@ -1,0 +1,1 @@
+* [#13118](https://github.com/rubocop/rubocop/issues/13118): Fix a false positive for `Style/MapIntoArray` when splatting. ([@earlopain][])

--- a/lib/rubocop/cop/style/map_into_array.rb
+++ b/lib/rubocop/cop/style/map_into_array.rb
@@ -58,7 +58,7 @@ module RuboCop
           [
             ^({begin kwbegin} ...)
             ({block numblock} (send !{nil? self} :each) _
-              (send (lvar _) {:<< :push :append} _))
+              (send (lvar _) {:<< :push :append} {send lvar begin}))
           ]
         PATTERN
 

--- a/spec/rubocop/cop/style/map_into_array_spec.rb
+++ b/spec/rubocop/cop/style/map_into_array_spec.rb
@@ -208,6 +208,13 @@ RSpec.describe RuboCop::Cop::Style::MapIntoArray, :config do
     RUBY
   end
 
+  it 'does not register an offense when pushing splat' do
+    expect_no_offenses(<<~RUBY)
+      dest = []
+      src.each { |e| dest.push(*e) }
+    RUBY
+  end
+
   context 'new method name for replacement' do
     context 'when `Style/CollectionMethods` is configured for `map`' do
       let(:other_cops) do


### PR DESCRIPTION
Fixes #13118

A proper correction would look something like this:
```rb
b = a.map do |x|
  x
end.flatten
```

which I don't think makes much sense for this cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
