### PR TITLE
[Fix #13365] Fix false positives for `Lint/SafeNavigationConsistency`

### DIFF
--- a/changelog/fix_false_positives_for_lint_safe_navigation_consistency.md
+++ b/changelog/fix_false_positives_for_lint_safe_navigation_consistency.md
@@ -1,0 +1,1 @@
+* [#13365](https://github.com/rubocop/rubocop/issues/13365): Fix false positives for `Lint/SafeNavigationConsistency` when using safe navigation on the LHS with operator method on the RHS of `&&`. ([@koic][])

--- a/lib/rubocop/cop/lint/safe_navigation_consistency.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_consistency.rb
@@ -94,7 +94,9 @@ module RuboCop
         # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def already_appropriate_call?(operand, dot_op)
-          (operand.safe_navigation? && dot_op == '&.') || (operand.dot? && dot_op == '.')
+          return true if operand.safe_navigation? && dot_op == '&.'
+
+          (operand.dot? || operand.operator_method?) && dot_op == '.'
         end
 
         def register_offense(operand, dot_operator)

--- a/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
@@ -142,6 +142,87 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency, :config do
     expect_no_corrections
   end
 
+  it 'does not register an offense when using safe navigation on the LHS with `==` on the RHS of `&&`' do
+    expect_no_offenses(<<~RUBY)
+      foo&.bar && foo == 1
+    RUBY
+  end
+
+  it 'does not register an offense when using safe navigation on the LHS with `!=` on the RHS of `&&`' do
+    expect_no_offenses(<<~RUBY)
+      foo&.bar && foo != 1
+    RUBY
+  end
+
+  it 'does not register an offense when using safe navigation on the LHS with `===` on the RHS of `&&`' do
+    expect_no_offenses(<<~RUBY)
+      foo&.bar && foo === 1
+    RUBY
+  end
+
+  it 'does not register an offense when using safe navigation on the LHS with `==` on the RHS of `||`' do
+    expect_no_offenses(<<~RUBY)
+      foo&.bar || foo == 1
+    RUBY
+  end
+
+  it 'does not register an offense when using safe navigation on the LHS with `!=` on the RHS of `||`' do
+    expect_no_offenses(<<~RUBY)
+      foo&.bar || foo != 1
+    RUBY
+  end
+
+  it 'does not register an offense when using safe navigation on the LHS with `===` on the RHS of `||`' do
+    expect_no_offenses(<<~RUBY)
+      foo&.bar || foo === 1
+    RUBY
+  end
+
+  it 'does not register an offense when using safe navigation on the LHS with `+` on the RHS of `&&`' do
+    expect_no_offenses(<<~RUBY)
+      foo&.bar && foo + 1
+    RUBY
+  end
+
+  it 'registers an offense when using safe navigation on the LHS with `+` on the RHS of `||`' do
+    expect_offense(<<~RUBY)
+      foo&.bar || foo + 1
+                  ^^^^^^^ Use `&.` for consistency with safe navigation.
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'does not register an offense when using safe navigation on the LHS with `-` on the RHS of `&&`' do
+    expect_no_offenses(<<~RUBY)
+      foo&.bar && foo - 1
+    RUBY
+  end
+
+  it 'registers an offense when using safe navigation on the LHS with `-` on the RHS of `||`' do
+    expect_offense(<<~RUBY)
+      foo&.bar || foo - 1
+                  ^^^^^^^ Use `&.` for consistency with safe navigation.
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'does not register an offense when using safe navigation on the LHS with `<<` on the RHS of `&&`' do
+    expect_no_offenses(<<~RUBY)
+      foo&.bar && foo << 1
+    RUBY
+  end
+
+  it 'registers an offense when using safe navigation on the LHS with `<<` on the RHS of `||`' do
+    expect_offense(<<~RUBY)
+      foo&.bar || foo << 1
+                  ^^^^^^^^ Use `&.` for consistency with safe navigation.
+    RUBY
+
+    expect_no_corrections
+  end
+
   it 'does not register an offense assignment when using safe navigation on the left `&`' do
     expect_no_offenses(<<~RUBY)
       foo&.bar && foo.baz = 1


### PR DESCRIPTION
Fixes #13365.

This PR fixes false positives for `Lint/SafeNavigationConsistency` when using safe navigation on the LHS with operator method on the RHS of `&&`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
