### PR TITLE
Fix wrong autocorrect for `Style/GuardClause` when using heredoc without `else` branch

### DIFF
--- a/changelog/fix_wrong_autocorrect_guard_clause_heredoc.md
+++ b/changelog/fix_wrong_autocorrect_guard_clause_heredoc.md
@@ -1,0 +1,1 @@
+* [#13211](https://github.com/rubocop/rubocop/pull/13211): Fix wrong autocorrect for `Style/GuardClause` when using heredoc without `else` branch. ([@earlopain][])

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -234,11 +234,11 @@ module RuboCop
         end
 
         def autocorrect_heredoc_argument(corrector, node, heredoc_branch, leave_branch, guard)
+          remove_whole_lines(corrector, node.loc.end)
           return unless node.else?
 
           remove_whole_lines(corrector, leave_branch.source_range)
           remove_whole_lines(corrector, node.loc.else)
-          remove_whole_lines(corrector, node.loc.end)
           remove_whole_lines(corrector, range_of_branch_to_remove(node, guard))
           corrector.insert_after(
             heredoc_branch.last_argument.loc.heredoc_end, "\n#{leave_branch.source}"

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -455,7 +455,6 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
           raise <<~MESSAGE
             oops
           MESSAGE
-        end
       end
     RUBY
   end


### PR DESCRIPTION
The correction is a syntax error: the `end` keyword must be removed.

----

I want to add an assertion to `expect_correction` that the correction is valid syntax, but first a few more fixes to come.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
