### PR TITLE
[Fix #13302] Fix incompatible autocorrect between `Style/RedundantBegin` and `Style/BlockDelimiters` with `EnforcedStyle: braces_for_chaining`

### DIFF
--- a/changelog/fix_wrong_autocorrect_redundant_begin_block_delims.md
+++ b/changelog/fix_wrong_autocorrect_redundant_begin_block_delims.md
@@ -1,0 +1,1 @@
+* [#13302](https://github.com/rubocop/rubocop/issues/13302): Fix incompatible autocorrect between `Style/RedundantBegin` and `Style/BlockDelimiters` with `EnforcedStyle: braces_for_chaining`. ([@earlopain][])

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -176,6 +176,10 @@ module RuboCop
 
         BRACES_REQUIRED_MESSAGE = "Brace delimiters `{...}` required for '%<method_name>s' method."
 
+        def self.autocorrect_incompatible_with
+          [Style::RedundantBegin]
+        end
+
         def on_send(node)
           return unless node.arguments?
           return if node.parenthesized?

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -68,6 +68,10 @@ module RuboCop
 
         MSG = 'Redundant `begin` block detected.'
 
+        def self.autocorrect_incompatible_with
+          [Style::BlockDelimiters]
+        end
+
         # @!method offensive_kwbegins(node)
         def_node_search :offensive_kwbegins, <<~PATTERN
           [(kwbegin ...) !#allowable_kwbegin?]

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2866,6 +2866,36 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Style/BlockDelimiters` with `EnforcedStyle: braces_for_chaining` and `Style/RedundantBegin` offenses' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/BlockDelimiters:
+        EnforcedStyle: braces_for_chaining
+    YAML
+
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~RUBY)
+      foo.map do |v|
+        begin
+          v.call
+        rescue StandardError
+          baz
+        end
+      end.compact
+    RUBY
+
+    expect(cli.run(['-A', '--only', 'Style/BlockDelimiters,Style/RedundantBegin'])).to eq(0)
+
+    expect(source_file.read).to eq(<<~RUBY)
+      foo.map { |v|
+        begin
+          v.call
+        rescue StandardError
+          baz
+        end
+      }.compact
+    RUBY
+  end
+
   it 'does not crash when using `Layout/CaseIndentation` and `Layout/ElseAlignment`' do
     source_file = Pathname('example.rb')
     create_file(source_file, <<~RUBY)


### PR DESCRIPTION
Fixes #13302 / https://github.com/rubocop/rubocop/discussions/13294#discussioncomment-10866113

```rb
foo.map do |v|
  begin
    v.call
  rescue StandardError
    baz
  end
end.compact
```

This previously turned into this:

```rb
foo.map { |v|

    v.call
  rescue StandardError
    baz

}.compact
```

which is invalid syntax.

It's probably only relevant when the EnforcedStyle is set to this value but `autocorrect_incompatible_with` does not provide such granularity.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
