### PR TITLE
[Fix #13286] Add `AllowedMethods` and `AllowedPatterns` configuration to `Layout/FirstMethodArgumentLineBreak`

### DIFF
--- a/changelog/change_add_allowed_methods_to_first_method_argument_line_break.md
+++ b/changelog/change_add_allowed_methods_to_first_method_argument_line_break.md
@@ -1,0 +1,1 @@
+* [#13286](https://github.com/rubocop/rubocop/issues/13286): Add `AllowedMethods` configuration to `Layout/FirstMethodArgumentLineBreak`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -861,6 +861,7 @@ Layout/FirstMethodArgumentLineBreak:
   Enabled: false
   VersionAdded: '0.49'
   AllowMultilineFinalElement: false
+  AllowedMethods: []
 
 Layout/FirstMethodParameterLineBreak:
   Description: >-

--- a/lib/rubocop/cop/layout/first_method_argument_line_break.rb
+++ b/lib/rubocop/cop/layout/first_method_argument_line_break.rb
@@ -63,13 +63,21 @@ module RuboCop
       #     }
       #   )
       #
+      # @example AllowedMethods: ['some_method']
+      #
+      #   # good
+      #   some_method(foo, bar,
+      #     baz)
       class FirstMethodArgumentLineBreak < Base
         include FirstElementLineBreak
+        include AllowedMethods
         extend AutoCorrector
 
         MSG = 'Add a line break before the first argument of a multi-line method argument list.'
 
         def on_send(node)
+          return if allowed_method?(node.method_name)
+
           args = node.arguments.dup
 
           # If there is a trailing hash arg without explicit braces, like this:

--- a/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
@@ -141,4 +141,15 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak, :config do
       RUBY
     end
   end
+
+  context 'AllowedMethods' do
+    let(:cop_config) { { 'AllowedMethods' => %w[something] } }
+
+    it 'does not register an offense for an allowed method' do
+      expect_no_offenses(<<~RUBY)
+        something(3, bar: 1,
+        baz: 2)
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Add `AllowedMethods` and `AllowedPatterns` to `Layout/FirstMethodArgumentLineBreak` allow for users to configure for methods they do not want to apply to the cop.

Fixes #13286.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
