### PR TITLE
Fix an incorrect autocorrect for `Style/TrailingBodyOnMethodDefinition`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_trailing_body_on_method_definition.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_trailing_body_on_method_definition.md
@@ -1,0 +1,1 @@
+* [#13132](https://github.com/rubocop/rubocop/pull/13132): Fix incorrect autocorrect for `Style/TrailingBodyOnMethodDefinition` when an expression precedes a method definition on the same line with a semicolon. ([@koic][])

--- a/lib/rubocop/cop/correctors/line_break_corrector.rb
+++ b/lib/rubocop/cop/correctors/line_break_corrector.rb
@@ -51,6 +51,8 @@ module RuboCop
         def semicolon(node)
           @semicolon ||= {}.compare_by_identity
           @semicolon[node] ||= processed_source.sorted_tokens.select(&:semicolon?).find do |token|
+            next if token.pos.end_pos <= node.source_range.begin_pos
+
             same_line?(token, node.body) && trailing_class_definition?(token, node.body)
           end
         end

--- a/spec/rubocop/cop/style/trailing_body_on_method_definition_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_method_definition_spec.rb
@@ -63,6 +63,20 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnMethodDefinition, :config do
     RUBY
   end
 
+  it 'registers an offense when an expression precedes a method definition on the same line with a semicolon' do
+    expect_offense(<<~RUBY)
+      foo;def some_method; body
+                           ^^^^ Place the first line of a multi-line method definition's body on its own line.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo;def some_method#{trailing_whitespace}
+            body
+      end
+    RUBY
+  end
+
   it 'accepts a method with one line of body' do
     expect_no_offenses(<<~RUBY)
       def some_method


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for `Style/TrailingBodyOnMethodDefinition` when an expression precedes a method definition on the same line with a semicolon:

```console
$ cat example.rb
foo;def some_method; body
end

$ rubocop --only Style/TrailingBodyOnMethodDefinition -a
```

## Before

It results in an autocorrection of the syntax error:

```ruby
foodef some_method
      body
end
```

## After

No syntax errors:

```ruby
foo;def some_method
      body
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
