### PR TITLE
Properly cache team checksums

### DIFF
--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -120,8 +120,12 @@ module RuboCop
       end
 
       def external_dependency_checksum
-        keys = cops.filter_map(&:external_dependency_checksum)
-        Digest::SHA1.hexdigest(keys.join)
+        # The external dependency checksums are cached per RuboCop team so that
+        # the checksums don't need to be recomputed for each file.
+        @external_dependency_checksum ||= begin
+          keys = cops.filter_map(&:external_dependency_checksum)
+          Digest::SHA1.hexdigest(keys.join)
+        end
       end
 
       private

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -222,19 +222,13 @@ module RuboCop
       options.to_s.gsub(/[^a-z]+/i, '_')
     end
 
-    # The external dependency checksums are cached per RuboCop team so that
-    # the checksums don't need to be recomputed for each file.
-    def team_checksum(team)
-      @checksum_by_team ||= {}.compare_by_identity
-      @checksum_by_team[team] ||= team.external_dependency_checksum
-    end
-
     # We combine team and options into a single "context" checksum to avoid
     # making file names that are too long for some filesystems to handle.
     # This context is for anything that's not (1) the RuboCop executable
     # checksum or (2) the inspected file checksum.
     def context_checksum(team, options)
-      Digest::SHA1.hexdigest([team_checksum(team), relevant_options_digest(options)].join)
+      keys = [team.external_dependency_checksum, relevant_options_digest(options)]
+      Digest::SHA1.hexdigest(keys.join)
     end
   end
 end


### PR DESCRIPTION
Since its inception in #7496, this never really worked despite good intentions. Because `ResultCache` instances are per-file, the instance variable supposed to do the heavy lifting just gets discarded.

Benchmarking with this change on the RuboCop repo itself yields about 100ms improvements for me with a primed cache. 3 warmup runs, 10 measured runs:

```
old:
$ hyperfine -w 3 "bundle exec rubocop"
Benchmark 1: bundle exec rubocop
  Time (mean ± σ):      1.800 s ±  0.023 s    [User: 2.247 s, System: 1.050 s]
  Range (min … max):    1.774 s …  1.845 s    10 runs

new:
$ hyperfine -w 3 "bundle exec rubocop"
Benchmark 1: bundle exec rubocop
  Time (mean ± σ):      1.670 s ±  0.014 s    [User: 1.999 s, System: 1.040 s]
  Range (min … max):    1.657 s …  1.696 s    10 runs
```

For Rails, ~3s improvement:

```
old:
$ hyperfine -w 3 "bundle exec rubocop"
Benchmark 1: bundle exec rubocop
  Time (mean ± σ):     10.302 s ±  0.173 s    [User: 26.179 s, System: 2.307 s]
  Range (min … max):   10.158 s … 10.743 s    10 runs

new:
$ hyperfine -w 3 "bundle exec rubocop"
Benchmark 1: bundle exec rubocop
  Time (mean ± σ):      7.574 s ±  0.102 s    [User: 17.133 s, System: 1.977 s]
  Range (min … max):    7.451 s …  7.758 s    10 runs
```

On the GitLab repo containing ~38k files (nice to benchmark against) the gains are even more impressive at 45s (~55% faster!). Lots more files (and cops) means lots more redundant work:

```
old:
$ hyperfine -w 3 "bundle exec rubocop"
Benchmark 1: bundle exec rubocop
  Time (mean ± σ):     80.163 s ±  0.944 s    [User: 199.783 s, System: 13.855 s]
  Range (min … max):   79.215 s … 81.796 s    10 runs

new:
$ hyperfine -w 3 "bundle exec rubocop"
Benchmark 1: bundle exec rubocop
  Time (mean ± σ):     35.413 s ±  0.312 s    [User: 93.588 s, System: 9.236 s]
  Range (min … max):   35.007 s … 35.989 s    10 runs
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
