### PR TITLE
[Fix #13387] Fix false positives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_parenthese.md
+++ b/changelog/fix_false_positives_for_style_redundant_parenthese.md
@@ -1,0 +1,1 @@
+* [#13387](https://github.com/rubocop/rubocop/issues/13387): Fix false positives in `Style/RedundantParentheses` when parentheses are used around method chain with `do`...`end` block in keyword argument. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -425,6 +425,36 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'registers an offense for parens around `lambda` with `{`...`}` block' do
+    expect_offense(<<~RUBY)
+      scope :my_scope, (lambda {
+                       ^^^^^^^^^ Don't use parentheses around an expression.
+        where(column: :value)
+      })
+    RUBY
+
+    expect_correction(<<~RUBY)
+      scope :my_scope, lambda {
+        where(column: :value)
+      }
+    RUBY
+  end
+
+  it 'registers an offense for parens around `proc` with `{`...`}` block' do
+    expect_offense(<<~RUBY)
+      scope :my_scope, (proc {
+                       ^^^^^^^ Don't use parentheses around an expression.
+        where(column: :value)
+      })
+    RUBY
+
+    expect_correction(<<~RUBY)
+      scope :my_scope, proc {
+        where(column: :value)
+      }
+    RUBY
+  end
+
   it 'does not register an offense for parens around `lambda` with `do`...`end` block' do
     expect_no_offenses(<<~RUBY)
       scope :my_scope, (lambda do
@@ -438,6 +468,60 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
       scope :my_scope, (proc do
         where(column: :value)
       end)
+    RUBY
+  end
+
+  it 'registers an offense for parentheses around a method chain with `{`...`}` block in keyword argument' do
+    expect_offense(<<~RUBY)
+      foo bar: (baz {
+               ^^^^^^ Don't use parentheses around a method call.
+      }.qux)
+    RUBY
+  end
+
+  it 'registers an offense for parentheses around a method chain with `{`...`}` numblock in keyword argument' do
+    expect_offense(<<~RUBY)
+      foo bar: (baz {
+               ^^^^^^ Don't use parentheses around a method call.
+        do_something(_1)
+      }.qux)
+    RUBY
+  end
+
+  it 'does not register an offense for parentheses around a method chain with `do`...`end` block in keyword argument' do
+    expect_no_offenses(<<~RUBY)
+      foo bar: (baz do
+      end.qux)
+    RUBY
+  end
+
+  it 'does not register an offense for parentheses around method chains with `do`...`end` block in keyword argument' do
+    expect_no_offenses(<<~RUBY)
+      foo bar: (baz do
+      end.qux.quux)
+    RUBY
+  end
+
+  it 'does not register an offense for parentheses around a method chain with `do`...`end` numblock in keyword argument' do
+    expect_no_offenses(<<~RUBY)
+      foo bar: (baz do
+        do_something(_1)
+      end.qux)
+    RUBY
+  end
+
+  it 'does not register an offense for parentheses around a method chain with `do`...`end` block in keyword argument for safe navigation call' do
+    expect_no_offenses(<<~RUBY)
+      obj&.foo bar: (baz do
+      end.qux)
+    RUBY
+  end
+
+  it 'does not register an offense for parentheses around a method chain with `do`...`end` numblock in keyword argument for safe navigation call' do
+    expect_no_offenses(<<~RUBY)
+      obj&.foo bar: (baz do
+        do_something(_1)
+      end.qux)
     RUBY
   end
 


### PR DESCRIPTION
Fixes #13387.

This PR fixes false positives in `Style/RedundantParentheses` when parentheses are used around method chain with `do`...`end` block in keyword argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
