### PR TITLE
Fix false negative for `Lint/Void` when using using frozen literals

### DIFF
--- a/changelog/fix_frozen_literal_detection_in_lint_void.md
+++ b/changelog/fix_frozen_literal_detection_in_lint_void.md
@@ -1,0 +1,1 @@
+* [#13134](https://github.com/rubocop/rubocop/pull/13134): Fix false negative for `Lint/Void` when using using frozen literals. ([@vlad-pisanov][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -245,14 +245,22 @@ module RuboCop
         def entirely_literal?(node)
           case node.type
           when :array
-            node.each_value.all? { |value| entirely_literal?(value) }
+            all_values_entirely_literal?(node)
           when :hash
-            return false unless node.each_key.all? { |key| entirely_literal?(key) }
-
-            node.each_value.all? { |value| entirely_literal?(value) }
+            all_keys_entirely_literal?(node) && all_values_entirely_literal?(node)
+          when :send, :csend
+            node.method?(:freeze) && node.receiver && entirely_literal?(node.receiver)
           else
             node.literal?
           end
+        end
+
+        def all_keys_entirely_literal?(node)
+          node.each_key.all? { |key| entirely_literal?(key) }
+        end
+
+        def all_values_entirely_literal?(node)
+          node.each_value.all? { |value| entirely_literal?(value) }
         end
       end
     end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -493,6 +493,54 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     RUBY
   end
 
+  it 'registers an offense for a frozen literal in a method definition' do
+    expect_offense(<<~RUBY)
+      def something
+        'foo'.freeze
+        ^^^^^^^^^^^^ Literal `'foo'.freeze` used in void context.
+        baz
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a literal frozen via safe navigation in a method definition' do
+    expect_offense(<<~RUBY)
+      def something
+        'foo'&.freeze
+        ^^^^^^^^^^^^^ Literal `'foo'&.freeze` used in void context.
+        baz
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for frozen non-literal in a method definition' do
+    expect_no_offenses(<<~RUBY)
+      def something
+        foo.freeze
+        baz
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a nested array literal composed of frozen and unfrozen literals in a method definition' do
+    expect_offense(<<~RUBY)
+      def something
+        [1, ['foo'.freeze]]
+        ^^^^^^^^^^^^^^^^^^^ Literal `[1, ['foo'.freeze]]` used in void context.
+        baz
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a nested array literal that includes frozen non-literal value elements in a method definition' do
+    expect_no_offenses(<<~RUBY)
+      def something
+        [1, [foo.freeze]]
+        baz
+      end
+    RUBY
+  end
+
   it 'does not register an offense for a hash literal that includes non-literal value elements in a method definition' do
     expect_no_offenses(<<~RUBY)
       def something


### PR DESCRIPTION
Currently, `Lint/Void` looks for literals, and arrays/hashes composed of literals. However, returning a _frozen_ literal into a void context is just as pointless as returning a plain literal (and more expensive). This PR adds support for frozen literal detection.

```ruby
def foo
  'hello'.freeze      # ⚠️ new offense: Literal 'hello'.freeze used in a void context
  [1,2,3].freeze      # ⚠️ new offense: Literal [1,2,3].freeze used in a void context
  [1, 'hello'.freeze] # ⚠️ new offense: Literal [1,'hello'.freeze] used in a void context
  baz
end
```

NOTE: this isn't the same as `Style/RedundantFreeze` which doesn't detect nested structures

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
