### PR TITLE
Enhance the autocorrect for `Naming/InclusiveLanguage`

### DIFF
--- a/changelog/change_enhance_autocorrect_for_naming_inclusive_language.md
+++ b/changelog/change_enhance_autocorrect_for_naming_inclusive_language.md
@@ -1,0 +1,1 @@
+* [#13254](https://github.com/rubocop/rubocop/pull/13254): Enhance the autocorrect for `Naming/InclusiveLanguage` when a sole suggestion is set. ([@koic][])

--- a/lib/rubocop/cop/naming/inclusive_language.rb
+++ b/lib/rubocop/cop/naming/inclusive_language.rb
@@ -116,9 +116,9 @@ module RuboCop
             add_offense(range, message: create_message(word)) do |corrector|
               suggestions = find_flagged_term(word)['Suggestions']
 
-              next unless suggestions.is_a?(String)
-
-              corrector.replace(range, suggestions)
+              if (preferred_term = preferred_sole_term(suggestions))
+                corrector.replace(range, preferred_term)
+              end
             end
           end
         end
@@ -155,6 +155,15 @@ module RuboCop
           end
 
           set_regexes(flagged_term_strings, allowed_strings)
+        end
+
+        def preferred_sole_term(suggestions)
+          case suggestions
+          when Array
+            suggestions.one? && preferred_sole_term(suggestions.first)
+          when String
+            suggestions
+          end
         end
 
         def extract_regexp(term, term_definition)

--- a/spec/rubocop/cop/naming/inclusive_language_spec.rb
+++ b/spec/rubocop/cop/naming/inclusive_language_spec.rb
@@ -168,6 +168,25 @@ RSpec.describe RuboCop::Cop::Naming::InclusiveLanguage, :config do
       end
     end
 
+    context 'flagged term with one suggestion in array' do
+      let(:cop_config) do
+        { 'FlaggedTerms' => {
+          'whitelist' => { 'Suggestions' => %w[allowlist] }
+        } }
+      end
+
+      it 'includes both suggestions in the offense message' do
+        expect_offense(<<~RUBY)
+          whitelist = %w(user1 user2)
+          ^^^^^^^^^ Consider replacing 'whitelist' with 'allowlist'.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          allowlist = %w(user1 user2)
+        RUBY
+      end
+    end
+
     context 'flagged term with two suggestions' do
       let(:cop_config) do
         { 'FlaggedTerms' => {


### PR DESCRIPTION
This PR enhances the autocorrect for `Naming/InclusiveLanguage` when a sole suggestion is set.

The value of `Suggestions` is an array `['an offense']`, but since it can be determined as a sole term, it is autocorrectable.

```yaml
Naming/InclusiveLanguage:
  FlaggedTerms:
    ' a offense':
      Suggestions:
        - an offense
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
