### PR TITLE
Fix an error for `StyleOneLineConditional`

### DIFF
--- a/changelog/fix_an_error_for_style_one_line_conditional.md
+++ b/changelog/fix_an_error_for_style_one_line_conditional.md
@@ -1,0 +1,1 @@
+* [#13159](https://github.com/rubocop/rubocop/pull/13159): Fix an error for `Style/OneLineConditional` when using if/then/else/end with multiple expressions in the `then` body. ([@koic][])

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -42,7 +42,7 @@ module RuboCop
         def on_normal_if_unless(node)
           return unless node.single_line?
           return unless node.else_branch
-          return if node.elsif?
+          return if node.elsif? || node.if_branch&.begin_type?
 
           message = message(node)
           add_offense(node, message: message) do |corrector|

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
       expect_no_offenses('if cond then run end')
     end
 
+    it 'does not register an offense when using if/then/else/end with multiple expressions in the `then` body' do
+      expect_no_offenses(<<~RUBY)
+        if cond then x; y else z end
+      RUBY
+    end
+
     it 'registers and corrects an offense with ternary operator for unless/then/else/end' do
       expect_offense(<<~RUBY)
         unless cond then run else dont end


### PR DESCRIPTION
This PR fixes the following error for `Style/OneLineConditional` when using if/then/else/end with multiple expressions in the `then` body:

```console
$ echo "if cond then x; y else z end" | bundle exec rubocop --stdin example.rb --only Style/OneLineConditional -a
Inspecting 1 file
F

Offenses:

example.rb:1:1: C: [Corrected] Style/OneLineConditional: Favor the ternary operator (?:) or multi-line constructs over single-line if/then/else/end constructs.
if cond then x; y else z end
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
example.rb:1:9: F: Lint/Syntax: unexpected token tSEMI
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
cond ? x; y : z
        ^

1 file inspected, 2 offenses detected, 1 offense corrected
====================
cond ? x; y : z
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
