### PR TITLE
Fix `TargetRubyVersion` from a gemspec when the gemspec is not named like the folder it is located in

### DIFF
--- a/changelog/fix_target_ruby_version_gemspec_name.md
+++ b/changelog/fix_target_ruby_version_gemspec_name.md
@@ -1,0 +1,1 @@
+* [#13293](https://github.com/rubocop/rubocop/pull/13293): Fix `TargetRubyVersion` from a gemspec when the gemspec is not named like the folder it is located in. ([@earlopain][])

--- a/lib/rubocop/file_finder.rb
+++ b/lib/rubocop/file_finder.rb
@@ -23,15 +23,20 @@ module RuboCop
       last_file
     end
 
+    def traverse_directories_upwards(start_dir, stop_dir = nil)
+      Pathname.new(start_dir).expand_path.ascend do |dir|
+        yield(dir)
+        dir = dir.to_s
+        break if dir == stop_dir || dir == FileFinder.root_level
+      end
+    end
+
     private
 
     def traverse_files_upwards(filename, start_dir, stop_dir)
-      Pathname.new(start_dir).expand_path.ascend do |dir|
+      traverse_directories_upwards(start_dir, stop_dir) do |dir|
         file = dir + filename
         yield(file.to_s) if file.exist?
-
-        dir = dir.to_s
-        break if dir == stop_dir || dir == FileFinder.root_level
       end
     end
   end

--- a/spec/rubocop/file_finder_spec.rb
+++ b/spec/rubocop/file_finder_spec.rb
@@ -40,4 +40,34 @@ RSpec.describe RuboCop::FileFinder, :isolated_environment do
       expect(finder.find_last_file_upwards('xyz', 'dir')).to be_nil
     end
   end
+
+  describe '#traverse_directories_upwards' do
+    subject(:match_paths) do
+      matches = []
+      finder.traverse_directories_upwards(start_dir, stop_dir) do |dir|
+        matches << dir.expand_path.to_s
+      end
+      matches
+    end
+
+    let(:start_dir) { 'dir' }
+
+    context 'when not specifying the stop dir' do
+      let(:stop_dir) { nil }
+
+      it 'returns directories' do
+        expect(match_paths).to eq(
+          [File.expand_path(start_dir), File.expand_path('.'), File.expand_path('..')]
+        )
+      end
+    end
+
+    context 'when specifying the stop dir' do
+      let(:stop_dir) { "#{Dir.pwd}/dir" }
+
+      it 'respects the stop dir parameter' do
+        expect(match_paths).to eq([File.expand_path(start_dir)])
+      end
+    end
+  end
 end

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -282,6 +282,42 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           expect(target_ruby.version).to eq default_version
         end
       end
+
+      context 'when the gemspec is not named the same as the directory' do
+        let(:gemspec_file_path) { File.join(base_path, 'whatever.gemspec') }
+
+        it 'sets target_ruby from the version' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = '~> 3.2.0'
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq 3.2
+        end
+      end
+
+      context 'when there are multiple gemspecs in the same directory' do
+        let(:first_gemspec_file_path) { File.join(base_path, 'first.gemspec') }
+        let(:second_gemspec_file_path) { File.join(base_path, 'second.gemspec') }
+
+        it 'takes neither' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = '~> 3.2.0'
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+
+          create_file(first_gemspec_file_path, content)
+          create_file(second_gemspec_file_path, content)
+          expect(target_ruby.version).to eq default_version
+        end
+      end
     end
 
     context 'when .ruby-version is present' do


### PR DESCRIPTION
As long as the folder contains only one gemspec, bundler will use it regardless of the name. For example, cloning rails (currently on 3.2 from the gemspec), renaming the folder to anything other than rails, and then running rubocop again results in 60 syntax errors since it's now failing to use the gemspec.

```
$ bundle exec rspec

[!] There was an error parsing `Gemfile`: There are no gemspecs at /home/earlopain/Documents/rubocop. Bundler cannot continue.

 #  from Gemfile:5
 #  -------------------------------------------
 #
 >  gemspec
 #
 #  -------------------------------------------
```

```
$ bundle exec rspec

[!] There was an error parsing `Gemfile`: There are multiple gemspecs at /home/earlopain/Documents/rubocop. Please use the :name option to specify which one should be used. Bundler cannot continue.

 #  from Gemfile:5
 #  -------------------------------------------
 #
 >  gemspec
 #
 #  -------------------------------------------
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
