### PR TITLE
Ensure that the code for `expect_correction` is valid syntax

### DIFF
--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -169,6 +169,7 @@ module RuboCop
         raise 'Expected correction but no corrections were made' if new_source == source
 
         expect(new_source).to eq(correction)
+        expect(@processed_source).to be_valid_syntax, 'Expected correction to be valid syntax'
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
 

--- a/spec/rubocop/cop/style/operator_method_call_spec.rb
+++ b/spec/rubocop/cop/style/operator_method_call_spec.rb
@@ -53,6 +53,8 @@ RSpec.describe RuboCop::Cop::Style::OperatorMethodCall, :config do
     end
 
     it "registers an offense when using `foo.#{operator_method}(bar)`" do
+      skip('https://github.com/rubocop/rubocop/issues/13225') if operator_method == :/
+
       expect_offense(<<~RUBY, operator_method: operator_method)
         foo.#{operator_method}(bar)
            ^ Redundant dot detected.


### PR DESCRIPTION
Issues found with this:
* https://github.com/rubocop/rubocop/pull/13211
* https://github.com/rubocop/rubocop/pull/13215
* https://github.com/rubocop/rubocop/pull/13216
* https://github.com/rubocop/rubocop/pull/13219
* https://github.com/rubocop/rubocop/pull/13224
* https://github.com/rubocop/rubocop/issues/13225 (pending, couldn't figure it out)

I checked some repos in the rubocop org and they seem to not be affected by this change

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
