### PR TITLE
[Fix #13364] Fix incorrect autocorrect with `Lint/UselessAssignment` a multiple assignment or `for` contains an inner assignment

### DIFF
--- a/changelog/fix_fix_incorrect_autocorrect_with.md
+++ b/changelog/fix_fix_incorrect_autocorrect_with.md
@@ -1,0 +1,1 @@
+* [#13364](https://github.com/rubocop/rubocop/issues/13364): Fix incorrect autocorrect with `Lint/UselessAssignment` a multiple assignment or `for` contains an inner assignment. ([@dvandersluis][])

--- a/lib/rubocop/cop/variable_force/assignment.rb
+++ b/lib/rubocop/cop/variable_force/assignment.rb
@@ -102,6 +102,7 @@ module RuboCop
         end
 
         def multiple_assignment_node
+          return nil unless node.parent&.mlhs_type?
           return nil unless (grandparent_node = node.parent&.parent)
           if (node = find_multiple_assignment_node(grandparent_node))
             return node
@@ -119,7 +120,13 @@ module RuboCop
         end
 
         def for_assignment_node
-          node.ancestors.find(&:for_type?)
+          return unless (parent_node = node.parent)
+          return parent_node if parent_node.for_type?
+
+          grandparent_node = parent_node.parent
+          return grandparent_node if parent_node.mlhs_type? && grandparent_node&.for_type?
+
+          nil
         end
 
         def find_multiple_assignment_node(grandparent_node)

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1185,6 +1185,36 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when a variable is assigned as an argument to a method given to multiple assignment' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        def some_method
+          a, b = func(c = 3)
+                      ^ Useless assignment to variable - `c`.
+          [a, b]
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          a, b = func(3)
+          [a, b]
+        end
+      RUBY
+    end
+  end
+
+  context 'when a variable is assigned as an argument to a method given to multiple assignment and later used' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        def some_method
+          a, b = func(c = 3)
+          [a, b, c]
+        end
+      RUBY
+    end
+  end
+
   context 'when variables are assigned using chained assignment and remain unreferenced' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
With code such as:

```ruby
a, b = func(c = 3)
[a, b]
```

`Lint/UselessAssignment` was previously considering the inner assignment (`c = 3`) to be part of the multiple assignment for autocorrection. This changes it to not consider assignment inside a method argument to be part of the containing `meta_assignment_node` for `masgn` and `for` nodes. 

Fixes #13364.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
