### PR TITLE
Replace forwardable with explicit delegation for performance

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -9,7 +9,6 @@ require 'fileutils'
 before_us = $LOADED_FEATURES.dup
 require 'rainbow'
 
-require 'forwardable'
 require 'regexp_parser'
 require 'set'
 require 'unicode/display_width'

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -4,8 +4,6 @@ module RuboCop
   # This class parses the special `rubocop:disable` comments in a source
   # and provides a way to check if each cop is enabled at arbitrary line.
   class CommentConfig
-    extend Forwardable
-
     CONFIG_DISABLED_LINE_RANGE_MIN = -Float::INFINITY
 
     # This class provides an API compatible with RuboCop::DirectiveComment
@@ -29,11 +27,17 @@ module RuboCop
 
     attr_reader :processed_source
 
-    def_delegators :@processed_source, :config, :registry
-
     def initialize(processed_source)
       @processed_source = processed_source
       @no_directives = !processed_source.raw_source.include?('rubocop')
+    end
+
+    def config
+      @processed_source.config
+    end
+
+    def registry
+      @processed_source.registry
     end
 
     def cop_enabled_at_line?(cop, line_number)

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -3,9 +3,7 @@
 module RuboCop
   # Handles validation of configuration, for example cop names, parameter
   # names, and Ruby versions.
-  class ConfigValidator
-    extend Forwardable
-
+  class ConfigValidator # rubocop:disable Metrics/ClassLength
     # @api private
     COMMON_PARAMS = %w[Exclude Include Severity inherit_mode AutoCorrect StyleGuide Details].freeze
     # @api private
@@ -21,12 +19,18 @@ module RuboCop
     CONFIG_CHECK_AUTOCORRECTS = %w[always contextual disabled].freeze
     private_constant :CONFIG_CHECK_KEYS, :CONFIG_CHECK_DEPARTMENTS
 
-    def_delegators :@config, :smart_loaded_path, :for_all_cops
-
     def initialize(config)
       @config = config
       @config_obsoletion = ConfigObsoletion.new(config)
       @target_ruby = TargetRuby.new(config)
+    end
+
+    def smart_loaded_path
+      @config.smart_loaded_path
+    end
+
+    def for_all_cops
+      @config.for_all_cops
     end
 
     def validate

--- a/lib/rubocop/cop/mixin/annotation_comment.rb
+++ b/lib/rubocop/cop/mixin/annotation_comment.rb
@@ -4,8 +4,6 @@ module RuboCop
   module Cop
     # Representation of an annotation comment in source code (eg. `# TODO: blah blah blah`).
     class AnnotationComment
-      extend Forwardable
-
       attr_reader :comment, :margin, :keyword, :colon, :space, :note
 
       # @param [Parser::Source::Comment] comment

--- a/lib/rubocop/cop/style/magic_comment_format.rb
+++ b/lib/rubocop/cop/style/magic_comment_format.rb
@@ -105,19 +105,24 @@ module RuboCop
 
         # Value object to extract source ranges for the different parts of a magic comment
         class CommentRange
-          extend Forwardable
-
           DIRECTIVE_REGEXP = Regexp.union(MagicComment::KEYWORDS.map do |_, v|
             Regexp.new(v, Regexp::IGNORECASE)
           end).freeze
 
           VALUE_REGEXP = Regexp.new("(?:#{DIRECTIVE_REGEXP}:\s*)(.*?)(?=;|$)")
 
-          def_delegators :@comment, :text, :loc
           attr_reader :comment
 
           def initialize(comment)
             @comment = comment
+          end
+
+          def text
+            @comment.text
+          end
+
+          def loc
+            @comment.loc
           end
 
           # A magic comment can contain one directive (normal style) or


### PR DESCRIPTION
I'm doing performance profiling and was surprised for these to appear at all in the samples. Here are some numbers (3 warmup runs, 20 measured runs, cache used)::

```
# with forwardable in both rubocop + rubocop-ast
$ hyperfine -w 3 -r 20 "bundle exec rubocop Rakefile"
Benchmark 1: bundle exec rubocop Rakefile
  Time (mean ± σ):      1.169 s ±  0.016 s    [User: 0.976 s, System: 0.190 s]
  Range (min … max):    1.138 s …  1.198 s    20 runs

# with forwardable only in rubocop-ast
$ hyperfine -w 3 -r 20 "bundle exec rubocop Rakefile"
Benchmark 1: bundle exec rubocop Rakefile
  Time (mean ± σ):      1.145 s ±  0.011 s    [User: 0.959 s, System: 0.185 s]
  Range (min … max):    1.131 s …  1.170 s    20 runs

# with forwardable in neither
$ hyperfine -w 3 -r 20 "bundle exec rubocop Rakefile"
Benchmark 1: bundle exec rubocop Rakefile
  Time (mean ± σ):      1.136 s ±  0.020 s    [User: 0.950 s, System: 0.183 s]
  Range (min … max):    1.098 s …  1.168 s    20 runs
```

Overall ~ 3% faster

-------

Full run, also about 3%:

```
# with forwardable in both rubocop + rubocop-ast
$ hyperfine -w 3 -r 20 "bundle exec rubocop"
Benchmark 1: bundle exec rubocop
  Time (mean ± σ):      1.704 s ±  0.018 s    [User: 1.903 s, System: 1.004 s]
  Range (min … max):    1.669 s …  1.742 s    20 runs

# with forwardable only in rubocop-ast
$ hyperfine -w 3 -r 20 "bundle exec rubocop"
Benchmark 1: bundle exec rubocop
  Time (mean ± σ):      1.677 s ±  0.025 s    [User: 1.847 s, System: 0.988 s]
  Range (min … max):    1.640 s …  1.763 s    20 runs

# with forwardable in neither
$ hyperfine -w 3 -r 20 "bundle exec rubocop"
Benchmark 1: bundle exec rubocop
  Time (mean ± σ):      1.656 s ±  0.020 s    [User: 1.817 s, System: 0.984 s]
  Range (min … max):    1.630 s …  1.700 s    20 runs
```

Companion PR for `rubocop-ast`: https://github.com/rubocop/rubocop-ast/pull/312

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
