### PR TITLE
[Fix #13324] Fix `--disable-uncorrectable` to not insert a comment inside a string continuation

### DIFF
--- a/changelog/fix_fix_disable_uncorrectable_to_not_insert_a_comment.md
+++ b/changelog/fix_fix_disable_uncorrectable_to_not_insert_a_comment.md
@@ -1,0 +1,1 @@
+* [#13324](https://github.com/rubocop/rubocop/issues/13324): Fix `--disable-uncorrectable` to not insert a comment inside a string continuation. ([@dvandersluis][])


### PR DESCRIPTION
With the following code and `--disable-uncorrectable` specified:

```ruby
{
  key1: "something",
  key1: "whatever"\
    "something else",
}
```

Previously RuboCop corrected to a syntax error:

```ruby
{
  key1: "something",
  key1: "whatever"\ # rubocop:todo Lint/DuplicateHashKey
    "something else",
}
```

With this correction, RuboCop uses the block form of `todo` instead:

```ruby
{
  key1: 'something',
  # rubocop:todo Lint/DuplicateHashKey
  key1: 'whatever'\
    'something else'
  # rubocop:enable Lint/DuplicateHashKey
}
```

Fixes #13324.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
