### PR TITLE
Fix false positive in `Style/MultipleComparison`

### DIFF
--- a/changelog/fix_style_multiple_comparison.md
+++ b/changelog/fix_style_multiple_comparison.md
@@ -1,0 +1,1 @@
+* [#13193](https://github.com/rubocop/rubocop/issues/13193): Fix false positive in `Style/MultipleComparison` when `ComparisonsThreshold` exceeds 2. ([@vlad-pisanov][])

--- a/spec/rubocop/cop/style/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/style/multiple_comparison_spec.rb
@@ -259,10 +259,43 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison, :config do
   context 'when `ComparisonsThreshold`: 3' do
     let(:cop_config) { { 'ComparisonsThreshold' => 3 } }
 
+    it 'registers an offense and corrects when `a` is compared thrice' do
+      expect_offense(<<~RUBY)
+        a = "a"
+        foo if a == "a" || a == "b" || a == "c"
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a = "a"
+        foo if ["a", "b", "c"].include?(a)
+      RUBY
+    end
+
     it 'does not register an offense when `a` is compared twice' do
       expect_no_offenses(<<~RUBY)
         a = "a"
         foo if a == "a" || a == "b"
+      RUBY
+    end
+
+    it 'does not register an offense when `a` is compared twice in multiple expressions' do
+      expect_no_offenses(<<~RUBY)
+        a = "a"
+        foo if a == "a" || a == "b"
+        bar if a == "a" || a == "b"
+      RUBY
+    end
+
+    it 'does not register an offense when `a` is compared twice in different contexts expressions' do
+      expect_no_offenses(<<~RUBY)
+        def foo(a)
+          a == "a" || a == "b"
+        end
+
+        def bar(a)
+          a == "a" || a == "b"
+        end
       RUBY
     end
   end


### PR DESCRIPTION
Fix for https://github.com/rubocop/rubocop/issues/13193

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
