### PR TITLE
Fix test failures caused by changes to the rubocop version

### DIFF
--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -32,8 +32,10 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
 
         options = '--server --only Style/FrozenStringLiteralComment,Style/StringLiterals'
         expect(`ruby -I . "#{rubocop}" #{options}`).to start_with('RuboCop server starting on')
-        # Emulating the SHA1 value of Gemfile.lock, .rubocop.yml, and .rubocop_todo.yml.
-        RuboCop::Server::Cache.write_version_file('615dfedabfe01face6557b935510309ae550f74f')
+
+        # Emulate the server starting with an older RuboCop version.
+        stub_const('RuboCop::Version::STRING', '0.0.1')
+        RuboCop::Server::Cache.write_version_file(RuboCop::Server::Cache.restart_key)
 
         expect(`ruby -I . "#{rubocop}" --server-status`).to match(/RuboCop server .* is running/)
         _stdout, stderr, _status = Open3.capture3("ruby -I . \"#{rubocop}\" #{options}")
@@ -218,8 +220,8 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
           match(/RuboCop server .* is running/), debug_output.join("\n")
         )
 
-        # Emulating the SHA1 value of Gemfile.lock and .rubocop.yml.
-        RuboCop::Server::Cache.write_version_file('f63c8f29b26472dae07bfa80c13a6f658361893d')
+        # Recompute the cache key with the modified .rubocop.yml content.
+        RuboCop::Server::Cache.write_version_file(RuboCop::Server::Cache.restart_key)
 
         message = expect(`ruby -I . "#{rubocop}" --server`)
         message.not_to start_with('RuboCop server starting on '), debug_output.join("\n")


### PR DESCRIPTION
These hashses are tied to the rubocop version, which means that a version bump will change these as well.

The first test previously passes since it relies on a changed hash, which it was always.
For the second test the hash must match when computed in the server.

Since the cache key is not cached itself, compute it again when preconditions changed instead of hardcoding it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
