### PR TITLE
Fix wrong autocorrect for `Lint/BigDecimalNew` when using `::BigDecimal.new`

### DIFF
--- a/changelog/fix_wrong_autocorrect_lint_big_decimal_new.md
+++ b/changelog/fix_wrong_autocorrect_lint_big_decimal_new.md
@@ -1,0 +1,1 @@
+* [#13215](https://github.com/rubocop/rubocop/pull/13215): Fix wrong autocorrect for `Lint/BigDecimalNew` when using `::BigDecimal.new`. ([@earlopain][])

--- a/lib/rubocop/cop/lint/big_decimal_new.rb
+++ b/lib/rubocop/cop/lint/big_decimal_new.rb
@@ -17,8 +17,7 @@ module RuboCop
       class BigDecimalNew < Base
         extend AutoCorrector
 
-        MSG = '`%<double_colon>sBigDecimal.new()` is deprecated. ' \
-              'Use `%<double_colon>sBigDecimal()` instead.'
+        MSG = '`BigDecimal.new()` is deprecated. Use `BigDecimal()` instead.'
         RESTRICT_ON_SEND = %i[new].freeze
 
         # @!method big_decimal_new(node)
@@ -28,13 +27,11 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          big_decimal_new(node) do |captured_value|
-            double_colon = captured_value ? '::' : ''
-            message = format(MSG, double_colon: double_colon)
-
-            add_offense(node.loc.selector, message: message) do |corrector|
+          big_decimal_new(node) do |cbase|
+            add_offense(node.loc.selector) do |corrector|
               corrector.remove(node.loc.selector)
               corrector.remove(node.loc.dot)
+              corrector.remove(cbase) if cbase
             end
           end
         end

--- a/spec/rubocop/cop/lint/big_decimal_new_spec.rb
+++ b/spec/rubocop/cop/lint/big_decimal_new_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe RuboCop::Cop::Lint::BigDecimalNew, :config do
   it 'registers an offense and corrects using `::BigDecimal.new()`' do
     expect_offense(<<~RUBY)
       ::BigDecimal.new(123.456, 3)
-                   ^^^ `::BigDecimal.new()` is deprecated. Use `::BigDecimal()` instead.
+                   ^^^ `BigDecimal.new()` is deprecated. Use `BigDecimal()` instead.
     RUBY
 
     expect_correction(<<~RUBY)
-      ::BigDecimal(123.456, 3)
+      BigDecimal(123.456, 3)
     RUBY
   end
 


### PR DESCRIPTION
`BigDecimal()` is a method defined on `Kernel`. `::BigDecimal(...)` is a syntax error

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
