### PR TITLE
Fix false positive for `Style/EmptyLiteral` with `Hash.new([])`

### DIFF
--- a/changelog/fix_false_positive_empty_literal.md
+++ b/changelog/fix_false_positive_empty_literal.md
@@ -1,0 +1,1 @@
+* [#13178](https://github.com/rubocop/rubocop/pull/13178): Fix false positive for `Style/EmptyLiteral` with `Hash.new([])`. ([@earlopain][])

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -34,7 +34,7 @@ module RuboCop
         def_node_matcher :array_node, '(send (const {nil? cbase} :Array) :new (array)?)'
 
         # @!method hash_node(node)
-        def_node_matcher :hash_node, '(send (const {nil? cbase} :Hash) :new (array)?)'
+        def_node_matcher :hash_node, '(send (const {nil? cbase} :Hash) :new)'
 
         # @!method str_node(node)
         def_node_matcher :str_node, '(send (const {nil? cbase} :String) :new)'

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -78,7 +78,6 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
       it_behaves_like 'registers_and_corrects', initializer: 'Hash.new()'
       it_behaves_like 'registers_and_corrects', initializer: 'Hash.new'
       it_behaves_like 'registers_and_corrects', initializer: '::Hash.new()'
-      it_behaves_like 'registers_and_corrects', initializer: 'Hash.new([])'
       it_behaves_like 'registers_and_corrects', initializer: 'Hash[]'
       it_behaves_like 'registers_and_corrects', initializer: 'Hash([])'
     end
@@ -105,6 +104,10 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
 
     it 'does not register an offense for ::Hash.new { block }' do
       expect_no_offenses('test = ::Hash.new { block }')
+    end
+
+    it 'does not register an offense for Hash.new([])' do
+      expect_no_offenses('Hash.new([])')
     end
 
     context 'Ruby 2.7', :ruby27 do


### PR DESCRIPTION
The first parameter for Hash.new is the default value:

```rb
Hash.new([])[:foo]
# => []
```

Side note: this usage is most likely a programming error. You want the block form where different keys _don't_ share the same underlying array.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
