### PR TITLE
[Fix #13378] Fix false positives for `Style/TernaryParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_style_ternary_parentheses.md
+++ b/changelog/fix_false_positives_for_style_ternary_parentheses.md
@@ -1,0 +1,1 @@
+* [#13378](https://github.com/rubocop/rubocop/issues/13378): Fix false positives for `Style/TernaryParentheses` when a ternary condition is a parenthesized operator method and its argument is also parenthesized. ([@koic][])

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -514,6 +514,40 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
       expect_no_offenses('(foo..bar).include?(baz) ? a : b')
     end
 
+    it 'registers a condition as a parenthesized operator method with dot (`.>`) when the argument is parenthesized' do
+      expect_offense(<<~RUBY)
+        (foo.>(bar)) ? baz : qux
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Omit parentheses for ternary conditions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo.>(bar) ? baz : qux
+      RUBY
+    end
+
+    it 'registers a condition as a parenthesized operator method with dot (`.>`) when the argument is not parenthesized' do
+      expect_no_offenses(<<~RUBY)
+        (foo.>bar) ? baz : qux
+      RUBY
+    end
+
+    it 'registers a condition as a parenthesized operator method with safe navigation (`&.>`) when the argument is parenthesized' do
+      expect_offense(<<~RUBY)
+        (foo&.>(bar)) ? baz : qux
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Omit parentheses for ternary conditions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo&.>(bar) ? baz : qux
+      RUBY
+    end
+
+    it 'registers a condition as a parenthesized operator method with safe navigation (`&.>`) when the argument is not parenthesized' do
+      expect_no_offenses(<<~RUBY)
+        (foo&.>bar) ? baz : qux
+      RUBY
+    end
+
     context 'with no space between the parentheses and question mark' do
       it 'registers an offense' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #13378.

This PR fixes false positives for `Style/TernaryParentheses` when a ternary condition is a parenthesized safe navigation operator method and its argument is also parenthesized.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
