### PR TITLE
Remove dependency on the `rexml` gem

### DIFF
--- a/changelog/change_remove_dependency_on_the_rexml_gem.md
+++ b/changelog/change_remove_dependency_on_the_rexml_gem.md
@@ -1,0 +1,1 @@
+* [#13165](https://github.com/rubocop/rubocop/pull/13165): Remove dependency on the `rexml` gem. ([@bquorning][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |s|
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.4', '< 3.0')
-  s.add_dependency('rexml', '>= 3.2.5', '< 4.0')
   s.add_dependency('rubocop-ast', '>= 1.32.1', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 3.0')

--- a/spec/rubocop/formatter/junit_formatter_spec.rb
+++ b/spec/rubocop/formatter/junit_formatter_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe RuboCop::Formatter::JUnitFormatter, :config do
     end
 
     it 'displays end of parsable text' do
-      expect(output.string).to end_with(<<~XML.chop)
+      expect(output.string).to end_with(<<~XML)
           </testsuite>
         </testsuites>
       XML
     end
 
-    it "displays an offense for `classname='test_1` in parsable text" do
+    it "displays an offense for `classname='test_1'` in parsable text" do
       expect(output.string).to include(<<-XML)
     <testcase classname='test_1' name='Layout/SpaceInsideBlockBraces'>
       <failure type='Layout/SpaceInsideBlockBraces' message='message 1'>
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Formatter::JUnitFormatter, :config do
       XML
     end
 
-    it "displays an offense for `classname='test_2` in parsable text" do
+    it "displays an offense for `classname='test_2'` in parsable text" do
       expect(output.string).to include(<<-XML)
     <testcase classname='test_2' name='Layout/SpaceInsideBlockBraces'>
       <failure type='Layout/SpaceInsideBlockBraces' message='message 1'>


### PR DESCRIPTION
ReXML has been plagued by quite a few security issues recently ([1](https://www.ruby-lang.org/en/news/2024/07/16/dos-rexml-cve-2024-39908/), [2](https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123/), [3](https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41946/), [4](https://www.ruby-lang.org/en/news/2024/08/22/dos-rexml-cve-2024-43398/)), all related to XML _parsing_. We don’t do any XML parsing in RuboCop, but we do do XML generation. And even that, we only do in one place: The jUnit formatter.

This PR removes our dependency on the `rexml` gem and instead builds the relatively simple XML from strings.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
