### PR TITLE
Fix an error for `InternalAffairs/EmptyLineBetweenExpectOffenseAndCorrection`

### DIFF
--- a/lib/rubocop/cop/internal_affairs/empty_line_between_expect_offense_and_correction.rb
+++ b/lib/rubocop/cop/internal_affairs/empty_line_between_expect_offense_and_correction.rb
@@ -38,7 +38,8 @@ module RuboCop
         CORRECTION_EXPECTATION_METHODS = %i[expect_correction expect_no_corrections].freeze
 
         def on_send(node)
-          return unless (next_sibling = node.right_sibling) && next_sibling.send_type?
+          return unless (next_sibling = node.right_sibling)
+          return unless next_sibling.respond_to?(:send_type?) && next_sibling.send_type?
 
           method_name = next_sibling.method_name
           return unless CORRECTION_EXPECTATION_METHODS.include?(method_name)

--- a/spec/rubocop/cop/internal_affairs/empty_line_between_expect_offense_and_correction_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/empty_line_between_expect_offense_and_correction_spec.rb
@@ -90,4 +90,10 @@ RSpec.describe RuboCop::Cop::InternalAffairs::EmptyLineBetweenExpectOffenseAndCo
       expect_no_corrections
     RUBY
   end
+
+  it 'does not register an offense for `expect_offense` with unexpected syntax' do
+    expect_no_offenses(<<~RUBY)
+      expect_offense << a
+    RUBY
+  end
 end


### PR DESCRIPTION
I mistyped and it errored. Forgot the bracket when starting the heredoc and other code was below it already

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
