### PR TITLE
Allow Style/WordArray to match words with non-whitespace characters

### DIFF
--- a/changelog/new_add_use_extended_words_option_to_word_arrays.md
+++ b/changelog/new_add_use_extended_words_option_to_word_arrays.md
@@ -1,0 +1,1 @@
+* [#13290](https://github.com/rubocop/rubocop/pull/13290): Allow `Style/WordArray` to match words with non-whitespace characters when `UseExtendedWords` option is enabled. ([@floriandejonckheere][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5801,6 +5801,12 @@ Style/WordArray:
   MinSize: 2
   # The regular expression `WordRegex` decides what is considered a word.
   WordRegex: !ruby/regexp '/\A(?:\p{Word}|\p{Word}-\p{Word}|\n|\t)+\z/'
+  # The `UseExtendedWords` option considers all non-whitespace characters
+  # to be part of a word. Enabling this option will ignore the `WordRegex`
+  # option in favour of `ExtendedWordRegex`.
+  UseExtendedWords: false
+  # The regular expression `ExtendedWordRegex` decides what is considered an extended word.
+  ExtendedWordRegex: !ruby/regexp '/\A(?:\p{Word}|\p{Word}\P{Z}\p{Word}|\n|\t)+\z/'
 
 Style/YAMLFileRead:
   Description: 'Checks for the use of `YAML.load`, `YAML.safe_load`, and `YAML.parse` with `File.read` argument.'

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -68,6 +68,13 @@ module RuboCop
       #     %w[two Two]
       #   ]
       #
+      # @example UseExtendedWords: true
+      #   # good
+      #   %w(foo bar foo-bar foo/bar foo#bar foo?bar foo@bar)
+      #
+      #   # bad
+      #   ['foo', 'bar', 'foo-bar', 'foo/bar', 'foo#bar', 'foo?bar', 'foo@bar']
+      #
       class WordArray < Base
         include ArrayMinSize
         include ArraySyntax
@@ -132,7 +139,11 @@ module RuboCop
         end
 
         def word_regex
-          Regexp.new(cop_config['WordRegex'])
+          if cop_config['UseExtendedWords']
+            Regexp.new(cop_config['ExtendedWordRegex'])
+          else
+            Regexp.new(cop_config['WordRegex'])
+          end
         end
 
         def build_bracketed_array(node)

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -684,4 +684,21 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       expect_no_offenses('["one"]')
     end
   end
+
+  context 'when UseExtendedWords is enabled' do
+    let(:cop_config) do
+      { 'UseExtendedWords' => true }
+    end
+
+    it 'registers an offense for arrays of strings containing hyphens, slashes, and other non-whitespace characters' do
+      expect_offense(<<~RUBY)
+        ['foo', 'bar', 'foo-bar', 'foo/bar', 'foo#bar', 'foo?bar', 'foo@bar']
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        %w(foo bar foo-bar foo/bar foo#bar foo?bar foo@bar)
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Allow `Style/WordArray` cop to match words that include non-whitespace characters. Before this change, words could only include letters, digits, underscores, and hyphens. After this change, words can include any non-whitespace characters. The word regex now uses the `\P{Z}` character class, which matches any non-whitespace character.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
