### PR TITLE
Fix `Style/AccessModifierDeclarations` to register access modifiers with multiple symbols

### DIFF
--- a/changelog/fix_fix_style_access_modifier_declarations_to_register.md
+++ b/changelog/fix_fix_style_access_modifier_declarations_to_register.md
@@ -1,0 +1,1 @@
+* [#13404](https://github.com/rubocop/rubocop/pull/13404): Fix `Style/AccessModifierDeclarations` to register (as positive or negative, depending on `AllowModifiersOnSymbols` value) access modifiers with multiple symbols. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -135,7 +135,7 @@ module RuboCop
         # @!method access_modifier_with_symbol?(node)
         def_node_matcher :access_modifier_with_symbol?, <<~PATTERN
           (send nil? {:private :protected :public :module_function}
-            {(sym _) (splat {#percent_symbol_array? const send})}
+            {(sym _)+ (splat {#percent_symbol_array? const send})}
           )
         PATTERN
 
@@ -214,7 +214,10 @@ module RuboCop
 
         def right_siblings_same_inline_method?(node)
           node.right_siblings.any? do |sibling|
-            sibling.send_type? && sibling.method?(node.method_name) && !sibling.arguments.empty?
+            sibling.send_type? &&
+              sibling.method?(node.method_name) &&
+              !sibling.arguments.empty? &&
+              find_corresponding_def_node(sibling)
           end
         end
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.4', '< 3.0')
-  s.add_dependency('rubocop-ast', '>= 1.32.2', '< 2.0')
+  s.add_dependency('rubocop-ast', '>= 1.33.1', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 3.0')
 end

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         RUBY
       end
 
+      it 'accepts when argument to #{access_modifier} is multiple symbols' do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            foo
+            #{access_modifier} :bar, :baz
+          end
+        RUBY
+      end
+
       it 'accepts when argument to #{access_modifier} is splat with a `%i` array literal' do
         expect_no_offenses(<<~RUBY)
           class Foo
@@ -59,6 +68,18 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
           class Foo
             foo
             %{access_modifier} :bar
+            ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense when argument to #{access_modifier} is multiple symbols' do
+        expect_offense(<<~RUBY, access_modifier: access_modifier)
+          class Foo
+            foo
+            %{access_modifier} :bar, :baz
             ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
           end
         RUBY


### PR DESCRIPTION
Although `private :foo, :bar` is listed in the examples for `Style/AccessModifierDeclarations` (either good or bad depending on the value of the `AllowModifiersOnSymbols` configuration), it isn't actually registered as an offense when `AllowModifiersOnSymbols` is false. 

This also affects autocorrection of groupable modifiers because as-is these are not considered properly when checking siblings (the `right_siblings_same_inline_method?` check). I added autocorrect specs for these. 

This adds test cases for `AllowModifiersOnSymbols` true and false, and fixes the false negative when false. 

NOTE: this relies on rubocop/rubocop-ast#325, and will have failing tests until that's merged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with loop a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
