### PR TITLE
Fix an incorrect autocorrect for `Style/IfWithSemicolon`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_if_with_semicolon_cop.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_if_with_semicolon_cop.md
@@ -1,0 +1,1 @@
+* [#13208](https://github.com/rubocop/rubocop/pull/13208): Fix an incorrect autocorrect for `Style/IfWithSemicolon` when single-line `if/;/end` when the then body contains a method call with `[]` or `[]=`. ([@koic][])

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -81,16 +81,14 @@ module RuboCop
           RUBY
         end
 
-        # rubocop:disable Metrics/AbcSize
         def build_expression(expr)
-          return expr.source if !expr.call_type? || expr.parenthesized? || expr.arguments.empty?
+          return expr.source unless require_argument_parentheses?(expr)
 
           method = expr.source_range.begin.join(expr.loc.selector.end)
           arguments = expr.first_argument.source_range.begin.join(expr.source_range.end)
 
           "#{method.source}(#{arguments.source})"
         end
-        # rubocop:enable Metrics/AbcSize
 
         def build_else_branch(second_condition)
           result = <<~RUBY
@@ -110,6 +108,12 @@ module RuboCop
           end
 
           result
+        end
+
+        def require_argument_parentheses?(node)
+          return false unless node.call_type?
+
+          !node.parenthesized? && node.arguments.any? && !node.method?(:[]) && !node.method?(:[]=)
         end
       end
     end

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -100,6 +100,28 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects a single-line `if/;/end` when the then body contains a method call with `[]`' do
+    expect_offense(<<~RUBY)
+      if cond; foo[key] else bar end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      cond ? foo[key] : bar
+    RUBY
+  end
+
+  it 'registers an offense and corrects a single-line `if/;/end` when the then body contains a method call with `[]=`' do
+    expect_offense(<<~RUBY)
+      if cond; foo[key] = value else bar end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      cond ? foo[key] = value : bar
+    RUBY
+  end
+
   it 'registers an offense when using multiple expressions in the `else` branch' do
     expect_offense(<<~RUBY)
       if cond; foo else bar'arg'; baz end


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for `Style/IfWithSemicolon` when single-line `if/;/end` when the then body contains a method call with `[]` or `[]=`:

```console
$ echo "if cond; foo[key] else bar end" | bundle exec rubocop --stdin dummy.rb -a --only Style/IfWithSemicolon
Inspecting 1 file
F

Offenses:

dummy.rb:1:1: C: [Corrected] Style/IfWithSemicolon: Do not use if cond; - use a ternary operator instead.
if cond; foo[key] else bar end
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dummy.rb:1:16: F: Lint/Syntax: unexpected token tLPAREN2
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
cond ? foo[key](key]) : bar
               ^

1 file inspected, 2 offenses detected, 1 offense corrected
====================
cond ? foo[key](key]) : bar
```

This is a syntax error, and this fix corrects it to the expected valid syntax: `cond ? foo[key] : bar`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
