### PR TITLE
Fix an error when running with Ruby 3.4-dev

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -11,6 +11,7 @@ require 'rainbow'
 
 require 'regexp_parser'
 require 'set'
+require 'stringio'
 require 'unicode/display_width'
 
 # we have to require RuboCop's version, before rubocop-ast's

--- a/lib/rubocop/cop/correctors/alignment_corrector.rb
+++ b/lib/rubocop/cop/correctors/alignment_corrector.rb
@@ -47,7 +47,7 @@ module RuboCop
           if column_delta.positive? && range.resize(1).source != "\n"
             corrector.insert_before(range, ' ' * column_delta)
           elsif /\A[ \t]+\z/.match?(range.source)
-            remove(range, corrector)
+            corrector.remove(range)
           end
         end
 
@@ -94,17 +94,6 @@ module RuboCop
           else
             range_between(line_begin_pos - column_delta.abs, line_begin_pos)
           end
-        end
-
-        def remove(range, corrector)
-          original_stderr = $stderr
-          $stderr = StringIO.new # Avoid error messages on console
-          corrector.remove(range)
-        rescue RuntimeError
-          range = range_between(range.begin_pos + 1, range.end_pos + 1)
-          retry if /^ +$/.match?(range.source)
-        ensure
-          $stderr = original_stderr
         end
 
         def each_line(expr)


### PR DESCRIPTION
Followup to #13234. I encountered the following errors when running rubocop:

<details><summary>Details</summary>
<p>

```rb
An error occurred while Layout/ElseAlignment cop was inspecting /home/user/code/rubocop/lib/rubocop/runner.rb:366:8.
uninitialized constant #<Class:RuboCop::Cop::AlignmentCorrector>::StringIO
/home/user/code/rubocop/lib/rubocop/cop/correctors/alignment_corrector.rb:101:in 'RuboCop::Cop::AlignmentCorrector.remove'
/home/user/code/rubocop/lib/rubocop/cop/correctors/alignment_corrector.rb:50:in 'RuboCop::Cop::AlignmentCorrector.autocorrect_line'
/home/user/code/rubocop/lib/rubocop/cop/correctors/alignment_corrector.rb:25:in 'block in RuboCop::Cop::AlignmentCorrector.correct'
/home/user/code/rubocop/lib/rubocop/cop/correctors/alignment_corrector.rb:113:in 'block in RuboCop::Cop::AlignmentCorrector.each_line'
/home/user/code/rubocop/lib/rubocop/cop/correctors/alignment_corrector.rb:112:in 'String#each_line'
/home/user/code/rubocop/lib/rubocop/cop/correctors/alignment_corrector.rb:112:in 'RuboCop::Cop::AlignmentCorrector.each_line'
/home/user/code/rubocop/lib/rubocop/cop/correctors/alignment_corrector.rb:24:in 'RuboCop::Cop::AlignmentCorrector.correct'
/home/user/code/rubocop/lib/rubocop/cop/layout/else_alignment.rb:72:in 'RuboCop::Cop::Layout::ElseAlignment#autocorrect'
/home/user/code/rubocop/lib/rubocop/cop/layout/else_alignment.rb:143:in 'block in RuboCop::Cop::Layout::ElseAlignment#check_alignment'
/home/user/code/rubocop/lib/rubocop/cop/base.rb:420:in 'RuboCop::Cop::Base#correct'
/home/user/code/rubocop/lib/rubocop/cop/base.rb:210:in 'RuboCop::Cop::Base#add_offense'
/home/user/code/rubocop/lib/rubocop/cop/layout/else_alignment.rb:142:in 'RuboCop::Cop::Layout::ElseAlignment#check_alignment'
/home/user/code/rubocop/lib/rubocop/cop/layout/else_alignment.rb:44:in 'RuboCop::Cop::Layout::ElseAlignment#on_if'
/home/user/code/rubocop/lib/rubocop/cop/layout/else_alignment.rb:76:in 'RuboCop::Cop::Layout::ElseAlignment#check_nested'
/home/user/code/rubocop/lib/rubocop/cop/layout/else_alignment.rb:128:in 'RuboCop::Cop::Layout::ElseAlignment#check_assignment'
/home/user/code/rubocop/lib/rubocop/cop/mixin/check_assignment.rb:8:in 'RuboCop::Cop::CheckAssignment#on_lvasgn'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:107:in 'Kernel#public_send'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:107:in 'block (2 levels) in RuboCop::Cop::Commissioner#trigger_responding_cops'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:171:in 'RuboCop::Cop::Commissioner#with_cop_error_handling'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:106:in 'block in RuboCop::Cop::Commissioner#trigger_responding_cops'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:105:in 'RuboCop::Cop::Commissioner#trigger_responding_cops'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:69:in 'RuboCop::Cop::Commissioner#on_lvasgn'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:137:in 'block in RuboCop::AST::Traversal#on_dstr'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:137:in 'RuboCop::AST::Traversal#on_dstr'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_begin'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:140:in 'block in RuboCop::AST::Traversal#on_case'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:140:in 'RuboCop::AST::Traversal#on_case'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_resbody'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:140:in 'block in RuboCop::AST::Traversal#on_case'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:140:in 'RuboCop::AST::Traversal#on_case'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_rescue'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:158:in 'RuboCop::AST::Traversal#on_block'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_block'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:154:in 'RuboCop::AST::Traversal#on_def'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_def'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:137:in 'block in RuboCop::AST::Traversal#on_dstr'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:137:in 'RuboCop::AST::Traversal#on_dstr'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_begin'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:154:in 'RuboCop::AST::Traversal#on_class'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_class'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:138:in 'RuboCop::AST::Traversal#on_while'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_module'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:137:in 'block in RuboCop::AST::Traversal#on_dstr'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:137:in 'RuboCop::AST::Traversal#on_dstr'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_begin'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:20:in 'RuboCop::AST::Traversal#walk'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:87:in 'RuboCop::Cop::Commissioner#investigate'
/home/user/code/rubocop/lib/rubocop/cop/team.rb:174:in 'RuboCop::Cop::Team#investigate_partial'
/home/user/code/rubocop/lib/rubocop/cop/team.rb:108:in 'RuboCop::Cop::Team#investigate'
/home/user/code/rubocop/lib/rubocop/runner.rb:349:in 'block in RuboCop::Runner#inspect_file'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop/lib/rubocop/runner.rb:348:in 'Enumerable#flat_map'
/home/user/code/rubocop/lib/rubocop/runner.rb:348:in 'RuboCop::Runner#inspect_file'
/home/user/code/rubocop/lib/rubocop/runner.rb:291:in 'block in RuboCop::Runner#do_inspection_loop'
/home/user/code/rubocop/lib/rubocop/runner.rb:325:in 'block in RuboCop::Runner#iterate_until_no_changes'
<internal:kernel>:168:in 'Kernel#loop'
/home/user/code/rubocop/lib/rubocop/runner.rb:318:in 'RuboCop::Runner#iterate_until_no_changes'
/home/user/code/rubocop/lib/rubocop/runner.rb:287:in 'RuboCop::Runner#do_inspection_loop'
/home/user/code/rubocop/lib/rubocop/runner.rb:168:in 'block in RuboCop::Runner#file_offenses'
/home/user/code/rubocop/lib/rubocop/runner.rb:193:in 'RuboCop::Runner#file_offense_cache'
/home/user/code/rubocop/lib/rubocop/runner.rb:167:in 'RuboCop::Runner#file_offenses'
/home/user/code/rubocop/lib/rubocop/runner.rb:158:in 'RuboCop::Runner#process_file'
/home/user/code/rubocop/lib/rubocop/runner.rb:139:in 'block in RuboCop::Runner#each_inspected_file'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop/lib/rubocop/runner.rb:138:in 'Enumerable#reduce'
/home/user/code/rubocop/lib/rubocop/runner.rb:138:in 'RuboCop::Runner#each_inspected_file'
/home/user/code/rubocop/lib/rubocop/runner.rb:124:in 'RuboCop::Runner#inspect_files'
/home/user/code/rubocop/lib/rubocop/runner.rb:77:in 'RuboCop::Runner#run'
/home/user/code/rubocop/lib/rubocop/cli/command/execute_runner.rb:26:in 'block in RuboCop::CLI::Command::ExecuteRunner#execute_runner'
/home/user/code/rubocop/lib/rubocop/cli/command/execute_runner.rb:52:in 'RuboCop::CLI::Command::ExecuteRunner#with_redirect'
/home/user/code/rubocop/lib/rubocop/cli/command/execute_runner.rb:25:in 'RuboCop::CLI::Command::ExecuteRunner#execute_runner'
/home/user/code/rubocop/lib/rubocop/cli/command/execute_runner.rb:17:in 'RuboCop::CLI::Command::ExecuteRunner#run'
/home/user/code/rubocop/lib/rubocop/cli/command.rb:11:in 'RuboCop::CLI::Command.run'
/home/user/code/rubocop/lib/rubocop/cli/environment.rb:18:in 'RuboCop::CLI::Environment#run'
/home/user/code/rubocop/lib/rubocop/cli.rb:122:in 'RuboCop::CLI#run_command'
/home/user/code/rubocop/lib/rubocop/cli.rb:129:in 'RuboCop::CLI#execute_runners'
/home/user/code/rubocop/lib/rubocop/cli.rb:51:in 'block in RuboCop::CLI#run'
/home/user/code/rubocop/lib/rubocop/cli.rb:81:in 'RuboCop::CLI#profile_if_needed'
/home/user/code/rubocop/lib/rubocop/cli.rb:43:in 'RuboCop::CLI#run'
/home/user/code/rubocop/exe/rubocop:19:in '<top (required)>'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/bin/rubocop:25:in 'Kernel#load'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/bin/rubocop:25:in '<top (required)>'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/cli/exec.rb:58:in 'Kernel.load'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/cli/exec.rb:58:in 'Bundler::CLI::Exec#kernel_load'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/cli.rb:455:in 'Bundler::CLI#exec'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/vendor/thor/lib/thor.rb:527:in 'Bundler::Thor.dispatch'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/exe/bundle:28:in 'block in <top (required)>'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/friendly_errors.rb:117:in 'Bundler.with_friendly_errors'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/exe/bundle:20:in '<top (required)>'
/home/user/.rbenv/versions/3.4-dev/bin/bundle:25:in 'Kernel#load'
/home/user/.rbenv/versions/3.4-dev/bin/bundle:25:in '<main>'
An error occurred while Layout/IndentationWidth cop was inspecting /home/user/code/rubocop/lib/rubocop/runner.rb:366:8.
uninitialized constant #<Class:RuboCop::Cop::AlignmentCorrector>::StringIO
/home/user/code/rubocop/lib/rubocop/cop/correctors/alignment_corrector.rb:101:in 'RuboCop::Cop::AlignmentCorrector.remove'
/home/user/code/rubocop/lib/rubocop/cop/correctors/alignment_corrector.rb:50:in 'RuboCop::Cop::AlignmentCorrector.autocorrect_line'
/home/user/code/rubocop/lib/rubocop/cop/correctors/alignment_corrector.rb:25:in 'block in RuboCop::Cop::AlignmentCorrector.correct'
/home/user/code/rubocop/lib/rubocop/cop/correctors/alignment_corrector.rb:113:in 'block in RuboCop::Cop::AlignmentCorrector.each_line'
/home/user/code/rubocop/lib/rubocop/cop/correctors/alignment_corrector.rb:112:in 'String#each_line'
/home/user/code/rubocop/lib/rubocop/cop/correctors/alignment_corrector.rb:112:in 'RuboCop::Cop::AlignmentCorrector.each_line'
/home/user/code/rubocop/lib/rubocop/cop/correctors/alignment_corrector.rb:24:in 'RuboCop::Cop::AlignmentCorrector.correct'
/home/user/code/rubocop/lib/rubocop/cop/layout/indentation_width.rb:165:in 'RuboCop::Cop::Layout::IndentationWidth#autocorrect'
/home/user/code/rubocop/lib/rubocop/cop/layout/indentation_width.rb:297:in 'block in RuboCop::Cop::Layout::IndentationWidth#offense'
/home/user/code/rubocop/lib/rubocop/cop/base.rb:420:in 'RuboCop::Cop::Base#correct'
/home/user/code/rubocop/lib/rubocop/cop/base.rb:210:in 'RuboCop::Cop::Base#add_offense'
/home/user/code/rubocop/lib/rubocop/cop/layout/indentation_width.rb:296:in 'RuboCop::Cop::Layout::IndentationWidth#offense'
/home/user/code/rubocop/lib/rubocop/cop/layout/indentation_width.rb:274:in 'RuboCop::Cop::Layout::IndentationWidth#check_indentation'
/home/user/code/rubocop/lib/rubocop/cop/layout/indentation_width.rb:257:in 'RuboCop::Cop::Layout::IndentationWidth#check_if'
/home/user/code/rubocop/lib/rubocop/cop/layout/indentation_width.rb:159:in 'RuboCop::Cop::Layout::IndentationWidth#on_if'
/home/user/code/rubocop/lib/rubocop/cop/layout/indentation_width.rb:246:in 'RuboCop::Cop::Layout::IndentationWidth#check_assignment'
/home/user/code/rubocop/lib/rubocop/cop/mixin/check_assignment.rb:8:in 'RuboCop::Cop::CheckAssignment#on_lvasgn'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:107:in 'Kernel#public_send'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:107:in 'block (2 levels) in RuboCop::Cop::Commissioner#trigger_responding_cops'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:171:in 'RuboCop::Cop::Commissioner#with_cop_error_handling'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:106:in 'block in RuboCop::Cop::Commissioner#trigger_responding_cops'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:105:in 'RuboCop::Cop::Commissioner#trigger_responding_cops'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:69:in 'RuboCop::Cop::Commissioner#on_lvasgn'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:137:in 'block in RuboCop::AST::Traversal#on_dstr'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:137:in 'RuboCop::AST::Traversal#on_dstr'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_begin'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:140:in 'block in RuboCop::AST::Traversal#on_case'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:140:in 'RuboCop::AST::Traversal#on_case'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_resbody'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:140:in 'block in RuboCop::AST::Traversal#on_case'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:140:in 'RuboCop::AST::Traversal#on_case'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_rescue'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:158:in 'RuboCop::AST::Traversal#on_block'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_block'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:154:in 'RuboCop::AST::Traversal#on_def'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_def'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:137:in 'block in RuboCop::AST::Traversal#on_dstr'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:137:in 'RuboCop::AST::Traversal#on_dstr'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_begin'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:154:in 'RuboCop::AST::Traversal#on_class'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_class'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:138:in 'RuboCop::AST::Traversal#on_while'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_module'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:137:in 'block in RuboCop::AST::Traversal#on_dstr'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:137:in 'RuboCop::AST::Traversal#on_dstr'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_begin'
/home/user/code/rubocop-ast/lib/rubocop/ast/traversal.rb:20:in 'RuboCop::AST::Traversal#walk'
/home/user/code/rubocop/lib/rubocop/cop/commissioner.rb:87:in 'RuboCop::Cop::Commissioner#investigate'
/home/user/code/rubocop/lib/rubocop/cop/team.rb:174:in 'RuboCop::Cop::Team#investigate_partial'
/home/user/code/rubocop/lib/rubocop/cop/team.rb:108:in 'RuboCop::Cop::Team#investigate'
/home/user/code/rubocop/lib/rubocop/runner.rb:349:in 'block in RuboCop::Runner#inspect_file'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop/lib/rubocop/runner.rb:348:in 'Enumerable#flat_map'
/home/user/code/rubocop/lib/rubocop/runner.rb:348:in 'RuboCop::Runner#inspect_file'
/home/user/code/rubocop/lib/rubocop/runner.rb:291:in 'block in RuboCop::Runner#do_inspection_loop'
/home/user/code/rubocop/lib/rubocop/runner.rb:325:in 'block in RuboCop::Runner#iterate_until_no_changes'
<internal:kernel>:168:in 'Kernel#loop'
/home/user/code/rubocop/lib/rubocop/runner.rb:318:in 'RuboCop::Runner#iterate_until_no_changes'
/home/user/code/rubocop/lib/rubocop/runner.rb:287:in 'RuboCop::Runner#do_inspection_loop'
/home/user/code/rubocop/lib/rubocop/runner.rb:168:in 'block in RuboCop::Runner#file_offenses'
/home/user/code/rubocop/lib/rubocop/runner.rb:193:in 'RuboCop::Runner#file_offense_cache'
/home/user/code/rubocop/lib/rubocop/runner.rb:167:in 'RuboCop::Runner#file_offenses'
/home/user/code/rubocop/lib/rubocop/runner.rb:158:in 'RuboCop::Runner#process_file'
/home/user/code/rubocop/lib/rubocop/runner.rb:139:in 'block in RuboCop::Runner#each_inspected_file'
<internal:array>:42:in 'Array#each'
/home/user/code/rubocop/lib/rubocop/runner.rb:138:in 'Enumerable#reduce'
/home/user/code/rubocop/lib/rubocop/runner.rb:138:in 'RuboCop::Runner#each_inspected_file'
/home/user/code/rubocop/lib/rubocop/runner.rb:124:in 'RuboCop::Runner#inspect_files'
/home/user/code/rubocop/lib/rubocop/runner.rb:77:in 'RuboCop::Runner#run'
/home/user/code/rubocop/lib/rubocop/cli/command/execute_runner.rb:26:in 'block in RuboCop::CLI::Command::ExecuteRunner#execute_runner'
/home/user/code/rubocop/lib/rubocop/cli/command/execute_runner.rb:52:in 'RuboCop::CLI::Command::ExecuteRunner#with_redirect'
/home/user/code/rubocop/lib/rubocop/cli/command/execute_runner.rb:25:in 'RuboCop::CLI::Command::ExecuteRunner#execute_runner'
/home/user/code/rubocop/lib/rubocop/cli/command/execute_runner.rb:17:in 'RuboCop::CLI::Command::ExecuteRunner#run'
/home/user/code/rubocop/lib/rubocop/cli/command.rb:11:in 'RuboCop::CLI::Command.run'
/home/user/code/rubocop/lib/rubocop/cli/environment.rb:18:in 'RuboCop::CLI::Environment#run'
/home/user/code/rubocop/lib/rubocop/cli.rb:122:in 'RuboCop::CLI#run_command'
/home/user/code/rubocop/lib/rubocop/cli.rb:129:in 'RuboCop::CLI#execute_runners'
/home/user/code/rubocop/lib/rubocop/cli.rb:51:in 'block in RuboCop::CLI#run'
/home/user/code/rubocop/lib/rubocop/cli.rb:81:in 'RuboCop::CLI#profile_if_needed'
/home/user/code/rubocop/lib/rubocop/cli.rb:43:in 'RuboCop::CLI#run'
/home/user/code/rubocop/exe/rubocop:19:in '<top (required)>'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/bin/rubocop:25:in 'Kernel#load'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/bin/rubocop:25:in '<top (required)>'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/cli/exec.rb:58:in 'Kernel.load'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/cli/exec.rb:58:in 'Bundler::CLI::Exec#kernel_load'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/cli.rb:455:in 'Bundler::CLI#exec'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/vendor/thor/lib/thor.rb:527:in 'Bundler::Thor.dispatch'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/exe/bundle:28:in 'block in <top (required)>'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/lib/bundler/friendly_errors.rb:117:in 'Bundler.with_friendly_errors'
/home/user/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/bundler-2.5.16/exe/bundle:20:in '<top (required)>'
/home/user/.rbenv/versions/3.4-dev/bin/bundle:25:in 'Kernel#load'
/home/user/.rbenv/versions/3.4-dev/bin/bundle:25:in '<main>'
```

</p>
</details> 

Tests load stringio before rubocop itself, so it is not surfaced. The stringio code from AlignmentCorrector seems useless today, so I just removed it. Still, stringio is used in `DisabledConfigFormatter`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
