### PR TITLE
Tweak docs for `Offense.correctable?`

### DIFF
--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -97,8 +97,8 @@ module RuboCop
       # @!attribute [r] correctable?
       #
       # @return [Boolean]
-      #   whether this offense can be automatically corrected via
-      #   autocorrect or a todo.
+      #   whether this offense can be automatically corrected via autocorrect.
+      #   This includes todo comments, for example when requested with `--disable-uncorrectable`.
       def correctable?
         @status != :unsupported
       end


### PR DESCRIPTION
Pretty much every offense can be disabled through a todo comment. This method will only consider those when the user actually requested that.

At least that is how I understand this to work.