### PR TITLE
[Fix #9816] Refine `Lint/SafeNavigationConsistency`

### DIFF
--- a/changelog/change_refine_lint_safe_navigation_consistency.md
+++ b/changelog/change_refine_lint_safe_navigation_consistency.md
@@ -1,0 +1,1 @@
+* [#9816](https://github.com/rubocop/rubocop/issues/9816): Refine `Lint/SafeNavigationConsistency` cop to check that the safe navigation operator is applied consistently and without excess or deficiency. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2333,9 +2333,9 @@ Lint/SafeNavigationChain:
 
 Lint/SafeNavigationConsistency:
   Description: >-
-                 Check to make sure that if safe navigation is used for a method
-                 call in an `&&` or `||` condition that safe navigation is used
-                 for all method calls on that same object.
+                 Check to make sure that if safe navigation is used in an `&&` or `||` condition,
+                 consistent and appropriate safe navigation, without excess or deficiency,
+                 is used for all method calls on the same object.
   Enabled: true
   VersionAdded: '0.55'
   VersionChanged: '0.77'

--- a/lib/rubocop/cop/correctors/parentheses_corrector.rb
+++ b/lib/rubocop/cop/correctors/parentheses_corrector.rb
@@ -22,7 +22,7 @@ module RuboCop
         private
 
         def ternary_condition?(node)
-          node.parent&.if_type? && node.parent&.ternary?
+          node.parent&.if_type? && node.parent.ternary?
         end
 
         def next_char_is_question_mark?(node)

--- a/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
@@ -135,7 +135,7 @@ module RuboCop
 
           parent = next_sibling.parent
 
-          parent&.if_type? && parent&.else?
+          parent&.if_type? && parent.else?
         end
 
         def next_sibling_empty_or_guard_clause?(node)

--- a/lib/rubocop/cop/lint/boolean_symbol.rb
+++ b/lib/rubocop/cop/lint/boolean_symbol.rb
@@ -36,7 +36,7 @@ module RuboCop
           return unless boolean_symbol?(node)
 
           parent = node.parent
-          return if parent&.array_type? && parent&.percent_literal?(:symbol)
+          return if parent&.array_type? && parent.percent_literal?(:symbol)
 
           add_offense(node, message: format(MSG, boolean: node.value)) do |corrector|
             autocorrect(corrector, node)

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -150,7 +150,7 @@ module RuboCop
 
         def ends_heredoc_line?(node)
           grandparent = node.parent.parent
-          return false unless grandparent&.dstr_type? && grandparent&.heredoc?
+          return false unless grandparent&.dstr_type? && grandparent.heredoc?
 
           line = processed_source.lines[node.last_line - 1]
           line.size == node.loc.last_column + 1
@@ -161,7 +161,7 @@ module RuboCop
           return false unless parent.dstr_type? || parent.dsym_type?
 
           grandparent = parent.parent
-          grandparent&.array_type? && grandparent&.percent_literal?
+          grandparent&.array_type? && grandparent.percent_literal?
         end
       end
     end

--- a/lib/rubocop/cop/lint/safe_navigation_consistency.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_consistency.rb
@@ -3,87 +3,152 @@
 module RuboCop
   module Cop
     module Lint
-      # Check to make sure that if safe navigation is used for a method
-      # call in an `&&` or `||` condition that safe navigation is used for all
-      # method calls on that same object.
+      # Check to make sure that if safe navigation is used in an `&&` or `||` condition,
+      # consistent and appropriate safe navigation, without excess or deficiency,
+      # is used for all method calls on the same object.
       #
       # @example
       #   # bad
+      #   foo&.bar && foo&.baz
+      #
+      #   # good
       #   foo&.bar && foo.baz
       #
       #   # bad
-      #   foo.bar || foo&.baz
-      #
-      #   # bad
-      #   foo&.bar && (foobar.baz || foo.baz)
+      #   foo.bar && foo&.baz
       #
       #   # good
       #   foo.bar && foo.baz
       #
+      #   # bad
+      #   foo&.bar || foo.baz
+      #
       #   # good
       #   foo&.bar || foo&.baz
       #
+      #   # bad
+      #   foo.bar || foo&.baz
+      #
       #   # good
+      #   foo.bar || foo.baz
+      #
+      #   # bad
       #   foo&.bar && (foobar.baz || foo&.baz)
       #
+      #   # good
+      #   foo&.bar && (foobar.baz || foo.baz)
+      #
       class SafeNavigationConsistency < Base
-        include IgnoredNode
         include NilMethods
         extend AutoCorrector
 
-        MSG = 'Ensure that safe navigation is used consistently inside of `&&` and `||`.'
+        USE_DOT_MSG = 'Use `.` instead of unnecessary `&.`.'
+        USE_SAFE_NAVIGATION_MSG = 'Use `&.` for consistency with safe navigation.'
 
-        def on_csend(node)
-          return unless node.parent&.operator_keyword?
+        def on_and(node)
+          all_operands = collect_operands(node, [])
+          operand_groups = all_operands.group_by { |operand| receiver_name_as_key(operand, +'') }
 
-          check(node)
-        end
+          operand_groups.each_value do |grouped_operands|
+            next unless (dot_op, begin_of_rest_operands = find_consistent_parts(grouped_operands))
 
-        def check(node)
-          ancestor = top_conditional_ancestor(node)
-          conditions = ancestor.conditions
-          safe_nav_receiver = node.receiver
+            rest_operands = grouped_operands[begin_of_rest_operands..]
+            rest_operands.each do |operand|
+              next if already_appropriate_call?(operand, dot_op)
 
-          method_calls = conditions.select(&:send_type?)
-          unsafe_method_calls = unsafe_method_calls(method_calls, safe_nav_receiver)
-
-          unsafe_method_calls.each do |unsafe_method_call|
-            location = location(node, unsafe_method_call)
-
-            add_offense(location) { |corrector| autocorrect(corrector, unsafe_method_call) }
-
-            ignore_node(unsafe_method_call)
+              register_offense(operand, dot_op)
+            end
           end
         end
+        alias on_or on_and
 
         private
 
-        def autocorrect(corrector, node)
-          return unless node.dot?
+        def collect_operands(node, operand_nodes)
+          operand_nodes(node.lhs, operand_nodes)
+          operand_nodes(node.rhs, operand_nodes)
 
-          corrector.insert_before(node.loc.dot, '&')
+          operand_nodes
         end
 
-        def location(node, unsafe_method_call)
-          node.source_range.join(unsafe_method_call.source_range)
+        def receiver_name_as_key(method, fully_receivers)
+          if method.parent.call_type?
+            receiver(method.parent, fully_receivers)
+          else
+            fully_receivers << method.receiver&.source.to_s
+          end
         end
 
-        def top_conditional_ancestor(node)
-          parent = node.parent
-          unless parent&.operator_keyword? ||
-                 (parent&.begin_type? && parent.parent&.operator_keyword?)
-            return node
+        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        def find_consistent_parts(grouped_operands)
+          csend_in_and, csend_in_or, send_in_and, send_in_or = most_left_indices(grouped_operands)
+
+          if csend_in_and
+            ['.', (send_in_and ? [send_in_and, csend_in_and].min : csend_in_and) + 1]
+          elsif send_in_or && csend_in_or
+            send_in_or < csend_in_or ? ['.', send_in_or + 1] : ['&.', csend_in_or + 1]
+          elsif send_in_and && csend_in_or && send_in_and < csend_in_or
+            ['.', csend_in_or]
+          end
+        end
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+        def already_appropriate_call?(operand, dot_op)
+          (operand.safe_navigation? && dot_op == '&.') || (operand.dot? && dot_op == '.')
+        end
+
+        def register_offense(operand, dot_operator)
+          offense_range = operand.operator_method? ? operand : operand.loc.dot
+          message = dot_operator == '.' ? USE_DOT_MSG : USE_SAFE_NAVIGATION_MSG
+
+          add_offense(offense_range, message: message) do |corrector|
+            next if operand.operator_method?
+
+            corrector.replace(operand.loc.dot, dot_operator)
+          end
+        end
+
+        def operand_nodes(operand, operand_nodes)
+          if operand.operator_keyword?
+            collect_operands(operand, operand_nodes)
+          elsif operand.call_type?
+            operand_nodes << operand
+          end
+        end
+
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        def most_left_indices(grouped_operands)
+          indices = { csend_in_and: nil, csend_in_or: nil, send_in_and: nil, send_in_or: nil }
+
+          grouped_operands.each_with_index do |operand, index|
+            indices[:csend_in_and] ||= index if operand_in_and?(operand) && operand.csend_type?
+            indices[:csend_in_or] ||= index if operand_in_or?(operand) && operand.csend_type?
+            indices[:send_in_and] ||= index if operand_in_and?(operand) && !nilable?(operand)
+            indices[:send_in_or] ||= index if operand_in_or?(operand) && !nilable?(operand)
           end
 
-          top_conditional_ancestor(parent)
+          indices.values
+        end
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+        def operand_in_and?(node)
+          return true if node.parent.and_type?
+
+          parent = node.parent.parent while node.parent.begin_type?
+
+          parent&.and_type?
         end
 
-        def unsafe_method_calls(method_calls, safe_nav_receiver)
-          method_calls.select do |method_call|
-            safe_nav_receiver == method_call.receiver &&
-              !nil_methods.include?(method_call.method_name) &&
-              !ignored_node?(method_call)
-          end
+        def operand_in_or?(node)
+          return true if node.parent.or_type?
+
+          parent = node.parent.parent while node.parent.begin_type?
+
+          parent&.or_type?
+        end
+
+        def nilable?(node)
+          node.csend_type? || nil_methods.include?(node.method_name)
         end
       end
     end

--- a/lib/rubocop/cop/lint/symbol_conversion.rb
+++ b/lib/rubocop/cop/lint/symbol_conversion.rb
@@ -141,7 +141,7 @@ module RuboCop
         end
 
         def in_percent_literal_array?(node)
-          node.parent&.array_type? && node.parent&.percent_literal?
+          node.parent&.array_type? && node.parent.percent_literal?
         end
 
         def correct_hash_key(node)

--- a/lib/rubocop/cop/mixin/percent_array.rb
+++ b/lib/rubocop/cop/mixin/percent_array.rb
@@ -15,7 +15,7 @@ module RuboCop
         parent = node.parent
 
         parent&.send_type? && parent.arguments.include?(node) &&
-          !parent.parenthesized? && parent&.block_literal?
+          !parent.parenthesized? && parent.block_literal?
       end
 
       # Override to determine values that are invalid in a percent array

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -73,7 +73,7 @@ module RuboCop
           elsif_branches << node.if_branch
 
           else_branch = node.else_branch
-          if else_branch&.if_type? && else_branch&.elsif?
+          if else_branch&.if_type? && else_branch.elsif?
             expand_elsif(else_branch, elsif_branches)
           else
             elsif_branches << else_branch

--- a/lib/rubocop/cop/style/if_inside_else.rb
+++ b/lib/rubocop/cop/style/if_inside_else.rb
@@ -71,7 +71,7 @@ module RuboCop
 
           else_branch = node.else_branch
 
-          return unless else_branch&.if_type? && else_branch&.if?
+          return unless else_branch&.if_type? && else_branch.if?
           return if allow_if_modifier_in_else_branch?(else_branch)
 
           add_offense(else_branch.loc.keyword) do |corrector|

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -132,7 +132,7 @@ module RuboCop
           end
 
           def call_in_single_line_inheritance?(node)
-            node.parent&.class_type? && node.parent&.single_line?
+            node.parent&.class_type? && node.parent.single_line?
           end
 
           def call_with_ambiguous_arguments?(node) # rubocop:disable Metrics/PerceivedComplexity
@@ -152,7 +152,7 @@ module RuboCop
           end
 
           def call_in_argument_with_block?(node)
-            parent = node.parent&.block_type? && node.parent&.parent
+            parent = node.parent&.block_type? && node.parent.parent
             return false unless parent
 
             parent.call_type? || parent.super_type? || parent.yield_type?
@@ -216,7 +216,7 @@ module RuboCop
 
           def unary_literal?(node)
             (node.numeric_type? && node.sign?) ||
-              (node.parent&.send_type? && node.parent&.unary_operation?)
+              (node.parent&.send_type? && node.parent.unary_operation?)
           end
 
           def assigned_before?(node, target)

--- a/lib/rubocop/cop/style/nested_modifier.rb
+++ b/lib/rubocop/cop/style/nested_modifier.rb
@@ -36,7 +36,7 @@ module RuboCop
         end
 
         def modifier?(node)
-          node&.basic_conditional? && node&.modifier_form?
+          node&.basic_conditional? && node.modifier_form?
         end
 
         def autocorrect(corrector, node)

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -94,7 +94,7 @@ module RuboCop
         end
 
         def use_hash_key_assignment?(else_branch)
-          else_branch&.send_type? && else_branch&.method?(:[]=)
+          else_branch&.send_type? && else_branch.method?(:[]=)
         end
 
         def use_hash_key_access?(node)

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -160,7 +160,7 @@ module RuboCop
             return if node.semantic_operator? && begin_node.parent
             return if node.multiline? && allow_in_multiline_conditions?
             return if ALLOWED_NODE_TYPES.include?(begin_node.parent&.type)
-            return if begin_node.parent&.if_type? && begin_node.parent&.ternary?
+            return if begin_node.parent&.if_type? && begin_node.parent.ternary?
 
             'a logical expression'
           elsif node.respond_to?(:comparison_method?) && node.comparison_method?

--- a/lib/rubocop/cop/style/require_order.rb
+++ b/lib/rubocop/cop/style/require_order.rb
@@ -103,7 +103,7 @@ module RuboCop
             next unless sibling.is_a?(AST::Node)
 
             sibling = sibling_node(sibling)
-            break unless sibling&.send_type? && sibling&.method?(node.method_name)
+            break unless sibling&.send_type? && sibling.method?(node.method_name)
             break unless sibling.arguments? && !sibling.receiver
             break unless in_same_section?(sibling, node)
             break unless node.first_argument.str_type? && sibling.first_argument.str_type?

--- a/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
@@ -3,6 +3,12 @@
 RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency, :config do
   let(:cop_config) { { 'AllowedMethods' => %w[present? blank? try presence] } }
 
+  it 'allows && without receiver' do
+    expect_no_offenses(<<~RUBY)
+      foo && bar
+    RUBY
+  end
+
   it 'allows && without safe navigation' do
     expect_no_offenses(<<~RUBY)
       foo.bar && foo.baz
@@ -15,44 +21,74 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency, :config do
     RUBY
   end
 
+  it 'allows || with comparison method' do
+    expect_no_offenses(<<~RUBY)
+      foo == bar || foo == baz
+    RUBY
+  end
+
   it 'allows safe navigation when different variables are used' do
     expect_no_offenses(<<~RUBY)
       foo&.bar || foobar.baz
     RUBY
   end
 
-  it 'allows calls to methods that nil responds to' do
+  it 'does not register an offense using calling `nil?` after safe navigation with `||`' do
+    expect_no_offenses(<<~RUBY)
+      foo&.bar || foo.nil?
+    RUBY
+  end
+
+  it 'does not register an offense using calling `nil?` before safe navigation with `&&`' do
+    expect_no_offenses(<<~RUBY)
+      foo.nil? && foo&.bar
+    RUBY
+  end
+
+  it 'does not register an offense when calling to methods that nil responds to' do
     expect_no_offenses(<<~RUBY)
       return true if a.nil? || a&.whatever?
     RUBY
   end
 
-  it 'registers an offense and corrects using safe navigation on the left of &&' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense using safe navigation on the left of &&' do
+    expect_no_offenses(<<~RUBY)
       foo&.bar && foo.baz
-      ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      foo&.bar && foo&.baz
     RUBY
   end
 
   it 'registers an offense and corrects using safe navigation on the right of &&' do
     expect_offense(<<~RUBY)
       foo.bar && foo&.baz
-      ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
+                    ^^ Use `.` instead of unnecessary `&.`.
     RUBY
 
     expect_correction(<<~RUBY)
+      foo.bar && foo.baz
+    RUBY
+  end
+
+  it 'does not register an offense using safe navigation for difference receiver on the right of &&' do
+    expect_no_offenses(<<~RUBY)
+      x.foo.bar && y.foo&.baz
+    RUBY
+  end
+
+  it 'registers an offense and corrects using safe navigation on the both of &&' do
+    expect_offense(<<~RUBY)
       foo&.bar && foo&.baz
+                     ^^ Use `.` instead of unnecessary `&.`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.bar && foo.baz
     RUBY
   end
 
   it 'registers an offense and corrects using safe navigation on the left of ||' do
     expect_offense(<<~RUBY)
       foo&.bar || foo.baz
-      ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
+                     ^ Use `&.` for consistency with safe navigation.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -63,11 +99,11 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency, :config do
   it 'registers an offense and corrects using safe navigation on the right of ||' do
     expect_offense(<<~RUBY)
       foo.bar || foo&.baz
-      ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
+                    ^^ Use `.` instead of unnecessary `&.`.
     RUBY
 
     expect_correction(<<~RUBY)
-      foo&.bar || foo&.baz
+      foo.bar || foo.baz
     RUBY
   end
 
@@ -75,7 +111,7 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency, :config do
     expect_offense(<<~RUBY)
       foo = nil
       foo&.bar || foo.baz
-      ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
+                     ^ Use `&.` for consistency with safe navigation.
       something
     RUBY
 
@@ -86,118 +122,143 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency, :config do
     RUBY
   end
 
-  it 'registers an offense but does not correct non dot method calls' do
+  it 'registers an offense and corrects non dot method calls for `&&` on LHS only' do
+    expect_offense(<<~RUBY)
+      foo > 5 && foo&.zero?
+                    ^^ Use `.` instead of unnecessary `&.`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo > 5 && foo.zero?
+    RUBY
+  end
+
+  it 'registers an offense but does not correct non dot method calls for `||` on RHS only' do
     expect_offense(<<~RUBY)
       foo&.zero? || foo > 5
-      ^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
+                    ^^^^^^^ Use `&.` for consistency with safe navigation.
     RUBY
 
     expect_no_corrections
   end
 
-  it 'registers an offense and corrects assignment' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense assignment when using safe navigation on the left `&`' do
+    expect_no_offenses(<<~RUBY)
       foo&.bar && foo.baz = 1
-      ^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
+    RUBY
+  end
+
+  it 'registers an offense and corrects assignment when using safe navigation on the right `&`' do
+    expect_offense(<<~RUBY)
+      foo.bar && foo&.baz = 1
+                    ^^ Use `.` instead of unnecessary `&.`.
     RUBY
 
     expect_correction(<<~RUBY)
+      foo.bar && foo.baz = 1
+    RUBY
+  end
+
+  it 'registers an offense and corrects assignment when using safe navigation on the both `&`' do
+    expect_offense(<<~RUBY)
       foo&.bar && foo&.baz = 1
+                     ^^ Use `.` instead of unnecessary `&.`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.bar && foo.baz = 1
     RUBY
   end
 
-  it 'registers an offense and corrects using safe navigation inside of separated conditions' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense using safe navigation on the left `&&` and inside of separated conditions' do
+    expect_no_offenses(<<~RUBY)
       foo&.bar && foobar.baz && foo.qux
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      foo&.bar && foobar.baz && foo&.qux
     RUBY
   end
 
-  it 'registers an offense and corrects using safe navigation in conditions ' \
-     'on the right hand side' do
+  it 'registers an offense and corrects using safe navigation on the right `&&` and inside of separated conditions' do
     expect_offense(<<~RUBY)
-      foobar.baz && foo&.bar && foo.qux
-                    ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
+      foo.bar && foobar.baz && foo&.qux
+                                  ^^ Use `.` instead of unnecessary `&.`.
     RUBY
 
     expect_correction(<<~RUBY)
-      foobar.baz && foo&.bar && foo&.qux
+      foo.bar && foobar.baz && foo.qux
+    RUBY
+  end
+
+  it 'registers an offense and corrects using safe navigation on the right `||` and inside of separated conditions' do
+    expect_offense(<<~RUBY)
+      foo.bar || foobar.baz || foo&.qux
+                                  ^^ Use `.` instead of unnecessary `&.`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.bar || foobar.baz || foo.qux
+    RUBY
+  end
+
+  it 'does not register an offense using safe navigation in conditions on the right hand side' do
+    expect_no_offenses(<<~RUBY)
+      foobar.baz && foo&.bar && foo.qux
     RUBY
   end
 
   it 'registers and corrects multiple offenses' do
-    expect_offense(<<~RUBY)
+    expect_no_offenses(<<~RUBY)
       foobar.baz && foo&.bar && foo.qux && foo.foobar
-                    ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      foobar.baz && foo&.bar && foo&.qux && foo&.foobar
     RUBY
   end
 
   it 'registers an offense and corrects using unsafe navigation with both && and ||' do
     expect_offense(<<~RUBY)
-      foo&.bar && foo.baz || foo.qux
-      ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
-    RUBY
-
-    expect_correction(<<~RUBY)
       foo&.bar && foo&.baz || foo&.qux
-    RUBY
-  end
-
-  it 'registers an offense and corrects using unsafe navigation with grouped conditions' do
-    expect_offense(<<~RUBY)
-      foo&.bar && (foo.baz || foo.qux)
-      ^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
+                     ^^ Use `.` instead of unnecessary `&.`.
+                                 ^^ Use `.` instead of unnecessary `&.`.
     RUBY
 
     expect_correction(<<~RUBY)
-      foo&.bar && (foo&.baz || foo&.qux)
+      foo&.bar && foo.baz || foo.qux
     RUBY
   end
 
-  it 'registers an offense and corrects unsafe navigation that appears before safe navigation' do
+  it 'does not register an offense using unsafe navigation with grouped conditions' do
+    expect_no_offenses(<<~RUBY)
+      foo&.bar && (foo.baz || foo.qux)
+    RUBY
+  end
+
+  it 'registers an offense and corrects safe navigation that appears after dot method call' do
     expect_offense(<<~RUBY)
       foo.bar && foo.baz || foo&.qux
-                 ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
+                               ^^ Use `.` instead of unnecessary `&.`.
     RUBY
 
     expect_correction(<<~RUBY)
-      foo&.bar && foo&.baz || foo&.qux
+      foo.bar && foo.baz || foo.qux
     RUBY
   end
 
-  it 'registers an offense and corrects using unsafe navigation ' \
-     'and the safe navigation appears in a group' do
-    expect_offense(<<~RUBY)
-      (foo&.bar && foo.baz) || foo.qux
-       ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
+  it 'does not register an offense safe navigation that appears before dot method call' do
+    expect_no_offenses(<<~RUBY)
+      foo&.bar || foo&.baz && foo.qux
     RUBY
+  end
 
-    expect_correction(<<~RUBY)
-      (foo&.bar && foo&.baz) || foo&.qux
+  it 'does not register an offense using unsafe navigation and the safe navigation appears in a group' do
+    expect_no_offenses(<<~RUBY)
+      (foo&.bar && foo.baz) || foo.qux
     RUBY
   end
 
   it 'registers a single offense and corrects when safe navigation is used multiple times' do
     expect_offense(<<~RUBY)
       foo&.bar && foo&.baz || foo.qux
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
+                     ^^ Use `.` instead of unnecessary `&.`.
     RUBY
 
     expect_correction(<<~RUBY)
-      foo&.bar && foo&.baz || foo&.qux
+      foo&.bar && foo.baz || foo.qux
     RUBY
   end
 end


### PR DESCRIPTION
Fixes #9816.

As highlighted in user feedback in #9816, the current implementation excessively requires the use of the safe navigation operator. This PR refines `Lint/SafeNavigationConsistency` cop to check that the safe navigation operator is applied consistently and without excess or deficiency.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
