### PR TITLE
Fix a wrongly memoized method in `VariableForce`

### DIFF
--- a/lib/rubocop/cop/variable_force/branch.rb
+++ b/lib/rubocop/cop/variable_force/branch.rb
@@ -74,7 +74,7 @@ module RuboCop
           def parent
             return @parent if instance_variable_defined?(:@parent)
 
-            @branch = Branch.of(control_node, scope: scope)
+            @parent = Branch.of(control_node, scope: scope)
           end
 
           def each_ancestor(include_self: false, &block)


### PR DESCRIPTION
This speeds the file from https://github.com/rubocop/rubocop/pull/13383 up from 1m21s to just 14s for me.

I see no measurable difference when running over RuboCop itself with this change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
