### PR TITLE
Update docs to make CountAsOne values more clear.

### DIFF
--- a/lib/rubocop/cop/metrics/block_length.rb
+++ b/lib/rubocop/cop/metrics/block_length.rb
@@ -9,8 +9,9 @@ module RuboCop
       # The cop can be configured to ignore blocks passed to certain methods.
       #
       # You can set constructs you want to fold with `CountAsOne`.
-      # Available are: 'array', 'hash', 'heredoc', and 'method_call'. Each construct
-      # will be counted as one line regardless of its actual size.
+      #
+      # Available are: 'array', 'hash', 'heredoc', and 'method_call'.
+      # Each construct will be counted as one line regardless of its actual size.
       #
       # NOTE: This cop does not apply for `Struct` definitions.
       #
@@ -18,7 +19,7 @@ module RuboCop
       # for backwards compatibility. Please use `AllowedMethods` and `AllowedPatterns`
       # instead. By default, there are no methods to allowed.
       #
-      # @example CountAsOne: ['array', 'heredoc', 'method_call']
+      # @example CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
       #
       #   something do
       #     array = [         # +1
@@ -26,7 +27,7 @@ module RuboCop
       #       2
       #     ]
       #
-      #     hash = {          # +3
+      #     hash = {          # +1
       #       key: 'value'
       #     }
       #
@@ -39,7 +40,7 @@ module RuboCop
       #       1,
       #       2
       #     )
-      #   end                 # 6 points
+      #   end                 # 4 points
       #
       class BlockLength < Base
         include CodeLength

--- a/lib/rubocop/cop/metrics/class_length.rb
+++ b/lib/rubocop/cop/metrics/class_length.rb
@@ -8,12 +8,13 @@ module RuboCop
       # The maximum allowed length is configurable.
       #
       # You can set constructs you want to fold with `CountAsOne`.
-      # Available are: 'array', 'hash', 'heredoc', and 'method_call'. Each construct
-      # will be counted as one line regardless of its actual size.
+      #
+      # Available are: 'array', 'hash', 'heredoc', and 'method_call'.
+      # Each construct will be counted as one line regardless of its actual size.
       #
       # NOTE: This cop also applies for `Struct` definitions.
       #
-      # @example CountAsOne: ['array', 'heredoc', 'method_call']
+      # @example CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
       #
       #   class Foo
       #     ARRAY = [         # +1
@@ -21,7 +22,7 @@ module RuboCop
       #       2
       #     ]
       #
-      #     HASH = {          # +3
+      #     HASH = {          # +1
       #       key: 'value'
       #     }
       #
@@ -34,7 +35,7 @@ module RuboCop
       #       1,
       #       2
       #     )
-      #   end                 # 6 points
+      #   end                 # 4 points
       #
       class ClassLength < Base
         include CodeLength

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -8,15 +8,16 @@ module RuboCop
       # The maximum allowed length is configurable.
       #
       # You can set constructs you want to fold with `CountAsOne`.
-      # Available are: 'array', 'hash', 'heredoc', and 'method_call'. Each construct
-      # will be counted as one line regardless of its actual size.
+      #
+      # Available are: 'array', 'hash', 'heredoc', and 'method_call'.
+      # Each construct will be counted as one line regardless of its actual size.
       #
       # NOTE: The `ExcludedMethods` and `IgnoredMethods` configuration is
       # deprecated and only kept for backwards compatibility.
       # Please use `AllowedMethods` and `AllowedPatterns` instead.
       # By default, there are no methods to allowed.
       #
-      # @example CountAsOne: ['array', 'heredoc', 'method_call']
+      # @example CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
       #
       #   def m
       #     array = [       # +1
@@ -24,7 +25,7 @@ module RuboCop
       #       2
       #     ]
       #
-      #     hash = {        # +3
+      #     hash = {        # +1
       #       key: 'value'
       #     }
       #
@@ -37,7 +38,7 @@ module RuboCop
       #       1,
       #       2
       #     )
-      #   end               # 6 points
+      #   end               # 4 points
       #
       class MethodLength < Base
         include CodeLength

--- a/lib/rubocop/cop/metrics/module_length.rb
+++ b/lib/rubocop/cop/metrics/module_length.rb
@@ -8,10 +8,11 @@ module RuboCop
       # The maximum allowed length is configurable.
       #
       # You can set constructs you want to fold with `CountAsOne`.
-      # Available are: 'array', 'hash', 'heredoc', and 'method_call'. Each construct
-      # will be counted as one line regardless of its actual size.
       #
-      # @example CountAsOne: ['array', 'heredoc', 'method_call']
+      # Available are: 'array', 'hash', 'heredoc', and 'method_call'.
+      # Each construct will be counted as one line regardless of its actual size.
+      #
+      # @example CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
       #
       #   module M
       #     ARRAY = [         # +1
@@ -19,7 +20,7 @@ module RuboCop
       #       2
       #     ]
       #
-      #     HASH = {          # +3
+      #     HASH = {          # +1
       #       key: 'value'
       #     }
       #
@@ -32,7 +33,7 @@ module RuboCop
       #       1,
       #       2
       #     )
-      #   end                 # 6 points
+      #   end                 # 4 points
       #
       class ModuleLength < Base
         include CodeLength


### PR DESCRIPTION
When looking at the docs for cops that have CountAsOne, it is not immediately clear that all support `hash` as a value.

The possible values are a little hidden and the examples do not include `hash` in the configured values.

Example:
https://docs.rubocop.org/rubocop/cops_metrics.html#metricsclasslength

This change makes it so that the available values are shown on a new line. It also changes the examples to have `hash` as one of the configured values.


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* ~[ ] Added tests.~ (only docs changed)
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* ~[ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
