### PR TITLE
Handle error in extractors when the extractor is a class

### DIFF
--- a/changelog/fix_error_handling_extractor_class.md
+++ b/changelog/fix_error_handling_extractor_class.md
@@ -1,0 +1,1 @@
+* [#13382](https://github.com/rubocop/rubocop/pull/13382): Fix an error during error handling for custom ruby extractors when the extractor is a class. ([@earlopain][])

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -363,8 +363,12 @@ module RuboCop
         result = ruby_extractor.call(processed_source)
         break result if result
       rescue StandardError
-        raise Error, "Ruby extractor #{ruby_extractor.source_location[0]} failed to process " \
-                     "#{processed_source.path}."
+        location = if ruby_extractor.is_a?(Proc)
+                     ruby_extractor.source_location
+                   else
+                     ruby_extractor.method(:call).source_location
+                   end
+        raise Error, "Ruby extractor #{location[0]} failed to process #{processed_source.path}."
       end
     end
 


### PR DESCRIPTION
Unfortunatly the change I made in #13263 is not sufficient. This gracefully handles the other case as well.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
