### PR TITLE
[Fix #13343] Prevent `Layout/LineLength` from breaking up a method with arguments chained onto a heredoc delimiter

### DIFF
--- a/changelog/fix_prevent_layout_line_length_from_breaking_up_a.md
+++ b/changelog/fix_prevent_layout_line_length_from_breaking_up_a.md
@@ -1,0 +1,1 @@
+* [#13343](https://github.com/rubocop/rubocop/issues/13343): Prevent `Layout/LineLength` from breaking up a method with arguments chained onto a heredoc delimiter. ([@dvandersluis][])

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -44,6 +44,8 @@ module RuboCop
     module CheckLineBreakable
       def extract_breakable_node(node, max)
         if node.send_type?
+          return if chained_to_heredoc?(node)
+
           args = process_args(node.arguments)
           return extract_breakable_node_from_elements(node, args, max)
         elsif node.def_type?
@@ -221,6 +223,14 @@ module RuboCop
         return node.first_line != node.last_argument.last_line if node.def_type?
 
         !node.single_line?
+      end
+
+      def chained_to_heredoc?(node)
+        while (node = node.receiver)
+          return true if (node.str_type? || node.dstr_type? || node.xstr_type?) && node.heredoc?
+        end
+
+        false
       end
     end
   end

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -1204,6 +1204,41 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           expect_no_corrections
         end
       end
+
+      context 'when HEREDOC start delimiter has a chained method with arguments that go over limit' do
+        it 'adds offense and does not autocorrect' do
+          expect_offense(<<~RUBY)
+            str = <<~HEREDOC.do_something.with_args(foo: '', bar: '', baz: '')
+                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [66/40]
+              text
+            HEREDOC
+          RUBY
+
+          expect_no_corrections
+        end
+
+        it 'adds offense and does not autocorrect for `dstr`' do
+          expect_offense(<<~'RUBY')
+            str = <<~HEREDOC.do_something.with_args(foo: '', bar: '', baz: '')
+                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [66/40]
+              #{text}
+            HEREDOC
+          RUBY
+
+          expect_no_corrections
+        end
+
+        it 'adds offense and does not autocorrect for `xstr`' do
+          expect_offense(<<~RUBY)
+            str = <<~`HEREDOC`.do_something.with_args(foo: '', bar: '', baz: '')
+                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [68/40]
+              text
+            HEREDOC
+          RUBY
+
+          expect_no_corrections
+        end
+      end
     end
 
     context 'comments' do


### PR DESCRIPTION
If a method chain starting with a heredoc goes over the line length limit, breaking it onto multiple lines is a syntax error. This prevents the autocorrection that would do so.

```ruby
str = <<~HEREDOC.do_something.with_args(foo: '', bar: '', baz: '')
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [66/40]
  text
HEREDOC
```

Fixes #13343.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
