### PR TITLE
Make `InternalAffairs/RedundantSourceRange` aware of `add_offense`

### DIFF
--- a/lib/rubocop/cop/internal_affairs/redundant_source_range.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_source_range.rb
@@ -14,6 +14,12 @@ module RuboCop
       #   node.source
       #
       #   # bad
+      #   add_offense(node.source_range)
+      #
+      #   # good
+      #   add_offense(node)
+      #
+      #   # bad
       #   add_offense(node) { |corrector| corrector.replace(node.source_range, prefer) }
       #   add_offense(node) { |corrector| corrector.insert_before(node.source_range, prefer) }
       #   add_offense(node) { |corrector| corrector.insert_before_multi(node.source_range, prefer) }
@@ -34,7 +40,7 @@ module RuboCop
 
         MSG = 'Remove the redundant `source_range`.'
         RESTRICT_ON_SEND = %i[
-          source
+          source add_offense
           replace remove insert_before insert_before_multi insert_after insert_after_multi swap
         ].freeze
 
@@ -42,6 +48,7 @@ module RuboCop
         def_node_matcher :redundant_source_range, <<~PATTERN
           {
             (send $(send _ :source_range) :source)
+            (send nil? :add_offense $(send _ :source_range) ...)
             (send _ {
               :replace :insert_before :insert_before_multi :insert_after :insert_after_multi
             } $(send _ :source_range) _)

--- a/lib/rubocop/cop/lint/erb_new_arguments.rb
+++ b/lib/rubocop/cop/lint/erb_new_arguments.rb
@@ -91,7 +91,7 @@ module RuboCop
               next if !argument || argument.hash_type?
 
               add_offense(
-                argument.source_range, message: message(i, argument.source)
+                argument, message: message(i, argument.source)
               ) do |corrector|
                 autocorrect(corrector, node)
               end

--- a/lib/rubocop/cop/naming/predicate_name.rb
+++ b/lib/rubocop/cop/naming/predicate_name.rb
@@ -88,7 +88,7 @@ module RuboCop
               next if allowed_method_name?(method_name.to_s, prefix)
 
               add_offense(
-                node.first_argument.source_range,
+                node.first_argument,
                 message: message(method_name, expected_name(method_name.to_s, prefix))
               )
             end

--- a/lib/rubocop/cop/style/data_inheritance.rb
+++ b/lib/rubocop/cop/style/data_inheritance.rb
@@ -36,7 +36,7 @@ module RuboCop
         def on_class(node)
           return unless data_define?(node.parent_class)
 
-          add_offense(node.parent_class.source_range) do |corrector|
+          add_offense(node.parent_class) do |corrector|
             corrector.remove(range_with_surrounding_space(node.loc.keyword, newlines: false))
             corrector.replace(node.loc.operator, '=')
 

--- a/lib/rubocop/cop/style/eval_with_location.rb
+++ b/lib/rubocop/cop/style/eval_with_location.rb
@@ -136,7 +136,7 @@ module RuboCop
                            actual: line_node.source,
                            expected: expected)
 
-          add_offense(line_node.source_range, message: message) do |corrector|
+          add_offense(line_node, message: message) do |corrector|
             corrector.replace(line_node, expected)
           end
         end

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -68,7 +68,7 @@ module RuboCop
 
           return unless offending_selector?(node, selector)
 
-          add_offense(node.send_node.source_range, message: message(node, selector)) do |corrector|
+          add_offense(node.send_node, message: message(node, selector)) do |corrector|
             if node.send_node.lambda_literal?
               LambdaLiteralToMethodCorrector.new(node).call(corrector)
             else

--- a/lib/rubocop/cop/style/multiline_memoization.rb
+++ b/lib/rubocop/cop/style/multiline_memoization.rb
@@ -43,7 +43,7 @@ module RuboCop
 
           return unless bad_rhs?(rhs)
 
-          add_offense(node.source_range) do |corrector|
+          add_offense(node) do |corrector|
             if style == :keyword
               keyword_autocorrect(rhs, corrector)
             else

--- a/lib/rubocop/cop/style/nested_parenthesized_calls.rb
+++ b/lib/rubocop/cop/style/nested_parenthesized_calls.rb
@@ -39,7 +39,7 @@ module RuboCop
             next if allowed_omission?(nested)
 
             message = format(MSG, source: nested.source)
-            add_offense(nested.source_range, message: message) do |corrector|
+            add_offense(nested, message: message) do |corrector|
               autocorrect(corrector, nested)
             end
           end

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -33,7 +33,7 @@ module RuboCop
         def on_class(node)
           return unless struct_constructor?(node.parent_class)
 
-          add_offense(node.parent_class.source_range) do |corrector|
+          add_offense(node.parent_class) do |corrector|
             corrector.remove(range_with_surrounding_space(node.loc.keyword, newlines: false))
             corrector.replace(node.loc.operator, '=')
 

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -75,7 +75,7 @@ module RuboCop
 
           message = message(node)
 
-          add_offense(node.source_range, message: message) do |corrector|
+          add_offense(node, message: message) do |corrector|
             autocorrect(corrector, node)
           end
         end

--- a/spec/rubocop/cop/internal_affairs/redundant_source_range_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_source_range_spec.rb
@@ -18,6 +18,34 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantSourceRange, :config do
     RUBY
   end
 
+  it 'registers an offense when using `add_offense(node.source_range)`' do
+    expect_offense(<<~RUBY)
+      add_offense(node.source_range)
+                       ^^^^^^^^^^^^ Remove the redundant `source_range`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      add_offense(node)
+    RUBY
+  end
+
+  it 'registers an offense when using `add_offense(node.source_range, message: message)`' do
+    expect_offense(<<~RUBY)
+      add_offense(node.source_range, message: message)
+                       ^^^^^^^^^^^^ Remove the redundant `source_range`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      add_offense(node, message: message)
+    RUBY
+  end
+
+  it 'does not register an offense when using `add_offense(node)`' do
+    expect_no_offenses(<<~RUBY)
+      add_offense(node)
+    RUBY
+  end
+
   it 'registers an offense when using `corrector.replace(node.source_range, content)`' do
     expect_offense(<<~RUBY)
       add_offense do |corrector|


### PR DESCRIPTION
This PR makes `InternalAffairs/RedundantSourceRange` aware that `source_range` is redundant in `add_offense(node.source_range)`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
