### PR TITLE
[Fix #13225] Avoid syntax error when correcting `Style/OperatorMethodCall` with `/` operations followed by a parenthesized argument

### DIFF
--- a/changelog/fix_avoid_syntax_error_when_correcting.md
+++ b/changelog/fix_avoid_syntax_error_when_correcting.md
@@ -1,0 +1,1 @@
+* [#13225](https://github.com/rubocop/rubocop/issues/13225): Avoid syntax error when correcting `Style/OperatorMethodCall` with `/` operations followed by a parenthesized argument. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/operator_method_call_spec.rb
+++ b/spec/rubocop/cop/style/operator_method_call_spec.rb
@@ -52,18 +52,18 @@ RSpec.describe RuboCop::Cop::Style::OperatorMethodCall, :config do
       RUBY
     end
 
-    it "registers an offense when using `foo.#{operator_method}(bar)`" do
-      skip('https://github.com/rubocop/rubocop/issues/13225') if operator_method == :/
+    unless operator_method == :/
+      it "registers an offense when using `foo.#{operator_method}(bar)`" do
+        expect_offense(<<~RUBY, operator_method: operator_method)
+          foo.#{operator_method}(bar)
+             ^ Redundant dot detected.
+        RUBY
 
-      expect_offense(<<~RUBY, operator_method: operator_method)
-        foo.#{operator_method}(bar)
-           ^ Redundant dot detected.
-      RUBY
-
-      # Redundant parentheses in `(bar)` are left to `Style/RedundantParentheses` to fix.
-      expect_correction(<<~RUBY)
-        foo #{operator_method}(bar)
-      RUBY
+        # Redundant parentheses in `(bar)` are left to `Style/RedundantParentheses` to fix.
+        expect_correction(<<~RUBY)
+          foo #{operator_method}(bar)
+        RUBY
+      end
     end
 
     it "registers an offense when chaining `foo.bar.#{operator_method}(baz).round(2)`" do
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::Style::OperatorMethodCall, :config do
     end
   end
 
-  it 'registers an offense when using `foo.+({})`' do
+  it 'registers an offense when using `foo.==({})`' do
     expect_offense(<<~RUBY)
       foo.==({})
          ^ Redundant dot detected.
@@ -103,6 +103,28 @@ RSpec.describe RuboCop::Cop::Style::OperatorMethodCall, :config do
 
     expect_correction(<<~RUBY)
       foo + @bar.to_s
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `foo./(bar)`' do
+    expect_offense(<<~RUBY)
+      foo./(bar)
+         ^ Redundant dot detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo / (bar)
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `foo./ (bar)`' do
+    expect_offense(<<~RUBY)
+      foo./ (bar)
+         ^ Redundant dot detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo / (bar)
     RUBY
   end
 


### PR DESCRIPTION
Previously, `foo./(bar)` was corrected to `foo /(bar)` which is a syntax error. 

This change ensures that a space is inserted for `/` operations to avoid this error.

Fixes #13225.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
