### PR TITLE
Fix a false positive for `Style/BlockDelimiters`

### DIFF
--- a/changelog/fix_a_false_postiive_for_style_block_delimiters.md
+++ b/changelog/fix_a_false_postiive_for_style_block_delimiters.md
@@ -1,0 +1,1 @@
+* [#13268](https://github.com/rubocop/rubocop/pull/13268): Fix a false positive for `Style/BlockDelimiters` when a single line do-end block with an inline `rescue` with a semicolon before `rescue`. ([@koic][])

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -341,8 +341,9 @@ module RuboCop
           end
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def proper_block_style?(node)
-          return true if require_braces?(node)
+          return true if require_braces?(node) || require_do_end?(node)
           return special_method_proper_block_style?(node) if special_method?(node.method_name)
 
           case style
@@ -352,6 +353,7 @@ module RuboCop
           when :always_braces       then braces_style?(node)
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def require_braces?(node)
           return false unless node.braces?
@@ -359,6 +361,13 @@ module RuboCop
           node.each_ancestor(:send).any? do |send|
             send.arithmetic_operation? && node.source_range.end_pos < send.loc.selector.begin_pos
           end
+        end
+
+        def require_do_end?(node)
+          return false if node.braces? || node.multiline?
+          return false unless (resbody = node.each_descendant(:resbody).first)
+
+          resbody.children.first&.array_type?
         end
 
         def special_method?(method_name)

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -644,6 +644,28 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
     end
+
+    context 'with a single line do-end block with an inline `rescue` without a semicolon before `rescue`' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          foo do next unless bar rescue StandardError; end
+              ^^ Prefer `{...}` over `do...end` for single-line blocks.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo { next unless bar rescue StandardError; }
+        RUBY
+      end
+    end
+
+    context 'with a single line do-end block with an inline `rescue` with a semicolon before `rescue`' do
+      it 'does not register an offense' do
+        # NOTE: `foo { next unless bar; rescue StandardError; }` is a syntax error.
+        expect_no_offenses(<<~RUBY)
+          foo do next unless bar; rescue StandardError; end
+        RUBY
+      end
+    end
   end
 
   context 'EnforcedStyle: braces_for_chaining' do


### PR DESCRIPTION
This PR fixes the following false positive for `Style/BlockDelimiters` when a single line do-end block with an inline `rescue` with a semicolon before `rescue`:

```console
$ echo "foo do next unless bar; rescue StandardError; end" | bundle exec rubocop --stdin dummy.rb -A --only Style/BlockDelimiters
Inspecting 1 file
F

Offenses:

dummy.rb:1:5: C: [Corrected] Style/BlockDelimiters: Prefer {...} over do...end for single-line blocks.
foo do next unless bar; rescue StandardError; end
    ^^
dummy.rb:1:24: F: Lint/Syntax: unexpected token kRESCUE
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
foo { next unless bar; rescue StandardError; }
                       ^^^^^^
dummy.rb:1:46: F: Lint/Syntax: unexpected token tRCURLY
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
foo { next unless bar; rescue StandardError; }
                                             ^

1 file inspected, 3 offenses detected, 1 offense corrected
====================
foo { next unless bar; rescue StandardError; }
```

The following code is a syntax error when detected:

```ruby
foo { next unless bar; rescue StandardError; }` # syntax error
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
