### PR TITLE
Fix documentation for `Lint/UnescapedBracketInRegexp`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2458,7 +2458,7 @@ Lint/UnderscorePrefixedVariableName:
   AllowKeywordBlockArguments: false
 
 Lint/UnescapedBracketInRegexp:
-  Description: 'Checks for unescaped literal `[` in Regexp.'
+  Description: 'Checks for unescaped literal `]` in Regexp.'
   Enabled: pending
   VersionAdded: '<<next>>'
 

--- a/lib/rubocop/cop/lint/unescaped_bracket_in_regexp.rb
+++ b/lib/rubocop/cop/lint/unescaped_bracket_in_regexp.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Lint
       # Checks for Regexpes (both literals and via `Regexp.new` / `Regexp.compile`)
-      # that contain unescaped `[` characters.
+      # that contain unescaped `]` characters.
       #
       # It emulates the following Ruby warning:
       #


### PR DESCRIPTION
Fixes incorrect documentation of `Lint/UnescapedBracketInRegexp`. Thanks @bquorning for noticing.

Re: https://github.com/rubocop/rubocop/pull/13385#discussion_r1815463298