### PR TITLE
Fix a false positive in Lint/ParenthesesAsGroupedExpression with compound ranges

### DIFF
--- a/changelog/fix_a_false_positive_in.md
+++ b/changelog/fix_a_false_positive_in.md
@@ -1,0 +1,1 @@
+* [#13217](https://github.com/rubocop/rubocop/pull/13217): Fix a false positive in `Lint/ParenthesesAsGroupedExpression` with compound ranges. ([@gsamokovarov][])

--- a/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
+++ b/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
@@ -37,9 +37,7 @@ module RuboCop
         private
 
         def valid_context?(node)
-          unless node.arguments.one? && first_argument_starts_with_left_parenthesis?(node)
-            return true
-          end
+          return true unless node.arguments.one? && node.first_argument.parenthesized_call?
           return true if first_argument_block_type?(node.first_argument)
 
           node.operator_method? || node.setter_method? || chained_calls?(node) ||
@@ -51,11 +49,12 @@ module RuboCop
         end
 
         def valid_first_argument?(first_arg)
-          first_arg.operator_keyword? || first_arg.hash_type? || ternary_expression?(first_arg)
+          first_arg.operator_keyword? || first_arg.hash_type? || ternary_expression?(first_arg) ||
+            compound_range?(first_arg)
         end
 
-        def first_argument_starts_with_left_parenthesis?(node)
-          node.first_argument.source.start_with?('(')
+        def compound_range?(first_arg)
+          first_arg.range_type? && first_arg.parenthesized_call?
         end
 
         def chained_calls?(node)

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -133,6 +133,23 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression, :config do
     expect_no_offenses('a( (b) )')
   end
 
+  it 'accepts parenthesis for compound range literals' do
+    expect_no_offenses(<<-RUBY)
+      rand (a - b)..(c - d)
+    RUBY
+  end
+
+  it 'does not accepts parenthesis for simple range literals' do
+    expect_offense(<<~RUBY)
+      rand (1..10)
+          ^ `(1..10)` interpreted as grouped expression.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      rand(1..10)
+    RUBY
+  end
+
   it 'does not register an offense for a call with multiple arguments' do
     expect_no_offenses('assert_equal (0..1.9), acceleration.domain')
   end


### PR DESCRIPTION
The parentheses in the code below are required if you choose to call `rand` without parens:

```ruby
rand (a - b)..(c - d)
```

However, the current version of `Lint/ParenthesesAsGroupedExpression` will issue an offense for it.