### PR TITLE
Resolve ruby-head uri deprecation warning

### DIFF
--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -239,8 +239,7 @@ module RuboCop
     end
 
     def remote_file?(uri)
-      regex = URI::DEFAULT_PARSER.make_regexp(%w[http https])
-      /\A#{regex}\z/.match?(uri)
+      uri.start_with?('http://', 'https://')
     end
 
     def handle_disabled_by_default(config, new_default_configuration)

--- a/lib/rubocop/cop/mixin/line_length_help.rb
+++ b/lib/rubocop/cop/mixin/line_length_help.rb
@@ -91,8 +91,13 @@ module RuboCop
       end
 
       def uri_regexp
-        @uri_regexp ||=
-          URI::DEFAULT_PARSER.make_regexp(config.for_cop('Layout/LineLength')['URISchemes'])
+        @uri_regexp ||= begin
+          # Ruby 3.4 changes the default parser to RFC3986 which warns on make_regexp.
+          # Additionally, the RFC2396_PARSER alias is only available on 3.4 for now.
+          # Extra info at https://github.com/ruby/uri/issues/118
+          parser = defined?(URI::RFC2396_PARSER) ? URI::RFC2396_PARSER : URI::DEFAULT_PARSER
+          parser.make_regexp(config.for_cop('Layout/LineLength')['URISchemes'])
+        end
       end
 
       def valid_uri?(uri_ish_string)

--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -12,7 +12,11 @@ module RuboCop
     CACHE_LIFETIME = 24 * 60 * 60
 
     def initialize(url, base_dir)
-      @uri = URI.parse(url)
+      begin
+        @uri = URI.parse(url)
+      rescue URI::InvalidURIError
+        raise ConfigNotFoundError, "Failed to resolve configuration: '#{url}' is not a valid URI"
+      end
       @base_dir = base_dir
     end
 

--- a/spec/rubocop/remote_config_spec.rb
+++ b/spec/rubocop/remote_config_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe RuboCop::RemoteConfig do
       assert_requested :get, remote_config_url
     end
 
+    context 'when the remote URL is not a valid URI' do
+      let(:remote_config_url) { 'http://example.com/rübocop.yml' }
+
+      it 'raises a configuration error' do
+        expect do
+          remote_config
+        end.to raise_error(RuboCop::ConfigNotFoundError, /is not a valid URI/)
+      end
+    end
+
     context 'when remote URL is configured with token auth' do
       let(:token) { 'personal_access_token' }
       let(:remote_config_url) { "http://#{token}@example.com/rubocop.yml" }


### PR DESCRIPTION
> URI::RFC3986_PARSER.make_regexp is obsoleted. Use URI::RFC2396_PARSER.make_regexp explicitly

The `uri` gem is switching over its default parser from RFC 2396 to 3986. The new parser doesn't have `make_regexp` available but for compatibility a fallback was added.

Additionally, old versions of `uri` don't have the RFC2396 parser available. See https://github.com/ruby/uri/issues/118

I guess, for Ruby 3.4, `Lint/UriRegexp` needs a change because as it is now it provides bad directions.
