### PR TITLE
Fix an error for `Layout/AccessModifierIndentation`

### DIFF
--- a/changelog/fix_an_error_for_layout_access_modifier_indentation.md
+++ b/changelog/fix_an_error_for_layout_access_modifier_indentation.md
@@ -1,0 +1,1 @@
+* [#13298](https://github.com/rubocop/rubocop/pull/13298): Fix an error for `Layout/AccessModifierIndentation` when the access modifier is on the same line as the class definition. ([@koic][])

--- a/lib/rubocop/cop/layout/access_modifier_indentation.rb
+++ b/lib/rubocop/cop/layout/access_modifier_indentation.rb
@@ -59,7 +59,11 @@ module RuboCop
           modifiers = body.each_child_node(:send).select(&:bare_access_modifier?)
           end_range = node.loc.end
 
-          modifiers.each { |modifier| check_modifier(modifier, end_range) }
+          modifiers.each do |modifier|
+            next if same_line?(node, modifier)
+
+            check_modifier(modifier, end_range)
+          end
         end
 
         def check_modifier(send_node, end_range)

--- a/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
@@ -341,6 +341,12 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation, :config do
       RUBY
     end
 
+    it 'does not register an offense when the access modifier is on the same line as the class definition' do
+      expect_no_offenses(<<~RUBY)
+        class A; private; def foo; end; end
+      RUBY
+    end
+
     context 'when 4 spaces per indent level are used' do
       let(:indentation_width) { 4 }
 


### PR DESCRIPTION
This PR fixes the following infinite loop error for `Layout/AccessModifierIndentation` when the access modifier is on the same line as the class definition.

```console
$ echo 'class A; private; def foo; end; end' | bundle exec rubocop --stdin dummy.rb -a --only Layout/AccessModifierIndentation
(snip)

Infinite loop detected in /Users/koic/src/github.com/rubocop/rubocop/dummy.rb and caused by Layout/AccessModifierIndentation
Hint: Please update to the latest RuboCop version if not already in use, and report a bug if the issue still occurs on this version.
Please check the latest version at https://rubygems.org/gems/rubocop.
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/runner.rb:322:in 'block in RuboCop::Runner#iterate_until_no_changes'
<internal:kernel>:191:in 'Kernel#loop'
```

In cases like this, where they are on the same line, the concept of indentation doesn't apply, so it can be ignored.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
