### PR TITLE
Fix an error for `InternalAffairs/NodeMatcherDirective` when no second argument

### DIFF
--- a/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
+++ b/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
@@ -45,7 +45,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return if node.arguments.none?
+          return unless node.arguments.count == 2
           return unless valid_method_name?(node)
 
           actual_name = node.first_argument.value.to_s

--- a/spec/rubocop/cop/internal_affairs/node_matcher_directive_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/node_matcher_directive_spec.rb
@@ -293,6 +293,12 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeMatcherDirective, :config do
       RUBY
     end
 
+    it 'registers no offense without second argument' do
+      expect_no_offenses(<<~RUBY)
+        #{method} :foo?
+      RUBY
+    end
+
     context 'when using class methods' do
       it 'registers an offense when the directive is missing' do
         expect_offense(<<~RUBY, method: method)


### PR DESCRIPTION
There is code below that assumes the existance of two arguments

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
