### PR TITLE
[Doc] Fix the broken example in the `Metrics/CyclomaticComplexity` document

### DIFF
--- a/lib/rubocop/cop/metrics/cyclomatic_complexity.rb
+++ b/lib/rubocop/cop/metrics/cyclomatic_complexity.rb
@@ -14,11 +14,14 @@ module RuboCop
       # and ||/or is shorthand for a sequence of ifs, so they also add one.
       # Loops can be said to have an exit condition, so they add one.
       # Blocks that are calls to builtin iteration methods
-      # (e.g. `ary.map{...}) also add one, others are ignored.
+      # (e.g. `ary.map{...}`) also add one, others are ignored.
+      #
+      # @example
       #
       #   def each_child_node(*types)               # count begins: 1
       #     unless block_given?                     # unless: +1
       #       return to_enum(__method__, *types)
+      #     end
       #
       #     children.each do |child|                # each{}: +1
       #       next unless child.is_a?(Node)         # unless: +1


### PR DESCRIPTION
This PR fixes the display of the broken example in the `Metrics/CyclomaticComplexity` document.
https://docs.rubocop.org/rubocop/cops_metrics.html#metricscyclomaticcomplexity

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
