### PR TITLE
Update `PercentLiteralCorrector` to be able to write pairs of delimiters without excessive escaping

### DIFF
--- a/changelog/fix_update_percent_literal_corrector_to_be_able_to.md
+++ b/changelog/fix_update_percent_literal_corrector_to_be_able_to.md
@@ -1,0 +1,1 @@
+* [#13397](https://github.com/rubocop/rubocop/pull/13397): Update `PercentLiteralCorrector` to be able to write pairs of delimiters without excessive escaping. ([@dvandersluis][])

--- a/lib/rubocop/cop/correctors/percent_literal_corrector.rb
+++ b/lib/rubocop/cop/correctors/percent_literal_corrector.rb
@@ -94,6 +94,16 @@ module RuboCop
       end
 
       def substitute_escaped_delimiters(content, delimiters)
+        if delimiters.first != delimiters.last
+          # With different delimiters (eg. `[]`, `()`), if there are the same
+          # number of each, escaping is not necessary
+          delimiter_counts = delimiters.each_with_object({}) do |delimiter, counts|
+            counts[delimiter] = content.count(delimiter)
+          end
+
+          return content if delimiter_counts[delimiters.first] == delimiter_counts[delimiters.last]
+        end
+
         delimiters.each { |delim| content.gsub!(delim, "\\#{delim}") }
       end
 

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -260,6 +260,17 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
           biz]
         RUBY
       end
+
+      it 'autocorrects balanced pairs of delimiters without excessive escaping' do
+        expect_offense(<<~RUBY)
+          [:a, :'b[]', :'c[][]']
+          ^^^^^^^^^^^^^^^^^^^^^^ Use `%i` or `%I` for an array of symbols.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          %i[a b[] c[][]]
+        RUBY
+      end
     end
   end
 

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -659,6 +659,17 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
           %w[) \] ( \[]
         RUBY
       end
+
+      it 'autocorrects balanced pairs of delimiters without excessive escaping' do
+        expect_offense(<<~RUBY)
+          ['a', 'b[]', 'c[][]']
+          ^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          %w[a b[] c[][]]
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
Ruby allows putting a pair of brackets/parentheses inside a `%i`/`%w`/etc. array with the same character as delimiters.

For example:

```ruby
%i[a b[] c[][]]
```

Previously, `PercentLiteralCorrector` when correcting to `percent` style would insert unnecessary escapes when encountering such pairs:

```ruby
# test.rb
[:a, :'b[]', :'c[][]']

$ rubocop -A --only Style/SymbolArray test.rb
Inspecting 1 file
C

Offenses:

test.rb:1:1: C: [Corrected] Style/SymbolArray: Use %i or %I for an array of symbols.
[:a, :'b[]', :'c[][]']
^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected

# test.rb becomes:
%i[a b\[\] c\[\]\[\]]
```

This change allows the backslashes to be omitted in this case, so the autocorrection is instead `%i[a b[] c[][]]`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
