### PR TITLE
Fix false negatives for `Style/MapIntoArray`

### DIFF
--- a/changelog/fix_false_negative_for_style_map_into_array.md
+++ b/changelog/fix_false_negative_for_style_map_into_array.md
@@ -1,0 +1,1 @@
+* [#13174](https://github.com/rubocop/rubocop/pull/13174): Fix false negatives for `Style/MapIntoArray` when initializing the destination using `Array[]`, `Array([])`, or `Array.new([])`. ([@vlad-pisanov][])

--- a/lib/rubocop/cop/style/map_into_array.rb
+++ b/lib/rubocop/cop/style/map_into_array.rb
@@ -63,7 +63,16 @@ module RuboCop
         PATTERN
 
         # @!method empty_array_asgn?(node)
-        def_node_matcher :empty_array_asgn?, '(lvasgn _ (array))'
+        def_node_matcher :empty_array_asgn?, <<~PATTERN
+          (
+            lvasgn _ {
+              (array)
+              (send (const {nil? cbase} :Array) :[])
+              (send (const {nil? cbase} :Array) :new (array)?)
+              (send nil? :Array (array))
+            }
+          )
+        PATTERN
 
         # @!method lvar_ref?(node, name)
         def_node_matcher :lvar_ref?, '(lvar %1)'

--- a/spec/rubocop/cop/style/map_into_array_spec.rb
+++ b/spec/rubocop/cop/style/map_into_array_spec.rb
@@ -215,6 +215,42 @@ RSpec.describe RuboCop::Cop::Style::MapIntoArray, :config do
     RUBY
   end
 
+  context 'destination initializer' do
+    shared_examples 'corrects' do |initializer:|
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          dest = #{initializer}
+          src.each { |e| dest << e * 2 }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `map` instead of `each` to map elements into an array.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          dest = src.map { |e| e * 2 }
+        RUBY
+      end
+    end
+
+    context '[]' do
+      it_behaves_like 'corrects', initializer: '[]'
+    end
+
+    context 'Array.new' do
+      it_behaves_like 'corrects', initializer: 'Array.new'
+    end
+
+    context 'Array[]' do
+      it_behaves_like 'corrects', initializer: 'Array[]'
+    end
+
+    context 'Array([])' do
+      it_behaves_like 'corrects', initializer: 'Array([])'
+    end
+
+    context 'Array.new([])' do
+      it_behaves_like 'corrects', initializer: 'Array.new([])'
+    end
+  end
+
   context 'new method name for replacement' do
     context 'when `Style/CollectionMethods` is configured for `map`' do
       let(:other_cops) do


### PR DESCRIPTION
Improve `Style/MapIntoArray` to detect cases where the destination array is initialized to an empty literal in ways other than `[]`.

```ruby
dest = []            # ✔️ currently supported

dest = Array.new     # ⚠️ new offense
dest = Array[]       # ⚠️ new offense
dest = Array([])     # ⚠️ new offense
dest = Array.new([]) # ⚠️ new offense

arr.each { |x| dest << x }
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
