### PR TITLE
Reduce node destructuring

### DIFF
--- a/lib/rubocop/cop/gemspec/deprecated_attribute_assignment.rb
+++ b/lib/rubocop/cop/gemspec/deprecated_attribute_assignment.rb
@@ -62,8 +62,7 @@ module RuboCop
 
         def node_and_method_name(node, attribute)
           if node.op_asgn_type?
-            lhs, _op, _rhs = *node
-            [lhs, attribute]
+            [node.lhs, attribute]
           else
             [node, :"#{attribute}="]
           end

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -189,7 +189,7 @@ module RuboCop
         # In offense message, we want to show the assignment LHS rather than
         # the entire assignment.
         def find_lhs_node(node)
-          node, = *node while node.op_asgn_type? || node.masgn_type?
+          node = node.lhs while node.op_asgn_type? || node.masgn_type?
           node
         end
 

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -92,6 +92,7 @@ module RuboCop
           )
         end
 
+        # rubocop:disable Metrics/AbcSize
         def alignment_source(node, starting_loc)
           ending_loc =
             case node.type
@@ -101,8 +102,7 @@ module RuboCop
                  :lvasgn, :ivasgn, :cvasgn, :gvasgn, :casgn
               node.loc.name
             when :masgn
-              mlhs_node, = *node
-              mlhs_node.source_range
+              node.lhs.source_range
             else
               # It is a wrapper with receiver of object attribute or access modifier.
               node.receiver&.source_range || node.child_nodes.first.loc.name
@@ -110,6 +110,7 @@ module RuboCop
 
           range_between(starting_loc.begin_pos, ending_loc.end_pos).source
         end
+        # rubocop:enable Metrics/AbcSize
 
         # We will use ancestor or wrapper with access modifier.
 

--- a/lib/rubocop/cop/lint/numbered_parameter_assignment.rb
+++ b/lib/rubocop/cop/lint/numbered_parameter_assignment.rb
@@ -33,8 +33,7 @@ module RuboCop
         NUMBERED_PARAMETER_RANGE = (1..9).freeze
 
         def on_lvasgn(node)
-          lhs, _rhs = *node
-          return unless /\A_(\d+)\z/ =~ lhs
+          return unless /\A_(\d+)\z/ =~ node.name
 
           number = Regexp.last_match(1).to_i
           template = NUMBERED_PARAMETER_RANGE.include?(number) ? NUM_PARAM_MSG : LVAR_MSG

--- a/lib/rubocop/cop/naming/variable_name.rb
+++ b/lib/rubocop/cop/naming/variable_name.rb
@@ -40,11 +40,10 @@ module RuboCop
         end
 
         def on_lvasgn(node)
-          name, = *node
-          return unless name
-          return if allowed_identifier?(name)
+          return unless node.name
+          return if allowed_identifier?(node.name)
 
-          check_name(node, name, node.loc.name)
+          check_name(node, node.name, node.loc.name)
         end
         alias on_ivasgn    on_lvasgn
         alias on_cvasgn    on_lvasgn

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -66,14 +66,12 @@ module RuboCop
         # Assignment of self.x
 
         def on_or_asgn(node)
-          lhs, _rhs = *node
-          allow_self(lhs)
+          allow_self(node.lhs)
         end
         alias on_and_asgn on_or_asgn
 
         def on_op_asgn(node)
-          lhs, _op, _rhs = *node
-          allow_self(lhs)
+          allow_self(node.lhs)
         end
 
         # Using self.x to distinguish from local variable x
@@ -92,13 +90,11 @@ module RuboCop
         end
 
         def on_masgn(node)
-          lhs, rhs = *node
-          add_masgn_lhs_variables(rhs, lhs)
+          add_masgn_lhs_variables(node.rhs, node.lhs)
         end
 
         def on_lvasgn(node)
-          lhs, rhs = *node
-          add_lhs_to_local_variables_scopes(rhs, lhs)
+          add_lhs_to_local_variables_scopes(node.rhs, node.lhs)
         end
 
         def on_in_pattern(node)
@@ -127,12 +123,10 @@ module RuboCop
           # Allow conditional nodes to use `self` in the condition if that variable
           # name is used in an `lvasgn` or `masgn` within the `if`.
           node.child_nodes.each do |child_node|
-            lhs, _rhs = *child_node
-
             if child_node.lvasgn_type?
-              add_lhs_to_local_variables_scopes(node.condition, lhs)
+              add_lhs_to_local_variables_scopes(node.condition, child_node.lhs)
             elsif child_node.masgn_type?
-              add_masgn_lhs_variables(node.condition, lhs)
+              add_masgn_lhs_variables(node.condition, child_node.lhs)
             end
           end
         end

--- a/lib/rubocop/cop/style/redundant_self_assignment_branch.rb
+++ b/lib/rubocop/cop/style/redundant_self_assignment_branch.rb
@@ -34,16 +34,17 @@ module RuboCop
         PATTERN
 
         def on_lvasgn(node)
-          variable, expression = *node
+          expression = node.expression
+
           return unless use_if_and_else_branch?(expression)
 
           if_branch = expression.if_branch
           else_branch = expression.else_branch
           return if inconvertible_to_modifier?(if_branch, else_branch)
 
-          if self_assign?(variable, if_branch)
+          if self_assign?(node.name, if_branch)
             register_offense(expression, if_branch, else_branch, 'unless')
-          elsif self_assign?(variable, else_branch)
+          elsif self_assign?(node.name, else_branch)
             register_offense(expression, else_branch, if_branch, 'if')
           end
         end

--- a/lib/rubocop/cop/style/trailing_underscore_variable.rb
+++ b/lib/rubocop/cop/style/trailing_underscore_variable.rb
@@ -94,7 +94,7 @@ module RuboCop
         end
 
         def unneeded_ranges(node)
-          node.masgn_type? ? (mlhs_node, = *node) : mlhs_node = node
+          mlhs_node = node.masgn_type? ? node.lhs : node
           variables = *mlhs_node
 
           main_offense = main_node_offense(node)
@@ -106,15 +106,15 @@ module RuboCop
         end
 
         def main_node_offense(node)
-          node.masgn_type? ? (mlhs_node, right = *node) : mlhs_node = node
-
+          mlhs_node = node.masgn_type? ? node.lhs : node
           variables = *mlhs_node
+
           first_offense = find_first_offense(variables)
 
           return unless first_offense
 
           if unused_variables_only?(first_offense, variables)
-            return unused_range(node.type, mlhs_node, right)
+            return unused_range(node.type, mlhs_node, node.rhs)
           end
 
           return range_for_parentheses(first_offense, mlhs_node) if Util.parentheses?(mlhs_node)

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.4', '< 3.0')
-  s.add_dependency('rubocop-ast', '>= 1.33.1', '< 2.0')
+  s.add_dependency('rubocop-ast', '>= 1.34.0', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 3.0')
 end


### PR DESCRIPTION
Now that rubocop-ast has a `MasgnNode` and a `MlhsNode`, and `CasgnNode`, `AsgnNode` etc. has gotten some extra methods, we can remove some node destructuring from our code base.

See https://github.com/rubocop/rubocop-ast/pull/203 and https://github.com/rubocop/rubocop-ast/pull/326 for the implementations I depend on.

cc @dvandersluis 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
