### PR TITLE
[Fix #13213] Fix false positives for `Style/AccessModifierDeclarations`

### DIFF
--- a/changelog/fix_false_positives_for_style_access_modifier_declarations.md
+++ b/changelog/fix_false_positives_for_style_access_modifier_declarations.md
@@ -1,0 +1,1 @@
+* [#13213](https://github.com/rubocop/rubocop/issues/13213): Fix false positives for `Style/AccessModifierDeclarations` when `AllowModifiersOnAttrs: true` and using splat with a percent symbol array, or with a constant. ([@koic][])

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -22,6 +22,24 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
           end
         RUBY
       end
+
+      it 'accepts when argument to #{access_modifier} is splat with a `%i` array literal' do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            foo
+            #{access_modifier} *%i[bar baz]
+          end
+        RUBY
+      end
+
+      it 'accepts when argument to #{access_modifier} is splat with a constant' do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            foo
+            #{access_modifier} *METHOD_NAMES
+          end
+        RUBY
+      end
     end
 
     context 'do not allow access modifiers on symbols' do
@@ -32,6 +50,30 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
           class Foo
             foo
             %{access_modifier} :bar
+            ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense when argument to #{access_modifier} is splat with a `%i` array literal' do
+        expect_offense(<<~RUBY, access_modifier: access_modifier)
+          class Foo
+            foo
+            %{access_modifier} *%i[bar baz]
+            ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense when argument to #{access_modifier} is splat with a constant' do
+        expect_offense(<<~RUBY, access_modifier: access_modifier)
+          class Foo
+            foo
+            %{access_modifier} *METHOD_NAMES
             ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
           end
         RUBY


### PR DESCRIPTION
Fixes #13213.

This PR fixes false positives for `Style/AccessModifierDeclarations` when `AllowModifiersOnAttrs: true` and using splat with a percent symbol array, or with a constant.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
