### PR TITLE
Set `EnforcedShorthandSyntax: either` by default for `Style/HashSyntax`

### DIFF
--- a/changelog/change_either_to_enforced_shorthand_syntax_for_hash_syntax.md
+++ b/changelog/change_either_to_enforced_shorthand_syntax_for_hash_syntax.md
@@ -1,0 +1,1 @@
+* [#13300](https://github.com/rubocop/rubocop/pull/13300): Set `EnforcedShorthandSyntax: either` by default for `Style/HashSyntax`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4075,7 +4075,7 @@ Style/HashSyntax:
   StyleGuide: '#hash-literals'
   Enabled: true
   VersionAdded: '0.9'
-  VersionChanged: '1.24'
+  VersionChanged: '<<next>>'
   EnforcedStyle: ruby19
   SupportedStyles:
     # checks for 1.9 syntax (e.g. {a: 1}) for all symbol keys
@@ -4087,7 +4087,7 @@ Style/HashSyntax:
     # enforces both ruby19 and no_mixed_keys styles
     - ruby19_no_mixed_keys
   # Force hashes that have a hash value omission
-  EnforcedShorthandSyntax: always
+  EnforcedShorthandSyntax: either
   SupportedShorthandSyntax:
     # forces use of the 3.1 syntax (e.g. {foo:}) when the hash key and value are the same.
     - always

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -68,7 +68,7 @@ module RuboCop
       #   {a: 1, b: 2}
       #   {:c => 3, 'd' => 4}
       #
-      # @example EnforcedShorthandSyntax: always (default)
+      # @example EnforcedShorthandSyntax: always
       #
       #   # bad
       #   {foo: foo, bar: bar}
@@ -84,7 +84,7 @@ module RuboCop
       #   # good
       #   {foo: foo, bar: bar}
       #
-      # @example EnforcedShorthandSyntax: either
+      # @example EnforcedShorthandSyntax: either (default)
       #
       #   # good
       #   {foo: foo, bar: bar}

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -1619,6 +1619,8 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           AllCops:
             NewCops: enable
             TargetRubyVersion: 3.1
+          Style/HashSyntax:
+            EnforcedShorthandSyntax: always
         YAML
         create_file('example1.rb', ['# frozen_string_literal: true', '', '{ a: a }'])
 


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10351#issuecomment-1008235461

As the current trend suggests, `EnforcedShorthandSyntax: either` seems to be a reasonable choice. Additionally, as a note from the developer, `either` was added later as an option for `EnforcedShorthandSyntax`. Had it been noticed from the beginning, it would likely have been the default. `EnforcedShorthandSyntax: always` is still maintained as an option, and users who prefer it will need to switch the setting. Rather than switching from `EnforcedShorthandSyntax: always` to the extreme of `EnforcedShorthandSyntax: never`, `EnforcedShorthandSyntax: either` leaves the choice to the user, making it a more balanced decision in that regard.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
