### PR TITLE
Fix false negatives for `Style/EmptyLiteral`

### DIFF
--- a/changelog/fix_false_negatives_for_style_empty_literal.md
+++ b/changelog/fix_false_negatives_for_style_empty_literal.md
@@ -1,0 +1,1 @@
+* [#13173](https://github.com/rubocop/rubocop/pull/13173): Fix false negatives for `Style/EmptyLiteral` when using `Array[]`, `Hash[]`, `Array.new([])` and `Hash.new([])`. ([@vlad-pisanov][])

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -9,7 +9,9 @@ module RuboCop
       # @example
       #   # bad
       #   a = Array.new
+      #   a = Array[]
       #   h = Hash.new
+      #   h = Hash[]
       #   s = String.new
       #
       #   # good
@@ -22,17 +24,17 @@ module RuboCop
         include StringLiteralsHelp
         extend AutoCorrector
 
-        ARR_MSG = 'Use array literal `[]` instead of `Array.new`.'
-        HASH_MSG = 'Use hash literal `{}` instead of `Hash.new`.'
+        ARR_MSG = 'Use array literal `[]` instead of `%<current>s`.'
+        HASH_MSG = 'Use hash literal `{}` instead of `%<current>s`.'
         STR_MSG = 'Use string literal `%<prefer>s` instead of `String.new`.'
 
-        RESTRICT_ON_SEND = %i[new].freeze
+        RESTRICT_ON_SEND = %i[new [] Array Hash].freeze
 
         # @!method array_node(node)
-        def_node_matcher :array_node, '(send (const {nil? cbase} :Array) :new)'
+        def_node_matcher :array_node, '(send (const {nil? cbase} :Array) :new (array)?)'
 
         # @!method hash_node(node)
-        def_node_matcher :hash_node, '(send (const {nil? cbase} :Hash) :new)'
+        def_node_matcher :hash_node, '(send (const {nil? cbase} :Hash) :new (array)?)'
 
         # @!method str_node(node)
         def_node_matcher :str_node, '(send (const {nil? cbase} :String) :new)'
@@ -48,6 +50,22 @@ module RuboCop
           }
         PATTERN
 
+        # @!method array_with_index(node)
+        def_node_matcher :array_with_index, <<~PATTERN
+          {
+            (send (const {nil? cbase} :Array) :[])
+            (send nil? :Array (array))
+          }
+        PATTERN
+
+        # @!method hash_with_index(node)
+        def_node_matcher :hash_with_index, <<~PATTERN
+          {
+            (send (const {nil? cbase} :Hash) :[])
+            (send nil? :Hash (array))
+          }
+        PATTERN
+
         def on_send(node)
           return unless (message = offense_message(node))
 
@@ -60,9 +78,9 @@ module RuboCop
 
         def offense_message(node)
           if offense_array_node?(node)
-            ARR_MSG
+            format(ARR_MSG, current: node.source)
           elsif offense_hash_node?(node)
-            HASH_MSG
+            format(HASH_MSG, current: node.source)
           elsif str_node(node) && !frozen_strings?
             format(STR_MSG, prefer: preferred_string_literal)
           end
@@ -89,12 +107,12 @@ module RuboCop
         end
 
         def offense_array_node?(node)
-          array_node(node) && !array_with_block(node.parent)
+          (array_node(node) && !array_with_block(node.parent)) || array_with_index(node)
         end
 
         def offense_hash_node?(node)
           # If Hash.new takes a block, it can't be changed to {}.
-          hash_node(node) && !hash_with_block(node.parent)
+          (hash_node(node) && !hash_with_block(node.parent)) || hash_with_index(node)
         end
 
         def correction(node)

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1825,7 +1825,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       {}
     RUBY
     expect($stdout.string).to eq(<<~RESULT)
-      #{abs('example.rb')}:1:1: C: [Corrected] Style/EmptyLiteral: Use hash literal `{}` instead of `Hash.new`.
+      #{abs('example.rb')}:1:1: C: [Corrected] Style/EmptyLiteral: Use hash literal `{}` instead of `Hash.new()`.
       #{abs('example.rb')}:1:9: C: [Corrected] Style/MethodCallWithoutArgsParentheses: Do not use parentheses for method calls with no arguments.
     RESULT
   end

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -2,37 +2,26 @@
 
 RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
   describe 'Empty Array' do
-    it 'registers an offense for Array.new()' do
-      expect_offense(<<~RUBY)
-        test = Array.new()
-               ^^^^^^^^^^^ Use array literal `[]` instead of `Array.new`.
-      RUBY
+    shared_examples 'registers_and_corrects' do |initializer:|
+      it "registers an offense for #{initializer}" do
+        expect_offense(<<~RUBY)
+          test = #{initializer}
+                 #{'^' * initializer.length} Use array literal `[]` instead of `#{initializer}`.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        test = []
-      RUBY
+        expect_correction(<<~RUBY)
+          test = []
+        RUBY
+      end
     end
 
-    it 'registers an offense for Array.new' do
-      expect_offense(<<~RUBY)
-        test = Array.new
-               ^^^^^^^^^ Use array literal `[]` instead of `Array.new`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        test = []
-      RUBY
-    end
-
-    it 'registers an offense for ::Array.new' do
-      expect_offense(<<~RUBY)
-        test = ::Array.new
-               ^^^^^^^^^^^ Use array literal `[]` instead of `Array.new`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        test = []
-      RUBY
+    context 'initializer resulting in an empty array literal' do
+      it_behaves_like 'registers_and_corrects', initializer: 'Array.new()'
+      it_behaves_like 'registers_and_corrects', initializer: 'Array.new'
+      it_behaves_like 'registers_and_corrects', initializer: '::Array.new()'
+      it_behaves_like 'registers_and_corrects', initializer: 'Array.new([])'
+      it_behaves_like 'registers_and_corrects', initializer: 'Array[]'
+      it_behaves_like 'registers_and_corrects', initializer: 'Array([])'
     end
 
     it 'does not register an offense for Array.new(3)' do
@@ -61,40 +50,45 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
     it 'does not register Array.new with block in other block' do
       expect_no_offenses('puts { Array.new { 1 } }')
     end
+
+    it 'does not register an offense for Array[3]' do
+      expect_no_offenses('Array[3]')
+    end
+
+    it 'does not register an offense for Array [3]' do
+      expect_no_offenses('Array [3]')
+    end
   end
 
   describe 'Empty Hash' do
-    it 'registers an offense for Hash.new()' do
-      expect_offense(<<~RUBY)
-        test = Hash.new()
-               ^^^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
-      RUBY
+    shared_examples 'registers_and_corrects' do |initializer:|
+      it "registers an offense for #{initializer}" do
+        expect_offense(<<~RUBY)
+          test = #{initializer}
+                 #{'^' * initializer.length} Use hash literal `{}` instead of `#{initializer}`.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        test = {}
-      RUBY
+        expect_correction(<<~RUBY)
+          test = {}
+        RUBY
+      end
     end
 
-    it 'registers an offense for Hash.new' do
-      expect_offense(<<~RUBY)
-        test = Hash.new
-               ^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        test = {}
-      RUBY
+    context 'initializer resulting in an empty hash literal' do
+      it_behaves_like 'registers_and_corrects', initializer: 'Hash.new()'
+      it_behaves_like 'registers_and_corrects', initializer: 'Hash.new'
+      it_behaves_like 'registers_and_corrects', initializer: '::Hash.new()'
+      it_behaves_like 'registers_and_corrects', initializer: 'Hash.new([])'
+      it_behaves_like 'registers_and_corrects', initializer: 'Hash[]'
+      it_behaves_like 'registers_and_corrects', initializer: 'Hash([])'
     end
 
-    it 'registers an offense for ::Hash.new' do
-      expect_offense(<<~RUBY)
-        test = ::Hash.new
-               ^^^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
-      RUBY
+    it 'does not register an offense for Hash[3,4]' do
+      expect_no_offenses('Hash[3,4]')
+    end
 
-      expect_correction(<<~RUBY)
-        test = {}
-      RUBY
+    it 'does not register an offense for Hash [3,4]' do
+      expect_no_offenses('Hash [3,4]')
     end
 
     it 'does not register an offense for Hash.new(3)' do


### PR DESCRIPTION
Improve `Style/EmptyLiteral` to detect other common ways of creating empty literals.

```ruby
Array.new      # ✔️ existing offense
Hash.new       # ✔️ existing offense

Array[]        # ⚠️ new offense
Array([])      # ⚠️ new offense
Array.new([])  # ⚠️ new offense
Hash[]         # ⚠️ new offense
Hash([])       # ⚠️ new offense
Hash.new([])   # ⚠️ new offense
```

Also: improve offense message by including the actual offense source

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
