### PR TITLE
Use Prism 1.1 for development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'asciidoctor'
 gem 'bump', require: false
 gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'memory_profiler', '!= 1.0.2', platform: :mri
-gem 'prism', '~> 1.0.0'
+gem 'prism', '~> 1.1.0'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.22.0'

--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -133,12 +133,12 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
         it "accepts a `when` clause that's equally indented with `case`" do
           expect_no_offenses(<<~RUBY)
             y = case a
-                when 0 then break
+                when 0 then raise
                 when 0 then return
                 else
                   z = case b
                       when 1 then return
-                      when 1 then break
+                      when 1 then raise
                       end
                 end
             case c
@@ -313,12 +313,12 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
         it "accepts an `in` clause that's equally indented with `case`" do
           expect_no_offenses(<<~RUBY)
             y = case a
-                in 0 then break
+                in 0 then raise
                 in 0 then return
                 else
                   z = case b
                       in 1 then return
-                      in 1 then break
+                      in 1 then raise
                       end
                 end
             case c
@@ -431,14 +431,14 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
         it 'registers an offense and corrects a `when` clause that is equally indented with `case`' do
           expect_offense(<<~RUBY)
             y = case a
-                when 0 then break
+                when 0 then raise
                 ^^^^ Indent `when` one step more than `case`.
                 when 0 then return
                 ^^^^ Indent `when` one step more than `case`.
                   z = case b
                       when 1 then return
                       ^^^^ Indent `when` one step more than `case`.
-                      when 1 then break
+                      when 1 then raise
                       ^^^^ Indent `when` one step more than `case`.
                       end
                 end
@@ -450,11 +450,11 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
 
           expect_correction(<<~RUBY)
             y = case a
-                  when 0 then break
+                  when 0 then raise
                   when 0 then return
                   z = case b
                         when 1 then return
-                        when 1 then break
+                        when 1 then raise
                       end
                 end
             case c
@@ -541,14 +541,14 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
         it 'registers an offense and corrects an `in` clause that is equally indented with `case`' do
           expect_offense(<<~RUBY)
             y = case a
-                in 0 then break
+                in 0 then raise
                 ^^ Indent `in` one step more than `case`.
                 in 0 then return
                 ^^ Indent `in` one step more than `case`.
                   z = case b
                       in 1 then return
                       ^^ Indent `in` one step more than `case`.
-                      in 1 then break
+                      in 1 then raise
                       ^^ Indent `in` one step more than `case`.
                       end
                 end
@@ -560,11 +560,11 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
 
           expect_correction(<<~RUBY)
             y = case a
-                  in 0 then break
+                  in 0 then raise
                   in 0 then return
                   z = case b
                         in 1 then return
-                        in 1 then break
+                        in 1 then raise
                       end
                 end
             case c

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
-  context 'Ruby <= 3.2', :ruby32 do
+  context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
     it 'registers an offense and corrects `next` guard clause not followed by empty line' do
       expect_offense(<<~RUBY)
         def foo
@@ -532,15 +532,15 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
   it 'registers an offense and corrects a method starting with end_' do
     expect_offense(<<~RUBY)
       def foo
-        next unless need_next?
-        ^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+        return unless need_next?
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
         end_this!
       end
     RUBY
 
     expect_correction(<<~RUBY)
       def foo
-        next unless need_next?
+        return unless need_next?
 
         end_this!
       end
@@ -550,17 +550,17 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
   it 'registers an offense and corrects only the last guard clause' do
     expect_offense(<<~RUBY)
       def foo
-        next if foo?
-        next if bar?
-        ^^^^^^^^^^^^ Add empty line after guard clause.
+        return if foo?
+        return if bar?
+        ^^^^^^^^^^^^^^ Add empty line after guard clause.
         foobar
       end
     RUBY
 
     expect_correction(<<~RUBY)
       def foo
-        next if foo?
-        next if bar?
+        return if foo?
+        return if bar?
 
         foobar
       end

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -551,7 +551,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation, :config do
         RUBY
       end
 
-      it "accepts indentation of next #{keyword} condition" do
+      it "accepts indentation of next #{keyword} condition", :ruby32, unsupported_on: :prism do
         expect_no_offenses(<<~RUBY)
           next #{keyword} 5 ||
             7

--- a/spec/rubocop/cop/layout/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_keyword_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
     end
   end
 
-  shared_examples 'missing after' do |highlight, expr, correct|
-    it "registers an offense for missing space after keyword in `#{expr}` and autocorrects" do
+  shared_examples 'missing after' do |highlight, expr, correct, options|
+    it "registers an offense for missing space after keyword in `#{expr}` and autocorrects", *options do
       h_index = expr.index(highlight)
       expect_offense(<<~RUBY)
         #{expr}
@@ -31,14 +31,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
     end
   end
 
-  shared_examples 'accept after' do |after, expr|
-    it "accepts `#{after}` after keyword in `#{expr}`" do
+  shared_examples 'accept after' do |after, expr, options|
+    it "accepts `#{after}` after keyword in `#{expr}`", *options do
       expect_no_offenses(expr)
     end
   end
 
-  shared_examples 'accept around' do |after, expr|
-    it "accepts `#{after}` around keyword in `#{expr}`" do
+  shared_examples 'accept around' do |after, expr, options|
+    it "accepts `#{after}` around keyword in `#{expr}`", *options do
       expect_no_offenses(expr)
     end
   end
@@ -49,8 +49,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   it_behaves_like 'missing after', 'and', '1 and(2)', '1 and (2)'
   it_behaves_like 'missing after', 'begin', 'begin"" end', 'begin "" end'
 
-  it_behaves_like 'missing after', 'break', 'break""', 'break ""'
-  it_behaves_like 'accept after', '(', 'break(1)'
+  it_behaves_like 'missing after', 'break', 'break""', 'break ""', [:ruby32, { unsupported_on: :prism }]
+  it_behaves_like 'accept after', '(', 'break(1)', [:ruby32, { unsupported_on: :prism }]
 
   it_behaves_like 'missing after', 'case', 'case"" when 1; end', 'case "" when 1; end'
 
@@ -106,8 +106,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
 
   it_behaves_like 'missing after', 'if', 'if""; end', 'if ""; end'
 
-  it_behaves_like 'missing after', 'next', 'next""', 'next ""'
-  it_behaves_like 'accept after', '(', 'next(1)'
+  it_behaves_like 'missing after', 'next', 'next""', 'next ""', [:ruby32, { unsupported_on: :prism }]
+  it_behaves_like 'accept after', '(', 'next(1)', [:ruby32, { unsupported_on: :prism }]
 
   it_behaves_like 'missing after', 'not', 'not""', 'not ""'
   it_behaves_like 'accept after', '(', 'not(1)'
@@ -162,7 +162,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   it_behaves_like 'accept after', '\\', "test do\\\nend"
   it_behaves_like 'accept after', '\n', "test do\nend"
 
-  it_behaves_like 'accept around', '()', '(next)'
+  it_behaves_like 'accept around', '()', '(next)', [:ruby32, { unsupported_on: :prism }]
   it_behaves_like 'accept before', '!', '!yield'
   it_behaves_like 'accept after', '.', 'yield.method'
   it_behaves_like 'accept before', '!', '!yield.method'
@@ -207,7 +207,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   it_behaves_like 'accept around', ',', 'a 1,foo,1'
 
   # Layout/SpaceBeforeComment
-  it_behaves_like 'accept after', '#', 'next#comment'
+  it_behaves_like 'accept after', '#', 'next#comment', [:ruby32, { unsupported_on: :prism }]
 
   # Layout/SpaceBeforeSemicolon, Layout/SpaceAfterSemicolon
   it_behaves_like 'accept around', ';', 'test do;end'

--- a/spec/rubocop/cop/lint/ambiguous_operator_precedence_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_operator_precedence_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousOperatorPrecedence, :config do
 
   it 'allows an operator with `and`' do
     expect_no_offenses(<<~RUBY)
-      array << i and next
+      array << i and return
     RUBY
   end
 

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition, :config do
       end
     end
 
-    context 'when using `break` before empty case condition' do
+    context 'when using `break` before empty case condition', :ruby32, unsupported_on: :prism do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)
           break case
@@ -369,7 +369,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition, :config do
       end
     end
 
-    context 'when using `next` before empty case condition' do
+    context 'when using `next` before empty case condition', :ruby32, unsupported_on: :prism do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)
           next case

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -641,8 +641,8 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
     end
   end
 
-  shared_examples 'on if nodes which exit current scope' do |kw|
-    it "registers an error with #{kw} in the if branch" do
+  shared_examples 'on if nodes which exit current scope' do |kw, options|
+    it "registers an error with #{kw} in the if branch", *options do
       expect_offense(<<~RUBY)
         if something
         ^^ Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression.
@@ -661,7 +661,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
       RUBY
     end
 
-    it "registers an error with #{kw} in the else branch" do
+    it "registers an error with #{kw} in the else branch", *options do
       expect_offense(<<~RUBY)
         if something
         ^^ Use a guard clause (`#{kw} unless something`) instead of wrapping the code inside a conditional expression.
@@ -680,7 +680,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
       RUBY
     end
 
-    it "doesn't register an error if condition has multiple lines" do
+    it "doesn't register an error if condition has multiple lines", *options do
       expect_no_offenses(<<~RUBY)
         if something &&
              something_else
@@ -691,7 +691,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
       RUBY
     end
 
-    it "does not report an offense if #{kw} is inside elsif" do
+    it "does not report an offense if #{kw} is inside elsif", *options do
       expect_no_offenses(<<~RUBY)
         if something
           a
@@ -701,7 +701,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
       RUBY
     end
 
-    it "does not report an offense if #{kw} is inside then body of if..elsif..end" do
+    it "does not report an offense if #{kw} is inside then body of if..elsif..end", *options do
       expect_no_offenses(<<~RUBY)
         if something
           #{kw}
@@ -711,7 +711,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
       RUBY
     end
 
-    it "does not report an offense if #{kw} is inside if..elsif..else..end" do
+    it "does not report an offense if #{kw} is inside if..elsif..else..end", *options do
       expect_no_offenses(<<~RUBY)
         if something
           a
@@ -723,7 +723,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
       RUBY
     end
 
-    it "doesn't register an error if control flow expr has multiple lines" do
+    it "doesn't register an error if control flow expr has multiple lines", *options do
       expect_no_offenses(<<~RUBY)
         if something
           #{kw} 'blah blah blah' \\
@@ -734,7 +734,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
       RUBY
     end
 
-    it 'registers an error if non-control-flow branch has multiple lines' do
+    it 'registers an error if non-control-flow branch has multiple lines', *options do
       expect_offense(<<~RUBY)
         if something
         ^^ Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression.
@@ -870,8 +870,12 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
   end
 
   include_examples('on if nodes which exit current scope', 'return')
-  include_examples('on if nodes which exit current scope', 'next')
-  include_examples('on if nodes which exit current scope', 'break')
+  include_examples(
+    'on if nodes which exit current scope', 'next', [:ruby32, { unsupported_on: :prism }]
+  )
+  include_examples(
+    'on if nodes which exit current scope', 'break', [:ruby32, { unsupported_on: :prism }]
+  )
   include_examples('on if nodes which exit current scope', 'raise "error"')
 
   context 'method in module' do

--- a/spec/rubocop/cop/style/map_compact_with_conditional_block_spec.rb
+++ b/spec/rubocop/cop/style/map_compact_with_conditional_block_spec.rb
@@ -402,8 +402,8 @@ RSpec.describe RuboCop::Cop::Style::MapCompactWithConditionalBlock, :config do
 
     it 'does not register offenses if there are multiple guard clauses' do
       expect_no_offenses(<<~RUBY)
-        next unless item.bar?
-        next unless item.baz?
+        return unless item.bar?
+        return unless item.baz?
 
         item
       RUBY

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -165,9 +165,9 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
       RUBY
     end
 
-    shared_examples 'if/then/else/end with keyword' do |keyword|
+    shared_examples 'if/then/else/end with keyword' do |keyword, options|
       it 'registers and corrects an offense with ternary operator when one of the branches of ' \
-         "if/then/else/end contains `#{keyword}` keyword" do
+         "if/then/else/end contains `#{keyword}` keyword", *options do
         expect_offense(<<~RUBY, keyword: keyword)
           if true then %{keyword} else 7 end
           ^^^^^^^^^^^^^^{keyword}^^^^^^^^^^^ #{if_offense_message}
@@ -183,7 +183,7 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
       it_behaves_like 'if/then/else/end with keyword', 'retry'
     end
 
-    it_behaves_like 'if/then/else/end with keyword', 'break'
+    it_behaves_like 'if/then/else/end with keyword', 'break', [:ruby32, { unsupported_on: :prism }]
 
     it_behaves_like 'if/then/else/end with keyword', 'self'
     it_behaves_like 'if/then/else/end with keyword', 'raise'
@@ -431,9 +431,9 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
       RUBY
     end
 
-    shared_examples 'if/then/else/end with keyword' do |keyword|
+    shared_examples 'if/then/else/end with keyword' do |keyword, options|
       it 'registers and corrects an offense with multi-line construct when one of the branches ' \
-         "of if/then/else/end contains `#{keyword}` keyword" do
+         "of if/then/else/end contains `#{keyword}` keyword", *options do
         expect_offense(<<~RUBY, keyword: keyword)
           if true then %{keyword} else 7 end
           ^^^^^^^^^^^^^^{keyword}^^^^^^^^^^^ #{if_offense_message}
@@ -453,7 +453,7 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
       it_behaves_like 'if/then/else/end with keyword', 'retry'
     end
 
-    it_behaves_like 'if/then/else/end with keyword', 'break'
+    it_behaves_like 'if/then/else/end with keyword', 'break', [:ruby32, { unsupported_on: :prism }]
 
     it_behaves_like 'if/then/else/end with keyword', 'self'
     it_behaves_like 'if/then/else/end with keyword', 'raise'

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
-  shared_examples 'redundant' do |expr, correct, type|
-    it "registers an offense for parentheses around #{type}" do
+  shared_examples 'redundant' do |expr, correct, type, options|
+    it "registers an offense for parentheses around #{type}", *options do
       expect_offense(<<~RUBY, expr: expr)
         %{expr}
         ^{expr} Don't use parentheses around #{type}.
@@ -14,17 +14,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     end
   end
 
-  shared_examples 'plausible' do |expr|
-    it 'accepts parentheses when arguments are unparenthesized' do
+  shared_examples 'plausible' do |expr, options|
+    it 'accepts parentheses when arguments are unparenthesized', *options do
       expect_no_offenses(expr)
     end
   end
 
-  shared_examples 'keyword with return value' do |keyword|
-    it_behaves_like 'redundant', "(#{keyword})", keyword, 'a keyword'
-    it_behaves_like 'redundant', "(#{keyword}())", "#{keyword}()", 'a keyword'
-    it_behaves_like 'redundant', "(#{keyword}(1))", "#{keyword}(1)", 'a keyword'
-    it_behaves_like 'plausible', "(#{keyword} 1, 2)"
+  shared_examples 'keyword with return value' do |keyword, options|
+    it_behaves_like 'redundant', "(#{keyword})", keyword, 'a keyword', options
+    it_behaves_like 'redundant', "(#{keyword}())", "#{keyword}()", 'a keyword', options
+    it_behaves_like 'redundant', "(#{keyword}(1))", "#{keyword}(1)", 'a keyword', options
+    it_behaves_like 'plausible', "(#{keyword} 1, 2)", options
   end
 
   shared_examples 'keyword with arguments' do |keyword|
@@ -53,7 +53,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   it_behaves_like 'redundant', '(__FILE__)', '__FILE__', 'a keyword'
   it_behaves_like 'redundant', '(__LINE__)', '__LINE__', 'a keyword'
   it_behaves_like 'redundant', '(__ENCODING__)', '__ENCODING__', 'a keyword'
-  it_behaves_like 'redundant', '(redo)', 'redo', 'a keyword'
+  it_behaves_like 'redundant', '(redo)', 'redo', 'a keyword', [:ruby32, { unsupported_on: :prism }]
 
   context 'Ruby <= 3.2', :ruby32, unsupported_on: :prism do
     it_behaves_like 'redundant', '(retry)', 'retry', 'a keyword'
@@ -122,8 +122,8 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     end
   end
 
-  it_behaves_like 'keyword with return value', 'break'
-  it_behaves_like 'keyword with return value', 'next'
+  it_behaves_like 'keyword with return value', 'break', [:ruby32, { unsupported_on: :prism }]
+  it_behaves_like 'keyword with return value', 'next', [:ruby32, { unsupported_on: :prism }]
   it_behaves_like 'keyword with arguments', 'yield'
 
   it_behaves_like 'keyword with return value', 'return'
@@ -817,7 +817,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
-  it 'accepts parentheses in `next` with multiline style argument' do
+  it 'accepts parentheses in `next` with multiline style argument', :ruby32, unsupported_on: :prism do
     expect_no_offenses(<<~RUBY)
       next (
         42
@@ -825,7 +825,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
-  it 'registers an offense when parentheses in `next` with single style argument' do
+  it 'registers an offense when parentheses in `next` with single style argument', :ruby32, unsupported_on: :prism do
     expect_offense(<<~RUBY)
       next (42)
            ^^^^ Don't use parentheses around a literal.
@@ -836,7 +836,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
-  it 'accepts parentheses in `break` with multiline style argument' do
+  it 'accepts parentheses in `break` with multiline style argument', :ruby32, unsupported_on: :prism do
     expect_no_offenses(<<~RUBY)
       break (
         42
@@ -844,7 +844,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
-  it 'registers an offense when parentheses in `break` with single style argument' do
+  it 'registers an offense when parentheses in `break` with single style argument', :ruby32, unsupported_on: :prism do
     expect_offense(<<~RUBY)
       break (42)
             ^^^^ Don't use parentheses around a literal.

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
         RUBY
       end
 
-      it 'does not to an endless class method definition when using `break`' do
+      it 'does not to an endless class method definition when using `break`', :ruby32, unsupported_on: :prism do
         expect_correction(<<~RUBY.strip, source: 'def foo(argument) break bar(argument); end')
           def foo(argument)#{trailing_whitespace}
             break bar(argument);#{trailing_whitespace}
@@ -248,7 +248,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
         RUBY
       end
 
-      it 'does not to an endless class method definition when using `next`' do
+      it 'does not to an endless class method definition when using `next`', :ruby32, unsupported_on: :prism do
         expect_correction(<<~RUBY.strip, source: 'def foo(argument) next bar(argument); end')
           def foo(argument)#{trailing_whitespace}
             next bar(argument);#{trailing_whitespace}


### PR DESCRIPTION
This PR uses Prism 1.1 for development.

It has been updated in Prism 1.1 to correctly handle the following behavior of `parse.y` in Ruby 3.3 and later.

Ruby 3.3 raises a syntax error:

```console
$ ruby -cve 'next unless foo'
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-darwin23]
-e:1: Invalid next
next unless foo
ruby: compile error (SyntaxError)
```

It is valid syntax in Ruby 3.2:

```console
$ ruby -cve 'next unless foo'
ruby 3.2.4 (2024-04-23 revision af471c0e01) [x86_64-darwin23]
Syntax OK
```

It is incorrect that the Parser gem can still parse it with `--3.3` and later. I will provide feedback separately.

```console
$ ruby-parse --33 -e 'next unless foo'
(if
(send nil :foo) nil
  (next))
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
