### PR TITLE
Fix an error for `Style/IfWithSemicolon`

### DIFF
--- a/changelog/fix_an_error_for_style_if_with_semicolon.md
+++ b/changelog/fix_an_error_for_style_if_with_semicolon.md
@@ -1,0 +1,1 @@
+* [#13191](https://github.com/rubocop/rubocop/pull/13191): Fix an error for `Style/IfWithSemicolon` when using nested single-line if/;/end in block of if/else branches. ([@koic][])

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -203,5 +203,57 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
         end
       RUBY
     end
+
+    it 'registers an offense and corrects when using nested single-line if/;/end in block of if body' do
+      expect_offense(<<~RUBY)
+        if foo?; bar { if qux?; quux else end } end
+                       ^^^^^^^^^^^^^^^^^^^^^^ Do not use `if qux?;` - use a ternary operator instead.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if foo?;` - use `if/else` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if foo?
+         bar { qux? ? quux : nil } end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using nested single-line if/;/end in the block of else body' do
+      expect_offense(<<~RUBY)
+        if foo?; bar else baz { if qux?; quux else end } end
+                                ^^^^^^^^^^^^^^^^^^^^^^ Do not use `if qux?;` - use a ternary operator instead.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if foo?;` - use `if/else` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if foo?
+         bar else baz { qux? ? quux : nil } end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using nested single-line if/;/end in numblock of if body' do
+      expect_offense(<<~RUBY)
+        if foo?; bar { if _1; quux else end } end
+                       ^^^^^^^^^^^^^^^^^^^^ Do not use `if _1;` - use a ternary operator instead.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if foo?;` - use `if/else` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if foo?
+         bar { _1 ? quux : nil } end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using nested single-line if/;/end in the numblock of else body' do
+      expect_offense(<<~RUBY)
+        if foo?; bar else baz { if _1; quux else end } end
+                                ^^^^^^^^^^^^^^^^^^^^ Do not use `if _1;` - use a ternary operator instead.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if foo?;` - use `if/else` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if foo?
+         bar else baz { _1 ? quux : nil } end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the following error for `Style/IfWithSemicolon` when when using nested single-line if/;/end in block of if/else branches.

```console
$ cat /tmpp/example.rb
if foo?;bar;else baz do if qux;else quux;end;end;end

$ bundle exec rubocop --only Style/IfWithSemicolon /tmp/example.rb -a -d
(snip)

An error occurred while Style/IfWithSemicolon cop was inspecting /tmp/example.rb:1:24.
Parser::Source::TreeRewriter detected clobbering
/Users/koic/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/parser-3.3.4.2/lib/parser/source/tree_rewriter.rb:427
:in 'Parser::Source::TreeRewriter#trigger_policy'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
