### PR TITLE
Fix a false positive for `Style/ZeroLengthPredicate` when using an Enumerator

### DIFF
--- a/changelog/fix_false_positive_enumerator_zero_length_predicate.md
+++ b/changelog/fix_false_positive_enumerator_zero_length_predicate.md
@@ -1,0 +1,1 @@
+* [#13371](https://github.com/rubocop/rubocop/pull/13371): Fix a false positive for `Style/ZeroLengthPredicate` when using an `Enumerator`. ([@punkstar][])

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -146,7 +146,7 @@ module RuboCop
         # @!method non_polymorphic_collection?(node)
         def_node_matcher :non_polymorphic_collection?, <<~PATTERN
           {(send (send (send (const {nil? cbase} :File) :stat _) ...) ...)
-           (send (send (send (const {nil? cbase} {:File :Tempfile :StringIO}) {:new :open} ...) ...) ...)}
+           (send (send (send (const {nil? cbase} {:File :Tempfile :StringIO :Enumerator}) {:new :open} ...) ...) ...)}
         PATTERN
       end
     end

--- a/spec/rubocop/cop/style/zero_length_predicate_spec.rb
+++ b/spec/rubocop/cop/style/zero_length_predicate_spec.rb
@@ -567,4 +567,30 @@ RSpec.describe RuboCop::Cop::Style::ZeroLengthPredicate, :config do
       RUBY
     end
   end
+
+  context 'when inspecting an Enumerator object' do
+    it 'does not register an offense using `size == 0`' do
+      expect_no_offenses(<<~RUBY)
+        Enumerator.new(-> {0}).size == 0
+      RUBY
+    end
+
+    it 'does not register an offense with top-level ::Enumerator using `size == 0`' do
+      expect_no_offenses(<<~RUBY)
+        ::Enumerator.new(-> {0}).size == 0
+      RUBY
+    end
+
+    it 'does not register an offense using `size.zero?`' do
+      expect_no_offenses(<<~RUBY)
+        Enumerator.new(-> {0}).size.zero?
+      RUBY
+    end
+
+    it 'does not register an offense with top-level ::Enumerator using `size.zero?`' do
+      expect_no_offenses(<<~RUBY)
+        ::Enumerator.new(-> {0}).size.zero?
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
We already ignore some stdlib classes like `File`, `Tempfile` and `StringIO` in the `#empty?` cop. This pull request adds [`Enumerator`](https://ruby-doc.org/core-2.6/Enumerator.html) to that list.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
