### PR TITLE
[Fix #11393] Update `Lint/UnusedMethodArgument` to allow the class names for `IgnoreNotImplementedMethods` to be configured

### DIFF
--- a/changelog/change_update_lint_unused_method_argument_to_allow_the.md
+++ b/changelog/change_update_lint_unused_method_argument_to_allow_the.md
@@ -1,0 +1,1 @@
+* [#11393](https://github.com/rubocop/rubocop/issues/11393): Update `Lint/UnusedMethodArgument` to allow the class names for `IgnoreNotImplementedMethods` to be configured. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2521,10 +2521,12 @@ Lint/UnusedMethodArgument:
   Enabled: true
   AutoCorrect: contextual
   VersionAdded: '0.21'
-  VersionChanged: '1.61'
+  VersionChanged: '<<next>>'
   AllowUnusedKeywordArguments: false
   IgnoreEmptyMethods: true
   IgnoreNotImplementedMethods: true
+  NotImplementedExceptions:
+    - NotImplementedError
 
 Lint/UriEscapeUnescape:
   Description: >-

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -571,5 +571,67 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
         end
       RUBY
     end
+
+    context 'when `NotImplementedExceptions` is configured' do
+      let(:cop_config) do
+        { 'IgnoreNotImplementedMethods' => true,
+          'NotImplementedExceptions' => ['AbstractMethodError'] }
+      end
+
+      it 'accepts a method with a single unused parameter & raises AbstractMethodError' do
+        expect_no_offenses(<<~RUBY)
+          def method(arg)
+            raise AbstractMethodError
+          end
+        RUBY
+      end
+
+      it 'accepts a method with a single unused parameter & raises AbstractMethodError, message' do
+        expect_no_offenses(<<~RUBY)
+          def method(arg)
+            raise AbstractMethodError, message
+          end
+        RUBY
+      end
+
+      it 'accepts a method with a single unused parameter & raises ::AbstractMethodError' do
+        expect_no_offenses(<<~RUBY)
+          def method(arg)
+            raise ::AbstractMethodError
+          end
+        RUBY
+      end
+
+      context 'when `NotImplementedExceptions` contains a namespaced exception class' do
+        let(:cop_config) do
+          { 'IgnoreNotImplementedMethods' => true,
+            'NotImplementedExceptions' => ['Library::AbstractMethodError'] }
+        end
+
+        it 'accepts a method with a single unused parameter & raises Library::AbstractMethodError' do
+          expect_no_offenses(<<~RUBY)
+            def method(arg)
+              raise Library::AbstractMethodError
+            end
+          RUBY
+        end
+
+        it 'accepts a method with a single unused parameter & raises Library::AbstractMethodError, message' do
+          expect_no_offenses(<<~RUBY)
+            def method(arg)
+              raise Library::AbstractMethodError, message
+            end
+          RUBY
+        end
+
+        it 'accepts a method with a single unused parameter & raises ::Library::AbstractMethodError' do
+          expect_no_offenses(<<~RUBY)
+            def method(arg)
+              raise ::Library::AbstractMethodError
+            end
+          RUBY
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Augments the update to `Lint/UnusedMethodArgument` in #7747 to allow the exception classes used to indicate a not implemented method to be customized (when `IgnoreNotImplementedMethods` is `true`). This allows for codebases that don't want to use `NotImplementedError` or want a custom exception to be handled.

Fixes #11393.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
