### PR TITLE
[Fix #13319] Handle literal forward slashes inside a `regexp` in `Lint/LiteralInInterpolation`

### DIFF
--- a/changelog/fix_handle_literal_forward_slashes_inside_a_regexp_in.md
+++ b/changelog/fix_handle_literal_forward_slashes_inside_a_regexp_in.md
@@ -1,0 +1,1 @@
+* [#13319](https://github.com/rubocop/rubocop/issues/13319): Handle literal forward slashes inside a `regexp` in `Lint/LiteralInInterpolation`. ([@dvandersluis][])

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -423,4 +423,89 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation, :config do
       RUBY
     end
   end
+
+  context 'handling regexp special characters' do
+    context 'when inside a `regexp` literal' do
+      it 'properly escapes a forward slash' do
+        expect_offense(<<~'RUBY')
+          /test#{'/'}test/
+                 ^^^ Literal interpolation detected.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          /test\/test/
+        RUBY
+      end
+
+      it 'properly escapes multiple forward slashes' do
+        expect_offense(<<~'RUBY')
+          /test#{'/a/b/c/'}test/
+                 ^^^^^^^^^ Literal interpolation detected.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          /test\/a\/b\/c\/test/
+        RUBY
+      end
+
+      it 'handles escaped forward slashes' do
+        expect_offense(<<~'RUBY')
+          /test#{'\\/'}test/
+                 ^^^^^ Literal interpolation detected.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          /test\/test/
+        RUBY
+      end
+
+      it 'handles escaped backslashes' do
+        expect_offense(<<~'RUBY')
+          /test#{'\\\\/'}test/
+                 ^^^^^^^ Literal interpolation detected.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          /test\\\/test/
+        RUBY
+      end
+
+      it 'handles slashes inside other non-strings' do
+        expect_offense(<<~'RUBY')
+          /test#{%w[/ \\]}test/
+                 ^^^^^^^^ Literal interpolation detected.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          /test[\"\/\", \"\\\\\"]test/
+        RUBY
+      end
+    end
+
+    context 'when inside a %r{} `regexp`' do
+      it 'does not escape the autocorrection' do
+        expect_offense(<<~'RUBY')
+          %r{test#{'/'}test}
+                   ^^^ Literal interpolation detected.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          %r{test/test}
+        RUBY
+      end
+    end
+
+    context 'when inside a non-`regexp` node' do
+      it 'does not escape the autocorrection' do
+        expect_offense(<<~'RUBY')
+          "test#{'/'}test"
+                 ^^^ Literal interpolation detected.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          "test/test"
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Handle interpolation of forward slashes inside a regexp. They must be escaped or else the resulting regexp will be a syntax error.

Fixes #13319.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
