### PR TITLE
[Fix #13260] Fix a false positive for `Lint/RedundantSafeNavigation` with namespaced constants

### DIFF
--- a/changelog/fix_false_positive_redundant_safe_navigation.md
+++ b/changelog/fix_false_positive_redundant_safe_navigation.md
@@ -1,0 +1,1 @@
+* [#13260](https://github.com/rubocop/rubocop/issues/13260): Fix a false positive for `Lint/RedundantSafeNavigation` with namespaced constants. ([@earlopain][])

--- a/lib/rubocop/cop/lint/redundant_safe_navigation.rb
+++ b/lib/rubocop/cop/lint/redundant_safe_navigation.rb
@@ -131,7 +131,7 @@ module RuboCop
         private
 
         def assume_receiver_instance_exists?(receiver)
-          return true if receiver.const_type? && !receiver.source.match?(SNAKE_CASE)
+          return true if receiver.const_type? && !receiver.short_name.match?(SNAKE_CASE)
 
           receiver.literal? && !receiver.nil_type?
         end


### PR DESCRIPTION
Fix #13260

`FOO::BAR` isn't in snakecase. It should only look at the last part.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
