### PR TITLE
 Fix wrong autocorrect for `Style/MethodCallWithArgsParentheses` with `EnforcedStyle: omit_parentheses` and whitespace

### DIFF
--- a/changelog/fix_wrong_autocorrect_method_call_arg_parens_omit_parens.md
+++ b/changelog/fix_wrong_autocorrect_method_call_arg_parens_omit_parens.md
@@ -1,0 +1,1 @@
+* [#13215](https://github.com/rubocop/rubocop/pull/13215): Fix wrong autocorrect for `Style/MethodCallWithArgsParentheses` with `EnforcedStyle: omit_parentheses` and whitespace. ([@earlopain][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -7,6 +7,8 @@ module RuboCop
         # Style omit_parentheses
         # rubocop:disable Metrics/ModuleLength, Metrics/CyclomaticComplexity
         module OmitParentheses
+          include RangeHelp
+
           TRAILING_WHITESPACE_REGEX = /\s+\Z/.freeze
           OMIT_MSG = 'Omit parentheses for method calls with arguments.'
           private_constant :OMIT_MSG
@@ -30,10 +32,13 @@ module RuboCop
           end
 
           def autocorrect(corrector, node)
+            range = args_begin(node)
             if parentheses_at_the_end_of_multiline_call?(node)
-              corrector.replace(args_begin(node), ' \\')
+              # Whitespace after line continuation (`\ `) is a syntax error
+              with_whitespace = range_with_surrounding_space(range, side: :right, newlines: false)
+              corrector.replace(with_whitespace, ' \\')
             else
-              corrector.replace(args_begin(node), ' ')
+              corrector.replace(range, ' ')
             end
             corrector.remove(node.loc.end)
           end

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -978,7 +978,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
 
       expect_correction(<<~RUBY)
-        foo \\#{trailing_whitespace}
+        foo \\
           bar: 3
 
       RUBY


### PR DESCRIPTION
Whitespace after the line continuation character is a syntax error

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
