### PR TITLE
Fix a false negative for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_a_false_negative_for_style_redundant_line_continuation.md
+++ b/changelog/fix_a_false_negative_for_style_redundant_line_continuation.md
@@ -1,0 +1,1 @@
+* [#13401](https://github.com/rubocop/rubocop/pull/13401): Fix a false negative for `Style/RedundantLineContinuation` when there is a line continuation at the EOF. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -707,4 +707,15 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
         baz)
     RUBY
   end
+
+  it 'registers an offense when there is a line continuation at the EOF' do
+    expect_offense(<<~'RUBY')
+      foo \
+          ^ Redundant line continuation.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo#{trailing_whitespace}
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes a false negative for `Style/RedundantLineContinuation` when there is a line continuation at the EOF.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
