### PR TITLE
Don't use `loop: false` for `AlignmentDirective` tests

### DIFF
--- a/spec/rubocop/cop/alignment_corrector_spec.rb
+++ b/spec/rubocop/cop/alignment_corrector_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe RuboCop::Cop::AlignmentCorrector, :config do
               ^^ Indent this node.
           RUBY
 
-          expect_correction(<<~RUBY, loop: false)
-            # >> 2
+          expect_correction(<<~RUBY)
+            #
                 42
           RUBY
         end
@@ -28,8 +28,8 @@ RSpec.describe RuboCop::Cop::AlignmentCorrector, :config do
                 ^^ Indent this node.
           RUBY
 
-          expect_correction(<<~RUBY, loop: false)
-            # << 3
+          expect_correction(<<~RUBY)
+            #
              42
           RUBY
         end
@@ -52,8 +52,8 @@ RSpec.describe RuboCop::Cop::AlignmentCorrector, :config do
           end
         RUBY
 
-        expect_correction(<<~RUBY, loop: false)
-          # >> #{column_delta}
+        expect_correction(<<~RUBY)
+          #
           #{indentation}begin
           #{indentation}  #{start_heredoc}
           a
@@ -87,8 +87,8 @@ RSpec.describe RuboCop::Cop::AlignmentCorrector, :config do
           end
         RUBY
 
-        expect_correction(<<~RUBY, loop: false)
-          # >> 2
+        expect_correction(<<~RUBY)
+          #
           #{indentation}begin
           #{indentation}  <<DOC
           single line
@@ -115,8 +115,8 @@ RSpec.describe RuboCop::Cop::AlignmentCorrector, :config do
           end
         RUBY
 
-        expect_correction(<<~RUBY, loop: false)
-          # >> 2
+        expect_correction(<<~RUBY)
+          #
             begin
               dstr =
             'a

--- a/spec/support/cops/alignment_directive.rb
+++ b/spec/support/cops/alignment_directive.rb
@@ -14,16 +14,19 @@ module RuboCop
 
         def on_new_investigation
           processed_source.ast_with_comments.each do |node, comments|
-            next unless comments.find { |c| @column_delta = delta(c) }
-
-            add_offense(node) { |corrector| autocorrect(corrector, node) }
+            comments.each do |c|
+              if (delta = delta(c))
+                add_offense(node) { |corrector| autocorrect(corrector, node, c, delta) }
+              end
+            end
           end
         end
 
         private
 
-        def autocorrect(corrector, node)
-          AlignmentCorrector.correct(corrector, processed_source, node, @column_delta)
+        def autocorrect(corrector, node, comment, delta)
+          AlignmentCorrector.correct(corrector, processed_source, node, delta)
+          corrector.replace(comment, '#')
         end
 
         def delta(comment)


### PR DESCRIPTION
I'd like to get rid of the `loop` option. This test has a semi-good reason to use this option. But it's also easy not to rely on it.

Simply remove the directive comment in the correction

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
