### PR TITLE
Refactor `style/select_by_regexp_spec` to prevent overwriting `ruby_version` within contexts

### DIFF
--- a/spec/rubocop/cop/style/select_by_regexp_spec.rb
+++ b/spec/rubocop/cop/style/select_by_regexp_spec.rb
@@ -261,113 +261,117 @@ RSpec.describe RuboCop::Cop::Style::SelectByRegexp, :config do
           ::ENV.#{method} { |x| x.match? /regexp/ }
         RUBY
       end
+    end
+  end
 
-      context 'with `numblock`s', :ruby27 do
-        it 'registers an offense and corrects for `match?`' do
-          expect_offense(<<~RUBY, method: method)
-            array.#{method} { _1.match? /regexp/ }
-            ^^^^^^^{method}^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-          RUBY
+  shared_examples 'regexp match with `numblock`s' do |method, correction|
+    message = "Prefer `#{correction}` to `#{method}` with a regexp match."
 
-          expect_correction(<<~RUBY)
-            array.#{correction}(/regexp/)
-          RUBY
-        end
+    it 'registers an offense and corrects for `match?`' do
+      expect_offense(<<~RUBY, method: method)
+        array.#{method} { _1.match? /regexp/ }
+        ^^^^^^^{method}^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
 
-        it 'registers an offense and corrects for `Regexp#match?`' do
-          expect_offense(<<~RUBY, method: method)
-            array.#{method} { /regexp/.match?(_1) }
-            ^^^^^^^{method}^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-          RUBY
-
-          expect_correction(<<~RUBY)
-            array.#{correction}(/regexp/)
-          RUBY
-        end
-
-        it 'registers an offense and corrects for `blockvar =~ regexp`' do
-          expect_offense(<<~RUBY, method: method)
-            array.#{method} { _1 =~ /regexp/ }
-            ^^^^^^^{method}^^^^^^^^^^^^^^^^^^^ #{message}
-          RUBY
-
-          expect_correction(<<~RUBY)
-            array.#{correction}(/regexp/)
-          RUBY
-        end
-
-        it 'registers an offense and corrects for `regexp =~ blockvar`' do
-          expect_offense(<<~RUBY, method: method)
-            array.#{method} { /regexp/ =~ _1 }
-            ^^^^^^^{method}^^^^^^^^^^^^^^^^^^^ #{message}
-          RUBY
-
-          expect_correction(<<~RUBY)
-            array.#{correction}(/regexp/)
-          RUBY
-        end
-
-        it 'does not register an offense if there is more than one numbered param' do
-          expect_no_offenses(<<~RUBY)
-            array.#{method} { _1 =~ _2 }
-          RUBY
-        end
-
-        it 'does not register an offense when the param is a method argument' do
-          expect_no_offenses(<<~RUBY)
-            array.#{method} { /regexp/.match?(foo(_1)) }
-          RUBY
-        end
-
-        it 'does not register an offense when using `match?` without a receiver' do
-          expect_no_offenses(<<~RUBY)
-            array.#{method} { |item| match?(item) }
-          RUBY
-        end
-      end
+      expect_correction(<<~RUBY)
+        array.#{correction}(/regexp/)
+      RUBY
     end
 
-    context "with safe navigation #{method}", :ruby23 do
-      it 'registers an offense and corrects for `match?`' do
-        expect_offense(<<~RUBY, method: method)
-          array&.#{method} { |x| x.match? /regexp/ }
-          ^^^^^^^^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-        RUBY
+    it 'registers an offense and corrects for `match?` with safe navigation' do
+      expect_offense(<<~RUBY, method: method)
+        array&.#{method} { _1.match? /regexp/ }
+        ^^^^^^^^{method}^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
 
-        expect_correction(<<~RUBY)
-          array&.#{correction}(/regexp/)
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        array&.#{correction}(/regexp/)
+      RUBY
+    end
 
-      it 'registers an offense and corrects for `match?`', :ruby27 do
-        expect_offense(<<~RUBY, method: method)
-          array&.#{method} { _1.match? /regexp/ }
-          ^^^^^^^^{method}^^^^^^^^^^^^^^^^^^^^^^^ #{message}
-        RUBY
+    it 'registers an offense and corrects for `Regexp#match?`' do
+      expect_offense(<<~RUBY, method: method)
+        array.#{method} { /regexp/.match?(_1) }
+        ^^^^^^^{method}^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
 
-        expect_correction(<<~RUBY)
-          array&.#{correction}(/regexp/)
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        array.#{correction}(/regexp/)
+      RUBY
+    end
 
-      it 'does not register an offense when the receiver is `Hash.new`' do
-        expect_no_offenses(<<~RUBY)
-          Hash&.new.#{method} { |x| x.match? /regexp/ }
-          Hash&.new { |hash, key| :default }.#{method} { |x| x.match? /regexp/ }
-        RUBY
-      end
+    it 'registers an offense and corrects for `blockvar =~ regexp`' do
+      expect_offense(<<~RUBY, method: method)
+        array.#{method} { _1 =~ /regexp/ }
+        ^^^^^^^{method}^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
 
-      it 'does not register an offense when the receiver is `to_h`' do
-        expect_no_offenses(<<~RUBY)
-          foo&.to_h.#{method} { |x| x.match? /regexp/ }
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        array.#{correction}(/regexp/)
+      RUBY
+    end
 
-      it 'does not register an offense when the receiver is `to_hash`' do
-        expect_no_offenses(<<~RUBY)
-          foo&.to_hash.#{method} { |x| x.match? /regexp/ }
-        RUBY
-      end
+    it 'registers an offense and corrects for `regexp =~ blockvar`' do
+      expect_offense(<<~RUBY, method: method)
+        array.#{method} { /regexp/ =~ _1 }
+        ^^^^^^^{method}^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.#{correction}(/regexp/)
+      RUBY
+    end
+
+    it 'does not register an offense if there is more than one numbered param' do
+      expect_no_offenses(<<~RUBY)
+        array.#{method} { _1 =~ _2 }
+      RUBY
+    end
+
+    it 'does not register an offense when the param is a method argument' do
+      expect_no_offenses(<<~RUBY)
+        array.#{method} { /regexp/.match?(foo(_1)) }
+      RUBY
+    end
+
+    it 'does not register an offense when using `match?` without a receiver' do
+      expect_no_offenses(<<~RUBY)
+        array.#{method} { |item| match?(item) }
+      RUBY
+    end
+  end
+
+  shared_examples 'regexp match with safe navigation' do |method, correction|
+    message = "Prefer `#{correction}` to `#{method}` with a regexp match."
+
+    it 'registers an offense and corrects for `match?`' do
+      expect_offense(<<~RUBY, method: method)
+        array&.#{method} { |x| x.match? /regexp/ }
+        ^^^^^^^^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array&.#{correction}(/regexp/)
+      RUBY
+    end
+
+    it 'does not register an offense when the receiver is `Hash.new`' do
+      expect_no_offenses(<<~RUBY)
+        Hash&.new.#{method} { |x| x.match? /regexp/ }
+        Hash&.new { |hash, key| :default }.#{method} { |x| x.match? /regexp/ }
+      RUBY
+    end
+
+    it 'does not register an offense when the receiver is `to_h`' do
+      expect_no_offenses(<<~RUBY)
+        foo&.to_h.#{method} { |x| x.match? /regexp/ }
+      RUBY
+    end
+
+    it 'does not register an offense when the receiver is `to_hash`' do
+      expect_no_offenses(<<~RUBY)
+        foo&.to_hash.#{method} { |x| x.match? /regexp/ }
+      RUBY
     end
   end
 
@@ -439,45 +443,60 @@ RSpec.describe RuboCop::Cop::Style::SelectByRegexp, :config do
           array.#{correction}(foo.bar.baz(quux))
         RUBY
       end
-
-      context 'with `numblock`s', :ruby27 do
-        it 'registers an offense and corrects for `blockvar !~ regexp`' do
-          expect_offense(<<~RUBY, method: method)
-            array.#{method} { _1 !~ /regexp/ }
-            ^^^^^^^{method}^^^^^^^^^^^^^^^^^^^ #{message}
-          RUBY
-
-          expect_correction(<<~RUBY)
-            array.#{correction}(/regexp/)
-          RUBY
-        end
-
-        it 'registers an offense and corrects for `regexp !~ blockvar`' do
-          expect_offense(<<~RUBY, method: method)
-            array.#{method} { /regexp/ !~ _1 }
-            ^^^^^^^{method}^^^^^^^^^^^^^^^^^^^ #{message}
-          RUBY
-
-          expect_correction(<<~RUBY)
-            array.#{correction}(/regexp/)
-          RUBY
-        end
-
-        it 'does not register an offense if there is more than one numbered param' do
-          expect_no_offenses(<<~RUBY)
-            array.#{method} { _1 !~ _2 }
-          RUBY
-        end
-      end
     end
+  end
+
+  shared_examples 'regexp mismatch with `numblock`s' do |method, correction|
+    message = "Prefer `#{correction}` to `#{method}` with a regexp match."
+
+    it 'registers an offense and corrects for `blockvar !~ regexp`' do
+      expect_offense(<<~RUBY, method: method)
+        array.#{method} { _1 !~ /regexp/ }
+        ^^^^^^^{method}^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.#{correction}(/regexp/)
+      RUBY
+    end
+
+    it 'registers an offense and corrects for `regexp !~ blockvar`' do
+      expect_offense(<<~RUBY, method: method)
+        array.#{method} { /regexp/ !~ _1 }
+        ^^^^^^^{method}^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.#{correction}(/regexp/)
+      RUBY
+    end
+
+    it 'does not register an offense if there is more than one numbered param' do
+      expect_no_offenses(<<~RUBY)
+        array.#{method} { _1 !~ _2 }
+      RUBY
+    end
+  end
+
+  context 'when Ruby >= 2.7', :ruby27 do
+    include_examples('regexp match with `numblock`s', 'select', 'grep')
+    include_examples('regexp match with `numblock`s', 'find_all', 'grep')
+    include_examples('regexp mismatch with `numblock`s', 'reject', 'grep')
+
+    include_examples('regexp match with `numblock`s', 'reject', 'grep_v')
+    include_examples('regexp mismatch with `numblock`s', 'select', 'grep_v')
+    include_examples('regexp mismatch with `numblock`s', 'find_all', 'grep_v')
   end
 
   context 'when Ruby >= 2.3', :ruby23 do
     include_examples('regexp match', 'select', 'grep')
+    include_examples('regexp match with safe navigation', 'select', 'grep')
     include_examples('regexp match', 'find_all', 'grep')
+    include_examples('regexp match with safe navigation', 'find_all', 'grep')
     include_examples('regexp mismatch', 'reject', 'grep')
 
     include_examples('regexp match', 'reject', 'grep_v')
+    include_examples('regexp match with safe navigation', 'reject', 'grep_v')
     include_examples('regexp mismatch', 'select', 'grep_v')
     include_examples('regexp mismatch', 'find_all', 'grep_v')
   end


### PR DESCRIPTION
This PR refactors `style/select_by_regexp_spec` to prevent overwriting `ruby_version` within contexts.
I have split the changes into multiple commits to make the review process easier. If you prefer to squash commits, I will do so.

### Background
In `style/select_by_regexp_spec`, the `ruby_version` is being overwritten within the context of the shared_examples. As a result, the test is executed with a different `ruby_version` than the `ruby_version` specified in the caller of shared_examples.

For example, in `context 'when Ruby <= 2.2', :ruby22`, `ruby_version` 2.2 is specified, but due to a different `ruby_version` being set within the following contexts inside the shared_examples, the tests are actually being run with a different version than intended:

- https://github.com/rubocop/rubocop/blob/master/spec/rubocop/cop/style/select_by_regexp_spec.rb#L330
- https://github.com/rubocop/rubocop/blob/master/spec/rubocop/cop/style/select_by_regexp_spec.rb#L443

### Motivation
This mismatch between test case names and the actual behavior is not ideal, as it can lead to confusion. It may also result in bugs or omissions in the specifications.
For maintainability, I believe this is a good opportunity to refactor the test structure.

In fact, when considering adding support for `filter` in `Style/SelectByRegexp`, I found it difficult to determine how to modify the tests due to this issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
