### PR TITLE
[Fix #13336] Update `Style/SafeNavigation` to not autocorrect if the RHS of an `and` node is an `or` node

### DIFF
--- a/changelog/fix_update_style_safe_navigation_to_not_autocorrect_if.md
+++ b/changelog/fix_update_style_safe_navigation_to_not_autocorrect_if.md
@@ -1,0 +1,1 @@
+* [#13336](https://github.com/rubocop/rubocop/issues/13336): Update `Style/SafeNavigation` to not autocorrect if the RHS of an `and` node is an `or` node. ([@dvandersluis][])


### PR DESCRIPTION
Updates `Style/SafeNavigation` to register an offense but not autocorrect code in the form

```
foo && (foo.bar? || (foo.baz? && foo.quux?))
```

Fixes #13336.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
