### PR TITLE
Improve yaml duplication checker performance

### DIFF
--- a/lib/rubocop/yaml_duplication_checker.rb
+++ b/lib/rubocop/yaml_duplication_checker.rb
@@ -19,10 +19,13 @@ module RuboCop
 
       def end_mapping
         mapping_node = super
-        mapping_node.children.each_slice(2).with_object([]) do |(key, _value), keys|
-          exist = keys.find { |key2| key2.value == key.value }
-          @block.call(exist, key) if exist
-          keys << key
+        # OPTIMIZE: Use a hash for faster lookup since there can
+        # be quite a few keys at the top-level.
+        keys = {}
+        mapping_node.children.each_slice(2) do |key, _value|
+          duplicate = keys[key.value]
+          @block.call(duplicate, key) if duplicate
+          keys[key.value] = key
         end
         mapping_node
       end


### PR DESCRIPTION
The first commit is an attempt at an optimization, where I made it not traverse the yaml ast. This is not necessary since psych offers an api to get tokens as they are emitted. There must be some improvement with this change but it's not measurable. I left it in anyways since I think the code is neater with that approach. I'm not attached, I can drop that commit if you want.

---------

The second commit does improve performance: The keys array can grow quite large and checking for the existance of a key becomes expensive. The worst case scenario is also the most common one, where the key is not found. Instead, use a hash:

Current:
```
$ hyperfine -w 10 -r 25 "bundle exec rubocop Rakefile"
Benchmark 1: bundle exec rubocop Rakefile
  Time (mean ± σ):     962.2 ms ±  11.4 ms    [User: 845.0 ms, System: 116.6 ms]
  Range (min … max):   944.9 ms … 985.0 ms    25 runs
```

Without any checks at all:
```
$ hyperfine -w 10 -r 25 "bundle exec rubocop Rakefile"
Benchmark 1: bundle exec rubocop Rakefile
  Time (mean ± σ):     922.5 ms ±  13.8 ms    [User: 807.8 ms, System: 113.4 ms]
  Range (min … max):   899.8 ms … 951.5 ms    25 runs
```

PR:
```
$ hyperfine -w 10 -r 25 "bundle exec rubocop Rakefile"
Benchmark 1: bundle exec rubocop Rakefile
  Time (mean ± σ):     929.8 ms ±  13.1 ms    [User: 810.1 ms, System: 119.3 ms]
  Range (min … max):   912.0 ms … 959.9 ms    25 runs
```

So, about 3.5% faster for RuboCop itself. Or in other words, ~40ms checking duplication previously, now only ~7ms.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
