### PR TITLE
[Fix #13199] Fix an incorrect autocorrect for `Style/RedundantCondition`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_condition.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_condition.md
@@ -1,0 +1,1 @@
+* [#13199](https://github.com/rubocop/rubocop/issues/13199): Make `Style/RedundantCondition` skip autocorrection when a branch has a comment. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -40,6 +40,34 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
+      it 'registers an offense and does not autocorrect when if branch has a comment' do
+        expect_offense(<<~RUBY)
+          if b
+          ^^^^ Use double pipes `||` instead.
+            # Important note.
+            b
+          else
+            c
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense and does not autocorrect when else branch has a comment' do
+        expect_offense(<<~RUBY)
+          if b
+          ^^^^ Use double pipes `||` instead.
+            b
+          else
+            # Important note.
+            c
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+
       it 'does not register an offense when using assignment by hash key access' do
         expect_no_offenses(<<~RUBY)
           if @cache[key]


### PR DESCRIPTION
Fixes #13199.

This PR makes `Style/RedundantCondition` skip autocorrection to avoid removing comments when a branch has a comment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
