### PR TITLE
Speed up variable force by 10x on pathological file

### DIFF
--- a/lib/rubocop/cop/variable_force/branch.rb
+++ b/lib/rubocop/cop/variable_force/branch.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Namespace for branch classes for each control structure.
       module Branch
         def self.of(target_node, scope: nil)
-          ([target_node] + target_node.ancestors).each do |node|
+          target_node.each_ancestor(include_self: true) do |node|
             return nil unless node.parent
             return nil unless scope.include?(node)
 


### PR DESCRIPTION
Running rubocop against the following file went from 35sec to about 3.5sec with this change
[plugin_pb.generated.rb.txt](https://github.com/user-attachments/files/17498087/plugin_pb.generated.rb.txt)

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
