### PR TITLE
Make `Style/SelectByRegexp` aware of `filter` in Ruby version 2.6 or above

### DIFF
--- a/changelog/change_make_style_select_by_regexp_aware_of_filter_in.md
+++ b/changelog/change_make_style_select_by_regexp_aware_of_filter_in.md
@@ -1,0 +1,1 @@
+* [#13270](https://github.com/rubocop/rubocop/pull/13270): Make `Style/SelectByRegexp` aware of `filter` in Ruby version 2.6 or above. ([@masato-bkn][])

--- a/spec/rubocop/cop/style/select_by_regexp_spec.rb
+++ b/spec/rubocop/cop/style/select_by_regexp_spec.rb
@@ -552,11 +552,35 @@ RSpec.describe RuboCop::Cop::Style::SelectByRegexp, :config do
   context 'when Ruby >= 2.7', :ruby27 do
     include_examples('regexp match with `numblock`s', 'select', 'grep')
     include_examples('regexp match with `numblock`s', 'find_all', 'grep')
+    include_examples('regexp match with `numblock`s', 'filter', 'grep')
     include_examples('regexp mismatch with `numblock`s', 'reject', 'grep')
 
     include_examples('regexp match with `numblock`s', 'reject', 'grep_v')
     include_examples('regexp mismatch with `numblock`s', 'select', 'grep_v')
     include_examples('regexp mismatch with `numblock`s', 'find_all', 'grep_v')
+    include_examples('regexp mismatch with `numblock`s', 'filter', 'grep_v')
+  end
+
+  context 'when Ruby >= 2.6', :ruby26 do
+    include_examples('regexp match', 'filter', 'grep')
+    include_examples('regexp match with safe navigation', 'filter', 'grep')
+
+    include_examples('regexp mismatch', 'filter', 'grep_v')
+    include_examples('regexp mismatch with safe navigation', 'filter', 'grep_v')
+  end
+
+  context 'when Ruby <= 2.5', :ruby25, unsupported_on: :prism do
+    it 'does not register an offense when `filter` with regexp match' do
+      expect_no_offenses(<<~RUBY)
+        array.filter { |x| x =~ /regexp/ }
+      RUBY
+    end
+
+    it 'does not register an offense when `filter` with regexp mismatch' do
+      expect_no_offenses(<<~RUBY)
+        array.filter { |x| x !~ /regexp/ }
+      RUBY
+    end
   end
 
   context 'when Ruby >= 2.3', :ruby23 do


### PR DESCRIPTION
This PR makes `Style/SelectByRegexp` aware of `filter` in Ruby version 2.6 or above similar to https://github.com/rubocop/rubocop/pull/13245.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
