### PR TITLE
[Fix #13232] Make server mode aware of auto-restart for local config update

### DIFF
--- a/changelog/change_make_server_mode_aware-of_auto_restart_for_config_update.md
+++ b/changelog/change_make_server_mode_aware-of_auto_restart_for_config_update.md
@@ -1,0 +1,1 @@
+* [#13232](https://github.com/rubocop/rubocop/issues/13232): Make server mode aware of auto-restart for local config update. ([@koic][])

--- a/docs/modules/ROOT/pages/usage/server.adoc
+++ b/docs/modules/ROOT/pages/usage/server.adoc
@@ -49,7 +49,7 @@ user             16060   0.0  0.0  5078568   2264   ??  S     7:54AM   0:00.00 r
 user             16337   0.0  0.0  5331560   2396   ??  S    23:51PM   0:00.00 rubocop --server /Users/user/src/github.com/rubocop/rubocop-rails
 ```
 
-When you `bundle update` and run `rubocop`, the server process will restart automatically.
+When you run `bundle update` or update a local config file (e.g., `.rubocop.yml`), and then run `rubocop`, the server process will automatically restart.
 
 ```console
 $ rubocop --server

--- a/lib/rubocop/server/cache.rb
+++ b/lib/rubocop/server/cache.rb
@@ -47,8 +47,10 @@ module RuboCop
           lockfile_path = LOCKFILE_NAMES.map do |lockfile_name|
             Pathname(project_dir).join(lockfile_name)
           end.find(&:exist?)
+          version_data = lockfile_path&.read || RuboCop::Version::STRING
+          config_data = Pathname(ConfigFinder.find_config_path(Dir.pwd)).read
 
-          Digest::SHA1.hexdigest(lockfile_path&.read || RuboCop::Version::STRING)
+          Digest::SHA1.hexdigest(version_data + config_data)
         end
 
         def dir

--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
 
         options = '--server --only Style/FrozenStringLiteralComment,Style/StringLiterals'
         expect(`ruby -I . "#{rubocop}" #{options}`).to start_with('RuboCop server starting on')
-        # Emulating the SHA1 value of Gemfile.lock.
+        # Emulating the SHA1 value of Gemfile.lock and .rubocop.yml.
         RuboCop::Server::Cache.write_version_file('615dfedabfe01face6557b935510309ae550f74f')
 
         expect(`ruby -I . "#{rubocop}" --server-status`).to match(/RuboCop server .* is running/)
@@ -217,6 +217,9 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
         expect(`ruby -I . "#{rubocop}" --server-status`).to(
           match(/RuboCop server .* is running/), debug_output.join("\n")
         )
+
+        # Emulating the SHA1 value of Gemfile.lock and .rubocop.yml.
+        RuboCop::Server::Cache.write_version_file('f63c8f29b26472dae07bfa80c13a6f658361893d')
 
         message = expect(`ruby -I . "#{rubocop}" --server`)
         message.not_to start_with('RuboCop server starting on '), debug_output.join("\n")


### PR DESCRIPTION
Fixes #13232.

This change was also planned in #13004. It is limited to detecting local files such as `.rubocop.yml`, but it should reduce the need to manually restart the server mode when configuration changes are detected. Since even in LSP, detection of configuration files beyond `.rubocop.yml` is not performed, it is expected to cover a reasonably practical use case.

Although the logic has increased compared to #13004, no significant speed degradation is anticipated.

Since it's unclear whether tracking dependencies between configuration files is practical, it will not be handled this, at least for now.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
