### PR TITLE
[Fix #13229] Update `Style/MapIntoArray` to be able to handle arrays created using `[].tap`

### DIFF
--- a/changelog/change_update_style_map_into_array_to_be_able_to_handle.md
+++ b/changelog/change_update_style_map_into_array_to_be_able_to_handle.md
@@ -1,0 +1,1 @@
+* [#13229](https://github.com/rubocop/rubocop/issues/13229): Update `Style/MapIntoArray` to be able to handle arrays created using `[].tap`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4319,6 +4319,7 @@ Style/MapIntoArray:
   StyleGuide: '#functional-code'
   Enabled: pending
   VersionAdded: '1.63'
+  VersionChanged: '<<next>>'
   Safe: false
 
 Style/MapToHash:


### PR DESCRIPTION
Updates `Style/MapIntoArray` to be able to handle code like:

```ruby
[].tap do |dest|
  src.each { |e| dest << e ** 2 }
end
```

This only applies when an empty array is tapped, and no other code is in the tap block.

Fixes #13229.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
