### PR TITLE
Grammar fixes

### DIFF
--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -60,7 +60,7 @@ module RuboCop
         []
       end
 
-      # Returns an url to view this cops documentation online.
+      # Returns a url to view this cops documentation online.
       # Requires 'DocumentationBaseURL' to be set for your department.
       # Will follow the convention of RuboCops own documentation structure,
       # overwrite this method to accommodate your custom layout.

--- a/lib/rubocop/cop/layout/multiline_method_call_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_brace_layout.rb
@@ -12,7 +12,7 @@ module RuboCop
       # argument of the call, then the closing brace should be on the same
       # line as the last argument of the call.
       #
-      # If an method call's opening brace is on the line above the first
+      # If a method call's opening brace is on the line above the first
       # argument of the call, then the closing brace should be on the line
       # below the last argument of the call.
       #

--- a/lib/rubocop/cop/layout/multiline_method_definition_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_method_definition_brace_layout.rb
@@ -12,7 +12,7 @@ module RuboCop
       # first parameter of the definition, then the closing brace should be
       # on the same line as the last parameter of the definition.
       #
-      # If an method definition's opening brace is on the line above the first
+      # If a method definition's opening brace is on the line above the first
       # parameter of the definition, then the closing brace should be on the
       # line below the last parameter of the definition.
       #

--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -111,7 +111,7 @@ module RuboCop
           range_between(start + begin_pos - 1, start + end_pos)
         end
 
-        # If the list of cops is comma-separated, but without a empty space after the comma,
+        # If the list of cops is comma-separated, but without an empty space after the comma,
         # we should **not** remove the prepending empty space, thus begin_pos += 1
         def range_with_comma_after(comment, start, begin_pos, end_pos)
           begin_pos += 1 if comment.source[end_pos + 1] != ' '

--- a/lib/rubocop/cop/style/select_by_regexp.rb
+++ b/lib/rubocop/cop/style/select_by_regexp.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # Looks for places where an subset of an Enumerable (array,
+      # Looks for places where a subset of an Enumerable (array,
       # range, set, etc.; see note below) is calculated based on a `Regexp`
       # match, and suggests `grep` or `grep_v` instead.
       #

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1682,7 +1682,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
   # In this example, the autocorrection (changing "fail" to "raise")
   # creates a new problem (alignment of parameters), which is also
   # corrected automatically.
-  it 'can correct a problems and the problem it creates' do
+  it 'can correct a problem and the problem it creates' do
     create_file('example.rb', <<~RUBY)
       fail NotImplementedError,
            'Method should be overridden in child classes'

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
   else
     context 'when not supporting server' do
       describe 'no server options' do
-        it 'displays an warning message' do
+        it 'displays a warning message' do
           stdout, stderr, status = Open3.capture3("ruby -I . \"#{rubocop}\"")
           expect(stdout).to eq(<<~RESULT)
             Inspecting 0 files
@@ -212,7 +212,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       end
 
       describe '--start-server' do
-        it 'displays an warning message' do
+        it 'displays a warning message' do
           stdout, stderr, status = Open3.capture3("ruby -I . \"#{rubocop}\" --start-server")
           expect(stdout).to eq ''
           expect(stderr).to include("RuboCop server is not supported by this Ruby.\n")

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -2028,7 +2028,7 @@ RSpec.describe RuboCop::ConfigLoader do
     end
   end
 
-  describe 'when a unqualified requirement is defined', :isolated_environment do
+  describe 'when an unqualified requirement is defined', :isolated_environment do
     let(:required_file_path) { 'required_file' }
 
     before do

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -391,7 +391,7 @@ RSpec.describe RuboCop::ConfigObsoletion do
         OUTPUT
       end
 
-      it 'prints a error message' do
+      it 'prints an error message' do
         config_obsoletion.reject_obsolete!
         raise 'Expected a RuboCop::ValidationError'
       rescue RuboCop::ValidationError => e

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe RuboCop::Config do
         YAML
       end
 
-      it 'raises an validation error' do
+      it 'raises a validation error' do
         expect { configuration }.to raise_error(
           RuboCop::ValidationError,
           'unrecognized cop or department LyneLenth found in .rubocop.yml'
@@ -744,7 +744,7 @@ RSpec.describe RuboCop::Config do
       end
     end
 
-    context 'when an nested cop department is disabled' do
+    context 'when a nested cop department is disabled' do
       context 'but an individual cop is enabled' do
         let(:hash) do
           {

--- a/spec/rubocop/cop/gemspec/require_mfa_spec.rb
+++ b/spec/rubocop/cop/gemspec/require_mfa_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::Gemspec::RequireMFA, :config do
     end
   end
 
-  context 'when the specification has an non-hash metadata' do
+  context 'when the specification has a non-hash metadata' do
     it 'registers an offense but does not correct' do
       expect_offense(<<~RUBY, 'my.gemspec')
         Gem::Specification.new do |spec|

--- a/spec/rubocop/cop/internal_affairs/style_detected_api_use_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/style_detected_api_use_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::StyleDetectedApiUse, :config do
       RUBY
     end
 
-    it "does not register an offense when correct_style_detected and a #{negative_style_detected_method} are both used" do
+    it "does not register an offense when correct_style_detected and #{negative_style_detected_method} are both used" do
       expect_no_offenses(<<~RUBY)
         def on_send(node)
           if offense?

--- a/spec/rubocop/cop/layout/block_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/block_alignment_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
       RUBY
     end
 
-    it 'registers an offenses for mismatched end alignment' do
+    it 'registers an offense for mismatched end alignment' do
       expect_offense(<<~RUBY)
         variable =
           a_long_method_that_dont_fit_on_the_line do |v|

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
     RUBY
   end
 
-  it 'registers an offenses for exponent operator with spaces' do
+  it 'registers an offense for exponent operator with spaces' do
     expect_offense(<<~RUBY)
       x = a * b ** 2
                 ^^ Space around operator `**` detected.
@@ -227,7 +227,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
     expect_no_offenses('x = a * b**2')
   end
 
-  it 'registers an offenses for slash in rational literals with spaces' do
+  it 'registers an offense for slash in rational literals with spaces' do
     expect_offense(<<~RUBY)
       x = a * b / 42r
                 ^ Space around operator `/` detected.
@@ -245,7 +245,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
     expect_no_offenses('x = a * b/42r')
   end
 
-  it 'does not register an offenses for slash in non rational literals without spaces' do
+  it 'does not register an offense for slash in non rational literals without spaces' do
     expect_no_offenses(<<~RUBY)
       x = a * b / 42
     RUBY
@@ -269,7 +269,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
     let(:target_ruby_version) { 2.7 }
 
     # NOTE: It is `Layout/SpaceAroundKeyword` cop's role to detect this offense.
-    it 'does not register an offenses for one-line pattern matching syntax (`in`)' do
+    it 'does not register an offense for one-line pattern matching syntax (`in`)' do
       expect_no_offenses(<<~RUBY)
         ""in foo
       RUBY
@@ -279,7 +279,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
   context '>= Ruby 3.0', :ruby30 do
     let(:target_ruby_version) { 3.0 }
 
-    it 'registers an offenses for one-line pattern matching syntax (`=>`)' do
+    it 'registers an offense for one-line pattern matching syntax (`=>`)' do
       expect_offense(<<~RUBY)
         ""=>foo
           ^^ Surrounding space missing for operator `=>`.
@@ -294,7 +294,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
   context 'when EnforcedStyleForExponentOperator is space' do
     let(:exponent_operator_style) { 'space' }
 
-    it 'registers an offenses for exponent operator without spaces' do
+    it 'registers an offense for exponent operator without spaces' do
       expect_offense(<<~RUBY)
         x = a * b**2
                  ^^ Surrounding space missing for operator `**`.
@@ -309,7 +309,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
   context 'when EnforcedStyleForRationalLiterals is space' do
     let(:rational_literals_style) { 'space' }
 
-    it 'registers an offenses for rational literals without spaces' do
+    it 'registers an offense for rational literals without spaces' do
       expect_offense(<<~RUBY)
         x = a * b/42r
                  ^ Surrounding space missing for operator `/`.
@@ -933,14 +933,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
       RUBY
     end
 
-    it 'does not register an offenses match operators between `<<` and `+=`' do
+    it 'does not register an offense match operators between `<<` and `+=`' do
       expect_no_offenses(<<~RUBY)
         x  << foo
         yz += bar
       RUBY
     end
 
-    it 'does not register an offenses match operators between `+=` and `<<`' do
+    it 'does not register an offense match operators between `+=` and `<<`' do
       expect_no_offenses(<<~RUBY)
         x  += foo
         yz << bar

--- a/spec/rubocop/cop/lint/constant_resolution_spec.rb
+++ b/spec/rubocop/cop/lint/constant_resolution_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe RuboCop::Cop::Lint::ConstantResolution, :config do
       RUBY
     end
 
-    it 'registers an with a namespace const' do
+    it 'registers an offense with a namespace const' do
       expect_offense(<<~RUBY)
         MyConst::MY_CONST
         ^^^^^^^ Fully qualify this constant to avoid possibly ambiguous resolution.

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -181,14 +181,14 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
   end
 
   context 'built-in methods' do
-    it 'registers an offense for a irb binding call' do
+    it 'registers an offense for a `binding.irb` call' do
       expect_offense(<<~RUBY)
         binding.irb
         ^^^^^^^^^^^ Remove debugger entry point `binding.irb`.
       RUBY
     end
 
-    it 'registers an offense for a binding.irb with Kernel call' do
+    it 'registers an offense for a `Kernel.binding.irb` call' do
       expect_offense(<<~RUBY)
         Kernel.binding.irb
         ^^^^^^^^^^^^^^^^^^ Remove debugger entry point `Kernel.binding.irb`.
@@ -257,7 +257,7 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
       RUBY
     end
 
-    it 'does not register an offense when `p` is a array argument of method call' do
+    it 'does not register an offense when `p` is an array argument of method call' do
       expect_no_offenses(<<~RUBY)
         let(:p) { foo }
 

--- a/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedOpenSSLConstant, :config do
     RUBY
   end
 
-  it 'registers an offense when building an instance using an digest constant and corrects' do
+  it 'registers an offense when building an instance using a digest constant and corrects' do
     expect_offense(<<~RUBY)
       OpenSSL::Digest::SHA256.new
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Digest.new('SHA256')` instead of `OpenSSL::Digest::SHA256.new`.
@@ -127,7 +127,7 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedOpenSSLConstant, :config do
     RUBY
   end
 
-  it 'registers an offense when using an digest constant with chained methods and corrects' do
+  it 'registers an offense when using a digest constant with chained methods and corrects' do
     expect_offense(<<~RUBY)
       OpenSSL::Digest::SHA256.new.digest('foo')
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Digest.new('SHA256')` instead of `OpenSSL::Digest::SHA256.new`.

--- a/spec/rubocop/cop/lint/mixed_regexp_capture_types_spec.rb
+++ b/spec/rubocop/cop/lint/mixed_regexp_capture_types_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::Lint::MixedRegexpCaptureTypes, :config do
       RUBY
     end
 
-    it 'does not register an offense when containing a ivar' do
+    it 'does not register an offense when containing an ivar' do
       expect_no_offenses(<<~'RUBY')
         /(?<foo>#{@var}*)/
       RUBY

--- a/spec/rubocop/cop/lint/non_deterministic_require_order_spec.rb
+++ b/spec/rubocop/cop/lint/non_deterministic_require_order_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe RuboCop::Cop::Lint::NonDeterministicRequireOrder, :config do
         end
 
         context 'with require block passed as parameter' do
-          it 'registers an offense an autocorrects to add sort' do
+          it 'registers an offense and autocorrects to add sort' do
             expect_offense(<<~RUBY)
               Dir["./lib/**/*.rb"].each(&method(:require))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
@@ -198,7 +198,7 @@ RSpec.describe RuboCop::Cop::Lint::NonDeterministicRequireOrder, :config do
         end
 
         context 'with require_relative block passed as parameter' do
-          it 'registers an offense an autocorrects to add sort' do
+          it 'registers an offense and autocorrects to add sort' do
             expect_offense(<<~RUBY)
               Dir["./lib/**/*.rb"].each(&method(:require_relative))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
@@ -245,7 +245,7 @@ RSpec.describe RuboCop::Cop::Lint::NonDeterministicRequireOrder, :config do
         end
 
         context 'with require block passed as parameter' do
-          it 'registers an offense an autocorrects to add sort' do
+          it 'registers an offense and autocorrects to add sort' do
             expect_offense(<<~RUBY)
               Dir.glob(Rails.root.join('test', '*.rb')).each(&method(:require))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.

--- a/spec/rubocop/cop/lint/number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/number_conversion_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
       RUBY
     end
 
-    it 'when `#to_i` called on a variable on a array' do
+    it 'when `#to_i` called on a variable on an array' do
       expect_offense(<<~RUBY)
         args = [1,2,3]
         args[0].to_i

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedException, :config do
       RUBY
     end
 
-    it 'rescue a exception without causing constant name deprecation warning' do
+    it 'rescue an exception without causing constant name deprecation warning' do
       expect do
         expect_no_offenses(<<~RUBY)
           def foo

--- a/spec/rubocop/cop/lint/unreachable_loop_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_loop_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableLoop, :config do
   context 'with AllowedPatterns' do
     let(:cop_config) { { 'AllowedPatterns' => [/exactly\(\d+\)\.times/] } }
 
-    context 'with a ignored method call' do
+    context 'with an ignored method call' do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)
           exactly(2).times { raise StandardError }

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -662,7 +662,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
-  context 'when a unreferenced variable is reassigned in same branch ' \
+  context 'when an unreferenced variable is reassigned in same branch ' \
           'and referenced after the branching' do
     it 'registers an offense for the unreferenced assignment' do
       expect_offense(<<~RUBY)
@@ -863,7 +863,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
-  context 'when a variable is reassigned and unreferenced in a if branch ' \
+  context 'when a variable is reassigned and unreferenced in an if branch ' \
           'while the variable is referenced in the paired else branch' do
     it 'registers an offense for the reassignment in the if branch' do
       expect_offense(<<~RUBY)
@@ -917,7 +917,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
-  context "when there's an unreferenced reassignment in a if branch " \
+  context "when there's an unreferenced reassignment in an if branch " \
           'while the variable is referenced in the paired elsif branch' do
     it 'registers an offense for the reassignment in the if branch' do
       expect_offense(<<~RUBY)
@@ -949,7 +949,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
-  context "when there's an unreferenced reassignment in a if branch " \
+  context "when there's an unreferenced reassignment in an if branch " \
           'while the variable is referenced in a case branch ' \
           'in the paired else branch' do
     it 'registers an offense for the reassignment in the if branch' do
@@ -988,7 +988,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
-  context 'when an assignment in a if branch is referenced in another if branch' do
+  context 'when an assignment in an if branch is referenced in another if branch' do
     it 'accepts' do
       expect_no_offenses(<<~RUBY)
         def some_method(flag_a, flag_b)
@@ -1047,7 +1047,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
-  context 'when a unreferenced variable is reassigned ' \
+  context 'when an unreferenced variable is reassigned ' \
           'on the left side of && and referenced after the &&' do
     it 'registers an offense for the unreferenced assignment' do
       expect_offense(<<~RUBY)
@@ -1069,7 +1069,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
-  context 'when a unreferenced variable is reassigned ' \
+  context 'when an unreferenced variable is reassigned ' \
           'on the right side of && and referenced after the &&' do
     it 'accepts' do
       expect_no_offenses(<<~RUBY)
@@ -1901,7 +1901,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
-  context 'when a optional keyword method argument is not used' do
+  context 'when an optional keyword method argument is not used' do
     it 'accepts' do
       expect_no_offenses(<<~RUBY)
         def some_method(name: value)

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -708,7 +708,7 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     RUBY
   end
 
-  it 'registers an offenses for void constant in a `#each` method' do
+  it 'registers an offense for void constant in a `#each` method' do
     expect_offense(<<~RUBY)
       array.each do |_item|
         CONST

--- a/spec/rubocop/cop/naming/variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/variable_name_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
         RUBY
       end
 
-      it 'does not register an offense for a instance variable name that is allowed' do
+      it 'does not register an offense for an instance variable name that is allowed' do
         expect_no_offenses(<<~RUBY)
           @#{identifier} = :foo
         RUBY
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
         RUBY
       end
 
-      it 'does not register an offense for a instance variable name that matches the allowed pattern' do
+      it 'does not register an offense for an instance variable name that matches the allowed pattern' do
         expect_no_offenses(<<~RUBY)
           @#{identifier} = :foo
         RUBY

--- a/spec/rubocop/cop/naming/variable_number_spec.rb
+++ b/spec/rubocop/cop/naming/variable_number_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
       RUBY
     end
 
-    it 'does not register an offense for a instance variable name that is allowed' do
+    it 'does not register an offense for an instance variable name that is allowed' do
       expect_no_offenses(<<~RUBY)
         @capture3 = :foo
       RUBY
@@ -360,14 +360,14 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
       RUBY
     end
 
-    it 'registers an offense for a instance variable name that does not match an allowed pattern' do
+    it 'registers an offense for an instance variable name that does not match an allowed pattern' do
       expect_offense(<<~RUBY)
         @foo_a1 = :foo
         ^^^^^^^ Use snake_case for variable numbers.
       RUBY
     end
 
-    it 'does not register an offense for a instance variable name that matches an allowed pattern' do
+    it 'does not register an offense for an instance variable name that matches an allowed pattern' do
       expect_no_offenses(<<~RUBY)
         @foo_v1 = :foo
         @foo_allow_me_a1 = :allowed

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
     context 'allow access modifiers on attrs' do
       let(:cop_config) { { 'AllowModifiersOnAttrs' => true } }
 
-      it 'accepts when argument to #{access_modifier} is a attr_*' do
+      it 'accepts when argument to #{access_modifier} is an attr_*' do
         expect_no_offenses(<<~RUBY)
           class Foo
             #{access_modifier} attr_reader :foo

--- a/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
+++ b/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
       end
     end
 
-    context 'when an non-allowed cop is disabled' do
+    context 'when a non-allowed cop is disabled' do
       it 'registers an offense and corrects' do
         expect_offense(<<~RUBY)
           def foo # rubocop:disable Layout/LineLength
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
       end
     end
 
-    context 'when an mix of cops are disabled' do
+    context 'when a mix of cops are disabled' do
       it 'registers an offense and corrects' do
         expect_offense(<<~RUBY)
           def foo # rubocop:disable Metrics/AbcSize, Layout/LineLength, Metrics/CyclomaticComplexity, Style/AndOr

--- a/spec/rubocop/cop/style/fetch_env_var_spec.rb
+++ b/spec/rubocop/cop/style/fetch_env_var_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     end
   end
 
-  context 'when the node is a assigned by `||=`' do
+  context 'when the node is assigned by `||=`' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         y ||= ENV['X']
@@ -92,7 +92,7 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     end
   end
 
-  context 'when the node is a assigned by `&&=`' do
+  context 'when the node is assigned by `&&=`' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         y &&= ENV['X']

--- a/spec/rubocop/cop/style/ip_addresses_spec.rb
+++ b/spec/rubocop/cop/style/ip_addresses_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe RuboCop::Cop::Style::IpAddresses, :config do
   context 'with allowed addresses' do
     let(:cop_config) { { 'AllowedAddresses' => ['a::b'] } }
 
-    it 'does not register an offense for a allowed addresses' do
+    it 'does not register an offense for an allowed address' do
       expect_no_offenses('"a::b"')
     end
 

--- a/spec/rubocop/cop/style/map_to_hash_spec.rb
+++ b/spec/rubocop/cop/style/map_to_hash_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe RuboCop::Cop::Style::MapToHash, :config do
         end
       end
 
-      context 'when the receiver is an hash' do
+      context 'when the receiver is a hash' do
         it 'registers an offense and corrects' do
           expect_offense(<<~RUBY, method: method)
             { foo: :bar }.#{method} { |x, y| [x.to_s, y.to_s] }.to_h

--- a/spec/rubocop/cop/style/map_to_set_spec.rb
+++ b/spec/rubocop/cop/style/map_to_set_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe RuboCop::Cop::Style::MapToSet, :config do
       end
     end
 
-    context 'when the receiver is an hash' do
+    context 'when the receiver is a hash' do
       it 'registers an offense and corrects' do
         expect_offense(<<~RUBY, method: method)
           { foo: :bar }.#{method} { |x, y| [x.to_s, y.to_s] }.to_set

--- a/spec/rubocop/cop/style/multiline_method_signature_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_signature_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
       end
     end
 
-    context 'when defining an class method' do
+    context 'when defining a class method' do
       context 'when arguments span a single line' do
         it 'registers an offense and corrects when closing paren is on the following line' do
           expect_offense(<<~RUBY)
@@ -175,7 +175,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
       end
     end
 
-    context 'when defining an class method' do
+    context 'when defining a class method' do
       it 'registers an offense and corrects when `end` is on the following line' do
         expect_offense(<<~RUBY)
           def self.foo(bar,

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -602,7 +602,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
     end
   end
 
-  context 'when return is inside a in-branch' do
+  context 'when return is inside an in-branch' do
     it 'registers an offense and autocorrects' do
       expect_offense(<<~RUBY)
         def func

--- a/spec/rubocop/cop/style/redundant_string_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_string_escape_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantStringEscape, :config do
     end
 
     if r != '"'
-      it 'registers an offense and corrects a escaped nested delimiter in a double quoted string' do
+      it 'registers an offense and corrects an escaped nested delimiter in a double quoted string' do
         expect_offense(<<~'RUBY', l: l, r: r)
           %{l}#{"\%{r}"}%{r}
           _{l}   ^^ Redundant escape of %{r} inside string literal.
@@ -234,19 +234,19 @@ RSpec.describe RuboCop::Cop::Style::RedundantStringEscape, :config do
     end
   end
 
-  it 'does not register an offense for a regexp literal' do
+  it 'does not register an offense for a `regexp` literal' do
     expect_no_offenses('/\#/')
   end
 
-  it 'does not register an offense for a x-str literal' do
+  it 'does not register an offense for an `xstr` literal' do
     expect_no_offenses('%x{\#}')
   end
 
-  it 'does not register an offense for a __FILE__ literal' do
+  it 'does not register an offense for a `__FILE__` literal' do
     expect_no_offenses('"__FILE__"')
   end
 
-  it 'does not register an offense for a __dir__ literal' do
+  it 'does not register an offense for a `__dir__` literal' do
     expect_no_offenses('"__dir__"')
   end
 

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
     RUBY
   end
 
-  it 'registers an offense when a semicolon at after a opening brace of string interpolation' do
+  it 'registers an offense when a semicolon at after an opening brace of string interpolation' do
     expect_offense(<<~'RUBY')
       "#{;foo}"
          ^ Do not use semicolons to terminate expressions.

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
     RUBY
   end
 
-  it 'does not crash on an method with a capitalized name' do
+  it 'does not crash on a method with a capitalized name' do
     expect_no_offenses(<<~RUBY)
       def NoSnakeCase
       end
@@ -297,7 +297,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
     context 'with `disallow` style' do
       let(:endless_method_config) { { 'EnforcedStyle' => 'disallow' } }
 
-      it 'corrects to an normal method' do
+      it 'corrects to a normal method' do
         expect_correction(<<~RUBY.strip, source: 'def some_method; body end')
           def some_method;#{trailing_whitespace}
             body#{trailing_whitespace}
@@ -334,7 +334,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
   context 'when `Style/EndlessMethod` is disabled', :ruby30 do
     before { config['Style/EndlessMethod'] = { 'Enabled' => false } }
 
-    it 'corrects to an normal method' do
+    it 'corrects to a normal method' do
       expect_correction(<<~RUBY.strip, source: 'def some_method; body end')
         def some_method;#{trailing_whitespace}
           body#{trailing_whitespace}

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
   context 'when style is use_builtin_english_names' do
     let(:cop_config) { { 'EnforcedStyle' => 'use_builtin_english_names' } }
 
-    it 'does not register an offenses for builtin names' do
+    it 'does not register an offense for builtin names' do
       expect_no_offenses(<<~RUBY)
         puts $LOAD_PATH
         puts $LOADED_FEATURES

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
       RUBY
     end
 
-    it "does not register an offense when receiver is a array literal and using `#{method}` with a block" do
+    it "does not register an offense when receiver is an array literal and using `#{method}` with a block" do
       expect_no_offenses(<<~RUBY)
         [1, 2, 3].#{method} {|item| item.foo }
       RUBY
@@ -470,7 +470,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
         RUBY
       end
 
-      it "does not register an offense when receiver is a array literal and using `#{method}` with a numblock" do
+      it "does not register an offense when receiver is an array literal and using `#{method}` with a numblock" do
         expect_no_offenses(<<~RUBY)
           [1, 2, 3].#{method} { _1.foo }
         RUBY

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
     expect_no_offenses('something { |x,| x.first }')
   end
 
-  it 'accepts a block with an unused argument with an method call' do
+  it 'accepts a block with an unused argument with a method call' do
     expect_no_offenses('something { |_x| y.call }')
   end
 
@@ -459,7 +459,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
     end
 
     %w[min max].each do |method|
-      it "registers an offense when receiver is an hash literal and using `#{method}` with a numblock" do
+      it "registers an offense when receiver is a hash literal and using `#{method}` with a numblock" do
         expect_offense(<<~RUBY, method: method)
           {foo: 42}.%{method} { _1.foo }
                     _{method} ^^^^^^^^^^ Pass `&:foo` as an argument to `#{method}` instead of a block.

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe RuboCop::Cop::Team do
       end
     end
 
-    context 'when a cops joining forces callback raises an error' do
+    context "when a cop's joining forces callback raises an error" do
       include_context 'mock console output'
       before do
         allow_any_instance_of(RuboCop::Cop::Lint::ShadowedArgument)

--- a/spec/rubocop/formatter/pacman_formatter_spec.rb
+++ b/spec/rubocop/formatter/pacman_formatter_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe RuboCop::Formatter::PacmanFormatter do
       let(:character) { Rainbow(described_class::GHOST).red }
       let(:expected_progress_line) { format('..%s%s', character, described_class::PACDOT) }
 
-      it 'removes the first • and puts a ghosts' do
+      it 'removes the first • and puts ghosts' do
         step
         expect(formatter.progress_line).to eq(expected_progress_line)
       end

--- a/spec/rubocop/lockfile_spec.rb
+++ b/spec/rubocop/lockfile_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Lockfile, :isolated_environment do
       it { is_expected.to eq([]) }
     end
 
-    context 'when there is an no lockfile' do
+    context 'when there is no lockfile' do
       let(:lockfile) { nil }
 
       it { is_expected.to eq([]) }

--- a/spec/rubocop/magic_comment_spec.rb
+++ b/spec/rubocop/magic_comment_spec.rb
@@ -201,13 +201,13 @@ RSpec.describe RuboCop::MagicComment do
       it { is_expected.to be(true) }
     end
 
-    context 'with an frozen string literal comment' do
+    context 'with a frozen string literal comment' do
       let(:comment) { '# frozen-string-literal: true' }
 
       it { is_expected.to be(true) }
     end
 
-    context 'with an shareable constant value comment' do
+    context 'with a shareable constant value comment' do
       let(:comment) { '# shareable-constant-value: literal' }
 
       it { is_expected.to be(true) }


### PR DESCRIPTION
Using the `Regex` option of `Naming/InclusiveLanguage`, I found and corrected 4 types of English issues in the codebase. I didn't include the changes into .rubocop.yml because they make things pretty slow (and also still need to be manually reviewed for false positive because English grammar is not a great use case for regex).

For ease of review I have them each as a separate commit.