### PR TITLE
Ship a config for `InternalAffairs`

### DIFF
--- a/config/internal_affairs.yml
+++ b/config/internal_affairs.yml
@@ -1,0 +1,11 @@
+# Configuration for InternalAffairs cops. This file will be
+# automatically loaded when `rubocop/cop/internal_affairs` is required.
+# Only do this when developing custom cops or a RuboCop extension.
+
+InternalAffairs/CopDescription:
+  Include:
+    - 'lib/rubocop/cop/**/*.rb'
+
+InternalAffairs/UselessMessageAssertion:
+  Include:
+    - '**/*_spec.rb'

--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -31,3 +31,19 @@ require_relative 'internal_affairs/style_detected_api_use'
 require_relative 'internal_affairs/undefined_config'
 require_relative 'internal_affairs/useless_message_assertion'
 require_relative 'internal_affairs/useless_restrict_on_send'
+
+module RuboCop
+  # Patch in the InternalAffairs specific config values
+  module InternalAffairs
+    def self.inject!
+      path = File.join(ConfigLoader::RUBOCOP_HOME, 'config', 'internal_affairs.yml')
+      hash = ConfigLoader.load_yaml_configuration(path)
+      config = Config.new(hash, path)
+      puts "configuration from #{path}" if ConfigLoader.debug?
+      config = ConfigLoader.merge_with_default(config, path)
+      ConfigLoader.instance_variable_set(:@default_configuration, config)
+    end
+  end
+end
+
+RuboCop::InternalAffairs.inject!

--- a/lib/rubocop/cop/internal_affairs/cop_description.rb
+++ b/lib/rubocop/cop/internal_affairs/cop_description.rb
@@ -112,10 +112,6 @@ module RuboCop
           body = comment_body(comment_line)
           node.source.index(body)
         end
-
-        def relevant_file?(file)
-          file.match?(%r{/cop/.*\.rb\z}) && super
-        end
       end
     end
   end

--- a/lib/rubocop/cop/internal_affairs/useless_message_assertion.rb
+++ b/lib/rubocop/cop/internal_affairs/useless_message_assertion.rb
@@ -43,11 +43,6 @@ module RuboCop
             node.ancestors.any? { |ancestor| rspec_expectation_on_msg?(ancestor) }
           end
         end
-
-        # Only process spec files
-        def relevant_file?(file)
-          file.end_with?('_spec.rb') && super
-        end
       end
     end
   end

--- a/spec/rubocop/cop/internal_affairs/cop_description_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/cop_description_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::InternalAffairs::CopDescription, :config do
-  before do
-    allow_any_instance_of(described_class).to receive(:relevant_file?).and_return(true) # rubocop:disable RSpec/AnyInstance
-  end
-
   context 'The description starts with `This cop ...`' do
     it 'registers an offense and corrects if using just a verb' do
       expect_offense(<<~RUBY)
@@ -144,35 +140,6 @@ RSpec.describe RuboCop::Cop::InternalAffairs::CopDescription, :config do
         module RuboCop
           module Cop
             module Lint
-              class Foo < Base
-              end
-            end
-          end
-        end
-      RUBY
-    end
-  end
-
-  context 'when the file is excluded' do
-    before do
-      allow_any_instance_of(described_class).to receive(:relevant_file?).and_call_original # rubocop:disable RSpec/AnyInstance
-    end
-
-    let(:config) do
-      RuboCop::Config.new(
-        'InternalAffairs/CopDescription' => { 'Exclude' => ['**/example_cop.rb'] }
-      )
-    end
-
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY, 'lib/rubocop/cop/example_cop.rb')
-        module RuboCop
-          module Cop
-            module Lint
-              #
-              # Checks some problem
-              #
-              # ...
               class Foo < Base
               end
             end

--- a/spec/rubocop/cop/internal_affairs/useless_message_assertion_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/useless_message_assertion_spec.rb
@@ -41,18 +41,4 @@ RSpec.describe RuboCop::Cop::InternalAffairs::UselessMessageAssertion, :config d
   it 'does not register an offense and no error when empty file' do
     expect_no_offenses('', 'example_spec.rb')
   end
-
-  context 'when the file is excluded' do
-    let(:config) do
-      RuboCop::Config.new(
-        'InternalAffairs/UselessMessageAssertion' => { 'Exclude' => ['**/example_spec.rb'] }
-      )
-    end
-
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY, 'example_spec.rb')
-        let(:msg) { described_class::MSG }
-      RUBY
-    end
-  end
 end


### PR DESCRIPTION
`InternalAffairs/CopDescription` and `InternalAffairs/UselessMessageAssertion` want to only look at a specific subset of files. To do that, they override the `relevant_file?` method.

Instead, just treat `InternalAffairs` like a RuboCop extension and inject the config so it goes through the usual processes.

There are more cops that could be added here (many only concern themselves with either specs or library code) but I'll leave that for a subsequent PR.

This removes the tests from https://github.com/rubocop/rubocop/pull/13209, the process of config inheritance is already well-tested and there nothing special here anymore. I've manually verified that this change works correctly in `rubocop-rails` and here as well of course (i.e. there are still offenses when there should be).

@splattael, do you want to give this a try and see if this works for you?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
