### PR TITLE
Improve wording of various `Style/` cops documentations

### DIFF
--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -11,8 +11,8 @@ module RuboCop
       # The reason is that _unannotated_ format is very similar
       # to encoded URLs or Date/Time formatting strings.
       #
-      # This cop can be customized allowed methods with `AllowedMethods`.
-      # By default, there are no methods to allowed.
+      # This cop's allowed methods can be customized with `AllowedMethods`.
+      # By default, there are no allowed methods.
       #
       # @example EnforcedStyle: annotated (default)
       #

--- a/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
@@ -5,8 +5,8 @@ module RuboCop
     module Style
       # Checks for unwanted parentheses in parameterless method calls.
       #
-      # This cop can be customized allowed methods with `AllowedMethods`.
-      # By default, there are no methods to allowed.
+      # This cop's allowed methods can be customized with `AllowedMethods`.
+      # By default, there are no allowed methods.
       #
       # NOTE: This cop allows the use of `it()` without arguments in blocks,
       # as in `0.times { it() }`, following `Lint/ItWithoutArgumentsInBlock` cop.

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -8,8 +8,8 @@ module RuboCop
       # These can be replaced by their respective predicate methods.
       # This cop can also be configured to do the reverse.
       #
-      # This cop can be customized allowed methods with `AllowedMethods`.
-      # By default, there are no methods to allowed.
+      # This cop's allowed methods can be customized with `AllowedMethods`.
+      # By default, there are no allowed methods.
       #
       # This cop disregards `#nonzero?` as its value is truthy or falsey,
       # but not `true` and `false`, and thus not always interchangeable with


### PR DESCRIPTION
Improve wording of `Style/NumericPredicate` docs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
