### PR TITLE
Fix an error during `TargetRubyVersion` detection if the gemspec is not valid syntax

### DIFF
--- a/changelog/fix_error_target_ruby_gemspec_syntax_error.md
+++ b/changelog/fix_error_target_ruby_gemspec_syntax_error.md
@@ -1,0 +1,1 @@
+* [#13143](https://github.com/rubocop/rubocop/pull/13143): Fix an error during `TargetRubyVersion` detection if the gemspec is not valid syntax. ([@earlopain][])

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -99,6 +99,8 @@ module RuboCop
         processed_source = ProcessedSource.from_file(
           file, DEFAULT_VERSION, parser_engine: @config.parser_engine
         )
+        return unless processed_source.valid_syntax?
+
         required_ruby_version(processed_source.ast).first
       end
 

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -269,6 +269,19 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           expect(target_ruby.version).to eq default_version
         end
       end
+
+      context 'when file contains a syntax error' do
+        it 'uses the default target ruby version' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.required_ruby_version = '>= 3.3.0'' # invalid syntax
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq default_version
+        end
+      end
     end
 
     context 'when .ruby-version is present' do


### PR DESCRIPTION
Just let `Lint/Syntax` notify the user instead of raising an error.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
