### PR TITLE
Fix `--auto-gen-config` when passing an absolute config path

### DIFF
--- a/changelog/fix_autogen_config_absolute_config_path.md
+++ b/changelog/fix_autogen_config_absolute_config_path.md
@@ -1,0 +1,1 @@
+* [#13226](https://github.com/rubocop/rubocop/pull/13226): Fix `--auto-gen-config` when passing an absolute config path. ([@earlopain][])

--- a/lib/rubocop/cli/command/auto_generate_config.rb
+++ b/lib/rubocop/cli/command/auto_generate_config.rb
@@ -151,16 +151,15 @@ module RuboCop
         end
 
         def relative_path_to_todo_from_options_config
-          return AUTO_GENERATED_FILE if !@options[:config] || options_config_in_root?
+          return AUTO_GENERATED_FILE unless @options[:config]
 
-          base = Pathname.new('.')
-          config_dir = Pathname.new(File.dirname(@options[:config]))
+          base = Pathname.new(Dir.pwd)
+          config_dir = Pathname.new(@options[:config]).realpath.dirname
+
+          # Don't have the path start with `/`
+          return AUTO_GENERATED_FILE if config_dir == base
 
           "#{base.relative_path_from(config_dir)}/#{AUTO_GENERATED_FILE}"
-        end
-
-        def options_config_in_root?
-          File.dirname(@options[:config]) == '.'
         end
       end
     end

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -540,6 +540,22 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         expect(cli.run(%w[--auto-gen-config --config dir/cop_config.yml])).to eq(0)
       end
 
+      context 'when --config is used with an absolute path' do
+        it 'can generate a todo list' do
+          create_file('example1.rb', ['$x = 0 ', '#' * 90, 'y ', 'puts x'])
+          create_empty_file('.rubocop.yml')
+          config_path = File.absolute_path('.rubocop.yml')
+          expect(cli.run(['--auto-gen-config', '--config', config_path])).to eq(0)
+          expect(Dir['.*']).to include('.rubocop_todo.yml')
+
+          # Check that paths are relativised correctly
+          expect(File.read('.rubocop_todo.yml')).to include(" - 'example1.rb'")
+          expect(File.read('.rubocop.yml')).to include('inherit_from: .rubocop_todo.yml')
+          # Checks that the command can be run again with config modified by itself.
+          expect(cli.run(['--auto-gen-config', '--config', config_path])).to eq(0)
+        end
+      end
+
       it 'can generate a todo list if default .rubocop.yml exists' do
         create_file('example1.rb', ['def foo', '  # bar', '  end'])
         create_file('.rubocop.yml', <<~YAML)


### PR DESCRIPTION
Rails does this in their `bin/rubocop` wrapper script. See https://github.com/rails/rails/issues/52878

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
