### PR TITLE
Fix false positives for `Style/RedundantInterpolationUnfreeze` and `Style/RedundantFreeze` with variable interpolation

### DIFF
--- a/changelog/fix_interpolated_string_detection.md
+++ b/changelog/fix_interpolated_string_detection.md
@@ -1,0 +1,1 @@
+* [#13361](https://github.com/rubocop/rubocop/issues/13361): Fix false positives for `Style/RedundantInterpolationUnfreeze` and `Style/RedundantFreeze` when strings contain interpolated global, instance, and class variables. ([@vlad-pisanov][])

--- a/lib/rubocop/cop/mixin/frozen_string_literal.rb
+++ b/lib/rubocop/cop/mixin/frozen_string_literal.rb
@@ -29,7 +29,9 @@ module RuboCop
       end
 
       def uninterpolated_string?(node)
-        node.str_type? || (node.dstr_type? && node.each_descendant(:begin).none?)
+        node.str_type? || (
+          node.dstr_type? && node.each_descendant(:begin, :ivar, :cvar, :gvar).none?
+        )
       end
 
       def uninterpolated_heredoc?(node)

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -38,6 +38,9 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze, :config do
   it_behaves_like 'mutable objects', '{ a: 1, b: 2 }'
   it_behaves_like 'mutable objects', "'str'"
   it_behaves_like 'mutable objects', '"top#{1 + 2}"'
+  it_behaves_like 'mutable objects', '"top#@foo"'
+  it_behaves_like 'mutable objects', '"top#@@foo"'
+  it_behaves_like 'mutable objects', '"top#$foo"'
   it_behaves_like 'mutable objects', "('a' + 'b')"
   it_behaves_like 'mutable objects', "('a' * 20)"
   it_behaves_like 'mutable objects', '(a + b)'
@@ -103,18 +106,27 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze, :config do
 
         context 'when the frozen string literal comment is missing' do
           it_behaves_like 'immutable objects', '"#{a}"'
+          it_behaves_like 'immutable objects', '"#@a"'
+          it_behaves_like 'immutable objects', '"#@@a"'
+          it_behaves_like 'immutable objects', '"#$a"'
         end
 
         context 'when the frozen string literal comment is true' do
           let(:prefix) { '# frozen_string_literal: true' }
 
           it_behaves_like 'immutable objects', '"#{a}"'
+          it_behaves_like 'immutable objects', '"#@a"'
+          it_behaves_like 'immutable objects', '"#@@a"'
+          it_behaves_like 'immutable objects', '"#$a"'
         end
 
         context 'when the frozen string literal comment is false' do
           let(:prefix) { '# frozen_string_literal: false' }
 
           it_behaves_like 'immutable objects', '"#{a}"'
+          it_behaves_like 'immutable objects', '"#@a"'
+          it_behaves_like 'immutable objects', '"#@@a"'
+          it_behaves_like 'immutable objects', '"#$a"'
         end
       end
     end
@@ -122,36 +134,54 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze, :config do
     context 'Ruby 3.0 or higher', :ruby30 do
       context 'when the frozen string literal comment is missing' do
         it_behaves_like 'mutable objects', '"#{a}"'
+        it_behaves_like 'mutable objects', '"#@a"'
+        it_behaves_like 'mutable objects', '"#@@a"'
+        it_behaves_like 'mutable objects', '"#$a"'
       end
 
       context 'when the frozen string literal comment is true' do
         let(:prefix) { '# frozen_string_literal: true' }
 
         it_behaves_like 'mutable objects', '"#{a}"'
+        it_behaves_like 'mutable objects', '"#@a"'
+        it_behaves_like 'mutable objects', '"#@@a"'
+        it_behaves_like 'mutable objects', '"#$a"'
       end
 
       context 'when the frozen string literal comment is false' do
         let(:prefix) { '# frozen_string_literal: false' }
 
         it_behaves_like 'mutable objects', '"#{a}"'
+        it_behaves_like 'mutable objects', '"#@a"'
+        it_behaves_like 'mutable objects', '"#@@a"'
+        it_behaves_like 'mutable objects', '"#$a"'
       end
     end
 
     context 'Ruby 2.7 or lower', :ruby27, unsupported_on: :prism do
       context 'when the frozen string literal comment is missing' do
         it_behaves_like 'mutable objects', '"#{a}"'
+        it_behaves_like 'mutable objects', '"#@a"'
+        it_behaves_like 'mutable objects', '"#@@a"'
+        it_behaves_like 'mutable objects', '"#$a"'
       end
 
       context 'when the frozen string literal comment is true' do
         let(:prefix) { '# frozen_string_literal: true' }
 
         it_behaves_like 'immutable objects', '"#{a}"'
+        it_behaves_like 'immutable objects', '"#@a"'
+        it_behaves_like 'immutable objects', '"#@@a"'
+        it_behaves_like 'immutable objects', '"#$a"'
       end
 
       context 'when the frozen string literal comment is false' do
         let(:prefix) { '# frozen_string_literal: false' }
 
         it_behaves_like 'mutable objects', '"#{a}"'
+        it_behaves_like 'mutable objects', '"#@a"'
+        it_behaves_like 'mutable objects', '"#@@a"'
+        it_behaves_like 'mutable objects', '"#$a"'
       end
     end
 

--- a/spec/rubocop/cop/style/redundant_interpolation_unfreeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_interpolation_unfreeze_spec.rb
@@ -52,6 +52,39 @@ RSpec.describe RuboCop::Cop::Style::RedundantInterpolationUnfreeze, :config do
       RUBY
     end
 
+    it 'registers an offense for interpolated strings with global variables' do
+      expect_offense(<<~'RUBY')
+        +"#$var"
+        ^ Don't unfreeze interpolated strings as they are already unfrozen.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "#$var"
+      RUBY
+    end
+
+    it 'registers an offense for strings with interpolated instance variables' do
+      expect_offense(<<~'RUBY')
+        +"#@var"
+        ^ Don't unfreeze interpolated strings as they are already unfrozen.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "#@var"
+      RUBY
+    end
+
+    it 'registers an offense for strings with interpolated class variables' do
+      expect_offense(<<~'RUBY')
+        +"#@@var"
+        ^ Don't unfreeze interpolated strings as they are already unfrozen.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "#@@var"
+      RUBY
+    end
+
     it 'registers an offense for interpolated heredoc with `dup`' do
       expect_offense(<<~'RUBY')
         foo(<<~MSG.dup)


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/13361

Adds support for the (less common) variable interpolation syntax:
```ruby
"#$global_var"
"#@instance_var"
"#@@class_var"
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
