### PR TITLE
Remove duplicated `Cop.qualified_cop_name` tests

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -4,10 +4,8 @@ RSpec.describe 'RuboCop Project', type: :feature do
   let(:cop_names) do
     RuboCop::Cop::Registry
       .global
-      .without_department(:Test)
-      .without_department(:Test2)
       .without_department(:InternalAffairs)
-      .cops
+      .reject { |cop| cop.cop_name.start_with?('Test/') }
       .map(&:cop_name)
   end
 
@@ -291,9 +289,7 @@ RSpec.describe 'RuboCop Project', type: :feature do
       let(:existing_cop_names) do
         RuboCop::Cop::Registry
           .global
-          .without_department(:Test)
-          .without_department(:Test2)
-          .cops
+          .reject { |cop| cop.cop_name.start_with?('Test/') }
           .map(&:cop_name)
       end
 

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -10,40 +10,9 @@ RSpec.describe RuboCop::Cop::Cop, :config do
     expect(cop.offenses).to be_empty
   end
 
-  describe '.qualified_cop_name' do
-    include_context 'mock console output'
-
-    it 'adds namespace if the cop name is found in exactly one namespace' do
-      expect(described_class.qualified_cop_name('LineLength', '--only')).to eq('Layout/LineLength')
-    end
-
-    it 'returns the given cop name if it is not found in any namespace' do
-      expect(described_class.qualified_cop_name('UnknownCop', '--only')).to eq('UnknownCop')
-    end
-
-    it 'returns the given cop name if it already has a namespace' do
-      expect(described_class.qualified_cop_name('Layout/LineLength', '--only'))
-        .to eq('Layout/LineLength')
-    end
-
-    it 'returns the cop name in a different namespace if the provided namespace is incorrect' do
-      expect(described_class.qualified_cop_name('Style/LineLength', '--only'))
-        .to eq('Layout/LineLength')
-    end
-
-    # `Rails/SafeNavigation` was extracted to rubocop-rails gem,
-    # there were no cop whose names overlapped.
-    it 'raises an error if the cop name is in more than one namespace' do
-      expect { described_class.qualified_cop_name('SameNameInMultipleNamespace', '--only') }
-        .to raise_error(RuboCop::Cop::AmbiguousCopName)
-    end
-
-    it 'returns the given cop name if it already has a namespace even when ' \
-       'the cop exists in multiple namespaces' do
-      qualified_cop_name = described_class.qualified_cop_name('Style/SafeNavigation', '--only')
-
-      expect(qualified_cop_name).to eq('Style/SafeNavigation')
-    end
+  it 'qualified_cop_name is deprecated' do
+    expect { described_class.qualified_cop_name('Layout/LineLength', '--only') }
+      .to output(/`Cop.qualified_cop_name` is deprecated/).to_stderr
   end
 
   describe '.documentation_url' do

--- a/spec/support/cops/same_name_in_multiple_namespace.rb
+++ b/spec/support/cops/same_name_in_multiple_namespace.rb
@@ -4,10 +4,14 @@ module RuboCop
   module Cop
     module Test
       class SameNameInMultipleNamespace < RuboCop::Cop::Base; end
-    end
 
-    module Test2
-      class SameNameInMultipleNamespace < RuboCop::Cop::Base; end
+      module Foo
+        class SameNameInMultipleNamespace < RuboCop::Cop::Base; end
+      end
+
+      module Bar
+        class SameNameInMultipleNamespace < RuboCop::Cop::Base; end
+      end
     end
   end
 end


### PR DESCRIPTION
This method is deprecated and just calls through to `Registry.qualified_cop_name`. I've checked that the tests from `cop_spec` are all covered by `registry_spec`. They all are except for the last test which just doesn't make sense right now, the history is lost on me.

Also add a test for an unambiguous case. `rubocop-rspec` and `rubocop-capybara` currently define `RSpec/PredicateMatcher` and `Capybara/RSpec/PredicateMatcher`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
