### PR TITLE
Fix a false positive for `Style/ArgumentForwarding` with Ruby 3.0 and optional position arguments

### DIFF
--- a/changelog/fix_false_positive_arg_forwarding_ruby_3.0.md
+++ b/changelog/fix_false_positive_arg_forwarding_ruby_3.0.md
@@ -1,0 +1,1 @@
+* [#13219](https://github.com/rubocop/rubocop/pull/13219): Fix a false positive for `Style/ArgumentsForwarding` with Ruby 3.0 and optional position arguments. ([@earlopain][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -414,16 +414,24 @@ module RuboCop
 
           private
 
+          # rubocop:disable Metrics/CyclomaticComplexity
           def can_forward_all?
             return false if any_arg_referenced?
-            return false if ruby_32_missing_rest_or_kwest?
+            return false if ruby_30_or_lower_optarg?
+            return false if ruby_32_or_higher_missing_rest_or_kwest?
             return false unless offensive_block_forwarding?
             return false if additional_kwargs_or_forwarded_kwargs?
 
             no_additional_args? || (target_ruby_version >= 3.0 && no_post_splat_args?)
           end
+          # rubocop:enable Metrics/CyclomaticComplexity
 
-          def ruby_32_missing_rest_or_kwest?
+          # def foo(a = 41, ...) is a syntax error in 3.0.
+          def ruby_30_or_lower_optarg?
+            target_ruby_version <= 3.0 && @def_node.arguments.any?(&:optarg_type?)
+          end
+
+          def ruby_32_or_higher_missing_rest_or_kwest?
             target_ruby_version >= 3.2 && !forwarded_rest_and_kwrest_args
           end
 

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -932,18 +932,10 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
-    it 'registers an offense when forwarding args with a leading default arg', unsupported_on: :prism do
-      expect_offense(<<~RUBY)
+    it 'registers no offense when forwarding args with a leading default arg', unsupported_on: :prism do
+      expect_no_offenses(<<~RUBY)
         def foo(x, y = 42, *args, &block)
-                           ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
           bar(x, y, *args, &block)
-                    ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        def foo(x, y = 42, ...)
-          bar(x, y, ...)
         end
       RUBY
     end
@@ -1110,6 +1102,22 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       expect_correction(<<~RUBY)
         def baz(qux, quuz, &)
           bar(qux, quuz, &)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when forwarding args with a leading default arg', unsupported_on: :prism do
+      expect_offense(<<~RUBY)
+        def foo(x, y = 42, *args, &block)
+                           ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+          bar(x, y, *args, &block)
+                    ^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(x, y = 42, ...)
+          bar(x, y, ...)
         end
       RUBY
     end


### PR DESCRIPTION
Having `...` and optional positional arguments is a syntax error in Ruyb 3.0 and lower

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
