### PR TITLE
[Fix #13348] Ensure `Style/BlockDelimiters` autocorrection does not move other code between the block and comment

### DIFF
--- a/changelog/fix_ensure_style_block_delimiters_autocorrection_does.md
+++ b/changelog/fix_ensure_style_block_delimiters_autocorrection_does.md
@@ -1,0 +1,1 @@
+* [#13348](https://github.com/rubocop/rubocop/issues/13348): Ensure `Style/BlockDelimiters` autocorrection does not move other code between the block and comment. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -455,11 +455,10 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
           }] # comment
         RUBY
 
-        expect_correction(<<~RUBY.chop)
+        expect_correction(<<~RUBY)
           [# comment
           foo do
-          end
-          ]#{trailing_whitespace}
+          end]
         RUBY
       end
 
@@ -628,6 +627,20 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
           my_method :arg1, arg2: proc {
             something
           }, arg3: :another_value
+        RUBY
+      end
+
+      it 'handles a multiline {} block with trailing comment' do
+        expect_offense(<<~RUBY)
+          my_method { |x|
+                    ^ Avoid using `{...}` for multi-line blocks.
+            x.foo } unless bar   # comment
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # comment
+          my_method do |x|
+            x.foo end unless bar
         RUBY
       end
     end


### PR DESCRIPTION
When `Style/BlockDelimiters` autocorrects `{...}` to `do...end` with a trailing comment, it previously would insert a newline after the end of the `block` range, but in the cases where additional code follows on that line, it could change semantics or even cause a syntax error. This change ensures that that code is retained on the same line as the end of the block.

Fixes #13348.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
