### PR TITLE
Fix false negatives in `Lint/Void` when using `ensure`, `defs` and `numblock`

### DIFF
--- a/changelog/fix_false_negative_for_lint_void.md
+++ b/changelog/fix_false_negative_for_lint_void.md
@@ -1,0 +1,1 @@
+* [#13131](https://github.com/rubocop/rubocop/pull/13131): Fix false negatives for `Lint/Void` when using `ensure`, `defs` and `numblock`. ([@vlad-pisanov][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.4', '< 3.0')
   s.add_dependency('rexml', '>= 3.2.5', '< 4.0')
-  s.add_dependency('rubocop-ast', '>= 1.32.0', '< 2.0')
+  s.add_dependency('rubocop-ast', '>= 1.32.1', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 3.0')
 end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -628,6 +628,22 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     RUBY
   end
 
+  it 'registers two offenses for void literals in a class setter method' do
+    expect_offense(<<~RUBY)
+      def self.foo=(rhs)
+        42
+        ^^ Literal `42` used in void context.
+        42
+        ^^ Literal `42` used in void context.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def self.foo=(rhs)
+      end
+    RUBY
+  end
+
   it 'registers two offenses for void literals in a `#each` method' do
     expect_offense(<<~RUBY)
       array.each do |_item|
@@ -701,6 +717,7 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
           _1
           ^^ Variable `_1` used in void context.
           42
+          ^^ Literal `42` used in void context.
         end
       RUBY
 
@@ -709,6 +726,22 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         end
       RUBY
     end
+  end
+
+  it 'registers two offenses for void literals in `#tap` method with a numbered block' do
+    expect_offense(<<~RUBY)
+      foo.tap do
+        _1
+        ^^ Variable `_1` used in void context.
+        42
+        ^^ Literal `42` used in void context.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.tap do
+      end
+    RUBY
   end
 
   it 'accepts empty block' do
@@ -745,6 +778,44 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
 
     expect_correction(<<~RUBY)
       for _item in array do
+      end
+    RUBY
+  end
+
+  it 'registers two offense for void literals in an `ensure`' do
+    expect_offense(<<~RUBY)
+      def foo
+      ensure
+        bar
+        42
+        ^^ Literal `42` used in void context.
+        42
+        ^^ Literal `42` used in void context.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+      ensure
+        bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the body of `ensure` is a literal' do
+    expect_offense(<<~RUBY)
+      def foo
+        bar
+      ensure
+        [1, 2, [3]]
+        ^^^^^^^^^^^ Literal `[1, 2, [3]]` used in void context.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        bar
+      ensure
       end
     RUBY
   end


### PR DESCRIPTION
Improve `Lint/Void` to detect more void contexts:

1. Literals returned from `ensure`: the return value of `ensure` is always discarded. This is a tripping point for many devs including myself (one might easily assume that `ensure` behaves just like `rescue` and that the "ensured" value is returned.)

```ruby
def foo
  bar
ensure
  baz
  42 # ⚠️ new offense: Literal `42` used in void context.
end
```

2. Handle void contexts in class method definitions (`defs`) and numbered parameter blocks (`numblock`):

```ruby
def self.foo=(value)
  42 # ⚠️ new offense: Literal `42` used in void context.
end
```

```ruby
foo.tap do
  _1 # ⚠️ new offense: Variable `_1` used in void context.
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
