### PR TITLE
Fix incorrect autocorrect behavior for `Layout/BlockAlignment`

### DIFF
--- a/changelog/fix_autocorrect_behavior_for_layout_block_alignment.md
+++ b/changelog/fix_autocorrect_behavior_for_layout_block_alignment.md
@@ -1,0 +1,1 @@
+* [#13164](https://github.com/rubocop/rubocop/pull/13164): Fix incorrect autocorrect behavior for `Layout/BlockAlignment` when `EnforcedStyleAlignWith: either (default)`. ([@koic][])

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -92,16 +92,6 @@ module RuboCop
 
         private
 
-        def start_for_block_node(block_node)
-          # Which node should we align the 'end' with?
-          result = block_end_align_target(block_node)
-
-          # In offense message, we want to show the assignment LHS rather than
-          # the entire assignment
-          result, = *result while result.op_asgn_type? || result.masgn_type?
-          result
-        end
-
         def block_end_align_target(node)
           lineage = [node, *node.ancestors]
 
@@ -153,7 +143,11 @@ module RuboCop
         end
 
         def autocorrect(corrector, node)
-          ancestor_node = start_for_block_node(node)
+          ancestor_node = if style == :start_of_block
+                            start_for_block_node(node)
+                          else
+                            start_for_line_node(node)
+                          end
           start_col = compute_start_col(ancestor_node, node)
           loc_end = node.loc.end
           delta = start_col - loc_end.column
@@ -173,6 +167,30 @@ module RuboCop
             prefer: format_source_line_column(error_source_line_column),
             alt_prefer: alt_start_msg(start_loc, do_source_line_column)
           )
+        end
+
+        def start_for_block_node(block_node)
+          # Which node should we align the 'end' with?
+          start_node = block_end_align_target(block_node)
+
+          find_lhs_node(start_node)
+        end
+
+        def start_for_line_node(block_node)
+          start_node = start_for_block_node(block_node)
+
+          start_node = start_node.each_ancestor.to_a.reverse.find do |node|
+            same_line?(start_node, node)
+          end || start_node
+
+          find_lhs_node(start_node)
+        end
+
+        # In offense message, we want to show the assignment LHS rather than
+        # the entire assignment.
+        def find_lhs_node(node)
+          node, = *node while node.op_asgn_type? || node.masgn_type?
+          node
         end
 
         def compute_do_source_line_column(node, end_loc)

--- a/spec/rubocop/cop/layout/block_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/block_alignment_spec.rb
@@ -390,6 +390,12 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         end)
         ^^^ `end` at 3, 2 is not aligned with `arr.all? do |o|` at 1, 7 or `expect(arr.all? do |o|` at 1, 0.
     RUBY
+
+    expect_correction(<<~RUBY)
+      expect(arr.all? do |o|
+        o.valid?
+      end)
+    RUBY
   end
 
   it 'accepts end aligned with an op-asgn (+=, -=)' do
@@ -407,6 +413,12 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         end
         ^^^ `end` at 3, 2 is not aligned with `rb` at 1, 0.
     RUBY
+
+    expect_correction(<<~RUBY)
+      rb += files.select do |file|
+        file << something
+      end
+    RUBY
   end
 
   it 'accepts end aligned with an and-asgn (&&=)' do
@@ -422,6 +434,11 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         end
         ^^^ `end` at 2, 2 is not aligned with `variable &&= test do |ala|` at 1, 0.
     RUBY
+
+    expect_correction(<<~RUBY)
+      variable &&= test do |ala|
+      end
+    RUBY
   end
 
   it 'accepts end aligned with an or-asgn (||=)' do
@@ -436,6 +453,11 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
       variable ||= test do |ala|
         end
         ^^^ `end` at 2, 2 is not aligned with `variable ||= test do |ala|` at 1, 0.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      variable ||= test do |ala|
+      end
     RUBY
   end
 
@@ -462,6 +484,12 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         end
         ^^^ `end` at 3, 2 is not aligned with `var1, var2` at 1, 0.
     RUBY
+
+    expect_correction(<<~RUBY)
+      var1, var2 = lambda do |test|
+        [1, 2]
+      end
+    RUBY
   end
 
   context 'when multiple similar-looking blocks have misaligned ends' do
@@ -473,6 +501,13 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         b = test do
          end
          ^^^ `end` at 4, 1 is not aligned with `b = test do` at 3, 0.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a = test do
+        end
+        b = test do
+        end
       RUBY
     end
   end
@@ -502,7 +537,7 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         def get_gems_by_name
           @gems ||= Hash[*get_latest_gems.map { |gem|
                            [gem.name, gem, gem.full_name, gem]
-                         }.flatten]
+          }.flatten]
         end
       RUBY
     end
@@ -533,7 +568,7 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         def abc
           @abc ||= A[~xyz { |x|
                        x
-                     }.flatten]
+          }.flatten]
         end
       RUBY
     end
@@ -564,7 +599,7 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         def abc
           @abc ||= A[!xyz { |x|
                        x
-                     }.flatten]
+          }.flatten]
         end
       RUBY
     end
@@ -595,7 +630,7 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         def abc
           @abc ||= A[-xyz { |x|
                        x
-                     }.flatten]
+          }.flatten]
         end
       RUBY
     end


### PR DESCRIPTION
Contrary to the documentation, the autocorrect for `either` was set to `block_of_line`:

> `either` (which is the default) : the `end` is allowed to be in either
> location. The autocorrect will default to `start_of_line`.

So this PR corrects it to `start_of_line`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
