### PR TITLE
Support Ruby 3.4 for `Lint/UriRegexp`

### DIFF
--- a/changelog/change_support_ruby34_for_lint_uri_regexp.md
+++ b/changelog/change_support_ruby34_for_lint_uri_regexp.md
@@ -1,0 +1,1 @@
+* [#13281](https://github.com/rubocop/rubocop/pull/13281): Support Ruby 3.4 for `Lint/UriRegexp` to avoid obsolete API. ([@koic][])

--- a/lib/rubocop/cop/lint/uri_regexp.rb
+++ b/lib/rubocop/cop/lint/uri_regexp.rb
@@ -3,29 +3,47 @@
 module RuboCop
   module Cop
     module Lint
-      # Identifies places where `URI.regexp` is obsolete and should
-      # not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp`.
+      # Identifies places where `URI.regexp` is obsolete and should not be used.
+      #
+      # For Ruby 3.3 or lower, use `URI::DEFAULT_PARSER.make_regexp`.
+      # For Ruby 3.4 or higher, use `URI::RFC2396_PARSER.make_regexp`.
+      #
+      # NOTE: If you need to support both Ruby 3.3 and lower as well as Ruby 3.4 and higher,
+      # consider manually changing the code as follows:
+      #
+      # [source,ruby]
+      # ----
+      # defined?(URI::RFC2396_PARSER) ? URI::RFC2396_PARSER : URI::DEFAULT_PARSER
+      # ----
       #
       # @example
       #   # bad
       #   URI.regexp('http://example.com')
       #
-      #   # good
+      #   # good - Ruby 3.3 or lower
       #   URI::DEFAULT_PARSER.make_regexp('http://example.com')
+      #
+      #   # good - Ruby 3.4 or higher
+      #   URI::RFC2396_PARSER.make_regexp('http://example.com')
       #
       class UriRegexp < Base
         extend AutoCorrector
 
         MSG = '`%<current>s` is obsolete and should not be used. Instead, use `%<preferred>s`.'
-        URI_CONSTANTS = ['URI', '::URI'].freeze
         RESTRICT_ON_SEND = %i[regexp].freeze
 
-        def on_send(node)
-          return unless node.receiver
-          return unless URI_CONSTANTS.include?(node.receiver.source)
+        # @!method uri_constant?(node)
+        def_node_matcher :uri_constant?, <<~PATTERN
+          (const {cbase nil?} :URI)
+        PATTERN
 
+        def on_send(node)
+          return unless uri_constant?(node.receiver)
+
+          parser = target_ruby_version >= 3.4 ? 'RFC2396_PARSER' : 'DEFAULT_PARSER'
           argument = node.first_argument ? "(#{node.first_argument.source})" : ''
-          preferred_method = "#{node.receiver.source}::DEFAULT_PARSER.make_regexp#{argument}"
+
+          preferred_method = "#{node.receiver.source}::#{parser}.make_regexp#{argument}"
           message = format(MSG, current: node.source, preferred: preferred_method)
 
           add_offense(node.loc.selector, message: message) do |corrector|

--- a/spec/rubocop/cop/lint/uri_regexp_spec.rb
+++ b/spec/rubocop/cop/lint/uri_regexp_spec.rb
@@ -13,81 +13,96 @@ RSpec.describe RuboCop::Cop::Lint::UriRegexp, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects using `URI.regexp` with argument' do
-    expect_offense(<<~RUBY)
-      URI.regexp('http://example.com')
-          ^^^^^^ `URI.regexp('http://example.com')` is obsolete and should not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp('http://example.com')`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      URI::DEFAULT_PARSER.make_regexp('http://example.com')
-    RUBY
-  end
-
-  it 'registers an offense and corrects using `::URI.regexp` with argument' do
-    expect_offense(<<~RUBY)
-      ::URI.regexp('http://example.com')
-            ^^^^^^ `::URI.regexp('http://example.com')` is obsolete and should not be used. Instead, use `::URI::DEFAULT_PARSER.make_regexp('http://example.com')`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      ::URI::DEFAULT_PARSER.make_regexp('http://example.com')
-    RUBY
-  end
-
-  it 'registers an offense and corrects using `URI.regexp` without argument' do
-    expect_offense(<<~RUBY)
-      URI.regexp
-          ^^^^^^ `URI.regexp` is obsolete and should not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      URI::DEFAULT_PARSER.make_regexp
-    RUBY
-  end
-
-  it 'registers an offense and corrects using `::URI.regexp` without argument' do
-    expect_offense(<<~RUBY)
-      ::URI.regexp
-            ^^^^^^ `::URI.regexp` is obsolete and should not be used. Instead, use `::URI::DEFAULT_PARSER.make_regexp`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      ::URI::DEFAULT_PARSER.make_regexp
-    RUBY
-  end
-
-  context 'array argument' do
-    it 'registers an offense and corrects using `URI.regexp` with literal arrays' do
+  context 'Ruby <= 3.3', :ruby33 do
+    it 'registers an offense and corrects using `URI.regexp` with argument' do
       expect_offense(<<~RUBY)
-        URI.regexp(['http', 'https'])
-            ^^^^^^ `URI.regexp(['http', 'https'])` is obsolete and should not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp(['http', 'https'])`.
+        URI.regexp('http://example.com')
+            ^^^^^^ `URI.regexp('http://example.com')` is obsolete and should not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp('http://example.com')`.
       RUBY
 
       expect_correction(<<~RUBY)
-        URI::DEFAULT_PARSER.make_regexp(['http', 'https'])
+        URI::DEFAULT_PARSER.make_regexp('http://example.com')
       RUBY
     end
 
-    it 'registers an offense and corrects using `URI.regexp` with %w arrays' do
+    it 'registers an offense and corrects using `::URI.regexp` with argument' do
       expect_offense(<<~RUBY)
-        URI.regexp(%w[http https])
-            ^^^^^^ `URI.regexp(%w[http https])` is obsolete and should not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp(%w[http https])`.
+        ::URI.regexp('http://example.com')
+              ^^^^^^ `::URI.regexp('http://example.com')` is obsolete and should not be used. Instead, use `::URI::DEFAULT_PARSER.make_regexp('http://example.com')`.
       RUBY
 
       expect_correction(<<~RUBY)
-        URI::DEFAULT_PARSER.make_regexp(%w[http https])
+        ::URI::DEFAULT_PARSER.make_regexp('http://example.com')
       RUBY
     end
 
-    it 'registers an offense and corrects using `URI.regexp` with %i arrays' do
+    it 'registers an offense and corrects using `URI.regexp` without argument' do
       expect_offense(<<~RUBY)
-        URI.regexp(%i[http https])
-            ^^^^^^ `URI.regexp(%i[http https])` is obsolete and should not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp(%i[http https])`.
+        URI.regexp
+            ^^^^^^ `URI.regexp` is obsolete and should not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp`.
       RUBY
 
       expect_correction(<<~RUBY)
-        URI::DEFAULT_PARSER.make_regexp(%i[http https])
+        URI::DEFAULT_PARSER.make_regexp
+      RUBY
+    end
+
+    it 'registers an offense and corrects using `::URI.regexp` without argument' do
+      expect_offense(<<~RUBY)
+        ::URI.regexp
+              ^^^^^^ `::URI.regexp` is obsolete and should not be used. Instead, use `::URI::DEFAULT_PARSER.make_regexp`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ::URI::DEFAULT_PARSER.make_regexp
+      RUBY
+    end
+
+    context 'array argument' do
+      it 'registers an offense and corrects using `URI.regexp` with literal arrays' do
+        expect_offense(<<~RUBY)
+          URI.regexp(['http', 'https'])
+              ^^^^^^ `URI.regexp(['http', 'https'])` is obsolete and should not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp(['http', 'https'])`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          URI::DEFAULT_PARSER.make_regexp(['http', 'https'])
+        RUBY
+      end
+
+      it 'registers an offense and corrects using `URI.regexp` with %w arrays' do
+        expect_offense(<<~RUBY)
+          URI.regexp(%w[http https])
+              ^^^^^^ `URI.regexp(%w[http https])` is obsolete and should not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp(%w[http https])`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          URI::DEFAULT_PARSER.make_regexp(%w[http https])
+        RUBY
+      end
+
+      it 'registers an offense and corrects using `URI.regexp` with %i arrays' do
+        expect_offense(<<~RUBY)
+          URI.regexp(%i[http https])
+              ^^^^^^ `URI.regexp(%i[http https])` is obsolete and should not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp(%i[http https])`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          URI::DEFAULT_PARSER.make_regexp(%i[http https])
+        RUBY
+      end
+    end
+  end
+
+  context 'Ruby >= 3.4', :ruby34 do
+    it 'registers an offense and corrects using `URI.regexp` with argument' do
+      expect_offense(<<~RUBY)
+        URI.regexp('http://example.com')
+            ^^^^^^ `URI.regexp('http://example.com')` is obsolete and should not be used. Instead, use `URI::RFC2396_PARSER.make_regexp('http://example.com')`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        URI::RFC2396_PARSER.make_regexp('http://example.com')
       RUBY
     end
   end


### PR DESCRIPTION
This PR supports Ruby 3.4 for `Lint/UriRegexp` to avoid the following warning:

```console
$ ruby -ruri -vwe "URI::DEFAULT_PARSER.make_regexp('http://example.com')"
ruby 3.4.0dev (2024-09-21T18:00:23Z master 9f574fa12f) +PRISM [x86_64-darwin23]
-e:1: warning: URI::RFC3986_PARSER.make_regexp is obsoleted. Use URI::RFC2396_PARSER.make_regexp explicitly.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
