### PR TITLE
Fix some false positives in `Lint/UnreachableCode`.

### DIFF
--- a/changelog/fix_false_positive_unreachable_code.md
+++ b/changelog/fix_false_positive_unreachable_code.md
@@ -1,0 +1,1 @@
+* [#13184](https://github.com/rubocop/rubocop/pull/13184): Fix some false positives in  `Lint/UnreachableCode`. ([@isuckatcs][])

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -32,6 +32,22 @@ module RuboCop
       class UnreachableCode < Base
         MSG = 'Unreachable code detected.'
 
+        def initialize(config = nil, options = nil)
+          super
+          @redefined = []
+          @instance_eval_count = 0
+        end
+
+        def on_block(node)
+          @instance_eval_count += 1 if instance_eval_block?(node)
+        end
+
+        alias on_numblock on_block
+
+        def after_block(node)
+          @instance_eval_count -= 1 if instance_eval_block?(node)
+        end
+
         def on_begin(node)
           expressions = *node
 
@@ -46,19 +62,23 @@ module RuboCop
 
         private
 
+        def redefinable_flow_method?(method)
+          %i[raise fail throw exit exit! abort].include? method
+        end
+
         # @!method flow_command?(node)
         def_node_matcher :flow_command?, <<~PATTERN
           {
             return next break retry redo
             (send
              {nil? (const {nil? cbase} :Kernel)}
-             {:raise :fail :throw :exit :exit! :abort}
+             #redefinable_flow_method?
              ...)
           }
         PATTERN
 
         def flow_expression?(node)
-          return true if flow_command?(node)
+          return report_on_flow_command?(node) if flow_command?(node)
 
           case node.type
           when :begin, :kwbegin
@@ -68,6 +88,8 @@ module RuboCop
             check_if(node)
           when :case, :case_match
             check_case(node)
+          when :def
+            register_redefinition(node)
           else
             false
           end
@@ -87,6 +109,33 @@ module RuboCop
           branches = node.case_type? ? node.when_branches : node.in_pattern_branches
 
           branches.all? { |branch| branch.body && flow_expression?(branch.body) }
+        end
+
+        def register_redefinition(node)
+          @redefined << node.method_name if redefinable_flow_method? node.method_name
+          false
+        end
+
+        def instance_eval_block?(node)
+          node.block_type? && node.method?(:instance_eval)
+        end
+
+        def report_on_flow_command?(node)
+          return true unless node.send_type?
+
+          # By the contract of this function, this case means that
+          # the method is called on `Kernel` in which case we
+          # always want to report a warning.
+          return true if node.receiver
+
+          # Inside an `instance_eval` we have no way to tell the
+          # type of `self` just by looking at the AST, so we can't
+          # tell if the give function that's called has been
+          # redefined or not, so to avoid false positives, we silence
+          # the warning.
+          return false if @instance_eval_count.positive?
+
+          !@redefined.include? node.method_name
         end
       end
     end

--- a/spec/rubocop/cop/lint/unreachable_code_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_code_spec.rb
@@ -214,5 +214,137 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableCode, :config do
         bar
       RUBY
     end
+
+    # These are keywords and cannot be redefined.
+    next if %w[return next break retry redo].include? t
+
+    it "registers an offense for `#{t}` after `instance_eval`" do
+      expect_offense <<~RUBY
+        class Dummy
+          def #{t}; end
+        end
+
+        d = Dummy.new
+        d.instance_eval do
+          #{t}
+          bar
+        end
+
+        #{t}
+        bar
+        ^^^ Unreachable code detected.
+      RUBY
+    end
+
+    it "registers an offense for `#{t}` with nested redefinition" do
+      expect_offense <<~RUBY
+        def foo
+          def #{t}; end
+        end
+
+        #{t}
+        bar
+        ^^^ Unreachable code detected.
+      RUBY
+    end
+
+    it "accepts `#{t}` if redefined" do
+      expect_no_offenses(wrap(<<~RUBY))
+        def #{t}; end
+        #{t}
+        bar
+      RUBY
+    end
+
+    it "accepts `#{t}` if redefined even if it's called recursively" do
+      expect_no_offenses(wrap(<<~RUBY))
+        def #{t}
+          #{t}
+          bar
+        end
+
+        #{t}
+        bar
+      RUBY
+    end
+
+    it "accepts `#{t}` if called in `instance_eval`" do
+      expect_no_offenses <<~RUBY
+        class Dummy
+          def #{t}; end
+        end
+
+        d = Dummy.new
+        d.instance_eval do
+          #{t}
+          bar
+        end
+      RUBY
+    end
+
+    it "accepts `#{t}` if called in nested `instance_eval`" do
+      expect_no_offenses <<~RUBY
+        class Dummy
+          def #{t}; end
+        end
+
+        d = Dummy.new
+        d.instance_eval do
+          d2 = Dummy.new
+          d2.instance_eval do
+            #{t}
+            bar
+          end
+        end
+      RUBY
+    end
+
+    it "registers an offense for redefined `#{t}` if it is called on Kernel" do
+      expect_offense <<~RUBY
+        def #{t}; end
+
+        Kernel.#{t}
+        foo
+        ^^^ Unreachable code detected.
+      RUBY
+    end
+
+    it "accepts redefined `#{t}` if it is called on a class other than Kernel" do
+      expect_no_offenses <<~RUBY
+        def #{t}; end
+
+        Dummy.#{t}
+        foo
+      RUBY
+    end
+
+    it "registers an offense for `#{t}` inside `instance_eval` if it is called on Kernel" do
+      expect_offense <<~RUBY
+        class Dummy
+          def #{t}; end
+        end
+
+        d = Dummy.new
+        d.instance_eval do
+          Kernel.#{t}
+          foo
+          ^^^ Unreachable code detected.
+        end
+      RUBY
+    end
+
+    it "accepts `#{t}` inside `instance_eval` if it is called on a class other than Kernel" do
+      expect_no_offenses <<~RUBY
+        class Dummy
+          def #{t}; end
+        end
+
+        d = Dummy.new
+        d.instance_eval do
+          Dummy.#{t}
+          foo
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
If a developer decides to either redefine builtin methods like `exit`, `throw`, etc. or defines methods with the same name inside a `class`, `Lint/UnreachableCode` will treat these methods as if they were still the builtin ones, which leads to false positive reports.

E.g.:
```ruby
def exit;end

exit
puts "this is reachable"
^^^^^^^^^^^^^^^^^^^^^^^^
# RuboCop: Unreachable code detected. [Lint/ UnreachableCode]
```
```ruby
class Dummy
  def exit; end
end

d = Dummy.new
d.instance_eval do
  exit
  puts "this is reachable"
  ^^^^^^^^^^^^^^^^^^^^^^^^
  # RuboCop: Unreachable code detected. [Lint/ UnreachableCode]
end
```

This patch aims to address these cases by also checking if the called builtin has been redefined or not. The only exception is inside `instance_eval`, as we have no way to check the type of `self` and decide which methods are called, so in that case coverage is dropped instead. As a result, in the following case, we get a false negative.
```ruby
o = Object.new
o.instance_eval do
  exit
  puts "this should be reported as unreachable"
end
```
If introduing a false negative as a drawback of removing false positives is not desired, the `instance_eval` related part of the patch can be removed.



-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
