### PR TITLE
Load only project specific config for `InternalAffairs/UndefinedConfig`

### DIFF
--- a/spec/rubocop/cop/internal_affairs/undefined_config_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/undefined_config_spec.rb
@@ -12,9 +12,8 @@ RSpec.describe RuboCop::Cop::InternalAffairs::UndefinedConfig, :config, :isolate
         Defined: true
     YAML
 
-    allow(RuboCop::ConfigLoader).to receive(:default_configuration).and_return(
-      RuboCop::ConfigLoader.load_file('config/default.yml', check: false)
-    )
+    stub_const('RuboCop::Cop::InternalAffairs::UndefinedConfig::CONFIG',
+               RuboCop::ConfigLoader.load_yaml_configuration('config/default.yml'))
   end
 
   it 'does not register an offense for implicit configuration keys' do

--- a/spec/rubocop/file_finder_spec.rb
+++ b/spec/rubocop/file_finder_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe RuboCop::FileFinder, :isolated_environment do
     it 'returns nil when file is not found' do
       expect(finder.find_file_upwards('file2', 'dir')).to be_nil
     end
+
+    context 'when searching for a file inside a directory' do
+      it 'returns a file to be found upwards' do
+        expect(finder.find_file_upwards('dir/file', Dir.pwd)).to eq(File.expand_path('file', 'dir'))
+      end
+
+      it 'returns nil when file is not found' do
+        expect(finder.find_file_upwards('dir2/file', Dir.pwd)).to be_nil
+      end
+    end
   end
 
   describe '#find_last_file_upwards' do


### PR DESCRIPTION
Going through the default config is fine for RuboCop itself but extensions need to inject their config for RuboCop to pick them up. This makes it necessary to load the extension, even if the extension itself doesn't make use of its own cops, like `rubocop-rails` or `rubocop-capybara`.

Instead just load `config/default.yml` from `Dir.pwd` in isolation and use just that. This would make https://github.com/rubocop/rubocop-capybara/pull/133 and https://github.com/rubocop/rubocop-rails/commit/288c7ce265d7fd0f5a244c6887224fc975ff2eb9 unnecessary. I also tested with https://github.com/rubocop/rubocop-rails/commit/9b450a8da5d5ff3fb73447a31ea09738f88dd6e4 and observed no issues with `bundle exec rake`.

-----------------

Not sure how to write proper tests for this but I tested manually against most first party extensions and it behaves as expected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
