### PR TITLE
Use `rubocop-ast` `SimpleForwardable`

### DIFF
--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -4,6 +4,8 @@ module RuboCop
   # This class parses the special `rubocop:disable` comments in a source
   # and provides a way to check if each cop is enabled at arbitrary line.
   class CommentConfig
+    extend SimpleForwardable
+
     CONFIG_DISABLED_LINE_RANGE_MIN = -Float::INFINITY
 
     # This class provides an API compatible with RuboCop::DirectiveComment
@@ -27,17 +29,11 @@ module RuboCop
 
     attr_reader :processed_source
 
+    def_delegators :@processed_source, :config, :registry
+
     def initialize(processed_source)
       @processed_source = processed_source
       @no_directives = !processed_source.raw_source.include?('rubocop')
-    end
-
-    def config
-      @processed_source.config
-    end
-
-    def registry
-      @processed_source.registry
     end
 
     def cop_enabled_at_line?(cop, line_number)

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -12,6 +12,7 @@ module RuboCop
   class Config
     include PathUtil
     include FileFinder
+    extend SimpleForwardable
 
     CopConfig = Struct.new(:name, :metadata)
 
@@ -59,22 +60,9 @@ module RuboCop
       self
     end
 
-    %i[[] []= delete dig each key? keys each_key fetch map merge replace to_h to_hash
-       transform_values].each do |method|
-      class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
-        def #{method}(...)     # def key?(...)
-          @hash.#{method}(...) #   @hash.key?(...)
-        end                    # end
-      RUBY
-    end
-
-    def validate(...)
-      @validator.validate(...)
-    end
-
-    def target_ruby_version
-      @validator.target_ruby_version
-    end
+    def_delegators :@hash, :[], :[]=, :delete, :dig, :each, :key?, :keys, :each_key,
+                   :fetch, :map, :merge, :replace, :to_h, :to_hash, :transform_values
+    def_delegators :@validator, :validate, :target_ruby_version
 
     def to_s
       @to_s ||= @hash.to_s

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -3,7 +3,9 @@
 module RuboCop
   # Handles validation of configuration, for example cop names, parameter
   # names, and Ruby versions.
-  class ConfigValidator # rubocop:disable Metrics/ClassLength
+  class ConfigValidator
+    extend SimpleForwardable
+
     # @api private
     COMMON_PARAMS = %w[Exclude Include Severity inherit_mode AutoCorrect StyleGuide Details].freeze
     # @api private
@@ -19,18 +21,12 @@ module RuboCop
     CONFIG_CHECK_AUTOCORRECTS = %w[always contextual disabled].freeze
     private_constant :CONFIG_CHECK_KEYS, :CONFIG_CHECK_DEPARTMENTS
 
+    def_delegators :@config, :smart_loaded_path, :for_all_cops
+
     def initialize(config)
       @config = config
       @config_obsoletion = ConfigObsoletion.new(config)
       @target_ruby = TargetRuby.new(config)
-    end
-
-    def smart_loaded_path
-      @config.smart_loaded_path
-    end
-
-    def for_all_cops
-      @config.for_all_cops
     end
 
     def validate

--- a/lib/rubocop/cop/style/magic_comment_format.rb
+++ b/lib/rubocop/cop/style/magic_comment_format.rb
@@ -105,24 +105,19 @@ module RuboCop
 
         # Value object to extract source ranges for the different parts of a magic comment
         class CommentRange
+          extend SimpleForwardable
+
           DIRECTIVE_REGEXP = Regexp.union(MagicComment::KEYWORDS.map do |_, v|
             Regexp.new(v, Regexp::IGNORECASE)
           end).freeze
 
           VALUE_REGEXP = Regexp.new("(?:#{DIRECTIVE_REGEXP}:\s*)(.*?)(?=;|$)")
 
+          def_delegators :@comment, :text, :loc
           attr_reader :comment
 
           def initialize(comment)
             @comment = comment
-          end
-
-          def text
-            @comment.text
-          end
-
-          def loc
-            @comment.loc
           end
 
           # A magic comment can contain one directive (normal style) or

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.4', '< 3.0')
-  s.add_dependency('rubocop-ast', '>= 1.32.1', '< 2.0')
+  s.add_dependency('rubocop-ast', '>= 1.32.2', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 3.0')
 end


### PR DESCRIPTION
Introduced in https://github.com/rubocop/rubocop-ast/pull/312
Also see https://github.com/rubocop/rubocop/pull/13175

I performance tested this change and found no significant difference, which makes sense since it's basically the same thing.

This is pretty much a revert of the previous PR, changing `Forwardable` to `SimpleForwardable` (except for one class, which just didn't use it so I left that out)

cc @marcandre