### PR TITLE
[Doc] Tweak the doc for `DisabledByDefault: true` in configuration

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -507,7 +507,9 @@ Style:
   Enabled: true
 ----
 
-All cops in the `Style` department are then enabled.
+All cops in the `Style` department are then enabled. In this case, only the cops
+in the `Style` department that are enabled by default will be enabled.
+The cops in the `Style` department that are disabled by default will remain disabled.
 
 If a department is disabled, cops in that department can still be individually
 enabled, and that setting overrides the setting for its department in the same


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/4304.

This PR tweaks the doc for `DisabledByDefault: true` in configuration.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
