### PR TITLE
[Fix #13150] Allow `get_!`, `set_!`, `get_?`, `set_?`, `get_=`, and `set_=` in `Naming/AccessorMethodName`

### DIFF
--- a/changelog/change_allow_invalid_attr_name_in_naming_accessor_method_name.md
+++ b/changelog/change_allow_invalid_attr_name_in_naming_accessor_method_name.md
@@ -1,0 +1,1 @@
+* [#13050](https://github.com/rubocop/rubocop/issues/13050): Allow `get_!`, `set_!`, `get_?`, `set_?`, `get_=`, and `set_=` in `Naming/AccessorMethodName`. ([@koic][])

--- a/lib/rubocop/cop/naming/accessor_method_name.rb
+++ b/lib/rubocop/cop/naming/accessor_method_name.rb
@@ -40,6 +40,7 @@ module RuboCop
         MSG_WRITER = 'Do not prefix writer method names with `set_`.'
 
         def on_def(node)
+          return unless proper_attribute_name?(node)
           return unless bad_reader_name?(node) || bad_writer_name?(node)
 
           message = message(node)
@@ -56,6 +57,10 @@ module RuboCop
           elsif bad_writer_name?(node)
             MSG_WRITER
           end
+        end
+
+        def proper_attribute_name?(node)
+          !node.method_name.to_s.end_with?('!', '?', '=')
         end
 
         def bad_reader_name?(node)

--- a/spec/rubocop/cop/naming/accessor_method_name_spec.rb
+++ b/spec/rubocop/cop/naming/accessor_method_name_spec.rb
@@ -142,4 +142,46 @@ RSpec.describe RuboCop::Cop::Naming::AccessorMethodName, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense for no args method name starts with `get_` and ends with `!`' do
+    expect_no_offenses(<<~RUBY)
+      def get_attribute!
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for no args method name starts with `get_` and ends with `?`' do
+    expect_no_offenses(<<~RUBY)
+      def get_attribute?
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for no args method name starts with `get_` and ends with `=`' do
+    expect_no_offenses(<<~RUBY)
+      def get_attribute=
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for one arg method name starts with `set_` and ends with `!`' do
+    expect_no_offenses(<<~RUBY)
+      def set_attribute!(attribute)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for one arg method name starts with `set_` and ends with `?`' do
+    expect_no_offenses(<<~RUBY)
+      def set_attribute?(attribute)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for one arg method name starts with `set_` and ends with `=`' do
+    expect_no_offenses(<<~RUBY)
+      def set_attribute=(attribute)
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #13150.

This PR allows `get_!`, `set_!`, `get_?`, `set_?`, `get_=`, and `set_=` method names in `Naming/AccessorMethodName`.

Names ending with `!`, `?`, or `=` are not appropriate as attribute names.

```console
$ ruby -e 'class X attr_reader :x! end'
-e:1:in 'Module#attr_reader': invalid attribute name 'x!' (NameError)

class X attr_reader :x! end
        ^^^^^^^^^^^
        from -e:1:in '<class:X>'
        from -e:1:in '<main>'
```

Therefore, they don't need to be recognized as intended accessor method names.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
