### PR TITLE
Fix an error for mixed and/or in begin node for `Style/SafeNavigation`

### DIFF
--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -290,7 +290,7 @@ module RuboCop
         end
 
         def find_matching_receiver_invocation(method_chain, checked_variable)
-          return nil unless method_chain
+          return nil unless method_chain.respond_to?(:receiver)
 
           receiver = method_chain.receiver
 

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -179,6 +179,12 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
     RUBY
   end
 
+  it 'allows mixed `||` and `&&` inside begin node' do
+    expect_no_offenses(<<~RUBY)
+      x? && (y? || z? && w?)
+    RUBY
+  end
+
   # See https://github.com/rubocop/rubocop/issues/8781
   it 'does not move comments that are inside an inner block' do
     expect_offense(<<~RUBY)


### PR DESCRIPTION
Small followup to #13267. Such a node doesn't have a receiver (it's a `Parser::Source::Range`:
```
(or
  (send nil :x?)
  (and
    (send nil :z?)
    (send nil :w?)))
```

```rb
foo? && (bar? || baz? && bat?)
# undefined method `receiver' for an instance of Parser::Source::Range
# lib/rubocop/cop/style/safe_navigation.rb:295:in `find_matching_receiver_invocation'
```

cc @dvandersluis. Hope you don't mind me picking this up. The PR got merged a bit early.

No changelog, not released yet.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
