### PR TITLE
[Fix #13395] False positive for `Lint/UselessAssignment` when assigning in branch and block

### DIFF
--- a/changelog/fix_false_positive_for_useless_assignment.md
+++ b/changelog/fix_false_positive_for_useless_assignment.md
@@ -1,0 +1,1 @@
+* [#13395](https://github.com/rubocop/rubocop/issues/13395): Fix a false positive for `Lint/UselessAssignment` when assigning in branch and block. ([@pCosta99][])

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -551,6 +551,51 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when assigning in branch' do
+    it 'accepts' do
+      expect_no_offenses(<<~RUBY)
+        def some_method
+          changed = false
+
+          if Random.rand > 1
+            changed = true
+          end
+
+          [].each do
+            changed = true
+          end
+
+          puts changed
+        end
+      RUBY
+    end
+  end
+
+  context 'when assigning in case' do
+    it 'accepts' do
+      expect_no_offenses(<<~RUBY)
+        def some_method
+          changed = false
+
+          case Random.rand
+          when 0.5
+            changed = true
+          when 1..20
+            changed = false
+          when 21..70
+            changed = true
+          end
+
+          [].each do
+            changed = true
+          end
+
+          puts changed
+        end
+      RUBY
+    end
+  end
+
   context "when a variable is reassigned in loop body but won't " \
           'be referenced either next iteration or loop condition' do
     it 'registers an offense' do


### PR DESCRIPTION
As demonstrated in the issue #13395, there is a false positive as such:
```ruby
changed = false
^^^^^^^ Useless assignment to variable - `changed`.

if Random.rand > 1
  changed = true
end

[].each do
  changed = true
end

puts changed
```

In the presence of a conditional, the cop `Lint/UselessAssignment` can't be certain if the variable will be reassigned or not, so, very much like the case for blocks, the best approach is simply to ignore it.

There appears to be no benefit in actually looking into all branches and checking if all branches reassign since even then the outer assignment defines the variable.

This also applies to case statements.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
