### PR TITLE
[Fix #13310] Display analysis Ruby version in `rubocop -V`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,7 +38,7 @@ output by `rubocop -V`, include them as well. Here's an example:
 
 ```
 $ [bundle exec] rubocop -V
-1.66.1 (using Parser 3.2.2.3, rubocop-ast 1.29.0, running on ruby 3.2.2) [x86_64-linux]
-  - rubocop-performance 1.18.0
-  - rubocop-rspec 2.23.2
+1.66.1 (using Parser 3.3.5.0, rubocop-ast 1.32.3, analyzing as Ruby 3.3, running on ruby 3.3.5) [x86_64-linux]
+  - rubocop-performance 1.22.1
+  - rubocop-rspec 3.1.0
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,9 @@ do so.
 
 ```console
 $ rubocop -V
-1.66.1 (using Parser 3.2.2.3, rubocop-ast 1.29.0, running on ruby 3.2.2) [x86_64-linux]
-  - rubocop-performance 1.18.0
-  - rubocop-rspec 2.23.2
+1.66.1 (using Parser 3.3.5.0, rubocop-ast 1.32.3, analyzing as Ruby 3.3, running on ruby 3.3.5) [x86_64-linux]
+  - rubocop-performance 1.22.1
+  - rubocop-rspec 3.1.0
 ```
 
 * Include any relevant code to the issue summary.

--- a/changelog/new_display_analysis_ruby_version.md
+++ b/changelog/new_display_analysis_ruby_version.md
@@ -1,0 +1,1 @@
+* [#13310](https://github.com/rubocop/rubocop/issues/13310): Display analysis Ruby version in `rubocop -V`. ([@koic][])

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -7,6 +7,7 @@ module RuboCop
 
     MSG = '%<version>s (using %<parser_version>s, ' \
           'rubocop-ast %<rubocop_ast_version>s, ' \
+          'analyzing as Ruby %<target_ruby_version>s, ' \
           'running on %<ruby_engine>s %<ruby_version>s)%<server_mode>s [%<ruby_platform>s]'
 
     CANONICAL_FEATURE_NAMES = {
@@ -22,6 +23,7 @@ module RuboCop
       if debug
         verbose_version = format(MSG, version: STRING, parser_version: parser_version,
                                       rubocop_ast_version: RuboCop::AST::Version::STRING,
+                                      target_ruby_version: TargetRuby.new(Config.new).version,
                                       ruby_engine: RUBY_ENGINE, ruby_version: RUBY_VERSION,
                                       server_mode: server_mode,
                                       ruby_platform: RUBY_PLATFORM)

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -293,6 +293,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       expect($stdout.string).to include(RuboCop::Version::STRING)
       expect($stdout.string).to match(/Parser \d+\.\d+\.\d+/)
       expect($stdout.string).to match(/rubocop-ast \d+\.\d+\.\d+/)
+      expect($stdout.string).to match(/analyzing as Ruby \d+\.\d+/)
     end
 
     context 'when requiring extension cops' do


### PR DESCRIPTION
Fixes #13310.

This PR makes rubocop -V show the Ruby version being analyzed.

## Before

The analysis Ruby version is not displayed:

```console
$ bundle exec rubocop -V
1.66.1 (using Parser 3.3.5.0, rubocop-ast 1.32.3, running on ruby 3.3.5) [x86_64-linux]
  - rubocop-performance 1.22.1
  - rubocop-rspec 3.1.0
```

## After

The analysis Ruby version is displayed:

```console
$ bundle exec rubocop -V
1.66.1 (using Parser 3.3.5.0, rubocop-ast 1.32.3, analyzing as Ruby 3.3, running on ruby 3.3.5) [x86_64-linux]
  - rubocop-performance 1.22.1
  - rubocop-rspec 3.1.0
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
