### PR TITLE
Fix false negatives for `Style/MapIntoArray` when using non-splatted arguments

### DIFF
--- a/changelog/fix_false_negatives_for_style_map_into_array.md
+++ b/changelog/fix_false_negatives_for_style_map_into_array.md
@@ -1,0 +1,1 @@
+* [#13255](https://github.com/rubocop/rubocop/pull/13255): Fix false negatives for `Style/MapIntoArray` when using non-splatted arguments. ([@vlad-pisanov][])

--- a/lib/rubocop/cop/style/map_into_array.rb
+++ b/lib/rubocop/cop/style/map_into_array.rb
@@ -53,12 +53,17 @@ module RuboCop
 
         MSG = 'Use `%<new_method_name>s` instead of `each` to map elements into an array.'
 
+        # @!method suitable_argument_node?(node)
+        def_node_matcher :suitable_argument_node?, <<-PATTERN
+          !{splat forwarded-restarg forwarded-args (hash (forwarded-kwrestarg)) (block-pass nil?)}
+        PATTERN
+
         # @!method each_block_with_push?(node)
         def_node_matcher :each_block_with_push?, <<-PATTERN
           [
             ^({begin kwbegin} ...)
             ({block numblock} (send !{nil? self} :each) _
-              (send (lvar _) {:<< :push :append} {send lvar begin}))
+              (send (lvar _) {:<< :push :append} #suitable_argument_node?))
           ]
         PATTERN
 


### PR DESCRIPTION
Bugfix https://github.com/rubocop/rubocop/pull/13119 fixed the splat bug in `Style/MapIntoArray`, but it also limited the types of offenses the cop recognized. For example,

```ruby
dest = []
arr.each { |e| dest << [1, e] }
arr.each { |e| dest << true }
arr.each { |e| dest << (cond? ? 1 : e) }
```

and several others are no longer detected as of 1.66.1

This PR restores the original cop behavior while preserving the splat fix.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
