### PR TITLE
[Fix #13271] Fix a false positive for `Lint/AmbiguousRange`

### DIFF
--- a/changelog/fix_false_positive_for_lint_ambiguous_range.md
+++ b/changelog/fix_false_positive_for_lint_ambiguous_range.md
@@ -1,0 +1,1 @@
+* [#13271](https://github.com/rubocop/rubocop/issues/13271): Fix a false positive for `Lint/AmbiguousRange` when using rational literals. ([@koic][])

--- a/lib/rubocop/cop/lint/ambiguous_range.rb
+++ b/lib/rubocop/cop/lint/ambiguous_range.rb
@@ -57,6 +57,7 @@ module RuboCop
       #   # good
       #   (a.foo)..(b.bar)
       class AmbiguousRange < Base
+        include RationalLiteral
         extend AutoCorrector
 
         MSG = 'Wrap complex range boundaries with parentheses to avoid ambiguity.'
@@ -79,12 +80,14 @@ module RuboCop
           yield range.end if range.end
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def acceptable?(node)
           node.begin_type? ||
-            node.literal? ||
+            node.literal? || rational_literal?(node) ||
             node.variable? || node.const_type? || node.self_type? ||
             (node.call_type? && acceptable_call?(node))
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def acceptable_call?(node)
           return true if node.unary_operation?

--- a/spec/rubocop/cop/lint/ambiguous_range_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_range_spec.rb
@@ -128,6 +128,12 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRange, :config do
             RUBY
           end
 
+          it 'does not register an offense for rational literals' do
+            expect_no_offenses(<<~RUBY)
+              1/10r#{operator}1/3r
+            RUBY
+          end
+
           it 'requires parens when calling a method on a basic literal' do
             expect_offense(<<~RUBY, operator: operator)
               1#{operator}2.to_a


### PR DESCRIPTION
Fixes #13271.

This PR fixes a false positive for `Lint/AmbiguousRange` when using rational literals.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
