### PR TITLE
Add basic support for conditional returns that always return to `Lint/UnreachableCode`

### DIFF
--- a/changelog/new_add_basic_support_for_conditional_returns_that.md
+++ b/changelog/new_add_basic_support_for_conditional_returns_that.md
@@ -1,0 +1,1 @@
+* [#13241](https://github.com/rubocop/rubocop/pull/13241): Add basic support for conditional returns that always return to `Lint/UnreachableCode`. ([@zopolis4][])

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -74,9 +74,19 @@ module RuboCop
         end
 
         def check_if(node)
+          return true if check_literal_if(node)
+
           if_branch = node.if_branch
           else_branch = node.else_branch
           if_branch && else_branch && flow_expression?(if_branch) && flow_expression?(else_branch)
+        end
+
+        def check_literal_if(node)
+          return false unless flow_expression?(node.if_branch)
+
+          return true if !node.unless? && node.condition.truthy_literal?
+
+          node.unless? && node.condition.falsey_literal?
         end
 
         def check_case(node)

--- a/spec/rubocop/cop/lint/unreachable_code_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_code_spec.rb
@@ -215,4 +215,45 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableCode, :config do
       RUBY
     end
   end
+
+  %w[1 :symbol true].each do |t|
+    it "registers an offense for code gated by `return if #{t}`" do
+      expect_offense(wrap(<<~RUBY))
+        return if #{t}
+        bar
+        ^^^ Unreachable code detected.
+      RUBY
+    end
+
+    it "does not register an offense for code gated by `return unless #{t}`" do
+      expect_no_offenses(wrap(<<~RUBY))
+        return unless #{t}
+        bar
+      RUBY
+    end
+  end
+
+  %w[false nil].each do |t|
+    it "registers an offense for code gated by `return unless #{t}`" do
+      expect_offense(wrap(<<~RUBY))
+        return unless #{t}
+        bar
+        ^^^ Unreachable code detected.
+      RUBY
+    end
+
+    it "does not register an offense for code gated by `return if #{t}`" do
+      expect_no_offenses(wrap(<<~RUBY))
+        return if #{t}
+        bar
+      RUBY
+    end
+  end
+
+  it 'does not register an offense for non flow expressions' do
+    expect_no_offenses(wrap(<<~RUBY))
+      foo if true
+      bar
+    RUBY
+  end
 end


### PR DESCRIPTION
Following up on https://github.com/rubocop/rubocop/pull/13117#issuecomment-2325419197. More could be done here, in particular for more traditional if statements like so:
```ruby
# bad
if false
  foo
end
```
But that would require a more significant rework of this cop, so for now I just covered the easy stuff.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
