### PR TITLE
Fix false positives for `Style/OperatorMethodCall` with named forwarding

### DIFF
--- a/changelog/fix_false_positives_for_operator_method_call.md
+++ b/changelog/fix_false_positives_for_operator_method_call.md
@@ -1,0 +1,1 @@
+* [#13224](https://github.com/rubocop/rubocop/pull/13224): Fix false positives for `Style/OperatorMethodCall` with named forwarding. ([@earlopain][])

--- a/spec/rubocop/cop/style/operator_method_call_spec.rb
+++ b/spec/rubocop/cop/style/operator_method_call_spec.rb
@@ -75,51 +75,6 @@ RSpec.describe RuboCop::Cop::Style::OperatorMethodCall, :config do
       RUBY
     end
 
-    it 'registers an offense when using named block forwarding' do
-      expect_offense(<<~RUBY)
-        def foo(&block)
-          bar.#{operator_method}(&block)
-             ^ Redundant dot detected.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        def foo(&block)
-          bar #{operator_method}(&block)
-        end
-      RUBY
-    end
-
-    it 'registers an offense when using named rest arguments forwarding' do
-      expect_offense(<<~RUBY)
-        def foo(*args)
-          bar.#{operator_method}(*args)
-             ^ Redundant dot detected.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        def foo(*args)
-          bar #{operator_method}(*args)
-        end
-      RUBY
-    end
-
-    it 'registers an offense when using named keyword rest arguments forwarding' do
-      expect_offense(<<~RUBY)
-        def foo(**options)
-          bar.#{operator_method}(**options)
-             ^ Redundant dot detected.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        def foo(**options)
-          bar #{operator_method}(**options)
-        end
-      RUBY
-    end
-
     it 'does not register an offense when using multiple arguments' do
       expect_no_offenses(<<~RUBY)
         foo.#{operator_method}(bar, baz)
@@ -205,6 +160,14 @@ RSpec.describe RuboCop::Cop::Style::OperatorMethodCall, :config do
     RUBY
   end
 
+  it 'does not register an offense when using named block forwarding' do
+    expect_no_offenses(<<~RUBY)
+      def foo(&blk)
+        bar.==(&blk)
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using anonymous block forwarding', :ruby31 do
     expect_no_offenses(<<~RUBY)
       def foo(&)
@@ -213,10 +176,26 @@ RSpec.describe RuboCop::Cop::Style::OperatorMethodCall, :config do
     RUBY
   end
 
+  it 'does not register an offense when using named rest arguments forwarding' do
+    expect_no_offenses(<<~RUBY)
+      def foo(*args)
+        bar.==(*args)
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using anonymous rest arguments forwarding', :ruby32 do
     expect_no_offenses(<<~RUBY)
       def foo(*)
         bar.==(*)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when named anonymous keyword rest arguments forwarding' do
+    expect_no_offenses(<<~RUBY)
+      def foo(**kwargs)
+        bar.==(**kwargs)
       end
     RUBY
   end


### PR DESCRIPTION
These cases are syntax errors as well, in addition to anonymous forwarding

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
