### PR TITLE
Fix an error for `Layout/EmptyLinesAroundExceptionHandlingKeywords`

### DIFF
--- a/changelog/fix_error_for_layout_empty_lines_around_exception_handling_keywords.md
+++ b/changelog/fix_error_for_layout_empty_lines_around_exception_handling_keywords.md
@@ -1,0 +1,1 @@
+* [#13172](https://github.com/rubocop/rubocop/pull/13172): Fix an error for `Layout/EmptyLinesAroundExceptionHandlingKeywords` when `ensure` or `else` and `end` are on the same line. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_lines_around_exception_handling_keywords.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_exception_handling_keywords.rb
@@ -83,7 +83,7 @@ module RuboCop
 
           locations.each do |loc|
             line = loc.line
-            next if line == line_of_def_or_kwbegin || last_rescue_and_end_on_same_line(body)
+            next if line == line_of_def_or_kwbegin || last_body_and_end_on_same_line?(body)
 
             keyword = loc.source
             # below the keyword
@@ -93,8 +93,13 @@ module RuboCop
           end
         end
 
-        def last_rescue_and_end_on_same_line(body)
-          body.rescue_type? && body.resbody_branches.last.loc.line == body.parent.loc.end.line
+        def last_body_and_end_on_same_line?(body)
+          end_keyword_line = body.parent.loc.end.line
+          return body.loc.last_line == end_keyword_line unless body.rescue_type?
+
+          last_body_line = body.else? ? body.loc.else.line : body.resbody_branches.last.loc.line
+
+          last_body_line == end_keyword_line
         end
 
         def message(location, keyword)

--- a/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
@@ -292,6 +292,29 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords, 
     def do_something; foo; rescue => e; end
   RUBY
 
+  include_examples 'accepts', '`ensure` and `end` are on the same line', <<~RUBY
+    def do_something
+    ensure end
+  RUBY
+
+  include_examples 'accepts', '`else` and `end` are on the same line', <<~RUBY
+    def do_something
+    rescue
+    else end
+  RUBY
+
+  include_examples 'accepts', '`ensure` body expression and `end` are on the same line', <<~RUBY
+    def do_something
+    foo
+    ensure bar end
+  RUBY
+
+  include_examples 'accepts', '`else` body expression and `end` are on the same line', <<~RUBY
+    def do_something
+    rescue
+    else foo end
+  RUBY
+
   it 'with complex begin-end - registers many offenses' do
     expect_offense(<<~RUBY)
       begin


### PR DESCRIPTION
This PR fixes the following error for `Layout/EmptyLinesAroundExceptionHandlingKeywords` when `ensure` and `end` are on the same line:

```console
$ cat /tmp/example.rb
def do_something
ensure end

$ ruby -c /tmp/example.rb
Syntax OK

$ bundle exec rubocop /tmp/example.rb -a -d --only Layout/EmptyLinesAroundExceptionHandlingKeywords
(snip)

For /tmp: An error occurred while Layout/EmptyLinesAroundExceptionHandlingKeywords cop was inspecting /tmp/example.rb:1:0.
The range 28...29 is outside the bounds of the source
/Users/koic/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/parser-3.3.4.2/lib/parser/source/tree_rewriter.rb:406:
in 'Parser::Source::TreeRewriter#check_range_validity'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/corrector.rb:120:in 'RuboCop::Cop::Corrector#check_range_validity'
```

A similar issue can occur with `else`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
