### PR TITLE
Fix crash in `Style/EmptyElse` when `AllowComments: true` and the else clause is missing

### DIFF
--- a/changelog/fix_style_empty_else_without_else.md
+++ b/changelog/fix_style_empty_else_without_else.md
@@ -1,0 +1,1 @@
+* [#13176](https://github.com/rubocop/rubocop/issues/13176): Fix crash in `Style/EmptyElse` when `AllowComments: true` and the else clause is missing. ([@vlad-pisanov][])

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -179,6 +179,7 @@ module RuboCop
 
         def comment_in_else?(node)
           node = node.parent while node.if_type? && node.elsif?
+          return false unless node.else?
 
           processed_source.contains_comment?(node.loc.else.join(node.source_range.end))
         end

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -646,6 +646,16 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
           RUBY
         end
       end
+
+      context 'without an else' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            if condition
+              statement
+            end
+          RUBY
+        end
+      end
     end
 
     context 'given an unless-statement' do
@@ -693,6 +703,16 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
               statement
             else
               nil # some comment
+            end
+          RUBY
+        end
+      end
+
+      context 'without an else' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            unless condition
+              statement
             end
           RUBY
         end
@@ -748,6 +768,17 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
               statement
             else
               nil # some comment
+            end
+          RUBY
+        end
+      end
+
+      context 'without an else' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            case a
+            when condition
+              statement
             end
           RUBY
         end


### PR DESCRIPTION
Fix for https://github.com/rubocop/rubocop/issues/13176

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
