### PR TITLE
[Fix #13110] Add support in `Style/ArgumentsForwarding` for detecting forwarding of all anonymous arguments

### DIFF
--- a/changelog/change_add_support_in_style_arguments_forwarding_for.md
+++ b/changelog/change_add_support_in_style_arguments_forwarding_for.md
@@ -1,0 +1,1 @@
+* [#13110](https://github.com/rubocop/rubocop/issues/13110): Add support in `Style/ArgumentsForwarding` for detecting forwarding of all anonymous arguments. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -2265,6 +2265,54 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
+    it 'registers an offense when forwarding anonymous arguments' do
+      expect_offense(<<~RUBY)
+        def foo(*, **, &)
+                ^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+          bar(*, **, &)
+              ^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(...)
+          bar(...)
+        end
+      RUBY
+    end
+
+    it 'registers an offense if an additional positional parameter is present with anonymous arguments' do
+      expect_offense(<<~RUBY)
+        def foo(m, *, **, &)
+                   ^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+          bar(m, *, **, &)
+                 ^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(m, ...)
+          bar(m, ...)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when forwarding partial anonymous arguments' do
+      expect_no_offenses(<<~RUBY)
+        def foo(*, &)
+          bar(*, &)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when forwarding non-block anonymous arguments' do
+      expect_no_offenses(<<~RUBY)
+        def foo(*, **)
+          bar(*, **)
+        end
+      RUBY
+    end
+
     it 'does not register an offense when rest arguments forwarding to a method in block' do
       expect_no_offenses(<<~RUBY)
         def foo(*args, &block)


### PR DESCRIPTION
Adds support to `Style/ArgumentsForwarding` for the following cases:

```ruby
def foo(*, **, &)
  bar(*, **, &)
end

# corrects to...

def foo(...)
  bar(...)
end
```

```ruby
def foo(m, *, **, &)
  bar(m, *, **, &)
end

# corrects to...

def foo(m, ...)
  bar(m, ...)
end
```

Fixes #13110.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
