### PR TITLE
Add `AllowRBSInlineAnnotation` option to `Layout/LeadingCommentSpace`

### DIFF
--- a/changelog/new_allow_rbs_inline_annotation_option.md
+++ b/changelog/new_allow_rbs_inline_annotation_option.md
@@ -1,0 +1,1 @@
+* [#13223](https://github.com/rubocop/rubocop/pull/13223): Add `AllowRBSInlineAnnotation` config option to `Layout/LeadingCommentSpace` to support RBS::Inline style annotation comments. ([@tk0miya][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1036,6 +1036,7 @@ Layout/LeadingCommentSpace:
   VersionChanged: '0.73'
   AllowDoxygenCommentStyle: false
   AllowGemfileRubyComment: false
+  AllowRBSInlineAnnotation: false
 
 Layout/LeadingEmptyLines:
   Description: Check for unnecessary blank lines at the beginning of a file.

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -221,4 +221,42 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
       end
     end
   end
+
+  describe 'RBS::Inline annotation' do
+    context 'when config option is disabled' do
+      let(:cop_config) { { 'AllowRBSInlineAnnotation' => false } }
+
+      it 'registers an offense and corrects using RBS::Inline annotation' do
+        expect_offense(<<~RUBY)
+          include Enumerable #[Integer]
+                             ^^^^^^^^^^ Missing space after `#`.
+
+          attr_reader :name #: String
+                            ^^^^^^^^^ Missing space after `#`.
+          attr_reader :age  #: Integer?
+                            ^^^^^^^^^^^ Missing space after `#`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          include Enumerable # [Integer]
+
+          attr_reader :name # : String
+          attr_reader :age  # : Integer?
+        RUBY
+      end
+    end
+
+    context 'when config option is enabled' do
+      let(:cop_config) { { 'AllowRBSInlineAnnotation' => true } }
+
+      it 'does not register an offense when using RBS::Inline annotation' do
+        expect_no_offenses(<<~RUBY)
+          include Enumerable #[Integer]
+
+          attr_reader :name #: String
+          attr_reader :age  #: Integer?
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
[rbs-inline](https://github.com/soutaro/rbs-inline) is a utility to embed RBS type declarations into Ruby code as comments.

The new option; `AllowRBSInlineAnnotation` for
`Layout/LeadingCommentSpace` allows to use rbs-inline's annotation comments in the Ruby code.

refs: https://github.com/soutaro/rbs-inline/wiki/Syntax-guide

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
