### PR TITLE
Make server mode aware of auto-restart for .rubocop_todo.yml update

### DIFF
--- a/changelog/change_make_server_mode_aware_of_auto_restart_for_rubocop_todo_update.md
+++ b/changelog/change_make_server_mode_aware_of_auto_restart_for_rubocop_todo_update.md
@@ -1,0 +1,1 @@
+* [#13327](https://github.com/rubocop/rubocop/pull/13327): Make server mode aware of auto-restart for .rubocop_todo.yml update. ([@koic][])

--- a/docs/modules/ROOT/pages/usage/server.adoc
+++ b/docs/modules/ROOT/pages/usage/server.adoc
@@ -49,7 +49,7 @@ user             16060   0.0  0.0  5078568   2264   ??  S     7:54AM   0:00.00 r
 user             16337   0.0  0.0  5331560   2396   ??  S    23:51PM   0:00.00 rubocop --server /Users/user/src/github.com/rubocop/rubocop-rails
 ```
 
-When you run `bundle update` or update a local config file (e.g., `.rubocop.yml`), and then run `rubocop`, the server process will automatically restart.
+When you run `bundle update` or update a local config file (e.g., `.rubocop.yml` or `.rubocop_todo.yml`), and then run `rubocop`, the server process will automatically restart.
 
 ```console
 $ rubocop --server

--- a/lib/rubocop/server/cache.rb
+++ b/lib/rubocop/server/cache.rb
@@ -43,15 +43,18 @@ module RuboCop
           @project_dir_cache_key ||= project_dir[1..].tr('/', '+')
         end
 
+        # rubocop:disable Metrics/AbcSize
         def restart_key
           lockfile_path = LOCKFILE_NAMES.map do |lockfile_name|
             Pathname(project_dir).join(lockfile_name)
           end.find(&:exist?)
           version_data = lockfile_path&.read || RuboCop::Version::STRING
           config_data = Pathname(ConfigFinder.find_config_path(Dir.pwd)).read
+          todo_data = (rubocop_todo = Pathname('.rubocop_todo.yml')).exist? ? rubocop_todo.read : ''
 
-          Digest::SHA1.hexdigest(version_data + config_data)
+          Digest::SHA1.hexdigest(version_data + config_data + todo_data)
         end
+        # rubocop:enable Metrics/AbcSize
 
         def dir
           Pathname.new(File.join(cache_path, project_dir_cache_key)).tap do |d|

--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
 
         options = '--server --only Style/FrozenStringLiteralComment,Style/StringLiterals'
         expect(`ruby -I . "#{rubocop}" #{options}`).to start_with('RuboCop server starting on')
-        # Emulating the SHA1 value of Gemfile.lock and .rubocop.yml.
+        # Emulating the SHA1 value of Gemfile.lock, .rubocop.yml, and .rubocop_todo.yml.
         RuboCop::Server::Cache.write_version_file('615dfedabfe01face6557b935510309ae550f74f')
 
         expect(`ruby -I . "#{rubocop}" --server-status`).to match(/RuboCop server .* is running/)


### PR DESCRIPTION
Follow up #13233.

This PR makes server mode aware of auto-restart for .rubocop_todo.yml update. Similar to .rubocop.yml, updates to the default configuration file .rubocop_todo.yml can also trigger a server mode restart."

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
