### PR TITLE
[Fix #13402] Fix a false positive for `Lint/SafeNavigationConsistency`

### DIFF
--- a/changelog/fix_false_positive_for_lint_safe_navigation_consistency.md
+++ b/changelog/fix_false_positive_for_lint_safe_navigation_consistency.md
@@ -1,0 +1,1 @@
+* [#13402](https://github.com/rubocop/rubocop/issues/13402): Fix a false positive for `Lint/SafeNavigationConsistency` when using unsafe navigation with both `&&` and `||`. ([@koic][])

--- a/lib/rubocop/cop/lint/safe_navigation_consistency.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_consistency.rb
@@ -83,6 +83,8 @@ module RuboCop
         def find_consistent_parts(grouped_operands)
           csend_in_and, csend_in_or, send_in_and, send_in_or = most_left_indices(grouped_operands)
 
+          return if csend_in_and && csend_in_or && csend_in_and < csend_in_or
+
           if csend_in_and
             ['.', (send_in_and ? [send_in_and, csend_in_and].min : csend_in_and) + 1]
           elsif send_in_or && csend_in_or

--- a/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
@@ -295,11 +295,10 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency, :config do
     expect_offense(<<~RUBY)
       foo&.bar && foo&.baz || foo&.qux
                      ^^ Use `.` instead of unnecessary `&.`.
-                                 ^^ Use `.` instead of unnecessary `&.`.
     RUBY
 
     expect_correction(<<~RUBY)
-      foo&.bar && foo.baz || foo.qux
+      foo&.bar && foo.baz || foo&.qux
     RUBY
   end
 


### PR DESCRIPTION
Fixes #13402.

This PR fixes a false positive for `Lint/SafeNavigationConsistency` when using unsafe navigation with both `&&` and `||`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
