### PR TITLE
[Fix #13372] Fix inconsistent cache directory when using --cache-root

### DIFF
--- a/changelog/fix_cache_pruning_path_when_cache_root_specified_with_cli_option.md
+++ b/changelog/fix_cache_pruning_path_when_cache_root_specified_with_cli_option.md
@@ -1,0 +1,1 @@
+* [#13372](https://github.com/rubocop/rubocop/issues/13372): Add `rubocop_cache` to the path given by `--cache-root` when pruning cache. ([@capncavedan][])


### PR DESCRIPTION
Fixes #13372.

This PR fixes inconsistent cache directory calculation during cache pruning when the `--cache-root` CLI option is used instead of ENV or YAML configuration.

In this work, I renamed method arguments and local variables to try to better distinguish among "cache root override" (an optional value), "cache root" e.g. `.cache`, and "cache working directory" e.g. `.cache/rubocop_cache`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
