### PR TITLE
Fix an incorrect autocorrect for `Style/IfWithSemicolon`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_if_with_semicolon_cop.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_if_with_semicolon_cop.md
@@ -1,0 +1,1 @@
+* [#13161](https://github.com/rubocop/rubocop/pull/13161): Fix incorrect autocorrect for `Style/IfWithSemicolon` when using multiple expressions in the `else` body. ([@koic][])

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -30,11 +30,7 @@ module RuboCop
           message = message(node)
 
           add_offense(node, message: message) do |corrector|
-            if node.if_branch&.begin_type?
-              corrector.replace(node.loc.begin, "\n")
-            else
-              corrector.replace(node, replacement(node))
-            end
+            autocorrect(corrector, node)
           end
         end
 
@@ -43,13 +39,21 @@ module RuboCop
         def message(node)
           template = if node.if_branch&.begin_type?
                        MSG_NEWLINE
-                     elsif node.else_branch&.if_type?
+                     elsif node.else_branch&.if_type? || node.else_branch&.begin_type?
                        MSG_IF_ELSE
                      else
                        MSG_TERNARY
                      end
 
           format(template, expr: node.condition.source)
+        end
+
+        def autocorrect(corrector, node)
+          if node.if_branch&.begin_type? || node.else_branch&.begin_type?
+            corrector.replace(node.loc.begin, "\n")
+          else
+            corrector.replace(node, replacement(node))
+          end
         end
 
         def replacement(node)

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -100,6 +100,18 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
     RUBY
   end
 
+  it 'registers an offense when using multiple expressions in the `else` branch' do
+    expect_offense(<<~RUBY)
+      if cond; foo else bar'arg'; baz end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use `if/else` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if cond
+       foo else bar'arg'; baz end
+    RUBY
+  end
+
   it 'can handle modifier conditionals' do
     expect_no_offenses(<<~RUBY)
       class Hash


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for `Style/IfWithSemicolon` when using multiple expressions in the `else` body:

```console
$ cat example.rb
if cond; foo else bar'arg'; baz end

$ bundle exec rubocop --only Style/IfWithSemicolon -a
```

## Before

It results in an autocorrection of the syntax error:

```ruby
cond ? foo : bar'arg'; baz
```

## After

No syntax errors:

```ruby
if cond
 foo else bar'arg'; baz end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
