### PR TITLE
[Fix #13126] Fix a false positive for `Style/Alias`

### DIFF
--- a/changelog/fix_false_positive_for_style_alias.md
+++ b/changelog/fix_false_positive_for_style_alias.md
@@ -1,0 +1,1 @@
+* [#13126](https://github.com/rubocop/rubocop/issues/13126): Fix a false positive for `Style/Alias` when using multiple `alias` in `def`. ([@koic][])

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -80,7 +80,7 @@ module RuboCop
         def alias_method_possible?(node)
           scope_type(node) != :instance_eval &&
             node.children.none?(&:gvar_type?) &&
-            node&.parent&.type != :def
+            node.each_ancestor(:def).none?
         end
 
         def add_offense_for_args(node, &block)

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -133,6 +133,15 @@ RSpec.describe RuboCop::Cop::Style::Alias, :config do
       RUBY
     end
 
+    it 'does not register an offense for multiple alias in a def' do
+      expect_no_offenses(<<~RUBY)
+        def foo
+          alias :foo :bar
+          alias :baz :qux
+        end
+      RUBY
+    end
+
     it 'does not register an offense for `alias` with interpolated symbol argument' do
       expect_no_offenses(<<~'RUBY')
         alias :"string#{interpolation}" :symbol


### PR DESCRIPTION
Fixes #13126.

This PR fixes a false positive for `Style/Alias` when using multiple `alias` in `def`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
