### PR TITLE
Fix deserialization of unknown encoding offenses

### DIFF
--- a/changelog/fix_deserialization_encoding.md
+++ b/changelog/fix_deserialization_encoding.md
@@ -1,0 +1,1 @@
+* [#13391](https://github.com/rubocop/rubocop/pull/13391): Fix deserialization of unknown encoding offenses. ([@earlopain][])

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -127,6 +127,23 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
           expect(cache.load[0].location).to eq(no_location)
         end
       end
+
+      context 'a global Lint/Syntax offense, caused by a parser error' do
+        before do
+          create_file('example.rb', ['# encoding: unknown'])
+        end
+
+        let(:no_location) { RuboCop::Cop::Offense::NO_LOCATION }
+        let(:global_offense) do
+          RuboCop::Cop::Offense.new(:warning, no_location, 'empty file', 'Lint/Syntax',
+                                    :unsupported)
+        end
+
+        it 'serializes the range correctly' do
+          cache.save([global_offense])
+          expect(cache.load[0].location).to eq(no_location)
+        end
+      end
     end
 
     context 'when no option is given' do


### PR DESCRIPTION
The first run would be fine but after loading rubocop would error. This is for the same reasons as https://github.com/rubocop/rubocop-ast/pull/289

Instead of rescuing the exception, delay buffer creation until it is first needed. This will prevent the error when all offenses are global.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
