### PR TITLE
[Fix #13316] Fix an incorrect autocorrect for `Lint/ImplicitStringConcatenation`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_implicit_string_concatenation.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_implicit_string_concatenation.md
@@ -1,0 +1,1 @@
+* [#13316](https://github.com/rubocop/rubocop/issues/13316): Fix an incorrect autocorrect for `Lint/ImplicitStringConcatenation` with `Lint/TripleQuotes` when string literals with triple quotes are used. ([@koic][])

--- a/lib/rubocop/cop/lint/implicit_string_concatenation.rb
+++ b/lib/rubocop/cop/lint/implicit_string_concatenation.rb
@@ -28,7 +28,7 @@ module RuboCop
         FOR_METHOD = ' Or, if they were intended to be separate method ' \
                      'arguments, separate them with a comma.'
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
         def on_dstr(node)
           each_bad_cons(node) do |lhs_node, rhs_node|
             range = lhs_node.source_range.join(rhs_node.source_range)
@@ -40,13 +40,19 @@ module RuboCop
             end
 
             add_offense(range, message: message) do |corrector|
-              range = lhs_node.source_range.end.join(rhs_node.source_range.begin)
+              if lhs_node.value == ''
+                corrector.remove(lhs_node)
+              elsif rhs_node.value == ''
+                corrector.remove(rhs_node)
+              else
+                range = lhs_node.source_range.end.join(rhs_node.source_range.begin)
 
-              corrector.replace(range, ' + ')
+                corrector.replace(range, ' + ')
+              end
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
 
         private
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -3175,6 +3175,36 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Lint/ImplicitStringConcatenation` with `Lint/TripleQuotes` offenses' do
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~RUBY)
+      """string"""
+    RUBY
+    status = cli.run(%w[--autocorrect --only Lint/ImplicitStringConcatenation,Lint/TripleQuotes])
+    expect($stdout.string).to eq(<<~RESULT)
+      Inspecting 1 file
+      W
+
+      Offenses:
+
+      example.rb:1:1: W: [Corrected] Lint/ImplicitStringConcatenation: Combine "" and "string" into a single string literal, rather than using implicit string concatenation.
+      """string"""
+      ^^^^^^^^^^
+      example.rb:1:1: W: [Corrected] Lint/TripleQuotes: Delimiting a string with multiple quotes has no effect, use a single quote instead.
+      """string"""
+      ^^^^^^^^^^^^
+      example.rb:1:3: W: [Corrected] Lint/ImplicitStringConcatenation: Combine "string" and "" into a single string literal, rather than using implicit string concatenation.
+      """string"""
+        ^^^^^^^^^^
+
+      1 file inspected, 3 offenses detected, 3 offenses corrected
+    RESULT
+    expect(status).to eq(0)
+    expect(source_file.read).to eq(<<~RUBY)
+      "string"
+    RUBY
+  end
+
   it 'corrects `Style/AccessModifierDeclarations` offenses when multiple groupable access modifiers are defined' do
     source_file = Pathname('example.rb')
     create_file(source_file, <<~RUBY)

--- a/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
+++ b/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
@@ -50,6 +50,20 @@ RSpec.describe RuboCop::Cop::Lint::ImplicitStringConcatenation, :config do
     end
   end
 
+  context 'on adjacent string literals with triple quotes' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        """string"""
+          ^^^^^^^^^^ Combine "string" and "" into a single string literal, rather than using implicit string concatenation.
+        ^^^^^^^^^^ Combine "" and "string" into a single string literal, rather than using implicit string concatenation.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        "string"
+      RUBY
+    end
+  end
+
   context 'on adjacent string literals on different lines' do
     it 'does not register an offense' do
       expect_no_offenses(<<~'RUBY')


### PR DESCRIPTION
Fixes #13316.

This PR fixes an incorrect autocorrect for `Lint/ImplicitStringConcatenation` with `Lint/TripleQuotes` when string literals with triple quotes are used.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
