### PR TITLE
[Fix #13372] Fix inconsistent cache directory when using --cache-root

### DIFF
--- a/changelog/fix_cache_cleanup_path_when_cache_root_specified_with_cli_option.md
+++ b/changelog/fix_cache_cleanup_path_when_cache_root_specified_with_cli_option.md
@@ -1,0 +1,1 @@
+* [#13372](https://github.com/rubocop/rubocop/issues/13372): Add `rubocop_cache` to the path given by `--cache-root` when pruning cache ([@capncavedan][])

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -28,6 +28,7 @@ module RuboCop
     def self.cleanup(config_store, verbose, cache_root = nil)
       return if inhibit_cleanup # OPTIMIZE: For faster testing
 
+      cache_root = File.join(cache_root, 'rubocop_cache') if cache_root
       cache_root ||= cache_root(config_store)
       return unless File.exist?(cache_root)
 

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
   let(:options) { {} }
   let(:config_store) { instance_double(RuboCop::ConfigStore, for_pwd: RuboCop::Config.new) }
   let(:cache_root) { "#{Dir.pwd}/rubocop_cache" }
+  let(:cache_root_as_option) { Dir.pwd }
   let(:offenses) do
     [RuboCop::Cop::Offense.new(:warning, location, 'unused var', 'Lint/UselessAssignment')]
   end
@@ -341,13 +342,13 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
       cache.save(offenses)
       cache2 = described_class.new('other.rb', team, options, config_store, cache_root)
       expect(Dir["#{cache_root}/*/*/*"].size).to eq(1)
-      cache.class.cleanup(config_store, :verbose, cache_root)
+      cache.class.cleanup(config_store, :verbose, cache_root_as_option)
       expect($stdout.string).to eq('')
 
       cache2.save(offenses)
       underscore_dir = Dir["#{cache_root}/*/*"].first
       expect(Dir["#{underscore_dir}/*"].size).to eq(2)
-      cache.class.cleanup(config_store, :verbose, cache_root)
+      cache.class.cleanup(config_store, :verbose, cache_root_as_option)
       expect(File).not_to exist(underscore_dir)
       expect($stdout.string).to eq("Removing the 2 oldest files from #{cache_root}\n")
     end


### PR DESCRIPTION
Fixes #13372.

This PR fixes inconsistent cache directory calculation during cache pruning when the --cache-root option is used instead of ENV or YAML configuration.

<hr>

Before submitting the PR make sure the following are checked:

* [x]  The PR relates to _only_ one subject with a clear title and description in grammatically correct, complete sentences.
* [x]  Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
* [x]  Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x]  Feature branch is up-to-date with `master` (if not - rebase it).
* [x]  Squashed related commits together.
* [x]  Added tests.
* [x]  Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x]  Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.