### PR TITLE
[Fix #13374] Return exit code 0 with `--display-only-correctable` and `--display-only-safe-correctable` when no offenses are displayed

### DIFF
--- a/changelog/fix_return_exit_code_0_with_display_only_correctable.md
+++ b/changelog/fix_return_exit_code_0_with_display_only_correctable.md
@@ -1,0 +1,1 @@
+* [#13374](https://github.com/rubocop/rubocop/issues/13374): Return exit code 0 with `--display-only-correctable` and `--display-only-safe-correctable` when no offenses are displayed. ([@dvandersluis][])

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -139,7 +139,7 @@ module RuboCop
         offenses = process_file(file)
         yield file
 
-        if offenses.any? { |o| considered_failure?(o) }
+        if offenses.any? { |o| considered_failure?(o) && offense_displayed?(o) }
           break false if @options[:fail_fast]
 
           next false
@@ -436,16 +436,20 @@ module RuboCop
       !offense.corrected? && offense.severity >= minimum_severity_to_fail
     end
 
-    def offenses_to_report(offenses)
+    def offense_displayed?(offense)
       if @options[:display_only_fail_level_offenses]
-        offenses.select { |o| considered_failure?(o) }
+        considered_failure?(offense)
       elsif @options[:display_only_safe_correctable]
-        offenses.select { |o| supports_safe_autocorrect?(o) }
+        supports_safe_autocorrect?(offense)
       elsif @options[:display_only_correctable]
-        offenses.select(&:correctable?)
+        offense.correctable?
       else
-        offenses
+        true
       end
+    end
+
+    def offenses_to_report(offenses)
+      offenses.select { |o| offense_displayed?(o) }
     end
 
     def supports_safe_autocorrect?(offense)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2166,6 +2166,51 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     end
   end
 
+  describe '--display-only-correctable' do
+    it 'returns 0 if there are no offenses shown' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          SuggestExtensions: false
+      YAML
+      create_file('example.rb', <<~RUBY)
+        # frozen_string_literal: true
+
+        @@var = 0
+      RUBY
+      expect(cli.run(['--display-only-correctable', 'example.rb'])).to eq(0)
+      expect($stderr.string).to eq('')
+      expect($stdout.string).to eq(<<~RESULT)
+        Inspecting 1 file
+        .
+
+        1 file inspected, no offenses detected
+      RESULT
+    end
+  end
+
+  describe '--display-only-safe-correctable' do
+    it 'returns 0 if there are no offenses shown' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          SuggestExtensions: false
+      YAML
+      create_file('example.rb', <<~RUBY)
+        # frozen_string_literal: true
+
+        if foo and bar
+        end
+      RUBY
+      expect(cli.run(['--display-only-safe-correctable', 'example.rb'])).to eq(0)
+      expect($stderr.string).to eq('')
+      expect($stdout.string).to eq(<<~RESULT)
+        Inspecting 1 file
+        .
+
+        1 file inspected, no offenses detected
+      RESULT
+    end
+  end
+
   if RUBY_ENGINE == 'ruby' && !RuboCop::Platform.windows?
     describe 'profiling' do
       let(:cpu_profile) { File.join('tmp', 'rubocop-stackprof.dump') }


### PR DESCRIPTION
When `--display-only-correctable` or `--display-only-safe-correctable` is specified, and therefore no offenses are included that'd otherwise be shown, return exit code 0 instead of 1.

Fixes #13374.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
