### PR TITLE
Fix `Lint/DeprecatedOpenSSLConstant` false positive when the argument is a `csend` node

### DIFF
--- a/changelog/fix_fix_lint_deprecated_open_ssl_constant_false.md
+++ b/changelog/fix_fix_lint_deprecated_open_ssl_constant_false.md
@@ -1,0 +1,1 @@
+* [#13419](https://github.com/rubocop/rubocop/pull/13419): Fix `Lint/DeprecatedOpenSSLConstant` false positive when the argument is a safe navigation method call. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
+++ b/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
@@ -51,7 +51,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return if node.arguments.any? { |arg| arg.variable? || arg.send_type? || arg.const_type? }
+          return if node.arguments.any? { |arg| arg.variable? || arg.call_type? || arg.const_type? }
           return if digest_const?(node.receiver)
           return unless algorithm_const(node)
 

--- a/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
@@ -93,9 +93,15 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedOpenSSLConstant, :config do
     RUBY
   end
 
-  it 'does not register an offense with cipher constant and send argument is a method' do
+  it 'does not register an offense with cipher constant and argument is a method call' do
     expect_no_offenses(<<~RUBY)
       OpenSSL::Cipher::AES128.new(do_something)
+    RUBY
+  end
+
+  it 'does not register an offense with cipher constant and argument is a safe navigation method call' do
+    expect_no_offenses(<<~RUBY)
+      OpenSSL::Cipher::AES128.new(foo&.bar)
     RUBY
   end
 


### PR DESCRIPTION
Correct a false positive with `Lint/DeprecatedOpenSSLConstant` when the argument is a `csend` node.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
