### PR TITLE
[Fix #13415] Fix false positives for `Naming/MemoizedInstanceVariableName`

### DIFF
--- a/changelog/fix_false_positives_for_naming_memoized_instance_variable_name.md
+++ b/changelog/fix_false_positives_for_naming_memoized_instance_variable_name.md
@@ -1,0 +1,1 @@
+* [#13415](https://github.com/rubocop/rubocop/issues/13415): Fix false positives for `Naming/MemoizedInstanceVariableName` when using `initialize_clone`, `initialize_copy`, or `initialize_dup`. ([@koic][])

--- a/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
+++ b/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
@@ -155,6 +155,7 @@ module RuboCop
         UNDERSCORE_REQUIRED = 'Memoized variable `%<var>s` does not start ' \
                               'with `_`. Use `@%<suggested_var>s` instead.'
         DYNAMIC_DEFINE_METHODS = %i[define_method define_singleton_method].to_set.freeze
+        INITIALIZE_METHODS = %i[initialize initialize_clone initialize_copy initialize_dup].freeze
 
         # @!method method_definition?(node)
         def_node_matcher :method_definition?, <<~PATTERN
@@ -251,7 +252,7 @@ module RuboCop
         end
 
         def matches?(method_name, ivar_assign)
-          return true if ivar_assign.nil? || method_name == :initialize
+          return true if ivar_assign.nil? || INITIALIZE_METHODS.include?(method_name)
 
           method_name = method_name.to_s.delete('!?')
           variable = ivar_assign.children.first

--- a/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
@@ -243,6 +243,36 @@ RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName, :config do
               RUBY
             end
           end
+
+          context 'instance variables in `initialize_clone` method' do
+            it 'does not register an offense' do
+              expect_no_offenses(<<~RUBY)
+                def initialize_clone(obj)
+                  @files_with_offenses ||= {}
+                end
+              RUBY
+            end
+          end
+
+          context 'instance variables in `initialize_copy` method' do
+            it 'does not register an offense' do
+              expect_no_offenses(<<~RUBY)
+                def initialize_copy(obj)
+                  @files_with_offenses ||= {}
+                end
+              RUBY
+            end
+          end
+
+          context 'instance variables in `initialize_dup` method' do
+            it 'does not register an offense' do
+              expect_no_offenses(<<~RUBY)
+                def initialize_dup(obj)
+                  @files_with_offenses ||= {}
+                end
+              RUBY
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Fixes #13415.

This PR fixes false positives for `Naming/MemoizedInstanceVariableName` when using `initialize_clone`, `initialize_copy`, or `initialize_dup`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
