### PR TITLE
[Fix #13103] Make `Lint/UselessAssignment` autocorrection safe

### DIFF
--- a/changelog/change_make_lint_useless_assignment_autocorrection_safe.md
+++ b/changelog/change_make_lint_useless_assignment_autocorrection_safe.md
@@ -1,0 +1,1 @@
+* [#13103](https://github.com/rubocop/rubocop/issues/13103): Make `Lint/UselessAssignment` autocorrection safe. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2543,8 +2543,7 @@ Lint/UselessAssignment:
   Enabled: true
   AutoCorrect: contextual
   VersionAdded: '0.11'
-  VersionChanged: '1.61'
-  SafeAutoCorrect: false
+  VersionChanged: '<<next>>'
 
 Lint/UselessElseWithoutRescue:
   Description: 'Checks for useless `else` in `begin..end` without `rescue`.'

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -979,7 +979,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
             1  Layout/SpaceAroundOperators [Safe Correctable]
             1  Layout/TrailingWhitespace [Safe Correctable]
             1  Lint/MissingCopEnableDirective
-            1  Lint/UselessAssignment [Unsafe Correctable]
+            1  Lint/UselessAssignment [Safe Correctable]
             1  Migration/DepartmentName [Safe Correctable]
             1  Style/FrozenStringLiteralComment [Unsafe Correctable]
             1  Style/NumericPredicate [Unsafe Correctable]
@@ -2016,11 +2016,10 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
           a = "Hello"
         RUBY
 
-        expect(cli.run(['--autocorrect', '--format', 'simple', target_file])).to eq(1)
+        expect(cli.run(['--autocorrect', '--format', 'simple', target_file])).to eq(0)
 
         expect($stdout.string.lines.to_a.last)
-          .to eq('1 file inspected, 2 offenses detected, 1 offense corrected, 1 more offense can ' \
-                 "be corrected with `rubocop -A`\n")
+          .to eq("1 file inspected, 3 offenses detected, 3 offenses corrected\n")
       end
     end
 
@@ -2073,8 +2072,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
         expect(cli.run(['--autocorrect', '--format', 'simple', target_file])).to eq(1)
         expect($stdout.string.lines.to_a.last).to eq(
-          '1 file inspected, 2 offenses detected, 1 more offense can be corrected with ' \
-          "`rubocop -A`\n"
+          "1 file inspected, 2 offenses detected, 1 offense corrected\n"
         )
       end
     end

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -321,9 +321,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         ^^^ Useless assignment to variable - `foo`. Use `||` instead of `||=`.
       RUBY
 
-      expect_correction(<<~RUBY)
-        foo || 1
-      RUBY
+      expect_no_corrections
     end
   end
 
@@ -1149,12 +1147,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         end
       RUBY
 
-      expect_correction(<<~RUBY)
-        def some_method
-          foo = do_something_returns_object_or_nil
-          foo || 1
-        end
-      RUBY
+      expect_no_corrections
     end
   end
 
@@ -1169,13 +1162,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         end
       RUBY
 
-      expect_correction(<<~RUBY)
-        def some_method
-          foo = do_something_returns_object_or_nil
-          foo || 1
-          some_return_value
-        end
-      RUBY
+      expect_no_corrections
     end
   end
 


### PR DESCRIPTION
Fixes #13103.

This PR makes `Lint/UselessAssignment` autocorrection safe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
