### PR TITLE
Call super in `relevant_file?` for InternalAffairs cops

### DIFF
--- a/lib/rubocop/cop/internal_affairs/cop_description.rb
+++ b/lib/rubocop/cop/internal_affairs/cop_description.rb
@@ -114,7 +114,7 @@ module RuboCop
         end
 
         def relevant_file?(file)
-          file.match?(%r{/cop/.*\.rb\z})
+          file.match?(%r{/cop/.*\.rb\z}) && super
         end
       end
     end

--- a/lib/rubocop/cop/internal_affairs/useless_message_assertion.rb
+++ b/lib/rubocop/cop/internal_affairs/useless_message_assertion.rb
@@ -46,7 +46,7 @@ module RuboCop
 
         # Only process spec files
         def relevant_file?(file)
-          file.end_with?('_spec.rb')
+          file.end_with?('_spec.rb') && super
         end
       end
     end

--- a/spec/rubocop/cop/internal_affairs/cop_description_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/cop_description_spec.rb
@@ -152,4 +152,33 @@ RSpec.describe RuboCop::Cop::InternalAffairs::CopDescription, :config do
       RUBY
     end
   end
+
+  context 'when the file is excluded' do
+    before do
+      allow_any_instance_of(described_class).to receive(:relevant_file?).and_call_original # rubocop:disable RSpec/AnyInstance
+    end
+
+    let(:config) do
+      RuboCop::Config.new(
+        'InternalAffairs/CopDescription' => { 'Exclude' => ['**/example_cop.rb'] }
+      )
+    end
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, 'lib/rubocop/cop/example_cop.rb')
+        module RuboCop
+          module Cop
+            module Lint
+              #
+              # Checks some problem
+              #
+              # ...
+              class Foo < Base
+              end
+            end
+          end
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/internal_affairs/useless_message_assertion_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/useless_message_assertion_spec.rb
@@ -41,4 +41,18 @@ RSpec.describe RuboCop::Cop::InternalAffairs::UselessMessageAssertion, :config d
   it 'does not register an offense and no error when empty file' do
     expect_no_offenses('', 'example_spec.rb')
   end
+
+  context 'when the file is excluded' do
+    let(:config) do
+      RuboCop::Config.new(
+        'InternalAffairs/UselessMessageAssertion' => { 'Exclude' => ['**/example_spec.rb'] }
+      )
+    end
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, 'example_spec.rb')
+        let(:msg) { described_class::MSG }
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This overwritten `relevant_file?` methods are preventing `Exclude` from working for these cops, since the behaviour is defined in the parent class `RuboCop::Cop::Base`.

You can verify this bug by applying the following patch and running `bundle exec rubocop`:

```patch
diff --git a/.rubocop_todo.yml b/.rubocop_todo.yml
index 8c0c585df..27293b8ff 100644
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,6 +10,10 @@
 InternalAffairs/NodeDestructuring:
   Enabled: false

+InternalAffairs/CopDescription:
+  Exclude:
+    - 'lib/rubocop/cop/internal_affairs/cop_description.rb'
+
 # Offense count: 55
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
diff --git a/lib/rubocop/cop/internal_affairs/cop_description.rb b/lib/rubocop/cop/internal_affairs/cop_description.rb
index d5097d4d3..bf1814d90 100644
--- a/lib/rubocop/cop/internal_affairs/cop_description.rb
+++ b/lib/rubocop/cop/internal_affairs/cop_description.rb
@@ -3,6 +3,7 @@
 module RuboCop
   module Cop
     module InternalAffairs
+      #
       # Enforces the cop description to start with a word such as verb.
       #
       # @example
```

You'll notice that on my branch it's green, whilst on master there is an offense which should have been ignored.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
  * I don't believe this is needed since it only affects internal affairs cops.

[1]: https://chris.beams.io/posts/git-commit/
