### PR TITLE
[Fix #13337] Fix false positives for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_line_continuation.md
+++ b/changelog/fix_false_positives_for_style_redundant_line_continuation.md
@@ -1,0 +1,1 @@
+* [#13337](https://github.com/rubocop/rubocop/issues/13337): Fix false positives for `Style/RedundantLineContinuation` when required line continuations for `&&` is used with an assignment after a line break. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -125,7 +125,10 @@ module RuboCop
           return true unless (node = find_node_for_line(range.last_line))
           return false if argument_newline?(node)
 
-          source = node.parent ? node.parent.source : node.source
+          source = node.source
+          while (node = node.parent)
+            source = node.source
+          end
           parse(source.gsub("\\\n", "\n")).valid_syntax?
         end
 

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -206,6 +206,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'does not register an offense when required line continuations for `&&` is used with an assignment after a line break' do
+    expect_no_offenses(<<~'RUBY')
+      if foo \
+        && (bar = baz)
+      end
+    RUBY
+  end
+
   it 'does not register an offense when required line continuations for multiline leading dot method chain with an empty line' do
     expect_no_offenses(<<~'RUBY')
       obj


### PR DESCRIPTION
Fixes #13337.

This PR fixes false positives for `Style/RedundantLineContinuation` when a line continuation starts with `&&` and an assignment is used after a line break.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
