### PR TITLE
[Fix #13291] Fix an incorrect autocorrect for `Style/RescueModifier`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_rescue_modifier.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_rescue_modifier.md
@@ -1,0 +1,1 @@
+* [#13291](https://github.com/rubocop/rubocop/issues/13291): Fix an incorrect autocorrect for `Style/RescueModifier` when using modifier rescue for method call with heredoc argument. ([@koic][])

--- a/lib/rubocop/cop/style/rescue_modifier.rb
+++ b/lib/rubocop/cop/style/rescue_modifier.rb
@@ -75,7 +75,7 @@ module RuboCop
 
           corrector.remove(range_between(operation.source_range.end_pos, node.source_range.end_pos))
           corrector.insert_before(operation, "begin\n#{node_indentation}")
-          corrector.insert_after(operation, <<~RESCUE_CLAUSE.chop)
+          corrector.insert_after(heredoc_end(operation) || operation, <<~RESCUE_CLAUSE.chop)
 
             #{node_offset}rescue
             #{node_indentation}#{rescue_args.source}
@@ -91,6 +91,18 @@ module RuboCop
             node_offset = node_offset[0...-1]
           end
           [node_indentation, node_offset]
+        end
+
+        def heredoc_end(node)
+          return unless node.call_type?
+
+          heredoc = node.arguments.reverse.find do |argument|
+            argument.respond_to?(:heredoc?) && argument.heredoc?
+          end
+
+          return unless heredoc
+
+          heredoc.loc.heredoc_end
         end
       end
     end

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -18,6 +18,86 @@ RSpec.describe RuboCop::Cop::Style::RescueModifier, :config do
     RUBY
   end
 
+  it 'registers an offense when using modifier rescue for method call with heredoc argument' do
+    expect_offense(<<~RUBY)
+      method(<<~EOS) rescue handle
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
+        str
+      EOS
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        method(<<~EOS)
+        str
+      EOS
+      rescue
+        handle
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using modifier rescue for safe navigation method call with heredoc argument' do
+    expect_offense(<<~RUBY)
+      obj&.method(<<~EOS) rescue handle
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
+        str
+      EOS
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        obj&.method(<<~EOS)
+        str
+      EOS
+      rescue
+        handle
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using modifier rescue for method call with heredoc argument and variable' do
+    expect_offense(<<~RUBY)
+      method(<<~EOS, var) rescue handle
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
+        str
+      EOS
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        method(<<~EOS, var)
+        str
+      EOS
+      rescue
+        handle
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using modifier rescue for method call with multiple heredoc arguments' do
+    expect_offense(<<~RUBY)
+      method(<<~EOS1, <<~EOS2) rescue handle
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
+        str1
+      EOS1
+        str2
+      EOS2
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        method(<<~EOS1, <<~EOS2)
+        str1
+      EOS1
+        str2
+      EOS2
+      rescue
+        handle
+      end
+    RUBY
+  end
+
   it 'registers an offense for modifier rescue around parallel assignment', :ruby26, unsupported_on: :prism do
     expect_offense(<<~RUBY)
       a, b = 1, 2 rescue nil


### PR DESCRIPTION
Fixes #13291.

This PR fixes an incorrect autocorrect for `Style/RescueModifier` when using modifier rescue for method call with heredoc argument. The autocorrection of heredoc indentation after autocorrect will be left to other cops, such as `Layout/ClosingHeredocIndentation` and `Layout/HeredocIndentation`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
