### PR TITLE
Fix `Style/BitwisePredicate` when using a method

### DIFF
--- a/changelog/fix_bitwise_predicate_when_using_a_method.md
+++ b/changelog/fix_bitwise_predicate_when_using_a_method.md
@@ -1,0 +1,1 @@
+* [#13411](https://github.com/rubocop/rubocop/pull/13411): Fix `Style/BitwisePredicate` when having regular method. ([@d4be4st][])

--- a/lib/rubocop/cop/style/bitwise_predicate.rb
+++ b/lib/rubocop/cop/style/bitwise_predicate.rb
@@ -71,6 +71,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return unless node.receiver
           return unless node.receiver.begin_type?
           return unless (preferred_method = preferred_method(node))
 

--- a/lib/rubocop/cop/style/bitwise_predicate.rb
+++ b/lib/rubocop/cop/style/bitwise_predicate.rb
@@ -71,8 +71,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return unless node.receiver
-          return unless node.receiver.begin_type?
+          return unless node.receiver&.begin_type?
           return unless (preferred_method = preferred_method(node))
 
           bit_operation = node.receiver.children.first

--- a/spec/rubocop/cop/style/bitwise_predicate_spec.rb
+++ b/spec/rubocop/cop/style/bitwise_predicate_spec.rb
@@ -160,4 +160,12 @@ RSpec.describe RuboCop::Cop::Style::BitwisePredicate, :config do
       end
     end
   end
+
+  context 'when using a simple method call' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        zero?
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fix `Style/BitwisePredicate` when using a method.

When having a regular method named `positive?` or `zero?` the cop would raise an error.

```ruby
def positive?
  some_ruby_code
end
```
Would throw a 
```
NoMethodError: undefined method `begin_type?' for nil:NilClass
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
