### PR TITLE
[Fix #13202] Fix an incorrect autocorrect for `Style/CombinableLoops`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_combinable_loops.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_combinable_loops.md
@@ -1,0 +1,1 @@
+* [#13202](https://github.com/rubocop/rubocop/issues/13202): Fix an incorrect autocorrect for `Style/CombinableLoops` when looping over the same data with different block variable names. ([@koic][])

--- a/lib/rubocop/cop/style/combinable_loops.rb
+++ b/lib/rubocop/cop/style/combinable_loops.rb
@@ -7,6 +7,9 @@ module RuboCop
       # can be combined into a single loop. It is very likely that combining them
       # will make the code more efficient and more concise.
       #
+      # NOTE: Autocorrection is not applied when the block variable names differ in separate loops,
+      # as it is impossible to determine which variable name should be prioritized.
+      #
       # @safety
       #   The cop is unsafe, because the first loop might modify state that the
       #   second loop depends on; these two aren't combinable.
@@ -61,6 +64,7 @@ module RuboCop
 
         MSG = 'Combine this loop with the previous loop.'
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def on_block(node)
           return unless node.parent&.begin_type?
           return unless collection_looping_method?(node)
@@ -68,9 +72,12 @@ module RuboCop
           return unless node.body && node.left_sibling.body
 
           add_offense(node) do |corrector|
+            next unless node.arguments == node.left_sibling.arguments
+
             combine_with_left_sibling(corrector, node)
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         alias on_numblock on_block
 

--- a/spec/rubocop/cop/style/combinable_loops_spec.rb
+++ b/spec/rubocop/cop/style/combinable_loops_spec.rb
@@ -60,6 +60,16 @@ RSpec.describe RuboCop::Cop::Style::CombinableLoops, :config do
       RUBY
     end
 
+    it 'registers an offense and does not correct when looping over the same data with different block variable names' do
+      expect_offense(<<~RUBY)
+        items.each { |item| foo(item) }
+        items.each { |x| bar(x) }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Combine this loop with the previous loop.
+      RUBY
+
+      expect_no_corrections
+    end
+
     it 'registers an offense when looping over the same data for the third consecutive time with numbered blocks' do
       expect_offense(<<~RUBY)
         items.each { foo(_1) }


### PR DESCRIPTION
Fixes #13202.

This PR fixes an incorrect autocorrect for `Style/CombinableLoops` when looping over the same data with different block variable names.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
