### PR TITLE
[Fix #13378] When removing parens in `Style/TernaryParentheses` with a `send` node condition, ensure its arguments are parenthesized

### DIFF
--- a/changelog/fix_when_removing_parens_in_style_ternary_parentheses.md
+++ b/changelog/fix_when_removing_parens_in_style_ternary_parentheses.md
@@ -1,0 +1,1 @@
+* [#13378](https://github.com/rubocop/rubocop/issues/13378): When removing parens in `Style/TernaryParentheses` with a `send` node condition, ensure its arguments are parenthesized. ([@dvandersluis][])


### PR DESCRIPTION
When the condition to a ternary is a send node with arguments, and `Style/TernaryParentheses` removes parentheses around that condition, ensure the arguments are themselves parenthesized, because otherwise removing the surrounding parens will change the semantics of the ternary.

This also allows a number of test cases to be autocorrected which previously did not have autocorrect.

Fixes #13378.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
