### PR TITLE
Fix an error when using Ruby 3.4-dev

### DIFF
--- a/lib/rubocop/server/core.rb
+++ b/lib/rubocop/server/core.rb
@@ -2,6 +2,7 @@
 
 require 'securerandom'
 require 'socket'
+require 'stringio'
 
 #
 # This code is based on https://github.com/fohte/rubocop-daemon.


### PR DESCRIPTION
This PR fixes the following error when using Ruby 3.4-dev (default by Prism).

```console
$ ruby -v
ruby 3.4.0dev (2024-09-13T00:28:51Z master d80a81c152) +PRISM [x86_64-darwin23]
$ bundle exec rspec './spec/rubocop/cli/options_spec.rb[1:2:5:1]' './spec/rubocop/cli/options_spec.rb[1:2:4:1]' \
'./spec/rubocop/server/rubocop_server_spec.rb[1:4:1]'
(snip)
       +/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/server/socket_reader.rb:36:in 'RuboCop::Server::SocketReader#read!':
undefined method 'string' for nil (NoMethodError)
       +
       +        Cache.stderr_path.write(stderr.string)
       +                                      ^^^^^^^
       +     from /Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/server/core.rb:90:in 'RuboCop::Server::Core#read_socket'
(snip)
       +/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/server/socket_reader.rb:27:in 'RuboCop::Server::SocketReader#read!':
uninitialized constant RuboCop::Server::SocketReader::StringIO (NameError)
       +
       +        stderr = StringIO.new
       +                 ^^^^^^^^
       +     from /Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/server/core.rb:90:in 'RuboCop::Server::Core#read_socket'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
