### PR TITLE
[Fix #13058] Update `Style/AccessModifierDeclarations` to accept modifier with splatted method call

### DIFF
--- a/changelog/change_update_style_access_modifier_declarations_to.md
+++ b/changelog/change_update_style_access_modifier_declarations_to.md
@@ -1,0 +1,1 @@
+* [#13058](https://github.com/rubocop/rubocop/issues/13058): Update `Style/AccessModifierDeclarations` to accept modifier with splatted method call. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -70,6 +70,7 @@ module RuboCop
       #     private :bar, :baz
       #     private *%i[qux quux]
       #     private *METHOD_NAMES
+      #     private *private_methods
       #
       #   end
       #
@@ -80,6 +81,7 @@ module RuboCop
       #     private :bar, :baz
       #     private *%i[qux quux]
       #     private *METHOD_NAMES
+      #     private *private_methods
       #
       #   end
       #
@@ -133,7 +135,7 @@ module RuboCop
         # @!method access_modifier_with_symbol?(node)
         def_node_matcher :access_modifier_with_symbol?, <<~PATTERN
           (send nil? {:private :protected :public :module_function}
-            {(sym _) (splat {#percent_symbol_array? const})}
+            {(sym _) (splat {#percent_symbol_array? const send})}
           )
         PATTERN
 

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
           end
         RUBY
       end
+
+      it 'accepts when argument to #{access_modifier} is a splat with a method call' do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            foo
+            #{access_modifier} *bar
+          end
+        RUBY
+      end
     end
 
     context 'do not allow access modifiers on symbols' do


### PR DESCRIPTION
Similar to #13214 adding support for constants and symbol arrays, this change allows `Style/AccessModifierDeclarations` to use inline modifiers with a splatted method call, eg.

```ruby
def Foo
  private *private_methods
end
```

Fixes #13058.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
