### PR TITLE
Fix typos `and offense` instead of `an offense`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -107,6 +107,9 @@ Naming/InclusiveLanguage:
     ' a offense':
       Suggestions:
         - an offense
+    ' and offense':
+      Suggestions:
+        - ' an offense'
     auto-correct:
       Suggestions:
         - autocorrect

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2132,7 +2132,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
-  it 'corrects `Lint/AmbiguousRange` and offenses and accepts Style/RedundantParentheses' do
+  it 'corrects `Lint/AmbiguousRange` offenses and accepts Style/RedundantParentheses' do
     create_file('example.rb', <<~RUBY)
       x...(y || z)
     RUBY
@@ -2144,7 +2144,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
-  it 'corrects Lint/ParenthesesAsGroupedExpression and offenses and ' \
+  it 'corrects Lint/ParenthesesAsGroupedExpression offenses and ' \
      'accepts Style/RedundantParentheses' do
     create_file('example.rb', <<~RUBY)
       do_something (argument)
@@ -2184,7 +2184,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     special_for_inner_method_call
     special_for_inner_method_call_in_parentheses
   ].each do |style|
-    it 'does not crash `Layout/ArgumentAlignment` and offenses and accepts `Layout/FirstArgumentIndentation` ' \
+    it 'does not crash `Layout/ArgumentAlignment` and accepts `Layout/FirstArgumentIndentation` ' \
        'when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` ' \
        "and `EnforcedStyle: #{style}` of `Layout/FirstArgumentIndentation`" do
       create_file('example.rb', <<~RUBY)
@@ -2550,7 +2550,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
-  it 'does not crash Lint/SafeNavigationWithEmpty and offenses and accepts Style/SafeNavigation ' \
+  it 'does not crash Lint/SafeNavigationWithEmpty and accepts Style/SafeNavigation ' \
      'when checking `foo&.empty?` in a conditional' do
     create_file('example.rb', <<~RUBY)
       do_something if ENV['VERSION'] && ENV['VERSION'].empty?

--- a/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementLineBreak, :config do
   end
 
   context 'array nested in a method call' do
-    it 'registers an corrects the offense' do
+    it 'registers and corrects the offense' do
       expect_offense(<<~RUBY)
         method([:foo,
                 ^^^^ Add a line break before the first element of a multi-line array.

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -693,7 +693,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
     RUBY
   end
 
-  it 'properly registers and offense when deeply nested' do
+  it 'properly registers an offense when deeply nested' do
     expect_offense(<<~RUBY, 'test.rb')
       module A
         module B

--- a/spec/rubocop/cop/style/ambiguous_endless_method_definition_spec.rb
+++ b/spec/rubocop/cop/style/ambiguous_endless_method_definition_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::Style::AmbiguousEndlessMethodDefinition, :config do
           end
         end
 
-        it "registers and offense and corrects an endless method followed by `#{operator}`" do
+        it "registers an offense and corrects an endless method followed by `#{operator}`" do
           expect_offense(<<~RUBY, operator: operator)
             def foo = true #{operator} bar
             ^^^^^^^^^^^^^^^^{operator}^^^^ Avoid using `#{operator}` statements with endless methods.

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       RUBY
     end
 
-    it 'registers and offense for deeply nested children' do
+    it 'registers an offense for deeply nested children' do
       expect_offense(<<~RUBY)
         class Foo
               ^^^ Use compact module/class definition instead of nested style.


### PR DESCRIPTION
Noticed a few typos of `and offense` instead of `an offense`, so I corrected them. There's a few that were detected that I manually edited to remove some extra words.