### PR TITLE
Fix the autocorrect of non_atomic_file_operation

### DIFF
--- a/changelog/fix_the_autocorrect_of_non_atomic_file_operation.md
+++ b/changelog/fix_the_autocorrect_of_non_atomic_file_operation.md
@@ -1,0 +1,1 @@
+* [#13325](https://github.com/rubocop/rubocop/pull/13325): Fix an incorrect autocorrect for `Lint/NonAtomicFileOperation` when using a postfix `unless` for file existence checks before creating a file, in cases with `Dir.mkdir`. ([@kotaro0522][])

--- a/lib/rubocop/cop/lint/non_atomic_file_operation.rb
+++ b/lib/rubocop/cop/lint/non_atomic_file_operation.rb
@@ -134,6 +134,7 @@ module RuboCop
 
           corrector.replace(node.child_nodes.first.loc.name, 'FileUtils')
           corrector.replace(node.loc.selector, replacement_method(node))
+          corrector.insert_before(node.last_argument, 'mode: ') if require_mode_keyword?(node)
         end
 
         def replacement_method(node)
@@ -150,6 +151,12 @@ module RuboCop
 
         def force_method?(node)
           force_method_name?(node) || force_option?(node)
+        end
+
+        def require_mode_keyword?(node)
+          return false unless node.receiver.const_name == 'Dir'
+
+          replacement_method(node) == 'mkdir_p' && node.arguments.length == 2
         end
 
         def force_option?(node)

--- a/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
+++ b/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
@@ -190,6 +190,30 @@ RSpec.describe RuboCop::Cop::Lint::NonAtomicFileOperation, :config do
     RUBY
   end
 
+  it 'registers an offense when use file existence checks `unless` by postfix before creating file while Dir.mkdir has 2 arguments' do
+    expect_offense(<<~RUBY)
+      Dir.mkdir(path, 0o0755) unless Dir.exist?(path)
+                              ^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary existence check `Dir.exist?`.
+      ^^^^^^^^^^^^^^^^^^^^^^^ Use atomic file operation method `FileUtils.mkdir_p`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      FileUtils.mkdir_p(path, mode: 0o0755)
+    RUBY
+  end
+
+  it 'registers an offense when use file existence checks `unless` by postfix before creating file while Dir.mkdir has an argument' do
+    expect_offense(<<~RUBY)
+      Dir.mkdir(path) unless Dir.exist?(path)
+                      ^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary existence check `Dir.exist?`.
+      ^^^^^^^^^^^^^^^ Use atomic file operation method `FileUtils.mkdir_p`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      FileUtils.mkdir_p(path)
+    RUBY
+  end
+
   it 'registers an offense when use file existence checks `if` by postfix before removing file' do
     expect_offense(<<~RUBY)
       FileUtils.remove(path) if FileTest.exist?(path)


### PR DESCRIPTION
The Dir.mkdir method can take two arguments (path and mode) without using keywords.
However, the FileUtils.mkdir_p method requires the keyword mode: before the argument.
This PR fixes an issue where the autocorrect feature would not work correctly in such situations.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x]  Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
