### PR TITLE
Improve performance of `Lint/ItWithoutArgumentsInBlock`

### DIFF
--- a/lib/rubocop/cop/lint/it_without_arguments_in_block.rb
+++ b/lib/rubocop/cop/lint/it_without_arguments_in_block.rb
@@ -29,25 +29,16 @@ module RuboCop
 
         MSG = '`it` calls without arguments will refer to the first block param in Ruby 3.4; ' \
               'use `it()` or `self.it`.'
+        RESTRICT_ON_SEND = %i[it].freeze
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
-          return unless (body = node.body)
-          return unless node.arguments.empty_and_without_delimiters?
+        def on_send(node)
+          return unless (block_node = node.each_ancestor(:block).first)
+          return unless block_node.arguments.empty_and_without_delimiters?
 
-          if body.send_type? && deprecated_it_method?(body)
-            add_offense(body)
-          else
-            body.each_descendant(:send).each do |send_node|
-              next unless deprecated_it_method?(send_node)
-
-              add_offense(send_node)
-            end
-          end
+          add_offense(node) if deprecated_it_method?(node)
         end
 
         def deprecated_it_method?(node)
-          return false unless node.method?(:it)
-
           !node.receiver && node.arguments.empty? && !node.parenthesized? && !node.block_literal?
         end
       end


### PR DESCRIPTION
Using `on_block` is expensive, since this checks each send node in a block. Instead, use `on_send`. This is much cheaper since a overwhelming majority of send nodes will not be named `it`.

From `bundle exec prof:slow_cops`
```
     551  (    2.9%)  RuboCop::Cop::Layout::IndentationConsistency#on_begin
     402  (    2.2%)  RuboCop::Cop::Layout::RedundantLineBreak#on_send
     358  (    1.9%)  RuboCop::Cop::Lint::ItWithoutArgumentsInBlock#on_block
(snip)
```

After:
```
(103 previous entries)
      42  (    0.2%)  RuboCop::Cop::Lint::ItWithoutArgumentsInBlock#on_send
(snip)
```

Overall, this saves about 200ms for the RuboCop repo.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
