### PR TITLE
Fix incorrect autocorrect for `Lint/EmptyConditionalBody`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_lint_empty_conditional_body.md
+++ b/changelog/fix_incorrect_autocorrect_for_lint_empty_conditional_body.md
@@ -1,0 +1,1 @@
+* [#13148](https://github.com/rubocop/rubocop/pull/13148): Fix incorrect autocorrect for `Lint/EmptyConditionalBody` when missing `elsif` body with `end` on the same line. ([@koic][])

--- a/lib/rubocop/cop/lint/empty_conditional_body.rb
+++ b/lib/rubocop/cop/lint/empty_conditional_body.rb
@@ -67,18 +67,30 @@ module RuboCop
 
         MSG = 'Avoid `%<keyword>s` branches without a body.'
 
+        # rubocop:disable Metrics/AbcSize
         def on_if(node)
           return if node.body || same_line?(node.loc.begin, node.loc.end)
           return if cop_config['AllowComments'] && contains_comments?(node)
 
-          add_offense(node, message: format(MSG, keyword: node.keyword)) do |corrector|
+          range = offense_range(node)
+
+          add_offense(range, message: format(MSG, keyword: node.keyword)) do |corrector|
             next if node.parent&.call_type?
 
             autocorrect(corrector, node)
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         private
+
+        def offense_range(node)
+          if node.loc.else
+            node.source_range.begin.join(node.loc.else.begin)
+          else
+            node.source_range
+          end
+        end
 
         def autocorrect(corrector, node)
           remove_comments(corrector, node)
@@ -93,13 +105,22 @@ module RuboCop
           end
         end
 
+        # rubocop:disable Metrics/AbcSize
         def remove_empty_branch(corrector, node)
-          if empty_if_branch?(node) && else_branch?(node)
-            corrector.remove(branch_range(node))
-          else
-            corrector.remove(deletion_range(branch_range(node)))
-          end
+          range = if empty_if_branch?(node) && else_branch?(node)
+                    branch_range(node)
+                  elsif same_line?(node, else_kw_loc = node.loc.else)
+                    node.source_range.begin.join(else_kw_loc.begin)
+                  elsif node.parent&.loc.respond_to?(:end) &&
+                        same_line?(node, end_loc = node.parent.loc.end)
+                    node.source_range.begin.join(end_loc.begin)
+                  else
+                    deletion_range(branch_range(node))
+                  end
+
+          corrector.remove(range)
         end
+        # rubocop:enable Metrics/AbcSize
 
         def correct_other_branches(corrector, node)
           return unless require_other_branches_correction?(node)

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -271,6 +271,36 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     RUBY
   end
 
+  it 'registers an offense for missing `elsif` body with `end` on the same line' do
+    expect_offense(<<~RUBY)
+      if cond_a
+        do_a
+      elsif cond_b;end
+      ^^^^^^^^^^^^^ Avoid `elsif` branches without a body.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if cond_a
+        do_a
+      end
+    RUBY
+  end
+
+  it 'registers an offense for missing `elsif` and `else` bodies with `end` on the same line' do
+    expect_offense(<<~RUBY)
+      if cond_a
+        do_a
+      elsif cond_b;else;end
+      ^^^^^^^^^^^^^ Avoid `elsif` branches without a body.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if cond_a
+        do_a
+      else;end
+    RUBY
+  end
+
   it 'does not register an offense for missing `elsif` body with a comment' do
     expect_no_offenses(<<~RUBY)
       if condition


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for `Lint/EmptyConditionalBody` when missing `elsif` body with `end` on the same line.

```console
$ cat example.rb
if cond_a
do_a
elsif cond_b;end

$ bundle exec rubocop -A --only Lint/EmptyConditionalBody
```

## Before

Syntax error with missing `end` keyword:

```ruby
$ cat example.rb
if cond_a
do_a
```

## After

No syntax errors:

```ruby
$ cat example.rb
if cond_a
do_a
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
