### PR TITLE
Fix another error for the documentation generator on Ruby 2.7

### DIFF
--- a/spec/rubocop/cops_documentation_generator_spec.rb
+++ b/spec/rubocop/cops_documentation_generator_spec.rb
@@ -2,16 +2,18 @@
 
 require 'rubocop/cops_documentation_generator'
 
-RSpec.describe CopsDocumentationGenerator, :isolated_environment do
+RSpec.describe CopsDocumentationGenerator do
   around do |example|
     new_global = RuboCop::Cop::Registry.new([RuboCop::Cop::Style::HashSyntax])
     RuboCop::Cop::Registry.with_temporary_global(new_global) { example.run }
   end
 
   it 'generates docs without errors' do
-    generator = described_class.new(departments: %w[Style])
-    expect do
-      generator.call
-    end.to output(%r{generated .*docs/modules/ROOT/pages/cops_style.adoc}).to_stdout
+    Dir.mktmpdir do |tmpdir|
+      generator = described_class.new(departments: %w[Style], base_dir: tmpdir)
+      expect do
+        generator.call
+      end.to output(%r{generated .*docs/modules/ROOT/pages/cops_style.adoc}).to_stdout
+    end
   end
 end


### PR DESCRIPTION
Using `:isolated_environment` results in yard not finding the annotations which causes it to not run a few codepaths. So, just generate the docs into a manually created tempfile and add an option to generate it into that folder instead of `Dir.pwd`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
