### PR TITLE
Tweak `InternalAffairs/RedundantMessageArgument` cop for v1 API

### DIFF
--- a/lib/rubocop/cop/internal_affairs/redundant_message_argument.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_message_argument.rb
@@ -11,13 +11,9 @@ module RuboCop
       #
       #   # bad
       #   add_offense(node, message: MSG)
-      #   add_offense(node, message: message)
-      #   add_offense(node, message: message(node))
       #
       #   # good
       #   add_offense(node)
-      #   add_offense(node, message: CUSTOM_MSG)
-      #   add_offense(node, message: message(other_node))
       #
       class RedundantMessageArgument < Base
         include RangeHelp
@@ -28,22 +24,21 @@ module RuboCop
 
         # @!method node_type_check(node)
         def_node_matcher :node_type_check, <<~PATTERN
-          (send nil? :add_offense $_node $hash)
+          (send nil? :add_offense _node $hash)
         PATTERN
 
         # @!method redundant_message_argument(node)
         def_node_matcher :redundant_message_argument, <<~PATTERN
           (pair
             (sym :message)
-            ${(const nil? :MSG) (send nil? :message) (send nil? :message _)})
+            $(const nil? :MSG))
         PATTERN
 
-        # @!method message_method_call(node)
-        def_node_matcher :message_method_call, '(send nil? :message $_node)'
-
         def on_send(node)
-          node_type_check(node) do |node_arg, kwargs|
-            find_offending_argument(node_arg, kwargs) do |pair|
+          return unless (kwargs = node_type_check(node))
+
+          kwargs.pairs.each do |pair|
+            redundant_message_argument(pair) do
               add_offense(pair) do |corrector|
                 range = offending_range(pair)
 
@@ -59,16 +54,6 @@ module RuboCop
           with_space = range_with_surrounding_space(node.source_range)
 
           range_with_surrounding_comma(with_space, :left)
-        end
-
-        def find_offending_argument(searched_node, kwargs)
-          kwargs.pairs.each do |pair|
-            redundant_message_argument(pair) do |message_argument|
-              node = message_method_call(message_argument)
-
-              yield pair if !node || node == searched_node
-            end
-          end
         end
       end
     end

--- a/spec/rubocop/cop/internal_affairs/redundant_message_argument_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_message_argument_spec.rb
@@ -21,21 +21,12 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantMessageArgument, :config 
   end
 
   context 'when `#message` is passed' do
-    it 'registers an offense' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
         add_offense(
           node,
           location: :expression,
           message: message,
-          ^^^^^^^^^^^^^^^^ Redundant message argument to `#add_offense`.
-          severity: :error
-        )
-      RUBY
-
-      expect_correction(<<~RUBY)
-        add_offense(
-          node,
-          location: :expression,
           severity: :error
         )
       RUBY
@@ -44,31 +35,19 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantMessageArgument, :config 
 
   context 'when `#message` with offending node is passed' do
     context 'when message is the only keyword argument' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY, 'example_cop.rb')
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY, 'example_cop.rb')
           add_offense(node, message: message(node))
-                            ^^^^^^^^^^^^^^^^^^^^^^ Redundant message argument to `#add_offense`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          add_offense(node)
         RUBY
       end
     end
 
     context 'when there are others keyword arguments' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY, 'example_cop.rb')
-          add_offense(node,
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY, 'example_cop.rb')
+          add_no_offenses(node,
                       location: :selector,
                       message: message(node),
-                      ^^^^^^^^^^^^^^^^^^^^^^ Redundant message argument to `#add_offense`.
-                      severity: :fatal)
-        RUBY
-
-        expect_correction(<<~RUBY)
-          add_offense(node,
-                      location: :selector,
                       severity: :fatal)
         RUBY
       end


### PR DESCRIPTION
The following `bad` cases cannot be replaced with the `good` case after v1 API:

```ruby
# bad
add_offense(node, message: message)
add_offense(node, message: message(node))

# good
add_offense(node)
```

v1 API: https://docs.rubocop.org/rubocop/v1_upgrade_notes.html

As a result, there was an incorrect detection for calls like `add_offense(message: message)` where the `message` method is the value. As a workaround, a technique involving assignment to a local variable named `message` was used, but fundamentally, these cases should no longer be detected by this cop.

This PR modifies the cop to detect only `add_offense(node, message: MSG)` which can still be replaced with the good cases after v1 API.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
