### PR TITLE
[Fix #13309] Fix false negative with `Lint/UselessAssignment` when an useless assignment exists followed by a block

### DIFF
--- a/changelog/fix_false_negative_for_useless_assignment.md
+++ b/changelog/fix_false_negative_for_useless_assignment.md
@@ -1,0 +1,1 @@
+* [#13309](https://github.com/rubocop/rubocop/issues/13309): Fix a false negative for `Lint/UselessAssignment` cop when there is a useless assignment followed by a block. ([@pCosta99][])

--- a/lib/rubocop/cop/variable_force/assignment.rb
+++ b/lib/rubocop/cop/variable_force/assignment.rb
@@ -9,9 +9,10 @@ module RuboCop
 
         MULTIPLE_LEFT_HAND_SIDE_TYPE = :mlhs
 
-        attr_reader :node, :variable, :referenced, :references
+        attr_reader :node, :variable, :referenced, :references, :reassigned
 
         alias referenced? referenced
+        alias reassigned? reassigned
 
         def initialize(node, variable)
           unless VARIABLE_ASSIGNMENT_TYPES.include?(node.type)
@@ -24,6 +25,7 @@ module RuboCop
           @variable = variable
           @referenced = false
           @references = []
+          @reassigned = false
         end
 
         def name
@@ -39,8 +41,14 @@ module RuboCop
           @referenced = true
         end
 
+        def reassigned!
+          return if referenced?
+
+          @reassigned = true
+        end
+
         def used?
-          @variable.captured_by_block? || @referenced
+          (!reassigned? && @variable.captured_by_block?) || @referenced
         end
 
         def regexp_named_capture?

--- a/lib/rubocop/cop/variable_force/variable.rb
+++ b/lib/rubocop/cop/variable_force/variable.rb
@@ -29,7 +29,11 @@ module RuboCop
         end
 
         def assign(node)
-          @assignments << Assignment.new(node, self)
+          assignment = Assignment.new(node, self)
+
+          @assignments.last&.reassigned! unless captured_by_block?
+
+          @assignments << assignment
         end
 
         def referenced?

--- a/lib/rubocop/cop/variable_force/variable_table.rb
+++ b/lib/rubocop/cop/variable_force/variable_table.rb
@@ -61,8 +61,8 @@ module RuboCop
                   "at #{node.source_range}, #{node.inspect}"
           end
 
-          variable.assign(node)
           mark_variable_as_captured_by_block_if_so(variable)
+          variable.assign(node)
         end
 
         def reference_variable(name, node)
@@ -87,8 +87,8 @@ module RuboCop
           # So just skip.
           return unless variable
 
-          variable.reference!(node)
           mark_variable_as_captured_by_block_if_so(variable)
+          variable.reference!(node)
         end
 
         def find_variable(name)

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -536,6 +536,21 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when a variable is reassigned before a block' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        def some_method
+          foo = 1
+          ^^^ Useless assignment to variable - `foo`.
+          foo = 2
+          bar {
+            foo = 3
+          }
+        end
+      RUBY
+    end
+  end
+
   context "when a variable is reassigned in loop body but won't " \
           'be referenced either next iteration or loop condition' do
     it 'registers an offense' do


### PR DESCRIPTION
Similar example false negative situation pointed in issue #13309 :
```ruby
foo = 1 # should have an offense
foo = 2
bar {
  foo = 3
}
```

The issue here is that `Lint/UselessAssignment` checks if assignments have been used, however, the assignments check it based on the assignment having been referenced or the variable being used in a block. So, the false negative occurs because of the first assignment being unused but having the variable captured in a block. One potential way of solving this is too track reassignments (a new assignment follows a not referenced assignment).

Fixes #13309.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
