### PR TITLE
[Fix #13139] Fix false positives for `Style/RedundantCondition`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_condition.md
+++ b/changelog/fix_false_positives_for_style_redundant_condition.md
@@ -1,0 +1,1 @@
+* [#13139](https://github.com/rubocop/rubocop/issues/13139): Fix false positives for `Style/RedundantCondition` when using modifier `if` or `unless`. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -39,9 +39,9 @@ module RuboCop
           splat block_pass forwarded_restarg forwarded_kwrestarg forwarded_args
         ].freeze
 
+        # rubocop:disable Metrics/AbcSize
         def on_if(node)
-          return if node.elsif_conditional?
-          return unless offense?(node)
+          return if node.modifier_form? || node.elsif_conditional? || !offense?(node)
 
           message = message(node)
 
@@ -57,6 +57,7 @@ module RuboCop
             end
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -178,14 +178,15 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
-      it 'registers an offense and corrects when using modifier if' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense when using modifier `if`' do
+        expect_no_offenses(<<~RUBY)
           bar if bar
-          ^^^^^^^^^^ This condition is not needed.
         RUBY
+      end
 
-        expect_correction(<<~RUBY)
-          bar
+      it 'does not register an offense when using modifier `unless`' do
+        expect_no_offenses(<<~RUBY)
+          bar unless bar
         RUBY
       end
 


### PR DESCRIPTION
Fix #13139.

This PR fixes false positives for `Style/RedundantCondition` when using modifier `if` or `unless`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
