### PR TITLE
Emit a deprecation when custom cops inherit from `RuboCop::Cop::Cop`

### DIFF
--- a/changelog/change_deprecation_for_cop_cop_cops.md
+++ b/changelog/change_deprecation_for_cop_cop_cops.md
@@ -1,0 +1,1 @@
+* [#13253](https://github.com/rubocop/rubocop/pull/13253): Emit a deprecation when custom cops inherit from `RuboCop::Cop::Cop`. ([@earlopain][])

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -22,6 +22,14 @@ module RuboCop
         end
       end
 
+      def self.inherited(_subclass)
+        super
+        warn Rainbow(<<~WARNING).yellow, uplevel: 1
+          Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
+          For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.
+        WARNING
+      end
+
       def self.support_autocorrect?
         method_defined?(:autocorrect)
       end

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -233,9 +233,13 @@ RSpec.describe RuboCop::Cop::Cop, :config do
 
     context 'when cop supports autocorrection', :restore_registry do
       let(:cop_class) do
-        stub_cop_class('RuboCop::Cop::Test::StubCop', inherit: described_class) do
-          def autocorrect(node); end
-        end
+        cop_class = nil
+        expect do # rubocop:disable RSpec/ExpectInLet
+          cop_class = stub_cop_class('RuboCop::Cop::Test::StubCop', inherit: described_class) do
+            def autocorrect(node); end
+          end
+        end.to output(/Inheriting from `RuboCop::Cop::Cop` is deprecated/).to_stderr
+        cop_class
       end
 
       context 'when offense was corrected' do


### PR DESCRIPTION
This has been long-marked as deprecated but not everyone has gotten the memo: https://github.com/search?q=%2F%3C+RuboCop%3A%3ACop%3A%3ACop%2F+lang%3Aruby+-is%3Afork&type=code

Some methods _are_ deprecated but its perfectly possible to just not use any of them.

Followup to https://github.com/rubocop/rubocop/pull/13032 and https://github.com/rubocop/rubocop/pull/13244

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
