### PR TITLE
Remove `benchmark` dependency

### DIFF
--- a/exe/rubocop
+++ b/exe/rubocop
@@ -11,13 +11,14 @@ exit exit_status if server_cli.exit?
 if RuboCop::Server.running?
   exit_status = RuboCop::Server::ClientCommand::Exec.new.run
 else
-  require 'benchmark'
   require 'rubocop'
 
   cli = RuboCop::CLI.new
 
-  time = Benchmark.realtime { exit_status = cli.run }
+  time_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  exit_status = cli.run
+  elapsed_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - time_start
 
-  puts "Finished in #{time} seconds" if cli.options[:debug] || cli.options[:display_time]
+  puts "Finished in #{elapsed_time} seconds" if cli.options[:debug] || cli.options[:display_time]
 end
 exit exit_status


### PR DESCRIPTION
Ruby wants to bundle it: https://github.com/ruby/ruby/pull/11492

This is pretty much all the gem does anyways (that's being used here): https://github.com/ruby/benchmark/blob/8d2c8a0d7ca72bff7e97a4800e16c72f232867e4/lib/benchmark.rb#L311-L315

I removed the `bench_cop` rake task since it uses `benchmark` and I believe it just isn't very useful. Dedicated tools like `vernier` or `stackprof` (which has buildin support in RuboCop these days) are much more suited for the task.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
