### PR TITLE
Support `filter/filter!` in `Style/CollectionCompact`

### DIFF
--- a/changelog/change_support_filter_filter_in_style_collection_compact.md
+++ b/changelog/change_support_filter_filter_in_style_collection_compact.md
@@ -1,0 +1,1 @@
+* [#13245](https://github.com/rubocop/rubocop/pull/13245): Support `filter/filter!` in `Style/CollectionCompact`. ([@masato-bkn][])

--- a/spec/rubocop/cop/style/collection_compact_spec.rb
+++ b/spec/rubocop/cop/style/collection_compact_spec.rb
@@ -249,6 +249,52 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
     end
   end
 
+  context 'Ruby >= 2.6', :ruby26, unsupported_on: :prism do
+    it 'registers an offense and corrects when using `filter/filter!` to reject nils' do
+      expect_offense(<<~RUBY)
+        array.filter { |e| !e.nil? }
+              ^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `filter { |e| !e.nil? }`.
+        hash.filter! { |k, v| !v.nil? }
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact!` instead of `filter! { |k, v| !v.nil? }`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.compact
+        hash.compact!
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using safe navigation `filter/filter!` call to reject nils' do
+      expect_offense(<<~RUBY)
+        array&.filter { |e| e&.nil?&.! }
+               ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact` instead of `filter { |e| e&.nil?&.! }`.
+        hash&.filter! { |k, v| v&.nil?&.! }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `compact!` instead of `filter! { |k, v| v&.nil?&.! }`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array&.compact
+        hash&.compact!
+      RUBY
+    end
+
+    it 'does not register an offense when using `filter/filter!` to reject nils without a receiver' do
+      expect_no_offenses(<<~RUBY)
+        filter { |e| !e.nil? }
+        filter! { |k, v| !v.nil? }
+      RUBY
+    end
+  end
+
+  context 'Ruby <= 2.5', :ruby25, unsupported_on: :prism do
+    it 'does not register an offense when using `filter/filter!`' do
+      expect_no_offenses(<<~RUBY)
+        array.filter { |e| !e.nil? }
+        hash.filter! { |k, v| !v.nil? }
+      RUBY
+    end
+  end
+
   context 'when Ruby <= 2.3', :ruby23, unsupported_on: :prism do
     it 'does not register an offense when using `reject` on hash to reject nils' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR changes `Style/CollectionCompact` to support `filter/filter!`.

`filter/filter!` was introduced in Ruby 2.6 as an alias for `select/select!`, so I think it can be handled as the same way in this cop.

- https://docs.ruby-lang.org/en/3.3/Array.html#method-i-filter
- https://docs.ruby-lang.org/en/3.3/Hash.html#method-i-filter

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
