### PR TITLE
Do not group accessors having rbs-inline annotations in `Style/AccessorGrouping`

### DIFF
--- a/changelog/change_accessor_grouping_supports_rbs_inline_annotations.md
+++ b/changelog/change_accessor_grouping_supports_rbs_inline_annotations.md
@@ -1,0 +1,1 @@
+* [#13221](https://github.com/rubocop/rubocop/pull/13221): Do not group accessors having RBS::Inline annotation comments in `Style/AccessorGrouping`. ([@tk0miya][])

--- a/spec/rubocop/cop/style/accessor_grouping_spec.rb
+++ b/spec/rubocop/cop/style/accessor_grouping_spec.rb
@@ -264,6 +264,33 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense for grouped accessors having RBS::Inline annotation' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          attr_reader :one #: String
+
+          attr_reader :two, :three
+        end
+      RUBY
+    end
+
+    it 'registers an offense for grouped accessors having non-RBS::Inline annotation' do
+      expect_offense(<<~RUBY)
+        class Foo
+          attr_reader :one # comment #: String
+          ^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes.
+          attr_reader :two, :three
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          attr_reader :one, :two, :three # comment #: String
+        end
+      RUBY
+    end
   end
 
   context 'when EnforcedStyle is separated' do


### PR DESCRIPTION
[rbs-inline](https://github.com/soutaro/rbs-inline) is a utility to embed RBS type declarations into Ruby code as comments.

This avoids to group accessors having rbs-inline annotation comments in `Style/AccessorGrouping`.

refs: https://github.com/soutaro/rbs-inline/wiki/Syntax-guide

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
