### PR TITLE
[Fix #13412] Fix a false positive for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_line_continuation.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_line_continuation.md
@@ -1,0 +1,1 @@
+* [#13412](https://github.com/rubocop/rubocop/issues/13412): Fix a false positive for `Style/RedundantLineContinuation` when there is a line continuation at the end of Ruby code followed by `__END__` data. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -69,7 +69,7 @@ module RuboCop
         extend AutoCorrector
 
         MSG = 'Redundant line continuation.'
-        LINE_CONTINUATION = "\\\n"
+        LINE_CONTINUATION = '\\'
         LINE_CONTINUATION_PATTERN = /(\\\n)/.freeze
         ALLOWED_STRING_TOKENS = %i[tSTRING tSTRING_CONTENT].freeze
         ARGUMENT_TYPES = %i[
@@ -90,7 +90,7 @@ module RuboCop
             end
           end
 
-          inspect_eof_line_continuation
+          inspect_end_of_ruby_code_line_continuation
         end
 
         private
@@ -136,11 +136,12 @@ module RuboCop
           parse(source.gsub("\\\n", "\n")).valid_syntax?
         end
 
-        def inspect_eof_line_continuation
-          return unless processed_source.raw_source.end_with?(LINE_CONTINUATION)
+        def inspect_end_of_ruby_code_line_continuation
+          last_line = processed_source.lines[processed_source.ast.last_line - 1]
+          return unless last_line.end_with?(LINE_CONTINUATION)
 
-          rindex = processed_source.raw_source.rindex(LINE_CONTINUATION)
-          line_continuation_range = range_between(rindex, rindex + 1)
+          last_column = last_line.length
+          line_continuation_range = range_between(last_column - 1, last_column)
 
           add_offense(line_continuation_range) do |corrector|
             corrector.remove_trailing(line_continuation_range, 1)

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -708,7 +708,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
-  it 'registers an offense when there is a line continuation at the EOF' do
+  it 'registers an offense when there is a line continuation at the end of Ruby code' do
     expect_offense(<<~'RUBY')
       foo \
           ^ Redundant line continuation.
@@ -716,6 +716,23 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
 
     expect_correction(<<~RUBY)
       foo#{trailing_whitespace}
+    RUBY
+  end
+
+  it 'registers an offense when there is a line continuation at the end of Ruby code followed by `__END__` data' do
+    expect_offense(<<~'RUBY')
+      foo \
+          ^ Redundant line continuation.
+
+      __END__
+      data \
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo#{trailing_whitespace}
+
+      __END__
+      data \\
     RUBY
   end
 end


### PR DESCRIPTION
Fixes #13412.

This PR fixes a false positive for `Style/RedundantLineContinuation` when there is a line continuation at the end of Ruby code followed by `__END__` data.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
