### PR TITLE
Consistently spell "Ruby" in `rubocop -V`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,7 +38,7 @@ output by `rubocop -V`, include them as well. Here's an example:
 
 ```
 $ [bundle exec] rubocop -V
-1.67.0 (using Parser 3.3.5.0, rubocop-ast 1.32.3, analyzing as Ruby 3.3, running on ruby 3.3.5) [x86_64-linux]
+1.67.0 (using Parser 3.3.5.0, rubocop-ast 1.32.3, analyzing as Ruby 3.3, running on Ruby 3.3.5) [x86_64-linux]
   - rubocop-performance 1.22.1
   - rubocop-rspec 3.1.0
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ do so.
 
 ```console
 $ rubocop -V
-1.67.0 (using Parser 3.3.5.0, rubocop-ast 1.32.3, analyzing as Ruby 3.3, running on ruby 3.3.5) [x86_64-linux]
+1.67.0 (using Parser 3.3.5.0, rubocop-ast 1.32.3, analyzing as Ruby 3.3, running on Ruby 3.3.5) [x86_64-linux]
   - rubocop-performance 1.22.1
   - rubocop-rspec 3.1.0
 ```

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -17,14 +17,17 @@ module RuboCop
     EXTENSION_PATH_NAMES = {
       'rubocop-md' => 'markdown', 'rubocop-factory_bot' => 'factory_bot'
     }.freeze
+    ENGINE_NAMES = { 'ruby' => 'Ruby', 'jruby' => 'JRuby' }.freeze
 
+    # rubocop:disable Metrics/MethodLength
     # @api private
     def self.version(debug: false, env: nil)
       if debug
         verbose_version = format(MSG, version: STRING, parser_version: parser_version,
                                       rubocop_ast_version: RuboCop::AST::Version::STRING,
                                       target_ruby_version: TargetRuby.new(Config.new).version,
-                                      ruby_engine: RUBY_ENGINE, ruby_version: RUBY_VERSION,
+                                      ruby_engine: ENGINE_NAMES.fetch(RUBY_ENGINE, RUBY_ENGINE),
+                                      ruby_version: RUBY_VERSION,
                                       server_mode: server_mode,
                                       ruby_platform: RUBY_PLATFORM)
         return verbose_version unless env
@@ -40,6 +43,7 @@ module RuboCop
         STRING
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     # @api private
     def self.parser_version


### PR DESCRIPTION
This is incredibly minor but since the running ruby version was added they are now cased in two different ways.
There doesn't seem to be a constant that contains the proper spelling, so I just added something for lookup.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
