### PR TITLE
[Fix #13331] Fix an error when using release task

### DIFF
--- a/lib/rubocop/cops_documentation_generator.rb
+++ b/lib/rubocop/cops_documentation_generator.rb
@@ -7,7 +7,7 @@ require 'fileutils'
 class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
   include ::RuboCop::Cop::Documentation
   CopData = Struct.new(
-    :cop, :description, :example_objects, :safety_objects, :see_objects, :config
+    :cop, :description, :example_objects, :safety_objects, :see_objects, :config, keyword_init: true
   )
 
   STRUCTURE = {


### PR DESCRIPTION
Fixes #13331.

This PR fixes an error when using release task.

In Ruby 3.2 and later, this does not result in an error, but in Ruby 3.1 and earlier, the following error occurs.

```console
$ ruby -v
ruby 3.1.5p252 (2024-04-23 revision 1945f8dc0e) [x86_64-darwin23]

$ bundle exec rake cut_release:minor
Files:         687
Modules:        92 (   13 undocumented)
Classes:       649 (    4 undocumented)
Constants:    1197 ( 1181 undocumented)
Attributes:     37 (    0 undocumented)
Methods:      1504 ( 1309 undocumented)
 27.94% documented
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cops_documentation_generator.rb:321:
warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2.
Please use a Hash literal like .new({k: v}) instead of .new(k: v).
rake aborted!
NoMethodError: undefined method `none?' for nil:NilClass

    return if example_objects.none?
                             ^^^^^^
```

This is due to a change in the behavior of `Struct` in Ruby 3.2. To maintain compatibility with Ruby 3.1 and earlier, `keyword_init: true` is required.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
