### PR TITLE
Add `Bundler/DebugRequire` cop

### DIFF
--- a/changelog/new_add_bundler_debug_require_cop.md
+++ b/changelog/new_add_bundler_debug_require_cop.md
@@ -1,0 +1,1 @@
+* [#13296](https://github.com/rubocop/rubocop/pull/13296): Add `Bundler/DebugRequire` cop. ([@sambostock][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -176,6 +176,15 @@ AllCops:
 
 #################### Bundler ###############################
 
+Bundler/DebugRequire:
+  Description: 'Enforces that if `gem "debug"` is present, `require: "debug/prelude"` or `require: false` is specified.'
+  Enabled: pending
+  VersionAdded: '<<next>>'
+  Include:
+    - '**/*.gemfile'
+    - '**/Gemfile'
+    - '**/gems.rb'
+
 Bundler/DuplicatedGem:
   Description: 'Checks for duplicate gem entries in Gemfile.'
   Enabled: true

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -165,6 +165,7 @@ require_relative 'rubocop/cop/correctors/space_corrector'
 require_relative 'rubocop/cop/correctors/string_literal_corrector'
 require_relative 'rubocop/cop/correctors/unused_arg_corrector'
 
+require_relative 'rubocop/cop/bundler/debug_require'
 require_relative 'rubocop/cop/bundler/duplicated_gem'
 require_relative 'rubocop/cop/bundler/duplicated_group'
 require_relative 'rubocop/cop/bundler/gem_comment'

--- a/lib/rubocop/cop/bundler/debug_require.rb
+++ b/lib/rubocop/cop/bundler/debug_require.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Bundler
+      # Enforces that if `gem "debug"` is present,
+      # `require: "debug/prelude"` or
+      # `require: false` is specified.
+      #
+      # @example
+      #   # bad
+      #   gem "debug"
+      #
+      #   # good
+      #   gem "debug", require: "debug/prelude"
+      #   gem "debug", require: false
+      #
+      class DebugRequire < Base
+        extend AutoCorrector
+        include MultilineExpressionIndentation
+
+        MSG = 'Specify `require: "debug/prelude"` or `require: false` when depending on the ' \
+              '`debug` gem.'
+        RESTRICT_ON_SEND = %i[gem].freeze
+        REQUIRE_CORRECTION = 'require: "debug/prelude"'
+
+        # @!method gem_debug_without_correct_require?(node)
+        def_node_matcher :gem_debug_without_correct_require?, <<~PATTERN
+          (send nil? :gem (str "debug")                                   # gem "debug", followed by
+            [!hash]*                                                      # maybe non-hashes (versions),
+            [
+              $hash                                                       # and a hash
+              !(hash                                                      # but not one containing the correct require:
+                <(pair (sym :require) {(str "debug/prelude") false}) ...>
+              )
+            ]?                                                            # (maybe)
+          )
+        PATTERN
+
+        def on_send(node)
+          gem_debug_without_correct_require?(node) do |captures|
+            add_offense(node) do |corrector|
+              if (kwargs = captures.first)
+                update_kwarg(corrector, kwargs)
+              else
+                append_require_kwarg(corrector, node)
+              end
+            end
+          end
+        end
+
+        private
+
+        def update_kwarg(corrector, kwargs)
+          pairs = kwargs.pairs
+
+          if (require_pair = pairs.find { |pair| pair.key.value == :require })
+            corrector.replace(require_pair, REQUIRE_CORRECTION)
+          else
+            first_pair = pairs.first
+            whitespace = kwargs.parent.multiline? ? "\n#{' ' * indentation(first_pair)}" : ' '
+            corrector.insert_before(first_pair, "#{REQUIRE_CORRECTION},#{whitespace}")
+          end
+        end
+
+        def append_require_kwarg(corrector, node)
+          corrector.insert_after(node.last_argument, ", #{REQUIRE_CORRECTION}")
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -672,6 +672,8 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
             create_file('.rubocop.yml', <<~YAML)
               require: rubocop_ext
 
+              Bundler:
+                Enabled: false
               Lint:
                 Enabled: false
               Style:

--- a/spec/rubocop/config_store_spec.rb
+++ b/spec/rubocop/config_store_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe RuboCop::ConfigStore do
 
   describe '.for' do
     it 'always uses config specified in command line' do
-      config_store.options_config = { options_config: true }
-      expect(config_store.for('file1')).to eq('merged {:options_config=>true}')
+      config = { options_config: true }
+      config_store.options_config = config
+      expect(config_store.for('file1')).to eq("merged #{config}")
     end
 
     context 'when no config specified in command line' do

--- a/spec/rubocop/cop/bundler/debug_require_spec.rb
+++ b/spec/rubocop/cop/bundler/debug_require_spec.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Bundler::DebugRequire, :config do
+  it 'registers an offense and corrects gem "debug" without require option' do
+    expect_offense(<<~RUBY)
+      gem "debug"
+      ^^^^^^^^^^^ Specify `require: "debug/prelude"` or `require: false` when depending on the `debug` gem.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      gem "debug", require: "debug/prelude"
+    RUBY
+  end
+
+  it 'registers an offense and corrects gem "debug" with incorrect require option' do
+    expect_offense(<<~RUBY)
+      gem "debug", require: "debug"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify `require: "debug/prelude"` or `require: false` when depending on the `debug` gem.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      gem "debug", require: "debug/prelude"
+    RUBY
+  end
+
+  it 'does not register an offense for gem "debug" with require: "debug/prelude"' do
+    expect_no_offenses(<<~RUBY)
+      gem "debug", require: "debug/prelude"
+    RUBY
+  end
+
+  it 'does not register an offense for gem "debug" with a version and require: "debug/prelude"' do
+    expect_no_offenses(<<~RUBY)
+      gem "debug", "1.0.0", require: "debug/prelude"
+    RUBY
+  end
+
+  it 'does not register an offense for gem "debug" with require: false' do
+    expect_no_offenses(<<~RUBY)
+      gem "debug", require: false
+    RUBY
+  end
+
+  it 'does not register an offense for gem "debug" with a version and require: false' do
+    expect_no_offenses(<<~RUBY)
+      gem "debug", "1.0.0", require: false
+    RUBY
+  end
+
+  it 'does not register an offense for other gems' do
+    expect_no_offenses(<<~RUBY)
+      gem "rails"
+      gem "rspec"
+    RUBY
+  end
+
+  it 'registers an offense and corrects gem "debug" with version specified' do
+    expect_offense(<<~RUBY)
+      gem "debug", "1.0.0"
+      ^^^^^^^^^^^^^^^^^^^^ Specify `require: "debug/prelude"` or `require: false` when depending on the `debug` gem.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      gem "debug", "1.0.0", require: "debug/prelude"
+    RUBY
+  end
+
+  it 'registers an offense and corrects gem "debug" with other options' do
+    expect_offense(<<~RUBY)
+      gem "debug", group: :development
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify `require: "debug/prelude"` or `require: false` when depending on the `debug` gem.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      gem "debug", require: "debug/prelude", group: :development
+    RUBY
+  end
+
+  it 'registers an offense and corrects gem "debug" with multiple options' do
+    expect_offense(<<~RUBY)
+      gem "debug", "1.0.0", group: :development, require: "debug"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify `require: "debug/prelude"` or `require: false` when depending on the `debug` gem.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      gem "debug", "1.0.0", group: :development, require: "debug/prelude"
+    RUBY
+  end
+
+  it 'registers an offense and corrects gem "debug" with multiple versions and multiple options' do
+    expect_offense(<<~RUBY)
+      gem "debug", ">= 1.0", "< 2.0", group: :development, require: "debug"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify `require: "debug/prelude"` or `require: false` when depending on the `debug` gem.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      gem "debug", ">= 1.0", "< 2.0", group: :development, require: "debug/prelude"
+    RUBY
+  end
+
+  it 'does not register an offense for gem "debug" with require: "debug/prelude" and other options' do
+    expect_no_offenses(<<~RUBY)
+      gem "debug", "1.0.0", group: :development, require: "debug/prelude"
+    RUBY
+  end
+
+  it 'does not register an offense for gem "debug" with require: false and other options' do
+    expect_no_offenses(<<~RUBY)
+      gem "debug", "1.0.0", group: :development, require: false
+    RUBY
+  end
+
+  it 'registers an offense and corrects incorrect multiline gem "debug" declaration' do
+    expect_offense(<<~RUBY)
+      gem "debug",
+      ^^^^^^^^^^^^ Specify `require: "debug/prelude"` or `require: false` when depending on the `debug` gem.
+          ">= 1.0.0",
+          group: :development
+    RUBY
+
+    expect_correction(<<~RUBY)
+      gem "debug",
+          ">= 1.0.0",
+          require: "debug/prelude",
+          group: :development
+    RUBY
+  end
+
+  it 'registers an offense and corrects incorrect multiline gem "debug" declaration with require as the last option' do
+    expect_offense(<<~RUBY)
+      gem "debug",
+      ^^^^^^^^^^^^ Specify `require: "debug/prelude"` or `require: false` when depending on the `debug` gem.
+          ">= 1.0.0",
+          group: :development,
+          require: "debug"
+    RUBY
+
+    expect_correction(<<~RUBY)
+      gem "debug",
+          ">= 1.0.0",
+          group: :development,
+          require: "debug/prelude"
+    RUBY
+  end
+
+  it 'registers an offense and corrects incorrect multiline gem "debug" declaration with multiple version specifiers' do
+    expect_offense(<<~RUBY)
+      gem "debug",
+      ^^^^^^^^^^^^ Specify `require: "debug/prelude"` or `require: false` when depending on the `debug` gem.
+          ">= 1.0",
+          "< 2.0",
+          group: :development
+    RUBY
+
+    expect_correction(<<~RUBY)
+      gem "debug",
+          ">= 1.0",
+          "< 2.0",
+          require: "debug/prelude",
+          group: :development
+    RUBY
+  end
+
+  it 'registers an offense for debug gem when multiple gems are declared on the same line' do
+    expect_offense(<<~RUBY)
+      gem "rails"; gem "debug"; gem "rspec"
+                   ^^^^^^^^^^^ Specify `require: "debug/prelude"` or `require: false` when depending on the `debug` gem.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      gem "rails"; gem "debug", require: "debug/prelude"; gem "rspec"
+    RUBY
+  end
+
+  context 'copy-pasted test suite' do
+    context 'when handling multiline declarations' do
+      it 'registers an offense for multiline debug gem declaration' do
+        expect_offense(<<~RUBY)
+          gem "debug",
+          ^^^^^^^^^^^^ Specify `require: "debug/prelude"` or `require: false` when depending on the `debug` gem.
+              ">= 1.0.0",
+              group: :development
+        RUBY
+
+        expect_correction(<<~RUBY)
+          gem "debug",
+              ">= 1.0.0",
+              require: "debug/prelude",
+              group: :development
+        RUBY
+      end
+
+      it 'correctly handles multiline declarations with require as the last option' do
+        expect_offense(<<~RUBY)
+          gem "debug",
+          ^^^^^^^^^^^^ Specify `require: "debug/prelude"` or `require: false` when depending on the `debug` gem.
+              ">= 1.0.0",
+              group: :development,
+              require: "debug"
+        RUBY
+
+        expect_correction(<<~RUBY)
+          gem "debug",
+              ">= 1.0.0",
+              group: :development,
+              require: "debug/prelude"
+        RUBY
+      end
+
+      it 'handles multiple version specifiers in multiline declarations' do
+        expect_offense(<<~RUBY)
+          gem "debug",
+          ^^^^^^^^^^^^ Specify `require: "debug/prelude"` or `require: false` when depending on the `debug` gem.
+              ">= 1.0",
+              "< 2.0",
+              group: :development
+        RUBY
+
+        expect_correction(<<~RUBY)
+          gem "debug",
+              ">= 1.0",
+              "< 2.0",
+              require: "debug/prelude",
+              group: :development
+        RUBY
+      end
+    end
+
+    context 'when handling multiple gem declarations' do
+      it 'registers an offense for debug gem when multiple gems are declared on the same line' do
+        expect_offense(<<~RUBY)
+          gem "rails"; gem "debug"; gem "rspec"
+                       ^^^^^^^^^^^ Specify `require: "debug/prelude"` or `require: false` when depending on the `debug` gem.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          gem "rails"; gem "debug", require: "debug/prelude"; gem "rspec"
+        RUBY
+      end
+    end
+  end
+end


### PR DESCRIPTION
The debug gem can create unnecessary overhead for applications, especially when it's not explicitly required. This can lead to unintended debugger activation in local development environments, potentially impacting performance and causing unexpected behaviour.

This cop enforces that if `gem "debug"` is present, one of the following is specified:

    gem "debug", ... require: "debug/prelude"
    gem "debug", ... require: false

Thanks to @alexcrocha for originally implementing a version of this cop in our codebase!

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
