### PR TITLE
Fix an error for `Style/OneLineConditional`

### DIFF
--- a/changelog/fix_an_error_for_style_one_line_conditional.md
+++ b/changelog/fix_an_error_for_style_one_line_conditional.md
@@ -1,0 +1,1 @@
+* [#13198](https://github.com/rubocop/rubocop/pull/13198): Fix an error for `Style/OneLineConditional` when using nested if/then/else/end. ([@koic][])

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -46,7 +46,11 @@ module RuboCop
 
           message = message(node)
           add_offense(node, message: message) do |corrector|
+            next if part_of_ignored_node?(node)
+
             autocorrect(corrector, node)
+
+            ignore_node(node)
           end
         end
 

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -70,6 +70,18 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
       RUBY
     end
 
+    it 'registers and corrects an offense with ternary operator for nested if/then/else/end' do
+      expect_offense(<<~RUBY)
+        if cond then foo else if cond2; bar else baz end; end
+                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ #{if_offense_message}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{if_offense_message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        cond ? foo : (if cond2; bar else baz end)
+      RUBY
+    end
+
     it 'does not register an offense for unless/then/else/end with empty else' do
       expect_no_offenses('unless cond then run else end')
     end
@@ -295,6 +307,22 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
           run
         else
           dont
+        end
+      RUBY
+    end
+
+    it 'registers and corrects an offense with ternary operator for nested if/then/else/end' do
+      expect_offense(<<~RUBY)
+        if cond then foo else if cond2; bar else baz end; end
+                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ #{if_offense_message}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{if_offense_message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if cond
+          foo
+        else
+          if cond2; bar else baz end
         end
       RUBY
     end


### PR DESCRIPTION
This PR fixes the following error for `Style/OneLineConditional` when using nested if/then/else/end:

```console
$ echo "if cond then foo else if cond2 then bar else baz; end; end" | bundle exec rubocop --stdin dummy.rb -A --only Style/OneLineConditional -d
(snip)

An error occurred while Style/OneLineConditional cop was inspecting /Users/koic/src/github.com/rubocop/rubocop/dummy.rb:1:18.
Parser::Source::TreeRewriter detected clobbering
/Users/koic/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/parser-3.3.4.2/lib/parser/source/tree_rewriter.rb:427
:in 'Parser::Source::TreeRewriter#trigger_policy'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
