### PR TITLE
[Fix #13341] Fix false positives for `Lint/SafeNavigationChain`

### DIFF
--- a/changelog/fix_false_positves_for_lint_safe_navigation_chain.md
+++ b/changelog/fix_false_positves_for_lint_safe_navigation_chain.md
@@ -1,0 +1,1 @@
+* [#13341](https://github.com/rubocop/rubocop/issues/13341): Fix false positives for `Lint/SafeNavigationChain` when a safe navigation operator is used with a method call as the RHS operand of `&&` for the same receiver. ([@koic][])

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -38,6 +38,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return unless require_safe_navigation?(node)
+
           bad_method?(node) do |safe_nav, method|
             return if nil_methods.include?(method) || PLUS_MINUS_METHODS.include?(node.method_name)
 
@@ -51,6 +53,13 @@ module RuboCop
         end
 
         private
+
+        def require_safe_navigation?(node)
+          parent = node.parent
+          return true unless parent&.and_type?
+
+          parent.rhs != node || parent.lhs.receiver != parent.rhs.receiver
+        end
 
         # @param [Parser::Source::Range] offense_range
         # @param [RuboCop::AST::SendNode] send_node

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -171,6 +171,68 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
       RUBY
     end
 
+    it 'registers an offense when a safe navigation operator is used with a method call as both the LHS and RHS operands of `&&` for the same receiver' do
+      expect_offense(<<~RUBY)
+        x&.foo.bar && x&.foo.baz
+              ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.foo&.bar && x&.foo.baz
+      RUBY
+    end
+
+    it 'does not register an offense when a safe navigation operator is used with a method call as the RHS operand of `&&` for the same receiver' do
+      expect_no_offenses(<<~RUBY)
+        x&.foo&.bar && x&.foo.baz
+      RUBY
+    end
+
+    it 'registers an offense when a safe navigation operator is used with a method call as the RHS operand of `&&` for a different receiver' do
+      expect_offense(<<~RUBY)
+        x&.foo&.bar && y&.foo.baz
+                             ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.foo&.bar && y&.foo&.baz
+      RUBY
+    end
+
+    it 'registers an offense when a safe navigation operator is used with a method call as both the LHS and RHS operands of `||` for the same receiver' do
+      expect_offense(<<~RUBY)
+        x&.foo.bar || x&.foo.baz
+                            ^^^^ Do not chain ordinary method call after safe navigation operator.
+              ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.foo&.bar || x&.foo&.baz
+      RUBY
+    end
+
+    it 'registers an offense when a safe navigation operator is used with a method call as the RHS operand of `||` for the same receiver' do
+      expect_offense(<<~RUBY)
+        x&.foo&.bar || x&.foo.baz
+                             ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.foo&.bar || x&.foo&.baz
+      RUBY
+    end
+
+    it 'registers an offense when a safe navigation operator is used with a method call as the RHS operand of `||` for a different receiver' do
+      expect_offense(<<~RUBY)
+        x&.foo&.bar || y&.foo.baz
+                             ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.foo&.bar || y&.foo&.baz
+      RUBY
+    end
+
     it 'registers an offense for safe navigation with a method call as an expression of `&&` operand' do
       expect_offense(<<~RUBY)
         do_something && x&.foo.bar


### PR DESCRIPTION
Fixes #13341.

This PR fixes false positives for `Lint/SafeNavigationChain` when a safe navigation operator is used with a method call as the RHS operand of `&&` for the same receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
