### PR TITLE
Fix an error for `Style/ParallelAssignment` when using `__FILE__`

### DIFF
--- a/changelog/fix_error_parallel_assignment.md
+++ b/changelog/fix_error_parallel_assignment.md
@@ -1,0 +1,1 @@
+* [#13137](https://github.com/rubocop/rubocop/pull/13137): Fix an error for `Style/ParallelAssignment` when using `__FILE__`. ([@earlopain][])

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -211,15 +211,16 @@ module RuboCop
           protected
 
           def assignment
-            @new_elements.map { |lhs, rhs| "#{lhs.source} = #{source(rhs)}" }
+            @new_elements.map { |lhs, rhs| "#{lhs.source} = #{source(rhs, rhs.loc)}" }
           end
 
           private
 
-          def source(node)
-            if node.str_type? && node.loc.begin.nil?
+          def source(node, loc)
+            # __FILE__ is treated as a StrNode but has no begin
+            if node.str_type? && loc.respond_to?(:begin) && loc.begin.nil?
               "'#{node.source}'"
-            elsif node.sym_type? && node.loc.begin.nil?
+            elsif node.sym_type? && loc.begin.nil?
               ":#{node.source}"
             else
               node.source

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -697,6 +697,18 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
     RUBY
   end
 
+  it 'corrects when assignments include __FILE__' do
+    expect_offense(<<~RUBY)
+      a, b = c, __FILE__
+      ^^^^^^^^^^^^^^^^^^ Do not use parallel assignment.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a = c
+      b = __FILE__
+    RUBY
+  end
+
   it 'allows more left variables than right variables' do
     expect_no_offenses(<<~RUBY)
       a, b, c, d = 1, 2


### PR DESCRIPTION
`__FILE__` is treated as a StrNode but has no `begin`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
