### PR TITLE
Make `ConfigStore.for` spec compatible with Ruby HEAD's new `Hash#inspect`

### DIFF
--- a/spec/rubocop/config_store_spec.rb
+++ b/spec/rubocop/config_store_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe RuboCop::ConfigStore do
 
   describe '.for' do
     it 'always uses config specified in command line' do
-      config_store.options_config = { options_config: true }
-      expect(config_store.for('file1')).to eq('merged {:options_config=>true}')
+      config = { options_config: true }
+      config_store.options_config = config
+      expect(config_store.for('file1')).to eq("merged #{config}")
     end
 
     context 'when no config specified in command line' do


### PR DESCRIPTION
`Hash#inspect` is changing to use the Ruby 1.9 syntax for symbol keys (see ruby/ruby#10924).

This updates the spec to interpolate the config hash, so it implicitly works with both the old and new versions of `Hash#inspect`, fixing compatibility with Ruby HEAD.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
