### PR TITLE
Update `Style/ReturnNilInPredicateMethodDefinition` to recognize implicit `nil` returns in `rescue` and `ensure`

### DIFF
--- a/changelog/change_style_return_nil_in_predicate_method_definition.md
+++ b/changelog/change_style_return_nil_in_predicate_method_definition.md
@@ -1,0 +1,1 @@
+* [#13125](https://github.com/rubocop/rubocop/pull/13125): Update `Style/ReturnNilInPredicateMethodDefinition` to recognize implicit `nil` returns in `rescue` and `ensure`. ([@vlad-pisanov][])

--- a/spec/rubocop/cop/style/return_nil_in_predicate_method_definition_spec.rb
+++ b/spec/rubocop/cop/style/return_nil_in_predicate_method_definition_spec.rb
@@ -74,6 +74,89 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
       RUBY
     end
 
+    it 'registers an offense when using `nil` before `rescue`' do
+      expect_offense(<<~RUBY)
+        def foo?
+          bar
+          nil
+          ^^^ Return `false` instead of `nil` in predicate methods.
+        rescue
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          bar
+          false
+        rescue
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using `nil` before `ensure`' do
+      expect_offense(<<~RUBY)
+        def foo?
+          bar
+          nil
+          ^^^ Return `false` instead of `nil` in predicate methods.
+        ensure
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          bar
+          false
+        ensure
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using `nil` inside `rescue`' do
+      expect_offense(<<~RUBY)
+        def foo?
+        rescue
+          bar
+          nil
+          ^^^ Return `false` instead of `nil` in predicate methods.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+        rescue
+          bar
+          false
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using `nil` in each `rescue` branch' do
+      expect_offense(<<~RUBY)
+        def foo?
+        rescue ArgumentError
+          bar
+          nil
+          ^^^ Return `false` instead of `nil` in predicate methods.
+        rescue
+          bar
+          nil
+          ^^^ Return `false` instead of `nil` in predicate methods.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+        rescue ArgumentError
+          bar
+          false
+        rescue
+          bar
+          false
+        end
+      RUBY
+    end
+
     it 'does not register an offense when using `return true`' do
       expect_no_offenses(<<~RUBY)
         def foo?
@@ -160,6 +243,15 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
         def foo?
           return false unless condition
         rescue
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when `ensure` ends in `nil`' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+        ensure
+          nil
         end
       RUBY
     end


### PR DESCRIPTION
`Style/ReturnNilInPredicateMethodDefinition` already recognizes implicit `nil` returns from predicates:
```ruby
def foo?
  nil # ⚠️ existing offense: Return false instead of nil in predicate methods
end
```

This PR expands implicit `nil` detection to predicates with `rescue` and `ensure` blocks. New cases detected:
```ruby
def foo?
  nil # ⚠️ new offense: Return false instead of nil in predicate methods
rescue
end
```

```ruby
def foo?
  nil # ⚠️ new offense: Return false instead of nil in predicate methods
ensure
end
```

```ruby
def foo?
rescue
  nil # ⚠️ new offense: Return false instead of nil in predicate methods
end
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
