### PR TITLE
Fix a false negative for `Style/Semicolon`

### DIFF
--- a/changelog/fix_a_false_negative_for_style_semicolon.md
+++ b/changelog/fix_a_false_negative_for_style_semicolon.md
@@ -1,0 +1,1 @@
+* [#13314](https://github.com/rubocop/rubocop/pull/13314): Fix a false negative for `Style/Semicolon` when using a semicolon between a closing parenthesis after a line break and a consequent expression. ([@koic][])

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -141,7 +141,7 @@ module RuboCop
 
         def expressions_per_line(exprs)
           # create a map matching lines to the number of expressions on them
-          exprs_lines = exprs.map(&:first_line)
+          exprs_lines = exprs.map(&:last_line)
           exprs_lines.group_by(&:itself)
         end
 

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -42,6 +42,20 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
     RUBY
   end
 
+  it 'registers an offense when using a semicolon between a closing parenthesis after a line break and a consequent expression' do
+    expect_offense(<<~RUBY)
+      foo(
+        bar); baz
+            ^ Do not use semicolons to terminate expressions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo(
+        bar)
+       baz
+    RUBY
+  end
+
   it 'accepts semicolon before end if so configured' do
     expect_no_offenses('def foo(a) z(3); end')
   end


### PR DESCRIPTION
This PR fixes a false negative for `Style/Semicolon` when using a semicolon between a closing parenthesis after a line break and a consequent expression.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
