### PR TITLE
[Fix #13235] Fix an error for `Style/IfUnlessModifier`

### DIFF
--- a/changelog/fix_error_for_style_if_unless_modifier.md
+++ b/changelog/fix_error_for_style_if_unless_modifier.md
@@ -1,0 +1,1 @@
+* [#13235](https://github.com/rubocop/rubocop/issues/13235): Fix an error for `Style/IfUnlessModifier` when multiline `if` that fits on one line and using implicit method call with hash value omission syntax. ([@koic][])

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -5,7 +5,6 @@ module RuboCop
     # Common functionality for modifier cops.
     module StatementModifier
       include LineLengthHelp
-      include RangeHelp
 
       private
 
@@ -65,7 +64,9 @@ module RuboCop
       end
 
       def method_source(if_body)
-        range_between(if_body.source_range.begin_pos, if_body.loc.selector.end_pos).source
+        end_range = if_body.implicit_call? ? if_body.loc.dot.end : if_body.loc.selector
+
+        if_body.source_range.begin.join(end_range).source
       end
 
       def first_line_comment(node)

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -448,6 +448,36 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
     end
   end
 
+  context 'multiline `if` that fits on one line and using dot method call with hash value omission syntax', :ruby31 do
+    it 'corrects it to normal form1' do
+      expect_offense(<<~RUBY)
+        if condition
+        ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+          obj.(attr:)
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        obj.(attr:) if condition
+      RUBY
+    end
+  end
+
+  context 'multiline `if` that fits on one line and using safe navigation dot method call with hash value omission syntax', :ruby31 do
+    it 'corrects it to normal form1' do
+      expect_offense(<<~RUBY)
+        if condition
+        ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+          obj&.(attr:)
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        obj&.(attr:) if condition
+      RUBY
+    end
+  end
+
   context 'using `defined?` in the condition' do
     it 'registers for argument value is defined' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #13235.

This PR fixes an error for `Style/IfUnlessModifier` when multiline `if` that fits on one line and using implicit method call with hash value omission syntax.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
