### PR TITLE
Allow to write rbs-inline annotation after method definition in `Style/CommentedKeyword`

### DIFF
--- a/changelog/change_commented_keyword_allows_rbs_inline_annoattions.md
+++ b/changelog/change_commented_keyword_allows_rbs_inline_annoattions.md
@@ -1,0 +1,1 @@
+* [#13222](https://github.com/rubocop/rubocop/pull/13222): Allow to write RBS::Inline annotation comments after method definition in `Style/CommentedKeyword`. ([@tk0miya][])

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -10,7 +10,7 @@ module RuboCop
       #
       # Note that some comments
       # (`:nodoc:`, `:yields:`, `rubocop:disable` and `rubocop:todo`)
-      # are allowed.
+      # and RBS::Inline annotation comments are allowed.
       #
       # Autocorrection removes comments from `end` keyword and keeps comments
       # for `class`, `module`, `def` and `begin` above the keyword.
@@ -82,12 +82,18 @@ module RuboCop
 
         def offensive?(comment)
           line = source_line(comment)
+          return false if rbs_inline_annotation?(line, comment)
+
           KEYWORD_REGEXES.any? { |r| r.match?(line) } &&
             ALLOWED_COMMENT_REGEXES.none? { |r| r.match?(line) }
         end
 
         def source_line(comment)
           comment.source_range.source_line
+        end
+
+        def rbs_inline_annotation?(line, comment)
+          comment.text.start_with?('#:') && line.start_with?(/\A\s*def\s/)
         end
       end
     end

--- a/spec/rubocop/cop/style/commented_keyword_spec.rb
+++ b/spec/rubocop/cop/style/commented_keyword_spec.rb
@@ -236,4 +236,43 @@ RSpec.describe RuboCop::Cop::Style::CommentedKeyword, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense for RBS::Inline annotation for method definition' do
+    expect_no_offenses(<<~RUBY)
+      def x #: String
+      end
+
+      class Y
+        def y #: String
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects for RBS::Inline annotation for non method definition' do
+    expect_offense(<<~RUBY)
+      class X #: String
+              ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+      end #: String
+          ^^^^^^^^^ Do not place comments on the same line as the `end` keyword.
+      module Y #: String
+               ^^^^^^^^^ Do not place comments on the same line as the `module` keyword.
+      end
+      begin #: String
+            ^^^^^^^^^ Do not place comments on the same line as the `begin` keyword.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      #: String
+      class X
+      end
+      #: String
+      module Y
+      end
+      #: String
+      begin
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
[rbs-inline](https://github.com/soutaro/rbs-inline) is a utility to embed RBS type declarations into Ruby code as comments.

This allows to write rbs-inline annotation comment just after method definition in `Style/CommentedKeyword`.

refs: https://github.com/soutaro/rbs-inline/wiki/Syntax-guide

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
