### PR TITLE
Fix docs for `Offense.cop_name`

### DIFF
--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -43,11 +43,10 @@ module RuboCop
       # @!attribute [r] cop_name
       #
       # @return [String]
-      #   a cop class name without department.
-      #   i.e. type of the violation.
+      #   the cop name as a String for which this offense is for.
       #
       # @example
-      #   'LineLength'
+      #   'Layout/LineLength'
       attr_reader :cop_name
 
       # @api private


### PR DESCRIPTION
It says the string will be without department, but that is not true.