### PR TITLE
Don't fail cache when too long directory path

### DIFF
--- a/changelog/fix_server_cache_enametoolong.md
+++ b/changelog/fix_server_cache_enametoolong.md
@@ -1,0 +1,1 @@
+* [#13155](https://github.com/rubocop/rubocop/pull/13155): Fixes an error when the server cache directory has too long path, causing rubocop to fail even with caching disabled. ([@protocol7][])

--- a/lib/rubocop/server/cache.rb
+++ b/lib/rubocop/server/cache.rb
@@ -126,7 +126,7 @@ module RuboCop
 
         def pid_running?
           Process.kill(0, pid_path.read.to_i) == 1
-        rescue Errno::ESRCH, Errno::ENOENT, Errno::EACCES, Errno::EROFS
+        rescue Errno::ESRCH, Errno::ENOENT, Errno::EACCES, Errno::EROFS, Errno::ENAMETOOLONG
           false
         end
 


### PR DESCRIPTION
Fixes an error when the server cache directory has too long path, causing rubocop to fail even with caching disabled.

This is similar to https://github.com/rubocop/rubocop/pull/11726.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
