### PR TITLE
[Fix #13318] Prevent modifying blocks with `Style/HashEachMethods` if the hash is modified within the block

### DIFF
--- a/changelog/fix_prevent_modifying_blocks_with.md
+++ b/changelog/fix_prevent_modifying_blocks_with.md
@@ -1,0 +1,1 @@
+* [#13318](https://github.com/rubocop/rubocop/issues/13318): Prevent modifying blocks with `Style/HashEachMethods` if the hash is modified within the block. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -57,6 +57,11 @@ module RuboCop
           (call $(call _ ${:keys :values}) :each (block_pass (sym _)))
         PATTERN
 
+        # @!method hash_mutated?(node, receiver)
+        def_node_matcher :hash_mutated?, <<~PATTERN
+          `(send %1 :[]= ...)
+        PATTERN
+
         def on_block(node)
           return unless handleable?(node)
 
@@ -103,6 +108,7 @@ module RuboCop
         def handleable?(node)
           return false if use_array_converter_method_as_preceding?(node)
           return false unless (root_receiver = root_receiver(node))
+          return false if hash_mutated?(node, root_receiver)
 
           !root_receiver.literal? || root_receiver.hash_type?
         end


### PR DESCRIPTION
If `keys.each` or `values.each` block that modifies the original hash is changed to `each_key` or `each_value`, it results in `RuntimeError: can't add a new key into hash during iteration`.

This change updates `Style/HashEachMethods` to not register an offense in these cases.

Fixes #13318.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
