### PR TITLE
[Fix #13256] Report and correct more `Style/SafeNavigation` offenses.

### DIFF
--- a/changelog/change_report_and_correct_more_style_safe_navigation.md
+++ b/changelog/change_report_and_correct_more_style_safe_navigation.md
@@ -1,0 +1,1 @@
+* [#13256](https://github.com/rubocop/rubocop/issues/13256): Report and correct more `Style/SafeNavigation` offenses. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2332,7 +2332,7 @@ Lint/SafeNavigationConsistency:
                  for all method calls on that same object.
   Enabled: true
   VersionAdded: '0.55'
-  VersionChanged: '0.77'
+  VersionChanged: '<<next>>'
   AllowedMethods:
     - present?
     - blank?

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -166,7 +166,7 @@ module RuboCop
       return unless duplicate_setting?(base_hash, derived_hash, key, opts[:inherited_file])
 
       inherit_mode = opts[:inherit_mode]['merge'] || opts[:inherit_mode]['override']
-      return if base_hash[key].is_a?(Array) && inherit_mode && inherit_mode.include?(key)
+      return if base_hash[key].is_a?(Array) && inherit_mode&.include?(key)
 
       puts "#{PathUtil.smart_path(opts[:file])}: " \
            "#{opts[:cop_name]}:#{key} overrides " \
@@ -194,11 +194,11 @@ module RuboCop
     end
 
     def should_merge?(mode, key)
-      mode && mode['merge'] && mode['merge'].include?(key)
+      mode && mode['merge']&.include?(key)
     end
 
     def should_override?(mode, key)
-      mode && mode['override'] && mode['override'].include?(key)
+      mode && mode['override']&.include?(key)
     end
 
     def merge_hashes?(base_hash, derived_hash, key)

--- a/lib/rubocop/cop/layout/def_end_alignment.rb
+++ b/lib/rubocop/cop/layout/def_end_alignment.rb
@@ -61,7 +61,7 @@ module RuboCop
         private
 
         def autocorrect(corrector, node)
-          if style == :start_of_line && node.parent && node.parent.send_type?
+          if style == :start_of_line && node.parent&.send_type?
             AlignmentCorrector.align_end(corrector, processed_source, node, node.parent)
           else
             AlignmentCorrector.align_end(corrector, processed_source, node, node)

--- a/lib/rubocop/cop/lint/safe_navigation_consistency.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_consistency.rb
@@ -70,9 +70,8 @@ module RuboCop
 
         def top_conditional_ancestor(node)
           parent = node.parent
-          unless parent &&
-                 (parent.operator_keyword? ||
-                  (parent.begin_type? && parent.parent && parent.parent.operator_keyword?))
+          unless parent&.operator_keyword? ||
+                 (parent&.begin_type? && parent.parent&.operator_keyword?)
             return node
           end
 

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -179,7 +179,7 @@ module RuboCop
         end
 
         def looks_like_trivial_reader?(node)
-          !node.arguments? && node.body && node.body.ivar_type?
+          !node.arguments? && node.body&.ivar_type?
         end
 
         def trivial_writer?(node)

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -32,7 +32,7 @@ module RuboCop
       end
 
       def parentheses?(node)
-        node.loc.respond_to?(:end) && node.loc.end && node.loc.end.is?(')')
+        node.loc.respond_to?(:end) && node.loc.end&.is?(')')
       end
 
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
     expect_no_offenses('nil&.bar')
   end
 
+  it 'allows non-object checks' do
+    expect_no_offenses('x.foo? && x.bar?')
+  end
+
+  it 'allows non-object checks with safe navigation' do
+    expect_no_offenses('x&.foo? && x&.bar?')
+  end
+
   it 'allows an object check before hash access' do
     expect_no_offenses('foo && foo[:bar]')
   end
@@ -148,6 +156,26 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
   it 'allows a method call safeguarded when using `unless nil?`' do
     expect_no_offenses(<<~RUBY)
       foo unless nil?
+    RUBY
+  end
+
+  it 'allows a negated `and` clause that does not do an object check' do
+    expect_no_offenses(<<~RUBY)
+      foo? && !((x.bar? || y.baz?) && z?)
+    RUBY
+  end
+
+  it 'allows an `and` with a `block` that contains an `and`' do
+    expect_no_offenses(<<~RUBY)
+      x? && y? do |b|
+        b.foo? && b.bar?
+      end
+    RUBY
+  end
+
+  it 'allows for nested `begin`s on the LHS' do
+    expect_no_offenses(<<~RUBY)
+      (x? + (y? && z?)) && !w?
     RUBY
   end
 
@@ -468,6 +496,29 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
           foo if #{variable}&.bar # comment
         RUBY
       end
+
+      context 'method chaining' do
+        context 'MaxChainLength: 1' do
+          let(:cop_config) { { 'MaxChainLength' => 1 } }
+
+          it 'registers an offense for an object check followed by 1 chained method calls' do
+            expect_offense(<<~RUBY, variable: variable)
+              %{variable}.one if %{variable}
+              ^{variable}^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              #{variable}&.one
+            RUBY
+          end
+
+          it 'allows an object check followed by 2 chained method calls' do
+            expect_no_offenses(<<~RUBY)
+              %{variable}.one.two if %{variable}
+            RUBY
+          end
+        end
+      end
     end
 
     context 'if expression' do
@@ -775,6 +826,33 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
           RUBY
         end
       end
+
+      context 'method chaining' do
+        context 'MaxChainLength: 1' do
+          let(:cop_config) { { 'MaxChainLength' => 1 } }
+
+          it 'registers an offense for an object check followed by 1 chained method calls' do
+            expect_offense(<<~RUBY, variable: variable)
+              if %{variable}
+              ^^^^{variable} Use safe navigation (`&.`) instead [...]
+                %{variable}.one
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              #{variable}&.one
+            RUBY
+          end
+
+          it 'allows an object check followed by 2 chained method calls' do
+            expect_no_offenses(<<~RUBY)
+              if #{variable}
+                #{variable}.one.two
+              end
+            RUBY
+          end
+        end
+      end
     end
 
     context 'object check before method call' do
@@ -839,6 +917,17 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
           RUBY
         end
 
+        it 'registers an offense for an object check followed by a method call on a chained receiver' do
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable}.bar && %{variable}.bar.baz
+            ^{variable}^^^^^^^^^{variable}^^^^^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{variable}.bar&.baz
+          RUBY
+        end
+
         it 'registers an offense for an object check followed by a method call with params' do
           expect_offense(<<~RUBY, variable: variable)
             %{variable} && %{variable}.bar(baz)
@@ -897,6 +986,50 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
 
           expect_correction(<<~RUBY)
             #{variable}&.bar && something
+          RUBY
+        end
+
+        it 'registers an offense if followed by a different variable' do
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} && %{variable}.bar && bar
+            ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{variable}&.bar && bar
+          RUBY
+        end
+
+        it 'registers an offense if followed by a different method' do
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} && %{variable}.bar && bar?
+            ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{variable}&.bar && bar?
+          RUBY
+        end
+
+        it 'registers an offense if preceded by a different variable' do
+          expect_offense(<<~RUBY, variable: variable)
+            bar && %{variable} && %{variable}.bar
+                   ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            bar && #{variable}&.bar
+          RUBY
+        end
+
+        it 'registers an offense if preceded by a different method' do
+          expect_offense(<<~RUBY, variable: variable)
+            bar? && %{variable} && %{variable}.bar
+                    ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            bar? && #{variable}&.bar
           RUBY
         end
 
@@ -1074,6 +1207,50 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
           RUBY
         end
 
+        it 'registers an offense if followed by a different variable' do
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} && %{variable}.bar && bar
+            ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{variable}&.bar && bar
+          RUBY
+        end
+
+        it 'registers an offense if followed by a different method' do
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} && %{variable}.bar && bar?
+            ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{variable}&.bar && bar?
+          RUBY
+        end
+
+        it 'registers an offense if preceded by a different variable' do
+          expect_offense(<<~RUBY, variable: variable)
+            bar && %{variable} && %{variable}.bar
+                   ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            bar && #{variable}&.bar
+          RUBY
+        end
+
+        it 'registers an offense if preceded by a different method' do
+          expect_offense(<<~RUBY, variable: variable)
+            bar? && %{variable} && %{variable}.bar
+                    ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            bar? && #{variable}&.bar
+          RUBY
+        end
+
         context 'method chaining' do
           it 'corrects an object check followed by a chained method call' do
             expect_offense(<<~RUBY, variable: variable)
@@ -1167,6 +1344,51 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
   it_behaves_like('all variable types', '@foo')
   it_behaves_like('all variable types', '@@foo')
   it_behaves_like('all variable types', '$FOO')
+
+  it 'registers and corrects when and clauses contain `begin` nodes' do
+    expect_offense(<<~RUBY)
+      foo && (bar && bar.y?)
+              ^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo && (bar&.y?)
+    RUBY
+  end
+
+  it 'registers and corrects when and clauses contain nested `begin` nodes' do
+    expect_offense(<<~RUBY)
+      foo && (bar && (bar.y?))
+              ^^^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo && ((bar&.y?))
+    RUBY
+  end
+
+  it 'registers and corrects when there are multiple clauses that could use safe navigation' do
+    expect_offense(<<~RUBY)
+      foo && foo.x? && bar && bar.y?
+      ^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+                       ^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.x? && bar&.y?
+    RUBY
+  end
+
+  it 'registers and corrects when the and keyword is used' do
+    expect_offense(<<~RUBY)
+      foo and foo.bar?
+      ^^^^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.bar?
+    RUBY
+  end
 
   context 'respond_to?' do
     it 'allows method calls safeguarded by a respond_to check' do


### PR DESCRIPTION
This change adds the ability for `Style/SafeNavigation` to detect offenses such as

```ruby
foo? && bar && bar.end_with?('baz')
```

`and` nodes nest leftward, ie. the above code becomes 

```
(and
  (and
    (send nil :foo?)
    (send nil :bar))
  (send
    (send nil :bar) :end_with?
    (send nil :baz)))
```

Because of this, the previously version of the cop was unable to find an offense for the above code because it was comparing `foo? && bar` with `bar.end_with?`. In order to support this, I had to greatly rewrite how `on_and` processes nodes. The new approach collects all the clauses of a (nested) `and` statement, and evaluates them in pairs. If a pair has an object detection on the LHS and a method call of that object on the RHS, it will be picked up by the cop as an offense and corrected. I also handled `begin` nodes within `and` nodes so code like `foo && (bar && bar.x?)` will be caught as well.

I mostly did not change the `on_if` code, other than using my new methods where appropriate. The core of it that finds which elements to operate on has not changed.

As part of my refactor, I added tests for a number of cases that were being covered by the cop but not tested for, to ensure the behaviour remains the same. I have run this new version of the cop against a number of codebases and do not get any crashes or false positives that I've seen.

A few new offenses were detected in the RuboCop codebase by the changes, which are fixed in the second commit.

Fixes #13256.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
