### PR TITLE
Don't parse YAML twice

### DIFF
--- a/lib/rubocop/yaml_duplication_checker.rb
+++ b/lib/rubocop/yaml_duplication_checker.rb
@@ -16,6 +16,7 @@ module RuboCop
       return unless tree
 
       traverse(tree, &on_duplicated)
+      tree
     end
 
     def self.traverse(tree, &on_duplicated)


### PR DESCRIPTION
Once for the duplication check, and once again to convert it to a ruby hash

We can instead use the yaml ast from the duplication check and convert that into a hash directly.

```
# Rubocop
# Base:
$ hyperfine -w 5 -r 20 "bundle exec rubocop Rakefile"
Benchmark 1: bundle exec rubocop Rakefile
  Time (mean ± σ):      1.041 s ±  0.014 s    [User: 0.898 s, System: 0.140 s]
  Range (min … max):    1.013 s …  1.061 s    20 runs

# Patch:
$ hyperfine -w 5 -r 20 "bundle exec rubocop Rakefile"
Benchmark 1: bundle exec rubocop Rakefile
  Time (mean ± σ):      1.013 s ±  0.008 s    [User: 0.865 s, System: 0.146 s]
  Range (min … max):    0.998 s …  1.027 s    20 runs
```

~2.7%  Faster

```
# Gitlab
# Base:
$ hyperfine -w 5 -r 20 "bundle exec rubocop Rakefile"
Benchmark 1: bundle exec rubocop Rakefile
  Time (mean ± σ):      3.485 s ±  0.027 s    [User: 2.565 s, System: 0.909 s]
  Range (min … max):    3.445 s …  3.529 s    20 runs

# Applied:
$ hyperfine -w 5 -r 20 "bundle exec rubocop Rakefile"
Benchmark 1: bundle exec rubocop Rakefile
  Time (mean ± σ):      3.401 s ±  0.029 s    [User: 2.483 s, System: 0.906 s]
  Range (min … max):    3.356 s …  3.466 s    20 runs
```

~2.5% faster. I expected more since they have so many config files but hey, still something.

-----

I checked https://docs.ruby-lang.org/en/3.3/table_of_contents.html#classes and they all seem to be documented and have been around since 2.1

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
