### PR TITLE
Update `Style/ReturnNilInPredicateMethodDefinition` to detect implicit `nil` returns inside `if`

### DIFF
--- a/changelog/change_update_style_return_nil_in_predicate_method_definition.md
+++ b/changelog/change_update_style_return_nil_in_predicate_method_definition.md
@@ -1,0 +1,1 @@
+* [#13305](https://github.com/rubocop/rubocop/pull/13305): Update `Style/ReturnNilInPredicateMethodDefinition` to detect implicit `nil` returns inside `if`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5215,6 +5215,7 @@ Style/ReturnNilInPredicateMethodDefinition:
   AllowedMethods: []
   AllowedPatterns: []
   VersionAdded: '1.53'
+  VersionChanged: '<<next>>'
 
 Style/SafeNavigation:
   Description: >-

--- a/spec/rubocop/cop/style/return_nil_in_predicate_method_definition_spec.rb
+++ b/spec/rubocop/cop/style/return_nil_in_predicate_method_definition_spec.rb
@@ -163,6 +163,94 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
         end
       RUBY
     end
+
+    context 'conditional implicit return nil' do
+      it 'registers an offense when in `if` branch' do
+        expect_offense(<<~RUBY)
+          def foo?
+            if bar
+              nil
+              ^^^ Return `false` instead of `nil` in predicate methods.
+            else
+              true
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo?
+            if bar
+              false
+            else
+              true
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense when in `else` branch' do
+        expect_offense(<<~RUBY)
+          def foo?
+            if bar
+              true
+            else
+              nil
+              ^^^ Return `false` instead of `nil` in predicate methods.
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo?
+            if bar
+              true
+            else
+              false
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense when in nested `if`' do
+        expect_offense(<<~RUBY)
+          def foo?
+            if bar
+              if baz
+                true
+              else
+                nil
+                ^^^ Return `false` instead of `nil` in predicate methods.
+              end
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo?
+            if bar
+              if baz
+                true
+              else
+                false
+              end
+            end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when the `if` statement is not an implicit return' do
+        expect_no_offenses(<<~RUBY)
+          def foo?
+            if bar
+              true
+            else
+              nil
+            end
+            baz
+          end
+        RUBY
+      end
+    end
   end
 
   context 'when defining predicate class method' do
@@ -213,6 +301,94 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
         end
       RUBY
     end
+
+    context 'conditional implicit return nil' do
+      it 'registers an offense when in `if` branch' do
+        expect_offense(<<~RUBY)
+          def self.foo?
+            if bar
+              nil
+              ^^^ Return `false` instead of `nil` in predicate methods.
+            else
+              true
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self.foo?
+            if bar
+              false
+            else
+              true
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense when in `else` branch' do
+        expect_offense(<<~RUBY)
+          def self.foo?
+            if bar
+              true
+            else
+              nil
+              ^^^ Return `false` instead of `nil` in predicate methods.
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self.foo?
+            if bar
+              true
+            else
+              false
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense when in nested `if`' do
+        expect_offense(<<~RUBY)
+          def self.foo?
+            if bar
+              if baz
+                true
+              else
+                nil
+                ^^^ Return `false` instead of `nil` in predicate methods.
+              end
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self.foo?
+            if bar
+              if baz
+                true
+              else
+                false
+              end
+            end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when the `if` statement is not an implicit return' do
+        expect_no_offenses(<<~RUBY)
+          def self.foo?
+            if bar
+              true
+            else
+              nil
+            end
+            baz
+          end
+        RUBY
+      end
+    end
   end
 
   context 'when not defining predicate method' do
@@ -222,6 +398,18 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
           return if condition
 
           bar?
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using `if`' do
+      expect_no_offenses(<<~RUBY)
+        def foo
+          if bar
+            nil
+          else
+            true
+          end
         end
       RUBY
     end
@@ -250,6 +438,18 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
           end
         RUBY
       end
+
+      it 'does not register an offense when returning nil in an `if`' do
+        expect_no_offenses(<<~RUBY)
+          def foo?
+            if bar
+              nil
+            else
+              true
+            end
+          end
+        RUBY
+      end
     end
 
     context 'when defining predicate class method' do
@@ -269,6 +469,18 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
             return nil if condition
 
             bar?
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when returning nil in an `if`' do
+        expect_no_offenses(<<~RUBY)
+          def self.foo?
+            if bar
+              nil
+            else
+              true
+            end
           end
         RUBY
       end
@@ -298,6 +510,18 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
           end
         RUBY
       end
+
+      it 'does not register an offense when returning nil in an `if`' do
+        expect_no_offenses(<<~RUBY)
+          def foo?
+            if bar
+              nil
+            else
+              true
+            end
+          end
+        RUBY
+      end
     end
 
     context 'when defining predicate class method' do
@@ -317,6 +541,18 @@ RSpec.describe RuboCop::Cop::Style::ReturnNilInPredicateMethodDefinition, :confi
             return nil if condition
 
             bar?
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when returning nil in an `if`' do
+        expect_no_offenses(<<~RUBY)
+          def self.foo?
+            if bar
+              nil
+            else
+              true
+            end
           end
         RUBY
       end


### PR DESCRIPTION
While looking into #13114, I noticed another situation that should be handled by `Style/ReturnNilInPredicateMethodDefinition`.

```ruby
def foo?
  if bar
    true
  else
    nil
  end
end
```

This change handles this situation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
