### PR TITLE
[Fix #13145] Fix false positives for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_line_continuation.md
+++ b/changelog/fix_false_positives_for_style_redundant_line_continuation.md
@@ -1,0 +1,1 @@
+* [#13145](https://github.com/rubocop/rubocop/issues/13145): Fix false positives for `Style/RedundantLineContinuation` when line continuations with comparison operator and the LHS is wrapped in parentheses. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -122,7 +122,7 @@ module RuboCop
         end
 
         def redundant_line_continuation?(range)
-          return true unless (node = find_node_for_line(range.line))
+          return true unless (node = find_node_for_line(range.last_line))
           return false if argument_newline?(node)
 
           source = node.parent ? node.parent.source : node.source
@@ -160,9 +160,9 @@ module RuboCop
         end
         # rubocop:enable Metrics/AbcSize
 
-        def find_node_for_line(line)
+        def find_node_for_line(last_line)
           processed_source.ast.each_node do |node|
-            return node if same_line?(node, line)
+            return node if node.respond_to?(:expression) && node.expression&.last_line == last_line
           end
         end
 

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -547,6 +547,30 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'does not register an offense when line continuations with comparison operator and the LHS is wrapped in parentheses' do
+    expect_no_offenses(<<~'RUBY')
+      (
+        42) \
+        == bar
+    RUBY
+  end
+
+  it 'does not register an offense when line continuations with comparison operator and the LHS is wrapped in brackets' do
+    expect_no_offenses(<<~'RUBY')
+      [
+        42] \
+        == bar
+    RUBY
+  end
+
+  it 'does not register an offense when line continuations with comparison operator and the LHS is wrapped in braces' do
+    expect_no_offenses(<<~'RUBY')
+      {
+        k: :v} \
+        == bar
+    RUBY
+  end
+
   it 'does not register an offense when line continuations with &&' do
     expect_no_offenses(<<~'RUBY')
       foo \
@@ -639,6 +663,15 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
       foo == other.foo \
         || bar == other.bar \
         || baz == other.baz
+    RUBY
+  end
+
+  it 'does not register an offense when line continuations with `&&` in method definition and before a destructuring assignment' do
+    expect_no_offenses(<<~'RUBY')
+      var, = *foo
+
+      bar \
+        && baz
     RUBY
   end
 


### PR DESCRIPTION
Fixes #13145.

This PR fixes false positives for `Style/RedundantLineContinuation` when line continuations with comparison operator and the LHS is wrapped in parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
