### PR TITLE
[Fix #13149] Handle crashes in custom Ruby extractors more gracefully

### DIFF
--- a/changelog/fix_handle_custom_extractors_crash.md
+++ b/changelog/fix_handle_custom_extractors_crash.md
@@ -1,0 +1,1 @@
+* [#13149](https://github.com/rubocop/rubocop/issues/13149): Handle crashes in custom Ruby extractors more gracefully. ([@earlopain][])

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -362,6 +362,9 @@ module RuboCop
       self.class.ruby_extractors.find do |ruby_extractor|
         result = ruby_extractor.call(processed_source)
         break result if result
+      rescue StandardError
+        raise Error, "Ruby extractor #{ruby_extractor.source_location[0]} failed to process " \
+                     "#{processed_source.path}."
       end
     end
 


### PR DESCRIPTION
This previously only showed where the extractor was located. Now it also includes the file it was processing.

This still fully halts execution instead of continuing on with the remaining files. Making that work properly would be a bunch more work.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
