### PR TITLE
Fix omit_parentheses style for pattern match with value omission in single-line branch

### DIFF
--- a/changelog/fix_fix_omit_parentheses_style_for_pattern_match_with.md
+++ b/changelog/fix_fix_omit_parentheses_style_for_pattern_match_with.md
@@ -1,0 +1,1 @@
+* [#13210](https://github.com/rubocop/rubocop/pull/13210): Fix omit_parentheses style for pattern match with value omission in single-line branch. ([@gsamokovarov][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -47,11 +47,11 @@ module RuboCop
             node.each_ancestor(:def, :defs).any?(&:endless?) && node.arguments.any?
           end
 
-          def require_parentheses_for_hash_value_omission?(node)
+          def require_parentheses_for_hash_value_omission?(node) # rubocop:disable Metrics/PerceivedComplexity
             return false unless (last_argument = node.last_argument)
             return false if !last_argument.hash_type? || !last_argument.pairs.last&.value_omission?
 
-            node.parent&.conditional? || !last_expression?(node)
+            node.parent&.conditional? || node.parent&.single_line? || !last_expression?(node)
           end
 
           # Require hash value omission be enclosed in parentheses to prevent the following issue:

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -468,6 +468,46 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
             end
         RUBY
       end
+
+      it 'registers an offense in case_match multi-line branches' do
+        expect_offense(<<~RUBY)
+          case match
+          in :pattern1
+            foo(value:)
+               ^^^^^^^^ Omit parentheses for method calls with arguments.
+          in :pattern2
+            bar(value:)
+               ^^^^^^^^ Omit parentheses for method calls with arguments.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          case match
+          in :pattern1
+            foo value:
+          in :pattern2
+            bar value:
+          end
+        RUBY
+      end
+
+      it 'does not register an offense in case_match single-line branches' do
+        expect_no_offenses(<<~RUBY)
+          case match
+          in :pattern1 then foo(value:)
+          in :pattern2 then bar(value:)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense in case single-line branches' do
+        expect_no_offenses(<<~RUBY)
+          case match
+          when /pattern1/ then foo(value:)
+          when /pattern2/ then bar(value:)
+          end
+        RUBY
+      end
     end
 
     context 'anonymous rest arguments in 3.2', :ruby32 do


### PR DESCRIPTION
When using the `omit_parentheses` style of Style/MethodCallWithArgsParentheses, RuboCop issued offenses for the following code:

```ruby
case match
in :pattern1 then foo(value:)
                   # ^^^^^^^^ Omit parentheses for method calls with arguments.
in :pattern2 then bar(value:)
                   # ^^^^^^^^ Omit parentheses for method calls with arguments.
end
```

Dropping the parentheses, however, is a syntax error as the dangling `value:` is expecting the next line to be its value. Yup, it's one of those endless edge cases around the parentheses omission Bulgarian style we enjoy over here. 😅