### PR TITLE
Add AllowSteepAnnotation option to Layout/LeadingCommentSpace

### DIFF
--- a/changelog/new_allow_steep_annotation_option.md
+++ b/changelog/new_allow_steep_annotation_option.md
@@ -1,0 +1,1 @@
+* [#13360](https://github.com/rubocop/rubocop/pull/13360): Add `AllowSteepAnnotation` config option to `Layout/LeadingCommentSpace`. ([@tk0miya][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1038,6 +1038,7 @@ Layout/LeadingCommentSpace:
   AllowDoxygenCommentStyle: false
   AllowGemfileRubyComment: false
   AllowRBSInlineAnnotation: false
+  AllowSteepAnnotation: false
 
 Layout/LeadingEmptyLines:
   Description: Check for unnecessary blank lines at the beginning of a file.

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -259,4 +259,44 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
       end
     end
   end
+
+  describe 'Steep annotation' do
+    context 'when config option is disabled' do
+      let(:cop_config) { { 'AllowSteepAnnotation' => false } }
+
+      it 'registers an offense and corrects using Steep annotation' do
+        expect_offense(<<~RUBY)
+          [1, 2, 3].each_with_object([]) do |n, list| #$ Array[Integer]
+                                                      ^^^^^^^^^^^^^^^^^ Missing space after `#`.
+            list << n
+          end
+
+          name = 'John'      #: String
+                             ^^^^^^^^^ Missing space after `#`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [1, 2, 3].each_with_object([]) do |n, list| # $ Array[Integer]
+            list << n
+          end
+
+          name = 'John'      # : String
+        RUBY
+      end
+    end
+
+    context 'when config option is enabled' do
+      let(:cop_config) { { 'AllowSteepAnnotation' => true } }
+
+      it 'does not register an offense when using Steep annotation' do
+        expect_no_offenses(<<~RUBY)
+          [1, 2, 3].each_with_object([]) do |n, list| #$ Array[Integer]
+            list << n
+          end
+
+          name = 'John'      #: String
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Steep](https://github.com/soutaro/steep) is a type checker for Ruby.

The new option; `AllowSteepAnnotation` for `Layout/LeadingCommentSpace` allows to use Steep's annotation comments in the Ruby code.

refs: https://github.com/soutaro/steep/wiki/Release-Note-1.3#add-type-assertion-and-type-application-syntax

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
