### PR TITLE
Fix false negatives in `Style/MapIntoArray` autocorrection

### DIFF
--- a/changelog/fix_style_map_into_array_autocorrect_detection.md
+++ b/changelog/fix_style_map_into_array_autocorrect_detection.md
@@ -1,0 +1,1 @@
+* [#13185](https://github.com/rubocop/rubocop/pull/13185): Fix false negatives in `Style/MapIntoArray` autocorrection when using `ensure`, `def`, `defs` and `for`. ([@vlad-pisanov][])

--- a/lib/rubocop/cop/style/map_into_array.rb
+++ b/lib/rubocop/cop/style/map_into_array.rb
@@ -147,10 +147,8 @@ module RuboCop
             false
           when :begin, :kwbegin
             !node.right_sibling && return_value_used?(parent)
-          when :block, :numblock
-            !parent.void_context?
           else
-            true
+            !parent.respond_to?(:void_context?) || !parent.void_context?
           end
         end
 

--- a/spec/rubocop/cop/style/map_into_array_spec.rb
+++ b/spec/rubocop/cop/style/map_into_array_spec.rb
@@ -374,6 +374,10 @@ RSpec.describe RuboCop::Cop::Style::MapIntoArray, :config do
           it_behaves_like 'corrects', template: 'begin; %s end'
         end
       end
+
+      context 'in an ensure' do
+        it_behaves_like 'corrects', template: 'begin; ensure; %s end'
+      end
     end
 
     context 'in a block' do
@@ -404,6 +408,18 @@ RSpec.describe RuboCop::Cop::Style::MapIntoArray, :config do
       context 'at the end' do
         it_behaves_like 'skip correcting', template: 'def foo; %s end'
       end
+
+      context 'in a constructor' do
+        it_behaves_like 'corrects', template: 'def initialize; %s; end'
+      end
+
+      context 'in an assignment method' do
+        it_behaves_like 'corrects', template: 'def foo=(value); %s; end'
+      end
+    end
+
+    context 'in a for loop' do
+      it_behaves_like 'corrects', template: 'for i in foo; %s; end'
     end
   end
 end


### PR DESCRIPTION
Small improvement to `Style/MapIntoArray`'s autocorrection detection.

This cop can only autocorrect in a void context, and currently it only checks (kw)begin/(num)block contexts. This PR adapts some of the new logic from `Lint/Void` to expand void context detection to `ensure`, `def`, `defs`, and `for` contexts by delegating the responsibility to `rubocop-ast`.

e.g.
```ruby
def initialize
  dest = []
  list.each { dest << _1 } # 🆕 can now be autocorrected since it's in constructor
end
```
```ruby
def self.name=(value)
  dest = []
  list.each { dest << _1 } # 🆕 can now be autocorrected since it's in an assignment method
end
```
```ruby
def foo
  bar
ensure
  dest = []
  list.each { dest << _1 } # 🆕 can now be autocorrected since ensure is always a void context
end
```
```ruby
for i in list
  dest = []
  list.each { dest << _1 } # 🆕 can now be autocorrected since it's in a for loop
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
