### PR TITLE
[Fix #13356] Fix a false positive for `Layout/SpaceBeforeBrackets` when there is a dot before `[]=`

### DIFF
--- a/changelog/fix_false_positive_space_before_brackets.md
+++ b/changelog/fix_false_positive_space_before_brackets.md
@@ -1,0 +1,1 @@
+* [#13356](https://github.com/rubocop/rubocop/issues/13356): Fix a false positive for `Layout/SpaceBeforeBrackets` when there is a dot before `[]=`. ([@earlopain][])

--- a/lib/rubocop/cop/layout/space_before_brackets.rb
+++ b/lib/rubocop/cop/layout/space_before_brackets.rb
@@ -33,12 +33,12 @@ module RuboCop
         private
 
         def offense_range(node, begin_pos)
-          if reference_variable_with_brackets?(node)
-            receiver_end_pos = node.receiver.source_range.end_pos
-            selector_begin_pos = node.loc.selector.begin_pos
-            return if receiver_end_pos >= selector_begin_pos
-            return if dot_before_brackets?(node, receiver_end_pos, selector_begin_pos)
+          receiver_end_pos = node.receiver.source_range.end_pos
+          selector_begin_pos = node.loc.selector.begin_pos
+          return if receiver_end_pos >= selector_begin_pos
+          return if dot_before_brackets?(node, receiver_end_pos, selector_begin_pos)
 
+          if reference_variable_with_brackets?(node)
             range_between(receiver_end_pos, selector_begin_pos)
           elsif node.method?(:[]=)
             offense_range_for_assignment(node, begin_pos)

--- a/spec/rubocop/cop/layout/space_before_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_brackets_spec.rb
@@ -108,6 +108,12 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBrackets, :config do
         @@collection.[](index_or_key)
       RUBY
     end
+
+    it 'does not register an offense when call desugared `Hash#[]=`' do
+      expect_no_offenses(<<~RUBY)
+        collection.[]=(index_or_key, value)
+      RUBY
+    end
   end
 
   context 'when assigning' do


### PR DESCRIPTION
In addition to checking `[]`, `[]=` must also be considered. Followup to #10575

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
